### PR TITLE
Housekeeping: nightly triage (lanes A/C/D fixed, B deferred to vol3) + Copilot closure + estate cleanup

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1064,25 +1064,22 @@ df -h /var | tail -1
 """
 
 [tasks."db:bootstrap"]
-description = "Apply babylon canonical schema to the running test container (idempotent)"
+# ensure_ddl_applied, not a bare per-statement loop (ADR074's own law): the
+# bare loop created every table but never the _babylon_schema_stamp digest
+# table (that DDL lives only inside ensure_ddl_applied), so nightly's
+# Postgres bootstrap silently diverged from the production schema path and
+# any test touching the stamp table failed (nightly 2026-07-19). The DDL set
+# is fully IF NOT EXISTS-idempotent, so the loop's error-swallowing bought
+# nothing; ensure_ddl_applied fails loudly instead (III.11).
+description = "Apply babylon canonical schema to the running test container (digest-stamped via ensure_ddl_applied, idempotent)"
 run = """
 poetry run python -c "
 import psycopg
-from babylon.persistence.postgres_schema import POSTGRES_SCHEMA_DDL
+from babylon.persistence.postgres_schema import POSTGRES_SCHEMA_DDL, ensure_ddl_applied
 dsn = 'host=localhost port=5433 dbname=babylon_test user=test password=test'
 with psycopg.connect(dsn, autocommit=True) as conn:
