### PR TITLE
feat: Program 21 — the Data Constitution (ADR075)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -369,6 +369,8 @@ jobs:
         with:
           gdal: "true"
       - uses: ./.github/actions/fetch-reference-db
+      - name: Catalog sentinel (DB probe — catalog↔DB reconciliation)
+        run: poetry run python tools/sentinel_check.py catalog --check
       - name: Run requires_reference_db suites
         run: >-
           poetry run pytest tests -m requires_reference_db

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -134,6 +134,8 @@ jobs:
         with:
           gdal: "true"
       - uses: ./.github/actions/fetch-reference-db
+      - name: Catalog sentinel (DB probe — catalog↔DB reconciliation)
+        run: poetry run python tools/sentinel_check.py catalog --check
       - name: Run requires_reference_db suites
         run: >-
           poetry run pytest tests -m requires_reference_db

--- a/ai/decisions/ADR075_data_constitution.yaml
+++ b/ai/decisions/ADR075_data_constitution.yaml
@@ -1,0 +1,88 @@
+ADR075_data_constitution:
+  status: "accepted"
+  date: "2026-07-16"
+  title: "Program 21 — the Data Constitution: per-table lineage registry in data-catalog.yaml (enforced by a catalog sentinel), the 99-table census triage, and the wealth-share axis Phase-1 shadow (the runtime consumer that unblocks contrapositive empirical invariants)"
+  context: |
+    Owner invocation (2026-07-16, ultracode): "address all the things in the
+    Mermaid flowchart" — the Data Constitution program proposed after the
+    test-estate sharpening (ADR074) exposed the data layer as the weakest
+    stratum: view_surplus_value SELECTing from an EMPTY table, 11 empty
+    tables, all-zero placeholder rows, a 15M-row vestigial __pre_086 copy,
+    and a reference DB whose schema accumulated faster than lineage — nobody
+    could answer, per table: source? extractor? consumers? tests?
+
+    Census evidence: a 56-agent workflow profiled all 99 tables + 10 views
+    (41 orphan/AMPUTATE claims adversarially re-verified; 11 overturned on
+    appeal — the census-then-refute pattern is now proven twice).
+    Deliverables: reports/data-constitution-triage-2026-07-16.md,
+    data-constitution-catalog-sentinel-brief.md,
+    data-constitution-wealth-axis-brief.md.
+  decision: |
+    1. DATA-CATALOG BECOMES ENFORCING. data-catalog.yaml (III.4.1) gains a
+       per-table `tables:` registry — name/kind/source/extractor/reads/
+       consumers/tests/disposition/subset_policy/material_relation — loaded
+       into frozen CatalogTable rows (sentinels/coverage/catalog.py; loud
+       SentinelCheckError on any malformation, III.11).
+    2. TWO SENTINEL TIERS. Static (fast-gate, extends the coverage sensor):
+       declared consumer/test paths must exist; subset_policy must byte-match
+       tools/make_reference_subset.py's TABLE dict (two SoTs pinned
+       together). DB-probe (new `catalog` sensor, refdata lane only, lazy
+       import): catalog<->DB bijection over fact_/dim_/bridge_/view_ objects
+       + the KEEP-emptiness law — a disposition:keep table with zero rows,
+       or a keep view over an empty base table, reds (the view_surplus_value
+       pathology as a permanent regression contract). fill/artifact/
+       amputate/investigate rows are DECLARED DEBT — tracked, not gated, so
+       CI stays green on known triage while new rot is loud. Subset DBs
+       carry no views (the generator copies type='table' only) — view rows
+       there are advisory, not violations.
+    3. TRIAGE DISPOSITIONS (census + adversarial verify + synthesis):
+       KEEP 47 / FILL 8 / ARTIFACT_IZE 6 / INVESTIGATE 15 / AMPUTATE 23.
+       Every AMPUTATE is a PROPOSAL — schema drops require an owner ruling,
+       always. The disposition lives in the catalog row; flipping it is a
+       reviewed edit that the sentinel then enforces.
+    4. WEALTH-SHARE AXIS PHASE 1 (the flowchart's endpoint). The orphaned
+       formulas/class_dynamics ODE is wired as WealthDistributionSystem
+       @21.5: national 4-bracket vector (top-1%/p90-99/p50-90/bottom-50)
+       seeded from equilibrium_w1..w4, advanced per tick (ticks_per_quarter
+       define), metadata round-trip via G.graph["wealth_distribution"]
+       (written only when set — EH ruling-6 byte-safety), wealth_share
+       projected onto social_class nodes as a DECLARED field. Observe-only:
+       qa:regression stayed 5/5 with zero baseline movement, verified.
+       This resolves the population-vs-wealth conflation the census found
+       (4 sites hardcode POPULATION shares; their docstrings lied) — those
+       sites are untouched; the wealth axis is additive.
+    5. OWNER RULINGS REQUIRED (recorded, not executed):
+       a. The 23 AMPUTATE proposals (schema drops; scripts to follow ruling).
+       b. The 8-role -> 4-bracket fold (PROVISIONAL: Fed-DFA babylon_class
+          correspondence; naming collision equilibrium_w3 "proletariat" vs
+          p50-90 = labor aristocracy needs authoritative resolution).
+       c. Phase-2 feedback (wealth axis -> consciousness/bifurcation) —
+          moves all baselines; gate like the EH phases.
+       d. National-vs-per-county wealth altitude (per-county needs data the
+          Data Constitution has not yet filled).
+    6. FILL/ARTIFACT_IZE EXECUTION is sequenced work, not this commit:
+       FILL rides recovered loaders (deleted @ 4ce7c96a^; babylon-data
+       trove) per triage row; ARTIFACT_IZE rides the Parquet artifact
+       program (task #8, owner-approved 2026-07-16) — per-table hashed
+       artifacts decompose the 1.19GB monolithic ci-data blob.
+  consequences: |
+    - A new table without a catalog row now reds the refdata lane; a new
+      table without a TablePolicy reds the fast-gate parity check. Schema
+      can no longer outrun lineage silently.
+    - data-catalog.yaml version 2.6.3 -> 2.7.0 (tables: block, 109 rows).
+    - CI: `sentinel_check.py catalog --check` added to refdata jobs in
+      main.yml + nightly.yml (needs fetch-reference-db; never fast-gate).
+    - qa:regression 5/5 byte-identical post-wealth-axis (no regeneration —
+      even the predicted defines_hash warning did not surface as a failure).
+    - The runtime contrapositive invariant (distribution leaves the
+      capitalist band => rupture event exists in history) is now BUILDABLE
+      as a replay assertion over SessionRecorder history; it stays pending
+      because the Phase-1 relaxation dynamics never leave the band — it
+      lands with Phase-2 feedback (ruling 5c).
+  evidence: |
+    reports/data-constitution-triage-2026-07-16.md (99-table matrix);
+    reports/data-constitution-catalog-sentinel-brief.md;
+    reports/data-constitution-wealth-axis-brief.md;
+    commits 8845cc6d (census deliverables), 828cdc84 (wealth axis Phase 1),
+    + the catalog/sentinel commit following the tables: backfill;
+    workflow wf_7b4c3bec (56 agents, 41 adversarial verdicts, 0 errors).

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -1,5 +1,5 @@
 meta:
-  version: 1.22.0
+  version: 1.23.0
   updated: '2026-07-16'
   description: Architecture Decision Records Index
   format: See individual ADR files in this directory
@@ -339,6 +339,11 @@ decisions:
     status: accepted
     date: '2026-07-15'
     file: ADR071_program20_means_of_production.yaml
+  ADR075_data_constitution:
+    title: 'Program 21 — the Data Constitution: per-table lineage registry in data-catalog.yaml enforced by a two-tier catalog sentinel (static path/parity checks in the fast-gate; catalog<->DB bijection + KEEP-emptiness law in the refdata lane), the 99-table census triage (KEEP 47 / FILL 8 / ARTIFACT_IZE 6 / INVESTIGATE 15 / AMPUTATE 23 — amputations are proposals pending owner ruling), and the wealth-share axis Phase-1 shadow (WealthDistributionSystem @21.5 wiring the orphaned class_dynamics ODE; qa:regression untouched)'
+    status: accepted
+    date: '2026-07-16'
+    file: ADR075_data_constitution.yaml
   ADR074_test_estate_sharpening:
     title: 'Test-estate sharpening: tier discipline (dev fast/loud, main heavy), digest-stamped concurrent DDL, first-party deprecation-as-error, emergent-endgames testing corollary (outcomes = fixture vehicles, never asserted subjects), declared-synthetic-data sentinel, and the empirical-invariants program (WID/DFA/BEA laws as behavioral contracts, capitalist-mode conditionality — contrapositive at runtime)'
     status: accepted

--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -2,9 +2,35 @@
 # What exists vs what's planned - KEEP THIS UPDATED
 
 meta:
-  version: "2.36.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
+  version: "2.37.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
   updated: "2026-07-16"
   truth_status: |
+    (2026-07-16 night) PROGRAM 21 — DATA CONSTITUTION (ADR075; owner ultracode
+    "address the flowchart"; branch feature/21-data-constitution; PR #201 /
+    ADR074 merged to dev @ 073e3b1e first, after healing two CI reds: the
+    global *.csv LFS pattern had turned the five empirical-invariant
+    artifacts into pointers in CI checkouts — now exempted like the dense
+    goldens — and CVE-2026-11332 (ansible-core, fix rc-only) carried as a
+    time-boxed pip-audit ignore expiring 2026-08-15). Census: 56-agent
+    workflow profiled all 99 refdb tables + 10 views, 41 orphan/AMPUTATE
+    claims adversarially re-verified (11 overturned) -> triage KEEP 47 /
+    FILL 8 / ARTIFACT_IZE 6 / INVESTIGATE 15 / AMPUTATE 23 (proposals ONLY;
+    owner ruling required). data-catalog.yaml v2.7.0 gains the per-table
+    tables: registry, enforced by two sentinel tiers: static (paths exist +
+    subset_policy parity vs make_reference_subset.TABLE) in the coverage
+    fast-gate sensor, and the new `catalog` DB-probe sensor (refdata lane:
+    catalog<->DB bijection + KEEP-emptiness law — the view_surplus_value
+    empty-under-consumed-view pathology is its permanent regression
+    contract). WEALTH-SHARE AXIS PHASE 1 SHADOW LIVE (828cdc84):
+    WealthDistributionSystem @21.5 wires the orphaned class_dynamics ODE —
+    national 4-bracket vector on G.graph["wealth_distribution"] (written
+    only when set), wealth_share declared field on SocialClass, new
+    ticks_per_quarter define; qa:regression 5/5 with ZERO baseline movement
+    verified. OWNER RULINGS PENDING: 23 amputations; the 8-role->4-bracket
+    fold (provisional Fed-DFA mapping); Phase-2 feedback (moves all
+    baselines); wealth altitude national-vs-county. Evidence:
+    reports/data-constitution-{triage-2026-07-16,catalog-sentinel-brief,
+    wealth-axis-brief}.md.
     (2026-07-16 evening) TEST-ESTATE SHARPENING COMPLETE (ADR074; owner-invoked
     full review, branch refactor/test-suite-sharpening). Every red fixed or
     discarded: unit gate 10,316+ green under NEW strict config (-n4 loadscope,

--- a/data-catalog.yaml
+++ b/data-catalog.yaml
@@ -3,7 +3,7 @@
 # Canonical machine-readable catalog for III.4 Data Source Traceability.
 # Runtime data sources are fetched/updated during operation.
 # Fixtures are pinned snapshots for reproducible tests and NEVER runtime dependencies.
-version: "2.6.3"
+version: "2.7.0"
 categories:
   - name: Federal Economic
     sources:
@@ -321,3 +321,1339 @@ categories:
         granularity: Tract
         cadence: Static
         class: Fixture
+tables:
+  - name: bridge_cfs_county
+    kind: table
+    source: CFS
+    disposition: investigate
+    subset_policy: full
+    material_relation: county-to-CFS-area allocation crosswalk — the geographic key
+      needed to scope FAF/CFS freight flows to counties; currently empty, blocking Michigan-scoping
+      of commodity-flow value.
+    notes: 0 rows; no loader ever populated it (never separately implemented from the
+      CFS family).
+  - name: bridge_county_bea_ea
+    kind: table
+    source: BEA_EA
+    extractor: deleted @ 4ce7c96a^ absent (scripts/load_bea_ea.py, deliberately retired
+      post-population)
+    tests:
+      - tests/integration/test_michigan_reference_data.py
+    disposition: artifact
+    subset_policy: full
+    material_relation: county-to-BEA-Economic-Area membership — the regional aggregation
+      key for BEA county-GDP redistribution/regional-multiplier analysis.
+    notes: one-shot loader deliberately removed after populating; target = checked-in
+      CSV artifact.
+  - name: bridge_county_h3
+    kind: table
+    source: derived
+    extractor: tools/ingest_tiger_geometry.py
+    consumers:
+      - src/babylon/engine/hydration/reference.py
+      - tools/ingest_tiger_geometry.py
+    tests:
+      - tests/integration/mvp/test_hydration.py
+      - tests/integration/test_michigan_reference_data.py
+    disposition: keep
+    subset_policy: full
+    material_relation: county-to-H3-hex spatial index — the hex-grid substrate join
+      enabling territory/hex hydration (Constitution spatial substrate).
+  - name: bridge_county_metro
+    kind: table
+    source: OMB_CBSA
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/cbsa_parser.py)
+    tests:
+      - tests/integration/test_michigan_reference_data.py
+    disposition: keep
+    subset_policy: full
+    material_relation: county-to-Metropolitan-Statistical-Area membership — the urban-agglomeration
+      key for the MSA-tier zoom hierarchy (Detroit MSA tests).
+  - name: bridge_lodes_block
+    kind: table
+    source: LODES
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/lodes/loader_3nf.py)
+    disposition: artifact
+    subset_policy: skip
+    material_relation: census-block-to-county crosswalk for LODES commuter flows — enables
+      future hex-level commuter disaggregation below county grain.
+    notes: 1.15M rows, 109.7MB; zero code consumers; ARTIFACT_IZE target = parquet.
+  - name: bridge_naics_bea
+    kind: table
+    source: BEA_NAICS_CONCORDANCE
+    extractor: tools/load_bea_io.py
+    consumers:
+      - src/babylon/reference/bea/share_lookup_service.py
+      - src/babylon/reference/bea/ingest/stale_share_summary.py
+      - src/babylon/domain/economics/tensor_hierarchy/leontief_rent/industry_to_county_allocator.py
+      - src/babylon/domain/economics/adapters.py
+      - tools/load_bea_io.py
+    tests:
+      - tests/integration/test_sc005_bea_cv_stddev.py
+      - tests/integration/test_tensor_hydration.py
+      - tests/unit/reference/bea/test_share_lookup_service.py
+      - tests/unit/reference/bea/test_stale_share_summary.py
+    disposition: keep
+    subset_policy: full
+    material_relation: NAICS-to-BEA-industry concordance — the crosswalk letting county
+      QCEW industry employment be allocated against BEA's ~70-industry Leontief input-output
+      structure (imperial-rent tensor base).
+  - name: dim_asset_category
+    kind: table
+    source: FRED
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/fred/z1_loader.py)
+    consumers:
+      - tools/analyze_wealth_distribution.py
+    disposition: keep
+    subset_policy: full
+    material_relation: asset-class taxonomy (real estate, equities, deposits...) for
+      wealth-concentration decomposition — anchors which asset form embodies extracted
+      surplus.
+  - name: dim_atus_activity_category
+    kind: table
+    source: ATUS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/atus/mappings.py, spec-005)
+    disposition: amputate
+    subset_policy: full
+    material_relation: ATUS time-use activity classification — the taxonomy key for
+      reproductive/shadow-labor time accounting (Department III).
+    notes: superseded by src/babylon/data/atus/seed_data.yaml, the production artifact.
+  - name: dim_bea_economic_area
+    kind: table
+    source: BEA_EA
+    extractor: deleted @ 4ce7c96a^ absent (scripts/load_bea_ea.py, deliberately retired
+      post-population)
+    tests:
+      - tests/integration/test_michigan_reference_data.py
+    disposition: artifact
+    subset_policy: full
+    material_relation: BEA Economic Area definitions (8 Michigan-region EAs) — the regional
+      dimension bridge_county_bea_ea joins against.
+  - name: dim_bea_industry
+    kind: table
+    source: BEA_IO_NATIONAL_SUPPLY
+    extractor: tools/load_bea_io.py
+    consumers:
+      - src/babylon/domain/economics/tensor_hierarchy/inter_industry.py
+      - src/babylon/domain/economics/tensor_hierarchy/production_chain_rent.py
+      - src/babylon/reference/bea/share_lookup_service.py
+      - src/babylon/reference/bea/shaikh_bands.py
+      - src/babylon/persistence/hex_hydrator.py
+      - tools/load_bea_io.py
+      - tools/validate_bea_io_against_shaikh.py
+    tests:
+      - tests/integration/economics/test_tensor_hierarchy.py
+      - tests/unit/reference/bea/test_national_writer_upsert.py
+      - tests/unit/engine/headless_runner/test_gamma_wiring.py
+      - tests/unit/economics/tensor_hierarchy/leontief_rent/test_production_chain_rent.py
+    disposition: keep
+    subset_policy: full
+    material_relation: BEA Summary industry classification (~70 sectors) — the fixed
+      industry taxonomy every Leontief IO/tensor-hierarchy table joins against.
+  - name: dim_bea_io_table_type
+    kind: table
+    source: derived
+    extractor: src/babylon/reference/bea/ingest/io_coefficient_writer.py
+    consumers:
+      - src/babylon/domain/economics/tensor_hierarchy/inter_industry.py
+      - src/babylon/domain/economics/tensor_hierarchy/production_chain_rent.py
+      - src/babylon/reference/bea/ingest/io_matrix_parser.py
+      - tools/ingest_bea_imports.py
+    tests:
+      - tests/unit/reference/bea/test_share_lookup_service.py
+    disposition: keep
+    subset_policy: full
+    material_relation: IO-ingest pipeline's table-type enum (USE/TOTAL_REQ/IMPORT_USE)
+      distinguishing which Leontief coefficient matrix a row belongs to.
+  - name: dim_cfs_area
+    kind: table
+    source: CFS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/bts/faf_loader.py, on-demand stub
+      creation)
+    consumers:
+      - src/babylon/domain/economics/tensor_hierarchy/geographic_flow.py
+    tests:
+      - tests/unit/economics/tensor_hierarchy/test_geographic_flow.py
+    disposition: fill
+    subset_policy: full
+    material_relation: Commodity Flow Survey area geography — the freight origin/destination
+      zone key for scoping FAF/CFS commodity flows.
+    notes: stub rows only, state_id 100% null; real CFS area definitions never loaded.
+  - name: dim_coercive_type
+    kind: table
+    source: HIFLD
+    disposition: keep
+    subset_policy: full
+    material_relation: carceral/coercive-facility type taxonomy (prison, jail, detention...)
+      — classifies the repressive-apparatus nodes fact_coercive_infrastructure counts.
+  - name: dim_commodity
+    kind: table
+    source: USGS_MCS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/materials/loader_3nf.py + parser.py)
+    disposition: investigate
+    subset_policy: full
+    material_relation: USGS Mineral Commodity Summaries commodity list (85 strategic
+      materials) — anchors the critical-minerals/extraction-dependency subsystem (owner-ratified
+      Prog-09 stretch).
+  - name: dim_commodity_metric
+    kind: table
+    source: USGS_MCS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/materials/loader_3nf.py + parser.py)
+    disposition: amputate
+    subset_policy: full
+    material_relation: USGS MCS per-commodity metric taxonomy (imports/exports/price/production)
+      — the measurement-type dimension for fact_commodity_observation.
+  - name: dim_commute_mode
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, table B08301)
+    disposition: amputate
+    subset_policy: full
+    material_relation: ACS commute-mode taxonomy (transit, drive-alone, walk...) — classifies
+      fact_census_commute's mode-of-transportation rows.
+  - name: dim_country
+    kind: table
+    source: Comtrade
+    extractor: tools/ingest/ricci_unequal.py
+    consumers:
+      - src/babylon/persistence/postgres_initialization.py
+      - src/babylon/persistence/sqlite_hydrator.py
+      - src/babylon/domain/economics/melt/gamma_hydration.py
+      - tools/ingest/ricci_unequal.py
+    tests:
+      - tests/unit/reference/test_exposure_schema.py
+      - tests/unit/economics/melt/test_gamma_hydration.py
+      - tests/unit/reference/test_unequal_exchange_refdb_sync.py
+    disposition: keep
+    subset_policy: full
+    material_relation: country/bloc registry with world-system-tier classification (core,
+      semi-periphery, periphery) — the geographic key for Phi imperial-rent bloc attribution
+      and bilateral trade.
+  - name: dim_county
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/cbsa_parser.py + census
+      loader tree)
+    consumers:
+      - src/babylon/engine/headless_runner/scopes.py
+      - src/babylon/engine/hydration/reference.py
+      - src/babylon/persistence/hex_hydrator.py
+      - src/babylon/persistence/tiger_ingestion.py
+      - src/babylon/domain/economics/county_exposure.py
+      - src/babylon/domain/economics/adapters.py
+      - src/babylon/domain/economics/tensor_registry.py
+      - src/babylon/persistence/county_aggregation.py
+      - src/babylon/persistence/sqlite_hydrator.py
+      - src/babylon/reference/bea/ingest/stale_share_summary.py
+      - tools/ingest_tiger_geometry.py
+      - tools/validate_detroit.py
+      - tools/normalize_qcew_rollups.py
+      - tools/demo_substrate.py
+    tests:
+      - tests/integration/test_michigan_reference_data.py
+      - tests/integration/test_db_initialization_queries.py
+      - tests/integration/test_post_067_consumer_queries.py
+      - tests/integration/test_tensor_hydration.py
+      - tests/integration/test_marx_identities.py
+      - tests/integration/economics/conftest.py
+      - tests/integration/tensors/conftest.py
+      - tests/unit/engine/hydration/test_hydrate_industry.py
+    disposition: keep
+    subset_policy: full
+    material_relation: the county dimension — the universal geographic join key underlying
+      nearly every Michigan-scoped fact table and the hex/territory substrate.
+  - name: dim_county_geometry
+    kind: table
+    source: TIGER
+    extractor: tools/ingest_tiger_geometry.py
+    consumers:
+      - src/babylon/persistence/hex_hydrator.py
+      - src/babylon/persistence/tiger_ingestion.py
+      - src/babylon/persistence/postgres_initialization.py
+      - tools/ingest_tiger_geometry.py
+    tests:
+      - tests/integration/test_michigan_reference_data.py
+      - tests/integration/test_db_initialization_queries.py
+      - tests/unit/persistence/test_substrate_apportionment.py
+      - tests/unit/tools/test_make_reference_subset.py
+    disposition: keep
+    subset_policy: full
+    material_relation: county polygon geometry (WKT + area) from TIGER/Line — the spatial
+      substrate hex_hydrator apportions into H3 territory cells.
+  - name: dim_data_source
+    kind: table
+    source: internal
+    tests:
+      - tests/integration/test_db_initialization_queries.py
+    disposition: keep
+    subset_policy: full
+    material_relation: provenance registry (agency/dataset per fact table) — the traceability
+      backbone every fact_* row's source_id FK resolves against (Constitution III.4).
+  - name: dim_education_level
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, table B15003)
+    disposition: amputate
+    subset_policy: full
+    material_relation: ACS educational-attainment taxonomy — classifies fact_census_education's
+      degree-level rows.
+  - name: dim_employment_area
+    kind: table
+    source: QCEW
+    disposition: keep
+    subset_policy: full
+    material_relation: BLS QCEW employment-area geographic definitions — the area-code
+      dimension underlying fact_employment_industry_annual's industry-by-area employment
+      breakdown.
+  - name: dim_employment_status
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, table B23025)
+    disposition: investigate
+    subset_policy: full
+    material_relation: ACS employment-status taxonomy (employed/unemployed/not-in-labor-force)
+      — the classification the Phase-5.1 gamma_III brief plans to join against fact_census_employment.
+  - name: dim_energy_series
+    kind: table
+    source: EIA
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/energy/loader_3nf.py)
+    disposition: investigate
+    subset_policy: full
+    material_relation: EIA energy-series metadata (production/consumption by fuel type)
+      — the series dimension for fact_energy_annual's metabolic-rift energy accounting.
+  - name: dim_energy_table
+    kind: table
+    source: EIA
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/energy/loader_3nf.py)
+    disposition: investigate
+    subset_policy: full
+    material_relation: EIA Monthly Energy Review table catalog — groups energy series
+      into their source-table/category for fact_energy_annual.
+  - name: dim_fred_series
+    kind: table
+    source: FRED
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/fred/loader_3nf.py + z1_loader.py)
+    consumers:
+      - src/babylon/domain/economics/factory.py
+      - src/babylon/persistence/sqlite_hydrator.py
+      - src/babylon/domain/economics/melt/adapters.py
+    tests:
+      - tests/integration/economics/test_melt_adapters.py
+      - tests/unit/reference/test_fred_wealth_shares.py
+    disposition: keep
+    subset_policy: full
+    material_relation: FRED series registry (CPI, macro indicators) — the series-code
+      dimension every fact_fred_national/MELT deflator read joins against.
+  - name: dim_gender
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py)
+    disposition: investigate
+    subset_policy: full
+    material_relation: gender classification dimension shared by Census worker-class
+      and ATUS time-use breakdowns.
+  - name: dim_geographic_hierarchy
+    kind: table
+    source: derived
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/geography/loader.py)
+    disposition: fill
+    subset_policy: full
+    material_relation: county population-weight hierarchy derived from Census/QCEW totals
+      — a geographic weighting scheme for allocating national/regional aggregates to
+      counties.
+  - name: dim_housing_tenure
+    kind: table
+    source: Census_ACS
+    extractor: babylon_data/src/babylon_data/census/loader_3nf.py
+    consumers:
+      - src/babylon/domain/economics/throughput/adapters.py
+    tests:
+      - tests/integration/economics/test_unemployment_adapter.py
+    disposition: keep
+    subset_policy: full
+    material_relation: owner/renter housing-tenure taxonomy — the classification behind
+      fact_census_housing's renter_share feeding the tick pipeline's housing-precarity
+      signal.
+  - name: dim_import_source
+    kind: table
+    source: USGS_MCS
+    disposition: fill
+    subset_policy: full
+    material_relation: import-source-country dimension for critical-materials analysis
+      — names which countries supply strategic minerals (import-dependency/unequal-exchange
+      linkage).
+    notes: 0 rows; never instantiated by any loader in project history despite a real
+      deleted loader lineage and an extant staged CSV (MCS2025_Fig3).
+  - name: dim_income_bracket
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py:1795)
+    consumers:
+      - src/babylon/domain/economics/throughput/adapters.py
+      - tools/validate_detroit.py
+    tests:
+      - tests/integration/economics/test_unemployment_adapter.py
+    disposition: keep
+    subset_policy: full
+    material_relation: household-income-bracket taxonomy (17 brackets) — the classification
+      behind the top/bottom bracket ratio used as a class-proxy signal (labor-aristocracy
+      banding).
+  - name: dim_industry
+    kind: table
+    source: QCEW
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/qcew/loader_3nf.py)
+    consumers:
+      - src/babylon/persistence/sqlite_hydrator.py
+      - src/babylon/domain/economics/adapters.py
+      - src/babylon/domain/economics/throughput/adapters.py
+      - src/babylon/reference/bea/share_lookup_service.py
+      - src/babylon/sentinels/coverage/registry.py
+      - tools/normalize_qcew_rollups.py
+    tests:
+      - tests/integration/tensors/conftest.py
+      - tests/integration/test_tensor_hydration.py
+      - tests/unit/reference/bea/test_share_lookup_service.py
+      - tests/unit/engine/hydration/test_hydrate_industry.py
+    disposition: keep
+    subset_policy: full
+    material_relation: NAICS industry hierarchy annotated with Marxian class_composition
+      — the industry dimension anchoring QCEW/BEA/Leontief reads across the whole economics
+      subsystem.
+  - name: dim_metro_area
+    kind: table
+    source: OMB_CBSA
+    extractor: babylon_data/src/babylon_data/census/loader_3nf.py
+    tests:
+      - tests/integration/test_michigan_reference_data.py
+    disposition: keep
+    subset_policy: full
+    material_relation: Metropolitan Statistical Area definitions — the MSA-tier geographic
+      zoom level (Detroit MSA) in the living-map zoom hierarchy.
+  - name: dim_occupation
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, table C24010)
+    disposition: investigate
+    subset_policy: full
+    material_relation: occupation taxonomy (74 codes) with an unfinished Marxian productive,
+      unproductive, reproductive, managerial labor_type classification.
+    notes: labor_type 100% NULL — view_labor_type is a guaranteed-empty no-op until
+      backfilled.
+  - name: dim_ownership
+    kind: table
+    source: QCEW
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/qcew/loader_3nf.py:1529)
+    consumers:
+      - src/babylon/domain/economics/throughput/adapters.py
+      - src/babylon/domain/economics/melt/adapters.py
+      - src/babylon/domain/economics/throughput/data_sources.py
+      - tools/normalize_qcew_rollups.py
+    tests:
+      - tests/unit/reference/qcew/test_schema_086.py
+      - tests/integration/test_qcew_provenance.py
+      - tests/integration/test_post_067_consumer_queries.py
+      - tests/integration/test_normalize_qcew_rollups.py
+      - tests/integration/test_qcew_impute_e2e.py
+    disposition: keep
+    subset_policy: full
+    material_relation: QCEW ownership-sector codes (private/federal/state/local, own_code)
+      — resolves the own_code='0' Total-covered rows every QCEW read filters on.
+  - name: dim_poverty_category
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, table B17001)
+    disposition: keep
+    subset_policy: full
+    material_relation: ACS poverty-status taxonomy (B17001) — the classification the
+      owner-ratified National-Oppression program's poverty analysis is set to consume.
+  - name: dim_race
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py)
+    consumers:
+      - src/babylon/domain/economics/throughput/adapters.py
+    tests:
+      - tests/unit/engine/headless_runner/conftest.py
+    disposition: keep
+    subset_policy: full
+    material_relation: race/ethnicity classification — resolves the race_code='T' (Total)
+      rows the throughput adapter filters on.
+  - name: dim_rent_burden
+    kind: table
+    source: Census_ACS
+    extractor: babylon_data/src/babylon_data/census/loader_3nf.py
+    disposition: investigate
+    subset_policy: full
+    material_relation: rent-burden severity taxonomy (cost-burdened/severely-burdened)
+      — the classification behind view_rent_crisis's housing-precarity metric.
+    notes: healthy live-loader data, zero code consumer; view_rent_crisis dormant and
+      broken.
+  - name: dim_sctg_commodity
+    kind: table
+    source: FAF5
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/bts/faf_loader.py, on-demand stub
+      creation)
+    disposition: investigate
+    subset_policy: full
+    material_relation: Standard Classification of Transported Goods commodity codes
+      — the freight-commodity dimension FK'd by fact_faf_commodity_flow (KEEP).
+    notes: 100% placeholder '{code}' names; FK of a KEEP table so cannot be dropped
+      outright.
+  - name: dim_sector
+    kind: table
+    source: derived
+    disposition: amputate
+    subset_policy: full
+    material_relation: intended 2-digit-NAICS-sector Marxian classification dimension
+      — designed but never populated by any historical loader.
+    notes: 0 rows.
+  - name: dim_state
+    kind: table
+    source: Census_ACS
+    extractor: babylon_data/src/babylon_data/census/loader_3nf.py
+    consumers:
+      - src/babylon/persistence/tiger_ingestion.py
+    tests:
+      - tests/integration/test_db_initialization_queries.py
+      - tests/integration/test_michigan_reference_data.py
+      - tests/unit/engine/headless_runner/conftest.py
+      - tests/unit/reference/qcew/test_schema_086.py
+      - tests/unit/reference/test_exposure_schema.py
+    disposition: keep
+    subset_policy: full
+    material_relation: state gazetteer/FIPS dimension — resolves michigan_state_id and
+      every state-level rollup/filter.
+  - name: dim_time
+    kind: table
+    source: derived
+    extractor: src/babylon/reference/bea/ingest/ (get_or_create_time() helpers)
+    consumers:
+      - src/babylon/domain/economics/throughput/adapters.py
+      - src/babylon/engine/hydration/reference.py
+      - src/babylon/persistence/sqlite_hydrator.py
+      - src/babylon/domain/economics/tensor_hierarchy/inter_industry.py
+      - src/babylon/reference/bea/ingest/io_matrix_parser.py
+      - tools/load_bea_io.py
+      - tools/ingest_bea_imports.py
+      - tools/ingest/bea_final_demand.py
+      - tools/ingest/ricci_unequal.py
+      - tools/ingest/hickel_erdi.py
+      - tools/ingest_hickel_ricci.py
+      - tools/validate_bea_io_against_shaikh.py
+      - tools/normalize_qcew_rollups.py
+    tests:
+      - tests/integration/test_db_initialization_queries.py
+      - tests/integration/test_tensor_hydration.py
+      - tests/integration/test_marx_identities.py
+      - tests/unit/engine/hydration/test_hydrate_industry.py
+      - tests/unit/reference/bea/test_stale_share_summary.py
+    disposition: keep
+    subset_policy: full
+    material_relation: the universal year/granularity time dimension every ingest pipeline
+      (Census/QCEW/BEA/FRED/Hickel/Ricci/ATUS) writes into and every fact table joins
+      against.
+  - name: dim_wealth_class
+    kind: table
+    source: FRED
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/fred/z1_loader.py)
+    consumers:
+      - tools/analyze_wealth_distribution.py
+    tests:
+      - tests/integration/test_db_initialization_queries.py
+      - tests/unit/reference/test_fred_wealth_shares.py
+    disposition: keep
+    subset_policy: full
+    material_relation: wealth-percentile-to-MLM-TW-class mapping (proletariat/labor-aristocracy/bourgeoisie
+      bands) — the classification anchoring wealth-concentration analysis to Babylon's
+      class model.
+  - name: dim_worker_class
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, table B24080)
+    disposition: investigate
+    subset_policy: full
+    material_relation: ACS class-of-worker taxonomy annotated with marxian_class — the
+      classification behind fact_census_worker_class's Marxian class-composition breakdown.
+    notes: 18/22 marxian_class rows populated; view_class_composition written but unconsumed.
+  - name: fact_atus_reproductive_labor
+    kind: table
+    source: ATUS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/atus/db_loader.py, unwired)
+    disposition: amputate
+    subset_policy: skip
+    material_relation: ATUS reproductive/shadow-labor time-use rows (Department III
+      unpaid labor) — superseded in production by the checked-in seed_data.yaml artifact.
+  - name: fact_bea_county_gdp
+    kind: table
+    source: BEA_GDP
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/bea/loader_county.py)
+    consumers:
+      - src/babylon/persistence/hex_hydrator.py
+      - src/babylon/persistence/postgres_initialization.py
+    tests:
+      - tests/integration/test_db_initialization_queries.py
+      - tests/integration/test_marx_identities.py
+      - tests/unit/persistence/test_hex_hydrator_marx.py
+      - tests/unit/tools/test_make_reference_subset.py
+    disposition: keep
+    subset_policy: full
+    material_relation: per-county GDP by industry — the primary county-level Value Produced
+      (V) term feeding hex GDP hydration and the Fundamental Theorem's national GDP
+      total.
+  - name: fact_bea_final_demand_annual
+    kind: table
+    source: BEA_IO_NATIONAL_USE
+    extractor: tools/ingest/bea_final_demand.py
+    consumers:
+      - src/babylon/domain/economics/tensor_hierarchy/leontief_rent/final_demand.py
+      - src/babylon/domain/economics/melt/gamma_hydration.py
+      - tools/ingest/bea_final_demand.py
+    tests:
+      - tests/unit/economics/tensor_hierarchy/leontief_rent/test_final_demand_source.py
+      - tests/unit/economics/melt/test_gamma_hydration.py
+    disposition: keep
+    subset_policy: full
+    material_relation: national final-demand totals by industry — the denominator ImperialRentSystem's
+      Leontief-rent final-demand allocation divides against.
+  - name: fact_bea_io_coefficient
+    kind: table
+    source: BEA_IO_TOTAL_REQ
+    extractor: tools/load_bea_io.py
+    consumers:
+      - src/babylon/persistence/sqlite_hydrator.py
+      - src/babylon/domain/economics/tensor_hierarchy/inter_industry.py
+      - src/babylon/domain/economics/tensor_hierarchy/production_chain_rent.py
+      - src/babylon/reference/bea/ingest/io_coefficient_writer.py
+      - tools/load_bea_io.py
+      - tools/ingest_bea_imports.py
+    tests:
+      - tests/integration/economics/tick/test_imperial_rent_real_wiring.py
+      - tests/integration/economics/test_tensor_hierarchy.py
+      - tests/integration/web/test_static_economy_flow.py
+    disposition: keep
+    subset_policy: full
+    material_relation: national Leontief input-output coefficients (direct + total requirements)
+      — the inter-industry technical-coefficient matrix underlying imperial-rent tensor
+      propagation.
+  - name: fact_bea_national_industry
+    kind: table
+    source: BEA_IO_NATIONAL_SUPPLY
+    extractor: tools/load_bea_io.py
+    consumers:
+      - src/babylon/reference/bea/share_lookup_service.py
+      - src/babylon/persistence/hex_hydrator.py
+      - src/babylon/persistence/postgres_initialization.py
+      - src/babylon/reference/bea/ingest/national_writer.py
+      - tools/load_bea_io.py
+      - tools/validate_bea_io_against_shaikh.py
+    tests:
+      - tests/integration/test_sc005_bea_cv_stddev.py
+      - tests/unit/reference/bea/test_share_lookup_service.py
+      - tests/unit/reference/bea/test_national_writer_upsert.py
+      - tests/unit/reference/bea/test_stale_share_summary.py
+    disposition: keep
+    subset_policy: full
+    material_relation: national industry gross-output/value-added — the fallback national
+      GDP source and BEA-share lookup base for county GDP disaggregation.
+  - name: fact_bilateral_trade_annual
+    kind: table
+    source: Comtrade
+    consumers:
+      - src/babylon/persistence/postgres_initialization.py
+      - src/babylon/domain/economics/melt/gamma_hydration.py
+    tests:
+      - tests/unit/persistence/test_phi_attribution.py
+      - tests/unit/reference/test_exposure_schema.py
+      - tests/unit/economics/melt/test_gamma_hydration.py
+    disposition: keep
+    subset_policy: full
+    material_relation: bloc-to-bloc annual bilateral trade totals — the trade-flow input
+      to D3 Phi-attribution (imperial rent via unequal exchange).
+    notes: schema-only since spec-100; no dedicated loader script, populated additively.
+  - name: fact_bls_productivity
+    kind: table
+    source: BLS_Productivity
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/bls_productivity/loader.py, stub)
+    disposition: amputate
+    subset_policy: skip
+    material_relation: BLS labor-productivity-by-industry stub (avg hourly earnings,
+      unit labor costs) — all-zero hardcoded placeholder, not real data.
+    notes: 5,320 rows, every numeric column hardcoded 0 at load time; not a substitute
+      for fact_productivity_annual.
+  - name: fact_bls_unemployment_decomposition
+    kind: table
+    source: BLS_LAUS
+    extractor: babylon_data/bls_unemployment/loader.py
+    consumers:
+      - src/babylon/domain/economics/throughput/adapters.py
+      - src/babylon/domain/economics/tick/system/__init__.py
+      - src/babylon/engine/headless_runner/runner.py
+    tests:
+      - tests/integration/economics/test_unemployment_adapter.py
+    disposition: keep
+    subset_policy: full
+    material_relation: county-level BLS LAUS U-3 unemployment decomposition — wired
+      into the tick pipeline's per-county unemployment_rate.
+  - name: fact_broadband_coverage
+    kind: table
+    source: FCC_BDC
+    extractor: src/babylon_data/fcc/{loader,downloader,parser}.py
+    consumers:
+      - src/babylon/persistence/hex_hydrator.py
+      - src/babylon/domain/geography/internet.py
+    tests:
+      - tests/unit/persistence/test_hex_hydrator_marx.py
+      - tests/unit/tools/test_make_reference_subset.py
+    disposition: keep
+    subset_policy: michigan
+    material_relation: per-county FCC broadband-coverage percentages — the material
+      basis for hex-level internet/infrastructure-access attributes.
+  - name: fact_census_commute
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, table B08301)
+    disposition: amputate
+    subset_policy: skip
+    material_relation: ACS commute-mode-by-county-year rows — worker journey-to-work
+      mode share, currently unconsumed.
+  - name: fact_census_education
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, table B15003)
+    disposition: investigate
+    subset_policy: skip
+    material_relation: ACS educational-attainment-by-county rows (single-year 2021 run)
+      — a stalled family-scoped repair-vs-drop decision.
+    notes: data_dictionary.md wrongly claims 0 rows / awaiting ETL — stale, 80,525 rows
+      verified.
+  - name: fact_census_employment
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, table B23025)
+    disposition: keep
+    subset_policy: skip
+    material_relation: ACS employment/labor-force-status-by-county rows (single-year
+      2021) — the planned join target for the Phase-5.1 gamma_III employment-status
+      brief.
+    notes: data_dictionary.md wrongly claims 0 rows / awaiting ETL — stale, 22,547 rows
+      verified.
+  - name: fact_census_gini
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, table B19083)
+    disposition: amputate
+    subset_policy: skip
+    material_relation: county-level Gini index of income inequality — a healthy, direct
+      inequality metric with no wired consumer (epoch Gini concept unbuilt).
+  - name: fact_census_hours
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, table B23020)
+    disposition: investigate
+    subset_policy: skip
+    material_relation: ACS mean-hours-worked-by-gender rows — aggregate_hours column
+      100% NULL from a silent label-match bug in the deleted loader.
+    notes: aggregate_hours 100% NULL; mean_hours branch appears populated.
+  - name: fact_census_housing
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, table B25003)
+    consumers:
+      - src/babylon/domain/economics/throughput/adapters.py
+      - src/babylon/engine/services.py
+      - src/babylon/sentinels/seam/registry.py
+    tests:
+      - tests/integration/economics/test_unemployment_adapter.py
+    disposition: keep
+    subset_policy: full
+    material_relation: ACS housing-tenure-by-county rows — the renter_share source wired
+      into the tick pipeline's housing-precarity signal.
+  - name: fact_census_income
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, table B19001)
+    consumers:
+      - src/babylon/domain/economics/throughput/adapters.py
+      - src/babylon/persistence/hex_hydrator.py
+      - src/babylon/persistence/postgres_initialization.py
+      - src/babylon/persistence/county_aggregation.py
+      - src/babylon/engine/headless_runner/reference_data_cache.py
+      - src/babylon/domain/economics/tick/system/__init__.py
+      - src/babylon/domain/economics/tick/types.py
+      - src/babylon/domain/economics/tick/graph_bridge.py
+      - src/babylon/engine/services.py
+      - src/babylon/sentinels/seam/registry.py
+      - tools/validate_detroit.py
+    tests:
+      - tests/integration/economics/test_unemployment_adapter.py
+      - tests/unit/economics/tick/test_bracket_ratio_source.py
+      - tests/unit/engine/headless_runner/conftest.py
+      - tests/unit/persistence/test_substrate_apportionment.py
+      - tests/integration/test_db_initialization_queries.py
+      - tests/unit/tools/test_make_reference_subset.py
+    disposition: keep
+    subset_policy: full
+    material_relation: ACS household-income-bracket-by-county rows — the nationwide
+      bracket-ratio source for the labor-aristocracy/class-proxy signal (Constitution
+      Amendment R canonical scale).
+  - name: fact_census_income_sources
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py, Pattern F)
+    disposition: fill
+    subset_policy: skip
+    material_relation: ACS income-source-type-by-county rows (wages/self-employment/transfer)
+      — Wave-6/Prog-098 census-wiring target, partially wired.
+  - name: fact_census_institutional_ownership
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census_housing/loader.py, Feature-021
+      scaffold)
+    tests:
+      - tests/integration/test_db_initialization_queries.py
+      - tests/unit/tools/test_make_reference_subset.py
+    disposition: fill
+    subset_policy: michigan
+    material_relation: county institutional (absentee) housing-ownership rows — all-zero
+      Feature-021 scaffold pending real ownership data.
+    notes: every numeric column 0 in all 6,570 rows, coverage 2010-2011 only; do not
+      wire an engine consumer until real data lands (owner-queue item 59).
+  - name: fact_census_median_income
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py)
+    disposition: amputate
+    subset_policy: skip
+    material_relation: ACS median-household-income-by-county rows — feeds the broken
+      view_rent_crisis rent-to-income ratio if repaired.
+  - name: fact_census_occupation
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py)
+    disposition: amputate
+    subset_policy: skip
+    material_relation: ACS occupation-by-county-worker-count rows (8.1M) — the fact
+      volume behind the unfinished labor_type Marxian occupation classification.
+  - name: fact_census_poverty
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py)
+    disposition: fill
+    subset_policy: skip
+    material_relation: ACS poverty-status-by-county rows (26.5M, largest poverty table)
+      — the owner-ratified National-Oppression program's poverty-rate data source.
+  - name: fact_census_rent
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py)
+    consumers:
+      - src/babylon/persistence/sqlite_hydrator.py
+    tests:
+      - tests/unit/tools/test_make_reference_subset.py
+    disposition: keep
+    subset_policy: michigan
+    material_relation: ACS median-gross-rent-by-county rows (BEA REIS proxy) — hydrated
+      into the runtime rent reference table for the headless-runner housing-cost path.
+  - name: fact_census_rent_burden
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py:2037)
+    disposition: amputate
+    subset_policy: skip
+    material_relation: ACS rent-burden-severity-by-county rows — pairs with fact_census_median_income
+      in the broken view_rent_crisis housing-precarity view.
+  - name: fact_census_worker_class
+    kind: table
+    source: Census_ACS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/census/loader_3nf.py:1897)
+    disposition: investigate
+    subset_policy: skip
+    material_relation: ACS class-of-worker-by-county rows (900K, marxian_class populated)
+      — the fact volume behind view_class_composition's proletariat/petty-bourgeois/state-worker
+      breakdown.
+  - name: fact_coercive_infrastructure
+    kind: table
+    source: HIFLD
+    extractor: src/babylon_data/hifld/prisons.py
+    consumers:
+      - src/babylon/persistence/hex_hydrator.py
+    tests:
+      - tests/unit/persistence/test_hex_hydrator_marx.py
+      - tests/unit/tools/test_make_reference_subset.py
+    disposition: keep
+    subset_policy: michigan
+    material_relation: per-county carceral/repressive-facility counts — the material
+      basis of the state's coercive apparatus (the Repression term in P(S|R)).
+  - name: fact_commodity_flow
+    kind: table
+    source: CFS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/cfs/loader.py + api_client.py)
+    disposition: amputate
+    subset_policy: skip
+    material_relation: county-level Commodity Flow Survey tonnage/value rows — never
+      populated at county disaggregation grain.
+    notes: 0 rows; distinct from fact_faf_commodity_flow (KEEP).
+  - name: fact_commodity_observation
+    kind: table
+    source: USGS_MCS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/materials/loader_3nf.py + parser.py)
+    disposition: amputate
+    subset_policy: skip
+    material_relation: per-commodity USGS MCS observations (imports/exports/price/production)
+      — the strategic-materials extraction data view_critical_materials surfaces.
+  - name: fact_county_exposure_by_external
+    kind: table
+    source: derived
+    extractor: src/babylon_data/exposure/{compute,writer,audit,validation}.py
+    consumers:
+      - src/babylon/domain/economics/county_exposure.py
+    tests:
+      - tests/unit/reference/test_exposure_schema.py
+      - tests/unit/tools/test_make_reference_subset.py
+      - tests/unit/economics/test_county_exposure.py
+    disposition: keep
+    subset_policy: michigan
+    material_relation: per-county exposure-weight to external trade blocs — the derived
+      product routing bloc-level Phi imperial rent down to individual counties.
+  - name: fact_employment_industry_annual
+    kind: table
+    source: QCEW
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/employment_industry/loader_3nf.py)
+    disposition: amputate
+    subset_policy: skip
+    material_relation: BLS QCEW employment-by-area-and-industry rows (1.49M, 60% zero)
+      — a finer industry grain than fact_qcew_annual, never wired to a consumer.
+  - name: fact_energy_annual
+    kind: table
+    source: EIA
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/energy/loader_3nf.py + api_client.py)
+    disposition: artifact
+    subset_policy: skip
+    material_relation: EIA Monthly Energy Review production series (1949-2023) — the
+      metabolic-rift energy-throughput data view_energy_consumption surfaces.
+    notes: 'ARTIFACT_IZE target: parquet + catalog; superseded by fact_state_minerals
+      per spec-065.'
+  - name: fact_eviction_lab_filing
+    kind: table
+    source: Eviction_Lab
+    extractor: src/babylon_data/eviction_lab/loader.py (stub, broken imports)
+    disposition: investigate
+    subset_policy: skip
+    material_relation: county-level eviction-filing/execution rates — an all-zero hardcoded
+      stub; data-shortages.md wants this for the Dispossession/TENANCY edge.
+    notes: all-zero stub; loader's own imports (babylon.data.loader_base) are broken
+      post-Program-14.
+  - name: fact_faf_commodity_flow
+    kind: table
+    source: FAF5
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/bts/faf_loader.py); pre-populated
+      in shipped DB
+    consumers:
+      - src/babylon/persistence/sqlite_hydrator.py
+      - src/babylon/domain/economics/tensor_hierarchy/geographic_flow.py
+    tests:
+      - tests/unit/tools/test_make_reference_subset.py
+      - tests/unit/economics/tensor_hierarchy/test_geographic_flow.py
+    disposition: keep
+    subset_policy: full
+    material_relation: Freight Analysis Framework county-to-county commodity tonnage/value
+      flows — the freight-substrate data required by the headless-runner's Determinism
+      Bundle hydration.
+  - name: fact_foreclosure_rate
+    kind: table
+    source: HUD_Foreclosure
+    extractor: src/babylon_data/foreclosure/loader.py (stub, broken imports)
+    disposition: investigate
+    subset_policy: skip
+    material_relation: county-level foreclosure filing/completion rates — an all-zero
+      hardcoded stub against a weak dispossession-finance want.
+    notes: all-zero stub; no data-catalog.yaml source id names this dataset.
+  - name: fact_fred_industry_unemployment
+    kind: table
+    source: FRED
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/fred/loader_3nf.py + z1_loader.py)
+    disposition: amputate
+    subset_policy: skip
+    material_relation: FRED industry-level unemployment series — superseded by the BLS-LAUS
+      decomposition (fact_bls_unemployment_decomposition).
+  - name: fact_fred_national
+    kind: table
+    source: FRED
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/fred/loader_3nf.py)
+    consumers:
+      - src/babylon/domain/economics/factory.py
+      - src/babylon/persistence/sqlite_hydrator.py
+      - src/babylon/domain/economics/melt/adapters.py
+      - src/babylon/engine/headless_runner/runner.py
+      - src/babylon/domain/economics/tick/system/__init__.py
+    tests:
+      - tests/integration/economics/test_melt_adapters.py
+    disposition: keep
+    subset_policy: full
+    material_relation: national FRED macro series (CPI, etc.) — the CPI deflator read
+      every tick for real-wage/MELT calculations.
+  - name: fact_fred_state_unemployment
+    kind: table
+    source: FRED
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/fred/loader_3nf.py + z1_loader.py)
+    disposition: amputate
+    subset_policy: skip
+    material_relation: FRED state-level unemployment series (LAUST) — superseded by
+      the BLS-LAUS decomposition.
+  - name: fact_fred_wealth_levels
+    kind: table
+    source: FRED
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/fred/z1_loader.py, DFA family)
+    tests:
+      - tests/integration/test_db_initialization_queries.py
+    disposition: keep
+    subset_policy: full
+    material_relation: Federal Reserve Distributional Financial Accounts net-worth-by-class-and-quarter
+      levels — the wealth-concentration time series backing the wealth-distribution
+      invariant tests.
+  - name: fact_fred_wealth_shares
+    kind: table
+    source: FRED
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/fred/z1_loader.py, DFA family)
+    consumers:
+      - tools/analyze_wealth_distribution.py
+    tests:
+      - tests/unit/reference/test_fred_wealth_shares.py
+      - tests/unit/config/test_wealth_distribution_invariants.py
+    disposition: keep
+    subset_policy: full
+    material_relation: Federal Reserve DFA net-worth percentage shares — the SCF-benchmarked
+      corroboration series for the WID wealth-distribution invariants.
+  - name: fact_hickel_drain
+    kind: table
+    source: Hickel_HSZ_Drain
+    extractor: tools/ingest_hickel_ricci.py (orphaned, not invoked by any task/CI)
+    consumers:
+      - tools/ingest_hickel_ricci.py
+    disposition: amputate
+    subset_policy: full
+    material_relation: Hickel/Sullivan/Zoomkawala drain series (duplicate schema, empty)
+      — superseded by fact_hickel_erdi_annual; only referenced unconditionally by the
+      hydrator's SELECT.
+    notes: 0 rows; the make_reference_subset.py comment calling it 'schema-only' is
+      stale — a real orphaned writer exists but nothing invokes it.
+  - name: fact_hickel_erdi_annual
+    kind: table
+    source: Hickel_HSZ_Drain
+    extractor: tools/ingest/hickel_erdi.py
+    consumers:
+      - src/babylon/domain/economics/melt/gamma_hydration.py
+      - src/babylon/persistence/postgres_initialization.py
+      - src/babylon/persistence/sqlite_hydrator.py
+      - src/babylon/domain/economics/tensor_hierarchy/leontief_rent/periphery_labor_coefficients.py
+      - tools/ingest/hickel_erdi.py
+    tests:
+      - tests/unit/economics/melt/test_gamma_hydration.py
+      - tests/unit/persistence/test_phi_attribution.py
+      - tests/unit/reference/test_unequal_exchange_artifacts.py
+      - tests/unit/reference/test_unequal_exchange_refdb_sync.py
+    disposition: keep
+    subset_policy: full
+    material_relation: Ecologically-adjusted Raw-material Drain Index (ERDI) by bloc/year
+      — the Phi imperial-rent bootstrap and gamma_import periphery-labor-coefficient
+      source.
+  - name: fact_hpms_road_segment
+    kind: table
+    source: HPMS
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/dot/loader_3nf.py)
+    disposition: investigate
+    subset_policy: skip
+    material_relation: FHWA Highway Performance Monitoring System road-segment rows
+      — the Transport Substrate (Program 11, Constitution II.13) corridor-mesh raw material.
+    notes: 0 rows despite RATIFIED Program 11 status — triage matrix marks KEEP but
+      the table is empty; catalogued as investigate here pending the loader being run
+      (see report).
+  - name: fact_lodes_commuter_flow
+    kind: table
+    source: LODES
+    extractor: tools/ingest_lodes_od.py (download-only; DB import needs the babylon-data
+      package)
+    consumers:
+      - src/babylon/domain/economics/throughput/adapters_lodes.py
+      - src/babylon/domain/economics/throughput/calculator.py
+      - src/babylon/domain/economics/factory.py
+      - tools/demo_substrate.py
+    tests:
+      - tests/integration/economics/test_throughput_validation.py
+      - tests/integration/test_db_initialization_queries.py
+    disposition: keep
+    subset_policy: michigan
+    material_relation: county-to-county commuter origin-destination flows (LEHD LODES)
+      — the labor-mobility substrate behind inbound/outbound commuter-balance reads
+      (Wayne job-importer / Oakland job-exporter tests).
+  - name: fact_mineral_employment
+    kind: table
+    source: USGS_MCS
+    disposition: fill
+    subset_policy: skip
+    material_relation: mining-sector employment by mineral/county — never populated;
+      a deferred Program-09 minerals stretch.
+    notes: 0 rows; real deleted loader + staged MCS2025_T1 CSV exist (FILL candidate
+      per triage).
+  - name: fact_mineral_production
+    kind: table
+    source: USGS_MCS
+    disposition: amputate
+    subset_policy: skip
+    material_relation: national mineral-production-by-type volumes — never parsed at
+      this grain despite raw USGS MCS files being staged.
+    notes: 0 rows.
+  - name: fact_productivity_annual
+    kind: table
+    source: BLS_Productivity
+    disposition: amputate
+    subset_policy: skip
+    material_relation: labor-productivity-by-detailed-industry rows (labor compensation
+      vs. sectoral output) — the direct W_c/V_c Fundamental-Theorem inputs view_imperial_rent
+      and view_surplus_value need.
+    notes: 0 rows; no loader has EVER targeted this table in project history (distinct
+      from the unrelated, all-zero fact_bls_productivity).
+  - name: fact_qcew_annual
+    kind: table
+    source: QCEW
+    extractor: babylon_data/src/babylon_data/qcew/writer.py
+    consumers:
+      - src/babylon/persistence/sqlite_hydrator.py
+      - src/babylon/persistence/county_aggregation.py
+      - src/babylon/persistence/hex_hydrator.py
+      - src/babylon/domain/economics/adapters.py
+      - src/babylon/persistence/postgres_initialization.py
+      - tools/normalize_qcew_rollups.py
+      - tools/inspect_qcew_audit.py
+    tests:
+      - tests/integration/economics/throughput/test_adapters.py
+      - tests/integration/test_qcew_provenance.py
+      - tests/unit/persistence/test_hex_hydrator_marx.py
+      - tests/integration/test_tensor_hydration.py
+    disposition: keep
+    subset_policy: michigan
+    material_relation: per-county-industry QCEW employment and wages — the variable-capital
+      (V) base for county value product and the Fundamental Theorem's core-wage term.
+  - name: fact_qcew_annual__pre_086
+    kind: table
+    source: QCEW
+    tests:
+      - tests/integration/test_qcew_swap.py
+      - tests/unit/reference/qcew/test_cli.py
+      - tests/unit/tools/test_make_reference_subset.py
+    disposition: amputate
+    subset_policy: skip
+    material_relation: pre-spec-086 swap-backup snapshot of fact_qcew_annual — a dead
+      rename artifact from the staged-swap re-ingest mechanism, not itself ETL'd data.
+    notes: 15.1M rows / ~522MB; --drop-backup tool exists, never run.
+  - name: fact_qcew_county_rollup
+    kind: table
+    source: QCEW
+    extractor: babylon_data/src/babylon_data/qcew/writer.py
+    consumers:
+      - src/babylon/domain/economics/melt/adapters.py
+      - src/babylon/domain/economics/throughput/adapters.py
+      - src/babylon/sentinels/coverage/registry.py
+      - tools/inspect_qcew_audit.py
+    tests:
+      - tests/integration/economics/test_melt_adapters.py
+      - tests/integration/test_qcew_provenance.py
+      - tests/integration/test_qcew_resume_idempotency.py
+      - tests/unit/sentinels/test_coverage.py
+    disposition: keep
+    subset_policy: full
+    material_relation: own_code='0' Total-Covered per-county employment rollup — the
+      national employment total MELT's [100M,200M] sanity bound depends on.
+  - name: fact_qcew_metro_annual
+    kind: table
+    source: QCEW
+    extractor: babylon_data/cli.py qcew command (broken, deleted babylon.data.* imports)
+    disposition: amputate
+    subset_policy: skip
+    material_relation: QCEW employment/wages aggregated to MSA level — stale rows from
+      a now-broken re-ingest path, no wired consumer.
+  - name: fact_qcew_state_annual
+    kind: table
+    source: QCEW
+    disposition: amputate
+    subset_policy: skip
+    material_relation: QCEW employment/wages aggregated to state level — never successfully
+      populated (0 rows).
+    notes: 0 rows.
+  - name: fact_ricci_unequal_exchange
+    kind: table
+    source: Ricci2021
+    extractor: tools/ingest/ricci_unequal.py
+    consumers:
+      - tools/ingest/ricci_unequal.py
+    tests:
+      - tests/unit/reference/test_unequal_exchange_artifacts.py
+      - tests/unit/reference/test_unequal_exchange_refdb_sync.py
+      - tests/integration/test_immutable_reference_readonly_at_runtime.py
+    disposition: artifact
+    subset_policy: full
+    material_relation: Ricci (2021) region-level unequal-exchange value-transfer totals
+      — a redundant-source corroboration series for the Hickel ERDI drain estimate.
+    notes: 'ARTIFACT_IZE: CSV (babylon_ricci_final.csv) already canonical; drop/demote
+      DB mirror.'
+  - name: fact_state_minerals
+    kind: table
+    source: USGS_MCS
+    consumers:
+      - src/babylon/persistence/hex_hydrator.py
+    disposition: fill
+    subset_policy: skip
+    material_relation: state-by-state mineral production values — hex_hydrator explicitly
+      branches on its emptiness pending a targeted USGS state-table pull (spec-065/ADR042).
+    notes: 0 rows.
+  - name: fact_trade_monthly
+    kind: table
+    source: Census_Trade
+    extractor: deleted @ 4ce7c96a^ (src/babylon/data/trade/loader_3nf.py + parser.py)
+    consumers:
+      - src/babylon/persistence/sqlite_hydrator.py
+    disposition: keep
+    subset_policy: full
+    material_relation: monthly bilateral country import/export values — the trade-balance
+      data behind the core/periphery unequal-exchange ratio (view_unequal_exchange).
+  - name: view_class_composition
+    kind: view
+    source: derived
+    reads:
+      - fact_census_worker_class
+      - dim_county
+      - dim_state
+      - dim_worker_class
+    disposition: keep
+    subset_policy: skip
+    material_relation: aggregates fact_census_worker_class into county x Marxian-class
+      total-worker counts — the proletariat/petty-bourgeois/state-worker/unpaid-labor
+      composition surface.
+    notes: well-formed, real non-trivial data; zero code consumers, ad hoc analytical
+      query surface only.
+  - name: view_critical_materials
+    kind: view
+    source: derived
+    reads:
+      - fact_commodity_observation
+      - dim_commodity
+      - dim_commodity_metric
+      - dim_time
+    disposition: keep
+    subset_policy: skip
+    material_relation: surfaces USGS MCS commodity observations restricted to is_critical=1
+      — the strategic-materials extraction-dependency view.
+    notes: well-formed, real data; zero code consumers, ad hoc analytical query surface
+      only.
+  - name: view_energy_consumption
+    kind: view
+    source: derived
+    reads:
+      - fact_energy_annual
+      - dim_energy_series
+      - dim_energy_table
+      - dim_time
+    disposition: keep
+    subset_policy: skip
+    material_relation: aggregates EIA energy-series production data by table/series/year
+      — the metabolic-rift energy-throughput surface.
+    notes: well-formed, real data; zero code consumers, ad hoc analytical query surface
+      only.
+  - name: view_imperial_rent
+    kind: view
+    source: derived
+    reads:
+      - fact_productivity_annual
+      - dim_industry
+      - dim_time
+    disposition: fill
+    subset_policy: skip
+    material_relation: computes imperial_rent_millions = wages_core - value_produced
+      (Phi = W_c - V_c) per industry-year, directly implementing the Fundamental Theorem
+      — the labor-aristocracy ratio surface.
+    notes: 'empty: base table fact_productivity_annual has 0 rows, no loader has ever
+      targeted it. View SQL sign-verified correct (not a formula bug).'
+  - name: view_labor_type
+    kind: view
+    source: derived
+    reads:
+      - fact_census_occupation
+      - dim_county
+      - dim_state
+      - dim_occupation
+    disposition: fill
+    subset_policy: skip
+    material_relation: aggregates fact_census_occupation worker counts by county x labor_type
+      — the intended productive/unproductive/reproductive/managerial labor surface.
+    notes: 'empty: dim_occupation.labor_type is 100% NULL across all 74 codes; the fact
+      rows (8.1M) are real, only the dimension classification needs backfilling.'
+  - name: view_rent_crisis
+    kind: view
+    source: derived
+    reads:
+      - fact_census_rent
+      - fact_census_median_income
+      - fact_census_rent_burden
+      - dim_rent_burden
+      - dim_county
+      - dim_state
+    disposition: investigate
+    subset_policy: skip
+    material_relation: intends to surface county rent-to-income ratio and cost-burdened-household
+      counts from fact_census_rent/median_income/rent_burden.
+    notes: 'BROKEN: join omits time_id/race_id, producing a 200K+-row Cartesian explosion
+      per county that never completes (2x 180s timeouts). Needs an owner decision: fix
+      the join predicate or amputate the view.'
+  - name: view_surplus_value
+    kind: view
+    source: derived
+    reads:
+      - fact_productivity_annual
+      - dim_industry
+      - dim_time
+    disposition: fill
+    subset_policy: skip
+    material_relation: computes surplus_value = gross_output - variable_capital and
+      rate_of_exploitation per industry-year — the classical S/V Marxist surplus-value
+      surface.
+    notes: empty for the same root cause as view_imperial_rent (fact_productivity_annual
+      unloaded); SQL sign-verified correct.
+  - name: view_trade_annual
+    kind: view
+    source: derived
+    reads:
+      - fact_trade_monthly
+      - dim_country
+      - dim_time
+    disposition: keep
+    subset_policy: skip
+    material_relation: aggregates fact_trade_monthly into country x year annual imports/exports/trade-balance
+      totals.
+    notes: base table is a genuine, alive runtime dependency (read directly by postgres_initialization.py);
+      only the view itself has no direct caller.
+  - name: view_unequal_exchange
+    kind: view
+    source: derived
+    reads:
+      - fact_trade_monthly
+      - dim_country
+      - dim_time
+    disposition: keep
+    subset_policy: skip
+    material_relation: aggregates trade by world-system-tier x year into an unequal_exchange_ratio
+      — the core-appropriates-value-via-trade signature.
+    notes: correct, data-bearing; same ad hoc analytical role as view_trade_annual.
+  - name: view_wealth_concentration
+    kind: view
+    source: derived
+    reads:
+      - fact_fred_wealth_levels
+      - dim_wealth_class
+      - dim_asset_category
+      - dim_time
+      - fact_fred_wealth_shares
+    disposition: keep
+    subset_policy: skip
+    material_relation: aggregates FRED DFA wealth levels/shares by percentile x asset-category
+      x quarter — the wealth-concentration-by-class surface.
+    notes: both base tables are alive and directly tested; only the view itself is unconsumed.

