### PR TITLE
fix(web): post-#211 nightly Postgres leg — veil-era contracts + null-params resolve crash

### DIFF
--- a/tests/integration/web/test_dashboards.py
+++ b/tests/integration/web/test_dashboards.py
@@ -73,13 +73,24 @@ class TestGameSummary:
     """get_game_summary: top-bar aggregate."""
 
     def test_summary_after_create_has_real_fields(self, bridge: object) -> None:
+        """A fresh session is veil-tier 0: value-axis fields are masked.
+
+        G4 (spec-116 §7, PR #211) server-gates the TopBar summary via
+        ``gate_value_axis_fields`` — ``imperial_rent``/``exploitation_rate``
+        are None until the player acquires the tier-1 doctrine node. The
+        pre-veil contract asserted ``imperial_rent is not None`` here; the
+        UNVEILED path is covered by ``test_summary_tick_advances_after_
+        resolves`` below (doctrine accrual lifts the tier past 0).
+        """
         session_id = bridge.create_game(scenario="wayne_county", rng_seed=0)  # type: ignore[attr-defined]
 
         summary = bridge.get_game_summary(session_id)  # type: ignore[attr-defined]
 
         assert summary["tick"] == 0
-        # imperial_rent_pool defaults to 100.0 in GlobalEconomy — always present.
-        assert summary["imperial_rent"] is not None
+        # Veiled at birth (tier 0) — masked server-side, never fabricated.
+        assert summary["imperial_rent"] is None
+        assert summary["exploitation_rate"] is None
+        # Money-form / non-value-axis fields stay real through the veil.
         assert summary["avg_consciousness"] is not None
         assert summary["population_total"] is not None
         assert summary["population_total"] > 0
@@ -103,12 +114,22 @@ class TestEconomyDashboard:
     """get_economy_dashboard: dashboard-wide economy aggregate."""
 
     def test_economy_dashboard_after_create_has_real_fields(self, bridge: object) -> None:
+        """A fresh session is veil-tier 0: value-axis fields are masked.
+
+        G4 (spec-116 §7, PR #211): ``imperial_rent_pool`` is tier-≥1 and
+        arrives None with a ``veil`` block at tier 0; money-form fields
+        (``current_super_wage_rate``, wealth by class role) stay real.
+        """
         session_id = bridge.create_game(scenario="wayne_county", rng_seed=0)  # type: ignore[attr-defined]
 
         economy = bridge.get_economy_dashboard(session_id)  # type: ignore[attr-defined]
 
         assert economy["tick"] == 0
-        assert economy["imperial_rent_pool"] is not None
+        # Veiled at birth (tier 0) — masked server-side, never fabricated.
+        assert economy["imperial_rent_pool"] is None
+        assert economy["veil"]["tier"] == 0
+        assert economy["veil"]["next_unlock_node_id"] == "class_consciousness"
+        # Money-form fields stay real through the veil.
         assert economy["current_super_wage_rate"] is not None
         assert isinstance(economy["wealth_by_class_role"], dict)
         assert economy["wealth_by_class_role"]  # wayne_county seeds several classes

--- a/tests/integration/web/test_game_lifecycle.py
+++ b/tests/integration/web/test_game_lifecycle.py
@@ -156,7 +156,12 @@ class TestGameLifecycle:
                 session_id=session_id,
                 tick=0,
                 org_id=first_org,
-                verb="AGITATE",
+                # "educate", not "AGITATE": affordability went live once #211
+                # made orgs resolve in state (the gate silently skipped on
+                # org=None before), and AGITATE was never in the player
+                # ACTION_COSTS table (vanguard_resources.py) — it is an OODA
+                # org action. Lowercase to match the real API path's casing.
+                verb="educate",
                 action_type=first_action.get("action_type"),
                 target_id=first_action.get("target_id"),
             )

--- a/tests/property/invariants/test_probability_bounds.py
+++ b/tests/property/invariants/test_probability_bounds.py
@@ -222,8 +222,14 @@ def test_discovery_walk_does_not_leak_deprecation_warnings() -> None:
 
     from tests.property.harness import probability_discovery
 
+    shim = "babylon.models.components.organization"
     probability_discovery.discover_probability_fields.cache_clear()
-    sys.modules.pop("babylon.models.components.organization", None)
+    # Pop (not delete-and-forget): the walk re-imports the shim, creating a
+    # SECOND class object — restoring the original module afterward keeps
+    # class identity intact for later tests in the same process
+    # (test_package_access_warns asserts `resolved is OrganizationComponent`;
+    # the 2026-07-19 verification nightly caught the duplicate).
+    saved_module = sys.modules.pop(shim, None)
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
@@ -231,3 +237,10 @@ def test_discovery_walk_does_not_leak_deprecation_warnings() -> None:
         assert pairs, "discovery returned no Probability fields"
     finally:
         probability_discovery.discover_probability_fields.cache_clear()
+        if saved_module is not None:
+            sys.modules[shim] = saved_module
+            import babylon.models.components as components_pkg
+
+            # Re-import also rebound the parent package's submodule
+            # attribute; point it back at the original module too.
+            components_pkg.organization = saved_module

--- a/web/game/engine_bridge.py
+++ b/web/game/engine_bridge.py
@@ -5449,7 +5449,11 @@ class EngineBridge:
                         "target_id": action.get("target_id", org_id),
                         "org_id": org_id,
                         "action_point_cost": 1,
-                        "params": action.get("params_json", {}),
+                        # `or {}`, not a .get default: a submit without params
+                        # persists params_json as JSON null, and .get's default
+                        # only covers an ABSENT key — None here fails Action's
+                        # params dict validation and 500s the whole resolve.
+                        "params": action.get("params_json") or {},
                     }
                 )
             persistent_context["player_actions"] = player_actions


### PR DESCRIPTION
## What

The dispatched nightly verification run ([29706258372](https://github.com/percy-raskova/babylon/actions/runs/29706258372)) surfaced 3 failures in the Postgres Integration job — all #211-era, all invisible to PR gates (integration tier only nightly runs):

1. **Two dashboard tests were pre-veil contracts.** A fresh session is veil-tier 0, so `imperial_rent`/`exploitation_rate`/`imperial_rent_pool` arrive **None by design** (G4 server gating); the after-resolves siblings pass because doctrine accrual lifts the tier and unveils. Tests amended to pin the veiled-at-birth contract including the `veil` block.
2. **The lifecycle test's `verb="AGITATE"` hit an affordability gate that just came alive.** Pre-#211 the gate silently skipped (org never resolved in state); #211's real org seeding/resolution armed it, and AGITATE was never in the player `ACTION_COSTS` table (it's an OODA org action). Switched to lowercase `educate` (real API casing).
3. **That exposed a genuine production bug:** a submit without params persists `params_json` as JSON null, and resolve built `Action(params=None)` — `.get`'s default only covers *absent* keys — ValidationError, 500 on the whole resolve. Fixed with `or {}` at the seam (`engine_bridge.py` player-actions build); the paramless lifecycle submit is the regression coverage.

## Verification
Local against the compose DB: dashboards **11/11**, lifecycle **6/6**; `check:quick` green (mypy 662 files). qa:regression untouched (web layer only).

After this merges, the Postgres Integration leg should be fully green; the only expected nightly reds remain grundrisse (Non-Unit + py3.13) until the vol3 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)