### PR TITLE
docs: hypergraph-rs design spec + Phase 0+1 plan; subrepo mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,5 +174,11 @@ deploy/ansible/.ansible/
 # program-20: local infra subrepo mount (becomes a submodule when it gets a remote)
 /infra/
 
+# hypergraph-rs: local subrepo mount (standalone Rust XGI port, own git repo —
+# same pattern as infra/; becomes a submodule/remote repo when published.
+# Owner ruling 2026-07-18: isolated dev environment, Babylon imports the built
+# extension. Spec: docs/superpowers/specs/2026-07-18-hypergraph-rs-design.md)
+/hypergraph-rs/
+
 # ADR076 release-tier data artifacts (parquet; shipped via ci-data releases)
 /dist/

--- a/docs/superpowers/plans/2026-07-18-hypergraph-rs-phase-0-1.md
+++ b/docs/superpowers/plans/2026-07-18-hypergraph-rs-phase-0-1.md
@@ -4,19 +4,19 @@
 
 **Goal:** Bootstrap the `hypergraph-rs` Cargo workspace with 4 crates and implement the core `Hypergraph<N, E, M>` data structure (bipartite `StableDiGraph`) with full node/edge CRUD, membership queries, attribute access, and insertion-ordered iteration — the foundation that Phase 2 (DiHypergraph, views, conformance testing) builds on.
 
-**Architecture:** The hypergraph IS a `rustworkx_core::petgraph::stable_graph::StableDiGraph` with two node kinds (`Agent` and `Hyperedge`) connected by `MembershipEdge` edges. This bipartite representation makes it a genuine rustworkx-core plugin. `IndexMap` bimaps provide O(1) id-based lookup while preserving insertion order (III.7 determinism parity). **Spec correction:** §3.5 of the design spec says `petgraph::graph::DiGraph` "removes nodes by leaving a hole" — that's actually `StableGraph` behavior. `Graph::remove_node` swaps the last node into the freed slot (compaction), which breaks insertion order under churn. We use `StableDiGraph` which leaves holes and preserves insertion order — matching the spec's INTENT if not its type name.
+**Architecture:** The hypergraph IS a `rustworkx_core::petgraph::stable_graph::StableDiGraph` with two node kinds (`Agent` and `Hyperedge`) connected by `MembershipEdge` edges. This bipartite representation makes it a genuine rustworkx-core plugin. `IndexMap` bimaps provide O(1) id-based lookup while preserving insertion order (III.7 determinism parity). **Spec alignment:** the spec originally named `petgraph::graph::DiGraph` while describing `StableGraph` hole-leaving behavior (`Graph::remove_node` swap-compacts, which breaks insertion order under churn); the spec was corrected in the same PR that landed this plan — both documents now specify `StableDiGraph`.
 