-    for ddl in POSTGRES_SCHEMA_DDL:
-        try:
-            conn.execute(ddl)
-        except psycopg.errors.DuplicateTable:
-            pass
-        except psycopg.errors.DuplicateObject:
-            pass
-        except psycopg.errors.UndefinedObject as e:
-            print(f'WARN missing extension: {e}')
-        except Exception as e:
-            print(f'WARN DDL: {e}')
-print('Schema bootstrap complete.')
+    executed = ensure_ddl_applied(conn, POSTGRES_SCHEMA_DDL)
+print(f'Schema bootstrap complete (executed={executed}, stamp table guaranteed).')
 "
 """
 

--- a/docs/superpowers/plans/2026-07-18-null-play-political-coupling.md
+++ b/docs/superpowers/plans/2026-07-18-null-play-political-coupling.md
@@ -1,0 +1,567 @@
+# Null-Play Political Coupling — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement
+> this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the five endgame recognizer axes drift over hundreds of ticks under null play, by
+(B) coupling consciousness to the *sustained* level of exploitation rather than its first difference,
+and (C) animating the political-topology layer that is currently seeded-but-static.
+
+**Architecture:** The causal spine this plan builds:
+
+```
+material base (already moves)
+  -> sustained wage-value defect  [B: new level term]
+  -> agitation -> class_consciousness / national_identity
+  -> solidarity (unfreezes: activation_threshold finally crossed)
+  -> faction influence_level        [C4]
+  -> winning faction -> ruling_faction_id   [C5]
+  -> colonial_stance                [C6]  -> ABOLISH/IGNORE/UPHOLD stance gates
+  -> state_violence_index           [C7]  -> fascist political-violence route
+  -> legitimacy erosion             [C8]  -> collapse path un-dormants
+  -> crisis sovereignty_type        [C9]  -> fragmented_collapse crisis gate
+```
+
+**Tech Stack:** Python 3.11, Pydantic (frozen models), rustworkx (`BabylonGraph`), pytest.
+
+**Owner rulings governing this plan (2026-07-18):** scope = **B + C together**; target arc =
+**instrument-decides** (tune via `mise run sim:pacing`, then report curves; treat as gameplay-tunable).
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **Determinism is a hard gate.** Iterate nodes/edges in `sorted()` ID order — never dict/set order.
+  Accumulate floats in sorted order. Any randomness comes from `resolve_rng(services, tick)`
+  (`src/babylon/kernel/system_base.py`) and **never** bare `random`. **Inserting a new RNG draw before an
+  existing one shifts the whole downstream RNG sequence and breaks `qa:regression` byte-identity even
+  with no intended behavior change** — prefer designs that draw no randomness at all.
+- **No hardcoded coefficients.** Every new number is a field on a `GameDefines` sub-model in
+  `src/babylon/config/defines/`, then `poetry run python tools/generate_defines_config.py` to
+  regenerate `src/babylon/data/defines.yaml`. Guarded by `tests/unit/config/test_constants_sync.py`.
+- **Mutate through the protocol.** `graph.update_node(id, **attrs)` / `graph.update_edge(src, dst,
+  edge_type, **attrs)` / `graph.set_graph_attr(key, value)`. Never mutate payload dicts directly.
+  Frozen Pydantic models are fine — `from_graph()` re-instantiates from the graph dict each time, so an
+  invalid value surfaces as a loud `ValidationError` (Constitution III.11), which is the desired behavior.
+- **TDD, red first.** Every task writes a failing test, watches it fail for the right reason, then
+  implements. `@pytest.mark.red_phase` for intentionally-failing tests.
+- **RST docstrings** on all new public functions/classes (Sphinx `-W` blocks CI).
+- **`qa:regression` must stay byte-identical on every task EXCEPT Task 10 (the ceremony).** If a task
+  moves a baseline unexpectedly, STOP and report — do not regenerate outside Task 10.
+- **Volume III collision boundary.** The owner is concurrently implementing
+  `specs/024-capital-volume-iii/` (scissors price-value engine, dialectic engine, money system) in
+  another worktree. Task 2's read of `opposition_states['wage']['balance']` touches that surface. It
+  MUST go through one narrow named helper plus a behavioral-contract test that fails loudly if the
+  field's scale or semantics move. Do not spread that read across files.
+- **Ground rent is OUT of scope** (it belongs to spec-024 User Story 4).
+
+---
+
+### Task 1: Fix the faction node-type mismatch (real pre-existing bug)
+
+**Files:**
+- Modify: `src/babylon/engine/systems/faction_influence.py:165,201`
+- Modify: `src/babylon/engine/systems/reactionary.py:218`
+- Test: `tests/unit/balkanization/test_faction_node_type_query.py` (create)
+
+**Why:** Faction nodes are stamped `_node_type="faction"` (`src/babylon/models/world_state.py:742`;
+corroborated by `web/game/engine_bridge.py:744`), but these three call sites query
+`node_type="balkanization_faction"`. `query_nodes` filters on `GraphNode.node_type` popped from
+`_node_type` (`src/babylon/topology/adapters/query_mixin.py:50-56`) with no aliasing, so **all three
+loops match zero nodes, always.** This silently disables `RED_SETTLER_TRAP_DETECTED`, secession-
+eligibility faction enumeration, and `_find_fascist_faction` → `FASCIST_RECRUITMENT`. Later tasks
+depend on faction enumeration working.
+
+**Interfaces:**
+- Consumes: `GraphProtocol.query_nodes(node_type=...)`.
+- Produces: working faction enumeration for Tasks 4-9.
+
+- [ ] **Step 1: Write the failing test**
+
+Build a `WorldState` with at least one `BalkanizationFaction`, call `to_graph()`, and assert that
+`query_nodes(node_type="faction")` returns it while `query_nodes(node_type="balkanization_faction")`
+returns nothing — pinning the canonical string. Then assert the *system* behavior: with a faction whose
+`class_reduction` exceeds the trap threshold and stance `UPHOLD`, `FactionInfluenceSystem.step()` emits
+`RED_SETTLER_TRAP_DETECTED`.
+
+- [ ] **Step 2: Run it and confirm it fails for the right reason**
+
+Run: `mise run test:q -- tests/unit/balkanization/test_faction_node_type_query.py -v`
+Expected: the emission assertion FAILS (no event), because the query matches nothing.
+
+- [ ] **Step 3: Fix the three literals**
+
+Replace `node_type="balkanization_faction"` with `node_type="faction"` at the three sites. Change
+nothing else.
+
+- [ ] **Step 4: Verify green + no regression**
+
+Run: `mise run test:q -- tests/unit/balkanization/ -v` then `mise run check` then
+`mise run qa:regression`.
+Expected: new tests pass; `qa:regression` **5/5 byte-identical** (the goldens contain no faction nodes,
+so this fix is inert there — confirm this rather than assume it, and record the confirmation).
+
+- [ ] **Step 5: Commit**
+
+```bash
+mise run commit -- "fix(balkanization): faction queries used a node_type that never matches"
+```
+
+---
+
+### Task 1b: Close the node-type vocabulary so this bug class cannot recur
+
+**Owner directive (2026-07-18):** *"ensure you fix it in a way that prevents that error class from ever
+happening again in the future, knowing im a solo dev using coding agents to do the coding so the
+solution should be legible to agents as well as humans."*
+
+**The error class, stated precisely:** a test fixture hand-stamps a `_node_type` string that production
+never emits, then queries with that same string, matches its own fixture, and passes. The test validates
+a convention that does not exist in production. Green tests, dead feature. It is a closed loop with no
+external referent.
+
+**Root enabling condition:** there is an `EdgeType` StrEnum (`src/babylon/models/enums/topology.py:12`)
+but **no `NodeType` enum** — node types are raw magic strings, so nothing can catch an invented one.
+
+**Evidence the guard is needed beyond this one bug** — stamped vocabulary (8, via literals in
+`src/`+`web/`): territory, social_class, key_figure, institution, sovereign, organization, industry,
+faction. Queried vocabulary (10): those 8 **plus `hex` and `community`, which no literal ever stamps**.
+Query sites: `substrate.py:75`, `vol2_circulation.py:163`, `territory_diagnostics.py:70` (hex),
+`domain/institution/queries.py:44` (community). If those are genuinely unstamped, `SubstrateSystem`
+(MATERIAL_BASE @2.5) iterates an empty set every tick. **Task 1b must resolve this question, not assume it.**
+
+**Files:**
+- Modify: `src/babylon/models/enums/topology.py` (add `NodeType` beside `EdgeType`)
+- Create: `src/babylon/sentinels/vocabulary/` (new sentinel, reusing `sentinels/_ast.py`)
+- Create: `tests/unit/sentinels/test_node_type_vocabulary.py`
+- Create/extend: a round-trip contract test under the existing `sentinels/roundtrip` idiom
+- Modify: `CLAUDE.md` (gotchas section)
+
+- [ ] **Step 1: Resolve the hex/community question FIRST.** Determine whether `hex` and `community`
+      nodes are ever added to the graph by any path. If they are not, report it loudly — that is a
+      separate real bug (dead systems), to be recorded and scoped, NOT silently fixed here.
+
+- [ ] **Step 2: Add the `NodeType` StrEnum** — single source of truth, members = the canonical stamped
+      vocabulary. Place beside `EdgeType` so the two are discovered together.
+
+- [ ] **Step 3: Replace magic strings** with `NodeType.*` at every stamp and query site in `src/` and
+      `web/`. Mechanical; MyPy strict then catches misuse at typecheck time, before tests run.
+
+- [ ] **Step 4: Write the vocabulary sentinel.** AST-scan `src/`, `web/`, **and `tests/`** and assert:
+      (a) every node-type literal is a `NodeType` member — kills invented strings *including in
+      fixtures*, which is the actual bug; and (b) **every queried type is stamped somewhere** — the
+      stamped/queried asymmetry is precisely the signal that made this bug invisible. A query for a type
+      nothing produces is dead by construction.
+      **Failure message must name the offending file:line, the offending string, and the allowed set** —
+      that is the agent-legibility requirement.
+
+- [ ] **Step 5: Write the round-trip contract test** — the one that would have caught this directly.
+      For every entity family in `WorldState`: after `to_graph()`, `query_nodes(node_type=NodeType.X)`
+      MUST find the entity. This uses the canonical construction path, so it is fixture-independent and
+      pins production's own convention rather than a fixture's.
+
+- [ ] **Step 6: Record the rule in `CLAUDE.md`** (standing permission to edit). Short and imperative,
+      because agents read it every session:
+      "**Never hand-stamp `_node_type` or query with a raw string — use `NodeType.*`.** A fixture that
+      stamps a type production never emits yields a green test over a dead feature. This happened:
+      `balkanization_faction` vs `faction` silently disabled RED_SETTLER_TRAP, secession enumeration,
+      and FASCIST_RECRUITMENT. The vocabulary sentinel now enforces this."
+
+- [ ] **Step 7: Verify** — `mise run check` green; `mise run qa:regression` byte-identical (pure
+      rename + new tests; if a baseline moves, STOP).
+
+- [ ] **Step 8: Commit** — `refactor(topology): close the node-type vocabulary with NodeType + sentinel`
+
+---
+
+### Task 2: B — couple consciousness to the sustained wage-value defect
+
+**Files:**
+- Create: `src/babylon/formulas/sustained_exploitation.py`
+- Modify: `src/babylon/engine/systems/ideology.py` (~line 120-124 read, ~line 212-217 term)
+- Modify: `src/babylon/config/defines/consciousness.py`
+- Modify: `src/babylon/data/defines.yaml` (regenerated, not hand-edited)
+- Test: `tests/unit/formulas/test_sustained_exploitation.py`, `tests/unit/engine/systems/test_ideology_sustained_term.py`
+
+**Why:** `agitation` — the sole driver of `class_consciousness`/`national_identity` — is a pure first
+difference (`consciousness_routing.py:45-88`), so it decays to zero once the Imperial Circuit reaches
+steady state. The sustained defect `opposition_states['wage']['balance']` is computed every tick
+(`opposition.py:503-510`) and is read at `ideology.py:123` **only as a boolean sign-gate**, never as a
+magnitude.
+
+**Interfaces:**
+- Produces: `sustained_exploitation_agitation(balance: float, sensitivity: float) -> float` — the ONLY
+  place in the codebase that interprets the scale/semantics of `opposition_states['wage']['balance']`.
+- Consumes: `GameDefines.consciousness.sustained_exploitation_sensitivity` (new).
+
+**Ordering note to document in the docstring and the ADR:** `ConsciousnessSystem` is @17.0 and
+`ContradictionSystem` (which writes `opposition_states`) is @18.0 — so this term reads the **previous
+tick's** opposition state. That one-tick lag is deterministic and acceptable; it must be stated
+explicitly, not discovered later.
+
+- [ ] **Step 1: Write the failing formula test + the Volume III contract test**
+
+```python
+def test_sustained_term_is_zero_when_labor_is_not_losing():
+    # balance >= 0 means labor is not on the losing side -> no sustained agitation
+    assert sustained_exploitation_agitation(0.0, 0.5) == 0.0
+    assert sustained_exploitation_agitation(1.25, 0.5) == 0.0
+
+def test_sustained_term_scales_with_defect_magnitude():
+    assert sustained_exploitation_agitation(-1.0, 0.5) == pytest.approx(0.5)
+    assert sustained_exploitation_agitation(-2.0, 0.5) == pytest.approx(1.0)
+
+def test_sustained_term_is_monotonic_in_defect():
+    a = sustained_exploitation_agitation(-1.0, 0.5)
+    b = sustained_exploitation_agitation(-3.0, 0.5)
+    assert b > a
+```
+
+Plus the **behavioral contract test** guarding the Volume III boundary — assert the shape and sign
+convention this formula depends on (that `opposition_states["wage"]["balance"]` is negative when labor
+loses, and is a magnitude in the same units the sensitivity is calibrated against). It must fail loudly
+with a message naming spec-024 if that convention changes.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mise run test:q -- tests/unit/formulas/test_sustained_exploitation.py -v`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the formula**
+
+```python
+def sustained_exploitation_agitation(balance: float, sensitivity: float) -> float:
+    """Agitation generated by the *sustained* wage-value defect.
+
+    :param balance: ``opposition_states["wage"]["balance"]`` — negative when labor is
+        on the losing side of the wage opposition (the W_c > V_c condition).
+    :param sensitivity: ``GameDefines.consciousness.sustained_exploitation_sensitivity``.
+    :returns: Non-negative agitation increment; ``0.0`` unless labor is losing.
+    """
+    if balance >= 0.0:
+        return 0.0
+    return -balance * sensitivity
+```
+
+- [ ] **Step 4: Add the define and regenerate the YAML**
+
+Add `sustained_exploitation_sensitivity: float` to the consciousness defines sub-model with a
+conservative provisional default (Task 9 calibrates it). Then:
+
+```bash
+poetry run python tools/generate_defines_config.py
+mise run test:q -- tests/unit/config/test_constants_sync.py
+```
+
+- [ ] **Step 5: Wire the term into ConsciousnessSystem**
+
+At `ideology.py` where `new_agitation` is assembled, add the sustained term alongside the existing
+delta terms. Keep the existing sign-gate behavior intact; this ADDS a magnitude term, it does not
+replace the rate term.
+
+- [ ] **Step 6: Write and run the system-level test**
+
+Assert that with a steady state (all deltas zero) but a persistently negative `balance`, agitation is
+**non-zero** and `class_consciousness` **moves** tick over tick — the exact property that is broken
+today.
+
+- [ ] **Step 7: Verify**
+
+Run: `mise run check`. Expected green.
+Run: `mise run qa:regression`. **Expected: baselines MOVE** (the goldens have social_class nodes). Do
+NOT regenerate here — record the observed drift and carry it to Task 10.
+
+- [ ] **Step 8: Commit**
+
+```bash
+mise run commit -- "feat(consciousness): sustained wage-value defect drives agitation"
+```
+
+---
+
+### Task 3: Verify where the political layer actually exists (scoping gate)
+
+**Files:**
+- Test: `tests/unit/balkanization/test_political_layer_presence.py` (create)
+
+**Why:** `_seed_balkanization_layer` is called only from `_build_initial_state_for_scenario`
+(`web/game/engine_bridge.py:6133`), web-side, tick-0. **No core engine scenario builder populates
+`WorldState.factions`.** So Tasks 4-9 are no-ops in the 5 `qa:regression` goldens and most engine
+tests. This task pins that fact as an executable contract so Task 10's ceremony can state, with
+evidence, which drift came from B and which from C.
+
+- [ ] **Step 1: Write characterization tests**
+
+Assert `WorldState.factions == {}` for the core scenarios (`us`, `wayne_county`, `two_node`,
+`imperial_circuit`), and that the web bridge path DOES seed factions. Mark clearly as characterization
+of current behavior, not an endorsement.
+
+- [ ] **Step 2: Confirm the null-play campaign path has factions**
+
+Run: `mise run sim:pacing -- --ticks 5` (or the probe's smallest useful invocation) and confirm from
+its output that faction/sovereign nodes are present on the web scenario path the campaign uses.
+Record the finding. If factions are ABSENT there, STOP — Tasks 5-9 cannot satisfy ruling #13 and the
+plan needs an engine-side seeding task inserted here.
+
+- [ ] **Step 3: Commit**
+
+```bash
+mise run commit -- "test(balkanization): pin where the political layer is actually seeded"
+```
+
+---
+
+### Task 4: C4 — per-tick `influence_level` writer
+
+**Files:**
+- Modify: `src/babylon/engine/systems/faction_influence.py`
+- Modify: `src/babylon/config/defines/balkanization.py`
+- Test: `tests/unit/balkanization/test_influence_level_writer.py`
+
+**Why:** `influence_level` (INFLUENCES edges, `BalkanizationFaction → Territory`,
+`relationship.py:124-129`) is written only at bootstrap. `FactionInfluenceSystem` @14.5 reads it and
+writes only the transient `persistent_data["balkanization.winning_faction_by_territory"]` — recomputed
+every tick from static inputs, so it never changes.
+
+**Design (owner-decided fork):** **self-contained**, driven by the consciousness/solidarity that Task 2
+sets in motion — NOT bridged to `Organization`. The `BalkanizationFaction`↔`Organization` linkage is a
+deliberate deferral (`balkanization_faction.py:1-24`) and `Organization` is absent from most paths.
+
+**Host:** `FactionInfluenceSystem` @14.5 — runs after `OODASystem` @14.0, already owns the read path,
+and can recompute `winning_faction_by_territory` from the freshly-written value in the same `step()`.
+Copy the `update_edge` idiom from `collapse_transition.py:265-271`.
+
+- [ ] **Step 1: Write the failing test** — a faction whose aligned classes gain consciousness gains
+      `influence_level` on its territories tick over tick; a faction whose base is demobilized loses it.
+      Assert values stay clamped to `[0.0, 1.0]`.
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Add the drift-rate define**, regenerate `defines.yaml`.
+- [ ] **Step 4: Implement `_update_influence_levels`** inserted before the existing
+      `_resolve_winning_factions` call. Iterate `sorted()` faction IDs then `sorted()` territory IDs.
+      Clamp with `min(1.0, max(0.0, ...))` — never rely on float equality. Draw NO randomness.
+- [ ] **Step 5: Verify** — `mise run check` green; `mise run qa:regression` byte-identical (goldens have
+      no factions — confirm, per Task 3).
+- [ ] **Step 6: Commit** — `feat(balkanization): influence_level responds to consciousness per tick`
+
+---
+
+### Task 5: C5 — `ruling_faction_id` tracks the winning faction
+
+**Files:**
+- Modify: `src/babylon/engine/systems/faction_influence.py` (or `sovereignty.py` — implementer's
+  call, justified in the report)
+- Test: `tests/unit/balkanization/test_ruling_faction_tracks_influence.py`
+
+**Why (owner-decided fork):** the recognizer reads `ruling_faction_id → colonial_stance`, and
+`ruling_faction_id` currently changes only on rare collapse/secession. Making rulership track actual
+influence is semantically correct ("who rules determines the stance"); rewiring `_has_stance_majority`
+to read the transient winning-faction dict would couple an observer to per-tick scratch state.
+
+- [ ] **Step 1: Failing test** — when a faction's influence over a sovereign's claimed territories
+      crosses a majority, that sovereign's `ruling_faction_id` follows, with hysteresis so it does not
+      oscillate tick to tick.
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Add hysteresis threshold define**, regenerate YAML.
+- [ ] **Step 4: Implement**, sorted iteration, incumbent-priority tie-break (reuse the existing
+      `winning_faction_for_territory` convention; do NOT add a new RNG draw).
+- [ ] **Step 5: Verify** (`check`, `qa:regression` byte-identical).
+- [ ] **Step 6: Commit** — `feat(balkanization): rulership follows factional influence`
+
+---
+
+### Task 6: C6 — `colonial_stance` drift
+
+**Files:**
+- Modify: `src/babylon/engine/systems/sovereignty.py` (@17.5)
+- Modify: `src/babylon/config/defines/balkanization.py`
+- Test: `tests/unit/balkanization/test_colonial_stance_drift.py`
+
+**Why:** `colonial_stance` is the **only live working input** to all three stance-majority gates
+(`endgame_detector.py:428` ABOLISH, `:535` UPHOLD, `:569` IGNORE) and has no writer.
+
+**Host:** `SovereigntySystem` @17.5 — after `Consciousness` @17.0 and `FascistFaction` @17.4 (both
+inputs fresh), before `CollapseTransition` @20.5 (which derives successor extraction policy from stance).
+
+**Hazard:** the loop `colonial_stance → derive_extraction_policy_from_stance → extraction_policy →
+metabolic_impact → habitability`. Read only pre-@17.5 state; never this pass's own output.
+
+- [ ] **Step 1: Failing test** — a faction whose base crosses a consciousness/solidarity threshold
+      drifts `UPHOLD → IGNORE → ABOLISH` as a **discrete deterministic step function** against defines
+      thresholds (never a rounded continuous score); and drifts back under reaction.
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Add stance-threshold defines**, regenerate YAML.
+- [ ] **Step 4: Implement** via `graph.update_node(faction_id, colonial_stance=new.value)`. Reuse
+      `derive_extraction_policy_from_stance`; do not duplicate the mapping.
+- [ ] **Step 5: Verify** (`check`, `qa:regression` byte-identical).
+- [ ] **Step 6: Commit** — `feat(balkanization): colonial stance responds to mass consciousness`
+
+---
+
+### Task 7: C7 — `state_violence_index` writer (wire the orphaned machinery)
+
+**Files:**
+- Modify: `src/babylon/ooda/action_effects.py` (import + dispatch to `state_ai.*`)
+- Modify: `src/babylon/engine/systems/sovereignty.py` (@17.5, `set_graph_attr`)
+- Modify: `src/babylon/config/defines/endgame.py` (add the max as a define)
+- Modify: `src/babylon/engine/observers/endgame_detector.py:542-544` (read max from defines)
+- Test: `tests/unit/engine/systems/test_state_violence_index.py`
+
+**Why:** `state_violence_index` has **no writer anywhere** — the comment at
+`endgame_detector.py:539-541` describes an intent spec-039 never implemented. Its gate is permanently
+`0.0`, so the FASCIST_CONSOLIDATION political-violence route is dead weight.
+
+**Reuse, do not reinvent:** `ooda/state_ai/repress_effects.py` (RAID/INFILTRATE/PROSECUTE/LIQUIDATE with
+legitimacy multipliers) and `administer_effects.py` (`FUND` → `violence_capacity`) are fully built and
+tested with **zero live callers** — `action_effects.py:11-26` never imports `state_ai.*`, and
+`_resolve_repressive` (`:265-299`) only raises the *acting* org's consciousness.
+
+`state_violence_index_max` should become an `EndgameDefines` field read directly by the detector
+(mirroring `fascist_majority_fraction`), NOT a graph attribute.
+
+- [ ] **Step 1: Failing tests** — (a) `resolve_action` on REPRESS/RAID raises the *target's*
+      `repression_faced`, not just the actor's consciousness; (b) sustained repression raises
+      `state_violence_index`; (c) the detector reads its max from defines.
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Add `state_violence_index_max` define**, regenerate YAML.
+- [ ] **Step 4: Wire the dispatcher** to `state_ai` effects; **Step 5: implement the index writer**
+      (`set_graph_attr`, sorted aggregation, `min(1.0, ...)` clamp).
+- [ ] **Step 6: Verify** — `check` green. `qa:regression`: the goldens have no state-apparatus orgs, so
+      expect byte-identical; **if it moves, STOP and report** (that means the dispatcher change touched
+      a live path).
+- [ ] **Step 7: Commit** — `feat(state): wire repression effects and state violence index`
+
+---
+
+### Task 8: C8 — legitimacy erosion (un-dormants the collapse path)
+
+**Files:**
+- Modify: `src/babylon/engine/systems/sovereignty.py` (@17.5)
+- Modify: `src/babylon/config/defines/balkanization.py`
+- Test: `tests/unit/balkanization/test_legitimacy_erosion.py`
+
+**Why:** nothing writes sovereign `legitimacy` or `balkanization.collapse_triggers`, so
+`CollapseTransitionSystem`'s entire collapse-driven path (`collapse_transition.py:84-87`) is dormant —
+it can only fire if a seed sovereign starts at `legitimacy <= 0.0`, and none do. Task 9's classifier
+needs collapse to be reachable.
+
+- [ ] **Step 1: Failing test** — sustained repression + falling consciousness alignment + extraction
+      intensity erode `legitimacy` monotonically toward 0; a legitimate, low-repression sovereign holds
+      steady. Assert clamped `[0.0, 1.0]`.
+- [ ] **Step 2: Run to verify failure.** **Step 3: Add erosion-rate defines**, regenerate YAML.
+- [ ] **Step 4: Implement** (sorted iteration, no RNG).
+- [ ] **Step 5: Verify** (`check`, `qa:regression` byte-identical — no sovereigns in goldens).
+- [ ] **Step 6: Commit** — `feat(balkanization): sovereign legitimacy erodes under repression`
+
+---
+
+### Task 9: C9 — crisis-sovereignty classifier
+
+**Files:**
+- Modify: `src/babylon/engine/systems/collapse_transition.py` (@20.5)
+- Modify: `src/babylon/config/defines/balkanization.py`
+- Modify: `src/babylon/engine/observers/endgame_detector.py` (docstring correction only)
+- Test: `tests/unit/balkanization/test_crisis_sovereignty_classifier.py`
+
+**Why:** `insurgent` / `occupation` / `emergency` are **never emitted anywhere in `src/`**, so
+`_axis_fragmented_collapse`'s `crisis_gate` (`endgame_detector.py:612-613`) is a binary gate stuck at
+`0.0`; progress caps at 0.75 and `matched` is provably always `False`.
+
+**De-risks confirmed:** PG migration `0025_balkanization.sql` already permits all six values;
+`sovereignty_type` round-trips losslessly; the fragmented_collapse axis is the ONLY gating consumer, so
+new emissions cannot break the other four axes.
+
+**Classification inputs (all computed before @20.5):** dual power (`SovereigntySystem` @17.5),
+control-ratio crisis (`ControlRatioSystem` @12.0), UPRISING/EXCESSIVE_FORCE (`StruggleSystem` @16.0),
+`dialectical_regime` (`ContradictionSystem` @18.0), percolation (`topology_monitor`), plus Task 7's
+`state_violence_index` and Task 8's `legitimacy`.
+
+- [ ] **Step 1: Failing test** — armed organized contestation ⇒ `insurgent`; external/dual-power
+      administration ⇒ `occupation`; martial-law/control-ratio crisis ⇒ `emergency`; and none of these
+      fire under quiescent conditions.
+- [ ] **Step 2: Run to verify failure.** **Step 3: Add classifier threshold defines**, regenerate YAML.
+- [ ] **Step 4: Implement** as a deterministic step function; write via `update_node`. Sorted iteration.
+- [ ] **Step 5: Fix the docstring mismatch** — `_axis_fragmented_collapse`'s docstring says "no Faction
+      holds the supermajority" but the code measures **ColonialStance** concentration. Correct the
+      docstring to match the code (do NOT change behavior).
+- [ ] **Step 6: Verify** (`check`, `qa:regression` byte-identical).
+- [ ] **Step 7: Commit** — `feat(balkanization): classify crisis sovereignty types`
+
+---
+
+### Task 10: Calibrate the arc with the instrument
+
+**Files:**
+- Modify: `src/babylon/data/defines.yaml` (via regeneration) and the defines sub-models
+- Create: `reports/null-play-arc-calibration.md`
+
+**Owner ruling:** instrument decides; report the curves back. Treat every coefficient as
+gameplay-tunable (same status as `endgame.fascist_majority_fraction`).
+
+- [ ] **Step 1:** Run the 520-tick nationwide null-play probe: `mise run sim:pacing`.
+- [ ] **Step 2:** Record, per tick, the five axis progress values plus `class_consciousness`,
+      `agitation`, `solidarity_strength`, and tick-of-first-crossing per axis.
+- [ ] **Step 3:** Tune `sustained_exploitation_sensitivity` (and the C drift rates) so the arc
+      **drifts across hundreds of ticks and does NOT saturate to 1.0 early**. The known hazard: a
+      currency-scale `balance` against normalized `[0,1]` ideology means a naive coefficient snaps the
+      axis to ceiling in ~3 ticks.
+- [ ] **Step 4:** Write `reports/null-play-arc-calibration.md` with the final coefficients, the curves,
+      tick-of-first-crossing per axis, and an explicit statement that these are gameplay-tunable.
+- [ ] **Step 5: Commit** — `chore(calibration): tune null-play arc coefficients`
+
+---
+
+### Task 11: THE CEREMONY — regenerate baselines with declared drift
+
+**Files:**
+- Modify: `tests/baselines/` (5 dense CSVs + 5 sampled JSONs, regenerated)
+- Modify: `tests/baselines/detroit-tri-county-5t.json`, `tests/baselines/michigan-e2e.json`
+- Create: `ai/decisions/ADR082_null_play_political_coupling.yaml` + `index.yaml` entry
+- Modify: `ai/state.yaml`
+
+**This is the first ceremony that actually regenerates baselines** — spine ceremony #1
+(`fascist_majority_fraction` 0.75→0.9, observer-only) and the Task-23 whitelist widening both came back
+byte-identical non-ceremonies.
+
+- [ ] **Step 1:** `mise run qa:regression-generate-dense` (regenerates dense CSVs AND sampled JSONs).
+- [ ] **Step 2:** `mise run qa:regression` — confirm the gate is green against the new baselines.
+- [ ] **Step 3:** Regenerate the two e2e baselines.
+- [ ] **Step 4:** **Declare per-scenario drift** — for EACH of the 5 scenarios, state the direction and
+      magnitude of the change and attribute it to B or to C. Per Task 3, expect most/all C writers to be
+      inert in the goldens (no factions/orgs); if C shows drift there, explain why before proceeding.
+- [ ] **Step 5:** Write ADR082 recording: the derivative-vs-level root cause, the B+C owner ruling, both
+      fork decisions with reasoning, the one-tick lag, the Volume III dependency, and the drift table.
+- [ ] **Step 6:** Update `ai/state.yaml`.
+- [ ] **Step 7: Commit** (ceremony commit body carries the full drift table).
+
+---
+
+### Task 12: Record the spine ratifications + revise #12
+
+**Files:**
+- Modify: `ai/decisions/ADR079_playability_spine.yaml`
+- Modify: `ai/state.yaml`
+
+- [ ] **Step 1:** Record all 13 owner ratifications from 2026-07-18 as an addendum.
+- [ ] **Step 2:** **Revise ratification #12** — it accepted `tick_ground_rent` as ACCEPT-DARK on the
+      premise that no county rental series exists. The trove audit disproved that for the urban leg
+      (`fact_census_rent`, 44,997 rows). Record the correction AND that ground rent now belongs to
+      spec-024 (Capital Volume III), not Track 2.
+- [ ] **Step 3:** Note `fascist_majority_fraction = 0.90` as provisional/gameplay-tunable.
+- [ ] **Step 4: Commit** — `docs(adr): record spine ratifications; revise ground-rent premise`
+
+---
+
+## Self-Review
+
+**Spec coverage:** B (Task 2) and all four originally-named C couplings are covered — `state_violence_index`
+(7), crisis sovereignty (9), `colonial_stance` (6), `influence_level` (4) — plus the two prerequisites
+research surfaced: the node-type bug (1) and legitimacy erosion (8), and the rulership link (5) without
+which the stance gates stay frozen regardless.
+
+**Ordering:** Task 1 must precede 4-9 (faction enumeration). Task 3 gates 4-9 (scoping). Task 8 must
+precede 9 (collapse must be reachable). Task 10 must follow all implementation. Task 11 must be last.
+
+**Known risk:** Task 10's calibration is the one genuinely uncertain step — the scale mismatch could
+require iterating. If the instrument shows saturation that no coefficient fixes, the relaxation term
+sketched in the investigation (consciousness tracks rather than ratchets) is the fallback, and that is a
+change to Task 2's formula requiring a re-run of Tasks 10-11.

--- a/src/babylon/reference/schema.py
+++ b/src/babylon/reference/schema.py
@@ -26,6 +26,12 @@ Facts (34 tables):
 Note:
     Census fact tables include time_id and race_id FKs for multi-year and
     race-disaggregated analysis (15 years x 10 race groups).
+
+    The census above is the pre-ADR076 schema. The 2026-07-17 execution
+    slate (ADR075/076) amputated 16 tables (incl. the Energy dims/fact
+    listed here) and demoted 8 — ``data-catalog.yaml`` is the authoritative
+    per-table registry; amputated tables live on as committed CSV artifacts
+    registered in ``data-artifacts.yaml``.
 """
 
 from datetime import date, datetime

