### PR TITLE
ci: harden the pipeline for promotion (advisory gate + docs + OOM fix)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -352,7 +352,7 @@ jobs:
         run: poetry run pytest tests/unit/ai -o addopts="" -vv -ra -l --tb=long --durations=0
 
   docs:
-    name: Documentation Build (non-strict — item-44 blocks -W)
+    name: Documentation Build (doctest blocks; manual advisory)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -364,9 +364,19 @@ jobs:
           # which initializes Django -> contrib.gis -> libgdal, so even the
           # formulas-scoped doctest run needs the system GDAL package.
           gdal: "true"
+      # The doctest run STAYS blocking: it verifies the formula docstring
+      # examples (III.12 float-honesty contract). It is cheap and deterministic.
       - name: Run doctest examples
         run: poetry run pytest --doctest-modules src/babylon/formulas -o addopts="" -vv -ra --tb=long
-      - name: Build documentation
+      # Bundling the manual is a RELEASE-TIME concern, not a per-push gate
+      # (owner ruling 2026-07-11: "we don't really need to bundle the docs as a
+      # manual until we're ready to release — lower priority"). Kept running so
+      # bit-rot stays visible as a red step, but continue-on-error so it never
+      # blocks a dev landing or the promotion. Flip back to blocking (or move to
+      # release.yml) when the manual becomes a release deliverable. item-44's
+      # 2.4k-warning wall still blocks the -W strict build regardless.
+      - name: Build documentation (advisory — manual bundled at release time)
+        continue-on-error: true
         working-directory: docs
         run: poetry run sphinx-build -b html . _build/html
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -145,7 +145,16 @@ poetry run coverage report --include='src/babylon/engine/systems/*' --fail-under
 """
 
 [tasks."test:rest-ci"]
-description = "CI heavy shard (program 15): everything outside tests/unit except the web-Postgres suites (their own job), PLUS slow-marked tests/unit tests (test:unit-ci excludes slow — without this second leg they would run nowhere in CI); max-verbosity output; full-tree coverage artifacts (no gate); includes slow; excludes red_phase/requires_reference_db"
+description = "CI heavy shard (program 15): everything outside tests/unit except the web-Postgres suites (their own job), PLUS slow-marked tests/unit tests (test:unit-ci excludes slow — without this second leg they would run nowhere in CI); max-verbosity output; includes slow; excludes red_phase/requires_reference_db"
+# NO coverage on this shard (program 15, 2026-07-11): pytest-cov under
+# `-n 4` xdist instruments all of src/babylon in every worker, and stacked on
+# the memory-heavy integration/property suites it OOM-killed a worker on the
+# hosted runner — a silent SIGKILL ("sh exited with non-zero status: no exit
+# status", no traceback), at a DIFFERENT test each attempt (cumulative memory,
+# not a test bug: every test passes standalone). The coverage GATE is unaffected
+# — it lives on the unit shard (test:unit-ci, engine/systems >=80). This shard's
+# full-tree coverage was non-gating artifact only; restoring it needs a proper
+# per-worker memory budget (owner item 54).
 run = """
 set -e
 mkdir -p reports/test-results/rest-ci
@@ -153,10 +162,6 @@ poetry run pytest tests --ignore=tests/unit --ignore=tests/integration/web \
   -o addopts="" -vv -ra -l --tb=long --durations=0 \
   -m 'not red_phase and not requires_reference_db' \
   -n 4 --dist loadscope \
-  --cov=src/babylon \
-  --cov-report=term-missing:skip-covered \
-  --cov-report=xml:reports/test-results/rest-ci/coverage.xml \
-  --cov-report=json:reports/test-results/rest-ci/coverage.json \
   --junit-xml=reports/test-results/rest-ci/junit.xml
 echo '=== slow-marked tests/unit tests (excluded from the test:unit-ci fast shard) ==='
 poetry run pytest tests/unit --ignore=tests/unit/ai \

