### PR TITLE
chore(data): bump pinned sqlite to 3.53.1 (CI runner parity; infra env owns the pin)

### DIFF
--- a/tools/build_reference_db.py
+++ b/tools/build_reference_db.py
@@ -79,7 +79,11 @@ from make_data_artifacts import (  # noqa: E402
 PAGE_SIZE = 4096
 APPLICATION_ID = 0x4241424C  # "BABL"
 USER_VERSION = 1  # pipeline major version
-PINNED_SQLITE_VERSION = "3.46.1"
+PINNED_SQLITE_VERSION = "3.53.1"  # owner ruling 2026-07-20: match the CI runner; the
+#: toolchain pin's source of truth moves to babylon-infra (Nix env) — dev-box builder
+#: runs require that env (or any 3.53.1 runtime) until the box migrates. Bumped
+#: pre-cutover: no build products were ever minted under 3.46.1, so no regeneration
+#: event is owed (the plan's "bump = declared regeneration event" rule is vacuous here).
 
 #: Default canonical locations (repo-root-relative), matching the sibling
 #: exporters' ``_DEFAULT_DB``/``DEFAULT_OUT`` precedent.


### PR DESCRIPTION
Owner ruling 2026-07-20: pin sqlite at 3.53.1 to match the CI runner; the toolchain pin's long-term home is the babylon-infra Nix environment (`../babylon-infra`, flake present, sqlite provision to be added there as the Program 20 / #46 cutover follow-through).

- One-constant change; bumped pre-cutover so no build product ever existed under the old pin — no regeneration event owed.
- Effect: parquet builder/roundtrip suites now RUN in CI (runtime 3.53.1) and skip on the 3.46.1 dev box until it migrates to the infra env — the reverse of the situation PR #221 shipped, and the direction we want: CI regains real coverage of the byte-identity tooling.
- Fixture `3.46.1` literals in manifest tests are inert (validator checks non-empty string, not pin equality); left untouched per the surgical-change rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)