### PR TITLE
test(engine): de-flake test_running_loop_executes_steps (wall-clock → bounded poll)

### DIFF
--- a/ai/decisions/ADR064_program15_gauntlet.yaml
+++ b/ai/decisions/ADR064_program15_gauntlet.yaml
@@ -91,4 +91,41 @@ ADR064_program15_gauntlet:
     hardcoded-path files via isolated worktree (44 pass + 1 intentional
     xfail). Full ruff (incl. S) zero findings; mypy strict green (567
     files); pip-audit wrapper exit 0; npm audit 0.
+  execution_followup: |
+    (2026-07-11 late afternoon, Opus 4.8) Phase 8 CLOSED + Dependabot made
+    reproducible (owner directive: "truly reproducible, non-recurring").
+    A second promotion carried the CI-hardening/proving-run wave to main
+    (82a92882 -> a491c22d, 28 commits, clean ff via promote.sh; gate 2 saw
+    21 green checks). Four proving runs (main.yml dispatched on dev) peeled
+    one gap each — never widen the subset speculatively:
+      #3 TIGER data path (data/tiger/county — the last engine-read path
+         outside data/sqlite) added to the fetch-reference-db composite as
+         a cached tarball; #3->#4 heavy-shard OOM (pytest-cov under -n4
+         instruments all of src/babylon per worker + memory-heavy suites =
+         SIGKILL) fixed by dropping non-gating coverage from the heavy shard;
+         that let the shard complete and exposed #4->#5 a headless-runner
+         trace test lacking the requires_reference_db marker (routed to the
+         Reference-Data job) + the advisory sphinx build CANCELLING the docs
+         job by breaching its 15-min JOB timeout (job-timeout is NOT swallowed
+         by continue-on-error — capped `timeout 480`). #5 = full green.
+    The real main run then flaked ONE blocking unit test
+    (test_running_loop_executes_steps, assert 1>=2) that had passed twice on
+    the identical SHA — a wall-clock test starved under CI load, de-flaked to
+    a bounded poll (PR #176). Determinism-first CI cannot carry timing-count
+    asserts.
+    DEPENDABOT REPRODUCIBILITY: alerts 34 -> 0 (poetry.lock/ansible resolved
+    by the wave landing on main; 27 uv.lock phantoms dismissed inaccurate —
+    manifest deleted spec-037, can't regenerate); PRs 11 -> 1 (3 phantom + 3
+    superseded + 5 deferred-major closed — Dependabot AUTO-closed 4 the moment
+    it re-read the new ignores from main, proving the mechanism). dependabot.yml
+    now ignores the deferred semver-majors (django/-stubs/mypy = item 55,
+    typescript = TS7, postgis = item 45), each with an UNBLOCK note; node pinned
+    via src/frontend/.nvmrc (single source: nvm + mise + setup-node); security
+    updates stay ON and route via dev (owner B4 ruling, no repo Settings change).
+    New owner items: 57 (frontend-majors #175 — react-router 8 + recharts 3
+    breaking, awaits owner), 58 (latent >=1 timing sibling). Two durable CI
+    gotchas: promote.sh gate 2 filters check-runs whose name contains "advisory"
+    (or equals "Dependabot") — every non-gating job carries that word by
+    convention; and a job-level timeout-minutes CANCELS the whole job, which
+    step-level continue-on-error does NOT rescue (cap the slow step itself).
   file: ADR064_program15_gauntlet.yaml

--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -2,9 +2,33 @@
 # What exists vs what's planned - KEEP THIS UPDATED
 
 meta:
-  version: "2.25.0"
+  version: "2.26.0"
   updated: "2026-07-11"
   truth_status: |
+    (2026-07-11 ~5pm) PHASE 8 CLOSED + DEPENDABOT MADE REPRODUCIBLE. A second
+    promotion carried the CI-hardening/proving-run wave to main (82a92882 ->
+    a491c22d, 28 commits, clean ff via promote.sh; gate 2 saw 21 green checks).
+    Proving-run saga: #4 exposed one real red once the heavy-shard OOM fix let
+    the shard complete — a headless-runner trace test lacking the
+    requires_reference_db marker (routed it to the Reference-Data job); the
+    advisory sphinx build was cancelling the docs job by breaching its 15-min
+    JOB timeout (job-timeout is NOT swallowed by continue-on-error) so it was
+    capped `timeout 480`. #5 = full pipeline green. The real main run then flaked
+    ONE blocking unit test (test_running_loop_executes_steps, assert 1>=2, a
+    wall-clock test starved under CI load — green twice on the same SHA), fixed
+    to a bounded poll (PR #176). DEPENDABOT: alerts 34 -> 0 (poetry.lock/ansible
+    auto-resolved by the wave; 27 uv.lock phantoms dismissed inaccurate — manifest
+    deleted, can't regenerate); PRs 11 -> 1 (3 phantom + 3 superseded + 5 deferred
+    majors closed — Dependabot AUTO-closed 4 the moment it re-read the new ignores
+    from main, proving the mechanism; #175 frontend-majors left for owner review,
+    item 57). dependabot.yml ignores the deferred semver-majors (django/-stubs/mypy
+    item 55, typescript TS7, postgis item 45); node pinned via src/frontend/.nvmrc;
+    security updates route via dev (owner B4 ruling). New owner items 57 (#175
+    frontend majors) + 58 (latent timing-flaky sibling). GOTCHAS: promote.sh gate 2
+    filters check-runs whose name contains "advisory" (+ "Dependabot") — every
+    non-gating job carries that word; a job-level timeout-minutes CANCELS the job
+    and continue-on-error does NOT save it (cap the slow step instead).
+
     (2026-07-11 late afternoon) PROMOTED + THE DEPENDABOT WAVE. main moved
     1a8c68a6 -> 82a92882 (790 commits, frozen since Apr 28) then took the
     dependabot wave; rulesets ACTIVE (main: no force-push/deletion; dev:

--- a/project/owner/owner-queue.md
+++ b/project/owner/owner-queue.md
@@ -514,3 +514,53 @@ closure tracked there too.
 | 54 | **testing-suite pass: slow-test taxonomy + fixture cost** (temporary fix shipped with the 2026-07-11 deps wave; the deeper pass below awaits your ruling) | The local fast gate (`mise run check` → test:unit) took 23 min because multi-minute real-sim tests sat unmarked in tests/unit: `TestRunSweep` (6 methods, 80–290s each, ~1075s total) + `TestSimulationRunner::test_simulation_returns_result_dict` (118s) drive real engine sweeps through the headless runner. **Temporary fix on the deps branch:** both marked `@pytest.mark.slow`; `test:unit` selector now `not red_phase and not slow`; `test:rest-ci` grew a second leg running slow-marked unit tests — before it, slow-marked unit tests ran NOWHERE in CI (unit-ci excludes `slow`, rest-ci `--ignore=tests/unit`). Deferred to the testing-suite pass: (a) ~310s of per-test Postgres fixture SETUP in tests/unit/persistence (test_per_tick_transaction_atomicity + test_trace_view_columns re-create partitions and re-hydrate 5053 QCEW + 1045 hex rows PER TEST — wants module/session-scoped or shared hydration); (b) no CI job that runs the slow leg has Postgres, so the PG-gated slow tests (sweep/tune) SKIP in CI — they need a PG-provisioned home (postgres-up in test-rest, or move to the postgres-integration job); (c) taxonomy: these are integration/scenario tests wearing a unit label — relocate under tests/scenarios or tests/integration; (d) `test:fast` (`-m 'not slow'`) is now a near-duplicate of test:unit and doesn't exclude red_phase — consolidate or fix its selector. |
 | 55 | **django 6 + mypy 2 modernization** (deferred from the deps wave) | django-stubs 6.0.6 and drf-stubs 3.17.0 both cap `mypy<2.2` via the compatible-mypy extras — mypy 2.2 is unsatisfiable alongside them; escapes are structural (drop the extras and forfeit tested-compat, or take mypy 2.0/2.1 with django 6 as a smaller move). Wants its own railed batch: manage.py check + web suites + typecheck across 567 files. |
 | 56 | **map view hex-persist transaction bug** (surfaced by first-ever CI execution of tests/integration/test_map_api.py) | `engine_bridge._persist_hex_state_safe -> bulk_create` raises TransactionManagementError under the sqlite test backend (identical pre-wave at 82a92882 and locally) — an earlier query inside the atomic block fails and the 'safe' wrapper doesn't contain it. Now an evidence-cited xfail; the fix is a real bridge investigation (on_commit/nested-atomic territory), not test cosmetics. |
+
+## 2026-07-11 late afternoon — Phase 8 CLOSE + Dependabot reproducibility (Opus 4.8)
+
+**WATCH from 2026-07-11 (proving dispatches) RESOLVED.** The fixes branch closed the
+last gaps and `dev` promoted to `main` a second time (`82a92882 → a491c22d`, 28 commits,
+clean ff via `tools/promote.sh`). The proving-run saga:
+
+- **Proving run #4** (main.yml on dev): the heavy-shard OOM fix let the shard complete
+  and exposed one real red — `test_parameter_analysis.py::test_full_trace_to_csv` drives
+  `run_trace()` → the headless runner (needs the SQLite reference DB the heavy shard
+  doesn't fetch). Fix: module-level `requires_reference_db` marker routes all 4 tests in
+  that class to the main-tier Reference-Data job (ci-data subset, detroit-tri-county). The
+  advisory sphinx build separately ran past the docs job's 15-min timeout (a job-level
+  timeout CANCELS the job — NOT swallowed by continue-on-error), so it was capped with
+  `timeout 480`. (PR #174.)
+- **Proving run #5** (same fixes, dev@a491c22d): full pipeline GREEN — Non-Unit Tests,
+  Documentation Build, Reference-Data all success; the only red is the advisory Image Scan
+  (postgis, item 45), which `promote.sh` filters by the "advisory" name convention.
+- Promoted. **Real main.yml run on main** then flaked ONE blocking unit test
+  (`test_running_loop_executes_steps`, `assert 1 >= 2`) that had passed twice on the
+  identical SHA — a wall-clock-dependent test starved by CI load. De-flaked to a bounded
+  poll (PR #176) → **item 58 below**. The promotion itself remains validly green (code
+  identical, verified green twice).
+
+**Dependabot — "truly reproducible, non-recurring" (your directive) DONE.** The
+post-promotion dependency-graph rescan + the config changes cleared the churn:
+
+- **Alerts 34 → 0 open.** The 6 poetry.lock (CVE-wave patches now on main) and 1 ansible
+  (main now at 14.1) auto-resolved on the rescan; the 27 `uv.lock` phantoms (manifest
+  deleted spec-037, absent from main HEAD) were dismissed as `inaccurate` with a traceable
+  note. They cannot regenerate — the manifest is gone.
+- **PRs 11 → 1 open.** Closed: 3 phantom (uv.lock/web-frontend deleted), 3 superseded
+  (dev already ≥), 5 deferred majors. Dependabot ITSELF auto-closed 4 of the deferred
+  majors the moment it re-read the new config from `main` — proving the `ignore` directives
+  work. The 1 remaining (#175) is a legitimate reviewable batch → **item 57**.
+- **B4 ruling recorded (yours, 2026-07-11): security updates stay ON, route via `dev`.** No
+  repo Settings change. `target-branch: dev` routes real security PRs through
+  validate→promote; the blocking pip-audit gate + weekly dev scan are the backstop.
+- **Reproducibility hardening:** `.github/dependabot.yml` now `ignore`s the deferred
+  semver-majors (django/django-stubs/mypy → item 55; typescript → TS7; postgis → item 45),
+  each with an UNBLOCK note; node pinned via `src/frontend/.nvmrc` (nvm + mise + setup-node
+  single source). Lockfiles (poetry.lock, package-lock.json) remain the reproducibility
+  anchor, gated by `poetry check --lock` / `npm ci`.
+
+**New items needing rulings:**
+
+| # | Item | Context |
+| --- | --- | --- |
+| 57 | **frontend-majors batch #175** (react-router 7→8, recharts 2→3, jsdom 28→29) | The `frontend-majors` group working as designed — one reviewable dev-targeted PR, never auto-merged; typescript 7 correctly EXCLUDED (ignored). react-router 8 + recharts 3 are **breaking** and the frontend is under active development on `feature/113-living-map`, so this wants deliberate handling (likely unbundle: jsdom 29 is low-risk dev-only). Left OPEN with a context comment; not a promotion blocker (targets dev, waits on the ruleset checks). |
+| 58 | **latent timing-flaky sibling** (`test_runner.py:~858`, real-Simulation lifecycle) | The de-flake (PR #176) fixed the `>= 2` test that actually red'd main; a sibling asserts `len(states) >= 1` after the same fixed 0.05s sleep — same genre, far lower flake risk (one tick, not two). Left as-is (surgical) — apply the same bounded-poll pattern if it ever flakes. |

--- a/project/programs/15-the-gauntlet.md
+++ b/project/programs/15-the-gauntlet.md
@@ -111,3 +111,64 @@ IS the headless runner's path; the Determinism Bundle died ENGINE_FAILURE withou
 pre-existing rest-leg failures surfaced by first-ever execution: an `rg` subprocess test (hosted
 runners have no ripgrep — rewritten pure-Python) and a real bridge transaction bug in the map
 view's hex-persist path (item 56, evidence-cited xfail).
+
+## Phase 8 close — the proving-run saga + second promotion (2026-07-11 late afternoon)
+
+The maiden main.yml reds and the ci-data FAF gap were fixed on a follow-up branch, then a second
+promotion carried the whole CI-hardening wave to main (`82a92882 → a491c22d`, 28 commits, clean
+ff via `tools/promote.sh`; gate 2 saw 21 green checks). Getting there took four proving runs
+(main.yml dispatched on dev) that peeled one gap each — the discipline was *never widen the subset
+speculatively; peel the next real gap*:
+
+1. **TIGER data path** (proving run #3): the Determinism Bundle needs `data/tiger/county` (the last
+   engine-read data path outside `data/sqlite`). Added a cached-tarball fetch to the
+   `fetch-reference-db` composite. Green.
+2. **Heavy-shard OOM** (proving run #3→#4): `pytest-cov` under `-n 4` instruments all of
+   `src/babylon` per worker; stacked on the memory-heavy integration/property suites it tripped the
+   OOM-killer (SIGKILL, no traceback, a different test each attempt). Dropped non-gating coverage
+   from the heavy shard (the coverage gate lives on the unit shard). The shard then *completed* and
+   exposed one real red:
+3. **Missing `requires_reference_db` marker** (proving run #4→#5): `test_full_trace_to_csv` drives
+   `run_trace()` → the headless runner (loads the SQLite reference DB), but sat in the heavy shard
+   with no marker → `ReferenceDataMissingError`. A module-level `requires_reference_db` marker routes
+   all four tests in that class to the main-tier Reference-Data job (ci-data subset,
+   detroit-tri-county scope — verified passing).
+4. **Docs job cancelled by a job timeout** (same fix set): the doctest step (blocking) passed, but
+   the advisory sphinx build breached the docs job's `timeout-minutes: 15` and the whole job was
+   **cancelled** — a job-level timeout is NOT swallowed by step-level `continue-on-error`. Capped the
+   build with coreutils `timeout 480` so a too-slow tree self-terminates as a swallowed step failure
+   well under the job cap.
+
+**Proving run #5 = full pipeline GREEN** (advisory Image Scan red is filtered by `promote.sh`). Promoted.
+
+**The flaky-test coda.** The real main.yml run on `main` then red'd ONE blocking unit test —
+`test_running_loop_executes_steps` (`assert 1 >= 2`) — that had passed on both PR #174's fast lane
+and proving run #5 on the *identical* SHA. A wall-clock test (fixed `sleep(0.05)`, assert `>= 2`
+steps at `tick_interval=0.01`) starved by CI load. De-flaked to a **bounded poll** (≤2s ceiling,
+breaks the instant two steps land) — the real contract (the loop executes repeatedly) asserted
+deterministically. The lesson: *a green pipeline on a wall-clock test is a coin that landed heads*;
+determinism-first CI can't carry timing-count asserts. (PR #176; a lower-risk `>= 1` sibling noted
+as item 58.)
+
+## Dependabot made reproducible (owner: "truly reproducible, non-recurring")
+
+The bot churn had two root causes, both now closed:
+
+- **Stale phantom graph.** `uv.lock` (spec-037) and `web/frontend` (spec-112) were deleted from both
+  branches, yet GitHub's dependency graph still flagged ~27 `uv.lock` alerts and opened
+  main-targeted security PRs. A push to the DEFAULT branch (the promotion) forces a rescan: the 6
+  poetry.lock (CVE-wave patches now on main) + 1 ansible (14.1) alerts **auto-resolved**; the 27
+  `uv.lock` phantoms were **dismissed `inaccurate`** with a traceable note — they can't regenerate
+  because the manifest is gone. **Alerts 34 → 0.**
+- **Deferred majors lived only in prose.** TS7, django 6, django-stubs 6, mypy 2 had no `ignore`
+  directive (only postgis did), so Dependabot re-opened them every scan. Added `ignore` entries
+  scoped to `version-update:semver-major` (minor/patch security still flows), each with an UNBLOCK
+  note tying it to its owner item. Dependabot **auto-closed 4 of the deferred-major PRs the instant
+  it re-read the new config from `main`** — the mechanism proving itself. **PRs 11 → 1** (the one
+  survivor, #175, is a *legitimate* frontend-majors batch → item 57).
+
+Plus reproducibility hardening: node pinned via `src/frontend/.nvmrc` (single source for nvm + mise
++ setup-node), lockfiles remain the anchor (gated by `poetry check --lock` / `npm ci`), and the
+owner's B4 ruling — security updates stay ON and route via `dev` (no repo Settings change) — is
+recorded. The steady state: weekly grouped version PRs to dev, majors as one reviewable dev PR
+(never auto-merged), deferred majors ignored-with-cause, phantoms structurally impossible.

--- a/tests/unit/engine/test_runner.py
+++ b/tests/unit/engine/test_runner.py
@@ -429,10 +429,21 @@ class TestStartStop:
         runner = AsyncSimulationRunner(mock_simulation, tick_interval=0.01)
         await runner.start()
 
-        # Wait for a few ticks
-        await asyncio.sleep(0.05)
-
-        await runner.stop()
+        # Poll until the loop has executed at least two steps rather than
+        # sleeping a fixed window and asserting a count. A loaded CI runner can
+        # starve the event loop so only one step lands in a 50ms sleep, making
+        # `assert 1 >= 2` flaky (observed on the 2026-07-11 main pipeline while
+        # proving-run #5 on the same SHA passed). Waiting for the condition
+        # asserts the real contract — the loop executes repeatedly — without a
+        # wall-clock dependency: a fast machine passes instantly, a slow one
+        # waits, and a genuinely broken loop still fails when the bound expires.
+        try:
+            for _ in range(200):  # bounded: 200 * 0.01s = 2s ceiling
+                if mock_simulation.step.call_count >= 2:
+                    break
+                await asyncio.sleep(0.01)
+        finally:
+            await runner.stop()
 
         # Should have executed multiple steps
         assert mock_simulation.step.call_count >= 2


### PR DESCRIPTION
The real main.yml pipeline (run 29167421553, on the promoted SHA a491c22d) red'd the **blocking** Unit Tests job on one timing-flaky test — while **proving-run #5 on the identical SHA passed**. 2 greens + 1 red on the same code = flake, not a regression; the promotion itself is validly green.

## The flake
`TestStartStop::test_running_loop_executes_steps` set `tick_interval=0.01`, slept a fixed `0.05s` expecting ~5 steps, and asserted `call_count >= 2`. A load-starved CI event loop landed only one step in the window → `assert 1 >= 2`.

## The fix
Replace sleep-then-assert-count with a **bounded poll** (`≤200 × 0.01s = 2s` ceiling, breaks the instant 2 steps land). This asserts the real contract — *the loop executes repeatedly until stopped* — deterministically: a fast machine passes instantly, a slow one waits, and a genuinely broken loop still fails when the bound expires. Verified **5/5 green** locally in ~0.10s.

Test-only change (`tests/unit/engine/test_runner.py`) — no engine/economics/defines touched, so `qa:regression` is unaffected; the dev fast-lane Unit Tests job validates it directly.

Noted for the owner (not changed here, surgical): the real-Simulation lifecycle test at ~L858 asserts `len(states) >= 1` after the same fixed sleep — same genre, far lower flake risk (one tick, not two). Left as a latent watch in owner-queue.