--- a/tools/promote.sh
+++ b/tools/promote.sh
@@ -46,9 +46,20 @@ CHECKS_JSON=$(gh api "repos/{owner}/{repo}/commits/${DEV_SHA}/check-runs" --pagi
 # minutes after a manifest-heavy push (lockfile/pyproject churn), and it recurs
 # on GitHub's own schedule — so it may sit PENDING, or re-run, long after our
 # real CI has gone green. Today it blocked a promotion for exactly that reason.
-# Filter it out of the check-run set ONCE here so the three evaluations below
-# (TOTAL / PENDING / BAD) reason only about our actual CI jobs.
-CI_CHECKS=$(echo "$CHECKS_JSON" | jq '[.check_runs[] | select(.name != "Dependabot")]')
+#
+# Advisory jobs are the second class we must drop. main.yml's `continue-on-error`
+# jobs (AI Tests, Image Scan) are DESIGNED not to gate — but GitHub still records
+# their failing outcome as a `failure` check-run conclusion. When main.yml is
+# dispatched on dev for a pre-promotion proving run, those check-runs land on dev
+# HEAD, and a permanently-red advisory (e.g. Image Scan's postgis-bullseye CVEs,
+# owner item 45) would wedge gate 2 forever. Our Loud Failure convention puts the
+# word "advisory" in every such job name ("AI Tests (advisory — non-deterministic)",
+# "Image Scan (trivy — advisory until postgis bump)"), so that word is a reliable,
+# self-documenting filter — exactly parallel to the Dependabot case. No blocking
+# job name contains it; every advisory one does.
+CI_CHECKS=$(echo "$CHECKS_JSON" | jq '[.check_runs[]
+  | select(.name != "Dependabot")
+  | select(.name | ascii_downcase | contains("advisory") | not)]')
 
 TOTAL=$(echo "$CI_CHECKS" | jq 'length')
 if [ "$TOTAL" -eq 0 ]; then


### PR DESCRIPTION
Three CI-hardening fixes surfaced by the pre-promotion proving runs. All are
gating/reliability corrections — no product-code change.

### 1. `promote.sh` gate 2 skips advisory check-runs (`b1b3dcf7`)
A proving run dispatches `main.yml` on dev, attaching the full pipeline's
check-runs to dev HEAD — including the two `continue-on-error` advisory jobs
(`AI Tests`, `Image Scan`). GitHub records a failing advisory as a `failure`
conclusion, so a permanently-red advisory (Image Scan's postgis CVEs, item 45)
would wedge gate 2 forever. Filter check-runs whose name contains `advisory`,
parallel to the existing Dependabot filter. Verified against a synthetic set;
shellcheck clean.

### 2. Docs manual build is advisory (`df4c9b1d`)
Owner ruling 2026-07-11: the manual is a release-time deliverable, not a
per-push gate. `sphinx-build` step → `continue-on-error`; the **doctest** step
stays blocking (III.12 float-honesty contract). Job goes green on the real main
run instead of being perpetually cancelled behind a blocking failure.

### 3. Drop coverage from the heavy shard — OOM fix (`e28de120`)
Proving run #3 (+ re-run) failed Non-Unit Tests with a silent SIGKILL at a
*different* test each attempt — the OOM-killer fingerprint. `pytest-cov` under
`-n 4` xdist instruments all of src/babylon per worker; stacked on the
memory-heavy integration/property suites it exhausted the runner. Every test
passes standalone; the same code was green on run #2. Drop `--cov` from this
shard (non-gating artifact only; the ≥80 gate lives on the unit shard). `-n 4`
speed retained. Restoring full-tree coverage needs a per-worker memory budget
(owner item 54).

Together these make the full pipeline reliably green so the promotion's real
main run isn't red on flaky infra. Determinism Bundle (the TIGER fix, PR #171)
was already green on proving run #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)