### PR TITLE
fix(ci): route refdb trace tests to reference-data job + cap advisory sphinx build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -378,7 +378,14 @@ jobs:
       - name: Build documentation (advisory — manual bundled at release time)
         continue-on-error: true
         working-directory: docs
-        run: poetry run sphinx-build -b html . _build/html
+        # Cap the advisory build at 8 min. Without this the huge doc tree
+        # (item-44's 2.4k-warning wall) can run past the job's 15-min
+        # timeout-minutes, which CANCELS the whole job — and a job-level
+        # cancellation is NOT swallowed by continue-on-error, so the docs job
+        # showed "cancelled" instead of green (proving run #4, 2026-07-11).
+        # coreutils `timeout` turns "too slow" into a swallowed step failure
+        # (exit 124) well under the job cap; real sphinx errors still show red.
+        run: timeout 480 poetry run sphinx-build -b html . _build/html
 
   gitleaks:
     name: Secret Scan (gitleaks, full history)

--- a/tests/integration/tools/test_parameter_analysis.py
+++ b/tests/integration/tools/test_parameter_analysis.py
@@ -16,6 +16,13 @@ import pytest
 
 from babylon.engine.headless_runner.runner import PostgresUnreachableError
 
+# Every test here drives run_trace() -> headless runner, which loads the SQLite
+# reference DB (data/sqlite/marxist-data-3NF.sqlite). The dev CI heavy shard has
+# no reference DB, so these belong to the main/nightly "Reference-Data Tests" job
+# that fetches the ci-data subset (item 40). Combines with the per-method
+# @pytest.mark.integration marks below.
+pytestmark = pytest.mark.requires_reference_db
+
 # Path to the project root (babylon/)
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
 


### PR DESCRIPTION
Two proving-run #4 gaps on the full main.yml pipeline, both blocking a clean promotion.

## 1. Non-Unit Tests heavy shard (blocking) — the one real red
The prior OOM fix (dropping non-gating coverage from the heavy shard) worked: the
shard now completes (1008 passed, 302 skipped). That surfaced one genuine failure it
had been masking — `tests/integration/tools/test_parameter_analysis.py::TestIntegration::test_full_trace_to_csv`
drives `run_trace()` → the headless runner, which needs the SQLite reference DB the
heavy shard doesn't fetch (`ReferenceDataMissingError`).

Every test in `TestIntegration` calls `run_trace`, so the honest fix is a module-level
`pytestmark = pytest.mark.requires_reference_db` (matching the `test_tensor_data_flow.py`
convention). This routes all 4 to the main/nightly **Reference-Data Tests** job
(ci-data-v1 subset, detroit-tri-county scope — which the trace uses).

- Heavy-shard filter (`-m 'not requires_reference_db'`) now **deselects all 4**.
- Reference-Data filter (`-m requires_reference_db`) now **selects all 4**.
- The real test **passes locally** against the reference DB (1 passed, 121s).

## 2. Documentation Build (advisory) — cancelled, not green
Doctest step (blocking) passed, but the advisory `sphinx-build` ran past the docs
job's `timeout-minutes: 15` (19:58:44 → 20:14:00) and was **cancelled** — a job-level
timeout is NOT swallowed by `continue-on-error`, so the job showed "cancelled". Wrap
the build in `timeout 480` so a too-slow tree self-terminates as a swallowed step
failure well under the job cap. Keeps the owner's "advisory, stays visible" intent
and makes the docs job actually green on both tiers.

Not a promote.sh blocker (the gate filters "advisory"-named check-runs), but required
for a clean-green main pipeline post-promotion.

actionlint + ruff + yamllint clean.