-**Tech Stack:** Rust 1.79+ (matches rustworkx-core MSRV), `rustworkx-core` 0.18 (re-exports `petgraph`), `indexmap` 2, `serde` + `serde_json`, `thiserror`. BSD-3-Clause license.
+**Tech Stack:** Rust 1.85+ (rustworkx-core 0.18's declared MSRV — verified from crates.io metadata 2026-07-18; local toolchain 1.91.1), `rustworkx-core` 0.18 (re-exports `petgraph` 0.8 — there is NO direct petgraph dependency; `rustworkx_core::petgraph` is the only petgraph path, a direct `petgraph = "0.6"` pin was empirically shown to pull a second type-incompatible copy), `indexmap` 2, `serde` + `serde_json`, `thiserror` 2. BSD-3-Clause license.
 
 ## Global Constraints
 
-- **Rust edition 2021**, MSRV 1.79 (matches `rustworkx-core`)
+- **Rust edition 2021**, MSRV 1.85 (rustworkx-core 0.18 declares `rust-version = "1.85"`; an edition-2021 crate can depend on its edition-2024 code)
 - **License:** BSD-3-Clause (every crate manifest declares it)
 - **Workspace location:** `/hypergraph-rs/` at the babylon repo root (external dep; NOT inside `src/`)
 - **Determinism (III.7 parity):** All iteration is insertion-ordered. `StableDiGraph` preserves insertion order for nodes and edges even under removal (leaves holes, doesn't compact). `IndexMap` bimaps enforce id-lookup order independently. No `HashMap` anywhere in the public iteration path.
 - **No `unsafe` code** in the core crate.
 - **TDD discipline:** Every task follows red → green → commit. Write the failing test first, verify it fails, implement minimal code to pass, verify it passes, commit.
-- **Commit convention:** Conventional commits (`type(scope): desc`). End with `Co-Authored-By: opencode <opencode@local>` trailer.
+- **Commit convention:** Conventional commits (`type(scope): desc`). End with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer.
 - **Generic type defaults:** `N = serde_json::Value, E = serde_json::Value, M = serde_json::Value` — XGI-style dynamic attrs by default.
 - **XGI API fidelity** (confirmed from `.venv/lib/python3.13/site-packages/xgi/core/hypergraph.py`):
   - `add_edge` auto-creates member nodes that don't exist (hypergraph.py:620-623)
@@ -24,8 +24,15 @@
   - `add_edge` with duplicate `idx` warns and returns (no-op) (hypergraph.py:613-615)
   - `add_edge` deduplicates members via `set(members)` (hypergraph.py:611)
   - `remove_node` has weak (default) and strong modes (hypergraph.py:435-478)
-  - `H.nodes.memberships(n)` returns a `set` of edge IDs (views.py:629)
-  - `H.edges.members(e)` returns a `set` of node IDs (views.py:706+)
+  - `H.nodes.memberships(n)` returns a `set` of edge IDs (views.py:604-630); missing ids raise `IDNotFound` (a `KeyError` subclass, NOT an `XGIError` subclass)
+  - `H.edges.members(e)` returns a `set` of node IDs when `e` is given (views.py:706-747; the no-arg form returns a list/dict of sets)
+- **Deliberate deviations from XGI** (each verified against the installed 0.10.2 source in the 2026-07-18 preflight; the Phase 7 Python binding shims where noted):
+  - Duplicate `idx` on `add_edge`: XGI warns and silently no-ops (hypergraph.py:613-615); we return `Err(EdgeError::AlreadyExists)`. Binding shims to warn+no-op for conformance.
+  - Empty members on `add_edge`: XGI's docstring claims `XGIError` but the code has NO check — it silently creates an empty edge (verified empirically); we return `Err(EdgeError::EmptyMembers)` — deliberate strictness.
+  - Member iteration order: XGI stores members in plain hash-ordered `set`s — order varies with `PYTHONHASHSEED` (verified empirically); our substrate is insertion-ordered. A determinism IMPROVEMENT, not parity. Conformance tests must compare memberships as sets, never as ordered lists.
+  - XGI's `update_uid_counter` call is guarded by `if idx:` (hypergraph.py:630) — a falsy explicit id (`0`, `""`) skips the counter update, so the next auto-id `add_edge` collides and silently loses the edge. We implement the correct semantics (any numeric id updates the counter, including `"0"`), fixing the upstream bug.
+  - `clear()` / `clear_edges()`: XGI does NOT reset the edge-uid counter (hypergraph.py:1231-1255 never touch `_edge_uid`) — neither do we.
+  - `copy()` of a frozen hypergraph returns an UNFROZEN copy in XGI (`copy()` builds a fresh instance; freeze monkeypatches only the original) — we match that.
 
 ---
 
@@ -40,13 +47,19 @@ hypergraph-rs/                                    # workspace root (repo top-lev
 ├── crates/
 │   ├── hypergraph-rs/                            # core library (this plan's focus)
 │   │   ├── Cargo.toml
-│   │   └── src/
-│   │       ├── lib.rs                            # crate root, re-exports
-│   │       └── core/
-│   │           ├── mod.rs
-│   │           ├── hypergraph.rs                 # Hypergraph<N,E,M> struct + impl
-│   │           ├── kinds.rs                      # NodeKind<N,E>, MembershipEdge<M>
-│   │           └── error.rs                      # NodeError, EdgeError
+│   │   ├── src/
+│   │   │   ├── lib.rs                            # crate root, re-exports
+│   │   │   └── core/
+│   │   │       ├── mod.rs
+│   │   │       ├── hypergraph.rs                 # Hypergraph<N,E,M> struct + impl
+│   │   │       ├── kinds.rs                      # NodeKind<N,E>, MembershipEdge<M>
+│   │   │       └── error.rs                      # NodeError, EdgeError
+│   │   └── tests/
+│   │       └── test_hypergraph.rs                # integration tests (TDD) — MUST be a
+│   │                                             #   direct child of the CRATE's tests/
+│   │                                             #   (cargo discovers targets only there;
+│   │                                             #   a workspace-root tests/ belongs to no
+│   │                                             #   package and is never compiled)
 │   ├── hypergraph-rs-python/                     # PyO3 bindings (stub in Phase 0)
 │   │   ├── Cargo.toml
 │   │   └── src/lib.rs
@@ -56,9 +69,8 @@ hypergraph-rs/                                    # workspace root (repo top-lev
 │   └── hypergraph-rs-cli/                        # CLI binary (stub in Phase 0)
 │       ├── Cargo.toml
 │       └── src/main.rs
-└── tests/
-    └── core/
-        └── test_hypergraph.rs                    # core unit tests (TDD)
+└── (workspace-root tests/ arrives in Phase 7 — Python conftest.py + ported/
+     XGI pytest files; it is NOT a cargo test location)
 ```
 
 **Responsibility split:**
@@ -120,8 +132,13 @@ Write to `hypergraph-rs/.gitignore`:
 ```
 /target
 **/*.rs.bk
-Cargo.lock
 ```
+
+Note: `Cargo.lock` is deliberately **committed** (not ignored) — the workspace
+contains a binary crate (`hypergraph-rs-cli`) and cdylibs, and committing the
+lockfile pins the exact `rustworkx-core`/`petgraph`/`indexmap` resolution
+(reproducible builds; the III.7 determinism culture applies to the toolchain
+too).
 
 - [ ] **Step 3: Create the README.md**
 
@@ -148,7 +165,7 @@ cd hypergraph-rs
 git add LICENSE README.md .gitignore
 git commit -m "docs(hypergraph-rs): bootstrap workspace root with LICENSE, README, .gitignore
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -187,18 +204,21 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.85"
 license = "BSD-3-Clause"
 authors = ["Babylon Project"]
 repository = "https://github.com/percy-raskova/babylon"
 
 [workspace.dependencies]
+# NO direct petgraph dependency: rustworkx-core 0.18 re-exports petgraph 0.8;
+# all petgraph types are reached via rustworkx_core::petgraph. A direct pin
+# (the spec's original petgraph = "0.6") resolves to a SECOND type-incompatible
+# petgraph copy (verified empirically via cargo tree, 2026-07-18 preflight).
 rustworkx-core = "0.18"
-petgraph = "0.6"
 indexmap = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "1"
+thiserror = "2"
 rand = "0.8"
 rand_pcg = "0.3"
 rayon = "1"
@@ -221,7 +241,6 @@ description = "A Rust port of XGI — hypergraph library built on rustworkx-core
 
 [dependencies]
 rustworkx-core.workspace = true
-petgraph.workspace = true
 indexmap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -414,8 +433,14 @@ crate-type = ["cdylib"]
 
 [dependencies]
 hypergraph-rs = { path = "../hypergraph-rs" }
-pyo3 = { version = "0.22", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }
 ```
+
+Note: pyo3 0.29 is the current release line (0.22 was stale at plan time).
+pyo3's build script needs a Python interpreter at build time
+(`pyo3-build-config` resolves the ABI from `python3` on PATH or
+`PYO3_PYTHON`) — present on this box, an explicit prerequisite for any
+clean CI runner.
 
 Write to `hypergraph-rs/crates/hypergraph-rs-python/src/lib.rs`:
 
@@ -425,7 +450,7 @@ Write to `hypergraph-rs/crates/hypergraph-rs-python/src/lib.rs`:
 use pyo3::prelude::*;
 
 #[pymodule]
-fn _hypergraph_rs_core(_py: Python, _m: &Bound<PyModule>) -> PyResult<()> {
+fn _hypergraph_rs_core(_m: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }
 ```
@@ -456,13 +481,17 @@ Write to `hypergraph-rs/crates/hypergraph-rs-wasm/src/lib.rs`:
 ```rust
 //! WASM bindings for hypergraph-rs (stub — Phase 8 implements the full surface).
 
+use wasm_bindgen::prelude::*;
+
 #[wasm_bindgen]
 pub fn _init() {
     // Stub — Phase 8 will implement the full WASM surface.
 }
 ```
 
-Note: add `use wasm_bindgen::prelude::*;` at the top if the compiler requires it.
+The `use wasm_bindgen::prelude::*;` import is MANDATORY — without it
+`#[wasm_bindgen]` is an unresolved attribute and the whole-workspace
+`cargo build` in Step 6 fails.
 
 Write to `hypergraph-rs/crates/hypergraph-rs-cli/Cargo.toml`:
 
@@ -520,7 +549,7 @@ Core crate: Hypergraph<N,E,M> struct with StableDiGraph bipartite substrate
 + IndexMap bimaps. NodeKind<N,E> and MembershipEdge<M> types. Error types
 for NodeError and EdgeError.
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -530,7 +559,7 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 3: Test and implement `add_node` + `has_node`
 
 **Files:**
-- Create: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Create: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 **Interfaces:**
@@ -538,7 +567,7 @@ Co-Authored-By: opencode <opencode@local>"
 
 - [ ] **Step 1: Write the failing test**
 
-Write to `hypergraph-rs/tests/core/test_hypergraph.rs`:
+Write to `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 use hypergraph_rs::Hypergraph;
@@ -617,7 +646,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement add_node + has_node
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -625,7 +654,7 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 4: Test and implement `add_edge` with auto-node-creation and auto-id
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 **Interfaces:**
@@ -633,7 +662,7 @@ Co-Authored-By: opencode <opencode@local>"
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 use hypergraph_rs::EdgeError;
@@ -778,7 +807,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement add_edge with auto-node-creation and auto-id
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -786,12 +815,12 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 5: Test and implement `has_edge`
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 #[test]
@@ -846,7 +875,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement has_edge
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -854,7 +883,7 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 6: Test and implement `memberships` + `members` queries
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 **Interfaces:**
@@ -862,7 +891,7 @@ Co-Authored-By: opencode <opencode@local>"
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 #[test]
@@ -966,7 +995,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement memberships + members queries
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -974,12 +1003,12 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 7: Test and implement insertion-ordered `node_ids` + `edge_ids`
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 #[test]
@@ -1042,7 +1071,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement insertion-ordered node_ids + edge_ids
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -1050,7 +1079,7 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 8: Test and implement `remove_node` (weak + strong modes)
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 **Interfaces:**
@@ -1058,7 +1087,7 @@ Co-Authored-By: opencode <opencode@local>"
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 use hypergraph_rs::NodeError;
@@ -1177,7 +1206,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement remove_node with weak + strong modes
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -1185,12 +1214,12 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 9: Test and implement `remove_edge`
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 #[test]
@@ -1268,7 +1297,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement remove_edge
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -1276,7 +1305,7 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 10: Test and implement attribute access (`node_attrs`, `edge_attrs`, mut variants)
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 **Interfaces:**
@@ -1284,7 +1313,7 @@ Co-Authored-By: opencode <opencode@local>"
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 #[test]
@@ -1398,7 +1427,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement node/edge attribute accessors
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -1406,12 +1435,12 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 11: Test and implement graph-level attributes + `clear`
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 #[test]
@@ -1473,11 +1502,14 @@ Add inside the impl block:
     }
 
     /// Remove all nodes and edges. XGI parity: `H.clear()`.
+    ///
+    /// The edge-uid counter is deliberately NOT reset — XGI's `clear()`
+    /// never touches `_edge_uid` (verified 0.10.2: auto-ids continue the
+    /// pre-clear sequence).
     pub fn clear(&mut self) {
         self.inner = StableDiGraph::new();
         self.agent_ids.clear();
         self.hyperedge_ids.clear();
-        self.edge_uid_counter = 0;
         self.graph_attrs.clear();
     }
 ```
@@ -1494,7 +1526,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement graph-level attrs + clear
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -1502,12 +1534,12 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 12: Test and implement `copy` (deep clone)
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 #[test]
@@ -1576,7 +1608,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement copy (deep clone)
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -1584,12 +1616,12 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 13: Test and implement bulk operations
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 #[test]
@@ -1672,7 +1704,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement add_nodes_from + add_edges_from
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -1680,12 +1712,12 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 14: Test and implement `PartialEq` (structural equality)
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 #[test]
@@ -1694,7 +1726,7 @@ fn test_eq_same_structure() {
     h1.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::json!({"w": 1})).unwrap();
     let mut h2: Hypergraph = Hypergraph::new();
     h2.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::json!({"w": 1})).unwrap();
-    assert_eq!(h1, h2);
+    assert!(h1 == h2);
 }
 
 #[test]
@@ -1703,7 +1735,7 @@ fn test_eq_different_edge_attrs() {
     h1.add_edge(vec!["a".to_string()], Some("e1".to_string()), serde_json::json!({"w": 1})).unwrap();
     let mut h2: Hypergraph = Hypergraph::new();
     h2.add_edge(vec!["a".to_string()], Some("e1".to_string()), serde_json::json!({"w": 2})).unwrap();
-    assert_ne!(h1, h2);
+    assert!(h1 != h2);
 }
 
 #[test]
@@ -1712,16 +1744,21 @@ fn test_eq_different_members() {
     h1.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
     let mut h2: Hypergraph = Hypergraph::new();
     h2.add_edge(vec!["a".to_string(), "c".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
-    assert_ne!(h1, h2);
+    assert!(h1 != h2);
 }
 
 #[test]
 fn test_eq_both_empty() {
     let h1: Hypergraph = Hypergraph::new();
     let h2: Hypergraph = Hypergraph::new();
-    assert_eq!(h1, h2);
+    assert!(h1 == h2);
 }
 ```
+
+Note: these tests use `assert!(h1 == h2)` / `assert!(h1 != h2)` rather than
+`assert_eq!`/`assert_ne!` — those macros require `Debug` on the operands
+(their failure branch formats with `{:?}`, type-checked even on pass), and
+`Hypergraph`'s `Debug` impl doesn't exist until Task 18.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -1772,7 +1809,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement PartialEq (structural equality)
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -1780,17 +1817,17 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 15: Test and implement `add_node_to_edge` + `remove_node_from_edge`
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 **Interfaces:**
 - Produces: `add_node_to_edge(&mut self, edge_id: &str, node_id: &str) -> Result<(), EdgeError>` where `N: Default` — adds a node to an existing edge; auto-creates both if missing. `remove_node_from_edge(&mut self, edge_id: &str, node_id: &str, remove_empty: bool) -> Result<(), NodeError>` — removes a node from an edge; optionally removes the edge if it becomes empty.
 
-**XGI source reference** (hypergraph.py:~860-890, ~920-950): `add_node_to_edge` auto-creates edge and node if either doesn't exist. `remove_node_from_edge` raises XGIError if edge/node missing or node not in edge; removes empty edge by default.
+**XGI source reference** (verified 2026-07-18: `add_node_to_edge` at hypergraph.py:1080-1117, `remove_node_from_edge` at hypergraph.py:1166-1208): `add_node_to_edge` auto-creates edge and node if either doesn't exist. `remove_node_from_edge` raises XGIError if edge/node missing or node not in edge; removes empty edge only when `remove_empty=True` (the default).
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 #[test]
@@ -1816,7 +1853,7 @@ fn test_add_node_to_edge_auto_creates_edge_and_node() {
 
 #[test]
 fn test_remove_node_from_edge_basic() {
-    let mut h: Hypergraph = Hypergraph = Hypergraph::new();
+    let mut h: Hypergraph = Hypergraph::new();
     h.add_edge(vec!["a".to_string(), "b".to_string(), "c".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
     h.remove_node_from_edge("e1", "b", true).unwrap();
     let members = h.members("e1").unwrap();
@@ -1878,6 +1915,7 @@ Add inside the impl block:
     pub fn add_node_to_edge(&mut self, edge_id: &str, node_id: &str) -> Result<(), EdgeError>
     where
         N: Default,
+        E: Default,
         M: Default + Clone,
     {
         // Auto-create edge if missing
@@ -1954,16 +1992,6 @@ Add inside the impl block:
     }
 ```
 
-Note: `add_node_to_edge` requires `E: Default` as well (to auto-create the edge with default attrs). Add that bound:
-
-```rust
-    pub fn add_node_to_edge(&mut self, edge_id: &str, node_id: &str) -> Result<(), EdgeError>
-    where
-        N: Default,
-        E: Default,
-        M: Default + Clone,
-```
-
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
@@ -1976,7 +2004,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement add_node_to_edge + remove_node_from_edge
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -1984,7 +2012,7 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 16: Test and implement `set_node_attributes` + `set_edge_attributes`
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 **Interfaces:**
@@ -1992,11 +2020,9 @@ Co-Authored-By: opencode <opencode@local>"
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
-use std::collections::BTreeMap;
-
 #[test]
 fn test_set_node_attributes_from_pairs() {
     let mut h: Hypergraph = Hypergraph::new();
@@ -2062,9 +2088,14 @@ Expected: FAIL — `set_node_attributes` and `set_edge_attributes` don't exist.
 
 - [ ] **Step 3: Implement both methods**
 
-Add inside the impl block:
+Add a SEPARATE concrete-typed impl block AFTER the generic `impl<N, E, M>`
+block (NOT inside it): these methods call `as_object_mut()`, an inherent
+method of `serde_json::Value` that does not exist on bare type parameters
+`N`/`E` — placing them in the generic block is a hard compile error
+(`no method named as_object_mut found for type parameter N`).
 
 ```rust
+impl<M> Hypergraph<serde_json::Value, serde_json::Value, M> {
     /// Set node attributes from (id, attr_map) pairs.
     /// XGI parity: `H.set_node_attributes(values, name=None)`.
     /// Silently skips missing node IDs (XGI warns).
@@ -2101,9 +2132,14 @@ Add inside the impl block:
             }
         }
     }
+}
 ```
 
-Note: This implementation assumes `N`/`E` are `serde_json::Value` (the default). For generic `N`/`E`, these methods would need different signatures. Since the defaults are `serde_json::Value`, this covers XGI parity. Babylon can later specialize with typed setters.
+Note: these methods live in a concrete `impl<M> Hypergraph<serde_json::Value,
+serde_json::Value, M>` block because `as_object_mut` is inherent to
+`serde_json::Value`. The default-typed test Hypergraph (`N=E=M=Value`) picks
+them up from this specialized impl; Babylon can later add typed setters for
+specialized `N`/`E`.
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -2117,7 +2153,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement set_node_attributes + set_edge_attributes
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -2125,7 +2161,7 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 17: Test and implement `clear_edges` + `freeze` / `is_frozen`
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 **Interfaces:**
@@ -2133,7 +2169,7 @@ Co-Authored-By: opencode <opencode@local>"
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 #[test]
@@ -2205,19 +2241,14 @@ Update `new()`:
     }
 ```
 
-Update `clear()` to also reset `frozen`:
-```rust
-    pub fn clear(&mut self) {
-        self.inner = StableDiGraph::new();
-        self.agent_ids.clear();
-        self.hyperedge_ids.clear();
-        self.edge_uid_counter = 0;
-        self.graph_attrs.clear();
-        self.frozen = false;  // NEW
-    }
-```
+`clear()` needs NO frozen change: XGI freezes `clear` too (hypergraph.py:1550
+puts `clear` in the frozen-method list, so a frozen hypergraph's `clear()`
+raises `XGIError`) — with the frozen guard added below, a `self.frozen = false`
+inside `clear()` would be unreachable dead state-change.
 
-Update `copy()` to copy `frozen`:
+Update `copy()` to initialize `frozen` (XGI parity: `copy()` of a frozen
+hypergraph returns an UNFROZEN copy — XGI's `copy()` constructs a fresh
+instance and `freeze()` monkeypatches only the original, verified 0.10.2):
 ```rust
     pub fn copy(&self) -> Self where N: Clone, E: Clone, M: Clone {
         Self {
@@ -2226,7 +2257,7 @@ Update `copy()` to copy `frozen`:
             hyperedge_ids: self.hyperedge_ids.clone(),
             edge_uid_counter: self.edge_uid_counter,
             graph_attrs: self.graph_attrs.clone(),
-            frozen: self.frozen,  // NEW
+            frozen: false,  // NEW — XGI parity: copies are always unfrozen
         }
     }
 ```
@@ -2235,15 +2266,15 @@ Add the new methods:
 
 ```rust
     /// Remove all edges, keeping nodes.
-    /// XGI parity: `H.clear_edges()`.
+    ///
+    /// XGI parity: `H.clear_edges()` — the edge-uid counter is NOT reset
+    /// (XGI's `clear_edges` never touches `_edge_uid`, verified 0.10.2).
     pub fn clear_edges(&mut self) {
-        // Remove all hyperedge nodes from the bipartite graph
-        for (_, &he_idx) in &self.hyperedge_ids.clone() {
+        let hyperedge_indices: Vec<NodeIndex> = self.hyperedge_ids.values().copied().collect();
+        for he_idx in hyperedge_indices {
             self.inner.remove_node(he_idx);
         }
         self.hyperedge_ids.clear();
-        // Reset edge counter
-        self.edge_uid_counter = 0;
     }
 
     /// Freeze the hypergraph, preventing modification.
@@ -2283,7 +2314,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement clear_edges + freeze/is_frozen
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -2291,7 +2322,7 @@ Co-Authored-By: opencode <opencode@local>"
 ### Task 18: Test and implement `__repr__` / `Debug` formatting
 
 **Files:**
-- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/tests/test_hypergraph.rs`
 - Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
 
 **Interfaces:**
@@ -2299,7 +2330,7 @@ Co-Authored-By: opencode <opencode@local>"
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/core/test_hypergraph.rs`:
+Append to `crates/hypergraph-rs/tests/test_hypergraph.rs`:
 
 ```rust
 #[test]
@@ -2364,7 +2395,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "feat(hypergraph-rs): implement Debug (XGI __repr__ parity)
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---
@@ -2383,6 +2414,12 @@ Expected: May have warnings. Fix all of them.
 
 Common fixes: remove unused imports, use `&str` instead of `&String`, add `#[allow(clippy::xxx)]` with a comment for false positives.
 
+If `clippy::map_entry` fires on `add_edge`/`add_node_to_edge` (the
+`if !map.contains_key(k) { … map.insert(k, v) }` shape), prefer
+`#[allow(clippy::map_entry)]` with a one-line justification — the inserted
+value comes from a separate `self.inner.add_node(...)` `&mut self` borrow,
+so the entry API would conflict — over an entry-API rewrite.
+
 - [ ] **Step 3: Run clippy on all workspace crates**
 
 Run: `cd hypergraph-rs && cargo clippy --workspace -- -D warnings`
@@ -2391,7 +2428,9 @@ Expected: PASS — no warnings.
 - [ ] **Step 4: Run the full test suite**
 
 Run: `cd hypergraph-rs && cargo test --workspace`
-Expected: PASS — all 49 tests, 0 failures.
+Expected: PASS — all 64 tests, 0 failures (the pyo3/wasm/cli stub crates each
+contribute 0 tests; the "49" that stood here previously was a stale copy of
+Task 14's checkpoint).
 
 - [ ] **Step 5: Run rustfmt**
 
@@ -2404,7 +2443,7 @@ cd hypergraph-rs
 git add -A
 git commit -m "chore(hypergraph-rs): clippy + fmt cleanup
 
-Co-Authored-By: opencode <opencode@local>"
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-07-18-hypergraph-rs-phase-0-1.md
+++ b/docs/superpowers/plans/2026-07-18-hypergraph-rs-phase-0-1.md
@@ -1,0 +1,2438 @@
+# hypergraph-rs Phase 0+1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bootstrap the `hypergraph-rs` Cargo workspace with 4 crates and implement the core `Hypergraph<N, E, M>` data structure (bipartite `StableDiGraph`) with full node/edge CRUD, membership queries, attribute access, and insertion-ordered iteration — the foundation that Phase 2 (DiHypergraph, views, conformance testing) builds on.
+
+**Architecture:** The hypergraph IS a `rustworkx_core::petgraph::stable_graph::StableDiGraph` with two node kinds (`Agent` and `Hyperedge`) connected by `MembershipEdge` edges. This bipartite representation makes it a genuine rustworkx-core plugin. `IndexMap` bimaps provide O(1) id-based lookup while preserving insertion order (III.7 determinism parity). **Spec correction:** §3.5 of the design spec says `petgraph::graph::DiGraph` "removes nodes by leaving a hole" — that's actually `StableGraph` behavior. `Graph::remove_node` swaps the last node into the freed slot (compaction), which breaks insertion order under churn. We use `StableDiGraph` which leaves holes and preserves insertion order — matching the spec's INTENT if not its type name.
+
+**Tech Stack:** Rust 1.79+ (matches rustworkx-core MSRV), `rustworkx-core` 0.18 (re-exports `petgraph`), `indexmap` 2, `serde` + `serde_json`, `thiserror`. BSD-3-Clause license.
+
+## Global Constraints
+
+- **Rust edition 2021**, MSRV 1.79 (matches `rustworkx-core`)
+- **License:** BSD-3-Clause (every crate manifest declares it)
+- **Workspace location:** `/hypergraph-rs/` at the babylon repo root (external dep; NOT inside `src/`)
+- **Determinism (III.7 parity):** All iteration is insertion-ordered. `StableDiGraph` preserves insertion order for nodes and edges even under removal (leaves holes, doesn't compact). `IndexMap` bimaps enforce id-lookup order independently. No `HashMap` anywhere in the public iteration path.
+- **No `unsafe` code** in the core crate.
+- **TDD discipline:** Every task follows red → green → commit. Write the failing test first, verify it fails, implement minimal code to pass, verify it passes, commit.
+- **Commit convention:** Conventional commits (`type(scope): desc`). End with `Co-Authored-By: opencode <opencode@local>` trailer.
+- **Generic type defaults:** `N = serde_json::Value, E = serde_json::Value, M = serde_json::Value` — XGI-style dynamic attrs by default.
+- **XGI API fidelity** (confirmed from `.venv/lib/python3.13/site-packages/xgi/core/hypergraph.py`):
+  - `add_edge` auto-creates member nodes that don't exist (hypergraph.py:620-623)
+  - `add_edge` with `idx=None` auto-generates integer IDs via a counter (hypergraph.py:617)
+  - `add_edge` with duplicate `idx` warns and returns (no-op) (hypergraph.py:613-615)
+  - `add_edge` deduplicates members via `set(members)` (hypergraph.py:611)
+  - `remove_node` has weak (default) and strong modes (hypergraph.py:435-478)
+  - `H.nodes.memberships(n)` returns a `set` of edge IDs (views.py:629)
+  - `H.edges.members(e)` returns a `set` of node IDs (views.py:706+)
+
+---
+
+## File Structure
+
+```
+hypergraph-rs/                                    # workspace root (repo top-level)
+├── Cargo.toml                                    # workspace manifest
+├── LICENSE                                       # BSD-3-Clause
+├── README.md
+├── .gitignore
+├── crates/
+│   ├── hypergraph-rs/                            # core library (this plan's focus)
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │       ├── lib.rs                            # crate root, re-exports
+│   │       └── core/
+│   │           ├── mod.rs
+│   │           ├── hypergraph.rs                 # Hypergraph<N,E,M> struct + impl
+│   │           ├── kinds.rs                      # NodeKind<N,E>, MembershipEdge<M>
+│   │           └── error.rs                      # NodeError, EdgeError
+│   ├── hypergraph-rs-python/                     # PyO3 bindings (stub in Phase 0)
+│   │   ├── Cargo.toml
+│   │   └── src/lib.rs
+│   ├── hypergraph-rs-wasm/                       # WASM bindings (stub in Phase 0)
+│   │   ├── Cargo.toml
+│   │   └── src/lib.rs
+│   └── hypergraph-rs-cli/                        # CLI binary (stub in Phase 0)
+│       ├── Cargo.toml
+│       └── src/main.rs
+└── tests/
+    └── core/
+        └── test_hypergraph.rs                    # core unit tests (TDD)
+```
+
+**Responsibility split:**
+- `core/kinds.rs` — `NodeKind<N,E>` enum and `MembershipEdge<M>` struct. Pure data.
+- `core/hypergraph.rs` — `Hypergraph<N,E,M>` struct and all methods. The bipartite substrate + IndexMap bimaps + all CRUD/query/iteration logic.
+- `core/error.rs` — error types for missing nodes/edges.
+- `lib.rs` — crate root, re-exports `core::*`.
+
+---
+
+## Phase 0: Workspace Bootstrap
+
+### Task 1: Create workspace root with LICENSE, README, .gitignore
+
+**Files:**
+- Create: `hypergraph-rs/LICENSE`
+- Create: `hypergraph-rs/README.md`
+- Create: `hypergraph-rs/.gitignore`
+
+- [ ] **Step 1: Create the LICENSE file (BSD-3-Clause)**
+
+Write to `hypergraph-rs/LICENSE`:
+
+```
+BSD 3-Clause License
+
+Copyright (c) 2026, Babylon Project
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+- [ ] **Step 2: Create the .gitignore**
+
+Write to `hypergraph-rs/.gitignore`:
+
+```
+/target
+**/*.rs.bk
+Cargo.lock
+```
+
+- [ ] **Step 3: Create the README.md**
+
+Write to `hypergraph-rs/README.md`:
+
+```markdown
+# hypergraph-rs
+
+A Rust port of [XGI](https://github.com/xgi-org/xgi) (the Python hypergraph library), built as a genuine [rustworkx-core](https://github.com/Qiskit/rustworkx/tree/main/rustworkx-core) plugin.
+
+## License
+
+BSD-3-Clause (same as XGI, compatible with rustworkx-core's Apache-2.0).
+
+## Status
+
+Work in progress — see `docs/superpowers/specs/2026-07-18-hypergraph-rs-design.md` for the design spec.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd hypergraph-rs
+git add LICENSE README.md .gitignore
+git commit -m "docs(hypergraph-rs): bootstrap workspace root with LICENSE, README, .gitignore
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 2: Create workspace Cargo.toml and 4 crate skeletons
+
+**Files:**
+- Create: `hypergraph-rs/Cargo.toml`
+- Create: `hypergraph-rs/crates/hypergraph-rs/Cargo.toml`
+- Create: `hypergraph-rs/crates/hypergraph-rs/src/lib.rs`
+- Create: `hypergraph-rs/crates/hypergraph-rs/src/core/mod.rs`
+- Create: `hypergraph-rs/crates/hypergraph-rs/src/core/kinds.rs`
+- Create: `hypergraph-rs/crates/hypergraph-rs/src/core/error.rs`
+- Create: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+- Create: `hypergraph-rs/crates/hypergraph-rs-python/Cargo.toml`
+- Create: `hypergraph-rs/crates/hypergraph-rs-python/src/lib.rs`
+- Create: `hypergraph-rs/crates/hypergraph-rs-wasm/Cargo.toml`
+- Create: `hypergraph-rs/crates/hypergraph-rs-wasm/src/lib.rs`
+- Create: `hypergraph-rs/crates/hypergraph-rs-cli/Cargo.toml`
+- Create: `hypergraph-rs/crates/hypergraph-rs-cli/src/main.rs`
+
+- [ ] **Step 1: Create the workspace Cargo.toml**
+
+Write to `hypergraph-rs/Cargo.toml`:
+
+```toml
+[workspace]
+members = [
+    "crates/hypergraph-rs",
+    "crates/hypergraph-rs-python",
+    "crates/hypergraph-rs-wasm",
+    "crates/hypergraph-rs-cli",
+]
+resolver = "2"
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.79"
+license = "BSD-3-Clause"
+authors = ["Babylon Project"]
+repository = "https://github.com/percy-raskova/babylon"
+
+[workspace.dependencies]
+rustworkx-core = "0.18"
+petgraph = "0.6"
+indexmap = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+rand = "0.8"
+rand_pcg = "0.3"
+rayon = "1"
+```
+
+- [ ] **Step 2: Create the core crate Cargo.toml**
+
+Write to `hypergraph-rs/crates/hypergraph-rs/Cargo.toml`:
+
+```toml
+[package]
+name = "hypergraph-rs"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "A Rust port of XGI — hypergraph library built on rustworkx-core"
+
+[dependencies]
+rustworkx-core.workspace = true
+petgraph.workspace = true
+indexmap.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+```
+
+- [ ] **Step 3: Create the core crate src/lib.rs**
+
+Write to `hypergraph-rs/crates/hypergraph-rs/src/lib.rs`:
+
+```rust
+//! # hypergraph-rs
+//!
+//! A Rust port of XGI (the Python hypergraph library), built as a genuine
+//! rustworkx-core plugin. The hypergraph IS a
+//! [`rustworkx_core::petgraph::stable_graph::StableDiGraph`] with two node
+//! kinds (`Agent` and `Hyperedge`) connected by `MembershipEdge` edges.
+
+pub mod core;
+
+pub use core::hypergraph::Hypergraph;
+pub use core::kinds::{MembershipEdge, NodeKind};
+pub use core::error::{EdgeError, NodeError};
+```
+
+- [ ] **Step 4: Create the core module files**
+
+Write to `hypergraph-rs/crates/hypergraph-rs/src/core/mod.rs`:
+
+```rust
+//! Core hypergraph data structures.
+
+pub mod error;
+pub mod hypergraph;
+pub mod kinds;
+```
+
+Write to `hypergraph-rs/crates/hypergraph-rs/src/core/kinds.rs`:
+
+```rust
+//! The two node kinds and membership edge type for the bipartite representation.
+
+use serde::{Deserialize, Serialize};
+
+/// The two roles in the bipartite structure.
+///
+/// `Agent` nodes are the hypergraph's nodes (entities). `Hyperedge` nodes
+/// are the hypergraph's edges — their members are exactly their `Agent`
+/// neighbors in the bipartite graph.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum NodeKind<N, E> {
+    /// An entity node (XGI "node"). Carries its own attributes.
+    Agent(N),
+    /// A hyperedge node (XGI "edge"). The members of the hyperedge are
+    /// exactly the Agent neighbors.
+    Hyperedge(E),
+}
+
+/// A membership edge in the bipartite graph: Agent <-> Hyperedge.
+///
+/// Carries per-membership attributes (XGI's edge-member attrs).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MembershipEdge<M> {
+    /// The per-membership data (e.g., role, strength, visibility).
+    pub member_data: M,
+}
+```
+
+Write to `hypergraph-rs/crates/hypergraph-rs/src/core/error.rs`:
+
+```rust
+//! Error types for hypergraph operations.
+
+use thiserror::Error;
+
+/// Error raised when a node operation fails.
+#[derive(Debug, Clone, Error)]
+pub enum NodeError {
+    /// The node ID was not found in the hypergraph.
+    #[error("node {node_id} does not exist")]
+    NotFound { node_id: String },
+}
+
+/// Error raised when an edge operation fails.
+#[derive(Debug, Clone, Error, PartialEq)]
+pub enum EdgeError {
+    /// The edge ID was not found in the hypergraph.
+    #[error("edge {edge_id} does not exist")]
+    NotFound { edge_id: String },
+    /// The edge ID already exists (duplicate on add_edge).
+    #[error("edge {edge_id} already exists")]
+    AlreadyExists { edge_id: String },
+    /// The members collection was empty.
+    #[error("cannot add an empty edge")]
+    EmptyMembers,
+}
+```
+
+Write to `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`:
+
+```rust
+//! The core `Hypergraph` data structure.
+
+use rustworkx_core::petgraph::stable_graph::{NodeIndex, StableDiGraph};
+use indexmap::IndexMap;
+
+use super::error::{EdgeError, NodeError};
+use super::kinds::{MembershipEdge, NodeKind};
+
+/// A hypergraph, represented as a bipartite graph.
+///
+/// The bipartite graph has two node kinds: `Agent` (the hypergraph's nodes)
+/// and `Hyperedge` (the hypergraph's edges). Membership edges connect agents
+/// to their hyperedges. This representation makes the hypergraph a genuine
+/// rustworkx-core plugin — all petgraph/rustworkx-core algorithms work on
+/// the bipartite graph directly.
+///
+/// # Type Parameters
+///
+/// - `N` — agent node attribute type (defaults to `serde_json::Value`)
+/// - `E` — hyperedge attribute type (defaults to `serde_json::Value`)
+/// - `M` — per-membership attribute type (defaults to `serde_json::Value`)
+pub struct Hypergraph<N = serde_json::Value, E = serde_json::Value, M = serde_json::Value> {
+    /// The bipartite graph: Agent nodes + Hyperedge nodes + membership edges.
+    /// StableDiGraph preserves insertion order under removal (leaves holes,
+    /// doesn't compact) — required for III.7 determinism parity.
+    inner: StableDiGraph<NodeKind<N, E>, MembershipEdge<M>>,
+
+    /// Insertion-ordered bimap: agent_id -> NodeIndex in `inner`.
+    agent_ids: IndexMap<String, NodeIndex>,
+
+    /// Insertion-ordered bimap: edge_id -> NodeIndex in `inner`.
+    hyperedge_ids: IndexMap<String, NodeIndex>,
+
+    /// Auto-incrementing counter for edges added without an explicit `idx`.
+    edge_uid_counter: u64,
+
+    /// Graph-level attributes (XGI's `H.graph` dict).
+    graph_attrs: serde_json::Map<String, serde_json::Value>,
+}
+
+impl<N, E, M> Default for Hypergraph<N, E, M> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<N, E, M> Hypergraph<N, E, M> {
+    /// Create an empty hypergraph.
+    pub fn new() -> Self {
+        Self {
+            inner: StableDiGraph::new(),
+            agent_ids: IndexMap::new(),
+            hyperedge_ids: IndexMap::new(),
+            edge_uid_counter: 0,
+            graph_attrs: serde_json::Map::new(),
+        }
+    }
+
+    /// The number of agent nodes in the hypergraph.
+    pub fn num_nodes(&self) -> usize {
+        self.agent_ids.len()
+    }
+
+    /// The number of hyperedges in the hypergraph.
+    pub fn num_edges(&self) -> usize {
+        self.hyperedge_ids.len()
+    }
+}
+```
+
+- [ ] **Step 5: Create the 3 binding crate skeletons**
+
+Write to `hypergraph-rs/crates/hypergraph-rs-python/Cargo.toml`:
+
+```toml
+[package]
+name = "hypergraph-rs-python"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "PyO3 bindings for hypergraph-rs"
+
+[lib]
+name = "_hypergraph_rs_core"
+crate-type = ["cdylib"]
+
+[dependencies]
+hypergraph-rs = { path = "../hypergraph-rs" }
+pyo3 = { version = "0.22", features = ["extension-module"] }
+```
+
+Write to `hypergraph-rs/crates/hypergraph-rs-python/src/lib.rs`:
+
+```rust
+//! PyO3 bindings for hypergraph-rs (stub — Phase 7 implements the full surface).
+
+use pyo3::prelude::*;
+
+#[pymodule]
+fn _hypergraph_rs_core(_py: Python, _m: &Bound<PyModule>) -> PyResult<()> {
+    Ok(())
+}
+```
+
+Write to `hypergraph-rs/crates/hypergraph-rs-wasm/Cargo.toml`:
+
+```toml
+[package]
+name = "hypergraph-rs-wasm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "WASM bindings for hypergraph-rs"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hypergraph-rs = { path = "../hypergraph-rs" }
+wasm-bindgen = "0.2"
+```
+
+Write to `hypergraph-rs/crates/hypergraph-rs-wasm/src/lib.rs`:
+
+```rust
+//! WASM bindings for hypergraph-rs (stub — Phase 8 implements the full surface).
+
+#[wasm_bindgen]
+pub fn _init() {
+    // Stub — Phase 8 will implement the full WASM surface.
+}
+```
+
+Note: add `use wasm_bindgen::prelude::*;` at the top if the compiler requires it.
+
+Write to `hypergraph-rs/crates/hypergraph-rs-cli/Cargo.toml`:
+
+```toml
+[package]
+name = "hypergraph-rs-cli"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "CLI for hypergraph-rs"
+
+[[bin]]
+name = "hypergraph-rs"
+path = "src/main.rs"
+
+[dependencies]
+hypergraph-rs = { path = "../hypergraph-rs" }
+clap = { version = "4", features = ["derive"] }
+```
+
+Write to `hypergraph-rs/crates/hypergraph-rs-cli/src/main.rs`:
+
+```rust
+// CLI for hypergraph-rs (stub — Phase 9 implements the full command surface).
+
+fn main() {
+    println!("hypergraph-rs CLI (stub — Phase 9 will implement commands)");
+}
+```
+
+- [ ] **Step 6: Verify the workspace builds**
+
+Run: `cd hypergraph-rs && cargo build`
+Expected: Builds successfully. Warnings OK (unused imports in stubs).
+
+- [ ] **Step 7: Verify the core crate tests pass (0 tests, compiles)**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs`
+Expected: PASS (0 tests, 0 failures — no tests defined yet).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): bootstrap workspace with 4 crates + core data structure stub
+
+Workspace: hypergraph-rs (core), hypergraph-rs-python (PyO3 stub),
+hypergraph-rs-wasm (wasm-bindgen stub), hypergraph-rs-cli (clap stub).
+
+Core crate: Hypergraph<N,E,M> struct with StableDiGraph bipartite substrate
++ IndexMap bimaps. NodeKind<N,E> and MembershipEdge<M> types. Error types
+for NodeError and EdgeError.
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+## Phase 1: Core Data Structure
+
+### Task 3: Test and implement `add_node` + `has_node`
+
+**Files:**
+- Create: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+**Interfaces:**
+- Produces: `Hypergraph::add_node(&mut self, node_id: &str, attrs: N) -> bool` — returns `true` if new, `false` if existing. `Hypergraph::has_node(&self, node_id: &str) -> bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Write to `hypergraph-rs/tests/core/test_hypergraph.rs`:
+
+```rust
+use hypergraph_rs::Hypergraph;
+
+#[test]
+fn test_add_node_creates_new_node() {
+    let mut h: Hypergraph = Hypergraph::new();
+    let created = h.add_node("a", serde_json::Value::Null);
+    assert!(created);
+    assert_eq!(h.num_nodes(), 1);
+    assert!(h.has_node("a"));
+}
+
+#[test]
+fn test_add_node_returns_false_for_existing() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_node("a", serde_json::Value::Null);
+    let created = h.add_node("a", serde_json::Value::Null);
+    assert!(!created);
+    assert_eq!(h.num_nodes(), 1);
+}
+
+#[test]
+fn test_has_node_returns_false_for_missing() {
+    let h: Hypergraph = Hypergraph::new();
+    assert!(!h.has_node("nonexistent"));
+}
+
+#[test]
+fn test_num_nodes_starts_at_zero() {
+    let h: Hypergraph = Hypergraph::new();
+    assert_eq!(h.num_nodes(), 0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `add_node` and `has_node` don't exist. Compile error.
+
+- [ ] **Step 3: Implement `add_node` and `has_node`**
+
+Add inside the `impl<N, E, M> Hypergraph<N, E, M>` block in `hypergraph.rs`, after `num_edges`:
+
+```rust
+    /// Add a node with attributes. Returns `true` if a new node was created,
+    /// `false` if it already existed.
+    ///
+    /// XGI parity: `H.add_node(node, **attr)`.
+    pub fn add_node(&mut self, node_id: &str, attrs: N) -> bool {
+        if self.agent_ids.contains_key(node_id) {
+            return false;
+        }
+        let idx = self.inner.add_node(NodeKind::Agent(attrs));
+        self.agent_ids.insert(node_id.to_string(), idx);
+        true
+    }
+
+    /// Check if a node exists in the hypergraph.
+    ///
+    /// XGI parity: `n in H` / `H.has_node(n)`.
+    pub fn has_node(&self, node_id: &str) -> bool {
+        self.agent_ids.contains_key(node_id)
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — 4 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement add_node + has_node
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 4: Test and implement `add_edge` with auto-node-creation and auto-id
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+**Interfaces:**
+- Produces: `Hypergraph::add_edge(&mut self, members: Vec<String>, idx: Option<String>, attrs: E) -> Result<String, EdgeError>` where `N: Default, M: Default + Clone`. Auto-creates member nodes. Deduplicates members. Returns `EdgeError::AlreadyExists` for duplicate `idx`, `EdgeError::EmptyMembers` for empty members.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+use hypergraph_rs::EdgeError;
+
+#[test]
+fn test_add_edge_with_explicit_idx() {
+    let mut h: Hypergraph = Hypergraph::new();
+    let edge_id = h.add_edge(
+        vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        Some("myedge".to_string()),
+        serde_json::Value::Null,
+    ).unwrap();
+    assert_eq!(edge_id, "myedge");
+    assert_eq!(h.num_edges(), 1);
+    assert_eq!(h.num_nodes(), 3);
+}
+
+#[test]
+fn test_add_edge_auto_generates_id() {
+    let mut h: Hypergraph = Hypergraph::new();
+    let id1 = h.add_edge(vec!["a".to_string(), "b".to_string()], None, serde_json::Value::Null).unwrap();
+    assert_eq!(id1, "0");
+    let id2 = h.add_edge(vec!["c".to_string(), "d".to_string()], None, serde_json::Value::Null).unwrap();
+    assert_eq!(id2, "1");
+}
+
+#[test]
+fn test_add_edge_duplicate_idx_returns_error() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    let result = h.add_edge(vec!["b".to_string()], Some("e1".to_string()), serde_json::Value::Null);
+    assert!(matches!(result, Err(EdgeError::AlreadyExists { .. })));
+    assert_eq!(h.num_edges(), 1);
+}
+
+#[test]
+fn test_add_edge_deduplicates_members() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    assert_eq!(h.num_nodes(), 2);
+}
+
+#[test]
+fn test_add_edge_empty_members_returns_error() {
+    let mut h: Hypergraph = Hypergraph::new();
+    let result = h.add_edge(vec![], Some("e1".to_string()), serde_json::Value::Null);
+    assert!(matches!(result, Err(EdgeError::EmptyMembers)));
+}
+
+#[test]
+fn test_add_edge_auto_id_after_explicit_idx() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string()], Some("5".to_string()), serde_json::Value::Null).unwrap();
+    let next = h.add_edge(vec!["b".to_string()], None, serde_json::Value::Null).unwrap();
+    assert_eq!(next, "6");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `add_edge` doesn't exist.
+
+- [ ] **Step 3: Implement `add_edge`**
+
+Add inside the impl block:
+
+```rust
+    /// Add a hyperedge connecting the given members.
+    ///
+    /// XGI parity: `H.add_edge(members, idx=id, **attr)`.
+    pub fn add_edge(
+        &mut self,
+        members: Vec<String>,
+        idx: Option<String>,
+        attrs: E,
+    ) -> Result<String, EdgeError>
+    where
+        N: Default,
+        M: Default + Clone,
+    {
+        if members.is_empty() {
+            return Err(EdgeError::EmptyMembers);
+        }
+
+        let edge_id = match &idx {
+            Some(id) => {
+                if self.hyperedge_ids.contains_key(id) {
+                    return Err(EdgeError::AlreadyExists { edge_id: id.clone() });
+                }
+                id.clone()
+            }
+            None => self.edge_uid_counter.to_string(),
+        };
+
+        if let Some(id) = &idx {
+            if let Ok(n) = id.parse::<u64>() {
+                if n >= self.edge_uid_counter {
+                    self.edge_uid_counter = n + 1;
+                }
+            }
+        } else {
+            self.edge_uid_counter += 1;
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        let unique_members: Vec<String> = members
+            .into_iter()
+            .filter(|m| seen.insert(m.clone()))
+            .collect();
+
+        for member in &unique_members {
+            if !self.agent_ids.contains_key(member) {
+                let nidx = self.inner.add_node(NodeKind::Agent(N::default()));
+                self.agent_ids.insert(member.clone(), nidx);
+            }
+        }
+
+        let he_idx = self.inner.add_node(NodeKind::Hyperedge(attrs));
+        self.hyperedge_ids.insert(edge_id.clone(), he_idx);
+
+        for member in &unique_members {
+            let agent_idx = self.agent_ids[member];
+            let membership = MembershipEdge { member_data: M::default() };
+            self.inner.add_edge(agent_idx, he_idx, membership.clone());
+            self.inner.add_edge(he_idx, agent_idx, membership);
+        }
+
+        Ok(edge_id)
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 10 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement add_edge with auto-node-creation and auto-id
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 5: Test and implement `has_edge`
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+#[test]
+fn test_has_edge_returns_true_for_existing() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    assert!(h.has_edge("e1"));
+}
+
+#[test]
+fn test_has_edge_returns_false_for_missing() {
+    let h: Hypergraph = Hypergraph::new();
+    assert!(!h.has_edge("nonexistent"));
+}
+
+#[test]
+fn test_num_edges_counts_correctly() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.add_edge(vec!["b".to_string()], Some("e2".to_string()), serde_json::Value::Null).unwrap();
+    h.add_edge(vec!["c".to_string()], Some("e3".to_string()), serde_json::Value::Null).unwrap();
+    assert_eq!(h.num_edges(), 3);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `has_edge` doesn't exist.
+
+- [ ] **Step 3: Implement `has_edge`**
+
+Add inside the impl block:
+
+```rust
+    /// Check if a hyperedge exists.
+    /// XGI parity: `id in H.edges`.
+    pub fn has_edge(&self, edge_id: &str) -> bool {
+        self.hyperedge_ids.contains_key(edge_id)
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 13 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement has_edge
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 6: Test and implement `memberships` + `members` queries
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+**Interfaces:**
+- Produces: `Hypergraph::memberships(&self, node_id: &str) -> Option<Vec<String>>`, `Hypergraph::members(&self, edge_id: &str) -> Option<Vec<String>>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+#[test]
+fn test_memberships_returns_edge_ids() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.add_edge(vec!["a".to_string(), "c".to_string()], Some("e2".to_string()), serde_json::Value::Null).unwrap();
+    let mships = h.memberships("a").unwrap();
+    assert_eq!(mships.len(), 2);
+    assert!(mships.contains(&"e1".to_string()));
+    assert!(mships.contains(&"e2".to_string()));
+}
+
+#[test]
+fn test_memberships_returns_empty_for_isolate() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_node("lonely", serde_json::Value::Null);
+    assert!(h.memberships("lonely").unwrap().is_empty());
+}
+
+#[test]
+fn test_memberships_returns_none_for_missing() {
+    let h: Hypergraph = Hypergraph::new();
+    assert!(h.memberships("nonexistent").is_none());
+}
+
+#[test]
+fn test_members_returns_node_ids() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "b".to_string(), "c".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    let members = h.members("e1").unwrap();
+    assert_eq!(members.len(), 3);
+    assert!(members.contains(&"a".to_string()));
+}
+
+#[test]
+fn test_members_returns_none_for_missing() {
+    let h: Hypergraph = Hypergraph::new();
+    assert!(h.members("nonexistent").is_none());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `memberships` and `members` don't exist.
+
+- [ ] **Step 3: Implement `memberships` and `members`**
+
+Add inside the impl block:
+
+```rust
+    /// Get the edge IDs of which a node is a member.
+    /// XGI parity: `H.nodes.memberships(n)`.
+    pub fn memberships(&self, node_id: &str) -> Option<Vec<String>> {
+        let agent_idx = *self.agent_ids.get(node_id)?;
+        let mut result: Vec<String> = Vec::new();
+        for neighbor_idx in self.inner.neighbors(agent_idx) {
+            if let Some(NodeKind::Hyperedge(_)) = self.inner.node_weight(neighbor_idx) {
+                for (eid, &idx) in &self.hyperedge_ids {
+                    if idx == neighbor_idx {
+                        result.push(eid.clone());
+                        break;
+                    }
+                }
+            }
+        }
+        Some(result)
+    }
+
+    /// Get the node IDs that are members of an edge.
+    /// XGI parity: `H.edges.members(e)`.
+    pub fn members(&self, edge_id: &str) -> Option<Vec<String>> {
+        let he_idx = *self.hyperedge_ids.get(edge_id)?;
+        let mut result: Vec<String> = Vec::new();
+        for neighbor_idx in self.inner.neighbors(he_idx) {
+            if let Some(NodeKind::Agent(_)) = self.inner.node_weight(neighbor_idx) {
+                for (nid, &idx) in &self.agent_ids {
+                    if idx == neighbor_idx {
+                        result.push(nid.clone());
+                        break;
+                    }
+                }
+            }
+        }
+        Some(result)
+    }
+```
+
+Note: The linear search through bimaps is O(n) per neighbor — a placeholder. A later optimization adds a reverse bimap for O(1) lookup. Babylon's scale (~1000 nodes / ~50 edges) makes this acceptable for now.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 18 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement memberships + members queries
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 7: Test and implement insertion-ordered `node_ids` + `edge_ids`
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+#[test]
+fn test_node_ids_insertion_order() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_node("c", serde_json::Value::Null);
+    h.add_node("a", serde_json::Value::Null);
+    h.add_node("b", serde_json::Value::Null);
+    assert_eq!(h.node_ids(), vec!["c", "a", "b"]);
+}
+
+#[test]
+fn test_edge_ids_insertion_order() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["x".to_string()], Some("e3".to_string()), serde_json::Value::Null).unwrap();
+    h.add_edge(vec!["x".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.add_edge(vec!["x".to_string()], Some("e2".to_string()), serde_json::Value::Null).unwrap();
+    assert_eq!(h.edge_ids(), vec!["e3", "e1", "e2"]);
+}
+
+#[test]
+fn test_node_ids_empty() {
+    let h: Hypergraph = Hypergraph::new();
+    assert!(h.node_ids().is_empty());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `node_ids` and `edge_ids` don't exist.
+
+- [ ] **Step 3: Implement `node_ids` and `edge_ids`**
+
+Add inside the impl block:
+
+```rust
+    /// All node IDs in insertion order (III.7 determinism parity).
+    /// XGI parity: `list(H.nodes)`.
+    pub fn node_ids(&self) -> Vec<String> {
+        self.agent_ids.keys().cloned().collect()
+    }
+
+    /// All edge IDs in insertion order (III.7 determinism parity).
+    /// XGI parity: `list(H.edges)`.
+    pub fn edge_ids(&self) -> Vec<String> {
+        self.hyperedge_ids.keys().cloned().collect()
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 21 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement insertion-ordered node_ids + edge_ids
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 8: Test and implement `remove_node` (weak + strong modes)
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+**Interfaces:**
+- Produces: `Hypergraph::remove_node(&mut self, node_id: &str, strong: bool) -> Result<(), NodeError>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+use hypergraph_rs::NodeError;
+
+#[test]
+fn test_remove_node_weak_removes_from_edges() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "b".to_string(), "c".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.remove_node("b", false).unwrap();
+    assert!(!h.has_node("b"));
+    assert!(h.has_edge("e1"));
+    let members = h.members("e1").unwrap();
+    assert!(!members.contains(&"b".to_string()));
+    assert!(members.contains(&"a".to_string()));
+}
+
+#[test]
+fn test_remove_node_weak_removes_singleton_edges() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.remove_node("a", false).unwrap();
+    assert!(!h.has_node("a"));
+    assert!(!h.has_edge("e1"));
+}
+
+#[test]
+fn test_remove_node_strong_removes_all_containing_edges() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.add_edge(vec!["a".to_string(), "c".to_string(), "d".to_string()], Some("e2".to_string()), serde_json::Value::Null).unwrap();
+    h.remove_node("a", true).unwrap();
+    assert!(!h.has_node("a"));
+    assert!(!h.has_edge("e1"));
+    assert!(!h.has_edge("e2"));
+    assert!(h.has_node("b"));
+    assert!(h.has_node("c"));
+}
+
+#[test]
+fn test_remove_node_missing_returns_error() {
+    let mut h: Hypergraph = Hypergraph::new();
+    let result = h.remove_node("nonexistent", false);
+    assert!(matches!(result, Err(NodeError::NotFound { .. })));
+}
+
+#[test]
+fn test_remove_node_preserves_insertion_order() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_node("a", serde_json::Value::Null);
+    h.add_node("b", serde_json::Value::Null);
+    h.add_node("c", serde_json::Value::Null);
+    h.remove_node("b", false).unwrap();
+    assert_eq!(h.node_ids(), vec!["a", "c"]);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `remove_node` doesn't exist.
+
+- [ ] **Step 3: Implement `remove_node`**
+
+Add inside the impl block:
+
+```rust
+    /// Remove a node from the hypergraph.
+    /// XGI parity: `H.remove_node(n, strong=False, remove_empty=True)`.
+    pub fn remove_node(&mut self, node_id: &str, strong: bool) -> Result<(), NodeError> {
+        let agent_idx = *self.agent_ids.get(node_id).ok_or(NodeError::NotFound {
+            node_id: node_id.to_string(),
+        })?;
+
+        let edge_ids: Vec<String> = self.memberships(node_id).unwrap_or_default();
+
+        if strong {
+            for eid in edge_ids {
+                self.remove_edge(&eid).map_err(|_| NodeError::NotFound {
+                    node_id: node_id.to_string(),
+                })?;
+            }
+        } else {
+            for eid in &edge_ids {
+                let he_idx = self.hyperedge_ids[eid];
+                if let Some(e) = self.inner.find_edge(agent_idx, he_idx) {
+                    self.inner.remove_edge(e);
+                }
+                if let Some(e) = self.inner.find_edge(he_idx, agent_idx) {
+                    self.inner.remove_edge(e);
+                }
+                let has_members = self.inner.neighbors(he_idx).any(|n| {
+                    matches!(self.inner.node_weight(n), Some(NodeKind::Agent(_)))
+                });
+                if !has_members {
+                    self.inner.remove_node(he_idx);
+                    self.hyperedge_ids.shift_remove(eid);
+                }
+            }
+        }
+
+        self.inner.remove_node(agent_idx);
+        self.agent_ids.shift_remove(node_id);
+        Ok(())
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 26 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement remove_node with weak + strong modes
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 9: Test and implement `remove_edge`
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+#[test]
+fn test_remove_edge_basic() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.remove_edge("e1").unwrap();
+    assert!(!h.has_edge("e1"));
+    assert_eq!(h.num_edges(), 0);
+    assert!(h.has_node("a"));
+    assert!(h.has_node("b"));
+    assert!(h.memberships("a").unwrap().is_empty());
+}
+
+#[test]
+fn test_remove_edge_missing_returns_error() {
+    let mut h: Hypergraph = Hypergraph::new();
+    let result = h.remove_edge("nonexistent");
+    assert!(matches!(result, Err(EdgeError::NotFound { .. })));
+}
+
+#[test]
+fn test_remove_edge_preserves_other_edges() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.add_edge(vec!["a".to_string(), "c".to_string()], Some("e2".to_string()), serde_json::Value::Null).unwrap();
+    h.remove_edge("e1").unwrap();
+    assert!(!h.has_edge("e1"));
+    assert!(h.has_edge("e2"));
+    assert_eq!(h.memberships("a").unwrap(), vec!["e2"]);
+}
+
+#[test]
+fn test_remove_edge_preserves_insertion_order() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.add_edge(vec!["a".to_string()], Some("e2".to_string()), serde_json::Value::Null).unwrap();
+    h.add_edge(vec!["a".to_string()], Some("e3".to_string()), serde_json::Value::Null).unwrap();
+    h.remove_edge("e2").unwrap();
+    assert_eq!(h.edge_ids(), vec!["e1", "e3"]);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `remove_edge` doesn't exist.
+
+- [ ] **Step 3: Implement `remove_edge`**
+
+Add inside the impl block:
+
+```rust
+    /// Remove a hyperedge from the hypergraph.
+    /// XGI parity: `H.remove_edge(e)`.
+    pub fn remove_edge(&mut self, edge_id: &str) -> Result<(), EdgeError> {
+        let he_idx = *self.hyperedge_ids.get(edge_id).ok_or(EdgeError::NotFound {
+            edge_id: edge_id.to_string(),
+        })?;
+        self.inner.remove_node(he_idx);
+        self.hyperedge_ids.shift_remove(edge_id);
+        Ok(())
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 30 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement remove_edge
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 10: Test and implement attribute access (`node_attrs`, `edge_attrs`, mut variants)
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+**Interfaces:**
+- Produces: `node_attrs(&self, node_id: &str) -> Option<&N>`, `node_attrs_mut(&mut self, node_id: &str) -> Option<&mut N>`, `edge_attrs(&self, edge_id: &str) -> Option<&E>`, `edge_attrs_mut(&mut self, edge_id: &str) -> Option<&mut E>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+#[test]
+fn test_node_attrs_read() {
+    let mut h: Hypergraph = Hypergraph::new();
+    let attrs = serde_json::json!({"color": "red", "weight": 42});
+    h.add_node("a", attrs.clone());
+    let read = h.node_attrs("a").unwrap();
+    assert_eq!(read, &attrs);
+}
+
+#[test]
+fn test_node_attrs_mut() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_node("a", serde_json::json!({"count": 0}));
+    {
+        let attrs = h.node_attrs_mut("a").unwrap();
+        attrs["count"] = serde_json::json!(5);
+    }
+    assert_eq!(h.node_attrs("a").unwrap()["count"], 5);
+}
+
+#[test]
+fn test_node_attrs_missing_returns_none() {
+    let h: Hypergraph = Hypergraph::new();
+    assert!(h.node_attrs("nonexistent").is_none());
+}
+
+#[test]
+fn test_edge_attrs_read() {
+    let mut h: Hypergraph = Hypergraph::new();
+    let attrs = serde_json::json!({"heat": 0.5, "cohesion": 0.8});
+    h.add_edge(vec!["a".to_string()], Some("e1".to_string()), attrs.clone()).unwrap();
+    assert_eq!(h.edge_attrs("e1").unwrap(), &attrs);
+}
+
+#[test]
+fn test_edge_attrs_mut() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string()], Some("e1".to_string()), serde_json::json!({"heat": 0.3})).unwrap();
+    {
+        let attrs = h.edge_attrs_mut("e1").unwrap();
+        attrs["heat"] = serde_json::json!(0.9);
+    }
+    assert_eq!(h.edge_attrs("e1").unwrap()["heat"], 0.9);
+}
+
+#[test]
+fn test_edge_attrs_missing_returns_none() {
+    let h: Hypergraph = Hypergraph::new();
+    assert!(h.edge_attrs("nonexistent").is_none());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — attribute accessor methods don't exist.
+
+- [ ] **Step 3: Implement attribute accessors**
+
+Add inside the impl block:
+
+```rust
+    /// Read a node's attributes. XGI parity: `H.nodes[n]`.
+    pub fn node_attrs(&self, node_id: &str) -> Option<&N> {
+        let idx = self.agent_ids.get(node_id)?;
+        match self.inner.node_weight(*idx)? {
+            NodeKind::Agent(attrs) => Some(attrs),
+            _ => None,
+        }
+    }
+
+    /// Mutably access a node's attributes.
+    pub fn node_attrs_mut(&mut self, node_id: &str) -> Option<&mut N> {
+        let idx = *self.agent_ids.get(node_id)?;
+        match self.inner.node_weight_mut(idx)? {
+            NodeKind::Agent(attrs) => Some(attrs),
+            _ => None,
+        }
+    }
+
+    /// Read a hyperedge's attributes. XGI parity: `H.edges[e]`.
+    pub fn edge_attrs(&self, edge_id: &str) -> Option<&E> {
+        let idx = self.hyperedge_ids.get(edge_id)?;
+        match self.inner.node_weight(*idx)? {
+            NodeKind::Hyperedge(attrs) => Some(attrs),
+            _ => None,
+        }
+    }
+
+    /// Mutably access a hyperedge's attributes.
+    pub fn edge_attrs_mut(&mut self, edge_id: &str) -> Option<&mut E> {
+        let idx = *self.hyperedge_ids.get(edge_id)?;
+        match self.inner.node_weight_mut(idx)? {
+            NodeKind::Hyperedge(attrs) => Some(attrs),
+            _ => None,
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 36 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement node/edge attribute accessors
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 11: Test and implement graph-level attributes + `clear`
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+#[test]
+fn test_graph_attr_set_and_get() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.set_graph_attr("name", serde_json::json!("wayne_county"));
+    h.set_graph_attr("tick", serde_json::json!(42));
+    assert_eq!(h.graph_attr("name"), Some(&serde_json::json!("wayne_county")));
+    assert_eq!(h.graph_attr("tick"), Some(&serde_json::json!(42)));
+}
+
+#[test]
+fn test_graph_attr_missing_returns_none() {
+    let h: Hypergraph = Hypergraph::new();
+    assert!(h.graph_attr("nonexistent").is_none());
+}
+
+#[test]
+fn test_graph_attr_overwrite() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.set_graph_attr("tick", serde_json::json!(1));
+    h.set_graph_attr("tick", serde_json::json!(99));
+    assert_eq!(h.graph_attr("tick"), Some(&serde_json::json!(99)));
+}
+
+#[test]
+fn test_clear_removes_everything() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::json!({"heat": 0.5})).unwrap();
+    h.add_node("lonely", serde_json::json!({"x": 1}));
+    h.set_graph_attr("name", serde_json::json!("test"));
+    h.clear();
+    assert_eq!(h.num_nodes(), 0);
+    assert_eq!(h.num_edges(), 0);
+    assert!(h.node_ids().is_empty());
+    assert!(h.edge_ids().is_empty());
+    assert!(h.graph_attr("name").is_none());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `graph_attr`, `set_graph_attr`, `clear` don't exist.
+
+- [ ] **Step 3: Implement graph attrs and clear**
+
+Add inside the impl block:
+
+```rust
+    /// Read a graph-level attribute. XGI parity: `H["name"]`.
+    pub fn graph_attr(&self, key: &str) -> Option<&serde_json::Value> {
+        self.graph_attrs.get(key)
+    }
+
+    /// Set a graph-level attribute. XGI parity: `H["name"] = value`.
+    pub fn set_graph_attr(&mut self, key: &str, value: serde_json::Value) {
+        self.graph_attrs.insert(key.to_string(), value);
+    }
+
+    /// Remove all nodes and edges. XGI parity: `H.clear()`.
+    pub fn clear(&mut self) {
+        self.inner = StableDiGraph::new();
+        self.agent_ids.clear();
+        self.hyperedge_ids.clear();
+        self.edge_uid_counter = 0;
+        self.graph_attrs.clear();
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 40 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement graph-level attrs + clear
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 12: Test and implement `copy` (deep clone)
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+#[test]
+fn test_copy_produces_independent_clone() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::json!({"heat": 0.5})).unwrap();
+    h.set_graph_attr("name", serde_json::json!("test"));
+
+    let mut h2 = h.copy();
+    assert_eq!(h2.num_nodes(), 2);
+    assert_eq!(h2.num_edges(), 1);
+    assert_eq!(h2.edge_attrs("e1").unwrap()["heat"], 0.5);
+
+    h2.add_node("c", serde_json::Value::Null);
+    h2.set_graph_attr("name", serde_json::json!("modified"));
+    assert_eq!(h.num_nodes(), 2);
+    assert!(!h.has_node("c"));
+    assert_eq!(h.graph_attr("name"), Some(&serde_json::json!("test")));
+}
+
+#[test]
+fn test_copy_of_empty() {
+    let h: Hypergraph = Hypergraph::new();
+    let h2 = h.copy();
+    assert_eq!(h2.num_nodes(), 0);
+    assert_eq!(h2.num_edges(), 0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `copy` doesn't exist.
+
+- [ ] **Step 3: Implement `copy`**
+
+Add inside the impl block:
+
+```rust
+    /// Return an independent deep copy. XGI parity: `H.copy()`.
+    pub fn copy(&self) -> Self
+    where
+        N: Clone,
+        E: Clone,
+        M: Clone,
+    {
+        Self {
+            inner: self.inner.clone(),
+            agent_ids: self.agent_ids.clone(),
+            hyperedge_ids: self.hyperedge_ids.clone(),
+            edge_uid_counter: self.edge_uid_counter,
+            graph_attrs: self.graph_attrs.clone(),
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 42 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement copy (deep clone)
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 13: Test and implement bulk operations
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+#[test]
+fn test_add_nodes_from_bulk() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_nodes_from(vec![
+        ("a".to_string(), serde_json::json!({"x": 1})),
+        ("b".to_string(), serde_json::json!({"x": 2})),
+    ]);
+    assert_eq!(h.num_nodes(), 2);
+    assert_eq!(h.node_attrs("a").unwrap()["x"], 1);
+}
+
+#[test]
+fn test_add_edges_from_bulk() {
+    let mut h: Hypergraph = Hypergraph::new();
+    let results = h.add_edges_from(vec![
+        (vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::json!({"w": 1})),
+        (vec!["b".to_string(), "c".to_string()], None, serde_json::Value::Null),
+    ]);
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().all(|r| r.is_ok()));
+    assert_eq!(h.num_edges(), 2);
+    assert_eq!(h.num_nodes(), 3);
+    assert_eq!(h.edge_ids(), vec!["e1", "0"]);
+}
+
+#[test]
+fn test_add_edges_from_with_duplicate_idx() {
+    let mut h: Hypergraph = Hypergraph::new();
+    let results = h.add_edges_from(vec![
+        (vec!["a".to_string()], Some("e1".to_string()), serde_json::Value::Null),
+        (vec!["b".to_string()], Some("e1".to_string()), serde_json::Value::Null),
+    ]);
+    assert!(results[0].is_ok());
+    assert!(results[1].is_err());
+    assert_eq!(h.num_edges(), 1);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — bulk methods don't exist.
+
+- [ ] **Step 3: Implement bulk operations**
+
+Add inside the impl block:
+
+```rust
+    /// Add multiple nodes. XGI parity: `H.add_nodes_from(nodes_for_adding)`.
+    pub fn add_nodes_from(&mut self, nodes: impl IntoIterator<Item = (String, N)>) {
+        for (node_id, attrs) in nodes {
+            self.add_node(&node_id, attrs);
+        }
+    }
+
+    /// Add multiple edges. Returns a result per edge.
+    pub fn add_edges_from(
+        &mut self,
+        edges: impl IntoIterator<Item = (Vec<String>, Option<String>, E)>,
+    ) -> Vec<Result<String, EdgeError>>
+    where
+        N: Default,
+        M: Default + Clone,
+    {
+        edges.into_iter().map(|(m, i, a)| self.add_edge(m, i, a)).collect()
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 45 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement add_nodes_from + add_edges_from
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 14: Test and implement `PartialEq` (structural equality)
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+#[test]
+fn test_eq_same_structure() {
+    let mut h1: Hypergraph = Hypergraph::new();
+    h1.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::json!({"w": 1})).unwrap();
+    let mut h2: Hypergraph = Hypergraph::new();
+    h2.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::json!({"w": 1})).unwrap();
+    assert_eq!(h1, h2);
+}
+
+#[test]
+fn test_eq_different_edge_attrs() {
+    let mut h1: Hypergraph = Hypergraph::new();
+    h1.add_edge(vec!["a".to_string()], Some("e1".to_string()), serde_json::json!({"w": 1})).unwrap();
+    let mut h2: Hypergraph = Hypergraph::new();
+    h2.add_edge(vec!["a".to_string()], Some("e1".to_string()), serde_json::json!({"w": 2})).unwrap();
+    assert_ne!(h1, h2);
+}
+
+#[test]
+fn test_eq_different_members() {
+    let mut h1: Hypergraph = Hypergraph::new();
+    h1.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    let mut h2: Hypergraph = Hypergraph::new();
+    h2.add_edge(vec!["a".to_string(), "c".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    assert_ne!(h1, h2);
+}
+
+#[test]
+fn test_eq_both_empty() {
+    let h1: Hypergraph = Hypergraph::new();
+    let h2: Hypergraph = Hypergraph::new();
+    assert_eq!(h1, h2);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `PartialEq` not implemented.
+
+- [ ] **Step 3: Implement `PartialEq`**
+
+Add OUTSIDE the inherent impl block (trait impl):
+
+```rust
+impl<N: PartialEq, E: PartialEq, M: PartialEq> PartialEq for Hypergraph<N, E, M> {
+    /// Two hypergraphs are equal if they have the same nodes, edges,
+    /// memberships, and attributes. XGI parity: `H1 == H2`.
+    fn eq(&self, other: &Self) -> bool {
+        if self.agent_ids.len() != other.agent_ids.len() { return false; }
+        for (nid, _) in &self.agent_ids {
+            match (self.node_attrs(nid), other.node_attrs(nid)) {
+                (Some(a), Some(b)) if a == b => {}
+                _ => return false,
+            }
+        }
+        if self.hyperedge_ids.len() != other.hyperedge_ids.len() { return false; }
+        for (eid, _) in &self.hyperedge_ids {
+            match (self.edge_attrs(eid), other.edge_attrs(eid)) {
+                (Some(a), Some(b)) if a == b => {}
+                _ => return false,
+            }
+            let mut m1 = self.members(eid).unwrap_or_default();
+            let mut m2 = other.members(eid).unwrap_or_default();
+            m1.sort(); m2.sort();
+            if m1 != m2 { return false; }
+        }
+        self.graph_attrs == other.graph_attrs
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 49 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement PartialEq (structural equality)
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 15: Test and implement `add_node_to_edge` + `remove_node_from_edge`
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+**Interfaces:**
+- Produces: `add_node_to_edge(&mut self, edge_id: &str, node_id: &str) -> Result<(), EdgeError>` where `N: Default` — adds a node to an existing edge; auto-creates both if missing. `remove_node_from_edge(&mut self, edge_id: &str, node_id: &str, remove_empty: bool) -> Result<(), NodeError>` — removes a node from an edge; optionally removes the edge if it becomes empty.
+
+**XGI source reference** (hypergraph.py:~860-890, ~920-950): `add_node_to_edge` auto-creates edge and node if either doesn't exist. `remove_node_from_edge` raises XGIError if edge/node missing or node not in edge; removes empty edge by default.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+#[test]
+fn test_add_node_to_edge_existing_edge() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.add_node_to_edge("e1", "c").unwrap();
+    let members = h.members("e1").unwrap();
+    assert!(members.contains(&"c".to_string()));
+    assert_eq!(members.len(), 3);
+}
+
+#[test]
+fn test_add_node_to_edge_auto_creates_edge_and_node() {
+    let mut h: Hypergraph = Hypergraph::new();
+    // Neither edge "new_edge" nor node "new_node" exist
+    h.add_node_to_edge("new_edge", "new_node").unwrap();
+    assert!(h.has_edge("new_edge"));
+    assert!(h.has_node("new_node"));
+    let members = h.members("new_edge").unwrap();
+    assert_eq!(members, vec!["new_node"]);
+}
+
+#[test]
+fn test_remove_node_from_edge_basic() {
+    let mut h: Hypergraph = Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "b".to_string(), "c".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.remove_node_from_edge("e1", "b", true).unwrap();
+    let members = h.members("e1").unwrap();
+    assert!(!members.contains(&"b".to_string()));
+    assert_eq!(members.len(), 2);
+    // Node b still exists (just not in e1 anymore)
+    assert!(h.has_node("b"));
+}
+
+#[test]
+fn test_remove_node_from_edge_removes_empty_edge() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.remove_node_from_edge("e1", "a", true).unwrap();
+    // e1 was a singleton, now empty — should be removed
+    assert!(!h.has_edge("e1"));
+    assert!(h.has_node("a"));
+}
+
+#[test]
+fn test_remove_node_from_edge_keep_empty() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.remove_node_from_edge("e1", "a", false).unwrap();
+    // remove_empty=false: edge stays (now empty)
+    assert!(h.has_edge("e1"));
+    assert!(h.members("e1").unwrap().is_empty());
+}
+
+#[test]
+fn test_remove_node_from_edge_missing_edge_returns_error() {
+    let mut h: Hypergraph = Hypergraph::new();
+    let result = h.remove_node_from_edge("nonexistent", "a", true);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_remove_node_from_edge_node_not_in_edge_returns_error() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.add_node("b", serde_json::Value::Null);
+    let result = h.remove_node_from_edge("e1", "b", true);
+    assert!(result.is_err());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `add_node_to_edge` and `remove_node_from_edge` don't exist.
+
+- [ ] **Step 3: Implement both methods**
+
+Add inside the impl block:
+
+```rust
+    /// Add a node to an existing edge. Auto-creates both if missing.
+    /// XGI parity: `H.add_node_to_edge(edge, node)`.
+    pub fn add_node_to_edge(&mut self, edge_id: &str, node_id: &str) -> Result<(), EdgeError>
+    where
+        N: Default,
+        M: Default + Clone,
+    {
+        // Auto-create edge if missing
+        if !self.hyperedge_ids.contains_key(edge_id) {
+            let he_idx = self.inner.add_node(NodeKind::Hyperedge(E::default()));
+            self.hyperedge_ids.insert(edge_id.to_string(), he_idx);
+            // Update uid counter if edge_id is numeric
+            if let Ok(n) = edge_id.parse::<u64>() {
+                if n >= self.edge_uid_counter {
+                    self.edge_uid_counter = n + 1;
+                }
+            }
+        }
+        // Auto-create node if missing
+        if !self.agent_ids.contains_key(node_id) {
+            let nidx = self.inner.add_node(NodeKind::Agent(N::default()));
+            self.agent_ids.insert(node_id.to_string(), nidx);
+        }
+        // Add the membership edges (both directions for undirected)
+        let agent_idx = self.agent_ids[node_id];
+        let he_idx = self.hyperedge_ids[edge_id];
+        // Check if membership already exists
+        if self.inner.find_edge(agent_idx, he_idx).is_none() {
+            let membership = MembershipEdge { member_data: M::default() };
+            self.inner.add_edge(agent_idx, he_idx, membership.clone());
+            self.inner.add_edge(he_idx, agent_idx, membership);
+        }
+        Ok(())
+    }
+
+    /// Remove a node from an existing edge.
+    /// XGI parity: `H.remove_node_from_edge(edge, node, remove_empty=True)`.
+    pub fn remove_node_from_edge(
+        &mut self,
+        edge_id: &str,
+        node_id: &str,
+        remove_empty: bool,
+    ) -> Result<(), NodeError> {
+        let he_idx = *self.hyperedge_ids.get(edge_id).ok_or(NodeError::NotFound {
+            node_id: edge_id.to_string(),
+        })?;
+        let agent_idx = *self.agent_ids.get(node_id).ok_or(NodeError::NotFound {
+            node_id: node_id.to_string(),
+        })?;
+
+        // Check if the node is actually in the edge
+        let edge_to_he = self.inner.find_edge(agent_idx, he_idx);
+        let edge_from_he = self.inner.find_edge(he_idx, agent_idx);
+        if edge_to_he.is_none() {
+            return Err(NodeError::NotFound {
+                node_id: format!("node {} not in edge {}", node_id, edge_id),
+            });
+        }
+
+        // Remove the bipartite membership edges
+        if let Some(e) = edge_to_he {
+            self.inner.remove_edge(e);
+        }
+        if let Some(e) = edge_from_he {
+            self.inner.remove_edge(e);
+        }
+
+        // Check if edge is now empty
+        if remove_empty {
+            let has_members = self.inner.neighbors(he_idx).any(|n| {
+                matches!(self.inner.node_weight(n), Some(NodeKind::Agent(_)))
+            });
+            if !has_members {
+                self.inner.remove_node(he_idx);
+                self.hyperedge_ids.shift_remove(edge_id);
+            }
+        }
+        Ok(())
+    }
+```
+
+Note: `add_node_to_edge` requires `E: Default` as well (to auto-create the edge with default attrs). Add that bound:
+
+```rust
+    pub fn add_node_to_edge(&mut self, edge_id: &str, node_id: &str) -> Result<(), EdgeError>
+    where
+        N: Default,
+        E: Default,
+        M: Default + Clone,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 56 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement add_node_to_edge + remove_node_from_edge
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 16: Test and implement `set_node_attributes` + `set_edge_attributes`
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+**Interfaces:**
+- Produces: `set_node_attributes(&mut self, values: impl Iterator<Item = (String, serde_json::Map)>)` — bulk set node attrs from (id, attr_map) pairs. `set_edge_attributes` — same for edges. Skips missing IDs silently (XGI behavior with a warning).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+use std::collections::BTreeMap;
+
+#[test]
+fn test_set_node_attributes_from_pairs() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_node("a", serde_json::Value::Null);
+    h.add_node("b", serde_json::Value::Null);
+
+    let mut attrs_a = serde_json::Map::new();
+    attrs_a.insert("color".to_string(), serde_json::json!("red"));
+    let mut attrs_b = serde_json::Map::new();
+    attrs_b.insert("color".to_string(), serde_json::json!("blue"));
+
+    h.set_node_attributes(vec![
+        ("a".to_string(), attrs_a),
+        ("b".to_string(), attrs_b),
+    ]);
+
+    assert_eq!(h.node_attrs("a").unwrap()["color"], "red");
+    assert_eq!(h.node_attrs("b").unwrap()["color"], "blue");
+}
+
+#[test]
+fn test_set_node_attributes_skips_missing() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_node("a", serde_json::Value::Null);
+
+    let mut attrs = serde_json::Map::new();
+    attrs.insert("x".to_string(), serde_json::json!(1));
+
+    h.set_node_attributes(vec![
+        ("a".to_string(), attrs.clone()),
+        ("nonexistent".to_string(), attrs),
+    ]);
+
+    // "a" got the attribute, "nonexistent" was silently skipped
+    assert_eq!(h.node_attrs("a").unwrap()["x"], 1);
+}
+
+#[test]
+fn test_set_edge_attributes_from_pairs() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string()], Some("e1".to_string()), serde_json::Value::Null).unwrap();
+    h.add_edge(vec!["b".to_string()], Some("e2".to_string()), serde_json::Value::Null).unwrap();
+
+    let mut attrs_e1 = serde_json::Map::new();
+    attrs_e1.insert("weight".to_string(), serde_json::json!(5));
+    let mut attrs_e2 = serde_json::Map::new();
+    attrs_e2.insert("weight".to_string(), serde_json::json!(10));
+
+    h.set_edge_attributes(vec![
+        ("e1".to_string(), attrs_e1),
+        ("e2".to_string(), attrs_e2),
+    ]);
+
+    assert_eq!(h.edge_attrs("e1").unwrap()["weight"], 5);
+    assert_eq!(h.edge_attrs("e2").unwrap()["weight"], 10);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `set_node_attributes` and `set_edge_attributes` don't exist.
+
+- [ ] **Step 3: Implement both methods**
+
+Add inside the impl block:
+
+```rust
+    /// Set node attributes from (id, attr_map) pairs.
+    /// XGI parity: `H.set_node_attributes(values, name=None)`.
+    /// Silently skips missing node IDs (XGI warns).
+    pub fn set_node_attributes(
+        &mut self,
+        values: impl IntoIterator<Item = (String, serde_json::Map<String, serde_json::Value>)>,
+    ) {
+        for (node_id, attrs) in values {
+            if let Some(node_attrs) = self.node_attrs_mut(&node_id) {
+                if let Some(obj) = node_attrs.as_object_mut() {
+                    for (k, v) in attrs {
+                        obj.insert(k, v);
+                    }
+                }
+            }
+            // Silently skip missing nodes (XGI warns)
+        }
+    }
+
+    /// Set edge attributes from (id, attr_map) pairs.
+    /// XGI parity: `H.set_edge_attributes(values, name=None)`.
+    /// Silently skips missing edge IDs (XGI warns).
+    pub fn set_edge_attributes(
+        &mut self,
+        values: impl IntoIterator<Item = (String, serde_json::Map<String, serde_json::Value>)>,
+    ) {
+        for (edge_id, attrs) in values {
+            if let Some(edge_attrs) = self.edge_attrs_mut(&edge_id) {
+                if let Some(obj) = edge_attrs.as_object_mut() {
+                    for (k, v) in attrs {
+                        obj.insert(k, v);
+                    }
+                }
+            }
+        }
+    }
+```
+
+Note: This implementation assumes `N`/`E` are `serde_json::Value` (the default). For generic `N`/`E`, these methods would need different signatures. Since the defaults are `serde_json::Value`, this covers XGI parity. Babylon can later specialize with typed setters.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 59 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement set_node_attributes + set_edge_attributes
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 17: Test and implement `clear_edges` + `freeze` / `is_frozen`
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+**Interfaces:**
+- Produces: `clear_edges(&mut self)` — removes all edges, keeps nodes. `freeze(&mut self)` — sets a frozen flag. `is_frozen(&self) -> bool`. When frozen, mutation methods should panic.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+#[test]
+fn test_clear_edges_keeps_nodes() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "b".to_string()], Some("e1".to_string()), serde_json::json!({"w": 1})).unwrap();
+    h.add_node("lonely", serde_json::json!({"x": 1}));
+    h.clear_edges();
+    assert_eq!(h.num_nodes(), 3); // a, b, lonely all kept
+    assert_eq!(h.num_edges(), 0);
+    // Node attrs preserved
+    assert_eq!(h.node_attrs("lonely").unwrap()["x"], 1);
+    // No memberships
+    assert!(h.memberships("a").unwrap().is_empty());
+}
+
+#[test]
+fn test_freeze_prevents_mutation() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_node("a", serde_json::Value::Null);
+    h.freeze();
+    assert!(h.is_frozen());
+    // Mutation should panic
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut h = h;
+        h.add_node("b", serde_json::Value::Null);
+    }));
+    assert!(result.is_err(), "add_node should panic when frozen");
+}
+
+#[test]
+fn test_is_frozen_false_by_default() {
+    let h: Hypergraph = Hypergraph::new();
+    assert!(!h.is_frozen());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `clear_edges`, `freeze`, `is_frozen` don't exist.
+
+- [ ] **Step 3: Add `frozen` field and implement the methods**
+
+First, add a `frozen` field to the `Hypergraph` struct:
+
+```rust
+pub struct Hypergraph<N = serde_json::Value, E = serde_json::Value, M = serde_json::Value> {
+    inner: StableDiGraph<NodeKind<N, E>, MembershipEdge<M>>,
+    agent_ids: IndexMap<String, NodeIndex>,
+    hyperedge_ids: IndexMap<String, NodeIndex>,
+    edge_uid_counter: u64,
+    graph_attrs: serde_json::Map<String, serde_json::Value>,
+    frozen: bool,  // NEW
+}
+```
+
+Update `new()`:
+```rust
+    pub fn new() -> Self {
+        Self {
+            inner: StableDiGraph::new(),
+            agent_ids: IndexMap::new(),
+            hyperedge_ids: IndexMap::new(),
+            edge_uid_counter: 0,
+            graph_attrs: serde_json::Map::new(),
+            frozen: false,  // NEW
+        }
+    }
+```
+
+Update `clear()` to also reset `frozen`:
+```rust
+    pub fn clear(&mut self) {
+        self.inner = StableDiGraph::new();
+        self.agent_ids.clear();
+        self.hyperedge_ids.clear();
+        self.edge_uid_counter = 0;
+        self.graph_attrs.clear();
+        self.frozen = false;  // NEW
+    }
+```
+
+Update `copy()` to copy `frozen`:
+```rust
+    pub fn copy(&self) -> Self where N: Clone, E: Clone, M: Clone {
+        Self {
+            inner: self.inner.clone(),
+            agent_ids: self.agent_ids.clone(),
+            hyperedge_ids: self.hyperedge_ids.clone(),
+            edge_uid_counter: self.edge_uid_counter,
+            graph_attrs: self.graph_attrs.clone(),
+            frozen: self.frozen,  // NEW
+        }
+    }
+```
+
+Add the new methods:
+
+```rust
+    /// Remove all edges, keeping nodes.
+    /// XGI parity: `H.clear_edges()`.
+    pub fn clear_edges(&mut self) {
+        // Remove all hyperedge nodes from the bipartite graph
+        for (_, &he_idx) in &self.hyperedge_ids.clone() {
+            self.inner.remove_node(he_idx);
+        }
+        self.hyperedge_ids.clear();
+        // Reset edge counter
+        self.edge_uid_counter = 0;
+    }
+
+    /// Freeze the hypergraph, preventing modification.
+    /// XGI parity: `H.freeze()`.
+    pub fn freeze(&mut self) {
+        self.frozen = true;
+    }
+
+    /// Check if the hypergraph is frozen.
+    /// XGI parity: `H.is_frozen`.
+    pub fn is_frozen(&self) -> bool {
+        self.frozen
+    }
+```
+
+Add a frozen guard to `add_node`, `add_edge`, `remove_node`, `remove_edge`, `add_node_to_edge`, `remove_node_from_edge`, `clear`, `clear_edges`:
+
+```rust
+    fn assert_not_frozen(&self) {
+        if self.frozen {
+            panic!("Frozen hypergraph can't be modified");
+        }
+    }
+```
+
+Call `self.assert_not_frozen();` at the top of each mutation method.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 62 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement clear_edges + freeze/is_frozen
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 18: Test and implement `__repr__` / `Debug` formatting
+
+**Files:**
+- Modify: `hypergraph-rs/tests/core/test_hypergraph.rs`
+- Modify: `hypergraph-rs/crates/hypergraph-rs/src/core/hypergraph.rs`
+
+**Interfaces:**
+- Produces: `impl std::fmt::Debug for Hypergraph` — XGI v0.10.2 `__repr__` parity: `Hypergraph([{members}, ...])`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/core/test_hypergraph.rs`:
+
+```rust
+#[test]
+fn test_debug_format_matches_xgi_repr() {
+    let mut h: Hypergraph = Hypergraph::new();
+    h.add_edge(vec!["a".to_string(), "b".to_string(), "c".to_string()], None, serde_json::Value::Null).unwrap();
+    h.add_edge(vec!["b".to_string(), "c".to_string()], None, serde_json::Value::Null).unwrap();
+    let repr = format!("{:?}", h);
+    // XGI __repr__ returns: Hypergraph([{a, b, c}, {b, c}])
+    // Our Debug should include the class name and edge members
+    assert!(repr.contains("Hypergraph"));
+    assert!(repr.contains("a"));
+    assert!(repr.contains("b"));
+    assert!(repr.contains("c"));
+}
+
+#[test]
+fn test_debug_format_empty() {
+    let h: Hypergraph = Hypergraph::new();
+    let repr = format!("{:?}", h);
+    assert!(repr.contains("Hypergraph"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: FAIL — `Debug` not implemented (the derive on the struct doesn't give XGI-parity repr).
+
+- [ ] **Step 3: Implement `Debug`**
+
+Add OUTSIDE the inherent impl block:
+
+```rust
+impl<N, E, M> std::fmt::Debug for Hypergraph<N, E, M>
+where
+    N: std::fmt::Debug,
+    E: std::fmt::Debug,
+    M: std::fmt::Debug,
+{
+    /// XGI parity: `__repr__` returns `Hypergraph([{members}, ...])`.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Hypergraph(")?;
+        let edges: Vec<String> = self.hyperedge_ids.keys().map(|eid| {
+            let members = self.members(eid).unwrap_or_default();
+            format!("{{{}}}", members.join(", "))
+        }).collect();
+        write!(f, "[{}])", edges.join(", "))
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hypergraph-rs && cargo test -p hypergraph-rs --test test_hypergraph`
+Expected: PASS — all 64 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "feat(hypergraph-rs): implement Debug (XGI __repr__ parity)
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+### Task 19: Run clippy, fix warnings, verify full suite
+
+**Files:**
+- Modify: any files with clippy warnings
+
+- [ ] **Step 1: Run clippy on the core crate**
+
+Run: `cd hypergraph-rs && cargo clippy -p hypergraph-rs -- -D warnings`
+Expected: May have warnings. Fix all of them.
+
+- [ ] **Step 2: Fix any clippy warnings**
+
+Common fixes: remove unused imports, use `&str` instead of `&String`, add `#[allow(clippy::xxx)]` with a comment for false positives.
+
+- [ ] **Step 3: Run clippy on all workspace crates**
+
+Run: `cd hypergraph-rs && cargo clippy --workspace -- -D warnings`
+Expected: PASS — no warnings.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `cd hypergraph-rs && cargo test --workspace`
+Expected: PASS — all 49 tests, 0 failures.
+
+- [ ] **Step 5: Run rustfmt**
+
+Run: `cd hypergraph-rs && cargo fmt --all`
+
+- [ ] **Step 6: Commit formatting/clippy fixes**
+
+```bash
+cd hypergraph-rs
+git add -A
+git commit -m "chore(hypergraph-rs): clippy + fmt cleanup
+
+Co-Authored-By: opencode <opencode@local>"
+```
+
+---
+
+## Phase 0+1 Completion Summary
+
+After completing all 19 tasks, the `hypergraph-rs` workspace has:
+
+- **4 crates**: `hypergraph-rs` (core), `hypergraph-rs-python` (PyO3 stub), `hypergraph-rs-wasm` (WASM stub), `hypergraph-rs-cli` (CLI stub)
+- **Core `Hypergraph<N, E, M>` struct** (XGI v0.10.2 API parity) with:
+  - `new`, `default`, `clear`, `clear_edges`, `copy`, `freeze`, `is_frozen`
+  - `add_node`, `has_node`, `remove_node` (weak + strong)
+  - `add_edge` (auto-node, auto-id, dedup), `has_edge`, `remove_edge`
+  - `add_node_to_edge`, `remove_node_from_edge`
+  - `memberships`, `members`
+  - `node_attrs`/`mut`, `edge_attrs`/`mut`
+  - `set_node_attributes`, `set_edge_attributes` (bulk)
+  - `graph_attr`, `set_graph_attr`
+  - `node_ids`, `edge_ids` (insertion-ordered)
+  - `num_nodes`, `num_edges`
+  - `add_nodes_from`, `add_edges_from` (bulk)
+  - `PartialEq` (structural equality), `Debug` (XGI `__repr__` parity)
+- **64 unit tests** all passing
+- **Clippy clean**, **rustfmt clean**
+- **StableDiGraph bipartite substrate** (genuine rustworkx-core plugin)
+- **IndexMap bimaps** for insertion-ordered id lookup (III.7 determinism parity)
+- **Frozen guard** on all mutation methods (XGI `freeze()` parity)
+
+**XGI v0.10.2 core API coverage**: all methods in `xgi/core/hypergraph.py` are now implemented except `double_edge_swap`, `random_edge_shuffle`, `merge_duplicate_edges`, `cleanup`, `dual`, and `update` — these are deferred to Phase 2 (they're higher-level operations, not core CRUD).
+
+**Next: Phase 2** — DiHypergraph, SimplicialComplex, NodeView/EdgeView proxy objects, and porting XGI's `test_hypergraph.py` as the first conformance gate.

--- a/docs/superpowers/specs/2026-07-18-hypergraph-rs-design.md
+++ b/docs/superpowers/specs/2026-07-18-hypergraph-rs-design.md
@@ -1,0 +1,1314 @@
+# hypergraph-rs — Design Spec
+
+**Status:** Draft, owner-approved in outline 2026-07-18. Standalone library;
+Babylon adoption deferred to a later ADR (see §11).
+
+**Constitutional framing:** Standalone, decoupled from Babylon. Article II.7
+(Edges vs Hyperedges) remains in `[TRANSITION STATE — Pending Amendment D]`.
+This library does NOT touch Babylon's hyperedge code; it is a portable
+computational rendering package that Babylon may adopt later via a separate
+spec/ADR when Amendment D is resolved. The library is "XGI semantics in Rust,
+as a rustworkx-core plugin" — not an ideological package.
+
+**Theory sources:** XGI 0.10.2 (`.venv/lib/python3.13/site-packages/xgi/`,
+20,412 LOC, 164 public symbols, BSD-3-Clause) and the rustworkx-core crate
+(Apache-2.0, pure-Rust, built on petgraph). Babylon's existing XGI usage
+lives in 7 files under `src/babylon/` (community system, bifurcation,
+graph_wrappers).
+
+---
+
+## 1. Vision
+
+A standalone, open-source (BSD-3-Clause) Rust port of XGI — the Python
+hypergraph library — built as a genuine `rustworkx-core` plugin, with three
+distribution surfaces:
+
+1. **Python extension** (PyO3 + Maturin) — `import hypergraph_rs as xgi` is a
+   literal 1-for-1 swap for `import xgi`.
+2. **WASM module** (wasm-bindgen) — React frontends can call the Rust core
+   directly in the browser.
+3. **CLI binary** (clap) — inspect, convert, validate, and render hypergraphs
+   without writing Python.
+
+Babylon does a literal `s/^import xgi$/import hypergraph_rs as xgi/` swap
+across 7 consumer files, removing the `xgi` Poetry dependency entirely.
+
+---
+
+## 2. Workspace architecture
+
+Top-level `/hypergraph-rs/` in the babylon repo (external dep — Babylon
+declares it via a Poetry path dependency).
+
+```
+hypergraph-rs/                          # top-level workspace, external dep
+├── Cargo.toml                          # workspace root
+├── LICENSE                             # BSD-3-Clause
+├── README.md
+├── crates/
+│   ├── hypergraph-rs/                  # core library (no bindings)
+│   │   ├── Cargo.toml                  # rustworkx-core, petgraph, indexmap, ndarray, sprs, serde, rand, rand_pcg
+│   │   └── src/
+│   │       ├── lib.rs
+│   │       ├── core/                   # Hypergraph, DiHypergraph, SimplicialComplex, views
+│   │       ├── algorithms/             # centrality, clustering, paths, assortativity
+│   │       ├── linalg/                 # incidence, adjacency, overlap matrices
+│   │       ├── generators/             # random, classic, lattice, uniform
+│   │       ├── readwrite/              # JSON, edgelist, HIF, BIGG (serde)
+│   │       ├── stats/                  # node/edge stat functions
+│   │       ├── convert/                # to/from rustworkx, bipartite, dict
+│   │       ├── dynamics/               # epidemic models
+│   │       ├── communities/            # spectral clustering
+│   │       ├── layout/                 # hyperedge-aware layouts (delegates to rustworkx-core)
+│   │       └── viz/                    # scene-graph serializer (JSON + SVG emit)
+│   ├── hypergraph-rs-python/           # PyO3 bindings (maturin)
+│   │   ├── Cargo.toml                  # hypergraph-rs, pyo3, numpy
+│   │   ├── pyproject.toml              # maturin build backend
+│   │   ├── src/lib.rs                  # PyO3 extension
+│   │   └── hypergraph_rs/              # pure-Python package skeleton mirroring XGI's __init__.py
+│   │       ├── __init__.py
+│   │       ├── drawing/                # matplotlib shim (mpl feature flag)
+│   │       └── ...
+│   ├── hypergraph-rs-wasm/             # wasm-bindgen bindings
+│   │   ├── Cargo.toml                  # hypergraph-rs, wasm-bindgen, js-sys, serde-wasm-bindgen
+│   │   └── src/lib.rs
+│   └── hypergraph-rs-cli/              # CLI binary
+│       ├── Cargo.toml                  # hypergraph-rs, clap, anyhow
+│       └── src/main.rs                 # 8 subcommands
+├── tests/
+│   ├── conftest.py
+│   └── ported/                         # XGI's 50 test files with import line swapped
+└── npm/
+    └── @hypergraph-rs/react/           # optional React components consuming SceneGraph JSON
+```
+
+**Key points:**
+
+- **One Rust core, three surfaces.** `hypergraph-rs` (pure Rust, no binding
+  deps) + three thin binding crates. The core does all the work; bindings are
+  thin adapters.
+- **`rustworkx-core` is the backbone.** The hypergraph IS a
+  `rustworkx_core::petgraph::Graph` under the hood (see §3) — this is what
+  makes it a "genuine plugin."
+- **The npm package is optional/secondary.** The scene-graph JSON is the
+  contract; the React renderer is one consumer.
+
+---
+
+## 3. Core data structure — bipartite rustworkx graph (Approach B)
+
+The hypergraph IS a `rustworkx_core::petgraph::Graph` with two node kinds.
+This is what makes it a genuine rustworkx plugin — we extend petgraph's data
+structure with n-ary semantics.
+
+```rust
+use rustworkx_core::petgraph::graph::{DiGraph, NodeIndex};
+use indexmap::IndexMap;
+
+/// The two roles in the bipartite structure.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub enum NodeKind<N, E> {
+    /// An entity node (XGI "node"). Carries its own attributes.
+    Agent(N),
+    /// A hyperedge node (XGI "edge"). The members of the hyperedge are
+    /// exactly the Agent neighbors.
+    Hyperedge(E),
+}
+
+/// A membership edge in the bipartite graph: Agent <-> Hyperedge.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct MembershipEdge<M> {
+    pub member_data: M,
+}
+
+/// The hypergraph. One field. Everything else is views over it.
+pub struct Hypergraph<N = serde_json::Value, E = serde_json::Value, M = serde_json::Value> {
+    /// Bipartite: Agent nodes + Hyperedge nodes + membership edges.
+    /// Insertion-ordered (petgraph::graph::DiGraph preserves insertion order
+    /// for both nodes and edges — required for III.7 determinism parity).
+    inner: DiGraph<NodeKind<N, E>, MembershipEdge<M>>,
+
+    /// Insertion-ordered bimaps for O(1) id-based lookup (mirrors
+    /// BabylonGraph's `_ids` / `_index_to_id` pattern from ADR052).
+    agent_ids:     IndexMap<String, NodeIndex>,   // agent_id  -> NodeIndex
+    hyperedge_ids: IndexMap<String, NodeIndex>,   // edge_id   -> NodeIndex
+
+    /// Graph-level attributes (XGI's `H.graph` dict).
+    graph_attrs: serde_json::Map<String, serde_json::Value>,
+}
+```
+
+### 3.1 XGI operation → bipartite implementation
+
+| XGI API | Bipartite implementation | Complexity |
+|---|---|---|
+| `H.add_node(id, **attrs)` | Insert `NodeKind::Agent(attrs)`; record in `agent_ids` | O(1) |
+| `H.add_edge(members, idx=id, **attrs)` | Insert `NodeKind::Hyperedge(attrs)`; for each member insert a `MembershipEdge` agent→hyperedge (and reverse for undirected) | O(\|members\|) |
+| `H.nodes` | Iterate `agent_ids` keys in insertion order | O(\|agents\|) |
+| `H.edges` | Iterate `hyperedge_ids` keys in insertion order | O(\|edges\|) |
+| `H.nodes.memberships(agent_id)` | Look up `NodeIndex`, iterate out-neighbors that are `NodeKind::Hyperedge`, return their ids | O(degree) |
+| `H.edges.members(edge_id)` | Look up `NodeIndex`, iterate in-neighbors that are `NodeKind::Agent`, return their ids | O(\|members\|) |
+| `H.edges[id]` (attrs) | Look up `NodeIndex`, read `NodeKind::Hyperedge` payload | O(1) |
+| `H.nodes[id]` (attrs) | Look up `NodeIndex`, read `NodeKind::Agent` payload | O(1) |
+| `xgi.incidence_matrix(H)` | The bipartite adjacency matrix — `sprs::CsMat` directly from `inner` | O(\|edges\|·\|agents\|) nnz |
+| `H.remove_node(id)` | `inner.remove_node(idx)` + purge from `agent_ids` | O(degree) |
+| `H.remove_edge(id)` | `inner.remove_node(hyperedge_idx)` + purge from `hyperedge_ids` | O(\|members\|) |
+| `H.copy()` | `inner.clone()` + clone the two IndexMaps | O(V+E) |
+
+### 3.2 Generic type parameters
+
+- `N` — agent node attribute type (defaults to `serde_json::Value` for
+  XGI-style dynamic attrs; Babylon can specialize to a Pydantic-validated
+  struct via PyO3).
+- `E` — hyperedge attribute type.
+- `M` — per-membership attribute type (XGI's edge-member attrs).
+
+Babylon can later type the generics tightly
+(`Hypergraph<BabylonAgent, CommunityState, MembershipRole>`) while the
+open-source lib ships with `serde_json::Value` defaults for XGI parity.
+
+### 3.3 Directed vs undirected hypergraphs
+
+- **`Hypergraph`** (undirected, XGI's main class) — bidirectional membership
+  edges (agent↔hyperedge, both directions).
+- **`DiHypergraph`** (XGI's directed class) — directed membership edges:
+  tail agents → hyperedge → head agents (a flag on `MembershipEdge`).
+
+Both share the same bipartite substrate; `DiHypergraph` adds direction
+semantics on top.
+
+### 3.4 SimplicialComplex
+
+```rust
+pub struct SimplicialComplex<N, E, M> {
+    inner: Hypergraph<N, E, M>,
+    // Cached face lattice: for each simplex, its cofaces and faces.
+    // Computed lazily, invalidated on mutation (OnceCell pattern).
+    face_lattice: OnceCell<rustworkx_core::petgraph::DiGraph<SimplexId, ()>>,
+}
+```
+
+### 3.5 Determinism (III.7 parity)
+
+`petgraph::graph::DiGraph` preserves insertion order for both nodes and edges
+(unlike rustworkx's `PyDiGraph` which reuses indices — the exact issue ADR052
+had to work around). So the bipartite substrate is *naturally* insertion
+ordered, no mirror dicts needed for ordering. The `agent_ids` /
+`hyperedge_ids` IndexMaps are for O(1) id lookup only, not ordering.
+
+`petgraph::graph::DiGraph` removes nodes by leaving a hole (the index is
+marked removed, not reused) — better for determinism than `PyDiGraph`.
+Iteration via `inner.node_indices()` skips holes automatically. The bimaps
+hide this entirely from the public API.
+
+---
+
+## 4. API surface — XGI conformance mapping
+
+The conformance gate is "XGI's 50 test files pass against the Rust port."
+That means the public Python API must be `import hypergraph_rs as xgi` — a
+literal swap.
+
+### 4.1 Core API
+
+```rust
+impl<N, E, M> Hypergraph<N, E, M> {
+    // Constructors
+    pub fn new() -> Self;
+    pub fn from_memberships(memberships: Vec<(String, Vec<String>)>) -> Self;
+    pub fn from_bipartite_graph(g: petgraph::graph::DiGraph<N, E>) -> Self;
+
+    // Node CRUD
+    pub fn add_node(&mut self, node_id: &str, attrs: N) -> bool;
+    pub fn add_nodes_from(&mut self, nodes: impl IntoIterator<Item = (String, N)>);
+    pub fn remove_node(&mut self, node_id: &str) -> Result<(), NodeError>;
+    pub fn has_node(&self, node_id: &str) -> bool;
+    pub fn num_nodes(&self) -> usize;
+
+    // Edge CRUD — XGI uses `idx=` for the edge ID (v0.9 breaking change, pinned)
+    pub fn add_edge(&mut self, members: Vec<String>, idx: Option<String>, attrs: E) -> String;
+    pub fn add_edges_from(&mut self, edges: impl IntoIterator<Item = (Vec<String>, Option<String>, E)>);
+    pub fn remove_edge(&mut self, edge_id: &str) -> Result<(), EdgeError>;
+    pub fn has_edge(&self, edge_id: &str) -> bool;
+    pub fn num_edges(&self) -> usize;
+
+    // Membership queries (the slice Babylon uses heavily)
+    pub fn memberships(&self, node_id: &str) -> Option<Vec<String>>;
+    pub fn members(&self, edge_id: &str) -> Option<Vec<String>>;
+    pub fn node_attrs(&self, node_id: &str) -> Option<&N>;
+    pub fn edge_attrs(&self, edge_id: &str) -> Option<&E>;
+    pub fn node_attrs_mut(&mut self, node_id: &str) -> Option<&mut N>;
+    pub fn edge_attrs_mut(&mut self, edge_id: &str) -> Option<&mut E>;
+
+    // Bulk
+    pub fn copy(&self) -> Self where N: Clone, E: Clone, M: Clone;
+    pub fn clear(&mut self);
+
+    // XGI `H.graph` dict equivalent
+    pub fn graph_attr(&self, key: &str) -> Option<&serde_json::Value>;
+    pub fn set_graph_attr(&mut self, key: &str, value: serde_json::Value);
+
+    // 1-skeleton and bipartite projections (rustworkx-native algorithms run on these)
+    pub fn skeleton(&self) -> rustworkx_core::petgraph::graph::Graph<String, f64>;
+    pub fn bipartite_graph(&self) -> &rustworkx_core::petgraph::graph::DiGraph<NodeKind<N,E>, MembershipEdge<M>>;
+
+    // Iteration (insertion-ordered, III.7 parity)
+    pub fn node_ids(&self) -> impl Iterator<Item = &str>;
+    pub fn edge_ids(&self) -> impl Iterator<Item = &str>;
+}
+```
+
+### 4.2 Views — PyO3 proxy objects
+
+XGI uses proxy view objects (`H.nodes`, `H.edges`) with their own methods.
+The PyO3 binding exposes `H.nodes` and `H.edges` as Python proxy objects to
+match XGI's surface exactly:
+
+```rust
+#[pyclass(name = "NodeView")]
+pub struct PyNodeView { /* ref to Hypergraph */ }
+#[pymethods]
+impl PyNodeView {
+    fn memberships(&self, node_id: &str) -> HashSet<String>;
+    fn __iter__(&self) -> PyNodeIter;
+    fn __len__(&self) -> usize;
+    fn __contains__(&self, node_id: &str) -> bool;
+    fn __getitem__(&self, node_id: &str) -> PyResult<PyNodeAttrs>;
+}
+```
+
+### 4.3 Full XGI module mapping (164 symbols → Rust crates)
+
+| XGI submodule | LOC | Rust module | Porting strategy |
+|---|---|---|---|
+| `core/` | 4,926 | `hypergraph-rs::core` | Direct port. The bipartite substrate makes most methods one-liners. |
+| `linalg/` | 840 | `hypergraph-rs::linalg` | Trivially derived from the bipartite graph via `sprs`. Returns `CsMat` (sparse) or `Array2` (dense). |
+| `generators/` | 2,086 | `hypergraph-rs::generators` | Seeded `rand_pcg` for deterministic reproducibility. |
+| `algorithms/` | 2,521 | `hypergraph-rs::algorithms` | Most delegate to `rustworkx-core` on the 1-skeleton or bipartite graph. |
+| `stats/` | 2,414 | `hypergraph-rs::stats` | Pure stat functions over node/edge attributes. Direct port. |
+| `convert/` | 1,741 | `hypergraph-rs::convert` | `networkx` → `rustworkx`; `pandas` → `Vec<Record>` (PyO3 converts to pandas on the Python side). |
+| `readwrite/` | 1,122 | `hypergraph-rs::readwrite` | `serde` + `serde_json` for JSON/HIF; custom parsers for edgelist/BIGG. `xgi_data` gated behind `network` feature. |
+| `dynamics/` | 296 | `hypergraph-rs::dynamics` | Small. Direct port. |
+| `communities/` | 140 | `hypergraph-rs::communities` | Small. Direct port using `ndarray`/`sprs` eigendecomposition. |
+| `utils/` | 1,006 | `hypergraph-rs::utils` | Utilities. Direct port. |
+| `drawing/` | 3,236 | `hypergraph-rs::layout` + `hypergraph-rs::viz` | **NOT a direct port.** See §5. |
+
+### 4.4 What we explicitly do NOT port
+
+- **`xgi.drawing` matplotlib code** — replaced by `layout` (pure math) + `viz`
+  (scene-graph serializer). The Python binding exposes a `draw_hypergraph()`
+  shim (feature-gated `mpl`) for backward compat that uses matplotlib on the
+  Python side over our layout.
+- **`xgi.utils` pure-Python conveniences** (e.g., `dispatch` decorator
+  machinery) — replaced with idiomatic Rust patterns.
+- **`pandas` integration** — replaced with `Vec<Record>` and converted to
+  pandas on the Python side if needed (Babylon doesn't use this slice).
+
+### 4.5 Python import surface (the 1-for-1 swap)
+
+```python
+# Before (Babylon today):
+import xgi
+H = xgi.Hypergraph()
+H.add_edge(members, idx=comm_type.value, heat=0.5)
+
+# After (the swap):
+import hypergraph_rs as xgi
+H = xgi.Hypergraph()
+H.add_edge(members, idx=comm_type.value, heat=0.5)
+```
+
+The PyO3 `__init__.py` (auto-generated by maturin, with a pure-Python
+skeleton) exposes the same names as XGI's `__init__.py` — `Hypergraph`,
+`DiHypergraph`, `SimplicialComplex`, `incidence_matrix`, `adjacency_matrix`,
+all generator functions, all algorithms, etc. The 164 symbols.
+
+### 4.6 Determinism contract (Constitution III.7 parity)
+
+XGI's iteration order is insertion order (Python dicts). Our
+`petgraph::graph::DiGraph` + `IndexMap` combo is insertion-ordered by
+construction. The conformance gate (XGI tests) will catch any order drift.
+We add a property-based test (like ADR052's `test_graph_iteration_order.py`)
+that differential-tests against the real XGI oracle on random hypergraph
+operation sequences.
+
+---
+
+## 5. Visualization — layout + scene-graph + three rendering surfaces
+
+### 5.1 Architecture: separate layout from render
+
+```
+Layout (pure math, Rust)        →    Scene-graph (serialized JSON)    →    Render (3 surfaces)
+==================================    ====================================    =====================
+hypergraph-rs::layout                hypergraph-rs::viz::SceneGraph         1. PyO3 → matplotlib shim (mpl feature)
+- node positions (rustworkx)         - nodes [{id, x, y, attrs}]           2. WASM → JS objects
+- hyperedge geometry                 - hyperedges [{id, members,           3. CLI → SVG file
+  (halos, convex hulls,                 geometry, attrs}]                  (also JSON dump)
+   bipartite stripes)                 - bounding box, viewport
+- 4 layout strategies
+  (spring, bipartite, hyperedge-aware, radial)
+```
+
+### 5.2 Layout (Rust, reuses rustworkx-core)
+
+```rust
+pub enum LayoutStrategy {
+    /// Delegate to rustworkx-core's spring layout on the 1-skeleton.
+    Spring { iterations: usize, seed: Option<u64> },
+    /// Bipartite layout — reuses rustworkx-core's bipartite_layout on the
+    /// inner bipartite graph.
+    Bipartite { align: BipartiteAlign },
+    /// Agent positions from spring layout on 1-skeleton, then each
+    /// hyperedge's geometry is the convex hull of its members (rendered as
+    /// a colored halo/region around the member nodes).
+    HyperedgeAware { iterations: usize, halo_padding: f64 },
+    /// Hyperedges as concentric rings, agents placed on rings based on
+    /// membership count.
+    Radial { rings: usize },
+}
+
+pub fn compute_layout(
+    h: &Hypergraph<N, E, M>,
+    strategy: LayoutStrategy,
+) -> LayoutResult;
+```
+
+### 5.3 Scene-graph (the contract between Rust and all renderers)
+
+```rust
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct SceneGraph {
+    pub nodes: Vec<NodeGlyph>,
+    pub hyperedges: Vec<HyperedgeGlyph>,
+    pub bounding_box: (f64, f64, f64, f64),  // min_x, min_y, max_x, max_y
+    pub metadata: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct NodeGlyph {
+    pub id: String,
+    pub x: f64,
+    pub y: f64,
+    pub radius: f64,
+    pub attrs: serde_json::Value,
+    pub style: NodeStyle,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct HyperedgeGlyph {
+    pub id: String,
+    pub member_ids: Vec<String>,
+    pub geometry: HyperedgeGeometry,
+    pub attrs: serde_json::Value,
+    pub style: HyperedgeStyle,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum HyperedgeGeometry {
+    /// Convex hull around member nodes (XGI "halo" style)
+    ConvexHull { points: Vec<(f64, f64)> },
+    /// Closed spline through members (XGI "elliptical" style)
+    Spline { control_points: Vec<(f64, f64)> },
+    /// Bipartite stripe (for bipartite layout)
+    Stripe { x: f64, y_min: f64, y_max: f64 },
+    /// Radial arc (for radial layout)
+    Arc { center: (f64, f64), radius: f64, angle_range: (f64, f64) },
+}
+
+impl Hypergraph<N, E, M> {
+    pub fn render(&self, strategy: LayoutStrategy) -> SceneGraph;
+    pub fn render_to_svg(&self, strategy: LayoutStrategy) -> String;
+    pub fn render_to_json(&self, strategy: LayoutStrategy) -> String;
+}
+```
+
+### 5.4 What we reuse from rustworkx visualizations
+
+| rustworkx viz asset | Reuse strategy |
+|---|---|
+| `spring_layout` (Rust) | Called directly via `rustworkx-core` on the 1-skeleton |
+| `kamada_kawai_layout` (Rust) | Same — direct call |
+| `circular_layout`, `shell_layout`, `spiral_layout`, `random_layout` (Rust) | Same — direct calls |
+| `bipartite_layout` (Rust) | Called on the inner bipartite graph directly |
+| `mpl_draw` (Python, matplotlib) | NOT reused — replaced by scene-graph + optional matplotlib shim |
+| `graphviz_draw` (Python, subprocess) | NOT reused — replaced by CLI SVG emit |
+
+**Net**: all 14 Rust layout functions are reused. The two Python rendering
+functions are replaced by our scene-graph + multi-surface renderers.
+
+---
+
+## 6. Python bindings & the Babylon swap mechanics
+
+### 6.1 PyO3 binding architecture
+
+The binding crate has BOTH Rust code (`src/lib.rs` for the PyO3 extension)
+AND a Python package skeleton (`hypergraph_rs/` directory with `__init__.py`
+and submodule shims). Maturin merges them at build time.
+
+```python
+# crates/hypergraph-rs-python/hypergraph_rs/__init__.py (auto-generated, mirrors XGI)
+from . import (utils, core, algorithms, communities, convert, drawing,
+               dynamics, generators, linalg, readwrite, stats)
+from .utils import *
+from .core import *
+# ... 164 symbols total
+__version__ = "0.10.2-xgi-parity"
+__all__ = (core.__all__ + algorithms.__all__ + ...)
+```
+
+### 6.2 The 1-for-1 swap in Babylon
+
+**Before** (7 Babylon files use XGI today):
+```python
+import xgi  # type: ignore[import-untyped, unused-ignore]
+```
+
+**After** (the swap):
+```python
+import hypergraph_rs as xgi  # fully typed — no ignore needed
+```
+
+The migration is literally `s/^import xgi$/import hypergraph_rs as xgi/`
+across 7 consumer files. No other Python code changes.
+
+### 6.3 The matplotlib shim — explicit optional feature
+
+**Declaration**: The matplotlib shim is an **optional feature**, gated
+behind the `mpl` extra. It is NOT installed by default. Users must opt in:
+
+```bash
+pip install hypergraph-rs          # no matplotlib
+pip install 'hypergraph-rs[mpl]'   # includes matplotlib + the shim
+```
+
+**Documentation**: The crate's README, the PyO3 crate's docstring, and the
+`drawing` submodule's docstring all declare:
+
+> The `drawing` submodule provides `draw_hypergraph()` and
+> `draw_dihypergraph()` functions that use matplotlib to render hypergraphs.
+> This is an OPTIONAL feature gated behind the `mpl` extra
+> (`pip install 'hypergraph-rs[mpl]'`). The primary visualization pathway is
+> the scene-graph JSON via `H.render()` — see `viz` module. The matplotlib
+> shim exists for backward compatibility with XGI's `xgi.draw()` API.
+
+```python
+# crates/hypergraph-rs-python/hypergraph_rs/drawing/__init__.py
+"""Matplotlib-based drawing for backward compat with XGI.
+
+OPTIONAL FEATURE: requires `pip install 'hypergraph-rs[mpl]'`.
+Primary viz pathway is scene-graph JSON via ``H.render()``.
+"""
+
+try:
+    import matplotlib.pyplot as plt
+    HAS_MPL = True
+except ImportError:
+    HAS_MPL = False
+
+__all__ = ["draw_hypergraph", "draw_dihypergraph", "NodeColor", "EdgeColor"]
+
+def draw_hypergraph(H, ax=None, layout="hyperedge_aware", **kwargs):
+    """Draw a Hypergraph using matplotlib (XGI ``xgi.draw`` parity).
+
+    Optional — requires the ``mpl`` extra. Uses the Rust layout engine
+    for node positions, then renders with matplotlib.
+    """
+    if not HAS_MPL:
+        raise ImportError(
+            "matplotlib drawing requires the `mpl` extra: "
+            "`pip install 'hypergraph-rs[mpl]'`. "
+            "For matplotlib-free rendering, use `H.render()` for a scene-graph."
+        )
+    from . import _core
+    scene = _core.compute_scene_graph(H, layout_strategy=layout)
+    ax = ax or plt.subplots()[1]
+    # ... render scene-graph with matplotlib
+    return ax
+```
+
+The shim calls into the Rust layout engine (no layout math in Python), then
+uses matplotlib only for the actual pixel rendering. This means:
+
+- **Layout determinism is preserved** (Rust does the math).
+- **matplotlib is a pure renderer**, not a layout engine.
+- The same scene-graph can be rendered to SVG/React/WASM without matplotlib.
+
+### 6.4 Poetry integration for Babylon
+
+```toml
+[tool.poetry.dependencies]
+# Existing:
+rustworkx = "^0.18.0"
+# Removed:
+# xgi = "^0.10"
+# New (path dependency to the top-level workspace):
+hypergraph-rs = { path = "../hypergraph-rs/crates/hypergraph-rs-python", develop = true }
+```
+
+Babylon installs the PyO3 extension via Poetry's path dependency. Maturin
+builds the Rust extension at `poetry install` time. No separate `pip install`
+step.
+
+**Fallback path** (during migration): Both `xgi` and `hypergraph-rs` can
+coexist temporarily. The 7 consumer files swap one at a time, each verified
+by `mise run qa:regression` (byte-identical baselines). After all 7 swap,
+`xgi` is removed from `pyproject.toml`.
+
+### 6.5 The mypy story — strict typing as a Babylon win
+
+XGI has `py.typed` but is `type: ignore[import-untyped]`-suppressed in
+Babylon's 7 consumers because XGI's stubs are incomplete. The PyO3 binding
+ships complete `.pyi` stubs (maturin generates them from the PyO3
+signatures), so the `type: ignore` comments are removed in the swap:
+
+```python
+# Before:
+import xgi  # type: ignore[import-untyped, unused-ignore]
+
+# After:
+import hypergraph_rs as xgi  # fully typed — no ignore needed
+```
+
+This is a small mypy-strictness win for Babylon, and a requirement since
+Babylon's CI runs mypy strict. **Owner directive: the richer and more
+principled and stricter our typing, the easier our Python life becomes.**
+
+### 6.6 Semgrep / vocabulary guard
+
+Babylon has a semgrep rule banning `networkx` imports (the ADR052 "permanent
+migration" enforcement). We add a parallel rule banning `xgi` imports after
+the swap completes:
+
+```yaml
+# .semgrep.yml addition
+- id: no-xgi-import
+  patterns:
+    - pattern: import xgi
+  message: "xgi has been replaced by hypergraph_rs; use `import hypergraph_rs as xgi`"
+  language: python
+  paths: {include: ["src/babylon/**/*.py"]}
+```
+
+This makes the migration permanent (same pattern ADR052 used for NetworkX).
+
+### 6.7 What the Babylon integration spec/ADR will need to cover
+
+When Babylon adopts `hypergraph-rs`, a new ADR (call it ADR083) will codify:
+- The substrate swap (XGI → hypergraph-rs) as a continuation of Amendment L
+- The conformance gate (XGI test suite passes; Babylon qa:regression byte-identical)
+- The semgrep rule making the swap permanent
+- The matplotlib shim's optionality declaration
+- Any baselines that needed regeneration (the ADR052 precedent: hopefully
+  none, but the gate proves it)
+
+This ADR is **deferred** — we're building the standalone lib first, swapping
+Babylon second. The ADR is written when the swap is ready to land.
+
+---
+
+## 7. WASM binding — `hypergraph-rs-wasm`
+
+The WASM crate is a thin adapter over the core, exposing the same API to
+JavaScript/TypeScript. This is what lets React call the Rust core directly.
+
+### 7.1 Crate structure
+
+```rust
+// crates/hypergraph-rs-wasm/Cargo.toml
+[package]
+name = "hypergraph-rs-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hypergraph-rs = { path = "../hypergraph-rs" }
+wasm-bindgen = "0.2"
+js-sys = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+getrandom = { version = "0.2", features = ["js"] }  # rand for browsers
+
+[profile.release]
+opt-level = "s"     # size-optimized for web
+lto = true
+```
+
+### 7.2 Binding pattern — JsValue-passing for attrs, typed methods for structure
+
+```rust
+use wasm_bindgen::prelude::*;
+use serde_wasm_bindgen::to_value;
+use hypergraph_rs::Hypergraph as RustHypergraph;
+use hypergraph_rs::layout::LayoutStrategy;
+use hypergraph_rs::viz::SceneGraph;
+
+#[wasm_bindgen]
+pub struct Hypergraph {
+    inner: RustHypergraph<serde_json::Value, serde_json::Value, serde_json::Value>,
+}
+
+#[wasm_bindgen]
+impl Hypergraph {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self { Self { inner: RustHypergraph::new() } }
+
+    #[wasm_bindgen(js_name = addNode)]
+    pub fn add_node(&mut self, id: &str, attrs: JsValue) -> bool {
+        let attrs = serde_wasm_bindgen::from_value(attrs).unwrap_or(serde_json::Value::Null);
+        self.inner.add_node(id, attrs)
+    }
+
+    #[wasm_bindgen(js_name = addEdge)]
+    pub fn add_edge(&mut self, members: Vec<String>, idx: Option<String>, attrs: JsValue) -> String {
+        let attrs = serde_wasm_bindgen::from_value(attrs).unwrap_or(serde_json::Value::Null);
+        self.inner.add_edge(members, idx, attrs)
+    }
+
+    #[wasm_bindgen(js_name = memberships)]
+    pub fn memberships(&self, node_id: &str) -> Vec<String> {
+        self.inner.memberships(node_id).unwrap_or_default()
+    }
+
+    /// Returns the scene-graph as a JS object (the rendering contract).
+    #[wasm_bindgen(js_name = render)]
+    pub fn render(&self, strategy: JsValue) -> JsValue {
+        let strategy: LayoutStrategy = if strategy.is_undefined() {
+            LayoutStrategy::HyperedgeAware { iterations: 100, halo_padding: 0.5 }
+        } else {
+            serde_wasm_bindgen::from_value(strategy).unwrap_or(LayoutStrategy::HyperedgeAware { iterations: 100, halo_padding: 0.5 })
+        };
+        let scene = self.inner.render(strategy);
+        serde_wasm_bindgen::to_value(&scene).unwrap_or(JsValue::NULL)
+    }
+
+    /// Load from JSON (the readwrite::json_load parity).
+    #[wasm_bindgen(js_name = fromJson)]
+    pub fn from_json(json: &str) -> Result<Hypergraph, JsValue> {
+        let inner = serde_json::from_str(json)
+            .map_err(|e| JsValue::from_str(&format!("JSON parse error: {e}")))?;
+        Ok(Self { inner })
+    }
+
+    /// Serialize to JSON.
+    #[wasm_bindgen(js_name = toJson)]
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(&self.inner).unwrap_or_else(|_| "{}".to_string())
+    }
+}
+```
+
+### 7.3 Consumption from React
+
+```typescript
+import init, { Hypergraph, LayoutStrategy } from 'hypergraph-rs-wasm';
+
+let wasmReady: Promise<void> | null = null;
+function ensureWasm() {
+  if (!wasmReady) wasmReady = init();
+  return wasmReady;
+}
+
+export function useHypergraph() {
+  const [scene, setScene] = useState<SceneGraph | null>(null);
+  const ref = useRef<Hypergraph | null>(null);
+
+  const build = useCallback(async (memberships: Membership[]) => {
+    await ensureWasm();
+    const H = new Hypergraph();
+    for (const m of memberships) H.addEdge(m.members, m.id, m.attrs);
+    ref.current = H;
+    setScene(H.render(LayoutStrategy.HyperedgeAware));
+  }, []);
+
+  return { scene, build };
+}
+```
+
+### 7.4 Distribution
+
+Two npm packages:
+- **`hypergraph-rs-wasm`** — the WASM module + TypeScript types (published
+  by `wasm-pack publish`)
+- **`@hypergraph-rs/react`** — the optional React components that consume a
+  `SceneGraph` (a separate pure-TypeScript package, no WASM dependency of its
+  own — it just takes JSON)
+
+### 7.5 Size budget
+
+WASM modules are size-sensitive for web. The release profile uses
+`opt-level = "s"` + `lto = true`. Target: <500KB gzipped for the core (no
+algorithms) and <1.5MB gzipped with all algorithms. Feature flags let users
+exclude `dynamics`, `communities`, `generators` if they only need core + viz.
+
+### 7.6 Determinism in the browser
+
+The `getrandom` crate with the `js` feature uses `crypto.getRandomValues` —
+non-deterministic. For **seeded** generators (the `generators` module), we
+use `rand_pcg::Pcg64Mcg` seeded explicitly, same as the native build.
+Determinism is opt-in per call (pass a seed), not a global property. This
+matches XGI's `seed=` parameter semantics.
+
+---
+
+## 8. CLI — `hypergraph-rs-cli`
+
+The CLI is the third surface — a binary for inspecting, converting,
+validating, and rendering hypergraphs without writing Python.
+
+### 8.1 Command surface (clap-derive)
+
+```rust
+#[derive(Parser)]
+#[command(name = "hypergraph-rs", version, about = "XGI-compatible hypergraph toolkit (Rust)")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Inspect a hypergraph file (stats summary)
+    Inspect { input: PathBuf, #[arg(long, default_value = "text")] format: InspectFormat },
+    /// Convert between formats (json, edgelist, hif, incidence-matrix)
+    Convert { input: PathBuf, #[arg(long, value_enum)] from: Format, #[arg(long, value_enum)] to: Format, #[arg(long, default_value = "-")] output: String },
+    /// Validate a hypergraph file against XGI semantics
+    Validate { input: PathBuf, #[arg(long)] strict: bool },
+    /// Render a hypergraph to SVG or scene-graph JSON
+    Render { input: PathBuf, #[arg(long, default_value = "output.svg")] output: PathBuf, #[arg(long, default_value = "hyperedge-aware")] layout: LayoutStrategyArg, #[arg(long, default_value = "svg")] format: RenderFormat, #[arg(long)] width: Option<f32>, #[arg(long)] height: Option<f32> },
+    /// Compute the incidence or adjacency matrix
+    Matrix { input: PathBuf, #[arg(long, value_enum, default_value = "incidence")] kind: MatrixKind, #[arg(long, default_value = "dense")] format: MatrixFormat, #[arg(long, default_value = "-")] output: String },
+    /// Run an algorithm (centrality, components, etc.) and print results
+    Run { input: PathBuf, #[arg(long)] algorithm: String, #[arg(long)] node: Option<String> },
+    /// Generate a hypergraph from a named generator
+    Generate { #[arg(long)] generator: String, #[arg(long)] output: PathBuf, #[arg(long)] seed: Option<u64>, #[arg(long)] params: Option<String> },
+    /// Self-test: run a subset of the conformance Suite
+    Selftest { #[arg(long, default_value = "fast")] mode: SelftestMode },
+}
+```
+
+### 8.2 Example sessions
+
+```bash
+# Inspect
+$ hypergraph-rs inspect community.json
+Hypergraph: community.json
+  Nodes:           247
+  Hyperedges:      18
+  Density:         0.43
+  Membership stats: min=1, max=87, mean=12.3, median=8
+
+# Render to SVG (the visual use case)
+$ hypergraph-rs render community.json --output community.svg --layout hyperedge-aware
+
+# Render to scene-graph JSON (for React consumption via CLI pipeline)
+$ hypergraph-rs render community.json --layout spring --format json --output scene.json
+
+# Validate
+$ hypergraph-rs validate community.json --strict
+OK: 247 nodes, 18 hyperedges, no semantic violations.
+
+# Self-test (CI use)
+$ hypergraph-rs selftest --mode fast
+Running 47 conformance tests (fast mode)...
+PASS: 47/47
+```
+
+### 8.3 Design principles
+
+1. **Thin wrapper** — the CLI has no business logic. Every command calls
+   into `hypergraph-rs` core.
+2. **Streaming where possible** — `--output -` writes to stdout for piping.
+3. **CI-friendly** — `validate` and `selftest` exit with non-zero on failure.
+4. **Render is the killer feature** — simplest way to get a hypergraph
+   visualization without writing any code.
+
+### 8.4 Exit codes
+
+- `0` — success
+- `1` — generic error (file not found, parse error)
+- `2` — validation failure (`validate` command)
+- `3` — conformance failure (`selftest` command)
+
+### 8.5 Distribution
+
+- **Cargo install**: `cargo install hypergraph-rs-cli` (Rust users)
+- **Pre-built binaries** on GitHub releases (Linux x86_64, macOS arm64/x86_64,
+  Windows x86_64) via `cargo-dist` or similar
+- **Not published to npm or PyPI** — it's a standalone binary
+
+---
+
+## 9. Conformance gate — XGI test suite as oracle
+
+The gate is "XGI's 50 test files pass against the Rust port." This is the
+primary definition of done for the port.
+
+### 9.1 The oracle: XGI's own test suite
+
+Source: `.pre-commit-cache/repov2jlq728/` (XGI 0.10.1 full clone with
+`tests/`).
+
+We copy these 50 test files into `hypergraph-rs/tests/ported/` and adapt
+them with a single transformation at port time:
+
+```python
+# Before (XGI's test):
+import xgi
+H = xgi.Hypergraph()
+assert H.num_nodes == 0
+
+# After (our port):
+import hypergraph_rs as xgi   # ← the only change
+H = xgi.Hypergraph()
+assert H.num_nodes == 0
+```
+
+The test logic is **unchanged** — same assertions, same fixtures, same
+expected values. If a test fails, it means our Rust port diverges from XGI's
+semantics.
+
+### 9.2 Test file inventory (the 50 files, ~650 assertions)
+
+| Path | ~Tests | Priority |
+|---|---|---|
+| `tests/core/test_hypergraph.py` | 80 | P0 — most-used API |
+| `tests/core/test_dihypergraph.py` | 50 | P0 |
+| `tests/core/test_views.py` | 30 | P0 — `H.nodes`/`H.edges` |
+| `tests/core/test_simplicialcomplex.py` | 40 | P1 |
+| `tests/core/test_globalviews.py` | 15 | P1 |
+| `tests/algorithms/test_centrality.py` | 25 | P1 |
+| `tests/algorithms/test_clustering.py` | 20 | P1 |
+| `tests/algorithms/test_shortest_path.py` | 15 | P1 |
+| `tests/algorithms/test_assortativity.py` | 15 | P2 |
+| `tests/algorithms/test_connected.py` | 10 | P1 |
+| `tests/algorithms/test_properties.py` | 20 | P2 |
+| `tests/algorithms/test_simpliciality.py` | 15 | P2 |
+| `tests/stats/test_nodestats.py` | 20 | P2 |
+| `tests/stats/test_edgestats.py` | 20 | P2 |
+| `tests/stats/test_dinodestats.py` | 15 | P2 |
+| `tests/stats/test_diedgestats.py` | 15 | P2 |
+| `tests/stats/test_core_stats_functions.py` | 20 | P2 |
+| `tests/generators/test_random.py` | 20 | P1 — determinism-sensitive |
+| `tests/generators/test_classic.py` | 15 | P1 |
+| `tests/generators/test_lattice.py` | 10 | P2 |
+| `tests/generators/test_uniform.py` | 10 | P2 |
+| `tests/generators/test_randomizing.py` | 10 | P2 |
+| `tests/generators/test_simplicial_complexes.py` | 10 | P2 |
+| `tests/readwrite/test_json.py` | 15 | P1 |
+| `tests/readwrite/test_edgelist.py` | 10 | P2 |
+| `tests/readwrite/test_incidence_matrix.py` | 15 | P1 — Babylon uses this |
+| `tests/readwrite/test_bigg_data.py` | 10 | P3 |
+| `tests/readwrite/test_hif.py` | 10 | P3 |
+| `tests/readwrite/test_bipartite_edgelist.py` | 10 | P2 |
+| `tests/readwrite/test_xgi_data.py` | 5 | P3 (network) |
+| `tests/communities/test_spectral.py` | 10 | P2 |
+| `tests/drawing/test_draw.py` | 20 | P3 — replaced by scene-graph tests |
+| `tests/drawing/test_draw_utils.py` | 10 | P3 |
+| `tests/drawing/test_layout.py` | 15 | P1 — layout is our viz base |
+| `tests/utils/test_utilities.py` | 15 | P2 |
+| `tests/conftest.py` | (fixtures) | P0 — shared fixtures |
+
+### 9.3 Drawing tests — special handling
+
+XGI's `tests/drawing/test_draw.py` uses matplotlib's image comparison
+(`@pytest.mark.mpl_image_compare`) — pixel-level comparison of rendered
+PNGs. We **do not port these as-is**. Instead:
+
+- `test_layout.py` → ported (layout math is reusable, asserts on node
+  position values not pixels)
+- `test_draw.py`, `test_draw_utils.py` → replaced with scene-graph tests:
+
+```python
+def test_render_produces_valid_scene_graph():
+    import hypergraph_rs as xgi
+    H = xgi.Hypergraph()
+    H.add_edge(["a", "b", "c"], idx="e1")
+    scene = H.render(xgi.LayoutStrategy.HYPEREDGE_AWARE)
+    assert len(scene["nodes"]) == 3
+    assert len(scene["hyperedges"]) == 1
+    assert scene["hyperedges"][0]["member_ids"] == ["a", "b", "c"]
+    assert scene["bounding_box"][2] > scene["bounding_box"][0]  # max_x > min_x
+```
+
+### 9.4 Generators — determinism sensitivity
+
+XGI's generator tests use `numpy.random` with explicit seeds. Our Rust port
+uses `rand_pcg` (Pcg64Mcg) with the same seeds. **This is a known conformance
+risk**: different RNGs produce different sequences even with the same seed.
+
+**Two options for the generator tests:**
+- **(a) Seed-portable tests**: XGI's tests that assert on *structural
+  properties* (e.g., "the generated hypergraph has 50 nodes and 10
+  hyperedges") pass regardless of RNG. Tests that assert on *exact
+  membership* (e.g., "edge 3 contains nodes [a, b, c]") will fail because
+  the RNG sequence differs.
+- **(b) Record-replay**: For exact-membership tests, we record XGI's output
+  once, save as fixtures, and assert against those fixtures. This makes the
+  tests deterministic but they no longer test the generator's *behavior*,
+  only its *output parity*.
+
+**Recommended**: Option (a) for most generator tests (structural property
+assertions), Option (b) for a small set of "golden output" tests where exact
+membership matters. We document which generator tests are property-based vs
+parity-based in the test file headers.
+
+### 9.5 Property-based drift backstop (the ADR052 pattern)
+
+Beyond XGI's tests, we add a property-based differential test mirroring
+ADR052's `test_graph_iteration_order.py`:
+
+```rust
+// hypergraph-rs/tests/property_differential.rs
+use proptest::prelude::*;
+
+proptest! {
+    /// Differential test: any sequence of add/remove operations on our
+    /// Hypergraph must produce the same membership/iteration behavior
+    /// as XGI's Hypergraph (run via PyO3 in the same test).
+    #[test]
+    fn differential_vs_xgi(ops: Vec<HyperOp>) {
+        let mut ours = hypergraph_rs::Hypergraph::new();
+        let mut theirs = xgi::Hypergraph::new();  // via PyO3
+
+        for op in ops {
+            // apply op to both
+            // assert membership queries, iteration order, num_nodes, num_edges all match
+        }
+    }
+}
+```
+
+This runs the real XGI as a Python oracle (via PyO3) inside a Rust proptest.
+Random operation sequences, same assertions on both. Catches any semantic
+drift the fixed test suite misses. Same pattern that proved BabylonGraph's
+order contract in ADR052.
+
+### 9.6 Babylon qa:regression as a secondary gate
+
+The user chose "XGI test suite as oracle" (not "both gates"). Babylon's
+`mise run qa:regression` (5-scenario byte-identical baselines) is a
+**secondary** gate that activates only when Babylon swaps. It's not part of
+the hypergraph-rs conformance gate itself, but it's the gate that proves the
+swap didn't perturb the simulation. Two independent verification strategies —
+matches Constitution III.12 (Redundant verification), but each is its own
+gate at its own phase.
+
+### 9.7 CI integration
+
+```yaml
+# hypergraph-rs/.github/workflows/ci.yml
+jobs:
+  rust-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo test -p hypergraph-rs
+      - run: cargo test -p hypergraph-rs-python
+
+  xgi-conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - run: pip install maturin && maturin develop
+      - run: pytest tests/ported/                      # XGI's 50 test files, adapted
+      - run: cargo test --test property_differential   # the proptest oracle
+
+  wasm-build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: wasm-pack build crates/hypergraph-rs-wasm --target web
+
+  cli-build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo build -p hypergraph-rs-cli --release
+```
+
+The `xgi-conformance` job is the primary gate. It runs the 50 ported test
+files + the property-based differential test. If it passes, the port is
+conformant.
+
+---
+
+## 10. Build, release, and implementation phasing
+
+### 10.1 Build system
+
+**Rust workspace** (`hypergraph-rs/Cargo.toml`):
+```toml
+[workspace]
+members = [
+    "crates/hypergraph-rs",
+    "crates/hypergraph-rs-python",
+    "crates/hypergraph-rs-wasm",
+    "crates/hypergraph-rs-cli",
+]
+resolver = "2"
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.79"  # match rustworkx-core MSRV
+license = "BSD-3-Clause"
+authors = ["Babylon Project"]
+
+[workspace.dependencies]
+rustworkx-core = "0.18"
+petgraph = "0.6"        # re-exported by rustworkx-core, pinned to match
+indexmap = "2"
+ndarray = "0.16"
+sprs = "0.11"           # sparse matrices (incidence, adjacency, overlap)
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+rand = "0.8"
+rand_pcg = "0.3"        # seeded RNG for deterministic generators
+rayon = "1"             # parallelism (matches rustworkx-core)
+```
+
+**Feature flags** (`crates/hypergraph-rs/Cargo.toml`):
+```toml
+[features]
+default = ["algorithms", "generators", "stats", "readwrite", "layout", "viz"]
+all = ["default", "dynamics", "communities", "convert", "network"]
+algorithms = []
+generators = []
+stats = []
+readwrite = []
+layout = []
+viz = []
+dynamics = []
+communities = []
+convert = []
+network = ["reqwest"]  # xgi_data fetches from network — off by default
+```
+
+This lets the WASM build exclude `dynamics`, `communities`, `network` to hit
+the size budget, while the CLI build uses `all`.
+
+### 10.2 Three build targets, one core
+
+| Surface | Build command | Output | Distributes via |
+|---|---|---|---|
+| **Rust core** | `cargo build -p hypergraph-rs` | `libhypergraph_rs.rlib` | crates.io (`hypergraph-rs`) |
+| **Python ext** | `maturin develop` (or `maturin build --release`) | `hypergraph_rs._core.so` + `.pyi` | PyPI (`hypergraph-rs`) |
+| **WASM** | `wasm-pack build crates/hypergraph-rs-wasm --target web --release` | `hypergraph_rs_wasm.js` + `.wasm` + `.d.ts` | npm (`hypergraph-rs-wasm`) |
+| **CLI** | `cargo build -p hypergraph-rs-cli --release` | `hypergraph-rs` binary | GitHub Releases + `cargo install` |
+
+### 10.3 Implementation phasing — the full-port-then-swap roadmap
+
+The user chose "Full port first, then swap." Phased breakdown:
+
+#### Phase 0: Workspace bootstrap (1-2 days)
+- Create `/hypergraph-rs/` workspace with 4 empty crates
+- `Cargo.toml` workspace + per-crate manifests with feature flags
+- CI skeleton (the matrix from §9.7, with placeholder tests)
+- LICENSE (BSD-3-Clause), README.md scaffold, CHANGELOG.md
+- Verify `cargo build` on all 4 crates passes
+
+#### Phase 1: Core data structure + minimal API (1-2 weeks)
+- `Hypergraph<N, E, M>` struct (bipartite `petgraph::graph::DiGraph`)
+- `add_node`, `add_edge`, `remove_node`, `remove_edge`, `memberships`,
+  `members`, `num_nodes`, `num_edges`
+- `agent_ids` / `hyperedge_ids` IndexMap bimaps
+- Insertion-ordered iteration (the III.7 parity contract)
+- Property-based differential test harness (PyO3 to real XGI as oracle)
+- **Conformance:** XGI's `tests/core/test_hypergraph.py` passes
+
+#### Phase 2: DiHypergraph + SimplicialComplex + views (1 week)
+- `DiHypergraph` (directed membership edges)
+- `SimplicialComplex` (hypergraph + face lattice cache)
+- `NodeView`, `EdgeView` proxy objects (Rust side; PyO3 side in Phase 7)
+- **Conformance:** `test_dihypergraph.py`, `test_simplicialcomplex.py`,
+  `test_views.py`, `test_globalviews.py` pass
+
+#### Phase 3: Linear algebra + algorithms (1-2 weeks)
+- `linalg/`: `incidence_matrix` (sparse + dense), `adjacency_matrix`, overlap
+  matrix — all derived from the bipartite graph via `sprs`
+- `algorithms/`: centrality, clustering, shortest paths, connected components,
+  assortativity — delegate to `rustworkx-core` on the 1-skeleton or bipartite
+  graph
+- **Conformance:** `tests/linalg/`, `tests/algorithms/` pass
+
+#### Phase 4: Generators + stats + readwrite (1-2 weeks)
+- `generators/`: random, classic, lattice, uniform, simplicial — seeded `rand_pcg`
+- `stats/`: nodestats, edgestats, diedgestats, dinodestats
+- `readwrite/`: JSON (serde), edgelist, HIF, incidence_matrix I/O, BIGG
+- **Conformance:** `tests/generators/`, `tests/stats/`, `tests/readwrite/`
+  pass (with the generator-test split from §9.4)
+
+#### Phase 5: Layout + viz (1 week)
+- `layout/`: 4 strategies, delegating to `rustworkx-core` layouts where possible
+- `viz/`: `SceneGraph` struct, `render()` method, `render_to_svg()`,
+  `render_to_json()`
+- **Conformance:** `tests/drawing/test_layout.py` passes (position
+  assertions); drawing tests replaced with scene-graph tests
+
+#### Phase 6: Secondary modules (3-5 days)
+- `convert/`: to/from rustworkx, bipartite, dict, edgelist
+- `dynamics/`: SIR, SIS epidemic models
+- `communities/`: spectral clustering
+- `utils/`: utilities
+- **Conformance:** `tests/convert/`, `tests/dynamics/`,
+  `tests/communities/`, `tests/utils/` pass
+
+#### Phase 7: Python bindings (1-2 weeks) — **the conformance gate**
+- PyO3 bindings for the full 164-symbol surface
+- Maturin build configuration, `pyproject.toml`
+- `hypergraph_rs/__init__.py` mirroring XGI's exactly
+- `.pyi` stubs (auto-generated from PyO3 signatures)
+- Matplotlib shim (`drawing` submodule, `mpl` feature flag)
+- **Gate:** All 50 XGI test files pass with `import hypergraph_rs as xgi`.
+  The conformance gate is met.
+
+#### Phase 8: WASM bindings (1 week)
+- `wasm-bindgen` wrappers
+- `serde-wasm-bindgen` for attribute passing
+- TypeScript types auto-generated by `wasm-pack`
+- `wasm-pack test` headless tests
+- Size budget verified (<500KB core gzipped, <1.5MB all algorithms)
+
+#### Phase 9: CLI (3-5 days)
+- `clap`-derive command surface (8 subcommands from §8.1)
+- Smoke tests for each command
+- Pre-built binaries via `cargo-dist` on GitHub Releases
+
+#### Phase 10: Optional `@hypergraph-rs/react` package (2-3 days)
+- Pure-TypeScript React components consuming a `SceneGraph`
+- Storybook for component development
+- npm publish
+
+#### Phase 11: Babylon swap (separate effort, post-port)
+- Deferred ADR083 written
+- `s/^import xgi$/import hypergraph_rs as xgi/` across 7 Babylon files
+- Babylon `pyproject.toml`: remove `xgi`, add `hypergraph-rs` path dep
+- Babylon `mise run qa:regression` byte-identical (the secondary gate)
+- Semgrep rule banning `import xgi` (the permanent-migration enforcement)
+- XGI removed from Babylon's dependency tree
+
+### 10.4 Estimated timeline
+
+| Phase | Duration | Cumulative |
+|---|---|---|
+| 0: Bootstrap | 1-2 days | 2 days |
+| 1: Core data structure | 1-2 weeks | 2.5 weeks |
+| 2: DiHypergraph + Simplicial + views | 1 week | 3.5 weeks |
+| 3: linalg + algorithms | 1-2 weeks | 5.5 weeks |
+| 4: generators + stats + readwrite | 1-2 weeks | 7.5 weeks |
+| 5: layout + viz | 1 week | 8.5 weeks |
+| 6: convert + dynamics + communities + utils | 3-5 days | 9.5 weeks |
+| 7: Python bindings (the conformance gate) | 1-2 weeks | 11 weeks |
+| 8: WASM | 1 week | 12 weeks |
+| 9: CLI | 3-5 days | 13 weeks |
+| 10: React package | 2-3 days | 13.5 weeks |
+| **Total to conformance gate** (Phase 7) | **~11 weeks** | |
+| **Total to all three surfaces shipping** (Phase 9) | **~13 weeks** | |
+| 11: Babylon swap | separate effort | |
+
+Solo-dev estimates with TDD discipline (the conformance tests are written
+alongside the implementation, red→green). Parallelizing with subagents could
+compress Phases 3-6 (the algorithm ports are largely independent).
+
+### 10.5 Risks and mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Generator RNG divergence (XGI uses numpy.random, we use rand_pcg) | High | Property-based tests for structural invariants; recorded fixtures for exact-membership tests (§9.4) |
+| Petgraph insertion order not matching XGI's dict order under churn | Medium | Property-based differential test (ADR052 pattern) catches any drift; the IndexMap bimaps enforce insertion order independently |
+| WASM size budget blown by algorithm code | Medium | Feature flags exclude unused modules; `opt-level = "s"` + `lto = true`; size CI check |
+| PyO3 binding overhead for 164 symbols | Low | Maturin auto-generates stubs; binding crate is thin (delegates to Rust core) |
+| rustworkx-core missing algorithms we need | Low | We can re-implement missing algorithms in `hypergraph-rs::algorithms` directly on petgraph; rustworkx-core is open to upstream contributions |
+| Babylon's qa:regression shifts on swap | Low (ADR052 precedent) | The conformance gate (XGI tests passing) makes this unlikely; if it happens, regenerate baselines with written proof (ADR052 pattern) |
+
+### 10.6 Definition of done
+
+**For hypergraph-rs v0.1.0 (the standalone library):**
+1. All 50 XGI test files pass with `import hypergraph_rs as xgi`
+2. The property-based differential test passes (proptest vs real XGI)
+3. All 4 crates build on Linux, macOS, Windows
+4. Python wheels for cp310-cp313 on all three OSes
+5. WASM module <1.5MB gzipped with all features, <500KB core
+6. CLI binary smoke-tested on all three OSes
+7. Documentation: README, crate docs, migration guide (XGI → hypergraph-rs)
+
+**For the Babylon swap (separate effort, v0.2.0):**
+1. ADR083 written and accepted
+2. 7 Babylon files swapped (`import xgi` → `import hypergraph_rs as xgi`)
+3. `mise run qa:regression` byte-identical (no baseline regeneration, or
+   regenerations with written proof)
+4. Semgrep rule banning `import xgi` active
+5. `xgi` removed from `pyproject.toml`
+
+---
+
+## 11. Constitutional framing & Amendment D
+
+### 11.1 Why this is standalone, not the v2 reimplementation
+
+Article II.7 (Edges vs Hyperedges) is in `[TRANSITION STATE — Pending
+Amendment D]` (CONSTITUTION.md:245, also I.18, II.3, VIII.9, IX.3 Transition
+State Protocol). The Constitution's own protocol states: *"If a principle is
+marked `[TRANSITION STATE]`, the agent MUST treat it as blocked. It MAY
+propose a spec to resolve the transition state, but it MUST NOT implement
+code that depends on the unresolved principle."*
+
+`hypergraph-rs` is therefore built as a **standalone, decoupled library** —
+XGI semantics in Rust, as a rustworkx-core plugin. It does NOT touch
+Babylon's hyperedge code. Babylon may adopt it later via a separate spec/ADR
+when Amendment D is resolved. The library is a portable computational
+rendering package, not an ideological package.
+
+### 11.2 Why the swap is a continuation of Amendment L, not a new amendment
+
+When Babylon does adopt `hypergraph-rs` (Phase 11, deferred), the swap is
+framed as a 1-for-1 substrate swap of the existing v1 XGI usage — analogous
+to ADR052 (NetworkX→rustworkx). Amendment L already says the dual-graph
+commitment is "rustworkx+XGI" — swapping XGI for a rustworkx-plugin
+hypergraph lib is a continuation of that, NOT the v2 reimplementation.
+Byte-identical behavior is the gate. No new amendment needed for the swap
+itself; ADR083 codifies the swap, not new constitutional principles.
+
+### 11.3 What WOULD require Amendment D
+
+If, after adopting `hypergraph-rs`, Babylon wants to evolve its hyperedge
+usage BEYOND a 1-for-1 swap of v1 XGI semantics — e.g., the "v2
+reimplementation" that reconciles the rustworkx+hypergraph dual-graph with
+the strictly-dyadic morphism constraint (II.9) while preserving Anti-Pattern
+VIII.9 — THAT would require drafting and ratifying Amendment D. The
+`hypergraph-rs` library is a tool that COULD be used to implement Amendment
+D's reconciliation, but the library itself does not depend on the amendment.
+
+### 11.4 License compatibility
+
+`hypergraph-rs` is BSD-3-Clause (matches XGI, the source we're porting).
+Babylon is AGPL-v3. rustworkx-core is Apache-2.0. Compatibility:
+
+- BSD-3-Clause → AGPL-v3: ✅ compatible (BSD-3 is permissive, works as a
+  dependency under AGPL)
+- BSD-3-Clause → Apache-2.0: ✅ compatible
+- Apache-2.0 (rustworkx-core) → BSD-3-Clause (our crate): ✅ compatible
+
+Owner directive: "babylon is AGPL-v3 so BSD should work fine with it" —
+confirmed correct.
+
+---
+
+## 12. Open questions / future work (out of scope for v0.1.0)
+
+- **Performance benchmarking vs XGI**: ADR052 produced a benchmark table
+  (`tools/benchmarks/graph_backend_bench.py`) showing 2.7-5x speedups. We
+  should produce the equivalent for hypergraph-rs vs XGI. Deferred to
+  post-conformance.
+- **`xgi_data` network integration**: fetching datasets from the XGI data
+  repository. Gated behind the `network` feature flag; not a v0.1.0 blocker.
+- **GPU acceleration**: trivially parallelizable algorithms (matrix ops,
+  centrality) could use `wgpu` in the WASM target. Future work.
+- **Babylon-specific generic typing**: `Hypergraph<BabylonAgent,
+  CommunityState, MembershipRole>` — a typed wrapper that Babylon can build
+  on top of the dynamic `serde_json::Value` defaults. Future work, post-swap.
+- **Amendment D reconciliation**: using `hypergraph-rs` to implement the v2
+  hyperedge semantics that resolve the II.7 transition state. Future
+  constitutional work, separate from this library.

--- a/docs/superpowers/specs/2026-07-18-hypergraph-rs-design.md
+++ b/docs/superpowers/specs/2026-07-18-hypergraph-rs-design.md
@@ -38,8 +38,12 @@ across 7 consumer files, removing the `xgi` Poetry dependency entirely.
 
 ## 2. Workspace architecture
 
-Top-level `/hypergraph-rs/` in the babylon repo (external dep — Babylon
-declares it via a Poetry path dependency).
+Top-level `/hypergraph-rs/` at the babylon repo root, mounted as its **own
+git repository** (the parent `.gitignore`s `/hypergraph-rs/` — the program-20
+`infra/` subrepo pattern; owner ruling 2026-07-18: isolated dev environment,
+becomes a submodule/remote repo when published). Babylon declares it via a
+Poetry path dependency at swap time (Phase 11) and imports only the built
+PyO3 extension.
 
 ```
 hypergraph-rs/                          # top-level workspace, external dep
@@ -89,8 +93,8 @@ hypergraph-rs/                          # top-level workspace, external dep
   deps) + three thin binding crates. The core does all the work; bindings are
   thin adapters.
 - **`rustworkx-core` is the backbone.** The hypergraph IS a
-  `rustworkx_core::petgraph::Graph` under the hood (see §3) — this is what
-  makes it a "genuine plugin."
+  `rustworkx_core::petgraph::stable_graph::StableDiGraph` under the hood
+  (see §3) — this is what makes it a "genuine plugin."
 - **The npm package is optional/secondary.** The scene-graph JSON is the
   contract; the React renderer is one consumer.
 
@@ -98,12 +102,12 @@ hypergraph-rs/                          # top-level workspace, external dep
 
 ## 3. Core data structure — bipartite rustworkx graph (Approach B)
 
-The hypergraph IS a `rustworkx_core::petgraph::Graph` with two node kinds.
-This is what makes it a genuine rustworkx plugin — we extend petgraph's data
-structure with n-ary semantics.
+The hypergraph IS a `rustworkx_core::petgraph::stable_graph::StableDiGraph`
+with two node kinds. This is what makes it a genuine rustworkx plugin — we
+extend petgraph's data structure with n-ary semantics.
 
 ```rust
-use rustworkx_core::petgraph::graph::{DiGraph, NodeIndex};
+use rustworkx_core::petgraph::stable_graph::{NodeIndex, StableDiGraph};
 use indexmap::IndexMap;
 
 /// The two roles in the bipartite structure.
@@ -125,9 +129,10 @@ pub struct MembershipEdge<M> {
 /// The hypergraph. One field. Everything else is views over it.
 pub struct Hypergraph<N = serde_json::Value, E = serde_json::Value, M = serde_json::Value> {
     /// Bipartite: Agent nodes + Hyperedge nodes + membership edges.
-    /// Insertion-ordered (petgraph::graph::DiGraph preserves insertion order
-    /// for both nodes and edges — required for III.7 determinism parity).
-    inner: DiGraph<NodeKind<N, E>, MembershipEdge<M>>,
+    /// Insertion-ordered (StableDiGraph preserves insertion order for both
+    /// nodes and edges, leaving holes on removal — required for III.7
+    /// determinism parity; plain Graph/DiGraph swap-compacts on removal).
+    inner: StableDiGraph<NodeKind<N, E>, MembershipEdge<M>>,
 
     /// Insertion-ordered bimaps for O(1) id-based lookup (mirrors
     /// BabylonGraph's `_ids` / `_index_to_id` pattern from ADR052).
@@ -191,16 +196,19 @@ pub struct SimplicialComplex<N, E, M> {
 
 ### 3.5 Determinism (III.7 parity)
 
-`petgraph::graph::DiGraph` preserves insertion order for both nodes and edges
-(unlike rustworkx's `PyDiGraph` which reuses indices — the exact issue ADR052
-had to work around). So the bipartite substrate is *naturally* insertion
-ordered, no mirror dicts needed for ordering. The `agent_ids` /
-`hyperedge_ids` IndexMaps are for O(1) id lookup only, not ordering.
+`petgraph::stable_graph::StableDiGraph` preserves insertion order for both
+nodes and edges even under removal (unlike rustworkx's `PyDiGraph` which
+reuses indices — the exact issue ADR052 had to work around; and unlike
+petgraph's plain `Graph`/`DiGraph`, whose `remove_node` swap-compacts the
+last node into the freed slot, breaking insertion order under churn). So the
+bipartite substrate is *naturally* insertion ordered, no mirror dicts needed
+for ordering. The `agent_ids` / `hyperedge_ids` IndexMaps are for O(1) id
+lookup only, not ordering.
 
-`petgraph::graph::DiGraph` removes nodes by leaving a hole (the index is
-marked removed, not reused) — better for determinism than `PyDiGraph`.
-Iteration via `inner.node_indices()` skips holes automatically. The bimaps
-hide this entirely from the public API.
+`StableDiGraph` removes nodes by leaving a hole — "The node index a is
+invalidated, but none other" (petgraph 0.8.3 docs, the version rustworkx-core
+0.18 resolves). Iteration via `inner.node_indices()` skips holes
+automatically. The bimaps hide this entirely from the public API.
 
 ---
 
@@ -217,7 +225,7 @@ impl<N, E, M> Hypergraph<N, E, M> {
     // Constructors
     pub fn new() -> Self;
     pub fn from_memberships(memberships: Vec<(String, Vec<String>)>) -> Self;
-    pub fn from_bipartite_graph(g: petgraph::graph::DiGraph<N, E>) -> Self;
+    pub fn from_bipartite_graph(g: petgraph::stable_graph::StableDiGraph<N, E>) -> Self;
 
     // Node CRUD
     pub fn add_node(&mut self, node_id: &str, attrs: N) -> bool;
@@ -226,8 +234,12 @@ impl<N, E, M> Hypergraph<N, E, M> {
     pub fn has_node(&self, node_id: &str) -> bool;
     pub fn num_nodes(&self) -> usize;
 
-    // Edge CRUD — XGI uses `idx=` for the edge ID (v0.9 breaking change, pinned)
-    pub fn add_edge(&mut self, members: Vec<String>, idx: Option<String>, attrs: E) -> String;
+    // Edge CRUD — XGI uses `idx=` for the edge ID (v0.9 breaking change, pinned).
+    // Result (not bare String): duplicate `idx` → Err(AlreadyExists), empty
+    // members → Err(EmptyMembers) — deliberate strictness deviations from XGI's
+    // warn+no-op / silent-empty-edge runtime behavior; the Python binding shims
+    // duplicate-idx back to warn+no-op for conformance.
+    pub fn add_edge(&mut self, members: Vec<String>, idx: Option<String>, attrs: E) -> Result<String, EdgeError>;
     pub fn add_edges_from(&mut self, edges: impl IntoIterator<Item = (Vec<String>, Option<String>, E)>);
     pub fn remove_edge(&mut self, edge_id: &str) -> Result<(), EdgeError>;
     pub fn has_edge(&self, edge_id: &str) -> bool;
@@ -251,7 +263,7 @@ impl<N, E, M> Hypergraph<N, E, M> {
 
     // 1-skeleton and bipartite projections (rustworkx-native algorithms run on these)
     pub fn skeleton(&self) -> rustworkx_core::petgraph::graph::Graph<String, f64>;
-    pub fn bipartite_graph(&self) -> &rustworkx_core::petgraph::graph::DiGraph<NodeKind<N,E>, MembershipEdge<M>>;
+    pub fn bipartite_graph(&self) -> &rustworkx_core::petgraph::stable_graph::StableDiGraph<NodeKind<N,E>, MembershipEdge<M>>;
 
     // Iteration (insertion-ordered, III.7 parity)
     pub fn node_ids(&self) -> impl Iterator<Item = &str>;
@@ -327,7 +339,7 @@ all generator functions, all algorithms, etc. The 164 symbols.
 ### 4.6 Determinism contract (Constitution III.7 parity)
 
 XGI's iteration order is insertion order (Python dicts). Our
-`petgraph::graph::DiGraph` + `IndexMap` combo is insertion-ordered by
+`petgraph::stable_graph::StableDiGraph` + `IndexMap` combo is insertion-ordered by
 construction. The conformance gate (XGI tests) will catch any order drift.
 We add a property-based test (like ADR052's `test_graph_iteration_order.py`)
 that differential-tests against the real XGI oracle on random hypergraph
@@ -545,7 +557,7 @@ rustworkx = "^0.18.0"
 # Removed:
 # xgi = "^0.10"
 # New (path dependency to the top-level workspace):
-hypergraph-rs = { path = "../hypergraph-rs/crates/hypergraph-rs-python", develop = true }
+hypergraph-rs = { path = "hypergraph-rs/crates/hypergraph-rs-python", develop = true }
 ```
 
 Babylon installs the PyO3 extension via Poetry's path dependency. Maturin
@@ -1052,13 +1064,15 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.79"  # match rustworkx-core MSRV
+rust-version = "1.85"  # rustworkx-core 0.18's declared MSRV (crates.io metadata)
 license = "BSD-3-Clause"
 authors = ["Babylon Project"]
 
 [workspace.dependencies]
+# NO direct petgraph dep: rustworkx-core 0.18 re-exports petgraph 0.8; all
+# petgraph types are reached via rustworkx_core::petgraph. A direct pin
+# resolves to a second, type-incompatible petgraph copy (verified 2026-07-18).
 rustworkx-core = "0.18"
-petgraph = "0.6"        # re-exported by rustworkx-core, pinned to match
 indexmap = "2"
 ndarray = "0.16"
 sprs = "0.11"           # sparse matrices (incidence, adjacency, overlap)
@@ -1110,7 +1124,7 @@ The user chose "Full port first, then swap." Phased breakdown:
 - Verify `cargo build` on all 4 crates passes
 
 #### Phase 1: Core data structure + minimal API (1-2 weeks)
-- `Hypergraph<N, E, M>` struct (bipartite `petgraph::graph::DiGraph`)
+- `Hypergraph<N, E, M>` struct (bipartite `petgraph::stable_graph::StableDiGraph`)
 - `add_node`, `add_edge`, `remove_node`, `remove_edge`, `memberships`,
   `members`, `num_nodes`, `num_edges`
 - `agent_ids` / `hyperedge_ids` IndexMap bimaps


### PR DESCRIPTION
## Summary

- **Design spec** (`docs/superpowers/specs/2026-07-18-hypergraph-rs-design.md`): standalone BSD-3-Clause Rust port of XGI 0.10.2 as a genuine rustworkx-core plugin — bipartite petgraph substrate, three surfaces (PyO3 / WASM / CLI), XGI's 50-file test suite as the conformance gate. Babylon swap deferred to ADR083 (Amendment D untouched — the library is standalone, per Constitution II.7 transition-state protocol).
- **Phase 0+1 implementation plan** (`docs/superpowers/plans/2026-07-18-hypergraph-rs-phase-0-1.md`): 19 TDD tasks — workspace bootstrap + core `Hypergraph<N,E,M>`.
- **Subrepo mount** (`.gitignore`): `/hypergraph-rs/` ignored at repo root, mirroring the program-20 `/infra/` pattern. Owner ruling 2026-07-18: hypergraph-rs develops as its own isolated git repo; Babylon imports the built PyO3 extension later.

## Owner-visible rulings encoded here

- hypergraph-rs = **isolated subrepo** (infra/ precedent), not a tracked directory of babylon
- Babylon-side integration deferred to Phase 11 / ADR083; nothing in `src/babylon/` changes in this program until then

Docs + one gitignore line only; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)