### PR TITLE
fix(ci-data): TIGER county shapefile for the Determinism Bundle

### DIFF
--- a/.github/actions/fetch-reference-db/action.yml
+++ b/.github/actions/fetch-reference-db/action.yml
@@ -24,6 +24,16 @@ inputs:
     description: Expected sha256 of the asset (pin — bump with the tag)
     required: false
     default: 922b5a660306006d04ec1d322795d975c33638c59cb1278fbefb555db363b339
+  tiger-asset:
+    description: TIGER county-shapefile tarball within the release (the
+      headless runner reads data/tiger/county/tl_2024_us_county.shp — proving
+      run 2 died FileNotFoundError without it)
+    required: false
+    default: tiger-county-2024.tar.gz
+  tiger-sha256:
+    description: Expected sha256 of the TIGER tarball
+    required: false
+    default: 516fe00e77ca374e5400c8d73ac830e126a576cebbb967651c2f72e0cf574095
 
 runs:
   using: composite
@@ -60,3 +70,29 @@ runs:
         # the first reader flips it to WAL and rewrites it.
         cp ~/refdb/'${{ inputs.asset }}' data/sqlite/marxist-data-3NF.sqlite
         ls -la data/sqlite/
+
+    - name: Restore cached TIGER tarball
+      id: tiger-cache
+      uses: actions/cache@v6
+      with:
+        path: ~/refdb/${{ inputs.tiger-asset }}
+        key: refdb-${{ inputs.tag }}-${{ inputs.tiger-sha256 }}
+
+    - name: Download TIGER tarball (cache miss)
+      if: steps.tiger-cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release download '${{ inputs.tag }}' \
+          --repo "$GITHUB_REPOSITORY" \
+          --pattern '${{ inputs.tiger-asset }}' \
+          --output ~/refdb/'${{ inputs.tiger-asset }}'
+
+    - name: Verify + extract TIGER county shapefile
+      shell: bash
+      run: |
+        echo '${{ inputs.tiger-sha256 }}  '"$HOME"'/refdb/${{ inputs.tiger-asset }}' | sha256sum -c -
+        mkdir -p data/tiger/county
+        tar xzf ~/refdb/'${{ inputs.tiger-asset }}' -C data/tiger/county
+        ls -la data/tiger/county/


### PR DESCRIPTION
## What

The full main pipeline's **Determinism Bundle** (`qa-e2e-regression`, the strict 5-tick
tri-county headless run) died on proving run #2 with:

```
ENGINE_FAILURE: FileNotFoundError: TIGER county shapefile not found at
data/tiger/county/tl_2024_us_county.shp; missing counties: ['26099', '26125', '26163']
```

The engine's geography layer (`persistence/tiger_ingestion.py`, `persistence/hex_hydrator.py`)
reads that shapefile directly via `geopandas.read_file`. It's a **filesystem** dependency the
SQLite subset can't carry, and CI checkouts have no `data/tiger/`.

## Fix

`fetch-reference-db` composite gains `tiger-asset` / `tiger-sha256` inputs plus
cache → download → **verify-before-extract** steps, mirroring the existing verify-before-first-use
integrity contract for the DB asset. The tarball (`tiger-county-2024.tar.gz`, 83.9 MB —
shp/shx/dbf/prj/cpg) is already published on the `ci-data-v2` release; sha256 pinned in the action.

## Why TIGER is the last gap

Exhaustive audit of engine-read `data/` paths outside `data/sqlite`:
- **natural-earth** → resolves to the static `STATE_FIPS_TO_CENSUS_DIVISION` dict, no file read at runtime.
- **geography.html** → ingestion-only, not on the runner's path.
- **TIGER** → the only remaining runtime filesystem read. This closes it.

## Local sufficiency proof (both legs, before dispatching proving run #3)

- **Subset leg**: `headless_runner --scope detroit-tri-county --ticks 5 --strict` against the v2
  subset (`BABYLON_NORMALIZED_DB_PATH` + `--sqlite-path`) → exit 0; `compare-bundle` vs
  `tests/baselines/detroit-tri-county-5t.json` → **all checks pass** (counties_alive == 3,
  total_v Δ=0.000%).
- **TIGER leg**: extracted tarball opens via `geopandas.read_file(columns=[...])` exactly as
  `tiger_ingestion.load_tiger_counties` does → 3235 counties, all three targets present
  (Wayne 26163, Macomb 26099, Oakland 26125) with non-empty geometry. shp/shx/dbf/prj/cpg is
  reader-complete without the `.iso.xml` metadata.

Program 15 Phase 8 — the last CI-subset gap before final promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)