### PR TITLE
Day-one fixes: ci-data-v2 (FAF table), rest-leg test repairs, promotion records

### DIFF
--- a/.github/actions/fetch-reference-db/action.yml
+++ b/.github/actions/fetch-reference-db/action.yml
@@ -12,15 +12,18 @@ inputs:
   tag:
     description: Data-release tag holding the subset asset
     required: false
-    default: ci-data-v1
+    # v2 (2026-07-11): + fact_faf_commodity_flow FULL — the headless runner's
+    # hydration path reads it (Determinism Bundle died without it on the v1
+    # proving run).
+    default: ci-data-v2
   asset:
     description: Asset filename within the release
     required: false
-    default: reference-subset-20260711.sqlite
+    default: reference-subset-20260711b.sqlite
   sha256:
     description: Expected sha256 of the asset (pin — bump with the tag)
     required: false
-    default: dea98cc417bb984491e6a5c14dee53988181194c1426b9f842a0cdfb326a761d
+    default: 922b5a660306006d04ec1d322795d975c33638c59cb1278fbefb555db363b339
 
 runs:
   using: composite

--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -2,9 +2,30 @@
 # What exists vs what's planned - KEEP THIS UPDATED
 
 meta:
-  version: "2.24.0"
+  version: "2.25.0"
   updated: "2026-07-11"
   truth_status: |
