### PR TITLE
§6.5 Provenance & Ceremony: baseline-ceremony gate + CLAUDE.md doctrine (#61)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,26 @@ jobs:
       - name: Poetry lock consistency
         run: poetry check --lock
 
+  # §6.5 Provenance & Ceremony (owner ruling 2026-07-20; doctrine in CLAUDE.md
+  # "Baseline ceremonies"): every PR commit touching tests/baselines/** must
+  # declare its ceremony with a `Baselines: blessed(<slug>)` trailer. PR-only:
+  # dev/main only move via PRs, so the PR range is the authoritative boundary
+  # (the commit-msg pre-commit hook is the best-effort local leg). Stdlib-only
+  # script — no poetry bootstrap needed.
+  ceremony-gate:
+    name: Baseline Ceremony Gate (§6.5 provenance)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Ceremony declarations present on baseline-touching commits
+        run: >-
+          python3 tools/check_baseline_ceremony.py
+          --range "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+
   test-unit:
     name: Unit Tests (xdist, coverage gate)
     runs-on: ubuntu-latest

--- a/.mise.toml
+++ b/.mise.toml
@@ -119,6 +119,10 @@ depends = ["lint", "format", "typecheck"]
 description = "Repo-hygiene gate: root allowlist, ignore-consistency, blob sizes (program 14)"
 run = "poetry run python tools/check_repo_hygiene.py"
 
+[tasks."check:ceremony"]
+description = "Baseline-ceremony gate (§6.5): commits touching tests/baselines/** must carry Baselines: blessed(<slug>)"
+run = "poetry run python tools/check_baseline_ceremony.py --range origin/dev..HEAD"
+
 [tasks."check:seams"]
 description = "Seam Observatory Sensor 1: observable-field continuity gate (Constitution VIII.12 / III.11)"
 run = "poetry run python tools/sentinel_check.py seam --check"

--- a/.mise.toml
+++ b/.mise.toml
@@ -121,7 +121,7 @@ run = "poetry run python tools/check_repo_hygiene.py"
 
 [tasks."check:ceremony"]
 description = "Baseline-ceremony gate (§6.5): commits touching tests/baselines/** must carry Baselines: blessed(<slug>)"
-run = "poetry run python tools/check_baseline_ceremony.py --range origin/dev..HEAD"
+run = "python3 tools/check_baseline_ceremony.py --range origin/dev..HEAD"
 
 [tasks."check:seams"]
 description = "Seam Observatory Sensor 1: observable-field continuity gate (Constitution VIII.12 / III.11)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,6 +128,21 @@ repos:
         stages: [commit-msg]
 
   # ==========================================================================
+  # BASELINE CEREMONY - §6.5 Provenance & Ceremony (owner ruling 2026-07-20)
+  # Commits touching tests/baselines/** must declare their ceremony with a
+  # `Baselines: blessed(<slug>)` trailer. Local leg is best-effort; the CI
+  # ceremony-gate job (PR range) is authoritative.
+  # ==========================================================================
+  - repo: local
+    hooks:
+      - id: baseline-ceremony
+        name: baseline ceremony declaration (§6.5)
+        entry: python3 tools/check_baseline_ceremony.py --commit-msg-file
+        language: system
+        always_run: true
+        stages: [commit-msg]
+
+  # ==========================================================================
   # GENERAL HYGIENE
   # ==========================================================================
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,8 @@ Three-layer local system, no external servers. Full map: `ai/architecture.yaml`.
 
 **Client status (owner ruling 2026-07-20; Amendment V / II.8):** the browser/web client (`web/`,
 `src/frontend/`) is **legacy** — its failures don't gate work and the web `engine_bridge` suite is
-disabled wholesale (`tests/unit/web/test_engine_bridge.py` docstring). The terminal Archive client
+disabled wholesale (module-level `pytestmark` skip in `tests/unit/web/test_engine_bridge.py`). The
+terminal Archive client
 is the successor (program unspecced; drafts in `ai/_inbox/tui/`). The `observe()` projection
 contract is the durable seam; clients are disposable.
 
@@ -150,8 +151,9 @@ files, so intertwined units force ugly giant commits. Use `mise run commit -- "t
   IS a ceremony — subject `test(baselines): …`, body records the drift table (per-scenario columns,
   cell counts, max |d|, attribution), and the message MUST carry a
   `Baselines: blessed(<ceremony-slug>)` trailer. Enforced by the commit-msg hook locally and the
-  CI ceremony-gate on PRs (`tools/check_baseline_ceremony.py`; audit trail:
-  `git log --grep 'Baselines: blessed' --format='%h %s'`). Undeclared drift = red gate, STOP.
+  CI ceremony-gate on PRs (`tools/check_baseline_ceremony.py`; evil merges included via
+  `diff-tree --cc`; audit trail: `git log -E --grep '^Baselines: blessed\(' --format='%h %s'`).
+  Undeclared drift = red gate, STOP.
 - After significant work: update `ai/state.yaml`; add an ADR in `ai/decisions/` (individual
   `ADR0NN_*.yaml` files + `index.yaml` catalog) for architectural decisions.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,9 @@ grounded code, and you follow the Babylon Constitution for architectural decisio
 
 ## Constitutional Compact
 
-Irreducible constraints. Full text: `CONSTITUTION.md` (v2.8.0, 10 Articles +
-Amendments A–P; the canonical governance doc — read it before proposing architecture).
+Irreducible constraints. Full text: `CONSTITUTION.md` (v2.12.0, 10 Articles +
+Amendments A–X, T reserved for ADR072; the canonical governance doc — read it before
+proposing architecture).
 
 **MUST**
 
@@ -53,6 +54,12 @@ Three-layer local system, no external servers. Full map: `ai/architecture.yaml`.
   (`persistence/pgvector_store.py`; replaced ChromaDB in spec-037). AI observes, never controls.
 
 **Principle:** state is pure data; the engine is pure transformation; they never mix.
+
+**Client status (owner ruling 2026-07-20; Amendment V / II.8):** the browser/web client (`web/`,
+`src/frontend/`) is **legacy** — its failures don't gate work and the web `engine_bridge` suite is
+disabled wholesale (`tests/unit/web/test_engine_bridge.py` docstring). The terminal Archive client
+is the successor (program unspecced; drafts in `ai/_inbox/tui/`). The `observe()` projection
+contract is the durable seam; clients are disposable.
 
 ## Engine
 
@@ -138,7 +145,13 @@ files, so intertwined units force ugly giant commits. Use `mise run commit -- "t
   + no-dead-columns leg + in-gate two-process determinism leg, ~10s local) plus `mise run
   check:gate-coverage` (static, fast lane) / `check:gate-coverage-truth` (dynamic, qa lane) —
   coverage is now declared and proved, not implicit (ADR090). If a value moves unintentionally,
