### PR TITLE
feat(infra): mount babylon-infra submodule at infra/ — canonical devshell (sqlite 3.53.1 pin)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,8 +174,8 @@ deploy/ansible/production_inventory.yml
 deploy/ansible/inventory.yml
 deploy/ansible/.ansible/
 
-# program-20: local infra subrepo mount (becomes a submodule when it gets a remote)
-/infra/
+# program-20: infra/ is now a proper git submodule (github.com/percy-raskova/babylon-infra),
+# so it is tracked as a gitlink — no ignore entry needed.
 
 # hypergraph-rs: local subrepo mount (standalone Rust XGI port, own git repo —
 # same pattern as infra/; becomes a submodule/remote repo when published.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "infra"]
+	path = infra
+	url = https://github.com/percy-raskova/babylon-infra.git

--- a/.mise.toml
+++ b/.mise.toml
@@ -46,6 +46,10 @@ AUDIO_OUTPUT_DIR = "assets/audio"
 # INSTALLATION
 # =============================================================================
 
+[tasks."nix"]
+description = "run any command inside the mounted infra devshell (pinned toolchain incl. sqlite-3.53.1 python), e.g. mise run nix -- poetry run python tools/build_reference_db.py; needs: git submodule update --init infra"
+run = 'nix develop "${MISE_PROJECT_ROOT:-$PWD}/infra" --command'
+
 [tasks.install]
 description = "Install all dependencies"
 run = "poetry install --with dev"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,18 @@ CI (`.github/workflows/ci.yml`) invokes the same mise tasks devs run (`test:unit
 `qa:regression`, …) — the only raw-poetry exceptions are the py3.13 forward-compat leg (`nightly.yml`)
 and a handful of documented one-offs (migrations, doc build, ad hoc pytest legs).
 
+## Environment — the infra devshell (canonical toolchain)
+
+`infra/` is a git submodule of [babylon-infra](https://github.com/percy-raskova/babylon-infra)
+(Program 20 / ADR069/071; mounted 2026-07-20 by owner ruling). Its Nix flake is the canonical
+toolchain: python 3.12 with **sqlite pinned 3.53.1** (lockstep with
+`tools/build_reference_db.py::PINNED_SQLITE_VERSION` — the reference-DB byte-identity contract),
+node, gdal/geos/proj, libpq, playwright browsers. Fresh clones/worktrees:
+`git submodule update --init infra`, then run pinned-toolchain commands via
+`mise run nix -- <cmd>`. The host venv (3.46.1 sqlite) still runs everything EXCEPT the
+reference-DB builder, which hard-fails off-pin by design. Bumping the flake's `nixpkgs-data`
+input IS a declared sqlite-pin change.
+
 ## Machine safety — resource limits (history: froze the dev box twice, 2026-07-12)
 
 Solo dev box (12 cores / 31 GB RAM). The 2026-07-12 freezes were root-caused and FIXED: BLAS

--- a/tools/check_repo_hygiene.py
+++ b/tools/check_repo_hygiene.py
@@ -43,6 +43,7 @@ ALLOWED_TOP_LEVEL_DIRS: frozenset[str] = frozenset(
         "design",
         "docker",
         "docs",
+        "infra",  # babylon-infra git submodule (gitlink) — canonical devshell/toolchain, ADR093 Amendment X
         "output",  # tracked delivery evidence: demo screenshots (spec-113 Living Map, ADR066)
         "project",  # long-horizon governance: programs/owner/execution/notes
         "reports",  # tracked audit evidence; run artifacts are gitignored


### PR DESCRIPTION
Executes the owner ruling 2026-07-20 ("import babylon-infra as a proper git subrepository and run that nix environment — make it consistent"), reviving Program 20's mount (ADR069/071) onto current dev.

- `infra/` = git submodule of github.com/percy-raskova/babylon-infra, pinned at `9d47d6a` — the rev whose flake provides the data-layer interpreter with **sqlite exactly 3.53.1** via a dedicated `nixpkgs-data` input (lockstep with `PINNED_SQLITE_VERSION`, PR #222). The infra repo's main was pushed (7e0bfd9..9d47d6a) so the gitlink is fetchable.
- `mise run nix -- <cmd>` wrapper (mirrors infra's own task) runs any command inside the mounted devshell; CLAUDE.md gains the environment section.
- CI-neutral: CI does not checkout submodules today. Recorded follow-ups: run the reference-DB builder legs inside the devshell in CI; migrate the plaintext `.envrc` API keys to sops (infra ships sops/age).
- The #46 cutover runs inside this environment (its worktree venv is built on the flake's exact interpreter store path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)