### PR TITLE
fix(web): devshell native-lib wiring — GeoDjango settings shim + infra a7f1008 bump

### DIFF
--- a/web/babylon_web/settings/base.py
+++ b/web/babylon_web/settings/base.py
@@ -26,6 +26,15 @@ DEBUG = False
 
 ALLOWED_HOSTS: list[str] = []
 
+# GeoDjango native libraries: under the infra devshell's nix python the
+# dynamic linker sees no host libs and ctypes find_library() locates
+# nothing, so the flake exports exact store paths (babylon-infra a7f1008).
+# Host installs leave these unset and keep the ldconfig lookup.
+if os.environ.get("GDAL_LIBRARY_PATH"):
+    GDAL_LIBRARY_PATH = os.environ["GDAL_LIBRARY_PATH"]
+if os.environ.get("GEOS_LIBRARY_PATH"):
+    GEOS_LIBRARY_PATH = os.environ["GEOS_LIBRARY_PATH"]
+
 # --------------------------------------------------------------------------- #
 # Application definition
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Companion to [babylon-infra a7f1008](https://github.com/percy-raskova/babylon-infra/commit/a7f1008) (native-lib wiring for the nix devshell).

- `web/babylon_web/settings/base.py`: consume `GDAL_LIBRARY_PATH`/`GEOS_LIBRARY_PATH` env exports when set — under the devshell's nix python the dynamic linker sees no host libs and GeoDjango's `find_library()` locates nothing. Host installs leave the vars unset and keep ldconfig lookup.
- `infra` submodule → a7f1008: adds `stdenv.cc.cc.lib` to the devshell `LD_LIBRARY_PATH` (manylinux C++ wheels: greenlet, pyarrow) and the GDAL/GEOS env exports.

Discovered running the babylon test estate under the pinned sqlite-3.53.1 interpreter during the #46 cutover (owner-authorized housekeeping wave, 2026-07-20). No reference-data surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)