--- a/reports/data-constitution-catalog-sentinel-brief.md
+++ b/reports/data-constitution-catalog-sentinel-brief.md
@@ -1,0 +1,87 @@
+I have a complete, verified picture. Here is the design.
+
+---
+
+# Data Constitution — data-catalog.yaml as an enforcing per-table registry + Coverage-sentinel extension
+
+**Evidence base (verified this session):**
+- `data-catalog.yaml:6-7` — top-level is `version` + `categories[].sources[]` (source-provenance only; 6 categories, ~45 agency-level sources). No per-*table* layer exists yet. III.4.1 pins it as the canonical machine catalog (`CONSTITUTION.md:269`).
+- Reference DB holds **99 tables + 10 views** (`sqlite_master`), yet the *code-consumed* dependency set is only 4 rows (`coverage/registry.py:81-130`, `DATA_REQUIREMENTS`).
+- **The pathology is real:** `view_surplus_value` (a shipped analytical view) `SELECT`s `FROM fact_productivity_annual`, which has **0 rows** — a view that silently returns empty, the exact III.11 silent-degradation `CONSTITUTION.md:297` forbids. Sibling `fact_bls_productivity` = 5,320 all-zero placeholder rows (`reports/test-estate-audit-2026-07-16.md:470-472`).
+- Two adjacent SoTs already exist and must be *reconciled*, not duplicated: `tools/make_reference_subset.py` `TABLE: dict[str, TablePolicy]` (per-table CI-subset scope, with a `find_unknown_tables` loud-failure at `:737-750`), and the coverage sentinel's `DataRequirement` literal.
+- CI lane exists: marker `requires_reference_db` (`pyproject.toml:180`), job `refdata-tests` in `main.yml:361` / `nightly.yml:124`, fed by `fetch-reference-db` (ci-data subset). Fast-gate (`dev`) excludes it.
+
+**One deliberate idiom deviation (justified):** coverage/synthetic use hand-written frozen `.py` literals *because they are not moddable YAML SoTs*. The catalog **is** a maintained YAML SoT (III.4.1), so the registry loads `data-catalog.yaml` into frozen Pydantic rows at check time — mirroring `GameDefines.load_default()` reading `defines.yaml`, not the `.py`-literal idiom. Everything else (frozen `extra="forbid"` rows, pure-AST static checks, `run_sensor` two-tier exit-code contract) is followed exactly.
+
+## (1) Per-table catalog entry schema
+
+Add a new top-level `tables:` block to `data-catalog.yaml` (leaving `version`/`categories` untouched — backward-compatible). Each entry loads into a frozen `CatalogTable` (new `babylon/sentinels/coverage/catalog.py`):
+
+```yaml
+tables:
+  - name: view_surplus_value          # table OR view name; must exist in sqlite_master
+    kind: view                          # Literal["table","view"]  (drives the empty-view probe)
+    source: BEA_IO_NATIONAL_USE         # FK → an id in categories[].sources[] (or "derived"/"internal")
+    extractor: null                     # "Class @ src/…/loader.py" or null (loaders deleted spec-037; archaeology only)
+    reads: [fact_productivity_annual]   # views only: base fact/dim tables (empty-view probe target)
+    consumers: []                       # code symbols that read it: "sym @ repo/rel/path.py" (AST-checked, static)
+    tests: [tests/unit/reference/test_view_columns.py]   # guarding tests (existence AST-checked)
+    disposition: vestige                # Literal["keep","fill","artifact","amputate","vestige"]  (task #11 triage)
+    subset_policy: full                 # Literal["full","michigan","skip"] — MUST equal TABLE[name].scope
+    material_relation: "s/v rate of exploitation by industry"   # Aleksandrov Test; required, non-blank
+    notes: "base table empty → view yields 0 rows (III.11); triage: fill or amputate"
+```
+
+`CatalogTable(BaseModel, frozen=True, extra="forbid")`, fields typed as above, with a `model_validator(mode="after")` rejecting: blank `name`/`material_relation`; a `view` with empty `reads`; a non-`view` with non-empty `reads`; `consumers`/`tests`/`extractor` entries not matching `"<symbol> @ <path>.py"` (or bare `path.py` for tests). Loud at import (III.11), same pattern as `DataRequirement._validate_shape` (`registry.py:56-72`).
+
+## (2) Sentinel checks
+
+Split by data need, matching the layer-0.5 boundary:
+
+**STATIC tier — extends the existing `coverage` sensor's `_GATING_CHECKS` (fast-gate, no DB):**
+- `check_catalog_symbols_exist` — every `consumers`/`extractor`/`tests` path parses and defines its named symbol, via the existing `symbol_exists`/`module_class_names` AST helpers (`_ast.py`, `synthetic/checks.py:99`). Orphaned consumer ⇒ red. *(Extends, does not replace, `check_source_classes_exist`.)*
+- `check_subset_policy_parity` — for every catalog row, `subset_policy` **==** `TABLE[name].scope` parsed statically from `make_reference_subset.py`. This is the **catalog-vs-DB-policy drift** guard against the two SoTs diverging (both are source files → pure AST, fast-gate-safe).
+
+**DB-PROBE tier — new `catalog` sensor, lazy-imported like `_partition_main` (refdata lane only):**
+- `check_no_undeclared_tables` — every `sqlite_master` table/view (filtered to `fact_/dim_/bridge_/view_` prefixes, reusing `find_unknown_tables`' prefix rule) must have a catalog row. Undeclared ⇒ red (III.4 traceability). Mirror of `find_unknown_tables`.
+- `check_no_declared_missing` — every catalog `name` must exist in `sqlite_master`. Phantom row ⇒ red.
+- `check_no_empty_consumed` — **the view_surplus_value guard.** For any row with `disposition ∈ {keep, fill}` **and** non-empty `consumers`: `SELECT COUNT(*)` must be `> 0`; for `kind: view`, each table in `reads` must be `> 0` (an empty base table = a silently-empty view). This is the check that would red today on `view_surplus_value`.
+
+DB access via a genuinely read-only connection (`mode=ro`, copy `_open_source_readonly`, `make_reference_subset.py:753`); a missing/unopenable DB raises `SentinelCheckError` → exit 2 (never a false pass), so the probe can never be run against no DB and report clean.
+
+## (3) CLI + CI wiring
+
+```mermaid
+flowchart LR
+  A[sentinel_check.py coverage --check] -->|static AST, fast-gate| B[mise run check / dev CI]
+  C[sentinel_check.py catalog --check] -->|sqlite3 ro probe| D[refdata-tests job\nmain.yml / nightly.yml]
+```
+
+- **`coverage`** sensor gains the two static checks in its `_GATING_CHECKS` (`coverage/checks.py:95`). Runs where it already runs: `mise run check` fast-gate. No new lane.
+- **`catalog`** is a *new* key in `tools/sentinel_check.py` `_SENSORS` (`:39`), routed through a `_catalog_main` lazy-import shim exactly like `_partition_main` (`:26-35`) because it opens sqlite3 and must not load into the layer-0.5 fast-gate. Invoked **only** in the `refdata-tests` job (add `poetry run python tools/sentinel_check.py catalog --check` beside `main.yml:372`/`nightly.yml:139`), which already has `fetch-reference-db`. Same 0/1/2 exit contract via `run_sensor`.
+
+## (4) TDD test list (`tests/unit/sentinels/test_catalog.py` static; `tests/integration/reference/test_catalog_db.py` `@requires_reference_db`)
+
+Static (fast-gate, mirror `test_coverage.py`):
+1. `test_catalog_yaml_loads` — real `data-catalog.yaml` parses to ≥1 `CatalogTable`, no `extra="forbid"` reject.
+2. `test_real_catalog_symbols_coherent` — `check_catalog_symbols_exist() == []` (invariant).
+3. `test_real_subset_policy_parity` — `check_subset_policy_parity() == []` (invariant; catalog == TABLE).
+4. Efficacy: injected row with a nonexistent consumer symbol reds; injected `subset_policy` mismatch reds.
+5. Loud: `CatalogTable` rejects blank `name`, a `view` with empty `reads`, a non-`.py` consumer path (raises at construction).
+6. Efficacy: missing catalog file / unparseable → `SentinelCheckError` (exit 2).
+
+DB (refdata lane, mirror the injectable-registry pattern):
+7. `test_no_undeclared_tables` / `test_no_declared_missing` against the ci-data subset == `[]`.
+8. `test_empty_consumed_reds` — a synthetic registry row (`kind=view`, `reads=[fact_productivity_annual]`, `disposition=fill`, non-empty consumers) **reds** — pins the `view_surplus_value` pathology as a regression contract.
+9. `test_probe_missing_db_is_loud` — pointed at a nonexistent DB path → `SentinelCheckError`.
+10. `test_cli_catalog_check_exit` — `sentinel_check.py catalog --check` subprocess exits 0 on the subset (idiom from `test_synthetic_registry_check.py:217`).
+
+## (5) Out of scope
+
+- **Populating/deleting data.** The sentinel *declares and detects*; FILL / ARTIFACT-IZE / AMPUTATE execution is task #13 and needs owner rulings (task #11 triage matrix). `disposition` is the declared verdict, not an action.
+- **Row-value profiling** (all-zero detection like `fact_bls_productivity`, distribution/coverage-by-county/year). The probe checks `COUNT(*) > 0` only; "present but all-zero/placeholder" is a nightly *value*-coverage probe, deferred (same boundary the coverage sentinel already draws, `coverage/checks.py:18-21`).
+- **Non-prefixed tables** (`ingest_checkpoint`, `staging_arcgis_feature`) — utility tables outside the `fact_/dim_/bridge_/view_` traceability scope; excluded exactly as `find_unknown_tables` excludes them.
+- **Regenerating the catalog from the DB.** The YAML stays hand-curated (it carries `material_relation`/`disposition` judgments no schema scan can infer); the sentinel enforces bijection, it does not author rows.
+- **Backfilling all ~109 rows in this task** — the *mechanism* + the `view_surplus_value` regression contract are the deliverable; full enumeration rides the census workflow (task #10).
+
+**Files touched (implementation, not this task):** `data-catalog.yaml` (+`tables:`), new `src/babylon/sentinels/coverage/catalog.py` (loader+model), edits to `coverage/checks.py` (+2 static checks), new `coverage/db_probe.py` (lazy, DB), `tools/sentinel_check.py` (+`catalog` route), 2 new test modules, +1 line in `main.yml`/`nightly.yml` refdata job. Bump `data-catalog.yaml` `version` 2.6.3 → 2.7.0; ADR in `ai/decisions/`.

--- a/reports/data-constitution-triage-2026-07-16.md
+++ b/reports/data-constitution-triage-2026-07-16.md
@@ -1,0 +1,159 @@
+# Babylon Data Constitution — Final Triage Matrix
+
+## 1. Executive counts
+
+**Tables (99):** KEEP 47 · FILL 8 · ARTIFACT_IZE 6 · INVESTIGATE 15 · **AMPUTATE 23** (all *proposed — owner ruling required*)
+**Views (10):** KEEP 6 · FILL 3 · INVESTIGATE 1
+
+Adversarial pass overturned **11** census AMPUTATE calls (`refuted=true`): →KEEP ×4 (`fact_census_employment`, `fact_hpms_road_segment`, `dim_employment_area`, `dim_poverty_category`); →FILL ×5 (`fact_census_income_sources`, `fact_census_poverty`, `dim_import_source`, `fact_mineral_employment`, `dim_geographic_hierarchy`); →INVESTIGATE ×2 (`dim_commodity`, `dim_employment_status`). Reviewer soft-downgrades (`refuted=false`, corrected disposition adopted): `fact_census_education`→INV, `fact_census_worker_class`→INV, `fact_energy_annual`→ARTIFACT, `bridge_lodes_block`→ARTIFACT, `staging_arcgis_feature`→ARTIFACT.
+
+## 2. Per-disposition tables
+
+### KEEP (47) — real consumer, healthy data
+| table | rows | consumer / lineage |
+|---|---|---|
+| fact_census_housing | 1.35M | SQLiteCensusHousingSource renter_share (adapters.py:634) / loader-deleted |
+| fact_census_income | 7.2M | bracket-ratio + county_aggregation + hex_hydrator; FULL exception / loader-deleted |
+| fact_census_employment | 22.5K | **override:** Phase-5.1 gamma_III brief (feat-gamma-atus-adapter.md) planned consumer |
+| fact_census_rent | 45K | sqlite_hydrator._copy_rent:508 / loader-deleted |
+| dim_income_bracket | 17 | SQLiteCensusIncomeSource bracket_order (adapters.py:865) |
+| fact_qcew_annual | 14.67M | 5+ src (hydrators, adapters, PG preflight) / loader live (writer.py) |
+| fact_qcew_county_rollup | 240K | MELT+throughput national employment / loader live |
+| fact_bls_unemployment_decomposition | 51K | unemployment_source tick pipeline (U-3 only) / loader stale-import |
+| dim_industry | 2.66K | every QCEW/BEA adapter; FK anchor / loader dead-import (data survives) |
+| fact_bea_county_gdp | 2.0M | hex_hydrator GDP (627) + PG init / trove loader |
+| fact_bea_final_demand_annual | 2.04K | Leontief-rent→ImperialRent / loader live (bea_final_demand.py) |
+| fact_bea_io_coefficient | 162.9K | inter_industry + production_chain_rent; all 3 types / loader live |
+| fact_bea_national_industry | 1.07K | BEAShareLookupService + PG init hydration / loader live |
+| bridge_naics_bea | 462 | II.11 concordance bridge / loader live (load_bea_io US3) |
+| dim_bea_industry | 107 | tensor_hierarchy + shaikh_bands + hydrator / loader live |
+| dim_bea_io_table_type | 3 | inter_industry table_type slice / writer live |
+| fact_fred_national | 1.4K | SQLiteCPISource per-tick deflator + 3 MELT sites / loader-deleted |
+| fact_fred_wealth_levels | 720 | TestWealthDistribution integration / loader-deleted |
+| fact_fred_wealth_shares | 480 | un-orphaned 2026-07-16, test_fred_wealth_shares / loader-deleted |
+| dim_fred_series | 41 | joined by every fred_* consumer / loader-deleted |
+| dim_wealth_class | 4 | 2 tests + analyze_wealth_distribution / loader-deleted |
+| dim_asset_category | 3 | FK for wealth facts + analyze tool / loader-deleted |
+| fact_trade_monthly | 45K | sqlite_hydrator._copy_ricci_unequal:365 / loader-deleted |
+| fact_bilateral_trade_annual | 120 | Φ-attribution + MELT alpha; fails loud / schema-only (spec-100) |
+| fact_hickel_erdi_annual | 58 | MELT gamma + Φ bootstrap + periphery labor / loader live |
+| dim_country | 273 | Φ bloc crosswalk + gamma + hydration / partial loader |
+| fact_faf_commodity_flow | 2.49M | sqlite_hydrator._copy_faf_freight (REQUIRED; ENGINE_FAILURE if absent) |
+| fact_hpms_road_segment | 0 | **override:** RATIFIED Program 11 (Const II.13/Amend O); loader recoverable @4ce7c96a^ |
+| fact_lodes_commuter_flow | 2.65M | SQLiteLODESCommuterFlowSource + real Wayne/Oakland tests (adapter dormant in factory) |
+| fact_broadband_coverage | 3.2K | hex_hydrator internet attrs / loader live (fcc) |
+| fact_coercive_infrastructure | 3.87K | hex_hydrator SUM(facility_count) / loader live (hifld) |
+| fact_county_exposure_by_external | 384K | county_exposure.py + 3 tests / loader live (data:exposure) |
+| dim_coercive_type | 15 | FK parent of coercive_infrastructure |
+| dim_housing_tenure | 3 | SQLiteCensusHousingSource tenure filter / loader live |
+| dim_county | 3.28K | pervasive (hydration/persistence/economics) / loader dead-import |
+| dim_county_geometry | 3.22K | hex_hydrator area + tiger_ingestion / loader live |
+| dim_state | 52 | FK for ~10 tables + tiger / loader dead-import |
+| dim_metro_area | 1.12K | MSA zoom-tier tests (no runtime SELECT yet) / loader dead-import |
+| bridge_county_h3 | 48.8K | query_hex_claims in hydration / loader live |
+| bridge_county_metro | 3.26K | paired w/ dim_metro_area (test-only) / loader dead-import |
+| dim_employment_area | 1.6K | **override:** ratified `full` policy + FK; real BLS data (KEEP not AMPUTATE) |
+| ingest_checkpoint | 47K | live qcew/writer.py resume mechanism + tests |
+| dim_data_source | 21 | FK provenance backbone + integration test |
+| dim_ownership | 7 | throughput+MELT own_code filter + coverage sentinel |
+| dim_poverty_category | 60 | **override:** owner-RATIFIED 2026-07-16 National-Oppression program consumer |
+| dim_race | 10 | throughput adapter race_code='T' filter |
+| dim_time | 485 | universal join key, dozens of consumers + 7 views |
+
+### FILL (8) — real/planned consumer, data absent or stub
+| table | rows | reason |
+|---|---|---|
+| fact_census_income_sources | 45K | **override:** Wave-6/Prog-098 census wiring target (epochs-gap-audit:690); 2/13 already wired |
+| fact_census_institutional_ownership | 6.57K | all-zero scaffold; test asserts existence + xfail; owner-queue #59 |
+| fact_census_poverty | 26.5M | **override:** owner-RATIFIED National-Oppression program (seed doc, ai/state.yaml:87) |
+| dim_import_source | 0 | **override:** real deleted loader (f1f7c917) + extant CSV (43 rows) MCS2025_Fig3 |
+| fact_mineral_employment | 0 | **override:** deleted loader (etl.py:2139) + staged MCS2025_T1 CSV |
+| fact_state_minerals | 0 | hex_hydrator branches on emptiness; spec-065/ADR042 contracted source |
+| dim_cfs_area | 132 | DefaultGeographicFlowSource reads it; rows are on-demand stubs (state_id 100% null) |
+| dim_geographic_hierarchy | 6.47K | **override:** deleted CFSLoader consumer recoverable @4ce7c96a^; real weight data |
+
+### ARTIFACT_IZE (6) — preserve as artifact, drop from live schema (destructive)
+| table | rows | target |
+|---|---|---|
+| bridge_county_bea_ea | 83 | → CSV (src/babylon/data/reference/, sibling precedent bea_us_labor_share.csv) |
+| dim_bea_economic_area | 8 | → CSV (pairs w/ above) |
+| fact_ricci_unequal_exchange | 29 | CSV already canonical (babylon_ricci_final.csv); drop/demote DB copy |
+| fact_energy_annual | 525 | → parquet + data-catalog; superseded by fact_state_minerals per spec-065 (+dim_energy_series/table lockstep) |
+| bridge_lodes_block | 1.15M | → parquet (109MB block crosswalk; design-intent hex-disagg unwired) |
+| staging_arcgis_feature | 5.97K | → parquet (per-facility HIFLD provenance behind aggregate) |
+
+### INVESTIGATE (15) — conflicting evidence, owner call
+| table | rows | tension |
+|---|---|---|
+| fact_census_education | 80.5K | dead babylon_data loader (import-rot) = family-scoped repair-vs-drop decision |
+| fact_census_hours | 16K | ORPHANED_DATA_INVENTORY D1 cites _FredProductivityAdapter but it reads FRED not this; aggregate_hours 100% NULL |
+| fact_census_worker_class | 900K | dead view_class_composition but maps to core Marxian classes; revivable |
+| dim_energy_series | 20 | lockstep w/ fact_energy_annual (→ARTIFACT_IZE) |
+| dim_energy_table | 14 | lockstep w/ fact_energy_annual (→ARTIFACT_IZE) |
+| dim_commodity | 85 | **override:** owner-ratified Prog-09 USGS-minerals stretch (deferred/gated); is_critical loader bug |
+| bridge_cfs_county | 0 | docs call it MUST-level Φ path but ImperialRentSystem has no CFS wiring; blocks FAF MI-scoping |
+| dim_sctg_commodity | 42 | FK of KEEP fact_faf (can't drop); 100% placeholder names — wire enrichment or accept scaffold |
+| fact_eviction_lab_filing | 6.57K | all-zero stub + broken loader vs data-shortages.md wants Eviction Lab for Dispossession/TENANCY |
+| fact_foreclosure_rate | 6.57K | all-zero stub vs weak dispossession-finance want (no catalog entry) |
+| dim_rent_burden | 11 | healthy live-loader data, zero consumer; dormant view_rent_crisis; HUD-burden named want |
+| dim_employment_status | 8 | **override:** Phase-5.1 gamma brief (owner-ruled, unexecuted) plans FactCensusEmployment join |
+| dim_gender | 6 | FK of fact_atus (105 rows, Dept-III named source); dual code-scheme artifact |
+| dim_occupation | 74 | labor_type 100% NULL — half-built Marxian classification (finish vs drop) |
+| dim_worker_class | 22 | marxian_class 18/22 populated, view written, zero consumer — class-composition wiring candidate |
+
+### AMPUTATE (23) — proposed, owner ruling required (see §4)
+
+## 3. Pathology honor roll
+
+**All-zero / placeholder-stub:** `fact_bls_productivity` (5.32K rows, hardcoded-0 loader stub, loader.py:70-81) · `fact_census_institutional_ownership` (6.57K SUM=0, Feature-021) · `fact_eviction_lab_filing` (6.57K, hardcoded 0s) · `fact_foreclosure_rate` (6.57K, hardcoded 0s) · `fact_census_hours` (aggregate_hours 100% NULL) · `dim_occupation.labor_type` (100% NULL → view_labor_type empty) · `dim_cfs_area`/`dim_sctg_commodity` (100% "{code}" stub names, state_id 100% null).
+
+**Empty-under-consumed-view:** `fact_productivity_annual` (0 rows, **never had a loader**, yet `view_imperial_rent` + `view_surplus_value` both SELECT it → §5.1).
+
+**Vestigial `__pre_086`:** `fact_qcew_annual__pre_086` (15.1M rows / ~522MB dead swap-backup; `--drop-backup` tool exists, never run).
+
+**Orphaned big tables (0 real consumers):** `fact_census_poverty` 26.5M (→FILL, ratified consumer) · `fact_census_occupation` 8.1M (AMPUTATE) · `fact_employment_industry_annual` 1.49M (AMPUTATE, 60% zero) · `bridge_lodes_block` 1.15M (→ARTIFACT) · `fact_census_commute` 945K · `fact_census_worker_class` 900K (→INV) · `fact_census_median_income` 314K.
+
+**Broken view:** `view_rent_crisis` — JOIN omits time_id/race_id → 200K+ Cartesian rows/county, `LIMIT 1` times out >180s (twice).
+
+## 4. Owner ruling list (23 AMPUTATE + 6 ARTIFACT_IZE = destructive)
+
+| # | table | rows | recommendation |
+|---|---|---|---|
+| A1 | fact_qcew_annual__pre_086 | 15.1M | **Run `babylon_data qcew --drop-backup`** (reclaims ~522MB); keep swap mechanism |
+| A2 | fact_census_commute | 945K | Drop schema (clean orphan) |
+| A3 | fact_census_gini | 45K | Drop (healthy but zero consumer; epoch Gini concept not wired) |
+| A4 | fact_census_median_income | 314K | Drop — but 1 consumer of dormant `view_rent_crisis` revives it + rent_burden |
+| A5 | fact_census_occupation | 8.1M | Drop (view_labor_type dead; labor_type unclassified) |
+| A6 | fact_census_rent_burden | 450K | Drop — pairs with A4 in `view_rent_crisis` (low-effort FILL alt) |
+| A7 | fact_qcew_metro_annual | 78K | Drop; re-derivable from same singlefile CSVs |
+| A8 | fact_qcew_state_annual | 0 | Drop (empty, dead loader) |
+| A9 | fact_employment_industry_annual | 1.49M | Drop **or** FILL if national/MSA grain wanted (dead loader, 60% zero) |
+| A10 | fact_bls_productivity | 5.32K | Drop schema; future work extends fact_productivity_annual (⚠ also empty — §5.1) |
+| A11 | fact_productivity_annual | 0 | **CONTRADICTION (§5.1)** — table=AMPUTATE, its 2 views=FILL. Escalate |
+| A12 | fact_fred_industry_unemployment | 720 | Drop; superseded by BLS-LAUS decomposition |
+| A13 | fact_fred_state_unemployment | 765 | Drop; superseded by BLS-LAUS decomposition |
+| A14 | fact_hickel_drain | 0 | Drop; superseded by fact_hickel_erdi_annual (TablePolicy comment is false) |
+| A15 | fact_mineral_production | 0 | Drop **or** FILL (raw MCS staged; repeatedly named deferred stretch) |
+| A16 | fact_commodity_observation | 3.79K | Drop (USGS commodity subtree, view_critical_materials dead) |
+| A17 | dim_commodity_metric | 593 | Drop (subtree w/ A16); `dim_commodity`→INVESTIGATE (ratified stretch) |
+| A18 | fact_commodity_flow | 0 | Drop (county-disagg never built) |
+| A19 | fact_atus_reproductive_labor | 105 | Drop; superseded by data/atus/seed_data.yaml |
+| A20 | dim_atus_activity_category | 26 | Drop (subtree w/ A19) |
+| A21 | dim_education_level | 26 | Drop (education subgraph dead) |
+| A22 | dim_sector | 0 | Drop; redundant w/ dim_industry.class_composition |
+| A23 | dim_commute_mode | 22 | Drop (distinct from LODES; no program) |
+| R1 | bridge_county_bea_ea + dim_bea_economic_area | 83+8 | → checked-in CSV artifacts |
+| R2 | fact_ricci_unequal_exchange | 29 | CSV already canonical; drop/demote DB mirror |
+| R3 | fact_energy_annual (+series/table) | 525 | → parquet + catalog; superseded by fact_state_minerals |
+| R4 | bridge_lodes_block | 1.15M | → parquet (future hex-disagg) |
+| R5 | staging_arcgis_feature | 5.97K | → parquet (facility-grain provenance) |
+
+## 5. Contradictions / uncertainties needing human eyes
+
+1. **`fact_productivity_annual` — table vs views split.** Table reviewers → AMPUTATE (0 rows, *no loader ever existed* in full git history, Program 10 §203 explicitly "not required for slice 1"). Views reviewer → FILL (ORM model exists schema.py:1415; raw `labor-productivity-detailed-industries.xlsx` staged in trove; formula sign-verified vs Fundamental Theorem). **Decide: build a real loader (FILL both views) or drop table + both views.** Note `fact_bls_productivity` (A10) is the wrong table (different schema, all-zero) — not a substitute.
+2. **Views KEEP over AMPUTATE/INVESTIGATE bases** — resolve view+base as a unit: `view_critical_materials`(KEEP) ← `fact_commodity_observation`(A16)+`dim_commodity_metric`(A17); `view_class_composition`(KEEP) ← `fact_census_worker_class`(INV); `view_energy_consumption`(KEEP) ← `fact_energy_annual`(R3). Dropping a base orphans the view.
+3. **`view_rent_crisis` broken** (missing-time_id combinatorial join, unrunnable) over KEEP/AMPUTATE/AMPUTATE bases → fix predicate (add time_id; rule on race_id) or drop.
+4. **`dim_energy_series`/`dim_energy_table`** left INVESTIGATE but census says lockstep w/ `fact_energy_annual` → should follow to ARTIFACT_IZE.
+5. **Data-Coverage sentinel bug** (not a disposition): `sentinels/coverage/registry.py:107-116` names `fact_lodes_od` — a table that does not exist — so the LODES coverage check is vacuous.
+6. **Stale test precondition:** `test_imperial_rent_real_wiring.py:23` docstring declares IMPORT_USE=0 "KNOWN-RED"; DB now has 31,688 IMPORT_USE rows — cheap re-run to confirm green.
+7. **Doc-drift (fix regardless of disposition):** `data_dictionary.md` says "0 rows / Awaiting ETL" for many populated tables (qcew_annual 14.67M, employment, education 80.5K, energy 525, dim_country 273, trade 45K…); `make_reference_subset.py` `_UNREFERENCED_REASON` cites deleted `tools/full_database_audit.py` (commit 0e26fe7e) across ~20 skip entries.

--- a/reports/data-constitution-wealth-axis-brief.md
+++ b/reports/data-constitution-wealth-axis-brief.md
@@ -1,0 +1,82 @@
+I have everything needed. Here is the design brief.
+
+---
+
+# Design Brief — Wealth-Share Axis for `social_class` Nodes
+
+**WHY:** `tests/unit/config/test_wealth_distribution_invariants.py:33-40` pins the *calibration* defines `equilibrium_w1..w4`, but explicitly defers the *runtime* contrapositive ("distribution leaves the capitalist band ⟹ a rupture event exists in history") because there is **no wealth-share axis in the tick engine**. `src/babylon/formulas/class_dynamics.py` (the ODE that would drive it) is exported (`formulas/__init__.py:41-46`) but has **zero runtime callers** — confirmed orphaned. This brief specifies the minimal runtime consumer.
+
+## 0. Core finding — two partitions, one conflation
+
+There are **two distinct substrates** and the codebase conflates population with wealth:
+
+- **Population partition (5-class, per-county).** The tick engine (`domain/economics/tick/`) carries `ClassDistribution` on `territory` nodes: fractions **of people** — `0.01/0.09/0.40/0.35/0.15` (bourgeoisie…lumpen). These sum to 1 and are *headcount* shares. **But** `dynamics/types.py:37-41` field docstrings mislabel them `"Top 1% wealth share"` etc. — the label lies; the values are population.
+- **Wealth partition (4-class, national).** `class_dynamics.py` tracks `(w1,w2,w3,w4)` = wealth held by top-1% / p90-99 / p50-90 / bottom-50, relaxing toward `equilibrium_w1..w4 = 0.305/0.382/0.294/0.020` (`economy_class.py:33-56`). Nobody runs it.
+- **`social_class` nodes** (the 28-system engine substrate) already carry `wealth: Currency` (per-capita, mutated by `economic.py:302-304` extraction) and `population: int` (`social_class.py:308,383`). They have **no distributional wealth-share axis**. `SocialClass.model_config` is `extra="forbid"` (`social_class.py:201-202`) → any new node attribute **must be a declared field** or `from_graph` rejects it (the "real field, never a shadow attr" lesson from the EH Phase-2 work).
+
+## 1. Exact current behavior at each hardcoded site
+
+All four sites hardcode the **population** partition; none is a wealth axis.
+
+1. **`initializer.py:31-36`** — module constants, then used at `:182-186`:
+   ```
+   _DEFAULT_BOURGEOISIE=0.01  _DEFAULT_PETIT_BOURGEOISIE=0.09
+   _DEFAULT_LABOR_ARISTOCRACY=0.40  _DEFAULT_PROLETARIAT=0.35  _DEFAULT_LUMPENPROLETARIAT=0.15
+   ```
+   Seeds the first-tick `ClassDistribution` when no census data flows in.
+
+2. **`graph_bridge.py:243-247`** — `from_graph`-side reconstruction fallbacks:
+   ```
+   bourgeoisie_share=dist_dict.get("bourgeoisie", 0.01)  … proletariat…0.35  lumpen…0.15
+   ```
+
+3. **`system/__init__.py:416-420`** — identical `dist_dict.get(...)` fallbacks when reading existing `tick_class_distribution`.
+
+4. **`system/__init__.py:732-736`** — literal `ClassDistribution(bourgeoisie_share=0.01, …, lumpenproletariat_share=0.15)` for territories with no prior distribution.
+
+These are the **population** substrate and stay as-is. The wealth axis is **additive**, not a rewrite of these.
+
+## 2. Minimal design — the wealth-share axis
+
+**Axis owner = national 4-vector; per-node read = projection.** The ODE is national (one `(w1..w4)`), so:
+
+- **State home:** round-trip via graph metadata `G.graph["wealth_distribution"]` — the exact pattern `to_graph` already uses for `economy`/`state_finances`/`tick_dynamics` (`world_state.py:630-643`, `session_recorder.py:188-192`). Add a frozen `WealthDistribution` Pydantic model (4 shares + a `tick` stamp) as a `WorldState` field; mutate via `model_copy` (frozen-state gotcha).
+- **Per-node read field:** add `wealth_share: Probability = Field(default=0.0, …)` to `SocialClass` (`social_class.py`) — a declared field so it survives `extra="forbid"` round-trip. It is the node's *bracket* share, projected from the national vector by the node's `SocialRole` bracket (§6 mapping).
+- **New system — `WealthDistributionSystem`**, Phase-1 **observe-only shadow**, positioned **last in the Consequence phase** mirroring `EpistemicHorizonSystem` (`simulation_engine.py:412`) — it reads the fully-mutated tick and writes **only** its own axis, touching no field the regression checkpoints sample. Add it to `CONSEQUENCE_SYSTEMS` (`simulation_engine.py:442-458`; the partition-drift assertion at `:468` forces classification).
+- **Per tick:** seed on first tick from `equilibrium_w*` mapped by role; thereafter relax via `calculate_full_dynamics(shares, velocities, params, second_order, resistances)` (`class_dynamics.py:231`) where `params`/`second_order` come from `GameDefines.class_dynamics` (already wired, `formulas/class_dynamics.py:34`). `resistances` read from each bracket's aggregate `class_consciousness`. Store new `(shares, velocities)` back to metadata; project shares onto nodes.
+- **One new define** likely required: `ticks_per_quarter` (the ODE rates are quarterly, `class_dynamics.py:41`) — add to `ClassDynamicsDefines`, regenerate `defines.yaml`. Never hardcode it.
+
+Phase-1 is **decoupled**: `wealth_share` is an overlay; it does **not** feed back into `wealth`/consciousness/bifurcation. That keeps the sampled regression surface byte-identical (§3).
+
+## 3. Determinism / qa:regression impact
+
+- **The frozen contract is the sampled baseline**, not the full dump. `tools/regression_test.py:83-84,528-531` samples per-entity `wealth`/`effective_wealth`/tension — **not** node `model_dump()`. A Phase-1 observe-only system that writes only `wealth_share` (and national metadata) **does not move those checkpoints** → `qa:regression` stays **5/5 green on values**.
+- **`defines_hash` WILL change** the moment we add `ticks_per_quarter` (or any define). The comparator emits a **WARNING, not a hard fail** (`regression_test.py:789-791`), but the baselines' `defines_hash` field must be regenerated (`mise run qa:regression-generate --force`) and the move **declared as intentional** per Definition-of-Done. This is the one guaranteed baseline movement in Phase 1.
+- **Phase 2 (feedback, owner-gated) DOES move value checkpoints** — once `wealth_share` drives consciousness/bifurcation, `wealth`/tension trajectories change → full baseline regeneration is mandatory and intentional.
+- Determinism-proper ("every tick a deterministic hash") is preserved iff the ODE is seeded from defines and iterates in **sorted node order** with **no unseeded RNG** (the StruggleSystem:312 `random.random()` bug is the cautionary precedent). BLAS pin already guarantees FP reduction order.
+
+## 4. How the runtime contrapositive invariant reads the axis
+
+The deferred runtime check (`test_wealth_distribution_invariants.py:33-40`) becomes: **for any tick where `G.graph["wealth_distribution"]` leaves the capitalist band** (`w1∉TOP1_BAND ∨ w4>BOTTOM50_HISTORICAL_CEILING ∨ (w1+w2)<TOP_DECILE_FLOOR`, reusing the bands at `test_…:54-66`), **assert a rupture event exists in `history`** — an `EventType.UPRISING / PERIPHERAL_REVOLT / REVOLUTIONARY_OFFENSIVE` (emitted by `struggle.py:389,704,583`) at or before that tick. Implemented as a **replay assertion over `SessionRecorder` history** (events are persisted per tick, `session_recorder.py:213-216`), not a live per-tick guard — matching the owner ruling that these are contrapositive, never asserted forward on a live trajectory. A distribution that breaks the band **without** a logged rupture is the failure signal.
+
+## 5. TDD plan (red first)
+
+1. **RED — orphan is wired:** assert `WealthDistributionSystem in _DEFAULT_SYSTEMS` and in `CONSEQUENCE_SYSTEMS`; assert `calculate_full_dynamics` has ≥1 runtime caller (guards against re-orphaning).
+2. **RED — axis exists & round-trips:** build a graph with `social_class` nodes, `to_graph`→`from_graph`, assert `wealth_share` survives (catches the `extra="forbid"` landmine) and `G.graph["wealth_distribution"]` is preserved.
+3. **RED — seeding matches calibration:** first tick, national vector == `equilibrium_w1..w4` under the role mapping; `abs(sum-1.0)<1e-9`.
+4. **RED — relaxation is mean-reverting & conserving:** perturb off-equilibrium, run N ticks, assert monotone approach to equilibrium and `Σshares==1` each tick (property law over `calculate_class_dynamics_derivative` constraint, `class_dynamics.py:195`).
+5. **RED — determinism:** two runs, identical seed ⇒ identical per-tick `wealth_distribution` bytes.
+6. **RED — contrapositive:** a fixture scenario forced out of band produces a rupture event in replay history; an in-band run produces a valid (vacuously-true) check. (Outcome is a *fixture vehicle*, per the 2026-07-16 testing corollary — test the mechanic, never a specific adjudicated outcome.)
+7. **GREEN → REFACTOR**, then `mise run qa:regression` (expect only `defines_hash` warning), regenerate, declare.
+
+## 6. Risks + owner-ruling vs mechanical
+
+**Needs an owner ruling:**
+- **Bracket mapping (8 → 4).** `SocialRole` has 8 members (`enums/social.py:35-43`); the ODE has 4 wealth classes. Which roles fold into w3 (p50-90) vs w4 (bottom-50)? The test docstring hints w3↔p50-90(=labor aristocracy), w4↔bottom-50(=proletariat+lumpen+internal_proletariat), but `equilibrium_w3` is *labelled* "proletariat" in `economy_class.py:49` — a naming collision that must be resolved authoritatively.
+- **Altitude:** national single vector (recommended, matches the ODE's FRED-DFA national fit) vs per-county wealth distributions. Per-county needs county wealth-share data we do not have (Data-Constitution territory).
+- **Decoupling vs identity:** is `wealth_share` an independent ODE axis (Phase 1) or eventually *derived* from `wealth×population` with the ODE as calibration attractor? These can diverge; the reconciliation is a modeling decision, and Constitution Aleksandrov-test grounding ("every formal construct traces to a material relation") applies.
+- **Phase-2 feedback authorization** (wiring the axis into bifurcation/consciousness) — moves all baselines; gate it like the EH phases.
+
+**Mechanical (no ruling needed):** adding the `wealth_share` field + `WealthDistribution` model; the metadata round-trip (copy the `economy` pattern); registering the system + partition-set entry; adding `ticks_per_quarter` define + `generate_defines_config.py` regen; the red-phase battery; baseline `defines_hash` regeneration.
+
+**Relevant paths:** `src/babylon/formulas/class_dynamics.py`, `src/babylon/config/defines/economy_class.py:33-56`, `src/babylon/data/defines.yaml:411-433`, `src/babylon/models/entities/social_class.py:201,308,383`, `src/babylon/models/world_state.py:630-656`, `src/babylon/engine/simulation_engine.py:378-458`, `src/babylon/engine/observers/session_recorder.py:152-216`, `src/babylon/domain/economics/dynamics/types.py:27-98`, `src/babylon/domain/economics/tick/{initializer.py:31-36,182-186, graph_bridge.py:243-247, system/__init__.py:416-420,732-736}`, `tests/unit/config/test_wealth_distribution_invariants.py`, `tools/regression_test.py:83-84,789-791`.

--- a/src/babylon/config/defines/economy_class.py
+++ b/src/babylon/config/defines/economy_class.py
@@ -30,6 +30,16 @@ class ClassDynamicsDefines(BaseModel):
         le=0.1,
         description="Imperial rent formation rate — superwages to core workers (quarterly)",
     )
+    ticks_per_quarter: float = Field(
+        default=13.0,
+        ge=1.0,
+        le=91.0,
+        description=(
+            "Engine ticks per calendar quarter (weekly ticks = 13). Converts the "
+            "quarterly FRED-DFA ODE rates to a per-tick Euler step in "
+            "WealthDistributionSystem (Program 21 Phase 1)"
+        ),
+    )
     equilibrium_w1: float = Field(
         default=0.305,
         ge=0.0,

--- a/src/babylon/data/defines.yaml
+++ b/src/babylon/data/defines.yaml
@@ -411,6 +411,7 @@ community:
 class_dynamics:
   alpha_21: 0.0006  # Extraction rate from petty bourgeoisie to bourgeoisie (quarterly) (>= 0.0, <= 0.01)
   gamma_3: 0.0057  # Imperial rent formation rate — superwages to core workers (quarterly) (>= 0.0, <= 0.1)
+  ticks_per_quarter: 13.0  # Engine ticks per calendar quarter (weekly ticks = 13). Converts the quarterly FRED-DFA ODE rates to a per-tick Euler step in WealthDistributionSystem (Program 21 Phase 1) (>= 1.0, <= 91.0)
   equilibrium_w1: 0.305  # Target equilibrium wealth share for class 1 (bourgeoisie) (>= 0.0, <= 1.0)
   equilibrium_w2: 0.382  # Target equilibrium wealth share for class 2 (petty bourgeoisie) (>= 0.0, <= 1.0)
   equilibrium_w3: 0.294  # Target equilibrium wealth share for class 3 (proletariat) (>= 0.0, <= 1.0)

--- a/src/babylon/engine/simulation_engine.py
+++ b/src/babylon/engine/simulation_engine.py
@@ -68,6 +68,7 @@ from babylon.engine.systems.substrate import SubstrateSystem
 from babylon.engine.systems.survival import SurvivalSystem
 from babylon.engine.systems.territory import TerritorySystem
 from babylon.engine.systems.vitality import VitalitySystem
+from babylon.engine.systems.wealth_distribution import WealthDistributionSystem
 from babylon.kernel.event_bus import Event
 from babylon.kernel.log import log_context_scope
 from babylon.kernel.system_protocol import ContextType, System
@@ -409,6 +410,7 @@ _DEFAULT_SYSTEMS: list[System] = [
     FieldDerivativeSystem(),  # 20. Spatial/temporal derivatives + principal (Feature 002)
     CollapseTransitionSystem(),  # 20.5. Spec-070 sovereign-collapse + territory partition
     EdgeTransitionSystem(),  # 21. Compound predicates + edge mode transitions (Feature 002)
+    WealthDistributionSystem(),  # 21.5. National wealth-share axis (Program 21 Phase-1 shadow; writes only its own axis)
     EpistemicHorizonSystem(),  # 22. Fog-of-war M_r/I_c shadow (Epistemic Horizon Phase 1) — LAST, observes fully-mutated tick
 ]
 
@@ -452,6 +454,7 @@ CONSEQUENCE_SYSTEMS: Final[frozenset[type[System]]] = frozenset(
         ContradictionFieldSystem,
         FieldDerivativeSystem,
         EdgeTransitionSystem,
+        WealthDistributionSystem,  # Program 21 Phase-1 shadow (national wealth-share axis)
         EpistemicHorizonSystem,  # Epistemic Horizon Phase 1 shadow (observes consequences)
         DoctrineSystem,  # Doctrine Tree per-org state (owner-ratified 2026-07-15)
     }

--- a/src/babylon/engine/systems/wealth_distribution.py
+++ b/src/babylon/engine/systems/wealth_distribution.py
@@ -1,0 +1,241 @@
+"""Wealth-distribution system — Phase 1 SHADOW ONLY (Program 21, Data Constitution).
+
+Wires the formerly-orphaned ``babylon.formulas.class_dynamics`` ODE (FRED-DFA
+fitted, Feature 016) into the tick as the **runtime wealth-share axis**: a
+single national 4-bracket vector ``(w1..w4)`` = wealth held by top-1% /
+p90-99 / p50-90 / bottom-50, relaxing toward the ``GameDefines.class_dynamics``
+equilibria that ``tests/unit/config/test_wealth_distribution_invariants.py``
+pins against 111 years of WID/Piketty data.
+
+This is the axis the population partition was conflated with (the census
+found four sites hardcoding *headcount* shares mislabelled as wealth); it is
+**additive** — the per-county 5-class population substrate is untouched.
+
+PHASE 1 SCOPE (binding, per the design brief): observe-only shadow.
+
+- State home: ``G.graph["wealth_distribution"]`` metadata (the
+  ``economy``/``state_finances`` round-trip pattern), plus a per-node
+  ``wealth_share`` projection onto ``social_class`` nodes (a **declared**
+  ``SocialClass`` field — the ``extra="forbid"`` landmine).
+- Nothing reads these outputs yet: no feedback into wealth, consciousness, or
+  bifurcation (Phase 2, owner-gated), so the sampled qa:regression
+  checkpoints stay byte-identical.
+- Deterministic by construction: seeded from defines, iterated in sorted node
+  order, no RNG (Constitution III.7).
+
+PROVISIONAL bracket mapping (owner ruling pending — the brief's §6 naming
+collision): the 8 ``SocialRole`` members fold onto the 4 wealth brackets by
+the Fed-DFA ``dim_wealth_class.babylon_class`` correspondence (LT01→core
+bourgeoisie, N09→petty bourgeoisie, N40→labor aristocracy, B50→internal
+proletariat) extended to the remaining roles by class position.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from babylon.formulas.class_dynamics import (
+    ClassDynamicsParams,
+    SecondOrderParams,
+    calculate_full_dynamics,
+)
+from babylon.kernel.system_base import SystemBase
+from babylon.kernel.system_protocol import ContextType
+from babylon.models.enums import SocialRole
+
+if TYPE_CHECKING:
+    from babylon.kernel.graph_protocol import GraphProtocol
+    from babylon.kernel.services import ServicesProtocol
+
+#: PROVISIONAL 8-role → 4-bracket fold (0=w1 top-1%, 1=w2 p90-99,
+#: 2=w3 p50-90, 3=w4 bottom-50). Owner ruling pending; see module docstring.
+_BRACKET_BY_ROLE: dict[SocialRole, int] = {
+    SocialRole.CORE_BOURGEOISIE: 0,
+    SocialRole.COMPRADOR_BOURGEOISIE: 0,
+    SocialRole.PETTY_BOURGEOISIE: 1,
+    SocialRole.LABOR_ARISTOCRACY: 2,
+    SocialRole.CARCERAL_ENFORCER: 2,
+    SocialRole.PERIPHERY_PROLETARIAT: 3,
+    SocialRole.INTERNAL_PROLETARIAT: 3,
+    SocialRole.LUMPENPROLETARIAT: 3,
+}
+
+_Vector = tuple[float, float, float, float]
+
+
+def bracket_of_role(role: SocialRole) -> int:
+    """Return the wealth-bracket index (0..3) a social role folds into.
+
+    :param role: Any :class:`SocialRole` member.
+    :returns: The bracket index under the PROVISIONAL mapping.
+    """
+    return _BRACKET_BY_ROLE[role]
+
+
+def _coerce_role(raw: object) -> SocialRole | None:
+    """Coerce a graph-node ``role`` attr to :class:`SocialRole` (or ``None``)."""
+    if isinstance(raw, SocialRole):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return SocialRole(raw)
+        except ValueError:
+            return None
+    return None
+
+
+def _seed_vector(defines: Any) -> _Vector:
+    """Seed the national vector from the calibration equilibria, normalized.
+
+    :param defines: This session's ``ClassDynamicsDefines``.
+    :returns: The equilibrium shares scaled to sum exactly to 1.
+    """
+    raw = (
+        defines.equilibrium_w1,
+        defines.equilibrium_w2,
+        defines.equilibrium_w3,
+        defines.equilibrium_w4,
+    )
+    total = sum(raw)
+    return (raw[0] / total, raw[1] / total, raw[2] / total, raw[3] / total)
+
+
+def _ode_params(defines: Any) -> tuple[ClassDynamicsParams, SecondOrderParams]:
+    """Build the ODE parameter sets from the SESSION defines (not import-time).
+
+    ``ClassDynamicsParams``' dataclass defaults are frozen at import from the
+    default ``GameDefines`` — a modded session would silently ignore its own
+    coefficients if we relied on them.
+
+    :param defines: This session's ``ClassDynamicsDefines``.
+    :returns: ``(first_order, second_order)`` parameter sets.
+    """
+    first = ClassDynamicsParams(
+        alpha_41=defines.alpha_41,
+        alpha_31=defines.alpha_31,
+        alpha_21=defines.alpha_21,
+        alpha_32=defines.alpha_32,
+        alpha_42=defines.alpha_42,
+        alpha_43=defines.alpha_43,
+        delta_1=defines.delta_1,
+        delta_2=defines.delta_2,
+        delta_3=defines.delta_3,
+        gamma_3=defines.gamma_3,
+    )
+    second = SecondOrderParams(
+        beta=(defines.beta_1, defines.beta_2, defines.beta_3, defines.beta_4),
+        omega=(defines.omega_1, defines.omega_2, defines.omega_3, defines.omega_4),
+        equilibrium=_seed_vector(defines),
+    )
+    return first, second
+
+
+def _bracket_resistances(graph: GraphProtocol) -> _Vector:
+    """Mean ``class_consciousness`` per bracket — the ODE's resistance input.
+
+    Deterministic: nodes visited in sorted-id order; brackets with no nodes
+    contribute zero resistance (honest absence, not a fabricated default).
+
+    :param graph: The live tick graph.
+    :returns: Per-bracket mean consciousness ``(r1..r4)``.
+    """
+    sums = [0.0, 0.0, 0.0, 0.0]
+    counts = [0, 0, 0, 0]
+    nodes = sorted(graph.query_nodes(node_type="social_class"), key=lambda n: n.id)
+    for node in nodes:
+        role = _coerce_role(node.attributes.get("role"))
+        if role is None:
+            continue
+        bracket = _BRACKET_BY_ROLE[role]
+        sums[bracket] += float(node.attributes.get("class_consciousness", 0.0))
+        counts[bracket] += 1
+    return tuple(s / c if c else 0.0 for s, c in zip(sums, counts, strict=True))  # type: ignore[return-value]
+
+
+def _advance(
+    shares: _Vector,
+    velocities: _Vector,
+    resistances: _Vector,
+    defines: Any,
+) -> tuple[_Vector, _Vector]:
+    """One deterministic Euler step of the class-dynamics ODE.
+
+    The ODE's rates are quarterly (Feature 016 FRED-DFA fit); one tick is
+    ``1 / ticks_per_quarter`` quarters. Velocity integrates the second-order
+    acceleration; shares integrate the first-order flow plus velocity, then
+    clamp to ``[0, 1]`` and renormalize so Σ == 1 exactly (conservation of
+    the whole — float drift never accumulates across ticks).
+
+    :param shares: Current ``(w1..w4)``.
+    :param velocities: Current ODE momentum state.
+    :param resistances: Per-bracket class-consciousness resistances.
+    :param defines: This session's ``ClassDynamicsDefines``.
+    :returns: ``(new_shares, new_velocities)``.
+    """
+    dt = 1.0 / defines.ticks_per_quarter
+    params, second_order = _ode_params(defines)
+    flows, accelerations = calculate_full_dynamics(
+        shares, velocities, params=params, second_order=second_order, resistances=resistances
+    )
+    new_velocities = tuple(v + a * dt for v, a in zip(velocities, accelerations, strict=True))
+    stepped = [
+        max(0.0, min(1.0, w + (f + v) * dt))
+        for w, f, v in zip(shares, flows, new_velocities, strict=True)
+    ]
+    total = sum(stepped)
+    normalized = tuple(w / total for w in stepped) if total > 0.0 else _seed_vector(defines)
+    return normalized, new_velocities
+
+
+class WealthDistributionSystem(SystemBase):
+    """Phase 1 SHADOW: the national 4-bracket wealth-share axis.
+
+    Runs at position 21.5 (end of the Consequence phase, just before the
+    Epistemic Horizon observer): it reads the tick's ``class_consciousness``
+    as ODE resistance and writes ONLY its own axis — the national vector to
+    graph metadata and the ``wealth_share`` bracket projection onto
+    ``social_class`` nodes. Nothing consumes either yet (Phase 2 owner-gated).
+    """
+
+    name: ClassVar[str] = "Wealth Distribution"
+    creates_value: ClassVar[bool] = False
+
+    def step(
+        self,
+        graph: GraphProtocol,
+        services: ServicesProtocol,
+        context: ContextType,
+    ) -> None:
+        """Advance (or seed) the national vector and project it onto nodes.
+
+        First tick (no metadata): seed from ``equilibrium_w1..w4`` with zero
+        velocity. Subsequent ticks: one Euler step of
+        :func:`~babylon.formulas.class_dynamics.calculate_full_dynamics`.
+        """
+        defines = services.defines.class_dynamics
+        tick = context.get("tick", 0) if isinstance(context, dict) else getattr(context, "tick", 0)
+        metadata = getattr(graph, "graph", None)
+        if not isinstance(metadata, dict):  # pragma: no cover — BabylonGraph always has it
+            return
+        prior = metadata.get("wealth_distribution")
+        if prior is None:
+            shares = _seed_vector(defines)
+            velocities: _Vector = (0.0, 0.0, 0.0, 0.0)
+        else:
+            shares, velocities = _advance(
+                tuple(prior["shares"]),
+                tuple(prior["velocities"]),
+                _bracket_resistances(graph),
+                defines,
+            )
+        metadata["wealth_distribution"] = {
+            "shares": list(shares),
+            "velocities": list(velocities),
+            "tick": int(tick),
+        }
+        nodes = sorted(graph.query_nodes(node_type="social_class"), key=lambda n: n.id)
+        for node in nodes:
+            role = _coerce_role(node.attributes.get("role"))
+            if role is None:
+                continue  # honest absence: no role, no bracket, no projection
+            graph.update_node(node.id, wealth_share=shares[_BRACKET_BY_ROLE[role]])

--- a/src/babylon/models/entities/social_class.py
+++ b/src/babylon/models/entities/social_class.py
@@ -309,6 +309,17 @@ class SocialClass(BaseModel):
         default=10.0,
         description="Economic resources",
     )
+    wealth_share: Probability = Field(
+        default=0.0,
+        description=(
+            "National wealth-bracket share this class's role folds into "
+            "(Program 21 Phase-1 shadow axis; projected each tick by "
+            "WealthDistributionSystem from G.graph['wealth_distribution']). "
+            "A declared field so the projection survives the extra='forbid' "
+            "graph round-trip; nothing feeds back from it yet (Phase 2 is "
+            "owner-gated)."
+        ),
+    )
     ideology: IdeologicalProfile = Field(
         default_factory=IdeologicalProfile,
         description="Multi-dimensional ideological profile (Sprint 3.4.3). Float input auto-converts via model_validator.",

--- a/src/babylon/models/wealth_distribution.py
+++ b/src/babylon/models/wealth_distribution.py
@@ -1,0 +1,52 @@
+"""National wealth-distribution state — the 4-bracket axis (Program 21 Phase 1).
+
+The wealth partition is **national and 4-class** (top-1% / p90-99 / p50-90 /
+bottom-50, the FRED-DFA / WID quantile structure pinned by
+``tests/unit/config/test_wealth_distribution_invariants.py``), distinct from
+the per-county 5-class **population** partition the tick engine carries. This
+model is the graph-metadata carrier for that axis: ``WorldState`` holds it as
+an optional field and round-trips it via ``G.graph["wealth_distribution"]``
+(the ``economy``/``state_finances`` metadata pattern), written only when set
+so axis-less graphs stay byte-identical (the EH ruling-6 precedent).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+#: Conservation tolerance: shares are renormalized by the writer, so any
+#: drift beyond this is a bug upstream, not float noise.
+_SUM_TOLERANCE = 1e-6
+
+
+class WealthDistribution(BaseModel):
+    """The national 4-bracket wealth-share vector and its ODE velocities.
+
+    :ivar shares: ``(w1, w2, w3, w4)`` — wealth held by top-1% / p90-99 /
+        p50-90 / bottom-50. Must sum to 1 (conservation of the whole).
+    :ivar velocities: ``(dw1..dw4)/dt`` — the second-order ODE momentum state
+        (``formulas.class_dynamics``), quarterly units.
+    :ivar tick: the tick this vector was computed at.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    shares: tuple[float, float, float, float]
+    velocities: tuple[float, float, float, float]
+    tick: int
+
+    @model_validator(mode="after")
+    def _validate_conservation(self) -> WealthDistribution:
+        """Reject a non-conserving vector loudly (Constitution III.11).
+
+        :returns: ``self`` when the shares sum to 1 within tolerance.
+        :raises ValueError: if any share is outside ``[0, 1]`` or the vector
+            does not sum to 1.
+        """
+        for share in self.shares:
+            if not 0.0 <= share <= 1.0:
+                raise ValueError(f"wealth share {share!r} outside [0, 1]")
+        total = sum(self.shares)
+        if abs(total - 1.0) > _SUM_TOLERANCE:
+            raise ValueError(f"wealth shares must sum to 1.0, got {total!r}")
+        return self

--- a/src/babylon/models/world_state.py
+++ b/src/babylon/models/world_state.py
@@ -42,6 +42,7 @@ from babylon.models.entities.territory import Territory
 from babylon.models.enums import EdgeType, OperationalProfile, OrgType, SectorType
 from babylon.models.events import EVENT_CLASS_MAP, SimulationEvent, TickEventAdapter
 from babylon.models.types import Currency
+from babylon.models.wealth_distribution import WealthDistribution
 
 if TYPE_CHECKING:
     from babylon.topology.graph import BabylonGraph
@@ -459,6 +460,17 @@ class WorldState(BaseModel):
         ),
     )
 
+    wealth_distribution: WealthDistribution | None = Field(
+        default=None,
+        description=(
+            "National 4-bracket wealth-share axis (Program 21 Phase-1 shadow; "
+            "WealthDistributionSystem seeds and advances it). Rides graph "
+            "metadata like economy/state_finances, written only when set so "
+            "axis-less graphs stay byte-identical (EH ruling-6 pattern). None "
+            "means the axis has not been computed for this state."
+        ),
+    )
+
     opposition_states: dict[str, Any] = Field(
         default_factory=dict,
         description=(
@@ -635,6 +647,11 @@ class WorldState(BaseModel):
         # only when set so synthetic/headless graphs stay byte-identical.
         if self.player_org_id is not None:
             G.graph["player_org_id"] = self.player_org_id
+
+        # Program 21 Phase 1: the national wealth-share axis rides metadata,
+        # written only when set (same byte-safety contract as player_org_id).
+        if self.wealth_distribution is not None:
+            G.graph["wealth_distribution"] = self.wealth_distribution.model_dump()
 
         # Store institution-org housing relations in graph metadata (Feature
         # 040). Relations are richer than the HOUSES edges to_graph derives
@@ -933,6 +950,13 @@ class WorldState(BaseModel):
             player_org_id=(
                 G.graph.get("player_org_id")
                 if isinstance(G.graph.get("player_org_id"), str)
+                else None
+            ),
+            # isinstance guard mirrors player_org_id: absent/foreign metadata
+            # means no axis, never a coerced default.
+            wealth_distribution=(
+                WealthDistribution(**G.graph["wealth_distribution"])
+                if isinstance(G.graph.get("wealth_distribution"), dict)
                 else None
             ),
         )

--- a/src/babylon/sentinels/coverage/catalog.py
+++ b/src/babylon/sentinels/coverage/catalog.py
@@ -1,0 +1,232 @@
+"""The per-table registry loader for ``data-catalog.yaml`` (Program 21).
+
+``data-catalog.yaml`` is the canonical machine-readable data catalog
+(Constitution III.4.1). Historically it carried *source-level* provenance only
+(agency, dataset, vintage); the Data Constitution program adds a ``tables:``
+block declaring, for every reference-DB table and view: its source lineage,
+extractor, code consumers, guarding tests, triage disposition, and CI-subset
+policy. This module loads that block into frozen :class:`CatalogTable` rows.
+
+Unlike the hand-written ``.py`` literals of the coverage/synthetic registries,
+the catalog **is** a maintained YAML source of truth — so the registry loads
+the YAML at check time (mirroring ``GameDefines.load_default()`` reading
+``defines.yaml``), and a missing, unparseable, or table-less catalog raises
+:class:`~babylon.sentinels.base.SentinelCheckError` (infrastructure failure,
+exit 2 — never a silent pass; Constitution III.11).
+
+The static checks over these rows live in
+:mod:`babylon.sentinels.coverage.checks`; the DB-probe tier lives in
+:mod:`babylon.sentinels.coverage.db_probe`.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from babylon.sentinels.base import SentinelCheckError
+
+#: Repo root (this file is ``<root>/src/babylon/sentinels/coverage/catalog.py``).
+_REPO_ROOT: Path = Path(__file__).resolve().parents[4]
+
+#: The canonical catalog location (repo root, Constitution III.4.1).
+CATALOG_PATH: Path = _REPO_ROOT / "data-catalog.yaml"
+
+#: The subset generator whose ``TABLE`` policy dict is the second SoT the
+#: parity check reconciles against.
+SUBSET_GENERATOR_PATH: Path = _REPO_ROOT / "tools" / "make_reference_subset.py"
+
+
+class CatalogTable(BaseModel):
+    """One reference-DB table or view declared in ``data-catalog.yaml``.
+
+    Frozen and ``extra="forbid"`` so a malformed row is a loud failure at load
+    time (Constitution III.11) rather than a quiet ``None`` at check time.
+
+    :ivar name: the ``sqlite_master`` object name (``fact_*``/``dim_*``/
+        ``bridge_*`` table or ``view_*`` view).
+    :ivar kind: ``"table"`` or ``"view"`` — drives the empty-base-table probe.
+    :ivar source: lineage pointer — an ``id`` from ``categories[].sources[]``
+        or ``"derived"``/``"internal"`` for computed/infrastructure objects.
+    :ivar extractor: loader/ingest lineage — a live repo path, an archaeology
+        note (e.g. ``"deleted @ 4ce7c96a^ tools/etl.py"``), or ``None``.
+    :ivar reads: views only — the base tables the view SELECTs from (the
+        empty-view probe target). Must be empty for ``kind="table"``.
+    :ivar consumers: repo-relative ``.py`` paths that read this object at
+        runtime or in tools; existence is asserted by the static sensor.
+    :ivar tests: repo-relative test paths guarding this object; existence is
+        asserted by the static sensor.
+    :ivar disposition: the Data Constitution triage verdict. ``amputate`` is a
+        *proposal* — execution always requires an owner ruling.
+    :ivar subset_policy: the CI-subset scope; for base tables this MUST equal
+        the generator's ``TABLE[name].scope`` (parity-checked); views are never
+        copied into subsets and must declare ``"skip"``.
+    :ivar material_relation: the material relation the data grounds
+        (Aleksandrov Test); required, non-blank.
+    :ivar notes: free-text clarification.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str
+    kind: Literal["table", "view"]
+    source: str
+    extractor: str | None = None
+    reads: tuple[str, ...] = ()
+    consumers: tuple[str, ...] = ()
+    tests: tuple[str, ...] = ()
+    disposition: Literal["keep", "fill", "artifact", "amputate", "investigate"]
+    subset_policy: Literal["full", "michigan", "skip"]
+    material_relation: str
+    notes: str = ""
+
+    @model_validator(mode="after")
+    def _validate_shape(self) -> CatalogTable:
+        """Reject malformed rows loudly at construction (III.11).
+
+        :returns: ``self`` when valid.
+        :raises ValueError: on a blank ``name``/``source``/``material_relation``,
+            a view without ``reads`` (or a table with them), a view whose
+            ``subset_policy`` is not ``"skip"``, or a non-``.py`` path in
+            ``consumers``/``tests``.
+        """
+        if not self.name.strip():
+            raise ValueError("CatalogTable.name must be non-empty")
+        if not self.source.strip():
+            raise ValueError(f"{self.name!r}: source must be non-empty")
+        if not self.material_relation.strip():
+            raise ValueError(f"{self.name!r}: material_relation must be non-empty (Aleksandrov)")
+        if self.kind == "view" and not self.reads:
+            raise ValueError(f"{self.name!r}: a view must declare the base tables it reads")
+        if self.kind == "table" and self.reads:
+            raise ValueError(f"{self.name!r}: only views declare reads")
+        if self.kind == "view" and self.subset_policy != "skip":
+            raise ValueError(
+                f"{self.name!r}: views are never copied into ci-data subsets — "
+                "subset_policy must be 'skip'"
+            )
+        for field_name, paths in (("consumers", self.consumers), ("tests", self.tests)):
+            for entry in paths:
+                if not entry.endswith(".py"):
+                    raise ValueError(
+                        f"{self.name!r}: {field_name} entry {entry!r} is not a .py path"
+                    )
+        return self
+
+
+def load_catalog_tables(path: Path = CATALOG_PATH) -> tuple[CatalogTable, ...]:
+    """Load the ``tables:`` block of ``data-catalog.yaml`` into frozen rows.
+
+    :param path: Catalog file to read (injectable for efficacy tests).
+    :returns: One :class:`CatalogTable` per declared table/view.
+    :raises SentinelCheckError: If the file is missing, unparseable, carries no
+        ``tables:`` block, or any row fails validation — all infrastructure
+        failures (exit 2), never swallowed into a false pass.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SentinelCheckError(f"cannot read data catalog {path}: {exc}") from exc
+    try:
+        document = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise SentinelCheckError(f"cannot parse data catalog {path}: {exc}") from exc
+    if not isinstance(document, dict) or "tables" not in document:
+        raise SentinelCheckError(
+            f"data catalog {path} has no 'tables' block — the per-table registry "
+            "is missing (Program 21 backfill absent?)"
+        )
+    rows_raw = document["tables"]
+    if not isinstance(rows_raw, list) or not rows_raw:
+        raise SentinelCheckError(f"data catalog {path}: 'tables' must be a non-empty list")
+    try:
+        return tuple(CatalogTable(**row) for row in rows_raw)
+    except (TypeError, ValueError) as exc:
+        raise SentinelCheckError(f"data catalog {path}: malformed table row — {exc}") from exc
+
+
+def subset_policy_map(path: Path = SUBSET_GENERATOR_PATH) -> dict[str, str]:
+    """Statically parse the generator's ``TABLE`` policy dict into name→scope.
+
+    Reads ``tools/make_reference_subset.py`` with :mod:`ast` (no import — the
+    generator opens databases at module scope elsewhere, and layer-0.5 must
+    stay static). Matches entries of the shape
+    ``"table_name": TablePolicy("scope", ...)``.
+
+    :param path: Generator source to parse (injectable for tests).
+    :returns: Mapping of table name to declared scope literal.
+    :raises SentinelCheckError: If the file is missing/unparseable or no
+        ``TABLE`` dict assignment is found.
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SentinelCheckError(f"cannot read subset generator {path}: {exc}") from exc
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        raise SentinelCheckError(f"cannot parse subset generator {path}: {exc}") from exc
+    for node in tree.body:
+        dict_node = _table_dict_value(node)
+        if dict_node is not None:
+            return _scopes_from_dict(dict_node, path)
+    raise SentinelCheckError(f"no module-level TABLE dict found in {path}")
+
+
+def _table_dict_value(node: ast.stmt) -> ast.Dict | None:
+    """Return the dict literal assigned to ``TABLE``, if ``node`` is it."""
+    if (
+        isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "TABLE"
+        and isinstance(node.value, ast.Dict)
+    ):
+        return node.value
+    if isinstance(node, ast.Assign) and isinstance(node.value, ast.Dict):
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "TABLE":
+                return node.value
+    return None
+
+
+def _scopes_from_dict(dict_node: ast.Dict, path: Path) -> dict[str, str]:
+    """Extract ``name -> scope`` from ``TABLE``'s dict literal.
+
+    :param dict_node: The parsed ``TABLE`` dict.
+    :param path: Source path, for error messages only.
+    :returns: Mapping of table name to the first positional/keyword scope
+        argument of its ``TablePolicy(...)`` call.
+    :raises SentinelCheckError: If an entry is not the expected
+        ``"name": TablePolicy("scope", ...)`` shape.
+    """
+    policies: dict[str, str] = {}
+    for key, value in zip(dict_node.keys, dict_node.values, strict=True):
+        if not (isinstance(key, ast.Constant) and isinstance(key.value, str)):
+            raise SentinelCheckError(f"{path}: TABLE key is not a string literal")
+        scope = _policy_scope(value)
+        if scope is None:
+            raise SentinelCheckError(
+                f"{path}: TABLE[{key.value!r}] is not a TablePolicy('<scope>', ...) call"
+            )
+        policies[key.value] = scope
+    return policies
+
+
+def _policy_scope(value: ast.expr) -> str | None:
+    """Return the scope literal of a ``TablePolicy(...)`` call node, else None."""
+    if not (isinstance(value, ast.Call) and isinstance(value.func, ast.Name)):
+        return None
+    if value.func.id != "TablePolicy":
+        return None
+    if value.args and isinstance(value.args[0], ast.Constant):
+        arg = value.args[0].value
+        return arg if isinstance(arg, str) else None
+    for keyword in value.keywords:
+        if keyword.arg == "scope" and isinstance(keyword.value, ast.Constant):
+            arg = keyword.value.value
+            return arg if isinstance(arg, str) else None
+    return None

--- a/src/babylon/sentinels/coverage/checks.py
+++ b/src/babylon/sentinels/coverage/checks.py
@@ -31,6 +31,11 @@ import sys
 from pathlib import Path
 
 from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.coverage.catalog import (
+    CatalogTable,
+    load_catalog_tables,
+    subset_policy_map,
+)
 from babylon.sentinels.coverage.registry import DATA_REQUIREMENTS, DataRequirement
 
 #: Repo root (this file is ``<root>/src/babylon/sentinels/coverage/checks.py``).
@@ -91,9 +96,76 @@ def check_source_classes_exist(
     return sorted(violations)
 
 
+def check_catalog_paths_exist(
+    catalog: tuple[CatalogTable, ...] | None = None,
+) -> list[str]:
+    """Every catalog row's declared consumer/test path must exist in the repo.
+
+    A ``consumers`` or ``tests`` entry pointing at a file the repo no longer
+    contains is a rotted lineage claim — the object it guards is either
+    orphaned or its consumer moved without the catalog following (the exact
+    drift Program 21 exists to make loud).
+
+    :param catalog: Rows to check (defaults to the real ``data-catalog.yaml``;
+        injectable so tests can supply a deliberately broken row).
+    :returns: Sorted violation strings (empty when every path exists).
+    :raises SentinelCheckError: If the catalog itself cannot be loaded.
+    """
+    rows = load_catalog_tables() if catalog is None else catalog
+    violations: list[str] = []
+    for row in rows:
+        for field_name, paths in (("consumers", row.consumers), ("tests", row.tests)):
+            for entry in paths:
+                if not (_REPO_ROOT / entry).is_file():
+                    violations.append(
+                        f"catalog row {row.name!r} declares {field_name} path {entry!r} "
+                        "which does not exist (moved/renamed/deleted? lineage rotted)"
+                    )
+    return sorted(violations)
+
+
+def check_subset_policy_parity(
+    catalog: tuple[CatalogTable, ...] | None = None,
+) -> list[str]:
+    """Every base table's ``subset_policy`` must equal the generator's scope.
+
+    ``data-catalog.yaml`` and ``tools/make_reference_subset.py``'s ``TABLE``
+    dict are two sources of truth for the same fact (which rows ship in the
+    ci-data subset); this check pins them together so neither can drift
+    silently. Views are exempt — the generator copies ``type='table'`` only,
+    and the model already forces views to declare ``skip``.
+
+    :param catalog: Rows to check (defaults to the real catalog; injectable).
+    :returns: Sorted violation strings (empty when the two SoTs agree).
+    :raises SentinelCheckError: If either source of truth cannot be parsed.
+    """
+    rows = load_catalog_tables() if catalog is None else catalog
+    policies = subset_policy_map()
+    violations: list[str] = []
+    for row in rows:
+        if row.kind != "table":
+            continue
+        scope = policies.get(row.name)
+        if scope is None:
+            violations.append(
+                f"catalog row {row.name!r} has no TablePolicy entry in "
+                "tools/make_reference_subset.py TABLE (new table without a "
+                "reviewed subset policy?)"
+            )
+        elif scope != row.subset_policy:
+            violations.append(
+                f"catalog row {row.name!r} declares subset_policy "
+                f"{row.subset_policy!r} but the generator's TABLE dict says "
+                f"{scope!r} — the two SoTs have drifted"
+            )
+    return sorted(violations)
+
+
 #: Gating checks: a violation reds the dev fast-gate (exit 1).
 _GATING_CHECKS: tuple[LabelledCheck, ...] = (
     ("declared reference-data source class does not exist", check_source_classes_exist),
+    ("catalog consumer/test path does not exist", check_catalog_paths_exist),
+    ("catalog subset_policy drifted from make_reference_subset.TABLE", check_subset_policy_parity),
 )
 
 #: No advisory tier yet — the reference-DB coverage probe is a nightly concern.
@@ -109,7 +181,9 @@ def _summary(advisory_count: int) -> str:
     """
     summary = (
         f"Data coverage (static): clean — {len(DATA_REQUIREMENTS)} reference-data "
-        f"requirements coherent (source classes exist)."
+        f"requirements coherent (source classes exist); "
+        f"{len(load_catalog_tables())} catalog rows coherent (paths exist, "
+        "subset policies in parity)."
     )
     if advisory_count:
         summary += f" ({advisory_count} advisory findings above.)"

--- a/src/babylon/sentinels/coverage/db_probe.py
+++ b/src/babylon/sentinels/coverage/db_probe.py
@@ -1,0 +1,240 @@
+"""The catalog DB probe — reconciles ``data-catalog.yaml`` against the real DB.
+
+The refdata-lane half of the Program 21 registry (the static half lives in
+:mod:`babylon.sentinels.coverage.checks`). Opens the reference database
+**read-only** and asserts the catalog↔DB bijection plus the emptiness law:
+
+- every ``fact_/dim_/bridge_`` table and ``view_`` view in ``sqlite_master``
+  has a catalog row (III.4 traceability — no undeclared data);
+- every catalog row names an object the DB actually contains (no phantoms);
+- no ``disposition: keep`` object is empty — a KEEP table with zero rows, or a
+  KEEP view over an empty base table, is the ``view_surplus_value`` pathology:
+  a consumer reading silence (Constitution III.11).
+
+``fill``/``artifact``/``amputate``/``investigate`` rows are *declared debt* —
+they are tracked by disposition and deliberately not gated on emptiness, so CI
+stays green on known triage while any KEEP object going dark reds loudly.
+
+**Subset awareness:** ci-data subsets carry base tables only (the generator
+copies ``type='table'``), so when the probed DB contains *no* views at all the
+view rows are reported as an advisory, not a violation.
+
+This module opens sqlite3, so the CLI loads it lazily (like the partition
+probe) and it runs only in the refdata lane — never the fast-gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.coverage.catalog import CatalogTable, load_catalog_tables
+
+#: Repo root (this file is ``<root>/src/babylon/sentinels/coverage/db_probe.py``).
+_REPO_ROOT: Path = Path(__file__).resolve().parents[4]
+
+#: Traceability scope: only these prefixes are governed by the catalog
+#: (utility tables like ``ingest_checkpoint``/``staging_arcgis_feature`` are
+#: outside it, exactly as the subset generator's find_unknown_tables excludes
+#: them from policy review).
+_GOVERNED_PREFIXES: tuple[str, ...] = ("fact_", "dim_", "bridge_", "view_")
+
+
+def _database_path() -> Path:
+    """Resolve the reference DB path (env override, then the canonical spot).
+
+    :returns: The path ``BABYLON_NORMALIZED_DB_PATH`` names, or
+        ``data/sqlite/marxist-data-3NF.sqlite`` under the repo root.
+    """
+    override = os.environ.get("BABYLON_NORMALIZED_DB_PATH")
+    if override:
+        return Path(override)
+    return _REPO_ROOT / "data" / "sqlite" / "marxist-data-3NF.sqlite"
+
+
+def _open_readonly(path: Path) -> sqlite3.Connection:
+    """Open the reference DB genuinely read-only (``mode=ro`` URI).
+
+    :param path: Database file.
+    :returns: A read-only connection.
+    :raises SentinelCheckError: If the file is missing or cannot be opened —
+        the probe must never run against no DB and report clean.
+    """
+    if not path.is_file():
+        raise SentinelCheckError(f"reference DB not found at {path} (probe cannot run)")
+    try:
+        return sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    except sqlite3.Error as exc:
+        raise SentinelCheckError(f"cannot open reference DB {path} read-only: {exc}") from exc
+
+
+def _db_objects(conn: sqlite3.Connection) -> dict[str, str]:
+    """Map every governed ``sqlite_master`` object name to its type.
+
+    :param conn: Open reference-DB connection.
+    :returns: ``{name: "table"|"view"}`` for governed-prefix objects.
+    """
+    rows = conn.execute(
+        "SELECT name, type FROM sqlite_master WHERE type IN ('table','view') "
+        "AND name NOT LIKE 'sqlite_%'"
+    ).fetchall()
+    return {name: kind for name, kind in rows if name.startswith(_GOVERNED_PREFIXES)}
+
+
+def _is_empty(conn: sqlite3.Connection, table: str) -> bool:
+    """O(1) emptiness probe (EXISTS, not COUNT — some tables hold 26M rows).
+
+    The identifier cannot be a bound parameter; every ``table`` passed here is
+    first verified against ``sqlite_master`` (see the callers), so the quoted
+    interpolation cannot inject.
+    """
+    row = conn.execute(f'SELECT EXISTS(SELECT 1 FROM "{table}" LIMIT 1)').fetchone()  # noqa: S608
+    return not bool(row[0])
+
+
+def check_catalog_db_reconciliation(
+    catalog: tuple[CatalogTable, ...] | None = None,
+    db_path: Path | None = None,
+) -> list[str]:
+    """Assert the catalog↔DB bijection and the KEEP-objects-not-empty law.
+
+    :param catalog: Rows to reconcile (defaults to the real catalog;
+        injectable so tests can pin the ``view_surplus_value`` pathology as a
+        regression contract with a synthetic row).
+    :param db_path: Database to probe (defaults to the canonical/env path).
+    :returns: Sorted violation strings (empty when catalog and DB agree and no
+        KEEP object is dark). Subset-environment view absences are advisory
+        and reported by :func:`check_subset_view_absence` instead.
+    :raises SentinelCheckError: If the catalog or DB cannot be opened/parsed.
+    """
+    rows = load_catalog_tables() if catalog is None else catalog
+    conn = _open_readonly(db_path if db_path is not None else _database_path())
+    try:
+        objects = _db_objects(conn)
+        subset_env = not any(kind == "view" for kind in objects.values())
+        declared = {row.name for row in rows}
+        violations = [
+            f"DB object {name!r} ({kind}) has no data-catalog.yaml row — undeclared "
+            "data violates III.4 traceability"
+            for name, kind in objects.items()
+            if name not in declared
+        ]
+        for row in rows:
+            if row.name not in objects:
+                if row.kind == "view" and subset_env:
+                    continue  # subset DBs carry no views — advisory tier's job
+                violations.append(
+                    f"catalog row {row.name!r} names an object the DB does not "
+                    "contain (phantom declaration)"
+                )
+                continue
+            violations.extend(_keep_emptiness_violations(conn, row, objects))
+        return sorted(violations)
+    finally:
+        conn.close()
+
+
+def _keep_emptiness_violations(
+    conn: sqlite3.Connection, row: CatalogTable, objects: dict[str, str]
+) -> list[str]:
+    """Emptiness law for one KEEP row (empty list for other dispositions)."""
+    if row.disposition != "keep":
+        return []
+    if row.kind == "table":
+        if _is_empty(conn, row.name):
+            return [
+                f"KEEP table {row.name!r} is EMPTY — a declared-healthy object "
+                "went dark (III.11 silent degradation)"
+            ]
+        return []
+    return [
+        f"KEEP view {row.name!r} reads {base!r} which is EMPTY — the view "
+        "silently returns nothing (the view_surplus_value pathology, III.11)"
+        for base in row.reads
+        if base in objects and _is_empty(conn, base)
+    ]
+
+
+def check_subset_view_absence(
+    catalog: tuple[CatalogTable, ...] | None = None,
+    db_path: Path | None = None,
+) -> list[str]:
+    """Advisory: name the catalog views a view-less (subset) DB cannot check.
+
+    :param catalog: Rows to inspect (defaults to the real catalog).
+    :param db_path: Database to probe (defaults to the canonical/env path).
+    :returns: One advisory string when the DB carries no views (naming the
+        count of unchecked view rows); empty against a full DB.
+    """
+    rows = load_catalog_tables() if catalog is None else catalog
+    conn = _open_readonly(db_path if db_path is not None else _database_path())
+    try:
+        has_views = bool(
+            conn.execute("SELECT 1 FROM sqlite_master WHERE type='view' LIMIT 1").fetchone()
+        )
+    finally:
+        conn.close()
+    if has_views:
+        return []
+    view_count = sum(1 for row in rows if row.kind == "view")
+    if not view_count:
+        return []
+    return [
+        f"probed DB carries no views (ci-data subset environment) — "
+        f"{view_count} catalog view rows unchecked here; the full-DB probe "
+        "covers them locally"
+    ]
+
+
+#: Gating checks: a violation reds the refdata lane (exit 1).
+_GATING_CHECKS: tuple[LabelledCheck, ...] = (
+    ("catalog↔DB reconciliation / KEEP emptiness law", check_catalog_db_reconciliation),
+)
+
+#: Advisory: subset environments cannot check view rows (prints, never gates).
+_ADVISORY_CHECKS: tuple[LabelledCheck, ...] = (
+    ("view rows unchecked in subset DB", check_subset_view_absence),
+)
+
+
+def _summary(advisory_count: int) -> str:
+    """Build the clean one-line summary printed when no gating violation occurred.
+
+    :param advisory_count: Number of advisory findings printed above.
+    :returns: The summary line naming the reconciled row count.
+    """
+    summary = (
+        f"Data catalog (DB probe): clean — {len(load_catalog_tables())} catalog rows "
+        "reconciled against the reference DB (no undeclared objects, no phantom "
+        "rows, no dark KEEP objects)."
+    )
+    if advisory_count:
+        summary += f" ({advisory_count} advisory findings above.)"
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the catalog DB probe and return the process exit code.
+
+    :param argv: CLI args (``--check`` is accepted as the CI-mode alias; the
+        behavior is always to gate).
+    :returns: 0 clean, 1 gating violations, 2 infrastructure failure.
+    """
+    parser = argparse.ArgumentParser(
+        description="Data catalog — DB reconciliation probe (III.4 / III.11 gate)."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="CI-mode alias; the tool always gates (exit 1 on violations).",
+    )
+    parser.parse_args(argv)
+    return run_sensor("CATALOG", _GATING_CHECKS, _ADVISORY_CHECKS, _summary)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/engine/test_system_order.py
+++ b/tests/unit/engine/test_system_order.py
@@ -81,6 +81,7 @@ class TestMaterialistCausalityOrder:
             "field_derivative",  # 20. FieldDerivativeSystem (Feature 002)
             "CollapseTransition",  # 20.5. CollapseTransitionSystem (Spec 070 FR-023)
             "edge_transition",  # 21. EdgeTransitionSystem (Feature 002)
+            "Wealth Distribution",  # 21.5. WealthDistributionSystem (Program 21 Phase-1 shadow)
             "Epistemic Horizon",  # 22. EpistemicHorizonSystem (Epistemic Horizon Phase 1 shadow)
         ]
         actual_order = [s.name for s in _DEFAULT_SYSTEMS]
@@ -166,17 +167,18 @@ class TestMaterialistCausalityOrder:
             "ContradictionSystem must be registered"
         )
 
-    def test_all_twenty_eight_systems_present(self) -> None:
-        """All 28 systems must be registered.
+    def test_all_twenty_nine_systems_present(self) -> None:
+        """All 29 systems must be registered.
 
         13 core + 2 Volume I + 1 community + 1 lifecycle + 3 field topology
         + 1 OODA + 1 substrate (Spec 062 US7) + 3 Spec-070 systems
         (FactionInfluenceSystem at 14.5 + SovereigntySystem at 17.5 +
         CollapseTransitionSystem at 20.5) + 1 Spec-071 system
         (FascistFactionSystem at 17.4) + 1 DoctrineSystem at 14.7 (ADR073)
+        + 1 WealthDistributionSystem at 21.5 (Program 21 Phase-1 shadow, ADR075)
         + 1 Epistemic Horizon Phase 1 system (EpistemicHorizonSystem, last).
         """
-        assert len(_DEFAULT_SYSTEMS) == 28, f"Expected 28 systems, got {len(_DEFAULT_SYSTEMS)}"
+        assert len(_DEFAULT_SYSTEMS) == 29, f"Expected 29 systems, got {len(_DEFAULT_SYSTEMS)}"
 
     def test_epistemic_horizon_runs_last(self) -> None:
         """EpistemicHorizonSystem must be the LAST system in _DEFAULT_SYSTEMS.

--- a/tests/unit/engine/test_wealth_distribution_system.py
+++ b/tests/unit/engine/test_wealth_distribution_system.py
@@ -1,0 +1,218 @@
+"""WealthDistributionSystem — the runtime wealth-share axis (Program 21 Phase 1).
+
+Red-phase battery per the Data Constitution wealth-axis design brief
+(``reports/data-constitution-wealth-axis-brief.md``):
+
+- the formerly-orphaned ``formulas/class_dynamics`` ODE is WIRED (registered
+  system, classified in the spec-056 partition);
+- the axis exists and round-trips (``SocialClass.wealth_share`` is a declared
+  field — the ``extra="forbid"`` landmine — and the national vector rides
+  ``G.graph["wealth_distribution"]`` metadata);
+- seeding matches the calibration defines (``equilibrium_w1..w4``);
+- relaxation is mean-reverting and share-conserving (Σ == 1 every tick);
+- byte-safety: a WorldState without the axis writes NO new metadata key
+  (golden preservation, the EH ruling-6 pattern);
+- determinism: identical inputs ⇒ identical per-tick vectors.
+
+Phase 1 is an observe-only shadow: ``wealth_share`` feeds nothing back into
+wealth/consciousness/bifurcation (Phase 2 is owner-gated), so the sampled
+qa:regression checkpoints stay byte-identical.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from babylon.config.defines import GameDefines
+from babylon.engine.simulation_engine import _DEFAULT_SYSTEMS, CONSEQUENCE_SYSTEMS
+from babylon.engine.systems.wealth_distribution import (
+    WealthDistributionSystem,
+    bracket_of_role,
+)
+from babylon.models.enums import SocialRole
+from babylon.models.wealth_distribution import WealthDistribution
+
+pytestmark = pytest.mark.unit
+
+
+def _services() -> SimpleNamespace:
+    """Minimal service stub — the system reads only ``defines.class_dynamics``."""
+    return SimpleNamespace(defines=GameDefines())
+
+
+def _graph_with_classes():  # type: ignore[no-untyped-def]
+    """A small BabylonGraph carrying one node per wealth bracket."""
+    from babylon.topology.graph import BabylonGraph
+
+    g = BabylonGraph()
+    roles = {
+        "c1": SocialRole.CORE_BOURGEOISIE,
+        "c2": SocialRole.PETTY_BOURGEOISIE,
+        "c3": SocialRole.LABOR_ARISTOCRACY,
+        "c4": SocialRole.INTERNAL_PROLETARIAT,
+    }
+    for node_id, role in roles.items():
+        g.add_node(
+            node_id,
+            _node_type="social_class",
+            role=role.value,
+            class_consciousness=0.2,
+            population=1000,
+        )
+    return g
+
+
+class TestWiring:
+    """The orphan is wired: registered, classified, formula consumed."""
+
+    def test_system_is_registered(self) -> None:
+        assert any(isinstance(s, WealthDistributionSystem) for s in _DEFAULT_SYSTEMS)
+
+    def test_system_is_classified_as_consequence(self) -> None:
+        assert WealthDistributionSystem in CONSEQUENCE_SYSTEMS
+
+    def test_ode_formula_is_the_engine(self) -> None:
+        # Guards against re-orphaning: the system module must consume the
+        # class_dynamics ODE, not reimplement it.
+        import babylon.engine.systems.wealth_distribution as mod
+
+        assert hasattr(mod, "calculate_full_dynamics")
+
+
+class TestSeeding:
+    """First tick seeds the national vector from the calibration defines."""
+
+    def test_seed_matches_equilibrium_defines(self) -> None:
+        graph = _graph_with_classes()
+        services = _services()
+        WealthDistributionSystem().step(graph, services, {"tick": 0})
+        meta = graph.graph["wealth_distribution"]
+        cd = services.defines.class_dynamics
+        expected = (cd.equilibrium_w1, cd.equilibrium_w2, cd.equilibrium_w3, cd.equilibrium_w4)
+        total = sum(expected)
+        for got, raw in zip(meta["shares"], expected, strict=True):
+            assert got == pytest.approx(raw / total, abs=1e-12)
+        assert sum(meta["shares"]) == pytest.approx(1.0, abs=1e-9)
+        assert meta["velocities"] == [0.0, 0.0, 0.0, 0.0]
+
+    def test_nodes_get_bracket_projection(self) -> None:
+        graph = _graph_with_classes()
+        WealthDistributionSystem().step(graph, _services(), {"tick": 0})
+        shares = graph.graph["wealth_distribution"]["shares"]
+        node = graph.get_node("c1")
+        assert node is not None
+        assert node.attributes["wealth_share"] == pytest.approx(shares[0])
+        node4 = graph.get_node("c4")
+        assert node4 is not None
+        assert node4.attributes["wealth_share"] == pytest.approx(shares[3])
+
+
+class TestDynamics:
+    """Relaxation is mean-reverting and conserving (property laws)."""
+
+    def test_shares_sum_to_one_every_tick(self) -> None:
+        graph = _graph_with_classes()
+        services = _services()
+        system = WealthDistributionSystem()
+        for tick in range(20):
+            system.step(graph, services, {"tick": tick})
+            assert sum(graph.graph["wealth_distribution"]["shares"]) == pytest.approx(1.0, abs=1e-9)
+
+    def test_perturbation_mean_reverts(self) -> None:
+        from babylon.formulas.class_dynamics import calculate_equilibrium_deviation
+
+        graph = _graph_with_classes()
+        services = _services()
+        system = WealthDistributionSystem()
+        system.step(graph, services, {"tick": 0})
+        # Perturb off-equilibrium (shift 5 points from w3 to w1).
+        meta = graph.graph["wealth_distribution"]
+        shares = list(meta["shares"])
+        shares[0] += 0.05
+        shares[2] -= 0.05
+        graph.graph["wealth_distribution"] = {**meta, "shares": shares}
+        d0 = calculate_equilibrium_deviation(tuple(shares))
+        for tick in range(1, 60):
+            system.step(graph, services, {"tick": tick})
+        d_final = calculate_equilibrium_deviation(
+            tuple(graph.graph["wealth_distribution"]["shares"])
+        )
+        assert d_final < d0, "ODE relaxation must reduce equilibrium deviation"
+
+    def test_determinism_identical_runs(self) -> None:
+        def run() -> list[list[float]]:
+            graph = _graph_with_classes()
+            services = _services()
+            system = WealthDistributionSystem()
+            out = []
+            for tick in range(10):
+                system.step(graph, services, {"tick": tick})
+                out.append(list(graph.graph["wealth_distribution"]["shares"]))
+            return out
+
+        assert run() == run()
+
+
+class TestRoundTrip:
+    """The axis survives to_graph → from_graph (the extra='forbid' landmine)."""
+
+    def test_wealth_distribution_metadata_round_trips(self) -> None:
+        from babylon.models.world_state import WorldState
+
+        wd = WealthDistribution(
+            shares=(0.305, 0.382, 0.294, 0.019),
+            velocities=(0.0, 0.0, 0.0, 0.0),
+            tick=7,
+        )
+        state = WorldState(tick=1, wealth_distribution=wd)
+        recovered = WorldState.from_graph(state.to_graph(), tick=1)
+        assert recovered.wealth_distribution is not None
+        assert recovered.wealth_distribution.shares == pytest.approx(wd.shares)
+        assert recovered.wealth_distribution.tick == 7
+
+    def test_absent_axis_writes_no_metadata_key(self) -> None:
+        # Golden preservation (EH ruling-6 pattern): synthetic/headless graphs
+        # without the axis stay byte-identical.
+        from babylon.models.world_state import WorldState
+
+        graph = WorldState(tick=1).to_graph()
+        assert "wealth_distribution" not in graph.graph
+
+    def test_wealth_share_is_a_declared_field(self) -> None:
+        from babylon.models.entities.social_class import SocialClass
+
+        assert "wealth_share" in SocialClass.model_fields
+        entity = SocialClass(
+            id="C001", name="t", role=SocialRole.LABOR_ARISTOCRACY, wealth_share=0.25
+        )
+        assert entity.wealth_share == 0.25
+
+
+class TestBracketMapping:
+    """The PROVISIONAL 8-role → 4-bracket fold (owner ruling pending)."""
+
+    def test_all_roles_map(self) -> None:
+        for role in SocialRole:
+            assert bracket_of_role(role) in (0, 1, 2, 3)
+
+    def test_hinted_mapping(self) -> None:
+        assert bracket_of_role(SocialRole.CORE_BOURGEOISIE) == 0
+        assert bracket_of_role(SocialRole.PETTY_BOURGEOISIE) == 1
+        assert bracket_of_role(SocialRole.LABOR_ARISTOCRACY) == 2
+        assert bracket_of_role(SocialRole.INTERNAL_PROLETARIAT) == 3
+        assert bracket_of_role(SocialRole.LUMPENPROLETARIAT) == 3
+
+
+class TestModel:
+    """WealthDistribution is frozen and validates conservation."""
+
+    def test_frozen(self) -> None:
+        wd = WealthDistribution(shares=(0.25, 0.25, 0.25, 0.25), velocities=(0, 0, 0, 0), tick=0)
+        with pytest.raises(Exception):  # noqa: B017 — pydantic frozen error class varies
+            wd.tick = 1  # type: ignore[misc]
+
+    def test_shares_must_conserve(self) -> None:
+        with pytest.raises(ValueError, match="sum"):
+            WealthDistribution(shares=(0.9, 0.5, 0.1, 0.1), velocities=(0, 0, 0, 0), tick=0)

--- a/tests/unit/reference/test_catalog_db_probe.py
+++ b/tests/unit/reference/test_catalog_db_probe.py
@@ -1,0 +1,101 @@
+"""DB-probe tier of the data-catalog sentinel (Program 21, refdata lane).
+
+Reconciles ``data-catalog.yaml`` against the actual reference database:
+no undeclared objects, no phantom rows, no dark KEEP objects. The synthetic-row
+efficacy test pins the ``view_surplus_value`` pathology (a consumed view over
+an EMPTY base table, Constitution III.11) as a regression contract — the exact
+defect the 2026-07-16 census found shipping.
+
+Requires the reference DB (full local copy or the ci-data subset); the module
+is skipped wherever the DB is absent.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from babylon.sentinels.base import SentinelCheckError
+from babylon.sentinels.coverage.catalog import CatalogTable
+from babylon.sentinels.coverage.db_probe import (
+    _database_path,
+    check_catalog_db_reconciliation,
+    check_subset_view_absence,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.requires_reference_db,
+    pytest.mark.skipif(
+        not _database_path().is_file(),
+        reason="reference DB absent (fetch-reference-db not run / drive unmounted)",
+    ),
+]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class TestRealCatalogAgainstRealDb:
+    """The shipped catalog reconciles cleanly with the shipped DB."""
+
+    def test_reconciliation_clean(self) -> None:
+        assert check_catalog_db_reconciliation() == []
+
+    def test_subset_view_absence_is_advisory_shape(self) -> None:
+        findings = check_subset_view_absence()
+        # Full DB → no findings; subset DB → exactly one advisory naming the
+        # unchecked view-row count. Either way, never a hard failure.
+        assert len(findings) <= 1
+
+    def test_cli_catalog_check_exits_clean(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(_REPO_ROOT / "tools" / "sentinel_check.py"), "catalog", "--check"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, (
+            f"catalog sentinel red:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+        )
+
+
+class TestEfficacy:
+    """Injected defects red; broken infrastructure raises (exit-2 class)."""
+
+    def test_empty_keep_view_reds_the_surplus_value_pathology(self) -> None:
+        # Regression contract: a KEEP view over the (still-empty)
+        # fact_productivity_annual must red. The shipped catalog carries the
+        # honest disposition instead; this synthetic row proves the guard
+        # would have caught the pathology the census found.
+        synthetic = CatalogTable(
+            name="view_surplus_value",
+            kind="view",
+            source="derived",
+            reads=("fact_productivity_annual",),
+            disposition="keep",
+            subset_policy="skip",
+            material_relation="s/v rate of exploitation by industry",
+        )
+        violations = check_catalog_db_reconciliation(catalog=(synthetic,))
+        assert any("view_surplus_value" in v and "EMPTY" in v for v in violations), (
+            f"expected the empty-base-table violation, got: {violations[:5]}"
+        )
+
+    def test_phantom_row_reds(self) -> None:
+        phantom = CatalogTable(
+            name="fact_absolutely_not_a_table",
+            kind="table",
+            source="internal",
+            disposition="investigate",
+            subset_policy="skip",
+            material_relation="efficacy probe",
+        )
+        violations = check_catalog_db_reconciliation(catalog=(phantom,))
+        assert any("phantom" in v for v in violations)
+
+    def test_missing_db_is_loud(self, tmp_path: Path) -> None:
+        with pytest.raises(SentinelCheckError):
+            check_catalog_db_reconciliation(db_path=tmp_path / "nope.sqlite")

--- a/tests/unit/sentinels/test_catalog.py
+++ b/tests/unit/sentinels/test_catalog.py
@@ -1,0 +1,180 @@
+"""Tests for the data-catalog registry sentinel (Program 21, Data Constitution).
+
+Two tiers, per the sentinel contract:
+
+- **Invariant** — the real ``data-catalog.yaml`` ``tables:`` block loads into
+  frozen :class:`CatalogTable` rows, every declared consumer/test path exists,
+  and every base table's ``subset_policy`` matches the
+  ``tools/make_reference_subset.py`` ``TABLE`` policy dict (two SoTs, one truth).
+- **Efficacy** — the sensor REDS on injected defects (phantom consumer path,
+  subset-policy mismatch) and raises :class:`SentinelCheckError` loudly on a
+  missing/unparseable catalog (infrastructure failure, never a false pass).
+
+This module is **purely static** (fast-gate tier): it never opens the reference
+DB. The DB-probe tier (undeclared tables, empty-under-consumed-view) lives in
+``tests/integration/reference/test_catalog_db.py`` behind
+``requires_reference_db``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from babylon.sentinels.base import SentinelCheckError
+from babylon.sentinels.coverage.catalog import (
+    CatalogTable,
+    load_catalog_tables,
+    subset_policy_map,
+)
+from babylon.sentinels.coverage.checks import (
+    check_catalog_paths_exist,
+    check_subset_policy_parity,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _row(**overrides: object) -> CatalogTable:
+    """Build a valid baseline row, then apply per-test overrides."""
+    base: dict[str, object] = {
+        "name": "fact_example",
+        "kind": "table",
+        "source": "QCEW",
+        "disposition": "keep",
+        "subset_policy": "full",
+        "material_relation": "example relation",
+    }
+    base.update(overrides)
+    return CatalogTable(**base)  # type: ignore[arg-type]
+
+
+class TestCatalogTableModel:
+    """Loud-at-construction shape validation (Constitution III.11)."""
+
+    def test_valid_row_constructs_frozen(self) -> None:
+        row = _row()
+        assert row.name == "fact_example"
+        with pytest.raises(ValidationError):
+            row.name = "mutated"  # type: ignore[misc]
+
+    def test_blank_name_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="name"):
+            _row(name="   ")
+
+    def test_blank_material_relation_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="material_relation"):
+            _row(material_relation="")
+
+    def test_view_requires_reads(self) -> None:
+        with pytest.raises(ValidationError, match="reads"):
+            _row(name="view_example", kind="view", reads=())
+
+    def test_table_must_not_declare_reads(self) -> None:
+        with pytest.raises(ValidationError, match="reads"):
+            _row(reads=("fact_other",))
+
+    def test_view_subset_policy_must_be_skip(self) -> None:
+        # Views are never copied into ci-data subsets (the generator copies
+        # type='table' only) — any other policy claim is a lie.
+        with pytest.raises(ValidationError, match="skip"):
+            _row(
+                name="view_example",
+                kind="view",
+                reads=("fact_example",),
+                subset_policy="full",
+            )
+
+    def test_non_py_consumer_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="consumers"):
+            _row(consumers=("src/babylon/notes.txt",))
+
+    def test_extra_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CatalogTable(  # type: ignore[call-arg]
+                name="fact_example",
+                kind="table",
+                source="QCEW",
+                disposition="keep",
+                subset_policy="full",
+                material_relation="x",
+                bogus_field=1,
+            )
+
+
+class TestRealCatalogInvariants:
+    """The shipped data-catalog.yaml satisfies its own contract."""
+
+    def test_catalog_loads_and_is_populated(self) -> None:
+        rows = load_catalog_tables()
+        assert len(rows) >= 99, "expected the full census backfill (99 tables + views)"
+        names = {r.name for r in rows}
+        assert "fact_qcew_annual" in names
+        assert "view_surplus_value" in names
+
+    def test_real_catalog_paths_coherent(self) -> None:
+        assert check_catalog_paths_exist() == []
+
+    def test_real_subset_policy_parity(self) -> None:
+        assert check_subset_policy_parity() == []
+
+    def test_no_duplicate_names(self) -> None:
+        rows = load_catalog_tables()
+        names = [r.name for r in rows]
+        assert len(names) == len(set(names))
+
+
+class TestEfficacy:
+    """Injected defects red; broken infrastructure raises (exit-2 class)."""
+
+    def test_phantom_consumer_path_reds(self) -> None:
+        bad = _row(consumers=("src/babylon/does_not_exist_anywhere.py",))
+        violations = check_catalog_paths_exist(catalog=(bad,))
+        assert len(violations) == 1
+        assert "does_not_exist_anywhere" in violations[0]
+
+    def test_phantom_test_path_reds(self) -> None:
+        bad = _row(tests=("tests/unit/reference/no_such_test_file.py",))
+        violations = check_catalog_paths_exist(catalog=(bad,))
+        assert len(violations) == 1
+
+    def test_subset_policy_mismatch_reds(self) -> None:
+        # fact_qcew_annual is 'michigan' in the generator's TABLE dict; a
+        # catalog row claiming 'skip' is drift between the two SoTs.
+        bad = _row(name="fact_qcew_annual", subset_policy="skip")
+        violations = check_subset_policy_parity(catalog=(bad,))
+        assert len(violations) == 1
+        assert "fact_qcew_annual" in violations[0]
+
+    def test_unknown_table_in_catalog_reds_parity(self) -> None:
+        bad = _row(name="fact_never_heard_of_it")
+        violations = check_subset_policy_parity(catalog=(bad,))
+        assert len(violations) == 1
+
+    def test_missing_catalog_file_is_loud(self, tmp_path: Path) -> None:
+        with pytest.raises(SentinelCheckError):
+            load_catalog_tables(path=tmp_path / "no-such-catalog.yaml")
+
+    def test_unparseable_catalog_is_loud(self, tmp_path: Path) -> None:
+        bad = tmp_path / "broken.yaml"
+        bad.write_text("tables: [unclosed", encoding="utf-8")
+        with pytest.raises(SentinelCheckError):
+            load_catalog_tables(path=bad)
+
+    def test_catalog_without_tables_block_is_loud(self, tmp_path: Path) -> None:
+        legacy = tmp_path / "legacy.yaml"
+        legacy.write_text("version: '2.6.3'\ncategories: []\n", encoding="utf-8")
+        with pytest.raises(SentinelCheckError, match="tables"):
+            load_catalog_tables(path=legacy)
+
+
+class TestSubsetPolicyMap:
+    """The AST parse of the generator's TABLE dict yields the real policies."""
+
+    def test_known_scopes(self) -> None:
+        policies = subset_policy_map()
+        assert policies["dim_asset_category"] == "full"
+        assert policies["fact_qcew_annual"] == "michigan"
+        assert len(policies) >= 90

--- a/tools/sentinel_check.py
+++ b/tools/sentinel_check.py
@@ -23,6 +23,17 @@ from babylon.sentinels.seam.checks import main as seam_main
 from babylon.sentinels.synthetic.checks import main as synthetic_main
 
 
+def _catalog_main(argv: list[str] | None) -> int:
+    """Route to the catalog DB probe (Program 21) — lazy import.
+
+    The probe opens sqlite3 against the reference DB, which the fast-gate must
+    never do, so its module loads only when selected (refdata lane).
+    """
+    from babylon.sentinels.coverage.db_probe import main as catalog_main
+
+    return catalog_main(argv)
+
+
 def _partition_main(argv: list[str] | None) -> int:
     """Route to the partition probe (Program 19, ADR070) — lazy import.
 
@@ -41,6 +52,7 @@ _SENSORS: dict[str, Callable[[list[str] | None], int]] = {
     "coverage": coverage_main,
     "partition": _partition_main,
     "synthetic": synthetic_main,
+    "catalog": _catalog_main,
 }
 
 


### PR DESCRIPTION
## Summary

The ultracode follow-on to ADR074: the data layer gets the same lineage discipline the test estate got. Census → triage → enforcing registry → the wealth-share axis. Decision record: `ai/decisions/ADR075_data_constitution.yaml`; evidence: three `reports/data-constitution-*.md` deliverables from a 56-agent census workflow (41 orphan claims adversarially re-verified, 11 overturned).

**What lands**
- **Enforcing per-table registry**: `data-catalog.yaml` v2.7.0 `tables:` block (107 rows) + two sentinel tiers — static path/parity checks in the fast-gate coverage sensor, and the new `catalog` DB-probe sensor in the refdata lanes (catalog↔DB bijection + KEEP-emptiness law). The `view_surplus_value`-over-empty-table pathology is pinned as a permanent regression contract.
- **Wealth-share axis, Phase-1 shadow**: `WealthDistributionSystem` @21.5 wires the formerly-orphaned `formulas/class_dynamics` ODE — national 4-bracket vector on graph metadata, `wealth_share` declared field on `SocialClass`, new `ticks_per_quarter` define. Observe-only: **qa:regression 5/5 with zero baseline movement, verified.** System count contract 28 → 29.
- **Triage dispositions** declared in the catalog: KEEP 47 / FILL 8 / ARTIFACT_IZE 6 / INVESTIGATE 15 / **AMPUTATE 23 — proposals only**.

**Owner rulings requested (nothing destructive executed)**
1. The 23 AMPUTATE schema-drop proposals (per-table evidence in the triage matrix).
2. The 8-role → 4-bracket wealth fold (PROVISIONAL Fed-DFA mapping; `equilibrium_w3` "proletariat" label vs p50-90 = labor-aristocracy naming collision).
3. Phase-2 feedback (wealth axis → consciousness/bifurcation) — moves all baselines.
4. Wealth altitude: national vector (shipped) vs per-county.

**Gates**: `mise run check` exit 0 (10,399 unit in 52s), qa:regression 5/5, all sentinels clean (seam / coverage / synthetic / catalog-DB-probe against the full 6.1GB DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)