-  STOP; if intentionally, regenerate baselines and say so.
+  STOP; if intentionally, regenerate baselines via a declared ceremony (next bullet).
+- **Baseline ceremonies (§6.5, owner ruling 2026-07-20):** any commit touching `tests/baselines/**`
+  IS a ceremony — subject `test(baselines): …`, body records the drift table (per-scenario columns,
+  cell counts, max |d|, attribution), and the message MUST carry a
+  `Baselines: blessed(<ceremony-slug>)` trailer. Enforced by the commit-msg hook locally and the
+  CI ceremony-gate on PRs (`tools/check_baseline_ceremony.py`; audit trail:
+  `git log --grep 'Baselines: blessed' --format='%h %s'`). Undeclared drift = red gate, STOP.
 - After significant work: update `ai/state.yaml`; add an ADR in `ai/decisions/` (individual
   `ADR0NN_*.yaml` files + `index.yaml` catalog) for architectural decisions.
 

--- a/tests/unit/tools/test_baseline_ceremony.py
+++ b/tests/unit/tools/test_baseline_ceremony.py
@@ -1,0 +1,220 @@
+"""Behavioral contract for the baseline-ceremony gate (§6.5 provenance & ceremony).
+
+Owner ruling 2026-07-20: the ceremony doctrine's home is CLAUDE.md + CI teeth,
+not a constitutional amendment. The gate (``tools/check_baseline_ceremony.py``)
+mechanizes Constitution III.7's "regenerate the baselines *and say so*": any
+commit that touches ``tests/baselines/**`` must machine-checkably declare its
+ceremony via a ``Baselines: blessed(<ceremony-slug>)`` trailer.
+
+Two enforcement modes, both covered here against synthetic git repos:
+
+a. ``--commit-msg-file`` — the local commit-msg hook (staged paths vs message);
+b. ``--range A..B``      — the CI leg (every non-merge commit in a PR range).
+
+The synthetic-violation tests are the mutation proof that each mode detects
+its violation class (Constitution III.11 — Loud Failure).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Mirror the import path used by tools/*.py and its existing unit tests
+# (see tests/unit/tools/test_repo_hygiene.py).
+TOOLS_DIR = Path(__file__).resolve().parents[3] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from check_baseline_ceremony import (  # type: ignore[import-not-found]  # noqa: E402
+    check_commit_msg,
+    check_range,
+    main,
+    message_declares_ceremony,
+    touches_baselines,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run git in ``repo``, failing the test loudly on nonzero exit."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "gate-test@example.invalid")
+    _git(repo, "config", "user.name", "Gate Test")
+    (repo / "README.md").write_text("seed\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "chore: seed")
+    return repo
+
+
+def _commit_file(repo: Path, rel_path: str, content: str, message: str) -> str:
+    target = repo / rel_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+    _git(repo, "add", rel_path)
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+BLESSED = "test(baselines): ceremony\n\nBaselines: blessed(unit-proof-ceremony)"
+
+
+class TestTrailerGrammar:
+    """The declaration is a strict trailer line, not a vibe."""
+
+    def test_valid_trailer_accepted(self) -> None:
+        assert message_declares_ceremony(BLESSED)
+
+    def test_missing_trailer_rejected(self) -> None:
+        assert not message_declares_ceremony("test(baselines): regen\n\nno declaration")
+
+    def test_empty_slug_rejected(self) -> None:
+        assert not message_declares_ceremony("msg\n\nBaselines: blessed()")
+
+    def test_uppercase_slug_rejected(self) -> None:
+        assert not message_declares_ceremony("msg\n\nBaselines: blessed(LOUD)")
+
+    def test_untouched_is_not_a_blessing(self) -> None:
+        assert not message_declares_ceremony("msg\n\nBaselines: untouched")
+
+    def test_mid_line_mention_rejected(self) -> None:
+        assert not message_declares_ceremony("msg\n\nsee Baselines: blessed(x) above")
+
+    def test_comment_line_rejected(self) -> None:
+        # git strips '#' comment lines at cleanup; the gate must not accept a
+        # declaration that only exists inside one.
+        assert not message_declares_ceremony("msg\n\n# Baselines: blessed(sneaky)")
+
+
+class TestPathScope:
+    def test_baseline_path_in_scope(self) -> None:
+        assert touches_baselines(["tests/baselines/glut.json"])
+
+    def test_dense_subdir_in_scope(self) -> None:
+        assert touches_baselines(["tests/baselines/dense/glut/C001_wealth.csv"])
+
+    def test_non_baseline_paths_out_of_scope(self) -> None:
+        assert not touches_baselines(["src/babylon/engine/simulation_engine.py"])
+
+    def test_lookalike_prefix_out_of_scope(self) -> None:
+        assert not touches_baselines(["tests/baselines_archive/old.json"])
+
+
+class TestCommitMsgMode:
+    """Local hook: staged baseline paths demand a declared message."""
+
+    def test_staged_baseline_without_trailer_is_violation(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        (repo / "tests/baselines").mkdir(parents=True)
+        (repo / "tests/baselines/glut.json").write_text("{}\n")
+        _git(repo, "add", "tests/baselines/glut.json")
+        msg = tmp_path / "msg.txt"
+        msg.write_text("test(baselines): regen without declaration\n")
+        violations = check_commit_msg(msg, repo)
+        assert violations, "undeclared staged baseline change must be flagged"
+
+    def test_staged_baseline_with_trailer_is_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        (repo / "tests/baselines").mkdir(parents=True)
+        (repo / "tests/baselines/glut.json").write_text("{}\n")
+        _git(repo, "add", "tests/baselines/glut.json")
+        msg = tmp_path / "msg.txt"
+        msg.write_text(BLESSED + "\n")
+        assert check_commit_msg(msg, repo) == []
+
+    def test_non_baseline_staging_needs_no_trailer(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        (repo / "notes.md").write_text("plain\n")
+        _git(repo, "add", "notes.md")
+        msg = tmp_path / "msg.txt"
+        msg.write_text("docs: plain change\n")
+        assert check_commit_msg(msg, repo) == []
+
+
+class TestRangeMode:
+    """CI leg: every non-merge commit in the range is inspected."""
+
+    def test_undeclared_commit_flagged_by_sha(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        base = _git(repo, "rev-parse", "HEAD")
+        sha = _commit_file(
+            repo, "tests/baselines/glut.json", "{}\n", "test(baselines): silent drift"
+        )
+        violations = check_range(f"{base}..HEAD", repo)
+        assert len(violations) == 1
+        assert sha[:12] in violations[0] or sha in violations[0]
+
+    def test_declared_commit_is_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        base = _git(repo, "rev-parse", "HEAD")
+        _commit_file(repo, "tests/baselines/glut.json", "{}\n", BLESSED)
+        assert check_range(f"{base}..HEAD", repo) == []
+
+    def test_non_baseline_commits_ignored(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        base = _git(repo, "rev-parse", "HEAD")
+        _commit_file(repo, "src/module.py", "x = 1\n", "feat: unrelated")
+        assert check_range(f"{base}..HEAD", repo) == []
+
+    def test_merge_commits_skipped(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        base = _git(repo, "rev-parse", "HEAD")
+        _git(repo, "switch", "-c", "side")
+        _commit_file(repo, "tests/baselines/glut.json", "{}\n", BLESSED)
+        _git(repo, "switch", "main")
+        _commit_file(repo, "other.md", "y\n", "docs: mainline drift")
+        _git(repo, "merge", "--no-ff", "-m", "merge side into main", "side")
+        # The merge commit itself carries no trailer; only its non-merge
+        # parents are inspected, and the side commit is blessed.
+        assert check_range(f"{base}..HEAD", repo) == []
+
+    def test_multiple_undeclared_commits_all_reported(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        base = _git(repo, "rev-parse", "HEAD")
+        _commit_file(repo, "tests/baselines/a.json", "{}\n", "test(baselines): one")
+        _commit_file(repo, "tests/baselines/b.json", "{}\n", "test(baselines): two")
+        assert len(check_range(f"{base}..HEAD", repo)) == 2
+
+
+class TestMainCli:
+    def test_range_mode_exit_codes(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        base = _git(repo, "rev-parse", "HEAD")
+        _commit_file(repo, "tests/baselines/glut.json", "{}\n", "test(baselines): silent")
+        assert main(["--range", f"{base}..HEAD", "--repo", str(repo)]) == 1
+        _git(repo, "commit", "--amend", "-m", BLESSED)
+        assert main(["--range", f"{base}..HEAD", "--repo", str(repo)]) == 0
+
+    def test_commit_msg_mode_exit_codes(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        (repo / "tests/baselines").mkdir(parents=True)
+        (repo / "tests/baselines/glut.json").write_text("{}\n")
+        _git(repo, "add", "tests/baselines/glut.json")
+        msg = tmp_path / "msg.txt"
+        msg.write_text("test(baselines): silent\n")
+        assert main(["--commit-msg-file", str(msg), "--repo", str(repo)]) == 1
+        msg.write_text(BLESSED + "\n")
+        assert main(["--commit-msg-file", str(msg), "--repo", str(repo)]) == 0
+
+    def test_no_mode_is_usage_error(self) -> None:
+        assert main([]) == 2
+
+    def test_bad_range_is_git_error(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        assert main(["--range", "nonexistent..HEAD", "--repo", str(repo)]) == 2

--- a/tests/unit/tools/test_baseline_ceremony.py
+++ b/tests/unit/tools/test_baseline_ceremony.py
@@ -9,7 +9,8 @@ ceremony via a ``Baselines: blessed(<ceremony-slug>)`` trailer.
 Two enforcement modes, both covered here against synthetic git repos:
 
 a. ``--commit-msg-file`` — the local commit-msg hook (staged paths vs message);
-b. ``--range A..B``      — the CI leg (every non-merge commit in a PR range).
+b. ``--range A..B``      — the CI leg (every commit in a PR range; merges
+   inspected for evil-merge content via ``diff-tree --cc``).
 
 The synthetic-violation tests are the mutation proof that each mode detects
 its violation class (Constitution III.11 — Loud Failure).
@@ -148,7 +149,7 @@ class TestCommitMsgMode:
 
 
 class TestRangeMode:
-    """CI leg: every non-merge commit in the range is inspected."""
+    """CI leg: every commit in the range is inspected (merges via --cc)."""
 
     def test_undeclared_commit_flagged_by_sha(self, tmp_path: Path) -> None:
         repo = _init_repo(tmp_path)
@@ -172,7 +173,7 @@ class TestRangeMode:
         _commit_file(repo, "src/module.py", "x = 1\n", "feat: unrelated")
         assert check_range(f"{base}..HEAD", repo) == []
 
-    def test_merge_commits_skipped(self, tmp_path: Path) -> None:
+    def test_clean_merge_commit_not_flagged(self, tmp_path: Path) -> None:
         repo = _init_repo(tmp_path)
         base = _git(repo, "rev-parse", "HEAD")
         _git(repo, "switch", "-c", "side")
@@ -180,8 +181,50 @@ class TestRangeMode:
         _git(repo, "switch", "main")
         _commit_file(repo, "other.md", "y\n", "docs: mainline drift")
         _git(repo, "merge", "--no-ff", "-m", "merge side into main", "side")
-        # The merge commit itself carries no trailer; only its non-merge
-        # parents are inspected, and the side commit is blessed.
+        # A clean merge introduces no content beyond its parents: the merge
+        # commit needs no trailer of its own (the side commit is blessed).
+        assert check_range(f"{base}..HEAD", repo) == []
+
+    def test_evil_merge_baseline_change_flagged(self, tmp_path: Path) -> None:
+        """A merge whose conflict resolution differs from BOTH parents is a
+        ceremony in its own right — the Opus-review evil-merge hole."""
+        repo = _init_repo(tmp_path)
+        _commit_file(repo, "tests/baselines/glut.json", "{}\n", BLESSED)
+        base = _git(repo, "rev-parse", "HEAD")
+        _git(repo, "switch", "-c", "side")
+        _commit_file(repo, "tests/baselines/glut.json", '{"v": 1}\n', BLESSED)
+        _git(repo, "switch", "main")
+        _commit_file(repo, "tests/baselines/glut.json", '{"v": 2}\n', BLESSED)
+        # Conflicting merge; resolve to content present in NEITHER parent.
+        merge = subprocess.run(["git", "merge", "side"], cwd=repo, capture_output=True, text=True)
+        assert merge.returncode != 0, "merge must conflict for the evil resolution"
+        (repo / "tests/baselines/glut.json").write_text('{"v": 999, "evil": true}\n')
+        _git(repo, "add", "tests/baselines/glut.json")
+        _git(repo, "commit", "--no-verify", "-m", "merge side into main")
+        merge_sha = _git(repo, "rev-parse", "HEAD")
+        violations = check_range(f"{base}..HEAD", repo)
+        assert len(violations) == 1
+        assert merge_sha[:12] in violations[0]
+
+    def test_evil_merge_with_trailer_is_clean(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        _commit_file(repo, "tests/baselines/glut.json", "{}\n", BLESSED)
+        base = _git(repo, "rev-parse", "HEAD")
+        _git(repo, "switch", "-c", "side")
+        _commit_file(repo, "tests/baselines/glut.json", '{"v": 1}\n', BLESSED)
+        _git(repo, "switch", "main")
+        _commit_file(repo, "tests/baselines/glut.json", '{"v": 2}\n', BLESSED)
+        merge = subprocess.run(["git", "merge", "side"], cwd=repo, capture_output=True, text=True)
+        assert merge.returncode != 0
+        (repo / "tests/baselines/glut.json").write_text('{"v": 999}\n')
+        _git(repo, "add", "tests/baselines/glut.json")
+        _git(
+            repo,
+            "commit",
+            "--no-verify",
+            "-m",
+            "merge side into main\n\nBaselines: blessed(evil-merge-resolution)",
+        )
         assert check_range(f"{base}..HEAD", repo) == []
 
     def test_multiple_undeclared_commits_all_reported(self, tmp_path: Path) -> None:

--- a/tools/check_baseline_ceremony.py
+++ b/tools/check_baseline_ceremony.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Baseline-ceremony gate — §6.5 Provenance & Ceremony (owner ruling 2026-07-20).
+r"""Baseline-ceremony gate — §6.5 Provenance & Ceremony (owner ruling 2026-07-20).
 
 Constitution III.7 says "regenerate the baselines *and say so*"; III.12 makes
 the baseline estate a behavioral-contract artifact. This gate makes "say so"
