### PR TITLE
fix: copacetic-verification findings — nightly stub red, C4 deflator evaporation, doctrine seam declaration

### DIFF
--- a/src/babylon/sentinels/seam/registry.py
+++ b/src/babylon/sentinels/seam/registry.py
@@ -1855,6 +1855,86 @@ _NETWORK_METRICS: tuple[SeamEntry, ...] = (
     ),
 )
 
+# --- DOCTRINE scope (ADR073 Units 4-7; scope enum added 2026-07-16) ---
+# The 2026-07-16 copacetic audit found the inverse of an orphan declaration:
+# get_doctrine_tree -> endpoints.ts doctrineTree -> DoctrineTakeover.tsx is a
+# real, wired, player-observable surface the Observatory never declared.
+# These rows retire that gap. Sensor 1's gating checks do not scan this
+# surface — rows are the declarative contract, same as NETWORK's.
+
+_DOCTRINE_EMITTERS: tuple[str, ...] = ("web/game/engine_bridge.py::EngineBridge.get_doctrine_tree",)
+
+_DOCTRINE_METRICS: tuple[SeamEntry, ...] = (
+    SeamEntry(
+        payload="acquired_doctrine_ids",
+        wire_keys=("acquired_ids",),
+        scope=SeamScope.DOCTRINE,
+        owner_layer="engine (DoctrineSystem @14.7 — Party Congress acquisitions)",
+        liveness_class=LivenessClass.DECLARED_CONDITIONAL,
+        dtype="json",
+        write_site=(
+            "src/babylon/engine/systems/doctrine.py::DoctrineSystem.step "
+            "(Unit 5 Party Congress: seeded-RNG acquisition weighted by tag "
+            "deltas; a real Organization model field, so it survives the "
+            "WorldState round trip — D2 snapshot->hydrate proof)"
+        ),
+        read_paths=_DOCTRINE_EMITTERS,
+        derivation_site="web/game/engine_bridge.py::EngineBridge.get_doctrine_tree",
+        spec_ref="ADR073 Doctrine Tree · Units 4-6 (PR #190)",
+        notes=(
+            "The player faction's acquired doctrine-node ids. "
+            "DECLARED_CONDITIONAL: live only when the scenario seeds a player "
+            "faction and a Congress has fired; honest [] before then "
+            "(never fabricated partial progress, Constitution III.11)."
+        ),
+    ),
+    SeamEntry(
+        payload="doctrine_tags",
+        wire_keys=("tags",),
+        scope=SeamScope.DOCTRINE,
+        owner_layer="engine (DoctrineSystem @14.7 — decaying tag accumulator)",
+        liveness_class=LivenessClass.DECLARED_CONDITIONAL,
+        dtype="json",
+        write_site=(
+            "src/babylon/engine/systems/doctrine.py::DoctrineSystem.step "
+            "(per-tick upkeep decay toward parent + acquisition tag_deltas)"
+        ),
+        read_paths=_DOCTRINE_EMITTERS,
+        derivation_site="web/game/engine_bridge.py::EngineBridge.get_doctrine_tree",
+        spec_ref="ADR073 Doctrine Tree · Units 4-6 (PR #190)",
+        notes=(
+            "The wire itself is never null — with no player faction the "
+            "bridge serves starting_tags() (the MVP corpus's declared "
+            "starting position, NOT compute_tags over an empty set). The "
+            "declared CONDITION governs when the values reflect live per-org "
+            "accumulator state instead of that static starting position."
+        ),
+    ),
+    SeamEntry(
+        payload="theoretical_labor",
+        wire_keys=("theoretical_labor", "study_target_id"),
+        scope=SeamScope.DOCTRINE,
+        owner_layer="engine (DoctrineSystem @14.7) + the Study verb (Unit 7b)",
+        liveness_class=LivenessClass.DECLARED_CONDITIONAL,
+        dtype="json",
+        write_site=(
+            "src/babylon/engine/systems/doctrine.py::DoctrineSystem.step "
+            "(accrue_theoretical_labor per tick); study_target_id is the "
+            "player's standing Educate(Doctrine) order set by the Unit 7b "
+            "study POST"
+        ),
+        read_paths=_DOCTRINE_EMITTERS,
+        derivation_site="web/game/engine_bridge.py::EngineBridge.get_doctrine_tree",
+        spec_ref="ADR073 Doctrine Tree · Units 4-7b (PR #190)",
+        notes=(
+            "TL accrues 0.0-up once a player faction exists; study_target_id "
+            "is an honest null until the player issues a Study order (the "
+            "canvas then stays read-only rather than offering an "
+            "unactionable affordance)."
+        ),
+    ),
+)
+
 #: The declared observable-field contract. Populated per build phase.
 SEAM_REGISTRY: tuple[SeamEntry, ...] = (
     _MAP_METRICS
@@ -1863,4 +1943,5 @@ SEAM_REGISTRY: tuple[SeamEntry, ...] = (
     + _FIELD_STATE_METRICS
     + _MAP_HISTORY_METRICS
     + _NETWORK_METRICS
+    + _DOCTRINE_METRICS
 )

--- a/src/babylon/sentinels/seam/types.py
+++ b/src/babylon/sentinels/seam/types.py
@@ -71,6 +71,13 @@ class SeamScope(StrEnum):
         solidarity-subgraph ``percolation_ratio``). Added after AW4-R1
         deliberately registered a documented scope gap rather than
         misclassify these under :attr:`INSPECTOR`/:attr:`TERRITORY`.