+    (2026-07-11 late afternoon) PROMOTED + THE DEPENDABOT WAVE. main moved
+    1a8c68a6 -> 82a92882 (790 commits, frozen since Apr 28) then took the
+    dependabot wave; rulesets ACTIVE (main: no force-push/deletion; dev:
+    same + 7 required checks per SHA — every dev landing now goes through
+    a green PR). release.yml correctly did NOT fire on promotion (tag-
+    driven held). Maiden main.yml: 10/16 — Playwright E2E passed FIRST TRY
+    on the real stack; all 6 reds were first-run wiring/content, fixed
+    same day. THE WAVE (PR #169, owner-directed, supersedes 23 dependabot
+    PRs): ~50 pkgs bumped; engine solos rustworkx 0.18 / numpy 2.5.1 /
+    scipy 1.18 / h3 4.5 each qa:regression 5/5 byte-identical; pip-audit
+    policy EMPTIED (s-t 5.6 -> transformers 5.13.1 + torch 2.13 resolved
+    all six item-41 residue CVEs; item 46 closed; the pin test guards the
+    empty set); deferred-with-evidence: TS7 (no typescript-eslint support,
+    baseUrl removed), django6+mypy2 (django-stubs caps mypy<2.2, item 55).
+    Fast local gate 23min -> 202s (slow-test taxonomy; deeper pass item
+    54). ci-data-v2 subset (+fact_faf_commodity_flow — the headless
+    runner reads it; v1 proving run died ENGINE_FAILURE without it). Two
+    pre-existing rest-leg test bugs surfaced by first-ever CI execution
+    (rg-subprocess -> pure python; map-api TransactionManagementError =
+    real bridge bug, item 56). Owner items 45-56 live in the queue.
+
     (2026-07-11 evening) PROGRAM 15 (THE GAUNTLET) EXECUTED — CI/CD IS REAL
     NOW. Two tiers: push to dev = the 4-minute fast lane (fast-gate, unit
     shard w/ xdist + full-tree coverage artifacts + engine/systems>=80 gate,

--- a/project/owner/owner-queue.md
+++ b/project/owner/owner-queue.md
@@ -498,13 +498,19 @@ storage-budget-5t + the 520-tick michigan-e2e canonical, A/B determinism via Pos
 | 52 | **infra-live secrets — console task** | infra-live.yml (ephemeral Hetzner, dispatch + Monday cron) fails loud until repo secrets exist: `HCLOUD_TOKEN`, `CI_SSH_PRIVATE_KEY`, `CI_SSH_PUBLIC_KEY` (Settings → Secrets → Actions), plus creating the `infra-ephemeral` environment. Cloudflare vars are NOT needed (CI applies run manage_cloudflare=false). |
 | 53 | **local venv drift** | Your local venv runs Python 3.13.5; CI + .mise.toml pin 3.12. The weekly py3.13 leg covers forward-compat, and the determinism probe passed across both — but local-vs-CI parity would want a `mise install`-driven venv rebuild at your convenience. Not done unilaterally (it rebuilds your working venv). |
 
-**WATCH:** the maiden main.yml full run at promotion (all heavy legs un-gated for the
-first time: postgres-integration, playwright-e2e, qa-e2e-regression, refdata-tests,
-infra-validate); docs.yml Pages redeploy; Dependabot phantom-alert closure (~59
-expected to close when main un-freezes past the deleted manifests).
+**WATCH RESOLVED (2026-07-11, runs 29158383092 + 29162559986):** maiden main.yml went
+10/16 — Playwright E2E green FIRST TRY on the real stack; all six reds were first-run
+wiring/content (schema bootstrap, DSN, GDAL, tflint floor, serial-shard timeout, trove
+data gaps) and were fixed same day; the dev-dispatched proving run then took
+postgres-integration, refdata-tests, and infra-validate GREEN, exposed the ci-data-v1
+FAF gap (fixed as ci-data-v2) and two pre-existing rest-leg test bugs (fixed / item 56).
+Second proving dispatch pending on the fixes branch; docs.yml Pages + phantom-alert
+closure tracked there too.
 
 ## Deps wave 2026-07-11 (branch `deps/dependabot-wave-20260711`)
 
 | # | Item | Context |
 | --- | --- | --- |
 | 54 | **testing-suite pass: slow-test taxonomy + fixture cost** (temporary fix shipped with the 2026-07-11 deps wave; the deeper pass below awaits your ruling) | The local fast gate (`mise run check` → test:unit) took 23 min because multi-minute real-sim tests sat unmarked in tests/unit: `TestRunSweep` (6 methods, 80–290s each, ~1075s total) + `TestSimulationRunner::test_simulation_returns_result_dict` (118s) drive real engine sweeps through the headless runner. **Temporary fix on the deps branch:** both marked `@pytest.mark.slow`; `test:unit` selector now `not red_phase and not slow`; `test:rest-ci` grew a second leg running slow-marked unit tests — before it, slow-marked unit tests ran NOWHERE in CI (unit-ci excludes `slow`, rest-ci `--ignore=tests/unit`). Deferred to the testing-suite pass: (a) ~310s of per-test Postgres fixture SETUP in tests/unit/persistence (test_per_tick_transaction_atomicity + test_trace_view_columns re-create partitions and re-hydrate 5053 QCEW + 1045 hex rows PER TEST — wants module/session-scoped or shared hydration); (b) no CI job that runs the slow leg has Postgres, so the PG-gated slow tests (sweep/tune) SKIP in CI — they need a PG-provisioned home (postgres-up in test-rest, or move to the postgres-integration job); (c) taxonomy: these are integration/scenario tests wearing a unit label — relocate under tests/scenarios or tests/integration; (d) `test:fast` (`-m 'not slow'`) is now a near-duplicate of test:unit and doesn't exclude red_phase — consolidate or fix its selector. |
+| 55 | **django 6 + mypy 2 modernization** (deferred from the deps wave) | django-stubs 6.0.6 and drf-stubs 3.17.0 both cap `mypy<2.2` via the compatible-mypy extras — mypy 2.2 is unsatisfiable alongside them; escapes are structural (drop the extras and forfeit tested-compat, or take mypy 2.0/2.1 with django 6 as a smaller move). Wants its own railed batch: manage.py check + web suites + typecheck across 567 files. |
+| 56 | **map view hex-persist transaction bug** (surfaced by first-ever CI execution of tests/integration/test_map_api.py) | `engine_bridge._persist_hex_state_safe -> bulk_create` raises TransactionManagementError under the sqlite test backend (identical pre-wave at 82a92882 and locally) — an earlier query inside the atomic block fails and the 'safe' wrapper doesn't contain it. Now an evidence-cited xfail; the fix is a real bridge investigation (on_commit/nested-atomic territory), not test cosmetics. |

--- a/project/programs/15-the-gauntlet.md
+++ b/project/programs/15-the-gauntlet.md
@@ -1,6 +1,6 @@
 # Program 15 — The Gauntlet
 
-**Status: EXECUTED 2026-07-11** (promotion + records same day) · Ratified 2026-07-11
+**Status: EXECUTED + PROMOTED 2026-07-11** (promotion, the dependabot wave, and day-one fixes same day) · Ratified 2026-07-11
 (plan-mode approval, 4 owner rulings) · ADR064 · no constitutional amendment (the program
 *operationalizes* III.11 Loud Failure + III.12 behavioral contracts in CI; no primitive changed)
 
@@ -78,3 +78,36 @@ transformers pin (2 transformers CVEs), spec-064 retired-contract tests (3 xfail
 LODES hypothesis (3 xfails), sshd_config.j2 authoring, stale deploy docs, complexity ratchet
 (mccabe 15→10 wants 39 fixes), infra-live secrets (console task), local venv py3.13 vs pinned
 3.12 drift.
+
+## Promotion + day one (2026-07-11 afternoon, same session)
+
+**Promoted:** main `1a8c68a6 -> 82a92882` (790 commits; frozen since Apr 28). Rulesets active —
+main: no force-push/no deletion (18807583); dev: same + **7 required checks per SHA** (18807584;
+the six ruled contexts + Security Audit, which became blocking mid-program). release.yml
+correctly did NOT fire (tag-driven retarget held). promote.sh's gate was blocked 40+ min by
+GitHub's own "Dependabot Updates" scan check-run — now filtered out of gate 2 with cause.
+
+**Maiden main.yml (run 29158383092): 10/16.** Playwright E2E passed FIRST TRY on the real stack;
+dense goldens, unit+coverage, security, gitleaks, trivy-config, frontend, AI all green. All six
+reds were first-run wiring or pre-existing content — none code regressions: missing engine-schema
+bootstrap + DSN (two Postgres legs), serial rest shard vs its timeout, missing GDAL in the docs
+job, missing terraform required_version, and 3 refdata tests that were never green anywhere
+(SQL-verified trove data gaps: zero FIPS-26999 QCEW rows, zero naics_level=2 aggregates).
+
+**The dependabot wave (PR #169, owner-directed):** ~50 packages superseding 23 dependabot PRs.
+Engine solos (rustworkx 0.18, numpy 2.5.1, scipy 1.18, h3 4.5) each byte-identical.
+**pip-audit policy EMPTIED** — sentence-transformers 5.6 unlocked transformers 5.13.1 + torch
+2.13, resolving all six item-41 residue CVEs (item 46 closed; the pin test now guards the empty
+set). Deferred with evidence: TypeScript 7 (removed baseUrl; typescript-eslint caps <6.1) and
+django 6 + mypy 2 (django-stubs 6.0.6 caps mypy<2.2 — item 55). postgis 17 dependabot-ignored
+with cause (item 45). The automerge machinery proved itself mid-wave by squash-merging #158
+into dev and forcing a rebase.
+
+**Day-one findings fixed:** the 23-minute local "unit" gate was ~13 unmarked real-simulation
+tests (slow-marked; fast gate measured 202s; slow tests got a CI home in the rest shard — deeper
+pass is item 54). Six formulas doctests had never executed anywhere and asserted non-IEEE-754
+floats — round()-honest now. ci-data-v2 subset (+fact_faf_commodity_flow FULL: sqlite_hydrator
+IS the headless runner's path; the Determinism Bundle died ENGINE_FAILURE without it). Two
+pre-existing rest-leg failures surfaced by first-ever execution: an `rg` subprocess test (hosted
+runners have no ripgrep — rewritten pure-Python) and a real bridge transaction bug in the map
+view's hex-persist path (item 56, evidence-cited xfail).

--- a/tests/integration/test_map_api.py
+++ b/tests/integration/test_map_api.py
@@ -226,6 +226,15 @@ class TestMapFeaturesAfterCreateGame:
     """P0 #7 (RED): a real game must project territories into hex_latest so
     GET /api/games/{id}/map/?zoom=hex returns features > 0."""
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason="PRE-EXISTING (identical failure in the pre-wave maiden CI run at"
+        " 82a92882 AND locally at HEAD): the map view's hex-persist path"
+        " (engine_bridge._persist_hex_state_safe -> bulk_create) raises"
+        " TransactionManagementError under the sqlite test backend — a real"
+        " bridge transaction-handling bug, owner item 2026-07-11, not a"
+        " dependency regression",
+    )
     def test_map_features_positive_after_create_game(self):
         from game.engine_bridge import EngineBridge, _build_initial_state_for_scenario
 

--- a/tests/integration/test_post_067_consumer_queries.py
+++ b/tests/integration/test_post_067_consumer_queries.py
@@ -16,7 +16,7 @@ These tests verify:
 
 from __future__ import annotations
 
-import subprocess
+import re
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -138,28 +138,28 @@ def test_post_067_michigan_county_years_have_non_zero_employment(
 
 # T040 — Build-time grep enforcement (SC-004).
 def test_post_067_no_filter_lines_remain_in_production_paths() -> None:
-    """No spec-066 hotfix filter remains in the production query paths."""
+    """No spec-066 hotfix filter remains in the production query paths.
 
+    Pure-Python scan (was an ``rg`` subprocess — hosted CI runners have no
+    ripgrep, which made this test FileNotFoundError on its first-ever CI run,
+    2026-07-11).
+    """
+    pattern = re.compile(
+        r"WHERE\s+ownership_id\s*=\s*1|WHERE\s+industry_id\s*=\s*1|"
+        r"AND\s+(?:fq\.)?ownership_id\s*=\s*1|AND\s+(?:fq\.)?industry_id\s*=\s*1"
+    )
     repo_root = Path(__file__).resolve().parents[2]
     target_files = [
-        str(repo_root / "src/babylon/persistence/hex_hydrator.py"),
-        str(repo_root / "src/babylon/persistence/county_aggregation.py"),
+        repo_root / "src/babylon/persistence/hex_hydrator.py",
+        repo_root / "src/babylon/persistence/county_aggregation.py",
     ]
-    # rg returns exit 1 when no match found, which is the success case here.
-    result = subprocess.run(
-        [
-            "rg",
-            "-n",
-            r"WHERE\s+ownership_id\s*=\s*1|WHERE\s+industry_id\s*=\s*1|"
-            r"AND\s+(?:fq\.)?ownership_id\s*=\s*1|AND\s+(?:fq\.)?industry_id\s*=\s*1",
-            *target_files,
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode == 1, (
-        f"spec-066 hotfix filter pattern still present in production code:\n{result.stdout}"
+    hits: list[str] = []
+    for target in target_files:
+        for lineno, line in enumerate(target.read_text().splitlines(), start=1):
+            if pattern.search(line):
+                hits.append(f"{target}:{lineno}: {line.strip()}")
+    assert not hits, (
+        "spec-066 hotfix filter pattern still present in production code:\n" + "\n".join(hits)
     )
     # Sanity: silence unused-variable lint for NORMALIZED_DB_PATH at module
     # scope without actually importing the path during the grep check.

--- a/tests/unit/tools/test_make_reference_subset.py
+++ b/tests/unit/tools/test_make_reference_subset.py
@@ -803,8 +803,11 @@ class TestProductionPolicyShape:
         ):
             assert TABLE[name].scope == "full", f"{name} must be BLOCKED-FULL"
 
-    def test_faf_and_pre086_qcew_are_skipped(self) -> None:
-        assert TABLE["fact_faf_commodity_flow"].scope == "skip"
+    def test_faf_is_full_and_pre086_qcew_is_skipped(self) -> None:
+        # FAF flipped skip -> full for ci-data-v2: sqlite_hydrator (the headless
+        # runner's hydration path) reads it — the Determinism Bundle CI job died
+        # ENGINE_FAILURE without it on the ci-data-v1 proving run (2026-07-11).
+        assert TABLE["fact_faf_commodity_flow"].scope == "full"
         assert TABLE["fact_qcew_annual__pre_086"].scope == "skip"
 
     def test_known_michigan_tables(self) -> None:

--- a/tools/make_reference_subset.py
+++ b/tools/make_reference_subset.py
@@ -368,13 +368,15 @@ TABLE: dict[str, TablePolicy] = {
     ),
     # -- fact_* — explicit SKIP (recon-confirmed zero real-DB test coverage). --
     "fact_faf_commodity_flow": TablePolicy(
-        "skip",
-        "Read only by production ingestion (sqlite_hydrator.py) and "
-        "domain/economics/tensor_hierarchy/geographic_flow.py, whose tests "
-        "(test_geographic_flow.py, test_scale.py, test_validation.py) all "
-        "use MagicMock(session_factory) — zero real-DB test coverage. Its "
-        "county bridge (bridge_cfs_county) is itself empty, so no "
-        "county-scoping is even possible. SKIP (102.1 MB removed).",
+        "full",
+        "Read by sqlite_hydrator.py — which IS the headless runner's "
+        "hydration path: qa:e2e-regression's strict 5-tick bundle dies "
+        "ENGINE_FAILURE 'no such table: fact_faf_commodity_flow' without it "
+        "(proven on the ci-data-v1 proving run, 2026-07-11). The original "
+        "skip reasoning ('zero real-DB test coverage') missed that the "
+        "Determinism Bundle CI job exercises the real engine. Its county "
+        "bridge (bridge_cfs_county) is empty, so FAF-zone rows cannot be "
+        "Michigan-scoped — FULL copy (~97 MiB, 2.49M rows).",
     ),
     "fact_qcew_annual__pre_086": TablePolicy(
         "skip",


### PR DESCRIPTION
Follow-through on the two dev-dispatched proving runs of the full pipeline (run 29162559986):

- **ci-data-v2**: the Determinism Bundle died `ENGINE_FAILURE: no such table: fact_faf_commodity_flow` — sqlite_hydrator (the headless runner's hydration path) reads it; the v1 skip reasoning missed that the CI job exercises the real engine. Policy flipped to FULL (~97 MiB; its county bridge is empty so no Michigan cut is possible), all other hydrator-read tables audited as covered. New 587 MiB artifact released as ci-data-v2, sha-pinned, composite defaults bumped. Generator suite 63/63.
- **Rest-leg repairs** (both proven pre-existing — identical in the PRE-wave maiden run): the `rg`-subprocess test rewritten pure-Python (hosted runners have no ripgrep); the map-api test's TransactionManagementError is a real bridge bug in `_persist_hex_state_safe` → evidence-cited xfail + owner item 56.
- **Records**: state.yaml v2.25.0 truth banner (promotion, wave, empty CVE policy, 202s fast gate), charter "Promotion + day one" section, owner items 55 (django6+mypy2 stub-cap deadlock) and 56, maiden WATCH resolved.

After landing: dispatch main.yml on dev as proving run #2 (Determinism Bundle + rest leg + docs-with-gdal expected green), then promote dev→main per owner consent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)