--- a/src/frontend/src/components/action/ActionComposer.test.tsx
+++ b/src/frontend/src/components/action/ActionComposer.test.tsx
@@ -271,6 +271,21 @@ describe("ActionComposer", () => {
       render(<ActionComposer gameId={DEFAULT_GAME_ID} />);
       expect(screen.queryByTestId("preset-target-note")).not.toBeInTheDocument();
     });
+
+    it("clears the preset target when the user switches verbs (PR #211 review)", async () => {
+      seedPlayerOrg();
+      useStore.getState().actions.presetInvestigate("territory-99", "Wayne County");
+
+      render(<ActionComposer gameId={DEFAULT_GAME_ID} />);
+      expect(await screen.findByTestId("preset-target-note")).toHaveTextContent("Wayne County");
+
+      await userEvent.click(screen.getByRole("button", { name: /educate/i }));
+
+      // The INVESTIGATE preset's target dies with the verb it was queued
+      // for — it must not silently pre-target EDUCATE (or any other verb
+      // the user switches to).
+      expect(screen.queryByTestId("preset-target-note")).not.toBeInTheDocument();
+    });
   });
 
   it("shows a loud submit error when the backend rejects the action", async () => {

--- a/src/frontend/src/components/action/useInvestigatePreset.ts
+++ b/src/frontend/src/components/action/useInvestigatePreset.ts
@@ -63,5 +63,14 @@ export function useInvestigatePreset(): InvestigatePreset {
     if (preset) consumePreset();
   }, [preset, consumePreset]);
 
-  return { verb, setVerb, presetTarget };
+  // PR #211 review: the preset's target dies with the verb it was queued
+  // for. `VerbForm` remounts on every verb change (keyed by org+verb) and
+  // reads `initialTargetId` fresh, so a lingering presetTarget would
+  // silently pre-target whatever verb the user switches to next.
+  const selectVerb = (next: PlayerVerb | null): void => {
+    setVerb(next);
+    setPresetTarget(null);
+  };
+
+  return { verb, setVerb: selectVerb, presetTarget };
 }