+    :cvar DOCTRINE: the Doctrine Tree canvas payload
+        (``EngineBridge.get_doctrine_tree`` on ``/doctrine-tree/``; ADR073
+        Units 4-7) — the player faction's ``acquired_doctrine_ids`` /
+        ``doctrine_tags`` / ``theoretical_labor`` overlay written by
+        ``DoctrineSystem`` @14.7. Added after the 2026-07-16 copacetic audit
+        found the inverse of an orphan declaration: a real, wired,
+        player-observable surface with no SeamEntry at all.
     """
 
     MAP = "map"
@@ -81,6 +88,7 @@ class SeamScope(StrEnum):
     INSPECTOR = "inspector"
     FIELD_STATE = "field_state"
     NETWORK = "network"
+    DOCTRINE = "doctrine"
 
 
 class LivenessClass(StrEnum):

--- a/tests/integration/balkanization/test_determinism_replay.py
+++ b/tests/integration/balkanization/test_determinism_replay.py
@@ -53,6 +53,8 @@ class _MetabolismDefines:
     entropy_factor: float = 0.5
     overshoot_threshold: float = 1.0
     max_overshoot_ratio: float = 10.0
+    # Epoch 1 hysteresis (PR #192): MetabolismSystem.step reads this every tick.
+    hysteresis_rate: float = 0.005
 
 
 @dataclass

--- a/tests/integration/balkanization/test_us1_extraction_trajectory.py
+++ b/tests/integration/balkanization/test_us1_extraction_trajectory.py
@@ -32,6 +32,8 @@ class _MetabolismDefines:
     entropy_factor: float = 0.5
     overshoot_threshold: float = 1.0
     max_overshoot_ratio: float = 10.0
+    # Epoch 1 hysteresis (PR #192): MetabolismSystem.step reads this every tick.
+    hysteresis_rate: float = 0.005
 
 
 @dataclass

--- a/tests/unit/web/test_carry_group_a_b.py
+++ b/tests/unit/web/test_carry_group_a_b.py
@@ -61,6 +61,7 @@ def _boundary_county_and_params() -> tuple[CountyEconomicState, NationalTickPara
         employment=500_000.0,
         class_distribution=dist,
         phi_hour=3.50,
+        real_wage_deflator=0.87,
         crisis_state=CrisisState(
             phase=CrisisPhase.DEEP,
             consecutive_below=6,
@@ -132,6 +133,10 @@ def test_carry_stamps_group_a_and_b_at_boundary() -> None:
         "lumpenproletariat": 0.20,
     }
     assert node["tick_unemployment_rate"] == pytest.approx(0.081)
+    # Wave 6 C4: the CPI deflator must ride the same carry as its C2/C3
+    # siblings — before this pin it was the ONE tick_* wire the boundary
+    # branch omitted, so it evaporated from every web-session graph.
+    assert node["tick_real_wage_deflator"] == pytest.approx(0.87)
 
 
 def test_carry_forwards_group_a_and_b_between_boundaries() -> None:
@@ -166,6 +171,7 @@ def test_carry_forwards_group_a_and_b_between_boundaries() -> None:
             "lumpenproletariat": 0.20,
         },
         tick_unemployment_rate=0.081,
+        tick_real_wage_deflator=0.87,
     )
     new_graph = _wayne_graph()
     ctx: dict[str, object] = {}  # no _tick_dynamics => not a boundary
@@ -185,3 +191,7 @@ def test_carry_forwards_group_a_and_b_between_boundaries() -> None:
         "lumpenproletariat": 0.20,
     }
     assert node["tick_unemployment_rate"] == pytest.approx(0.081)
+    # Wave 6 C4: carried forward byte-identical between boundaries, same
+    # pattern as tick_unemployment_rate — evaporation here silently reset
+    # the deflator to the rehydrate fallback (1.0) on the web path.
+    assert node["tick_real_wage_deflator"] == pytest.approx(0.87)

--- a/web/game/engine_bridge.py
+++ b/web/game/engine_bridge.py
@@ -6210,6 +6210,12 @@ def _carry_tick_dynamics_flows(
                 # evaporation-on-round-trip fix, symmetric with
                 # tick_unemployment_rate immediately above.
                 tick_bracket_ratio=county.bracket_ratio,
+                # Wave 6 C4: the CPI real-wage deflator rides the same carry —
+                # it was the one tick_* wire omitted here, so on the web path
+                # it evaporated every tick (real wage rendered None; the next
+                # rehydrate fell back to 1.0). Caught by the 2026-07-16
+                # copacetic verification sweep.
+                tick_real_wage_deflator=county.real_wage_deflator,
                 # Wave 2 owner ruling 1: throughput_position/supply_chain_depth
                 # are real now that _bridge_economics_overrides wires a
                 # throughput_calculator — same evaporation-on-round-trip fix
@@ -6264,6 +6270,9 @@ def _carry_tick_dynamics_flows(
             # Wave 6 C3: carry forward byte-identical between boundaries,
             # same pattern as tick_unemployment_rate immediately above.
             tick_bracket_ratio=old_data.get("tick_bracket_ratio"),
+            # Wave 6 C4: same annual carry as C2/C3 — honest None before the
+            # first year boundary, byte-identical between boundaries after.
+            tick_real_wage_deflator=old_data.get("tick_real_wage_deflator"),
             # Wave 2 owner ruling 1: carry forward byte-identical between
             # boundaries, same pattern as the derived rates/Group A/B above.
             tick_throughput_position=old_data.get("tick_throughput_position"),


### PR DESCRIPTION
## What

Three fixes from the 2026-07-16 copacetic verification sweep (full `mise run check` + qa:regression + all sentinel CLIs + a 10-stream parallel read-only audit of the six waves):

1. **fix(tests): Nightly red** — `_MetabolismDefines` test stubs in `tests/integration/balkanization/` (2 files) were missing `hysteresis_rate`, which `MetabolismSystem.step` has read every tick since the Wave-6 hysteresis ratchet (PR #192). All 9 Nightly failures (run 29477664596) traced to this one gap; integration tests only run in Nightly, so every fast gate stayed green. Stubs stay hand-rolled dataclasses deliberately — they use out-of-range coefficients (`entropy_factor=0.5` vs the real field's `gt=1.0`) the real Pydantic model would reject. Red-green verified: 9/9 pass locally post-fix.

2. **fix(web): C4 deflator evaporation** — `_carry_tick_dynamics_flows` re-injected every `tick_*` sibling (renter share, bracket ratio, unemployment, crisis group) **except** `tick_real_wage_deflator`, so on the web path the CPI deflator evaporated on the WorldState round trip every tick: real median wage rendered honest-None forever and the next rehydrate fell back to 1.0. Headless was unaffected (single in-place graph), which is why unit gates never saw it. TDD: both carry tests extended red-first (`KeyError: 'tick_real_wage_deflator'`), then the two sibling-pattern kwargs added. Found by the audit's wiring stream.

3. **feat(sentinels): doctrine seam declaration** — the audit's one FAILED finding: `get_doctrine_tree` → `endpoints.ts doctrineTree` → `DoctrineTakeover.tsx` is a real, wired, player-observable surface with zero Seam Observatory representation (the inverse of an orphan declaration). Added `SeamScope.DOCTRINE` + 3 declarative rows (`acquired_ids`, `tags`, `theoretical_labor`/`study_target_id`), same pattern as the NETWORK scope extension (task #76). Registry now 86 observables; seam sentinel exit 0; all 84 sentinel unit tests green.

## Gates

- `mise run check` exit 0 (10,328 unit tests passed) on the pre-fix dev merge; scoped suites re-run green on every commit here
- qa:regression 5/5 byte-identical, baselines UNMODIFIED (web-bridge + test-only + registry changes can't move headless goldens)
- `sentinel_check.py seam|coverage|partition --check` all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)