### PR TITLE
fix(persistence): _persist_events reads event_type key, not "type"

### DIFF
--- a/src/babylon/persistence/postgres_runtime/_legacy.py
+++ b/src/babylon/persistence/postgres_runtime/_legacy.py
@@ -2341,17 +2341,28 @@ class PostgresRuntime:
     ) -> None:
         """Persist simulation events."""
         with conn.cursor() as cur:
+            # The event key is "event_type" — that is the field name on
+            # SimulationEvent (models/events/_legacy.py) and therefore the key
+            # model_dump(mode="json") emits. Reading "type" here silently
+            # persisted EVERY event as "UNKNOWN", which (a) collapsed distinct
+            # events at one tick onto the same ux_simulation_event_session_tick_
+            # natural key and (b) starved the web layer's urgency classifier.
+            # ON CONFLICT DO NOTHING makes the write retry-safe against that
+            # natural key regardless (mirrors migration 0009's stated intent).
             cur.executemany(
                 """
                 INSERT INTO simulation_event
                     (session_id, tick, event_type, entity_id, community_type, details)
                 VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (session_id, tick, event_type,
+                             COALESCE(entity_id, ''), COALESCE(community_type, ''))
+                DO NOTHING
                 """,
                 [
                     (
                         session_id,
                         tick,
-                        e.get("type", "UNKNOWN"),
+                        e.get("event_type", "UNKNOWN"),
                         e.get("entity_id"),
                         e.get("community_type"),
                         json.dumps(e, default=_json_default),

--- a/tests/integration/test_persistence_monotonic_postgres.py
+++ b/tests/integration/test_persistence_monotonic_postgres.py
@@ -154,3 +154,35 @@ class TestPostgresMonotonicIdempotent:
         different = dict(ev, entity_id="other")
         with pytest.raises(MonotonicityViolationError):
             runtime.persist_tick(tick=0, graph=graph, events=[different], session_id=session_id)
+
+
+class TestSimulationEventTypeKey:
+    """spec-113 engine defect: ``_persist_events`` must read the ``"event_type"``
+    key — the field name on ``SimulationEvent`` and therefore the key
+    ``model_dump(mode="json")`` emits — not ``"type"``. Reading ``"type"``
+    persisted EVERY event as ``"UNKNOWN"``, so two distinct events at one tick
+    collapsed onto the same ``ux_simulation_event_session_tick_natural`` key
+    (resolve-loop UniqueViolation, session death ~tick 18) and the web layer
+    never saw a real type (silent wire / no toasts)."""
+
+    def test_distinct_event_types_at_one_tick_persist_as_distinct_rows(
+        self, runtime: PostgresRuntime, session_id: uuid.UUID, pg_pool
+    ) -> None:
+        # Same tick, same (empty) entity, DIFFERENT event_type. Pre-fix both
+        # serialized to "UNKNOWN" -> identical natural key -> UniqueViolation
+        # inside persist_tick's transaction. Post-fix they carry real, distinct
+        # types and both rows land.
+        events = [
+            {"event_type": "SURPLUS_EXTRACTION", "tick": 4},
+            {"event_type": "RADICALIZATION", "tick": 4},
+        ]
+        runtime.persist_tick(
+            tick=4, graph=_payload_to_graph("evt", 1), events=events, session_id=session_id
+        )
+        with pg_pool.connection() as conn:
+            rows = conn.execute(
+                "SELECT event_type FROM simulation_event "
+                "WHERE session_id = %s AND tick = %s ORDER BY event_type",
+                (session_id, 4),
+            ).fetchall()
+        assert [r[0] for r in rows] == ["RADICALIZATION", "SURPLUS_EXTRACTION"]

--- a/tests/unit/persistence/test_postgres_runtime.py
+++ b/tests/unit/persistence/test_postgres_runtime.py
@@ -264,7 +264,10 @@ class TestPersistTick:
         """persist_tick writes simulation events."""
         events = [
             {
-                "type": "UPRISING",
+                # Real runtime shape: SimulationEvent.model_dump(mode="json")
+                # emits the field name "event_type" (no alias). The old "type"
+                # here matched the _persist_events bug, not the engine.
+                "event_type": "UPRISING",
                 "entity_id": "worker_1",
                 "community_type": "NEIGHBORHOOD",
                 "message": "Workers revolt!",
@@ -304,7 +307,7 @@ class TestPersistTick:
         reproduce the TypeError.
         """
         events = [
-            {"type": "UPRISING", "entity_id": "w1", "timestamp": datetime(2026, 7, 8, 1, 0)},
+            {"event_type": "UPRISING", "entity_id": "w1", "timestamp": datetime(2026, 7, 8, 1, 0)},
         ]
         graph = _build_graph(nodes={"w1": {"type": "SocialClass"}})
         runtime.persist_tick(tick=5, graph=graph, events=events, session_id=session_id)


### PR DESCRIPTION
## What

One-line field-name fix in the interactive/web event-persistence path, plus a defence-in-depth `ON CONFLICT`. Surfaced **live** by the spec-113 Living Map audit; full writeup in `specs/113-living-map/ENGINE-DEFECTS.md` (on `feature/113-living-map`).

## Root cause — one typo, two P1 symptoms

`SimulationEvent`'s field is `event_type` (no alias) → `model_dump(mode="json")` emits key `"event_type"`. But `_persist_events` read `e.get("type")`, so **every web-persisted event landed as `event_type = "UNKNOWN"`.**

- **Resolve 500 → session death ~tick 18.** Two events at one tick both became `UNKNOWN` with empty `entity_id`/`community_type`, colliding on the unique index `ux_simulation_event_session_tick_natural`. The `executemany` had no `ON CONFLICT` → `UniqueViolation` → the resolve request 500s.
- **Silent wire.** The web layer classifies urgency by event type; with everything `UNKNOWN`, nothing was ever urgent → zero toasts across 20+ live ticks.

## The fix

- `e.get("type")` → `e.get("event_type")` — the true runtime key (`_extract_event_type` and the rest of the web layer already read `event_type`).
- `ON CONFLICT (session_id, tick, event_type, COALESCE(entity_id,''), COALESCE(community_type,'')) DO NOTHING` so a genuine same-signature retry can never 500 again (mirrors migration 0009's stated intent).

## Tests

- **New** `TestSimulationEventTypeKey`: two distinct-typed events at one tick persist as two distinct rows. **RED before the fix** — both serialize to `UNKNOWN` → identical natural key → `UniqueViolation`.
- **Corrected** two unit tests (`test_persists_events`, `test_persists_events_with_datetime_timestamp`) that had encoded the bug's wrong `"type"` key — a real `model_dump` never emits `"type"`.

## Determinism — `qa:regression` 5/5 byte-identical

The gate runs the engine **in-memory** (`regression_test.py` `step()` over `WorldState` → dense-trace CSV) and never calls `persist_tick`/`_persist_events`. The headless runner uses the separately-patched `persist_tick_atomic` and captures events via the EventBus enum. The change is isolated to the interactive Postgres write path — verified by the diff (sole caller of `_persist_events` is `persist_tick`) and confirmed byte-identical.

## Downstream

Flips the two intentionally-RED spec-113 live e2e specs (`event-popup.spec.ts`, `end-turn-flow.spec.ts`) green: the wire/toasts come alive and sessions play past tick 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)