--- a/tests/integration/test_alarm_event_emission.py
+++ b/tests/integration/test_alarm_event_emission.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import pytest
 
+from babylon.engine.context import TickContext
 from babylon.topology.graph import BabylonGraph
 
 pytestmark = [pytest.mark.cross_scale, pytest.mark.integration]
@@ -72,7 +73,10 @@ def test_conservation_alarm_event_published_to_bus():
         event_bus = bus
 
     sid = uuid4()
-    engine.run_tick(graph, _Services(), {"tick": 7, "session_id": sid})
+    # TickContext, not a raw dict: 444b5216 collapsed ContextType to
+    # TickContext and deleted the dict fallback (this nightly-only file was
+    # missed by that commit's fixture-migration census).
+    engine.run_tick(graph, _Services(), TickContext(tick=7, session_id=sid))
 
     assert len(received) == 1, f"Expected one alarm event, got {len(received)}"
     event = received[0]
@@ -120,6 +124,6 @@ def test_no_alarm_event_when_severity_ok():
     class _Services:
         event_bus = bus
 
-    engine.run_tick(graph, _Services(), {"tick": 0, "session_id": uuid4()})
+    engine.run_tick(graph, _Services(), TickContext(tick=0, session_id=uuid4()))
 
     assert received == []

--- a/tests/integration/test_michigan_reference_data.py
+++ b/tests/integration/test_michigan_reference_data.py
@@ -307,11 +307,31 @@ class TestZoomHierarchyCompleteness:
         assert row is not None
         assert row["n"] == 1
 
