### PR TITLE
fix(ci): un-red the nightly legs — pg schema bootstrap, sim-trace refdb fetch, mutmut symlink guard

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,6 +82,13 @@ jobs:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test
         run: poetry run python manage.py migrate
+      # The engine-runtime tables (node_state, edge_state, dynamic_*, …) are
+      # NOT Django's — locally test:int-pg applies POSTGRES_SCHEMA_DDL via
+      # db:bootstrap after db:up. This step was missing since the workflow's
+      # maiden run (2026-07-12), so every session-hydrating test failed with
+      # UndefinedTable: node_state (37 of 69 in run 29512575415).
+      - name: Babylon runtime schema bootstrap (node_state et al.)
+        run: mise run db:bootstrap
       - name: Run web integration suites
         env:
           POSTGRES_HOST: localhost
@@ -99,7 +106,7 @@ jobs:
   # dev unit shard and tests outside unit are excluded from test-rest by
   # the marker, so this job is their ONE home on the main tier.
   refdata-tests:
-    name: Reference-Data Tests (dev HEAD, ci-data-v1 subset)
+    name: Reference-Data Tests (dev HEAD, pinned ci-data subset)
     if: github.event.schedule != '0 4 * * 0' && vars.CI_REFDB_READY == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -158,6 +165,13 @@ jobs:
         with:
           ref: dev
       - uses: ./.github/actions/bootstrap-python
+      # sim:trace's headless runner requires the reference DB at
+      # data/sqlite/marxist-data-3NF.sqlite — exactly where this action
+      # installs the pinned ci-data subset. Without it the leg died at
+      # startup (ReferenceDataMissingError) on every dispatch. Whether the
+      # subset's rows satisfy the trace scenario is a data-coverage question
+      # this step surfaces honestly instead of masking behind a missing file.
+      - uses: ./.github/actions/fetch-reference-db
       - name: Simulation trace
         run: mise run sim:trace
       - name: Parameter sweep
@@ -184,6 +198,12 @@ jobs:
       - uses: ./.github/actions/bootstrap-python
         with:
           gdal: "true"
+      # src/babylon_data is a committed absolute symlink into the dev box's
+      # babylon-data repo — always dangling on CI checkout, and mutmut's
+      # src/ -> mutants/src/ copytree raises shutil.Error on it. Nothing
+      # under mutation imports it (loader-land, not engine), so drop it.
+      - name: Drop dangling babylon-data symlink (mutmut copytree chokes on it)
+        run: rm -f src/babylon_data
       - name: Run mutation testing (critical paths)
         run: poetry run python tools/run_mutmut.py --critical
       - name: Score vs committed baseline


### PR DESCRIPTION
The copacetic verification's manual Nightly dispatch (run 29512575415) surfaced that the workflow has **never had a fully-green run** — three legs fail for infrastructure reasons unrelated to the code they test:

1. **Postgres Integration — red every night since the maiden run (2026-07-12).** All 37 failures are `UndefinedTable: node_state`: the job runs Django migrate but never applies `POSTGRES_SCHEMA_DDL` (the engine-runtime tables). Locally `test:int-pg` runs `db:bootstrap` after `db:up`; the job was missing that exact step. Added it after Django migrate (same DSN the job env already uses).
2. **Simulation Trace + Sweep (weekly/dispatch-only)** — dies at startup with `ReferenceDataMissingError`: the job never fetches the reference DB. Added the `fetch-reference-db` step, which installs the pinned subset at exactly the path `sim:trace` reads. If the subset's rows don't satisfy the trace scenario, the leg will now fail with an honest data-coverage error instead of a missing file.
3. **Mutation Testing (weekly/dispatch-only, advisory)** — `shutil.Error` because `src/babylon_data` is a committed absolute symlink into the dev box's babylon-data repo, always dangling on CI checkout; mutmut's `src/ → mutants/src/` copytree chokes on it. Added an `rm -f` guard step — nothing under mutation imports it.

Also renamed the refdata job to "pinned ci-data subset" (it said v1; the pin is v4 and rides the action default — the name can't go stale again).

Daily-leg proof pending: the stub fix for the Non-Unit red merged in #196; this PR completes the set needed for a fully green Nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)