@@ -13,20 +13,22 @@ where the slug is a lowercase ``[a-z0-9-]`` name for the ceremony (convention:
 stays the existing ``test(baselines): ...`` convention and the body records
 the drift table; the trailer is the greppable provenance record::
 
-    git log --grep 'Baselines: blessed' --format='%h %s'
+    git log -E --grep '^Baselines: blessed\(' --format='%h %s'
 
 Two modes (Constitution III.11 — both fail loudly):
 
 ``--commit-msg-file PATH``
     Local commit-msg hook: if staged paths touch the baseline estate, the
-    commit message must declare the ceremony. Best-effort (an ``--amend``
-    with an already-committed baseline change can slip it); CI is
-    authoritative.
+    commit message must declare the ceremony. Best-effort — an ``--amend``
+    of an already-committed baseline change, or a pathspec commit
+    (``git commit <path>``, which uses a temporary index), can slip past
+    it; the CI range leg catches both and is authoritative.
 
 ``--range A..B``
-    CI leg: every non-merge commit in the range that touches the baseline
-    estate must declare its ceremony. Merge commits are skipped — their
-    non-merge parents are inspected individually.
+    CI leg: every commit in the range that touches the baseline estate
+    must declare its ceremony. Merge commits are inspected for evil-merge
+    content only (paths differing from ALL parents via ``diff-tree --cc``);
+    clean merges need no trailer of their own.
 
 Exit codes: 0 = clean, 1 = undeclared ceremony, 2 = usage or git failure.
 Doctrine home: CLAUDE.md "Baseline ceremonies"; the ruling deliberately kept
@@ -102,12 +104,27 @@ def check_commit_msg(msg_file: Path, repo_root: Path) -> list[str]:
     return [f"staged baseline change(s) without declaration: {hit}"]
 
 
+def _is_merge_commit(sha: str, repo_root: Path) -> bool:
+    parent_tokens = _git(repo_root, "rev-list", "--parents", "-n", "1", sha).split()
+    return len(parent_tokens) > 2
+
+
 def check_range(range_spec: str, repo_root: Path) -> list[str]:
-    """CI leg: every non-merge commit in the range must declare its ceremony."""
-    shas_raw = _git(repo_root, "rev-list", "--no-merges", range_spec)
+    """CI leg: every commit in the range must declare its ceremony.
+
+    Non-merge commits are diffed against their parent. Merge commits are
+    inspected with ``diff-tree --cc``, which lists only paths whose content
+    differs from ALL parents — exactly evil-merge material. A clean merge
+    yields no such paths and needs no trailer of its own; an evil merge
+    that hand-resolves a baseline file is a ceremony in its own right.
+    """
+    shas_raw = _git(repo_root, "rev-list", range_spec)
     violations: list[str] = []
     for sha in [line for line in shas_raw.splitlines() if line]:
-        changed_raw = _git(repo_root, "diff-tree", "--no-commit-id", "--name-only", "-r", sha)
+        if _is_merge_commit(sha, repo_root):
+            changed_raw = _git(repo_root, "diff-tree", "--cc", "--no-commit-id", "--name-only", sha)
+        else:
+            changed_raw = _git(repo_root, "diff-tree", "--no-commit-id", "--name-only", "-r", sha)
         changed = [line for line in changed_raw.splitlines() if line]
         if not touches_baselines(changed):
             continue

--- a/tools/check_baseline_ceremony.py
+++ b/tools/check_baseline_ceremony.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Baseline-ceremony gate — §6.5 Provenance & Ceremony (owner ruling 2026-07-20).
+
+Constitution III.7 says "regenerate the baselines *and say so*"; III.12 makes
+the baseline estate a behavioral-contract artifact. This gate makes "say so"
+machine-checkable: any commit that touches ``tests/baselines/**`` is a
+*ceremony* and must carry a declaration trailer::
+
+    Baselines: blessed(<ceremony-slug>)
+
+where the slug is a lowercase ``[a-z0-9-]`` name for the ceremony (convention:
+``<what>-<date>``, e.g. ``post-merge-regen-2026-07-20``). The commit subject
+stays the existing ``test(baselines): ...`` convention and the body records
+the drift table; the trailer is the greppable provenance record::
+
+    git log --grep 'Baselines: blessed' --format='%h %s'
+
+Two modes (Constitution III.11 — both fail loudly):
+
+``--commit-msg-file PATH``
+    Local commit-msg hook: if staged paths touch the baseline estate, the
+    commit message must declare the ceremony. Best-effort (an ``--amend``
+    with an already-committed baseline change can slip it); CI is
+    authoritative.
+
+``--range A..B``
+    CI leg: every non-merge commit in the range that touches the baseline
+    estate must declare its ceremony. Merge commits are skipped — their
+    non-merge parents are inspected individually.
+
+Exit codes: 0 = clean, 1 = undeclared ceremony, 2 = usage or git failure.
+Doctrine home: CLAUDE.md "Baseline ceremonies"; the ruling deliberately kept
+this out of the constitution (workflow, not law).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# The governed artifact estate. Everything under these prefixes is a pinned
+# behavioral-contract artifact (regression baselines, dense goldens, the
+# mutation and storage-budget baselines); moving any of it is a ceremony.
+BASELINE_PREFIXES: tuple[str, ...] = ("tests/baselines/",)
+
+# Strict trailer grammar: a full line, lowercase slug, no empty blessing.
+_TRAILER_RE = re.compile(r"^Baselines: blessed\([a-z0-9][a-z0-9-]*\)$", re.MULTILINE)
+
+_DOCTRINE = """\
+tests/baselines/** changed without a ceremony declaration.
+
+  If UNINTENDED: STOP — unexplained baseline drift is a red gate.
+  Investigate before committing (Constitution III.7).
+
+  If INTENTIONAL: this commit is a ceremony. Declare it:
+    - subject:  test(baselines): <what moved and why>
+    - body:     the drift table (per-scenario columns, cell counts, max |d|)
+    - trailer:  Baselines: blessed(<ceremony-slug>)
+  See CLAUDE.md "Baseline ceremonies".
+"""
+
+
+def _git(repo_root: Path, *args: str) -> str:
+    """Run a git plumbing command, raising ``CalledProcessError`` on failure."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def message_declares_ceremony(message: str) -> bool:
+    """True iff the message carries a well-formed blessing trailer.
+
+    Comment lines (``#``-prefixed, stripped by git's default cleanup) are
+    removed first so a declaration cannot live only inside one.
+    """
+    effective = "\n".join(line for line in message.splitlines() if not line.startswith("#"))
+    return _TRAILER_RE.search(effective) is not None
+
+
+def touches_baselines(paths: list[str]) -> bool:
+    """True iff any path lies inside the governed baseline estate."""
+    return any(path.startswith(BASELINE_PREFIXES) for path in paths)
+
+
+def check_commit_msg(msg_file: Path, repo_root: Path) -> list[str]:
+    """commit-msg hook leg: staged baseline paths demand a declared message."""
+    staged_raw = _git(repo_root, "diff", "--cached", "--name-only")
+    staged = [line for line in staged_raw.splitlines() if line]
+    if not touches_baselines(staged):
+        return []
+    if message_declares_ceremony(msg_file.read_text(encoding="utf-8")):
+        return []
+    hit = ", ".join(p for p in staged if p.startswith(BASELINE_PREFIXES))
+    return [f"staged baseline change(s) without declaration: {hit}"]
+
+
+def check_range(range_spec: str, repo_root: Path) -> list[str]:
+    """CI leg: every non-merge commit in the range must declare its ceremony."""
+    shas_raw = _git(repo_root, "rev-list", "--no-merges", range_spec)
+    violations: list[str] = []
+    for sha in [line for line in shas_raw.splitlines() if line]:
+        changed_raw = _git(repo_root, "diff-tree", "--no-commit-id", "--name-only", "-r", sha)
+        changed = [line for line in changed_raw.splitlines() if line]
+        if not touches_baselines(changed):
+            continue
+        message = _git(repo_root, "log", "-1", "--format=%B", sha)
+        if message_declares_ceremony(message):
+            continue
+        subject = message.splitlines()[0] if message.splitlines() else ""
+        violations.append(f"{sha[:12]} ({subject}): baseline change undeclared")
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Baseline-ceremony gate — §6.5 Provenance & Ceremony"
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--commit-msg-file",
+        type=Path,
+        help="commit-msg hook mode: path to the message file under edit",
+    )
+    mode.add_argument(
+        "--range",
+        dest="range_spec",
+        help="CI mode: git revision range (BASE..HEAD) to inspect",
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="repository root (default: current directory)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.commit_msg_file is None and args.range_spec is None:
+        parser.print_usage(sys.stderr)
+        print("check_baseline_ceremony: one of --commit-msg-file/--range required", file=sys.stderr)
+        return 2
+
+    try:
+        if args.commit_msg_file is not None:
+            violations = check_commit_msg(args.commit_msg_file, args.repo)
+        else:
+            violations = check_range(args.range_spec, args.repo)
+    except subprocess.CalledProcessError as exc:
+        print(f"check_baseline_ceremony: git failed: {exc.stderr.strip()}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"check_baseline_ceremony: {exc}", file=sys.stderr)
+        return 2
+
+    if violations:
+        for violation in violations:
+            print(f"CEREMONY VIOLATION: {violation}", file=sys.stderr)
+        print(_DOCTRINE, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## What

Owner ruling 2026-07-20: §6.5's home is **CLAUDE.md doctrine + CI teeth**, not a constitutional amendment. This PR is that ruling executed.

- **`tools/check_baseline_ceremony.py`** — any commit touching `tests/baselines/**` must carry a `Baselines: blessed(<ceremony-slug>)` trailer (Constitution III.7's *regenerate the baselines and say so*, made machine-checkable). Stdlib-only.
- **Enforcement**: commit-msg pre-commit hook (local, best-effort) + `ceremony-gate` CI job (PR range, authoritative — evil merges included via `diff-tree --cc`) + `mise run check:ceremony`.
- **CLAUDE.md**: Baseline-ceremonies doctrine bullet; fact refresh (Constitution v2.8.0/A–P → v2.12.0/A–X, T reserved); client-status note (web = legacy per Amendment V ruling, terminal Archive successor).

## Verification

- TDD red→green: 25 tests against synthetic git repos (incl. evil-merge conflict-resolution construction).
- **Mutation-validated**: trailer-always-matches and scope-emptied both KILLED; revert green.
- **Live-fire**: undeclared baseline commit rejected by the installed hook with the doctrine message; declared accepted.
- **Opus adversarial review**: CHANGES_REQUIRED → Important (evil-merge escape via `--no-merges`, reproduced live) CLOSED with `--cc` inspection + red→green test; all 4 Minors applied. Reviewer confirmed: CI range semantics correct (`base.sha..head.sha` reachable under `fetch-depth: 0`), zero false positives on ordinary commits, historical trailer-less ceremonies can never retro-fail (PR-range-only), repo-law compliant.
- Known accepted limitations (documented in the module docstring): local leg misses `--amend` and pathspec commits — CI leg catches both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)