-    def test_bea_tier_exists(self, db: sqlite3.Connection) -> None:
-        """BEA tier: at least 1 BEA EA exists."""
-        row = db.execute("SELECT count(*) AS n FROM dim_bea_economic_area").fetchone()
-        assert row is not None
-        assert row["n"] >= 1
+    def test_bea_tier_exists(self) -> None:
+        """BEA tier: at least 1 BEA EA exists — read from the successor CSV.
+
+        ``dim_bea_economic_area`` was amputated from the reference DB by
+        ADR076 (36f4cb98) with a committed CSV successor registered in
+        ``data-artifacts.yaml``. That commit migrated the whole
+        ``TestBEAEconomicAreas`` class but missed this straggler, which kept
+        querying the dropped table (nightly Reference-Data red since
+        2026-07-17). The zoom-hierarchy claim now reads the successor the
+        same way ``tests/unit/reference/test_data_artifacts.py`` does; that
+        file additionally pins the full 8-row content.
+        """
+        import csv
+
+        csv_path = (
+            Path(__file__).resolve().parents[2]
+            / "src"
+            / "babylon"
+            / "data"
+            / "reference"
+            / "dim_bea_economic_area.csv"
+        )
+        with csv_path.open(encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+        assert len(rows) >= 1
 
     def test_msa_tier_exists(self, db: sqlite3.Connection) -> None:
         """MSA tier: at least 1 metro area exists."""

--- a/tests/integration/test_qcew_live_reconciliation.py
+++ b/tests/integration/test_qcew_live_reconciliation.py
@@ -60,6 +60,32 @@ class TestWayne2010:
         assert delta_pct <= 2.0, f"Wayne 2010 proxy {proxy} vs {WAYNE_2010_PUBLISHED}"
 
 
+#: The full reference DB carries 3,232 distinct counties in fact_qcew_annual;
+#: the pinned CI subset carries Michigan's 83 (+1 AL regression-guard row).
+_NATIONAL_SCOPE_MIN_COUNTIES = 3_000
+
+
+def _require_national_scope(live: sqlite3.Connection) -> None:
+    """Skip the national SC gates on the Michigan-scoped CI subset.
+
+    ``tools/make_reference_subset.py`` deliberately pins ``fact_qcew_annual``
+    to ``michigan`` scope while ``fact_qcew_county_rollup`` stays ``full``
+    (the BLOCKED-FULL trio) — so on the CI subset the rollup⟷annual JOINs
+    these gates are built on compare national rollups against Michigan-only
+    leaves and the bands collapse (nightly Reference-Data red since
+    2026-07-17). The full DB satisfies the gates exactly as specced (SC-001/
+    002/004/006), so re-banding for the subset would paper over a genuine
+    scope mismatch as sampling noise; the honest disposition is a cited skip.
+    """
+    (n,) = live.execute("SELECT COUNT(DISTINCT county_id) FROM fact_qcew_annual").fetchone()
+    if n < _NATIONAL_SCOPE_MIN_COUNTIES:
+        pytest.skip(
+            f"fact_qcew_annual has {n} counties — Michigan-scoped CI subset "
+            "(tools/make_reference_subset.py); the SC national bands need the "
+            "full reference DB"
+        )
+
+
 def _within_band_share(live: sqlite3.Connection, metric: str) -> tuple[int, int]:
     rows = live.execute(
         f"""
@@ -82,15 +108,18 @@ def _within_band_share(live: sqlite3.Connection, metric: str) -> tuple[int, int]
 
 class TestBands:
     def test_sc001_employment_99pct_within_2pct(self, live: sqlite3.Connection) -> None:
+        _require_national_scope(live)
         total, within = _within_band_share(live, "employment")
         assert total > 40_000  # ~3,220 counties × 15 years
         assert within / total * 100.0 >= 99.0, f"{within}/{total}"
 
     def test_sc002_wages_99pct_within_2pct(self, live: sqlite3.Connection) -> None:
+        _require_national_scope(live)
         total, within = _within_band_share(live, "total_wages_usd")
         assert within / total * 100.0 >= 99.0, f"{within}/{total}"
 
     def test_sc004_ownership_95pct_within_2pct(self, live: sqlite3.Connection) -> None:
+        _require_national_scope(live)
         rows = live.execute(
             """
             SELECT COUNT(*),
@@ -114,6 +143,7 @@ class TestBands:
 
 class TestProvenanceAtScale:
     def test_sc006_full_coverage_and_semantics(self, live: sqlite3.Connection) -> None:
+        _require_national_scope(live)
         total, determinate = live.execute(
             "SELECT COUNT(*), SUM(CASE WHEN is_imputed IN (0,1) THEN 1 ELSE 0 END)"
             " FROM fact_qcew_annual"

--- a/tests/integration/test_qcew_live_reconciliation.py
+++ b/tests/integration/test_qcew_live_reconciliation.py
@@ -70,12 +70,16 @@ def _require_national_scope(live: sqlite3.Connection) -> None:
 
     ``tools/make_reference_subset.py`` deliberately pins ``fact_qcew_annual``
     to ``michigan`` scope while ``fact_qcew_county_rollup`` stays ``full``
-    (the BLOCKED-FULL trio) — so on the CI subset the rollup⟷annual JOINs
-    these gates are built on compare national rollups against Michigan-only
-    leaves and the bands collapse (nightly Reference-Data red since
-    2026-07-17). The full DB satisfies the gates exactly as specced (SC-001/
-    002/004/006), so re-banding for the subset would paper over a genuine
-    scope mismatch as sampling noise; the honest disposition is a cited skip.
+    (the BLOCKED-FULL trio) — so on the CI subset, gates that assert
+    NATIONAL scale (sc001's row-count floor, sc004's national ownership
+    JOIN, sc006's 10M-row floor) collapse by construction (nightly
+    Reference-Data red since 2026-07-17). The full DB satisfies them
+    exactly as specced, so re-banding for the subset would paper over a
+    genuine scope mismatch as sampling noise; the honest disposition is a
+    cited skip. sc002 deliberately does NOT guard: it asserts only a
+    within-band SHARE over whatever county-years both tables carry, which
+    is a meaningful reconciliation on the Michigan subset too (empirically
+    1680/1680 within band there).
     """
     (n,) = live.execute("SELECT COUNT(DISTINCT county_id) FROM fact_qcew_annual").fetchone()
     if n < _NATIONAL_SCOPE_MIN_COUNTIES:
@@ -114,7 +118,8 @@ class TestBands:
         assert within / total * 100.0 >= 99.0, f"{within}/{total}"
 
     def test_sc002_wages_99pct_within_2pct(self, live: sqlite3.Connection) -> None:
-        _require_national_scope(live)
+        # No scope guard: share-only assertion, meaningful on both the full
+        # DB and the Michigan subset — see _require_national_scope's docstring.
         total, within = _within_band_share(live, "total_wages_usd")
         assert within / total * 100.0 >= 99.0, f"{within}/{total}"
 

--- a/tests/integration/web/test_full_persistence.py
+++ b/tests/integration/web/test_full_persistence.py
@@ -24,6 +24,8 @@ import uuid
 
 import pytest
 
+from babylon.persistence.postgres_schema import POSTGRES_SCHEMA_DDL, ensure_ddl_applied
+
 pytestmark = [
     pytest.mark.requires_postgres,
     pytest.mark.skipif(
@@ -162,6 +164,12 @@ class TestWebPathMigrations:
         )
         with pool.connection() as conn:
             conn.autocommit = True
+            # Self-sufficient setup (nightly 2026-07-19): guarantee the stamp
+            # table exists whatever bootstrapped this DB — the old bare-loop
+            # db:bootstrap created every schema table EXCEPT the stamp table
+            # (its DDL lives only inside ensure_ddl_applied), so the DELETE
+            # below crashed with UndefinedTable on nightly's Postgres.
+            ensure_ddl_applied(conn, POSTGRES_SCHEMA_DDL)
             for column in dropped:
                 conn.execute(f"ALTER TABLE tick_summary DROP COLUMN IF EXISTS {column}")
             # ensure_ddl_applied is digest-stamped: clear the stamps so the

--- a/tests/property/harness/probability_discovery.py
+++ b/tests/property/harness/probability_discovery.py
@@ -128,15 +128,25 @@ def _iter_public_formulas() -> list[Callable[..., Any]]:
     return sorted(seen, key=lambda f: (f.__module__, f.__qualname__))
 
 
+#: Modules whose IMPORT deliberately emits DeprecationWarning (deprecated
+#: shims kept for their own unit tests). The walker imports everything by
+#: contract, so these warnings are expected there and suppressed by name —
+#: name-scoped so a NEW unexpected import-time deprecation anywhere else
+#: still detonates under pyproject's ``error::DeprecationWarning:babylon.*``
+#: policy instead of being silently swallowed.
+_DEPRECATED_SHIM_MODULES: frozenset[str] = frozenset({"babylon.models.components.organization"})
+
+
 def _iter_package_modules(package: Any) -> list[Any]:
     """Recursively import every submodule of a package and return them.
 
-    Deprecated shims (e.g. ``babylon.models.components.organization``) warn
-    at module import; this walker imports EVERYTHING by contract, so that
-    warning is expected here and suppressed exactly here — otherwise
-    pyproject's ``error::DeprecationWarning:babylon.*`` policy detonates the
-    first discovery call per pytest worker (nightly 2026-07-19, an
-    order-dependent failure only later tests escaped via the module cache).
+    Known deprecated shims warn at module import; without the name-scoped
+    suppression below, pyproject's ``error::DeprecationWarning:babylon.*``
+    policy detonates the first discovery call per pytest worker (nightly
+    2026-07-19, an order-dependent failure only later tests escaped via the
+    module cache). A shim not yet listed in ``_DEPRECATED_SHIM_MODULES``
+    fails loudly here — add it to the registry deliberately, never blanket-
+    suppress.
     """
     modules: list[Any] = [package]
     if not hasattr(package, "__path__"):
@@ -145,8 +155,11 @@ def _iter_package_modules(package: Any) -> list[Any]:
         if mod_info.name.endswith(".__main__"):
             continue
         try:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", DeprecationWarning)
+            if mod_info.name in _DEPRECATED_SHIM_MODULES:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", DeprecationWarning)
+                    mod = importlib.import_module(mod_info.name)
+            else:
                 mod = importlib.import_module(mod_info.name)
         except ImportError:
             continue

--- a/tests/property/harness/probability_discovery.py
+++ b/tests/property/harness/probability_discovery.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import pkgutil
+import warnings
 from collections.abc import Callable
 from functools import lru_cache
 from typing import Any, get_type_hints
@@ -128,7 +129,15 @@ def _iter_public_formulas() -> list[Callable[..., Any]]:
 
 
 def _iter_package_modules(package: Any) -> list[Any]:
-    """Recursively import every submodule of a package and return them."""
+    """Recursively import every submodule of a package and return them.
+
+    Deprecated shims (e.g. ``babylon.models.components.organization``) warn
+    at module import; this walker imports EVERYTHING by contract, so that
+    warning is expected here and suppressed exactly here — otherwise
+    pyproject's ``error::DeprecationWarning:babylon.*`` policy detonates the
+    first discovery call per pytest worker (nightly 2026-07-19, an
+    order-dependent failure only later tests escaped via the module cache).
+    """
     modules: list[Any] = [package]
     if not hasattr(package, "__path__"):
         return modules
@@ -136,7 +145,9 @@ def _iter_package_modules(package: Any) -> list[Any]:
         if mod_info.name.endswith(".__main__"):
             continue
         try:
-            mod = importlib.import_module(mod_info.name)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                mod = importlib.import_module(mod_info.name)
         except ImportError:
             continue
         modules.append(mod)

--- a/tests/property/invariants/test_probability_bounds.py
+++ b/tests/property/invariants/test_probability_bounds.py
@@ -205,3 +205,29 @@ class TestProbabilityBounds:
         invariant = ProbabilityInRange(field_pairs=discover_probability_fields())
         result = invariant.check(state, rehydrated)
         assert result.ok, result.msg
+
+
+def test_discovery_walk_does_not_leak_deprecation_warnings() -> None:
+    """Regression (nightly 2026-07-19, pre-existing since before spec-116):
+    ``discover_probability_fields`` recursively imports every submodule of
+    ``babylon.models`` — including the deprecated ``components.organization``
+    shim, which warns at module import. Under pyproject's
+    ``error::DeprecationWarning:babylon.*`` policy that import EXPLODED the
+    first test to trigger discovery in a worker (order-dependent: later
+    tests saw the cached module and passed). The walker must treat a
+    deprecated shim as a legitimate walk member whose warning is expected.
+    """
+    import sys
+    import warnings
+
+    from tests.property.harness import probability_discovery
+
+    probability_discovery.discover_probability_fields.cache_clear()
+    sys.modules.pop("babylon.models.components.organization", None)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            pairs = probability_discovery.discover_probability_fields()
+        assert pairs, "discovery returned no Probability fields"
+    finally:
+        probability_discovery.discover_probability_fields.cache_clear()

--- a/tests/scenarios/test_endgame_flow.py
+++ b/tests/scenarios/test_endgame_flow.py
@@ -102,15 +102,20 @@ def create_fascist_state() -> WorldState:
     """Create a WorldState that meets fascist consolidation conditions.
 
     Conditions:
-    - national_identity > class_consciousness for 3+ nodes
+    - national_identity > class_consciousness for a supermajority of nodes:
+      ``EndgameDefines.fascist_majority_fraction`` = 0.9 since d14d2c42
+      (spec-116 pacing ceremony #1 — the 0.75 gate false-positive-locked
+      FASCIST_CONSOLIDATION on small-archetype scenarios). 9 fascist of 10
+      entities = 0.9 clears the gate exactly; the old 4-of-5 = 0.8 no
+      longer does.
 
     Returns:
         WorldState configured for fascist consolidation.
     """
-    # Create entities where 4 have fascist consciousness
+    # Create entities where 9 of 10 have fascist consciousness
     entities = {}
-    for i in range(5):
-        if i < 4:  # 4 fascist nodes
+    for i in range(10):
+        if i < 9:  # 9 fascist nodes
             entities[f"C{i:03d}"] = SocialClass(
                 id=f"C{i:03d}",
                 name=f"Fascist Worker {i}",

--- a/tests/unit/web/test_stub_bridge_parity.py
+++ b/tests/unit/web/test_stub_bridge_parity.py
@@ -304,6 +304,60 @@ class TestSmokeTheTwentyRestoredMethods:
         assert "story" in result
 
 
+class TestResolveTickParity:
+    """``resolve_tick`` is the one non-``get_*`` method the production API
+    calls on whichever bridge ``_get_bridge()`` returns (``web/game/api.py``
+    resolve view → ``tick_resolver.resolve_game_tick``) — and it sat outside
+    this file's ``get_*``-only sweep, which is exactly how it drifted: PR
+    #211's review caught the stub lagging the real signature (no
+    ``persistent_context``/``force_endgame_test_hook``, list-not-snapshot
+    return), so the fallback path 500'd on every resolve."""
+
+    def test_signature_matches_real_bridge_exactly(self) -> None:
+        from game.engine_bridge import EngineBridge
+        from game.stub_bridge import StubEngineBridge
+
+        real = inspect.signature(EngineBridge.resolve_tick)
+        stub = inspect.signature(StubEngineBridge.resolve_tick)
+        real_params = {n: p.kind for n, p in real.parameters.items() if n != "self"}
+        stub_params = {
+            _strip_leading_underscore(n): p.kind for n, p in stub.parameters.items() if n != "self"
+        }
+        # Full-name parity, not just required-param parity: the drift that
+        # broke the fallback path was in OPTIONAL parameters, which the
+        # required-only check in _signature_mismatches cannot see.
+        assert real_params == stub_params
+
+    def test_resolve_game_tick_returns_snapshot_through_production_seam(self) -> None:
+        from game.tick_resolver import resolve_game_tick
+
+        bridge, session_id = _stub_session()
+        before = bridge.get_snapshot(session_id)["tick"]
+
+        snapshot = resolve_game_tick(
+            bridge,
+            session_id,
+            persistent_context=None,
+            force_endgame_test_hook=True,  # inert on the stub — no engine, no endgame
+        )
+
+        # The resolve view reads snapshot.get("tick") off this return; a list
+        # (the old stub shape) has no .get and crashed even past the kwargs.
+        assert isinstance(snapshot, dict)
+        assert snapshot["tick"] == before + 1
+        assert snapshot["session_id"] == str(session_id)
+
+    def test_resolve_tick_still_drains_queued_actions(self) -> None:
+        bridge, session_id = _stub_session()
+        bridge.submit_action(session_id, 0, _ORG_ID, "educate")
+
+        bridge.resolve_tick(session_id)
+
+        from game.stub_bridge import _stub_actions
+
+        assert _stub_actions[session_id] == []
+
+
 class TestVerbEligibilityStub:
     """Spec-116 FR-4.8 twin: coherent with the stub's own target methods
     (mobilize honestly empty; negotiate ineligible because ORG001 is the

--- a/tests/unit/web/test_tensor_registry_wiring.py
+++ b/tests/unit/web/test_tensor_registry_wiring.py
@@ -15,11 +15,101 @@ hydration pass over the reference DB, not two.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
 import pytest
 
 pytestmark = pytest.mark.unit
 
 WAYNE_FIPS = "26163"
+
+
+class TestEconomicsCacheHygiene:
+    """PR #209 Copilot review, both findings on the module caches.
+
+    (a) ``_build_tensor_registry`` caches by ``frozenset(fips_codes)`` but
+        hydrated ``sorted(fips_codes)`` — duplicate FIPS in the tuple made
+        the hydration work diverge from the cache key.
+    (b) ``_TENSOR_REGISTRY_CACHE``/``_CAPITAL_CALCULATOR_CACHE`` grew without
+        bound: one hydrated registry retained per distinct FIPS-set for the
+        life of the process.
+
+    No reference DB here: hydration is stubbed and the stub records the
+    county list each call receives, which is the very thing under test.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_caches(self) -> Iterator[None]:
+        from game import engine_bridge
+
+        saved_registries = dict(engine_bridge._TENSOR_REGISTRY_CACHE)
+        saved_calculators = dict(engine_bridge._CAPITAL_CALCULATOR_CACHE)
+        engine_bridge._TENSOR_REGISTRY_CACHE.clear()
+        engine_bridge._CAPITAL_CALCULATOR_CACHE.clear()
+        yield
+        engine_bridge._TENSOR_REGISTRY_CACHE.clear()
+        engine_bridge._TENSOR_REGISTRY_CACHE.update(saved_registries)
+        engine_bridge._CAPITAL_CALCULATOR_CACHE.clear()
+        engine_bridge._CAPITAL_CALCULATOR_CACHE.update(saved_calculators)
+
+    @pytest.fixture()
+    def hydrated_county_lists(self, monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+        """Stub the DB seam; return the counties list each hydration received."""
+        import babylon.reference.database as reference_database
+        from babylon.domain.economics.tensor_registry import TensorRegistry
+
+        calls: list[list[str]] = []
+
+        def record_hydration(
+            self: TensorRegistry, hydrator: Any, counties: list[str], years: list[int]
+        ) -> None:
+            del hydrator, years
+            calls.append(list(counties))
+
+        @contextmanager
+        def no_session() -> Iterator[None]:
+            yield None
+
+        monkeypatch.setattr(TensorRegistry, "hydrate_counties", record_hydration)
+        monkeypatch.setattr(reference_database, "get_reference_session", no_session)
+        return calls
+
+    def test_duplicate_fips_hydrate_the_deduped_key(
+        self, hydrated_county_lists: list[list[str]]
+    ) -> None:
+        from game.engine_bridge import _build_tensor_registry
+
+        _build_tensor_registry(("26163", "26099", "26163"))
+
+        # Hydration must cover exactly the deduped, sorted cache key —
+        # a duplicate county in the tuple is one hydration, not two.
+        assert hydrated_county_lists == [["26099", "26163"]]
+
+    def test_registry_cache_is_bounded_fifo(self, hydrated_county_lists: list[list[str]]) -> None:
+        from game import engine_bridge
+
+        cap = engine_bridge._ECONOMICS_CACHE_MAX
+        keys = [(f"{10000 + i:05d}",) for i in range(cap + 3)]
+        for key in keys:
+            engine_bridge._build_tensor_registry(key)
+
+        assert len(engine_bridge._TENSOR_REGISTRY_CACHE) == cap
+        assert frozenset(keys[0]) not in engine_bridge._TENSOR_REGISTRY_CACHE  # oldest evicted
+        assert frozenset(keys[-1]) in engine_bridge._TENSOR_REGISTRY_CACHE
+
+    def test_calculator_cache_is_bounded_fifo(self, hydrated_county_lists: list[list[str]]) -> None:
+        from game import engine_bridge
+
+        cap = engine_bridge._ECONOMICS_CACHE_MAX
+        keys = [(f"{20000 + i:05d}",) for i in range(cap + 3)]
+        for key in keys:
+            engine_bridge._build_capital_calculator(key)
+
+        assert len(engine_bridge._CAPITAL_CALCULATOR_CACHE) == cap
+        assert frozenset(keys[0]) not in engine_bridge._CAPITAL_CALCULATOR_CACHE
+        assert frozenset(keys[-1]) in engine_bridge._CAPITAL_CALCULATOR_CACHE
 
 
 @pytest.mark.requires_reference_db

--- a/web/game/engine_bridge.py
+++ b/web/game/engine_bridge.py
@@ -7626,6 +7626,26 @@ def _has_county_resolution_territory(state: WorldState) -> bool:
 _TENSOR_REGISTRY_CACHE: dict[frozenset[str], Any] = {}
 _CAPITAL_CALCULATOR_CACHE: dict[frozenset[str], Any] = {}
 
+#: PR #209 review: both caches above hold a fully-hydrated registry (15 years
+#: × every county in the key) per distinct FIPS-set for the life of the web
+#: worker — unbounded, that grows with every new scenario/county-set a session
+#: requests. 8 comfortably covers every canonical scenario while capping the
+#: worst case; infra bound, not a gameplay coefficient, hence no GameDefines.
+_ECONOMICS_CACHE_MAX: Final[int] = 8
+
+
+def _cache_put_bounded(cache: dict[frozenset[str], Any], key: frozenset[str], value: Any) -> None:
+    """FIFO-bounded insert shared by both economics caches (PR #209 review).
+
+    Dicts iterate in insertion order, so ``next(iter(cache))`` is the oldest
+    entry; one eviction per insert keeps ``len(cache) <= _ECONOMICS_CACHE_MAX``
+    because this is the caches' only writer.
+    """
+    if len(cache) >= _ECONOMICS_CACHE_MAX:
+        cache.pop(next(iter(cache)))
+    cache[key] = value
+
+
 #: QCEW county coverage runs 2010–2024; hydrate the full span once so the
 #: perpetual-inventory ``get_K`` has every year the sim can advance into.
 _CAPITAL_HYDRATION_YEARS: Final[tuple[int, ...]] = tuple(range(2010, 2025))
@@ -7679,10 +7699,13 @@ def _build_tensor_registry(fips_codes: tuple[str, ...]) -> Any:
             StubBEASource(),  # falls back to DepartmentMapper department ratios
             DepartmentMapper.from_yaml(naics_yaml),
         )
-        # sorted: fixes hydration/summation order across sessions (III.7, §5 hazard 1)
-        registry.hydrate_counties(hydrator, sorted(fips_codes), list(_CAPITAL_HYDRATION_YEARS))
+        # sorted(key), not sorted(fips_codes): fixes hydration/summation order
+        # across sessions (III.7, §5 hazard 1) AND hydrates exactly the deduped
+        # cache key — a duplicate county in the tuple is one hydration, not two
+        # (PR #209 review).
+        registry.hydrate_counties(hydrator, sorted(key), list(_CAPITAL_HYDRATION_YEARS))
 
-    _TENSOR_REGISTRY_CACHE[key] = registry
+    _cache_put_bounded(_TENSOR_REGISTRY_CACHE, key, registry)
     return registry
 
 
@@ -7715,7 +7738,7 @@ def _build_capital_calculator(fips_codes: tuple[str, ...]) -> Any:
 
     registry = _build_tensor_registry(fips_codes)
     calculator = CapitalStockCalculator(registry)
-    _CAPITAL_CALCULATOR_CACHE[key] = calculator
+    _cache_put_bounded(_CAPITAL_CALCULATOR_CACHE, key, calculator)
     return calculator
 
 

--- a/web/game/stub_bridge.py
+++ b/web/game/stub_bridge.py
@@ -15,7 +15,6 @@ Or set ``BABYLON_STUB_BRIDGE=1`` to auto-initialize in ``_get_bridge()``.
 from __future__ import annotations
 
 import logging
-import random
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -1207,8 +1206,26 @@ class StubEngineBridge:
     def resolve_tick(
         self,
         session_id: UUID,
-    ) -> list[dict[str, Any]]:
-        """Advance the game by one tick. Returns action results."""
+        persistent_context: dict[str, Any] | None = None,
+        *,
+        force_endgame_test_hook: bool = False,
+    ) -> dict[str, Any]:
+        """Advance the game by one tick and return the new snapshot.
+
+        Signature and return shape mirror ``EngineBridge.resolve_tick`` (the
+        protocol authority) so the ``_get_bridge()`` fallback actually serves
+        the ``/resolve/`` view — which reads ``snapshot.get("tick")`` off
+        this return — instead of 500ing on the old ``(session_id)``-only,
+        list-returning shape. Both extra parameters keep the REAL bridge's
+        names (``tick_resolver.resolve_game_tick`` passes them by keyword,
+        so the underscore unused-param convention would break the call) and
+        are deliberately inert: the stub carries no engine, so there is no
+        cross-tick context to thread and no EndgameDetector for the e2e
+        hook to fire — an honest no-op, never a fabricated endgame. Queued
+        actions are drained each tick so repeat submissions don't
+        accumulate; the stub invents no per-action results for them.
+        """
+        del persistent_context, force_endgame_test_hook  # inert: no engine behind the stub
         session = _stub_sessions.get(session_id)
         if session:
             session["tick"] += 1
@@ -1222,25 +1239,8 @@ class StubEngineBridge:
             except Exception:
                 pass
 
-        actions = _stub_actions.get(session_id, [])
-        results = []
-        for action in actions:
-            results.append(
-                {
-                    "org_id": action["org_id"],
-                    "action_type": action["verb"].upper(),
-                    "target_id": action.get("target_id"),
-                    "initiative_score": round(random.uniform(0.3, 0.9), 2),
-                    "action_cost": 1.0,
-                    "success": random.random() > 0.3,
-                    "consciousness_delta": round(random.uniform(-0.02, 0.08), 3),
-                    "heat_delta": round(random.uniform(0.0, 0.1), 3),
-                    "details": {},
-                }
-            )
-
         _stub_actions[session_id] = []
-        return results
+        return self.get_snapshot(session_id)
 
     # ------------------------------------------------------------------ #
     # Spec 103: Trade surfaces — stub returns honest empty states.


### PR DESCRIPTION
## What this PR is

The owner-directed housekeeping pass: triage + fix of every failing nightly job, closure of all outstanding Copilot review findings (#209/#210/#211), and the git-estate cleanup (worktrees, branches, stale Dependabot alerts). Every fix was diagnosed with commit-level provenance first (three read-only diagnosis agents + real `gh run` log archaeology), implemented test-first, and the whole branch passed an independent adversarial review (all 10 claims CONFIRMED, its one Important finding fixed in the final commit).

## Nightly triage — the four lanes

The initial framing ("all failures appeared with PR #209") was **wrong**, and the diagnosis proves it: #209 and #210 are provably innocent of every failure.

| Lane | Failing job/tests | Root cause (provenance) | Fix |
|---|---|---|---|
| A1 | Non-Unit: `test_alarm_event_emission` (2) | PR #207's ContextType collapse (`444b5216`) missed this nightly-only file's raw-dict contexts — the commit's own census-gap prediction | Migrated to `TickContext`, cited |
| A2 | Non-Unit + py3.13: `test_endgame_flow` (4) | `d14d2c42`'s deliberate 0.75→0.9 `fascist_majority_fraction` calibration updated 3 referencing test files but not this fixture (4/5 = 0.8) | Fixture widened to 9/10 = 0.9 (detector gate is `>=`, exact in IEEE-754), cited |
| A3 | Non-Unit: `test_probability_bounds` (2) | **Pre-existing** (red on the 07-18 nightly too): the discovery walker imports the deprecated `OrganizationComponent` shim, whose import-time warning detonates under `error::DeprecationWarning:babylon.*` — order-dependent per xdist worker | Name-scoped suppression via a `_DEPRECATED_SHIM_MODULES` registry (an unlisted future shim still fails loudly) + a fresh-import regression test |
| B | Non-Unit + py3.13: `test_grundrisse_cycle` (1) | Stale "5 oppositions" assumption vs the 10-key registry | **NO FIX HERE** — already repaired on the live vol3 branch (`refactor/vol3-money-scissors`); lands at the vol3→dev merge. This is the one job-level red expected to remain until then. |
| C | Postgres Integration (1) | Nightly bootstrapped via a bare DDL loop (the exact ADR074-forbidden pattern) that creates every table EXCEPT `_babylon_schema_stamp` (its DDL lives only in `ensure_ddl_applied`) — nightly's schema path silently diverged from production's; the spine's new healing test (`1f7eae3e`) was the first to notice | `db:bootstrap` now calls `ensure_ddl_applied` (DDL is fully IF-NOT-EXISTS-idempotent; loud failure is intended III.11) + the healing test's setup is self-sufficient. Verified on a DB with the stamp table deliberately dropped — nightly's exact red condition. |
| D | Reference-Data (4) — **red since 07-17**, ci-data-v6 boundary, not the #209 window | (a) `test_bea_tier_exists` still queried `dim_bea_economic_area`, amputated by ADR076 (`36f4cb98`) whose verification swept only `tests/unit/reference/`; (b) SC-001/004/006 assert NATIONAL scale but the subset pins `fact_qcew_annual` to Michigan while `fact_qcew_county_rollup` stays full (BLOCKED-FULL trio) — the JOINs collapse by construction | (a) repointed to the registered successor CSV; (b) cited scope-guard skips (skip proven to fire on subset-scoped data; all gates pass as specced on the full DB). **sc002 deliberately keeps running on the subset** — it asserts only a within-band share, empirically meaningful there (1680/1680) — per the adversarial review's F1. |

## Copilot findings (all 10 threads on #209/#210/#211 replied + resolved)

- **`StubEngineBridge.resolve_tick` protocol parity** — the `_get_bridge()` fallback 500'd on every resolve (kwargs TypeError, then `.get` on a list). Stub now mirrors the real signature + snapshot return; `TestResolveTickParity` pins the exact signature (the drift lived precisely outside the parity file's `get_*`-only sweep) plus the production seam.
- **Economics caches** — hydration now covers exactly the deduped cache key; both caches FIFO-bounded at 8 via one shared insert helper, eviction-tested. (Review confirmed the two-cache pairing cannot desync and determinism is unaffected.)
- **Investigate preset leak** — switching INVESTIGATE→any verb no longer silently pre-targets it; preset target dies with its verb, regression-tested.
- **#210's 8 doc comments** — already addressed pre-merge by `9f586ec4`; verified in the current docs and resolved with citation.

## Estate cleanup (already executed, not in this diff)

- 33 stale worktrees removed; 44 local + 14 remote merged branches deleted — every deletion verified merged or content-shipped first (`git cherry` / on-dev content checks for the 4 force-deletes). Kept: `babylon-vol3` (live session), `feature/hypergraph-rs-phase-0-1` (paused program, 45 unmerged commits), `archive/old-dev-jan2025`, owner-spared `053-conservation-invariants` + `101-trade-activation`.
- Local `main` was 821 commits stale (plain ancestor) → fast-forwarded to origin/main.
- 3 stale HIGH Dependabot alerts dismissed `not_used` with citation: they point at `uv.lock`, deleted from dev in `a4b46cd1` (2026-07-10); the repo is Poetry-managed and `poetry.lock` sits under the blocking pip-audit gate.

## Honest ledger

- **Expected residual nightly red:** grundrisse (lane B) in Non-Unit + py3.13 until vol3 merges — everything else should green on the next run. A `workflow_dispatch` verification run follows this merge.
- The adversarial review's remaining Minor/informational findings, left deliberately: `test_bea_tier_exists` retains the module-level `requires_reference_db` marker though it now reads a committed CSV (follow-up split candidate); the economics caches are FIFO not LRU (efficiency only at cap=8); the stub's pre-existing broad `except Exception` in its Django sync predates this branch.
- Systemic debts recorded for the sentinel queue (sentinel-every-error-class rule): (1) tests JOINing tables with mismatched `subset_policy` are an ungated class (db_probe only validates skip-policy absence); (2) nightly's PG bootstrap and production's schema path were two divergent code paths — now unified, but the class ("CI env bootstrap ≠ production bootstrap") is worth a gate.
- `src/babylon/reference/schema.py`'s docstring table census predates ADR076; it now points at `data-catalog.yaml` as authoritative rather than hand-recounting.

## Verification

- Lane-scoped suites all green locally (alarm 2/2, endgame 12/12, probability 6/6, QCEW+michigan 19/19, healing tests 2/2 on a deliberately-stampless DB).
- Full `mise run check`: 11,449 passed + 1 documented xfail, exit 0. `qa:regression`: 5/5 byte-identical (branch provably touches no engine/economics/defines/baseline files). Frontend `npm run check`: 1,402 tests, exit 0.
- Independent adversarial review (Opus): 10/10 claims CONFIRMED, no Critical; F1 fixed, F2 hardened, F3–F5 disclosed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
