### PR TITLE
Parquet-canonical reference pipeline — Phase 6 cutover (#46)

### DIFF
--- a/.github/actions/fetch-reference-db/action.yml
+++ b/.github/actions/fetch-reference-db/action.yml
@@ -35,15 +35,22 @@ inputs:
     # Program 22 minerals surfaces FULL. Release also carries the four ADR076
     # parquet artifacts (manifest-pinned in data-artifacts.yaml). tiger
     # tarball unchanged from v3.
-    default: ci-data-v6
+    # v7 (2026-07-20, parquet-canonical cutover): subset now DERIVED from the
+    # rebuilt build product (product sha f760bab5..., sqlite 3.53.1,
+    # double-build byte-identical; qa:regression 6/6 pre- and post-flip);
+    # release adds full per-table parquet (80 files) + canonical schema.sql,
+    # all manifest-pinned — the manifest-driven step below fetches them
+    # without any action-input bump. ingest_checkpoint left the governed
+    # estate (loaders recreate on demand). tiger tarball unchanged from v3.
+    default: ci-data-v7
   asset:
     description: Asset filename within the release
     required: false
-    default: reference-subset-20260717-v6.sqlite
+    default: reference-subset-20260720-v7.sqlite
   sha256:
     description: Expected sha256 of the asset (pin — bump with the tag)
     required: false
-    default: 65128960cadb2cd4ba59004e9942b594c83a94562556318f57ba35e6b80d7b88
+    default: f193d44e1b11d4eee9675cbb129b72bd6cd3c05e50a90c3bdd136cb54d56b32f
   tiger-asset:
     description: TIGER county-shapefile tarball within the release (the
       headless runner reads data/tiger/county/tl_2024_us_county.shp — proving

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -147,6 +147,21 @@ jobs:
             echo "::notice::no product block in data-artifacts.yaml yet — rebuild-verify inert (pre-cutover)"
             exit 0
           fi
+          # The byte-identity contract is defined ONLY under the pinned sqlite
+          # (the builder hard-gates on PINNED_SQLITE_VERSION). Stock runners
+          # ship an older sqlite, so off-pin this leg warns LOUDLY and skips
+          # instead of hard-failing every nightly. Declared follow-up (ADR098):
+          # run this step inside the infra devshell on CI
+          # (cachix/install-nix-action, nix-release.yml prior art), then DELETE
+          # this warning path so the leg becomes the true remote identity proof.
+          RUNTIME=$(poetry run python -c 'import sqlite3; print(sqlite3.sqlite_version)')
+          PINNED=$(rg -o 'sqlite_version: "([0-9.]+)"' -r '$1' data-artifacts.yaml | head -1)
+          if [ "$RUNTIME" != "$PINNED" ]; then
+            MSG="runner sqlite ${RUNTIME} != pinned ${PINNED} — byte-identity leg"
+            MSG="${MSG} skipped; CI-devshell pinning is the ADR098 declared follow-up"
+            echo "::warning title=rebuild-verify OFF-PIN::${MSG}"
+            exit 0
+          fi
           poetry run python tools/build_reference_db.py --out /tmp/rebuilt.sqlite
           poetry run python - <<'EOF'
           import hashlib, pathlib, sys, yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,11 @@ Amendments A–P; the canonical governance doc — read it before proposing arch
 Three-layer local system, no external servers. Full map: `ai/architecture.yaml`.
 
 - **The Ledger** — rigid material state. SQLite reference DB (`data/sqlite/marxist-data-3NF.sqlite`,
-  read-only) + PostgreSQL runtime (`src/babylon/persistence/`) + a few JSON seeds in
-  `src/babylon/data/game/`.
+  read-only — a deterministic BUILD PRODUCT since ADR098: parquet sources + `schema.sql` in
+  `data-artifacts.yaml` are canonical, `mise run data:build-db` rebuilds it sha-identically on the
+  pinned toolchain; loaders never write it, they produce sources via `tools/loader_to_sources.py` —
+  see `docs/how-to/reference-data-pipeline.rst`) + PostgreSQL runtime (`src/babylon/persistence/`)
+  + a few JSON seeds in `src/babylon/data/game/`.
 - **The Topology** — fluid relational state via **rustworkx** (`babylon.topology.BabylonGraph`;
   its own package since Program 14; NetworkX was removed, Amendment L / ADR052).
   `WorldState.to_graph()` / `from_graph()`. Foundational node types

--- a/ai/architecture.yaml
+++ b/ai/architecture.yaml
@@ -39,6 +39,12 @@ core_architecture:
         relationships: "Directed edges (exploitation, solidarity, etc.)"
       data_flow: "Hydration Pattern - load at startup, persist on save, NO DB I/O during tick"
       key_insight: "Database is cold storage; simulation runs in RAM"
+      reference_data:
+        authority: "PARQUET-CANONICAL since ADR098 (2026-07-20)"
+        sources: "per-table parquet + schema.sql, sha-pinned in data-artifacts.yaml (lineage authority); data-catalog.yaml = per-table KEEP registry"
+        product: "data/sqlite/marxist-data-3NF.sqlite is a deterministic BUILD PRODUCT of tools/build_reference_db.py (sqlite pinned 3.53.1, double-build byte-identical, product sha in the manifest)"
+        ingest_law: "loaders produce SOURCES via tools/loader_to_sources.py (scratch-copy discipline); only the builder produces the DB; the shared DB is never opened for write"
+        how_to: "docs/how-to/reference-data-pipeline.rst"
 
     topology:
       purpose: "Fluid, relational state (hot computation environment)"

--- a/ai/decisions/ADR098_parquet_canonical_reference.yaml
+++ b/ai/decisions/ADR098_parquet_canonical_reference.yaml
@@ -1,0 +1,109 @@
+ADR098_parquet_canonical_reference:
+  status: "accepted"
+  date: "2026-07-20"
+  title: "Parquet-canonical reference pipeline EXECUTED (Phase 6 cutover, #46): the authority inversion — per-table parquet sources + schema.sql are canonical, the SQLite reference DB is a deterministic BUILD PRODUCT (sha-pinned, double-build byte-identical on sqlite 3.53.1); the working DB flipped with a byte-verified pre-parquet backup; ci-data-v7 released (subset DERIVED from the product); loaders produce sources via tools/loader_to_sources.py, only the builder produces the DB — and the plan's IMPORT_USE ingest was discovered ALREADY LANDED out-of-band, so the dark-Φ consumers lit up with zero code changes"
+  context: |
+    Owner intent (2026-07-18, verbatim in the spec): "Can you make a Parquet
+    representation of that sqlite database, then in CI for the load process you
+    can make a byte-identical version of the same sqlite database, and have the
+    added benefit of adding whatever else you want to it?" Spec:
+    docs/superpowers/specs/2026-07-18-parquet-reference-pipeline-design.md;
+    plan: docs/superpowers/plans/2026-07-19-parquet-reference-pipeline.md
+    (Phases 0-5 merged with queue PR #221; Phase 6 = this cutover, run ALONE
+    per owner sequencing). Before this ADR the 4.5 GB marxist-data-3NF.sqlite
+    on the data drive WAS the source of truth — unrebuildable (loaders deleted
+    spec-037-era), unpinned, and mutated in place by any ingest.
+  decision: |
+    THE INVERSION. Canonical sources = 80 full-coverage per-table parquet files
+    + 4 in-repo register CSVs (data-artifacts.yaml, 84 entries) + schema.sql
+    (canonical DDL, tools/extract_reference_schema.py). The SQLite DB is a
+    deterministic build product of tools/build_reference_db.py under the pinned
+    toolchain (infra devshell python 3.12.13 / sqlite EXACTLY 3.53.1;
+    PINNED_SQLITE_VERSION hard-gate). Manifest product block pins sha256
+    f760bab5c63ce879decd72cfe3bf51c569a5a4ba2a4a57e0ccbb5d90f5e6fa42
+    (75 tables, 59,827,795 rows, page_size 4096, sqlite 3.53.1).
+
+    LAYERED CONTRACT (D2 refined): container file hash = drift alarm on the
+    BUILD PRODUCT (rebuild-vs-rebuild identity; the working copy flips to WAL
+    on first open BY DESIGN and its bytes are not the contract); tick hash =
+    the invariant (qa:regression 6/6 byte-identical + two-process determinism
+    leg, proven pre- AND post-flip); per-table content-hash round trip =
+    working-copy guard (verify_reference_roundtrip, 83/83 objects ok).
+
+    D1-D4 AS RULED: D1 IMPORT_USE lands as ROWS in fact_bea_io_coefficient
+    (table_type='IMPORT_USE'), faithful to the written loader, not the spec's
+    phantom new table. D2 above. D3 sharding = guarded contingency only
+    (exporter hard-fails at 1.8 GB/table; largest real table 112 MB). D4
+    ceremony pre-authorization was requested and NOT NEEDED (zero baseline
+    drift end-to-end).
+
+    GOVERNANCE DISCOVERED DURING EXECUTION (each with a gate): (a)
+    GOVERNED_PREFIXES single SoT in sentinels/coverage/catalog.py — three
+    surfaces had divergent governed-scope definitions; all six now scope
+    through one constant (tests/unit/reference/test_governed_scope.py). (b)
+    Demotion-handoff law: every generate-mode curated ArtifactSpec must name a
+    catalogued table — 7 stale ADR076 specs flipped to register mode. (c)
+    Builder replays indexes POST-LOAD in schema.sql statement order with a
+    loud interleave precondition (index rowid order is part of byte identity).
+    (d) VACUUM temp pinned next to the output via PRAGMA temp_store_directory
+    (tmpfs /tmp boxes). (e) ingest_checkpoint (47,339 rows) is OUTSIDE the
+    governed estate: dropped from the build product; preserved in the pre-flip
+    backup; loaders recreate via metadata.create_all on demand.
+
+    THE FLIP (2026-07-20): old DB (sha a0cad5d1...) byte-verified into
+    backups/marxist-data-3NF.pre-parquet-20260720.sqlite, then the drive
+    canonical replaced by the product (sha verified == manifest,
+    programmatically extracted — no hand-typed hashes). Post-flip qa 6/6 +
+    catalog sentinel clean (83 rows bijective, no dark KEEP objects).
+
+    RELEASE ci-data-v7: subset now DERIVED from the product (14,191,827 rows;
+    tools/make_reference_subset.py --source dist/build/...); release carries
+    the 80 parquet + schema.sql (all manifest-pinned — the fetch action's
+    manifest-driven step needs no input bump ever again) + TIGER (v3 lineage);
+    .github/actions/fetch-reference-db defaults bumped (tag/asset/sha256, sha
+    verified against the computed sidecar).
+
+    LOADER DOCTRINE: tools/loader_to_sources.py (Task 11; synthetic TDD +
+    adversarial review) is the standing mechanism — a legacy DB-writing loader
+    runs against a SCRATCH COPY of the product, affected tables re-export as
+    parquet sources, manifest regenerates; the shared DB is never opened for
+    write. PLAN-VS-REALITY: the scheduled IMPORT_USE ingest was discovered
+    ALREADY DONE out-of-band (31,688 rows, 2010-2024, landed between the
+    2026-07-12 known-red audit and the cutover; present in the pre-flip backup
+    => carried faithfully by export->build->flip). The wrapper's live abort on
+    the UNIQUE collision was its invariant machinery working (scratch cleaned,
+    product untouched). The known-red Φ test passed UNTOUCHED (per-county
+    phi_hour varies) — acceptance gate 5 green with zero code changes; its
+    docstring now records the history. Companion repair: detroit_wiring's
+    ==24 count-floor was stale since CreditState (2f6bd849) added the 25th
+    override — the dev nightly refdata red since 2026-07-19; fixed to 25 with
+    credit_aggregate_source pinned by name (both reds reproduced against the
+    pre-parquet backup: pre-existing, not cutover-caused).
+  consequences: |
+    POSITIVE: reference data is regenerable, diffable per-table, pinned, and
+    CI-fetchable at full coverage; the subset cannot drift from the product by
+    construction; any future ingest is a reviewed source-only operation.
+    DEBT/FOLLOW-UPS (declared): (1) CI-devshell pinning — the nightly
+    rebuild-verify leg runs on stock-runner sqlite (~3.45), off the 3.53.1
+    pin; the step now WARNS LOUDLY and exits clean when off-pin instead of
+    hard-failing every nightly; the real fix (run the builder inside the infra
+    devshell on CI, cachix/install-nix-action prior art in the ADR096
+    nix-release workflow) is the recorded next work item, after which the
+    warning path is deleted and the leg becomes the true remote byte-identity
+    proof. (2) ingest_bea_imports is one-shot, not idempotent — acceptable for
+    a loader that now only ever runs against scratch copies; noted in its
+    docstring. (3) The owed auto-create-masks-absence sentinel (sqlalchemy
+    create-on-connect masking a missing DB) remains owed — the G1 nightly red
+    of 2026-07-20 is that exact class, in the pacing job that claims no
+    reference-DB dependency (owner triage flagged).
+  verification: |
+    Double-build identity: ref-a == ref-b == manifest sha (two independent
+    full builds). Schema fixed point: extract(build(sources)) == schema.sql
+    byte-identical (75 tables / 8 views / 99 indexes, contiguous). Roundtrip:
+    83/83 objects ok vs the live DB. Simulation: qa:regression 6/6
+    byte-identical + E5b two-process determinism, pre-flip (override path)
+    AND post-flip (symlink path). Catalog sentinel clean post-flip. mise run
+    check on the branch: 11,768 passed / 303 skipped (pin-gated skips
+    by design, proven by direct pinned invocation) / 1 deliberate xfail.
+    Economics integration delta: 165 passed, 1 pre-existing failure (fixed),
+    27 skipped, 3 xfailed.

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -1,9 +1,14 @@
 meta:
-  version: 1.37.0
+  version: 1.38.0
   updated: '2026-07-20'
   description: Architecture Decision Records Index
   format: See individual ADR files in this directory
 decisions:
+  ADR098_parquet_canonical_reference:
+    title: 'Parquet-canonical reference pipeline EXECUTED (Phase 6 cutover, #46): per-table parquet sources + schema.sql canonical, the SQLite reference DB a deterministic sha-pinned BUILD PRODUCT (double-build byte-identical on sqlite 3.53.1, product f760bab5...); working DB flipped with byte-verified pre-parquet backup; ci-data-v7 (subset DERIVED from the product, 80 parquet + schema.sql manifest-pinned); loaders produce sources only (tools/loader_to_sources.py) — the shared DB is never opened for write; D1-D4 as ruled, GOVERNED_PREFIXES single SoT, demotion-handoff law, index-order fidelity, ingest_checkpoint out of the estate; IMPORT_USE discovered ALREADY LANDED out-of-band so the dark-Φ consumers lit up with zero code changes; declared follow-ups: CI-devshell sqlite pinning for the nightly rebuild-verify leg (loud off-pin warning until then), auto-create-masks-absence sentinel still owed. NOTE: numbered 098 because 094-097 are claimed by the nix-player-channel packet on the concurrently-active dev line'
+    status: accepted
+    date: '2026-07-20'
+    file: ADR098_parquet_canonical_reference.yaml
   ADR093_amendments_v_w_x:
     title: 'Amendments V/W/X (CONSTITUTION v2.12.0, owner-ratified 2026-07-20): V = narrator-only AI (no LLM in the input path, Amendment I superseded-in-part; local-first provider stack) + transport-generalized client contract (in-process/HTTP/file materialization; browser client legacy, Archive TUI successor) + III.6 pinning generalized to all persisted AI artifacts; W = III.13 Deterministic Materialization [PENDING CODE] (ORDER BY projections, sandboxed sim-time templates, byte-identical artifacts, golden vault, Loud Failure extends to pixels); X = infra domain delegated to the babylon-infra constitution v1.0.0 (infra/ submodule), X.1 scoped to the production estate (no-Nix letter corrected), the infra flake = sole toolchain pinning authority in sqlite-3.53.1 lockstep [IMPLEMENTED], X.8 local-first Periphery/Metropole distribution [PENDING CODE] (embedded player PG17+pgvector, Nix flake beta channel, Metropole observes-never-adjudicates), X.6 Grafana+SQL carve-out (D3). Sources committed under ai/_inbox/tui/; roadmap 6.5 provenance-ceremony amendment HELD on the open BD home ruling'
     status: accepted

--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -2,9 +2,28 @@
 # What exists vs what's planned - KEEP THIS UPDATED
 
 meta:
-  version: "2.44.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
+  version: "2.45.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
   updated: "2026-07-20"
   truth_status: |
+    (2026-07-20) PARQUET-CANONICAL CUTOVER EXECUTED (#46 Phase 6, ADR098,
+    branch feat/parquet-cutover): the reference DB is now a deterministic
+    BUILD PRODUCT -- 80 per-table parquet sources + schema.sql canonical
+    (data-artifacts.yaml = lineage authority, product sha f760bab5...,
+    sqlite 3.53.1 double-build byte-identical); working drive DB FLIPPED
+    with byte-verified pre-parquet backup (qa:regression 6/6 + determinism
+    leg green pre- AND post-flip; catalog sentinel clean); ci-data-v7
+    released (subset DERIVED from the product, fetch-action pins bumped);
+    loaders now produce sources only (tools/loader_to_sources.py, Task 11).
+    PLAN-VS-REALITY: the scheduled IMPORT_USE ingest was ALREADY LANDED
+    out-of-band (31,688 rows) -- the known-red per-county Phi test passed
+    untouched (dark Phi consumers LIVE); detroit_wiring ==24 count-floor
+    repaired (CreditState's 25th override, pre-existing nightly red).
+    DECLARED FOLLOW-UPS: CI-devshell sqlite pinning for the nightly
+    rebuild-verify leg (loud off-pin warning until then); the
+    auto-create-masks-absence sentinel (G1 nightly red 2026-07-20 = that
+    class, owner triage flagged). Section 6.5 provenance-ceremony RESOLVED
+    same day: CLAUDE.md + CI teeth, PR #226 (Baselines: blessed trailer
+    gate live repo-wide).
     (2026-07-20) CONSTITUTION v2.12.0 -- AMENDMENTS V/W/X (ADR093): the
     Archive-pivot + infrastructure package, owner-ratified in-session.
     V narrator-only AI + transport-generalized client (browser = legacy,

--- a/data-artifacts.yaml
+++ b/data-artifacts.yaml
@@ -10,6 +10,13 @@ schema:
   tables: 75
   views: 8
   indexes: 99
+product:
+  name: marxist-data-3NF.sqlite
+  sha256: f760bab5c63ce879decd72cfe3bf51c569a5a4ba2a4a57e0ccbb5d90f5e6fa42
+  page_size: 4096
+  application_id: 1111573068
+  user_version: 1
+  sqlite_version: "3.53.1"
 artifacts:
   - name: bridge_county_bea_ea
     format: csv

--- a/data-artifacts.yaml
+++ b/data-artifacts.yaml
@@ -4,29 +4,37 @@
 # tools/make_data_artifacts.py — do not edit entries by hand.
 ---
 version: "2.0.0"
+schema:
+  file: dist/data-artifacts/schema.sql
+  sha256: b8e2a06972bf05a9372f672052953348d965d9bd43bba82ab23ca0ed69d457fa
+  tables: 75
+  views: 8
+  indexes: 99
 artifacts:
   - name: bridge_county_bea_ea
     format: csv
     source_table: bridge_county_bea_ea
     generator: tools/make_data_artifacts.py
-    mode: generate
+    mode: register
     rows: 83
     sha256: cfd7d2b42a7edd0bad87eda05e83faa2a80a277b68502a39676feb23ad792c4d
     home: src/babylon/data/reference/bridge_county_bea_ea.csv
     material_relation: >-
       county -> BEA Economic Area membership map — the regional-market aggregation geography
-      for cross-border metropolitan gravity.
+      for cross-border metropolitan gravity. R1 one-shot export (36f4cb98) then DB-table
+      demotion; the CSV has been canonical since (register, like babylon_ricci_final).
   - name: dim_bea_economic_area
     format: csv
     source_table: dim_bea_economic_area
     generator: tools/make_data_artifacts.py
-    mode: generate
+    mode: register
     rows: 8
     sha256: f1fab81b74eca9ff5de50402048ff1d4bca3a8c2d00f9e3273f9309e55d86db7
     home: src/babylon/data/reference/dim_bea_economic_area.csv
     material_relation: >-
       the 8 BEA Economic Areas (cross-border metro market regions) the bridge maps counties
-      onto.
+      onto. R1 one-shot export (36f4cb98) then DB-table demotion; the CSV has been canonical
+      since (register, like babylon_ricci_final).
   - name: babylon_ricci_final
     format: csv
     source_table: fact_ricci_unequal_exchange
@@ -58,52 +66,891 @@ artifacts:
     format: parquet
     source_table: fact_energy_annual
     generator: tools/make_data_artifacts.py
-    mode: generate
+    mode: register
     rows: 525
     sha256: 9adb800fc734547196937f5206cd5fa0dcefbede18fb7bea8724e11d1c175327
     home: dist/data-artifacts/fact_energy_annual.parquet
     material_relation: >-
       EIA MER annual energy series values 1949-2023 (series x year) — national
-      energy-metabolism history.
+      energy-metabolism history. R3 one-shot export then DB-table demotion; the parquet has
+      been canonical since.
   - name: dim_energy_series
     format: parquet
     source_table: dim_energy_series
     generator: tools/make_data_artifacts.py
-    mode: generate
+    mode: register
     rows: 20
     sha256: a666b507893bfbf3e3f565826a33df1c47968251a777eabd0fa9ecfe462fab2c
     home: dist/data-artifacts/dim_energy_series.parquet
     material_relation: >-
-      EIA MER series definitions for fact_energy_annual.
+      EIA MER series definitions for fact_energy_annual. R3 one-shot export then DB-table
+      demotion; the parquet has been canonical since.
   - name: dim_energy_table
     format: parquet
     source_table: dim_energy_table
     generator: tools/make_data_artifacts.py
-    mode: generate
+    mode: register
     rows: 14
     sha256: 2a91aa2934d650bc8d0728b1c52e0477a5e2e74dae906ed74954e972dca9eca1
     home: dist/data-artifacts/dim_energy_table.parquet
     material_relation: >-
-      EIA MER table taxonomy (with marxian_interpretation labels) for the energy series.
+      EIA MER table taxonomy (with marxian_interpretation labels) for the energy series. R3
+      one-shot export then DB-table demotion; the parquet has been canonical since.
   - name: bridge_lodes_block
     format: parquet
     source_table: bridge_lodes_block
     generator: tools/make_data_artifacts.py
-    mode: generate
+    mode: register
     rows: 1150562
     sha256: 92eb4c9e1c3f03f7a25b85a758f758a50a20ea8ada2cd15e7cf105a6c30dce98
     home: dist/data-artifacts/bridge_lodes_block.parquet
     material_relation: >-
       census-block -> county/tract/CBSA/ZCTA crosswalk with block centroids (1,150,562 blocks)
-      — the future hex-level commuter disaggregation geography.
+      — the future hex-level commuter disaggregation geography. R4 spike export then DB-table
+      demotion; the parquet has been canonical since.
   - name: staging_arcgis_feature
     format: parquet
     source_table: staging_arcgis_feature
     generator: tools/make_data_artifacts.py
-    mode: generate
+    mode: register
     rows: 5974
     sha256: 968a5d2b822c64d5b6093078ba0ebb0c45f99310aaf8651dd94aed97d649527c
     home: dist/data-artifacts/staging_arcgis_feature.parquet
     material_relation: >-
       facility-grain ArcGIS provenance rows (5,974 features: source, object id, county, type,
-      capacity) behind fact_coercive_infrastructure — kept as raw-provenance artifact.
+      capacity) behind fact_coercive_infrastructure — kept as raw-provenance artifact. R5
+      one-shot export then DB-table demotion; the parquet has been canonical since.
+  - name: bridge_cfs_county
+    format: parquet
+    source_table: bridge_cfs_county
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 0
+    sha256: f394e8f6b8726135fe017f2986d01e324af8c266bf255eedbb6a73975ded509e
+    home: dist/data-artifacts/bridge_cfs_county.parquet
+    material_relation: >-
+      county-to-CFS-area allocation crosswalk — the geographic key needed to scope FAF/CFS
+      freight flows to counties; currently empty, blocking Michigan-scoping of commodity-flow
+      value.
+  - name: bridge_county_h3
+    format: parquet
+    source_table: bridge_county_h3
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 48764
+    sha256: e60d93a43d6c66e84f1e53ecaf633af5911bd5b48b0ef0ad6a012f6d9f5b13a9
+    home: dist/data-artifacts/bridge_county_h3.parquet
+    material_relation: >-
+      county-to-H3-hex spatial index — the hex-grid substrate join enabling territory/hex
+      hydration (Constitution spatial substrate).
+  - name: bridge_county_metro
+    format: parquet
+    source_table: bridge_county_metro
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 3256
+    sha256: d520318a0b7ae11a44c289a5338bdb032b69bdca08eb028debc6cc7e8c3ce612
+    home: dist/data-artifacts/bridge_county_metro.parquet
+    material_relation: >-
+      county-to-Metropolitan-Statistical-Area membership — the urban-agglomeration key for the
+      MSA-tier zoom hierarchy (Detroit MSA tests).
+  - name: bridge_naics_bea
+    format: parquet
+    source_table: bridge_naics_bea
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 462
+    sha256: d630fa3fc90b1e407306aa8513c7109b8d3bc5c9873ed7897a9c2bc4b9e1c563
+    home: dist/data-artifacts/bridge_naics_bea.parquet
+    material_relation: >-
+      NAICS-to-BEA-industry concordance — the crosswalk letting county QCEW industry employment
+      be allocated against BEA's ~70-industry Leontief input-output structure (imperial-rent
+      tensor base).
+  - name: dim_asset_category
+    format: parquet
+    source_table: dim_asset_category
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 3
+    sha256: 697633289d17e09bac93adfaabffe82e346cbb9bf12f1bf414cc79287b7a01b7
+    home: dist/data-artifacts/dim_asset_category.parquet
+    material_relation: >-
+      asset-class taxonomy (real estate, equities, deposits...) for wealth-concentration
+      decomposition — anchors which asset form embodies extracted surplus.
+  - name: dim_bea_industry
+    format: parquet
+    source_table: dim_bea_industry
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 107
+    sha256: 21be93068ec272b415780a077a4c9ad25c82915d4eafc00a208b55c2deb79b49
+    home: dist/data-artifacts/dim_bea_industry.parquet
+    material_relation: >-
+      BEA Summary industry classification (~70 sectors) — the fixed industry taxonomy every
+      Leontief IO/tensor-hierarchy table joins against.
+  - name: dim_bea_io_table_type
+    format: parquet
+    source_table: dim_bea_io_table_type
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 3
+    sha256: f57c620e822f87fce8a5a5dfe272d4eee1694ec4adb8d4d602621b0c1125293f
+    home: dist/data-artifacts/dim_bea_io_table_type.parquet
+    material_relation: >-
+      IO-ingest pipeline's table-type enum (USE/TOTAL_REQ/IMPORT_USE) distinguishing which
+      Leontief coefficient matrix a row belongs to.
+  - name: dim_cfs_area
+    format: parquet
+    source_table: dim_cfs_area
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 132
+    sha256: 9a733b95c6c3cdc8534aa773030bcbdfc91f30bca4ba0ac5c06faeb3dd7a7bfa
+    home: dist/data-artifacts/dim_cfs_area.parquet
+    material_relation: >-
+      Commodity Flow Survey area geography — the freight origin/destination zone key for
+      scoping FAF/CFS commodity flows.
+  - name: dim_coercive_type
+    format: parquet
+    source_table: dim_coercive_type
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 15
+    sha256: bc3301f4037e23459a43629e8b8e3c1bd7ffad05e0abd277b19214555da29ecd
+    home: dist/data-artifacts/dim_coercive_type.parquet
+    material_relation: >-
+      carceral/coercive-facility type taxonomy (prison, jail, detention...) — classifies the
+      repressive-apparatus nodes fact_coercive_infrastructure counts.
+  - name: dim_commodity
+    format: parquet
+    source_table: dim_commodity
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 85
+    sha256: de3443afa3f63b2b2b93db01519957a85bc365a450a55db0f51634662667aea7
+    home: dist/data-artifacts/dim_commodity.parquet
+    material_relation: >-
+      USGS Mineral Commodity Summaries commodity list (85 strategic materials) — anchors the
+      critical-minerals/extraction-dependency subsystem (owner-ratified Prog-09 stretch).
+  - name: dim_commodity_metric
+    format: parquet
+    source_table: dim_commodity_metric
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 593
+    sha256: efbcc0dbe8dcd0717b53c186a17094f29cecf085ed1be83ec3676c9a150613ad
+    home: dist/data-artifacts/dim_commodity_metric.parquet
+    material_relation: >-
+      USGS MCS per-commodity metric taxonomy (imports/exports/price/production) — the
+      measurement-type dimension for fact_commodity_observation.
+  - name: dim_country
+    format: parquet
+    source_table: dim_country
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 273
+    sha256: 0d9f8d56ea44a04e0957b12cbd1a4d3121ed197e326a15695c2192e5c646bb82
+    home: dist/data-artifacts/dim_country.parquet
+    material_relation: >-
+      country/bloc registry with world-system-tier classification (core, semi-periphery,
+      periphery) — the geographic key for Phi imperial-rent bloc attribution and bilateral
+      trade.
+  - name: dim_county
+    format: parquet
+    source_table: dim_county
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 3285
+    sha256: 130b7679d0441d5c3c2183a2bef858073d3011039550bfbf015b380566c72032
+    home: dist/data-artifacts/dim_county.parquet
+    material_relation: >-
+      the county dimension — the universal geographic join key underlying nearly every
+      Michigan-scoped fact table and the hex/territory substrate.
+  - name: dim_county_geometry
+    format: parquet
+    source_table: dim_county_geometry
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 3222
+    sha256: b838852e16175628e397a8f23fa178fd769f1aaf565f144cda63fbd6fe0d16ee
+    home: dist/data-artifacts/dim_county_geometry.parquet
+    material_relation: >-
+      county polygon geometry (WKT + area) from TIGER/Line — the spatial substrate hex_hydrator
+      apportions into H3 territory cells.
+  - name: dim_data_source
+    format: parquet
+    source_table: dim_data_source
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 21
+    sha256: cf03d6be85ef94da5cee948896c9147993cabbfdf574be3eba30e0069379929f
+    home: dist/data-artifacts/dim_data_source.parquet
+    material_relation: >-
+      provenance registry (agency/dataset per fact table) — the traceability backbone every
+      fact_* row's source_id FK resolves against (Constitution III.4).
+  - name: dim_education_level
+    format: parquet
+    source_table: dim_education_level
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 26
+    sha256: b26b33e9193914c39904fb8cb54ed95721670bb9521513aa88443361d94cd7e5
+    home: dist/data-artifacts/dim_education_level.parquet
+    material_relation: >-
+      ACS educational-attainment taxonomy — classifies fact_census_education's degree-level
+      rows.
+  - name: dim_employment_area
+    format: parquet
+    source_table: dim_employment_area
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 1607
+    sha256: 1913be20e9db76f815023f4506bff20717ff035b14bd032e6191425076fbfdf4
+    home: dist/data-artifacts/dim_employment_area.parquet
+    material_relation: >-
+      BLS QCEW employment-area geographic definitions — the area-code dimension underlying
+      fact_employment_industry_annual's industry-by-area employment breakdown.
+  - name: dim_employment_status
+    format: parquet
+    source_table: dim_employment_status
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 8
+    sha256: f1091e804b776d100ccef4d3568ea654b34249db88f92aa296bdfcb28d76f37e
+    home: dist/data-artifacts/dim_employment_status.parquet
+    material_relation: >-
+      ACS employment-status taxonomy (employed/unemployed/not-in-labor-force) — the
+      classification the Phase-5.1 gamma_III brief plans to join against
+      fact_census_employment.
+  - name: dim_fred_series
+    format: parquet
+    source_table: dim_fred_series
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 41
+    sha256: 3904812a086ebefb966cb8feb8fa417874ba6407820c8dde633f40710e4433ad
+    home: dist/data-artifacts/dim_fred_series.parquet
+    material_relation: >-
+      FRED series registry (CPI, macro indicators) — the series-code dimension every
+      fact_fred_national/MELT deflator read joins against.
+  - name: dim_gender
+    format: parquet
+    source_table: dim_gender
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 6
+    sha256: 3eb9462b9cae5afdbe0f2108690c889fab972c8de0420b76033f7373e9bd76a5
+    home: dist/data-artifacts/dim_gender.parquet
+    material_relation: >-
+      gender classification dimension shared by Census worker-class and ATUS time-use
+      breakdowns.
+  - name: dim_geographic_hierarchy
+    format: parquet
+    source_table: dim_geographic_hierarchy
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 6468
+    sha256: 60509c3d7662821baf2dc560967e8951ef85cbeda7d1649d188b36c777d1d7d3
+    home: dist/data-artifacts/dim_geographic_hierarchy.parquet
+    material_relation: >-
+      county population-weight hierarchy derived from Census/QCEW totals — a geographic
+      weighting scheme for allocating national/regional aggregates to counties.
+  - name: dim_housing_tenure
+    format: parquet
+    source_table: dim_housing_tenure
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 3
+    sha256: f8afedd901c152680f405984c778f97d5c926c6ceeacd152d825ecc06bf28085
+    home: dist/data-artifacts/dim_housing_tenure.parquet
+    material_relation: >-
+      owner/renter housing-tenure taxonomy — the classification behind fact_census_housing's
+      renter_share feeding the tick pipeline's housing-precarity signal.
+  - name: dim_import_source
+    format: parquet
+    source_table: dim_import_source
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 43
+    sha256: 03e2e357c2bbd7d5c027009dbf42bf45de0b2b8fc6d432b3b86f6082b222cc28
+    home: dist/data-artifacts/dim_import_source.parquet
+    material_relation: >-
+      import-source-country dimension for critical-materials analysis — names which countries
+      supply strategic minerals (import-dependency/unequal-exchange linkage).
+  - name: dim_income_bracket
+    format: parquet
+    source_table: dim_income_bracket
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 17
+    sha256: 5cb3e0949da883cda632180ceaf3ba4513da18477d8169a8da4832afa47c01d5
+    home: dist/data-artifacts/dim_income_bracket.parquet
+    material_relation: >-
+      household-income-bracket taxonomy (17 brackets) — the classification behind the
+      top/bottom bracket ratio used as a class-proxy signal (labor-aristocracy banding).
+  - name: dim_industry
+    format: parquet
+    source_table: dim_industry
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 2660
+    sha256: 35d44434de50c30596c8fb4d6579d9b3f15988e9a523c98d75b6b5b65d82cd78
+    home: dist/data-artifacts/dim_industry.parquet
+    material_relation: >-
+      NAICS industry hierarchy annotated with Marxian class_composition — the industry
+      dimension anchoring QCEW/BEA/Leontief reads across the whole economics subsystem.
+  - name: dim_metro_area
+    format: parquet
+    source_table: dim_metro_area
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 1119
+    sha256: 1568b8f9f5ef1b56fd2625dd04106e48725cb124701be91a41a983dfedbb9ac1
+    home: dist/data-artifacts/dim_metro_area.parquet
+    material_relation: >-
+      Metropolitan Statistical Area definitions — the MSA-tier geographic zoom level (Detroit
+      MSA) in the living-map zoom hierarchy.
+  - name: dim_occupation
+    format: parquet
+    source_table: dim_occupation
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 74
+    sha256: e3b9321a1fd29beecc5c7ca68cb9d317fb2fa387132be4b2529ea7cfe0c803e7
+    home: dist/data-artifacts/dim_occupation.parquet
+    material_relation: >-
+      occupation taxonomy (74 codes) with an unfinished Marxian productive, unproductive,
+      reproductive, managerial labor_type classification.
+  - name: dim_ownership
+    format: parquet
+    source_table: dim_ownership
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 7
+    sha256: d8a50b0d2f293b7daab6771b1fd718faaf2a4fc137da1976b9cac587bc97c54e
+    home: dist/data-artifacts/dim_ownership.parquet
+    material_relation: >-
+      QCEW ownership-sector codes (private/federal/state/local, own_code) — resolves the
+      own_code='0' Total-covered rows every QCEW read filters on.
+  - name: dim_poverty_category
+    format: parquet
+    source_table: dim_poverty_category
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 60
+    sha256: 9849ea803928b2cb3ac8e8b51aab2eab0e93ce0e2d4dd169ede26bb604812506
+    home: dist/data-artifacts/dim_poverty_category.parquet
+    material_relation: >-
+      ACS poverty-status taxonomy (B17001) — the classification the owner-ratified
+      National-Oppression program's poverty analysis is set to consume.
+  - name: dim_race
+    format: parquet
+    source_table: dim_race
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 10
+    sha256: e7fe6e44956d3e3fbdab9aa1099cdd1d402e2ea4d3c1a9e448620ca1d227a02d
+    home: dist/data-artifacts/dim_race.parquet
+    material_relation: >-
+      race/ethnicity classification — resolves the race_code='T' (Total) rows the throughput
+      adapter filters on.
+  - name: dim_rent_burden
+    format: parquet
+    source_table: dim_rent_burden
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 11
+    sha256: 9f9c850c4c66cbe45faac638a77d65e13ddac693a34ea8990393743b37a558bc
+    home: dist/data-artifacts/dim_rent_burden.parquet
+    material_relation: >-
+      rent-burden severity taxonomy (cost-burdened/severely-burdened) — the classification
+      behind view_rent_crisis's housing-precarity metric.
+  - name: dim_sctg_commodity
+    format: parquet
+    source_table: dim_sctg_commodity
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 42
+    sha256: 54b2f15d5be3fa11263257406cbd0486a6522e83e22aa3cdb9777a238ba01554
+    home: dist/data-artifacts/dim_sctg_commodity.parquet
+    material_relation: >-
+      Standard Classification of Transported Goods commodity codes — the freight-commodity
+      dimension FK'd by fact_faf_commodity_flow (KEEP).
+  - name: dim_state
+    format: parquet
+    source_table: dim_state
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 52
+    sha256: 22245af6240648b4f3c50b748ad142204c2c985017db80b2451c5140b8898398
+    home: dist/data-artifacts/dim_state.parquet
+    material_relation: >-
+      state gazetteer/FIPS dimension — resolves michigan_state_id and every state-level
+      rollup/filter.
+  - name: dim_time
+    format: parquet
+    source_table: dim_time
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 485
+    sha256: 6049f93d5686eea1aa954d831d19aad91320e449b284250b9dd7a61775ed849b
+    home: dist/data-artifacts/dim_time.parquet
+    material_relation: >-
+      the universal year/granularity time dimension every ingest pipeline
+      (Census/QCEW/BEA/FRED/Hickel/Ricci/ATUS) writes into and every fact table joins against.
+  - name: dim_wealth_class
+    format: parquet
+    source_table: dim_wealth_class
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 4
+    sha256: 6fbcd36d709dbec4260d2037bc2b5f014c2923c9bd2e2910fa544f096a029d53
+    home: dist/data-artifacts/dim_wealth_class.parquet
+    material_relation: >-
+      wealth-percentile-to-MLM-TW-class mapping (proletariat/labor-aristocracy/bourgeoisie
+      bands) — the classification anchoring wealth-concentration analysis to Babylon's class
+      model.
+  - name: dim_worker_class
+    format: parquet
+    source_table: dim_worker_class
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 22
+    sha256: 5b2387324a0aa63ab1b294a26e8a975876ab3e1134edce6fa3368f069978d0f7
+    home: dist/data-artifacts/dim_worker_class.parquet
+    material_relation: >-
+      ACS class-of-worker taxonomy annotated with marxian_class — the classification behind
+      fact_census_worker_class's Marxian class-composition breakdown.
+  - name: fact_bea_county_gdp
+    format: parquet
+    source_table: fact_bea_county_gdp
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 1995283
+    sha256: 5706ee36478f3bd1d324511b1c2901f70148ca92e1bec6835964c3608a9a7422
+    home: dist/data-artifacts/fact_bea_county_gdp.parquet
+    material_relation: >-
+      per-county GDP by industry — the primary county-level Value Produced (V) term feeding hex
+      GDP hydration and the Fundamental Theorem's national GDP total.
+  - name: fact_bea_final_demand_annual
+    format: parquet
+    source_table: fact_bea_final_demand_annual
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 2044
+    sha256: 2bd5e4c850bd259a4d2aca303dd3bfc29e8ecae7d47d3975d299ca0516624c98
+    home: dist/data-artifacts/fact_bea_final_demand_annual.parquet
+    material_relation: >-
+      national final-demand totals by industry — the denominator ImperialRentSystem's
+      Leontief-rent final-demand allocation divides against.
+  - name: fact_bea_io_coefficient
+    format: parquet
+    source_table: fact_bea_io_coefficient
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 162927
+    sha256: 750166543a34ca3cb1b8693b20f54927dd66a34610b0181d29037a445bfe2e2f
+    home: dist/data-artifacts/fact_bea_io_coefficient.parquet
+    material_relation: >-
+      national Leontief input-output coefficients (direct + total requirements) — the
+      inter-industry technical-coefficient matrix underlying imperial-rent tensor propagation.
+  - name: fact_bea_national_industry
+    format: parquet
+    source_table: fact_bea_national_industry
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 1065
+    sha256: 7e32a0bd2f61eb3ca2f222851c2111f0a51ecf5f9f24c52791bc1b37c3fd0b54
+    home: dist/data-artifacts/fact_bea_national_industry.parquet
+    material_relation: >-
+      national industry gross-output/value-added — the fallback national GDP source and
+      BEA-share lookup base for county GDP disaggregation.
+  - name: fact_bilateral_trade_annual
+    format: parquet
+    source_table: fact_bilateral_trade_annual
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 120
+    sha256: f208495b4944f1c55144f7142b0a36d4d511b3bc96cd43466f1dd93eba34ec40
+    home: dist/data-artifacts/fact_bilateral_trade_annual.parquet
+    material_relation: >-
+      bloc-to-bloc annual bilateral trade totals — the trade-flow input to D3 Phi-attribution
+      (imperial rent via unequal exchange).
+  - name: fact_bls_unemployment_decomposition
+    format: parquet
+    source_table: fact_bls_unemployment_decomposition
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 51404
+    sha256: b09eed8fcb4b38f687cffd243514337ef9c79404fff24c8db1e1e6a221f4d442
+    home: dist/data-artifacts/fact_bls_unemployment_decomposition.parquet
+    material_relation: >-
+      county-level BLS LAUS U-3 unemployment decomposition — wired into the tick pipeline's
+      per-county unemployment_rate.
+  - name: fact_broadband_coverage
+    format: parquet
+    source_table: fact_broadband_coverage
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 3221
+    sha256: 5cdf214c24d9f2eb307dbe678199d833fd45d5f31d5772e656289305a4b69e2c
+    home: dist/data-artifacts/fact_broadband_coverage.parquet
+    material_relation: >-
+      per-county FCC broadband-coverage percentages — the material basis for hex-level
+      internet/infrastructure-access attributes.
+  - name: fact_census_education
+    format: parquet
+    source_table: fact_census_education
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 80525
+    sha256: 2184120615a21f23aaf0ab0004a785a6d42585df39565b3680b53ef882dd59a3
+    home: dist/data-artifacts/fact_census_education.parquet
+    material_relation: >-
+      ACS educational-attainment-by-county rows (single-year 2021 run) — a stalled
+      family-scoped repair-vs-drop decision.
+  - name: fact_census_employment
+    format: parquet
+    source_table: fact_census_employment
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 22547
+    sha256: 8ed86ce38067f5a6ed70964051d0af547059ed410f215962b605f51e39ce358b
+    home: dist/data-artifacts/fact_census_employment.parquet
+    material_relation: >-
+      ACS employment/labor-force-status-by-county rows (single-year 2021) — the planned join
+      target for the Phase-5.1 gamma_III employment-status brief.
+  - name: fact_census_hours
+    format: parquet
+    source_table: fact_census_hours
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 16062
+    sha256: fd1c562b4c389f32346954c4bd6e0182b6769c7775fce5a2bc1b6ca3d19bc4c2
+    home: dist/data-artifacts/fact_census_hours.parquet
+    material_relation: >-
+      ACS mean-hours-worked-by-gender rows — aggregate_hours column 100% NULL from a silent
+      label-match bug in the deleted loader.
+  - name: fact_census_housing
+    format: parquet
+    source_table: fact_census_housing
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 1351380
+    sha256: 09ff2d9666b3f5ef267b65cbc77c14e99384f0157b6a4c898ac37df2e67ca59f
+    home: dist/data-artifacts/fact_census_housing.parquet
+    material_relation: >-
+      ACS housing-tenure-by-county rows — the renter_share source wired into the tick
+      pipeline's housing-precarity signal.
+  - name: fact_census_income
+    format: parquet
+    source_table: fact_census_income
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 7207200
+    sha256: aa5155864166c309594f983cb52a44218f5f9ada3c020d1698a97bbe1065faad
+    home: dist/data-artifacts/fact_census_income.parquet
+    material_relation: >-
+      ACS household-income-bracket-by-county rows — the nationwide bracket-ratio source for the
+      labor-aristocracy/class-proxy signal (Constitution Amendment R canonical scale).
+  - name: fact_census_income_sources
+    format: parquet
+    source_table: fact_census_income_sources
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 45046
+    sha256: 6b2a7c8dbd9ff8c7576c1055f733ba2ee3cc3c04f53a7a75a7c0921f60e7216d
+    home: dist/data-artifacts/fact_census_income_sources.parquet
+    material_relation: >-
+      ACS income-source-type-by-county rows (wages/self-employment/transfer) — Wave-6/Prog-098
+      census-wiring target, partially wired.
+  - name: fact_census_institutional_ownership
+    format: parquet
+    source_table: fact_census_institutional_ownership
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 6570
+    sha256: 8564ef4357e33c6691befe0cc5d4e181f03d136146171321c00dce5d5d78de8c
+    home: dist/data-artifacts/fact_census_institutional_ownership.parquet
+    material_relation: >-
+      county institutional (absentee) housing-ownership rows — all-zero Feature-021 scaffold
+      pending real ownership data.
+  - name: fact_census_median_income
+    format: parquet
+    source_table: fact_census_median_income
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 314704
+    sha256: 2b0365c4d53319f50b6731d461e169cdbb36bf5d33c792f1f80319dbbf773055
+    home: dist/data-artifacts/fact_census_median_income.parquet
+    material_relation: >-
+      ACS median-household-income-by-county rows — the rent-to-income denominator in the
+      repaired view_rent_crisis, and a Phase-2 wealth-axis local observable (specs/114
+      per-county derived sections).
+  - name: fact_census_poverty
+    format: parquet
+    source_table: fact_census_poverty
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 26576550
+    sha256: 6ec12391668d2f59533819db7b73a4efc02c6c62a2613ad22d6f228dbb31ab4e
+    home: dist/data-artifacts/fact_census_poverty.parquet
+    material_relation: >-
+      ACS poverty-status-by-county rows (26.5M, largest poverty table) — the owner-ratified
+      National-Oppression program's poverty-rate data source.
+  - name: fact_census_rent
+    format: parquet
+    source_table: fact_census_rent
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 44997
+    sha256: 4c8cc134ec490ca75961d83485fc97c6bf240b32128e9d0517e00e62d578a99e
+    home: dist/data-artifacts/fact_census_rent.parquet
+    material_relation: >-
+      ACS median-gross-rent-by-county rows (BEA REIS proxy) — hydrated into the runtime rent
+      reference table for the headless-runner housing-cost path.
+  - name: fact_census_rent_burden
+    format: parquet
+    source_table: fact_census_rent_burden
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 450450
+    sha256: 8a42a51c17bf3ebee09f0b0b5145d5c8253c7e3446eec8c75714f9951b20df12
+    home: dist/data-artifacts/fact_census_rent_burden.parquet
+    material_relation: >-
+      ACS rent-burden-severity-by-county rows — the cost-burdened household counts in the
+      repaired view_rent_crisis, and a Phase-2 wealth-axis local observable (specs/114
+      per-county derived sections).
+  - name: fact_census_worker_class
+    format: parquet
+    source_table: fact_census_worker_class
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 900900
+    sha256: 6e2a80a2fa2fba1d927b10c503253f83a9bf05d3ed862bbed148d72f2ff31e7f
+    home: dist/data-artifacts/fact_census_worker_class.parquet
+    material_relation: >-
+      ACS class-of-worker-by-county rows (900K, marxian_class populated) — the fact volume
+      behind view_class_composition's proletariat/petty-bourgeois/state-worker breakdown.
+  - name: fact_coercive_infrastructure
+    format: parquet
+    source_table: fact_coercive_infrastructure
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 3867
+    sha256: 33e6558d2b438e7aea672021f0e15f743f1ea331ab82407c0805a428b29cf808
+    home: dist/data-artifacts/fact_coercive_infrastructure.parquet
+    material_relation: >-
+      per-county carceral/repressive-facility counts — the material basis of the state's
+      coercive apparatus (the Repression term in P(S|R)).
+  - name: fact_commodity_flow
+    format: parquet
+    source_table: fact_commodity_flow
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 0
+    sha256: d1f3f3a9f9793745f74d7424dd3e8012205fca79cbdda970e4c849dfa95727f2
+    home: dist/data-artifacts/fact_commodity_flow.parquet
+    material_relation: >-
+      county-level Commodity Flow Survey tonnage/value rows — never populated at county
+      disaggregation grain.
+  - name: fact_commodity_observation
+    format: parquet
+    source_table: fact_commodity_observation
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 4735
+    sha256: ced32578d048d304f19aa0b8b53edf4707d5c4b045f175abed08e574735a3b14
+    home: dist/data-artifacts/fact_commodity_observation.parquet
+    material_relation: >-
+      per-commodity USGS MCS observations (imports/exports/price/production) — the
+      strategic-materials extraction data view_critical_materials surfaces.
+  - name: fact_county_exposure_by_external
+    format: parquet
+    source_table: fact_county_exposure_by_external
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 384200
+    sha256: 6aedae2e7f920b261370178c87100b39d94a9f9ab4c26f58f247de8ec23c6139
+    home: dist/data-artifacts/fact_county_exposure_by_external.parquet
+    material_relation: >-
+      per-county exposure-weight to external trade blocs — the derived product routing
+      bloc-level Phi imperial rent down to individual counties.
+  - name: fact_eviction_lab_filing
+    format: parquet
+    source_table: fact_eviction_lab_filing
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 6570
+    sha256: cea271e9b5ca13d660ea95a66e7895dfc7c0c3897730500197f34b2745969a9e
+    home: dist/data-artifacts/fact_eviction_lab_filing.parquet
+    material_relation: >-
+      county-level eviction-filing/execution rates — an all-zero hardcoded stub;
+      data-shortages.md wants this for the Dispossession/TENANCY edge.
+  - name: fact_faf_commodity_flow
+    format: parquet
+    source_table: fact_faf_commodity_flow
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 2494901
+    sha256: 6c49666e28cef02ad6bc9afb2ed5d6a969626beefa712d2a2d9e65d04b09fc7a
+    home: dist/data-artifacts/fact_faf_commodity_flow.parquet
+    material_relation: >-
+      Freight Analysis Framework county-to-county commodity tonnage/value flows — the
+      freight-substrate data required by the headless-runner's Determinism Bundle hydration.
+  - name: fact_foreclosure_rate
+    format: parquet
+    source_table: fact_foreclosure_rate
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 6570
+    sha256: 08970242e2d07208ceee4f3553139850645d41cbae4248f598e90553ba8c225e
+    home: dist/data-artifacts/fact_foreclosure_rate.parquet
+    material_relation: >-
+      county-level foreclosure filing/completion rates — an all-zero hardcoded stub against a
+      weak dispossession-finance want.
+  - name: fact_fred_national
+    format: parquet
+    source_table: fact_fred_national
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 1395
+    sha256: 5251b51fb8c185bb7783b60a137a87ef131fbc9f3d4310ea8314a88d139937d2
+    home: dist/data-artifacts/fact_fred_national.parquet
+    material_relation: >-
+      national FRED macro series (CPI, etc.) — the CPI deflator read every tick for
+      real-wage/MELT calculations.
+  - name: fact_fred_wealth_levels
+    format: parquet
+    source_table: fact_fred_wealth_levels
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 720
+    sha256: 77035a8d8cc981295ed36a9a1bc62508509d9d889dd0ca51199290e9dfa11f95
+    home: dist/data-artifacts/fact_fred_wealth_levels.parquet
+    material_relation: >-
+      Federal Reserve Distributional Financial Accounts net-worth-by-class-and-quarter levels —
+      the wealth-concentration time series backing the wealth-distribution invariant tests.
+  - name: fact_fred_wealth_shares
+    format: parquet
+    source_table: fact_fred_wealth_shares
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 480
+    sha256: 87123cf968c216afa60148f3bff20b1bee6d8d1a1d9387ea99ba8436593a988e
+    home: dist/data-artifacts/fact_fred_wealth_shares.parquet
+    material_relation: >-
+      Federal Reserve DFA net-worth percentage shares — the SCF-benchmarked corroboration
+      series for the WID wealth-distribution invariants.
+  - name: fact_hickel_erdi_annual
+    format: parquet
+    source_table: fact_hickel_erdi_annual
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 58
+    sha256: c7311e13c6cbddbcfaefde3b7803da866117fd795862161855b7b33b1e141125
+    home: dist/data-artifacts/fact_hickel_erdi_annual.parquet
+    material_relation: >-
+      Ecologically-adjusted Raw-material Drain Index (ERDI) by bloc/year — the Phi
+      imperial-rent bootstrap and gamma_import periphery-labor-coefficient source.
+  - name: fact_hpms_road_segment
+    format: parquet
+    source_table: fact_hpms_road_segment
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 0
+    sha256: d7ed3725edddd71881c9e5974aff21f5c0bbe4daec43d2b1e86ec2dfcacfad96
+    home: dist/data-artifacts/fact_hpms_road_segment.parquet
+    material_relation: >-
+      FHWA Highway Performance Monitoring System road-segment rows — the Transport Substrate
+      (Program 11, Constitution II.13) corridor-mesh raw material.
+  - name: fact_lodes_commuter_flow
+    format: parquet
+    source_table: fact_lodes_commuter_flow
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 2645347
+    sha256: d3745f8def09cd8c7a38e1870e6ec2c1853e210b777d8e8358cfce36665bd64d
+    home: dist/data-artifacts/fact_lodes_commuter_flow.parquet
+    material_relation: >-
+      county-to-county commuter origin-destination flows (LEHD LODES) — the labor-mobility
+      substrate behind inbound/outbound commuter-balance reads (Wayne job-importer / Oakland
+      job-exporter tests).
+  - name: fact_mineral_employment
+    format: parquet
+    source_table: fact_mineral_employment
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 25
+    sha256: cf7909beb884af8641804179a4f67102682c8fc4d0700c429f0be6980e3f59de
+    home: dist/data-artifacts/fact_mineral_employment.parquet
+    material_relation: >-
+      mining-sector employment and weekly earnings by sector (annual, T1 trends) — the
+      variable-capital base of the extraction industries.
+  - name: fact_mineral_production
+    format: parquet
+    source_table: fact_mineral_production
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 15
+    sha256: e9790033130fc1ca75300b309751c41f86dd704eca384af4cc02795c4cba89a7
+    home: dist/data-artifacts/fact_mineral_production.parquet
+    material_relation: >-
+      national mineral-production-by-type volumes (metals/industrial/coal, annual, USD
+      millions) — the Altitude-1 national extraction aggregate.
+  - name: fact_productivity_annual
+    format: parquet
+    source_table: fact_productivity_annual
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 17336
+    sha256: 8983644c0aba732d6e4494096c9040c023d6b56bfb342a2f6d1de892a506f99f
+    home: dist/data-artifacts/fact_productivity_annual.parquet
+    material_relation: >-
+      labor-productivity-by-detailed-industry rows (labor compensation vs. sectoral output) —
+      the direct W_c/V_c Fundamental-Theorem inputs view_imperial_rent and view_surplus_value
+      need.
+  - name: fact_qcew_annual
+    format: parquet
+    source_table: fact_qcew_annual
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 14670249
+    sha256: ca3825a3d60831479313632073b7fc9a941d57dcf9b8940181c4713b6d442248
+    home: dist/data-artifacts/fact_qcew_annual.parquet
+    material_relation: >-
+      per-county-industry QCEW employment and wages — the variable-capital (V) base for county
+      value product and the Fundamental Theorem's core-wage term.
+  - name: fact_qcew_county_rollup
+    format: parquet
+    source_table: fact_qcew_county_rollup
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 240488
+    sha256: 34c2bbb935f79b3c8076a97092b004b14cca120e8272b93c35b3ac9dc2721d13
+    home: dist/data-artifacts/fact_qcew_county_rollup.parquet
+    material_relation: >-
+      own_code='0' Total-Covered per-county employment rollup — the national employment total
+      MELT's [100M,200M] sanity bound depends on.
+  - name: fact_state_minerals
+    format: parquet
+    source_table: fact_state_minerals
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 50
+    sha256: ab4b4554047d8fc0125ed6fd7056ce22501788296808805923022b8a16639b42
+    home: dist/data-artifacts/fact_state_minerals.parquet
+    material_relation: >-
+      state-by-state mineral production values — hex_hydrator explicitly branches on its
+      emptiness pending a targeted USGS state-table pull (spec-065/ADR042).
+  - name: fact_trade_monthly
+    format: parquet
+    source_table: fact_trade_monthly
+    generator: tools/make_data_artifacts.py
+    mode: generate
+    rows: 44808
+    sha256: 00e3b4b6464575b00cd250f54bc176dcf0807e781b57937171c22085a39a0ea9
+    home: dist/data-artifacts/fact_trade_monthly.parquet
+    material_relation: >-
+      monthly bilateral country import/export values — the trade-balance data behind the
+      core/periphery unequal-exchange ratio (view_unequal_exchange).

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -34,6 +34,20 @@ Guides for extending and customizing the simulation mechanics.
    Load, modify, and analyze ``GameDefines`` parameters. Includes parameter
    sweeps and sensitivity analysis workflows.
 
+Reference Data
+--------------
+
+.. toctree::
+   :maxdepth: 1
+
+   reference-data-pipeline
+
+**Add or Change Reference Data (parquet-canonical pipeline)**
+   Add tables or ingest rows through the source-only pipeline: parquet +
+   ``schema.sql`` are canonical, the SQLite reference DB is a deterministic
+   build product, and loaders run against scratch copies via
+   ``tools/loader_to_sources.py`` (ADR098).
+
 State Apparatus AI (Feature 039)
 ---------------------------------
 

--- a/docs/how-to/reference-data-pipeline.rst
+++ b/docs/how-to/reference-data-pipeline.rst
@@ -1,0 +1,76 @@
+How to add or change reference data (parquet-canonical pipeline)
+================================================================
+
+.. note::
+   Since the Phase-6 cutover (ADR098, 2026-07-20) the canonical reference
+   sources are per-table parquet files plus ``schema.sql``, both registered in
+   ``data-artifacts.yaml``. The SQLite file ``data/sqlite/marxist-data-3NF.sqlite``
+   is a **build product** — never edit it in place.
+
+Prerequisites
+-------------
+
+- The pinned toolchain (the builder hard-gates on SQLite 3.53.1):
+  ``git submodule update --init infra``, then run builder commands through
+  ``mise run nix -- <cmd>`` or a poetry venv built on the devshell interpreter.
+- The data drive mounted (``mise run data:doctor`` green) for drive-sourced
+  ingests.
+
+Add a new table
+---------------
+
+1. Add the table's DDL to the schema by creating it in a scratch build and
+   re-extracting — the canonical DDL is whatever
+   ``tools/extract_reference_schema.py`` emits; ``schema.sql`` must be the
+   fixed point of build→extract.
+2. Add a catalog row in ``data-catalog.yaml`` (the per-table lineage registry;
+   the catalog sentinel enforces catalog↔DB bijection).
+3. Emit the table's parquet into ``dist/data-artifacts/`` and register it:
+   ``mise run data:artifacts`` regenerates the manifest with per-file sha256
+   pins.
+4. Rebuild and verify::
+
+       mise run data:build-db        # deterministic rebuild from sources
+       mise run data:verify-build    # double-build byte identity
+       mise run data:verify-roundtrip
+
+5. Run ``mise run qa:regression`` — byte-identical, or STOP.
+
+Change rows in an existing table (ingest)
+-----------------------------------------
+
+Loaders produce **sources**; only the builder produces the DB. Run any legacy
+DB-writing loader through the wrapper::
+
+    poetry run python tools/loader_to_sources.py \
+        --loader <module_name_in_tools> \
+        --tables <comma-separated affected tables>
+
+The wrapper copies the build product to a scratch file, runs the loader
+against the scratch (``--db-url sqlite:///<scratch>``), re-exports each
+affected table as parquet, regenerates the manifest, and deletes the scratch.
+The shared DB is never opened for write. A loader that exits nonzero aborts
+loudly with nothing changed.
+
+Then rebuild + verify as above, and flip the working DB only after
+``qa:regression`` is green (backup first — see the ADR098 flip procedure).
+If baselines move, that is a declared ceremony: ``test(baselines):`` commit
+with a drift table and a ``Baselines: blessed(<slug>)`` trailer.
+
+Gotchas (hard-won at the cutover)
+---------------------------------
+
+- **Never hand-type a sha256** — extract pins programmatically from the
+  manifest and compare computed-vs-computed.
+- The working copy's container bytes change on first open (WAL) **by
+  design** — the container sha pins the *build product*; the working copy's
+  guard is the per-table content-hash roundtrip.
+- ``ingest_bea_imports`` (and loaders of its era) are one-shot, not
+  idempotent: re-running against data that already contains their rows aborts
+  on UNIQUE keys. Check the target table first.
+- On a tmpfs-``/tmp`` box, VACUUM spills a full DB copy — the builder pins
+  its temp dir next to the output; if a "database or disk is full" appears
+  anyway, ``df`` the **output path's** filesystem, not ``/``.
+- CI note: the nightly rebuild-verify leg skips loudly when the runner's
+  sqlite is off-pin (ADR098 declared follow-up: run it inside the infra
+  devshell).

--- a/docs/superpowers/specs/2026-07-18-parquet-reference-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-18-parquet-reference-pipeline-design.md
@@ -1,6 +1,6 @@
 # Parquet Reference-Data Pipeline — Design
 
-**Status:** owner-ruled 2026-07-18 ("Parquet pipeline, ingest lands as a source"), spec pending owner review.
+**Status:** EXECUTED 2026-07-20 (Phase 6 cutover, ADR098; plan `docs/superpowers/plans/2026-07-19-parquet-reference-pipeline.md`). Originally owner-ruled 2026-07-18 ("Parquet pipeline, ingest lands as a source").
 **Owner intent (verbatim):** "Can you make a Parquet representation of that sqlite database, then in CI
 for the load process you can make a byte-identical version of the same sqlite database, and have the
 added benefit of adding whatever else you want to it?"

--- a/src/babylon/reference/schema.py
+++ b/src/babylon/reference/schema.py
@@ -32,6 +32,13 @@ Note:
     listed here) and demoted 8 — ``data-catalog.yaml`` is the authoritative
     per-table registry; amputated tables live on as committed CSV artifacts
     registered in ``data-artifacts.yaml``.
+
+    Since the parquet-canonical cutover (ADR098, 2026-07-20),
+    ``data-artifacts.yaml`` is the LINEAGE AUTHORITY for the whole estate:
+    per-table parquet sources + ``schema.sql`` are canonical (sha-pinned in
+    the manifest), and the SQLite reference DB is a deterministic build
+    product of ``tools/build_reference_db.py``. These ORM classes describe
+    that product for readers; the DDL of record is ``schema.sql``.
 """
 
 from datetime import date, datetime

--- a/src/babylon/sentinels/coverage/catalog.py
+++ b/src/babylon/sentinels/coverage/catalog.py
@@ -40,6 +40,16 @@ CATALOG_PATH: Path = _REPO_ROOT / "data-catalog.yaml"
 #: parity check reconciles against.
 SUBSET_GENERATOR_PATH: Path = _REPO_ROOT / "tools" / "make_reference_subset.py"
 
+#: The governed reference estate: only ``sqlite_master`` objects with these
+#: name prefixes are governed by the catalog, exported as parquet sources,
+#: replayed into the build product, and content-compared at roundtrip.
+#: Utility bookkeeping tables (``ingest_checkpoint``, ``staging_*``) are
+#: OUTSIDE the estate by design — loaders recreate them on demand via
+#: ``metadata.create_all``. This is the single source of truth; every sweep
+#: surface (catalog sentinel, exporter, schema extractor, roundtrip verifier,
+#: subset policy review) must scope through it, never restate it.
+GOVERNED_PREFIXES: tuple[str, ...] = ("fact_", "dim_", "bridge_", "view_")
+
 
 class CatalogTable(BaseModel):
     """One reference-DB table or view declared in ``data-catalog.yaml``.

--- a/src/babylon/sentinels/coverage/db_probe.py
+++ b/src/babylon/sentinels/coverage/db_probe.py
@@ -32,7 +32,11 @@ import sys
 from pathlib import Path
 
 from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
-from babylon.sentinels.coverage.catalog import CatalogTable, load_catalog_tables
+from babylon.sentinels.coverage.catalog import (
+    GOVERNED_PREFIXES,
+    CatalogTable,
+    load_catalog_tables,
+)
 
 #: Repo root (this file is ``<root>/src/babylon/sentinels/coverage/db_probe.py``).
 _REPO_ROOT: Path = Path(__file__).resolve().parents[4]
@@ -40,8 +44,9 @@ _REPO_ROOT: Path = Path(__file__).resolve().parents[4]
 #: Traceability scope: only these prefixes are governed by the catalog
 #: (utility tables like ``ingest_checkpoint``/``staging_arcgis_feature`` are
 #: outside it, exactly as the subset generator's find_unknown_tables excludes
-#: them from policy review).
-_GOVERNED_PREFIXES: tuple[str, ...] = ("fact_", "dim_", "bridge_", "view_")
+#: them from policy review). Shared with every pipeline sweep surface —
+#: the definition lives in :mod:`babylon.sentinels.coverage.catalog`.
+_GOVERNED_PREFIXES: tuple[str, ...] = GOVERNED_PREFIXES
 
 
 def _database_path() -> Path:

--- a/tests/integration/economics/test_detroit_wiring.py
+++ b/tests/integration/economics/test_detroit_wiring.py
@@ -45,12 +45,14 @@ class TestDetroitWiring:
         assert sim._calculator_overrides is not None
         assert "melt_calculator" in sim._calculator_overrides
         assert "tensor_registry" in sim._calculator_overrides
-        # Vol III financial (11) + Vol II circulation (3) + Vol I production (3) + base (7)
+        # Vol III financial (12) + Vol II circulation (3) + Vol I production (3) + base (7)
         # Spec 057: base count is 7 (was 8 — 'imperial_rent_calculator' removed in
         # commit a5f73139; new Leontief pipeline wires 4 fields directly via
-        # ServiceContainer, not through this factory).
-        assert len(sim._calculator_overrides) == 24
+        # ServiceContainer, not through this factory). Vol III is 12 since commit
+        # 2f6bd849 (CreditState publication) added credit_aggregate_source.
+        assert len(sim._calculator_overrides) == 25
         # Key volume-specific calculators present
+        assert "credit_aggregate_source" in sim._calculator_overrides
         assert "interest_calculator" in sim._calculator_overrides
         assert "distribution_calculator" in sim._calculator_overrides
         assert "turnover_profile_source" in sim._calculator_overrides

--- a/tests/integration/economics/tick/test_imperial_rent_real_wiring.py
+++ b/tests/integration/economics/tick/test_imperial_rent_real_wiring.py
@@ -16,29 +16,23 @@ runs without raising but silently degrades to an identical value for every
 county (e.g. a broadcast/constant that looks "wired" but isn't actually
 county-resolution).
 
-KNOWN-RED (Program 17 / Item 1a, verified 2026-07-12, code-correct):
-this test currently FAILS at assertion 2 — every county's phi_hour is
-exactly 0.0 — for a data-availability reason, not a wiring bug. Root cause,
-verified directly against ``data/sqlite/marxist-data-3NF.sqlite``:
-``fact_bea_io_coefficient`` has 131,239 rows split only between
-``table_type='USE'`` (57,876) and ``'TOTAL_REQ'`` (73,363) — ZERO rows with
-``table_type='IMPORT_USE'``, for any year. ``DBImportShareSource`` therefore
-always computes ``m_j = 0.0`` for every industry (correctly, given the
-data), which zeroes the import-content matrix ``M = A_m @ L_d``, which
-zeroes ``phi_vector``, which zeroes every county's allocated ``phi_hour`` —
-deterministically, regardless of how correctly the rest of the pipeline is
-wired. A loader for this exact data exists (``tools/ingest_bea_imports.py``,
-writes ``table_type='IMPORT_USE'``) and its source archive IS present in
-the trove (``/media/user/data/babylon-data/bea/MAKE-USE-IMPORTS (BEFORE
-REDEFINITIONS).zip``) — it was simply never run against the canonical
-reference DB. Running a data-ingestion tool against the shared 6GB
-reference DB is out of scope for "wire the pipeline" (Item 1a) and needs
-its own reviewed remediation step (mirrors the existing spec-086/097/098
-reference-DB remediation program) — see
-``tests/integration/economics/`` for the ~34 other data-availability
-failures already tolerated in this codebase for the same reason. This test
-is expected to start passing, with NO further code changes, the day
-IMPORT_USE data is loaded.
+GREEN since 2026-07-20 (parquet-canonical cutover, plan Task 11 Step 5).
+History, preserved because the reasoning was correct at the time: this test
+was KNOWN-RED from 2026-07-12 (Program 17 / Item 1a) — every county's
+phi_hour was exactly 0.0 because ``fact_bea_io_coefficient`` then held only
+``USE`` (57,876) and ``TOTAL_REQ`` (73,363) rows, ZERO ``IMPORT_USE``, so
+``DBImportShareSource`` computed ``m_j = 0.0`` and the whole Φ chain zeroed
+deterministically. The docstring predicted it would "start passing, with NO
+further code changes, the day IMPORT_USE data is loaded" — verified at the
+cutover: the reference DB now carries 31,688 ``IMPORT_USE`` rows
+(2010–2024, ~2,100/year; ingested out-of-band after 2026-07-12; carried
+byte-faithfully through the parquet export → deterministic rebuild → flip),
+and the test passed untouched, phi_hour varying across the 3 counties. The
+standing mechanism for any FUTURE reference-data ingest is
+``tools/loader_to_sources.py`` (loaders produce sources; only the builder
+produces the DB) — note ``ingest_bea_imports`` itself is one-shot, not
+idempotent: re-running it against a DB that already has IMPORT_USE rows
+aborts loudly on the UNIQUE key, by design.
 """
 
 from __future__ import annotations

--- a/tests/unit/reference/test_build_reference_db.py
+++ b/tests/unit/reference/test_build_reference_db.py
@@ -68,12 +68,14 @@ def _make_source_db(tmp_path: Path) -> sqlite3.Connection:
     BOOLEAN+DATE parquet table and a CSV-tier table."""
     conn = sqlite3.connect(tmp_path / "src.sqlite")
     conn.executescript(
+        # Canonical contiguous-block DDL shape (tables, then indexes, then
+        # views) — the builder's replay contract hard-fails interleavings.
         "CREATE TABLE dim_k (id INTEGER PRIMARY KEY, name TEXT);\n"
         "CREATE TABLE fact_m (id INTEGER PRIMARY KEY, k_id INTEGER, v REAL);\n"
-        "CREATE INDEX idx_fact_m_k ON fact_m (k_id);\n"
-        "CREATE VIEW view_m AS SELECT k_id, SUM(v) s FROM fact_m GROUP BY k_id;\n"
         "CREATE TABLE fact_flag (id INTEGER PRIMARY KEY, active BOOLEAN, seen_on DATE);\n"
         "CREATE TABLE dim_note (id INTEGER PRIMARY KEY, code TEXT, note TEXT, weight NUMERIC);\n"
+        "CREATE INDEX idx_fact_m_k ON fact_m (k_id);\n"
+        "CREATE VIEW view_m AS SELECT k_id, SUM(v) s FROM fact_m GROUP BY k_id;\n"
     )
     conn.executemany("INSERT INTO dim_k VALUES (?,?)", [(1, "a"), (2, "b")])
     conn.executemany("INSERT INTO fact_m VALUES (?,?,?)", [(1, 1, 2.5), (2, 2, 4.0)])
@@ -147,6 +149,72 @@ class TestDoubleBuildByteIdentity:
         assert r1.sha256 == r2.sha256
         assert isinstance(r1, BuildResult)
         assert r1.sqlite_version == PINNED_SQLITE_VERSION
+
+
+class TestSchemaOrderFidelity:
+    def test_index_rowid_order_survives_manifest_order_divergence(self, tmp_path: Path) -> None:
+        # Cutover Step 3 regression (2026-07-20): the real DB's sqlite_master
+        # carries indexes in historical creation order while manifest entries
+        # are name-sorted; creating each table's indexes per-load (manifest
+        # order) broke the schema fixed point. Creation order here (fact_z
+        # before fact_a, indexes interleaved) deliberately inverts the
+        # manifest's alphabetical order to pin the law: extract(source) ==
+        # extract(rebuilt), byte for byte.
+        # Same shape as the real schema.sql (all tables, then all indexes,
+        # then views — verified TABLE*75/INDEX*99/VIEW*8 at cutover): the
+        # builder's replay contract requires that shape and hard-fails on
+        # interleavings, so the fixture keeps the blocks contiguous while
+        # inverting alphabetical order inside each.
+        conn = sqlite3.connect(tmp_path / "src.sqlite")
+        conn.executescript(
+            "CREATE TABLE fact_z (id INTEGER PRIMARY KEY, v REAL);\n"
+            "CREATE TABLE fact_a (id INTEGER PRIMARY KEY, w REAL);\n"
+            "CREATE INDEX idx_fact_z_v ON fact_z (v);\n"
+            "CREATE INDEX idx_fact_a_w ON fact_a (w);\n"
+        )
+        conn.execute("INSERT INTO fact_z VALUES (1, 1.0)")
+        conn.execute("INSERT INTO fact_a VALUES (1, 2.0)")
+        conn.commit()
+
+        entries: list[dict[str, object]] = []
+        for table in ("fact_a", "fact_z"):  # name-sorted, inverting creation order
+            home = tmp_path / f"{table}.parquet"
+            rows, _size = export_table_parquet(conn, table, home)
+            entries.append(
+                {
+                    "name": table,
+                    "format": "parquet",
+                    "source_table": table,
+                    "mode": "generate",
+                    "rows": rows,
+                    "sha256": _sha256(home),
+                    "home": str(home.relative_to(tmp_path)),
+                    "material_relation": f"synthetic fixture table {table}",
+                }
+            )
+        source_schema = extract_schema_sql(conn)
+        schema_path = tmp_path / "schema.sql"
+        schema_path.write_text(source_schema)
+        census = schema_census(conn)
+        conn.close()
+        manifest_path = tmp_path / "data-artifacts.yaml"
+        _write_manifest(
+            entries,
+            schema_entry={
+                "file": str(schema_path.relative_to(tmp_path)),
+                "sha256": _sha256(schema_path),
+                **census,
+            },
+            path=manifest_path,
+        )
+
+        result = build_db(manifest_path, schema_path, tmp_path, tmp_path / "out.sqlite")
+        rebuilt = sqlite3.connect(result.path)
+        try:
+            rebuilt_schema = extract_schema_sql(rebuilt)
+        finally:
+            rebuilt.close()
+        assert rebuilt_schema == source_schema
 
 
 class TestBuildContentRoundTrip:

--- a/tests/unit/reference/test_data_artifacts.py
+++ b/tests/unit/reference/test_data_artifacts.py
@@ -68,9 +68,13 @@ class TestManifest:
         )  # the four registered canonical CSVs (R1 pair post-demotion, ricci, county->CZ)
 
     def test_manifest_carries_all_registered_artifacts(self) -> None:
+        # Post-cutover the manifest is FULL-COVERAGE: the nine registered
+        # canonical artifacts plus one generate-mode parquet per governed
+        # table (Task 10 Step 2, 2026-07-20) — so the law is containment of
+        # the curated set plus catalog-complete coverage, not set equality.
         manifest = yaml.safe_load(_MANIFEST.read_text())
         names = {entry["name"] for entry in manifest["artifacts"]}
-        assert names == {
+        curated = {
             "bridge_county_bea_ea",
             "dim_bea_economic_area",
             "babylon_ricci_final",
@@ -81,6 +85,12 @@ class TestManifest:
             "bridge_lodes_block",
             "staging_arcgis_feature",
         }
+        assert curated <= names
+        from babylon.sentinels.coverage.catalog import load_catalog_tables
+
+        governed_tables = {t.name for t in load_catalog_tables() if t.kind == "table"}
+        missing = governed_tables - names
+        assert missing == set(), f"governed tables with no manifest source: {sorted(missing)}"
 
 
 class TestR1BeaCsvPreservation:

--- a/tests/unit/reference/test_data_artifacts.py
+++ b/tests/unit/reference/test_data_artifacts.py
@@ -221,10 +221,25 @@ class TestGeneratorDeterminism:
         finally:
             conn.close()
 
-    def test_generate_requires_every_spec_table(self, source_db: Path) -> None:
-        # The real ARTIFACTS specs must hard-fail against a DB lacking them —
+    def test_generate_mode_requires_its_spec_table(
+        self, source_db: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A generate-mode spec must hard-fail against a DB lacking its table —
         # the loud-policy discipline inherited from make_reference_subset.
-        with pytest.raises(ArtifactError):
+        # Synthetic spec: every CURATED spec is register-mode post-demotion
+        # (all nine adopt canonical artifacts), so the law is pinned here
+        # directly; full-coverage enumerated specs are the live generate path.
+        import make_data_artifacts as mda
+
+        spec = mda.ArtifactSpec(
+            name="fact_missing",
+            format="parquet",
+            source_table="fact_missing",
+            home="dist/data-artifacts/fact_missing.parquet",
+            material_relation="test: names a table the DB does not have.",
+        )
+        monkeypatch.setattr(mda, "ARTIFACTS", (spec,))
+        with pytest.raises(ArtifactError, match="fact_missing"):
             generate(source_db)
 
 

--- a/tests/unit/reference/test_data_artifacts.py
+++ b/tests/unit/reference/test_data_artifacts.py
@@ -63,7 +63,9 @@ class TestManifest:
             digest = hashlib.sha256(path.read_bytes()).hexdigest()
             assert digest == entry["sha256"], f"{entry['name']} drifted from its manifest hash"
             checked += 1
-        assert checked == 4  # the two R1 CSVs + the ricci and county->CZ registered CSVs
+        assert (
+            checked == 4
+        )  # the four registered canonical CSVs (R1 pair post-demotion, ricci, county->CZ)
 
     def test_manifest_carries_all_registered_artifacts(self) -> None:
         manifest = yaml.safe_load(_MANIFEST.read_text())

--- a/tests/unit/reference/test_governed_scope.py
+++ b/tests/unit/reference/test_governed_scope.py
@@ -1,0 +1,136 @@
+"""Governed-estate boundary — one source of truth across the parquet pipeline.
+
+Error class (discovered at cutover Step 2, 2026-07-20): three modules defined
+the governed sweep surface divergently — the catalog sentinel scoped to
+``fact_/dim_/bridge_/view_`` prefixes while the exporter, roundtrip verifier
+and schema extractor swept every non-``sqlite_%`` object — so the first
+full-coverage export against the real DB demanded a catalog row for
+``ingest_checkpoint``, utility bookkeeping the governance model deliberately
+leaves uncatalogued (see ``db_probe`` scope note and the subset generator's
+``find_unknown_tables``). These tests pin the boundary to ONE shared constant
+(``babylon.sentinels.coverage.catalog.GOVERNED_PREFIXES``) and the
+utility-table exclusion at every sweep surface.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+TOOLS_DIR = _REPO_ROOT / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+import make_data_artifacts  # type: ignore[import-not-found]  # noqa: E402
+from extract_reference_schema import (  # type: ignore[import-not-found]  # noqa: E402
+    extract_schema_sql,
+    schema_census,
+)
+from make_data_artifacts import (  # type: ignore[import-not-found]  # noqa: E402
+    governed_db_tables,
+)
+from make_reference_subset import (  # type: ignore[import-not-found]  # noqa: E402
+    find_unknown_tables,
+)
+from verify_reference_roundtrip import (  # type: ignore[import-not-found]  # noqa: E402
+    compare_databases,
+)
+
+from babylon.sentinels.coverage import db_probe  # noqa: E402
+from babylon.sentinels.coverage.catalog import GOVERNED_PREFIXES  # noqa: E402
+
+
+def _estate_db(path: Path, with_utility: bool = True) -> sqlite3.Connection:
+    """Governed mini-estate plus (optionally) a utility bookkeeping table.
+
+    Mirrors the real failure: ``ingest_checkpoint`` exists in the live DB
+    with rows and an index, but is outside the governed estate.
+    """
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        "CREATE TABLE fact_a (id INTEGER PRIMARY KEY, v REAL);\n"
+        "CREATE INDEX idx_fact_a_v ON fact_a (v);\n"
+        "CREATE TABLE dim_b (id INTEGER PRIMARY KEY, label TEXT);\n"
+        "CREATE VIEW view_a AS SELECT id FROM fact_a;\n"
+    )
+    conn.execute("INSERT INTO fact_a VALUES (1, 2.0)")
+    conn.execute("INSERT INTO dim_b VALUES (1, 'x')")
+    if with_utility:
+        conn.executescript(
+            "CREATE TABLE ingest_checkpoint ("
+            "checkpoint_id INTEGER PRIMARY KEY, source_code TEXT NOT NULL);\n"
+            "CREATE INDEX idx_ingest_checkpoint_src "
+            "ON ingest_checkpoint (source_code);\n"
+        )
+        conn.execute("INSERT INTO ingest_checkpoint VALUES (1, 'census')")
+    conn.commit()
+    return conn
+
+
+class TestGovernedTableSweep:
+    def test_governed_db_tables_excludes_utility_tables(self, tmp_path: Path) -> None:
+        conn = _estate_db(tmp_path / "e.sqlite")
+        assert governed_db_tables(conn) == ["dim_b", "fact_a"]
+
+    def test_full_coverage_enumeration_skips_utility_tables(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The exact production failure of 2026-07-20: before the boundary fix
+        # this raised KeyError("ingest_checkpoint: DB table has no
+        # data-catalog.yaml row") despite the catalog being complete.
+        conn = _estate_db(tmp_path / "e.sqlite")
+        rows = {
+            name: SimpleNamespace(material_relation=f"test relation for {name}")
+            for name in ("fact_a", "dim_b")
+        }
+        monkeypatch.setattr(make_data_artifacts, "_catalog_by_name", lambda: rows)
+        specs = make_data_artifacts.enumerate_full_coverage_specs(conn)
+        assert {s.name for s in specs} == {"fact_a", "dim_b"}
+
+
+class TestSchemaExtractionScope:
+    def test_extract_schema_sql_excludes_utility_ddl(self, tmp_path: Path) -> None:
+        conn = _estate_db(tmp_path / "e.sqlite")
+        text = extract_schema_sql(conn)
+        assert "CREATE TABLE fact_a" in text
+        assert "idx_fact_a_v" in text
+        assert "CREATE VIEW view_a" in text
+        assert "ingest_checkpoint" not in text  # neither the table nor its index
+
+    def test_schema_census_counts_governed_objects_only(self, tmp_path: Path) -> None:
+        conn = _estate_db(tmp_path / "e.sqlite")
+        assert schema_census(conn) == {"tables": 2, "views": 1, "indexes": 1}
+
+
+class TestRoundtripScope:
+    def test_roundtrip_ok_when_only_live_has_utility_table(self, tmp_path: Path) -> None:
+        # Live carries the bookkeeping table; the rebuilt product (governed
+        # estate only) must still verify clean — and the report must not
+        # mention the utility table at all.
+        live = tmp_path / "live.sqlite"
+        rebuilt = tmp_path / "rebuilt.sqlite"
+        _estate_db(live, with_utility=True).close()
+        _estate_db(rebuilt, with_utility=False).close()
+        report = compare_databases(live, rebuilt)
+        assert report.ok
+        assert "ingest_checkpoint" not in report.tables
+
+
+class TestSingleSourceOfTruth:
+    def test_prefix_constant_value_is_pinned(self) -> None:
+        assert GOVERNED_PREFIXES == ("fact_", "dim_", "bridge_", "view_")
+
+    def test_db_probe_uses_the_shared_constant(self) -> None:
+        assert db_probe._GOVERNED_PREFIXES is GOVERNED_PREFIXES
+
+    def test_subset_policy_review_matches_table_prefixes(self) -> None:
+        # find_unknown_tables reviews exactly the table-side governed
+        # prefixes: each governed table prefix is flagged when unclassified,
+        # utility names never are.
+        unknown = [f"{p}zzz" for p in GOVERNED_PREFIXES if p != "view_"]
+        names = [*unknown, "ingest_checkpoint", "staging_arcgis_feature"]
+        assert find_unknown_tables(names, {}) == sorted(unknown)

--- a/tests/unit/reference/test_governed_scope.py
+++ b/tests/unit/reference/test_governed_scope.py
@@ -41,7 +41,10 @@ from verify_reference_roundtrip import (  # type: ignore[import-not-found]  # no
 )
 
 from babylon.sentinels.coverage import db_probe  # noqa: E402
-from babylon.sentinels.coverage.catalog import GOVERNED_PREFIXES  # noqa: E402
+from babylon.sentinels.coverage.catalog import (  # noqa: E402
+    GOVERNED_PREFIXES,
+    load_catalog_tables,
+)
 
 
 def _estate_db(path: Path, with_utility: bool = True) -> sqlite3.Connection:
@@ -118,6 +121,45 @@ class TestRoundtripScope:
         report = compare_databases(live, rebuilt)
         assert report.ok
         assert "ingest_checkpoint" not in report.tables
+
+
+class TestCuratedSpecLiveness:
+    def test_generate_mode_specs_name_catalogued_tables(self) -> None:
+        # The demotion-handoff law (would have caught all seven 2026-07-20
+        # cutover reds at unit time): a generate-mode spec reads its
+        # source_table from the DB at export, and the catalog is DB-bijective
+        # (sentinel-enforced) — so a generate spec whose table has no catalog
+        # row names a demoted or never-existing table and MUST be register.
+        catalog = {t.name for t in load_catalog_tables()}
+        stale = [
+            spec.name
+            for spec in make_data_artifacts.ARTIFACTS
+            if spec.mode == "generate" and spec.source_table not in catalog
+        ]
+        assert stale == []
+
+    def test_register_mode_counts_parquet_rows(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        artifact = tmp_path / "fact_toy.parquet"
+        pq.write_table(pa.table({"id": [1, 2, 3]}), artifact)
+        spec = make_data_artifacts.ArtifactSpec(
+            name="fact_toy",
+            format="parquet",
+            source_table="fact_toy",
+            home=str(artifact),
+            material_relation="test: three toy rows.",
+            mode="register",
+        )
+        monkeypatch.setattr(make_data_artifacts, "ARTIFACTS", (spec,))
+        db = tmp_path / "empty.sqlite"
+        sqlite3.connect(db).close()
+        entries = make_data_artifacts.generate(db)
+        assert entries[0]["rows"] == 3
+        assert entries[0]["mode"] == "register"
 
 
 class TestSingleSourceOfTruth:

--- a/tests/unit/reference/test_loader_to_sources.py
+++ b/tests/unit/reference/test_loader_to_sources.py
@@ -1,0 +1,255 @@
+"""Behavioral contract for ``tools/loader_to_sources.py`` (parquet-canonical
+cutover plan, Task 11).
+
+The invariant under test: a legacy DB-writing loader (``ingest_bea_imports.main``
+and friends) must never open the shared build product for write. The wrapper
+runs the loader against a throwaway scratch copy, re-exports only the affected
+tables as parquet sources, regenerates the manifest, and reports which of
+those tables' content actually changed — everything else in the manifest
+(and the original build product on disk) must come out byte-identical.
+
+Synthetic (not real-BEA) input throughout: a toy loader inserting one row
+into a scratch sqlite DB, proven against a two-table manifest fixture so the
+"all other entries' hashes unchanged" law has something to violate if the
+wrapper regenerated more than it was told to.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+TOOLS_DIR = _REPO_ROOT / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+import make_data_artifacts  # type: ignore[import-not-found]  # noqa: E402
+from loader_to_sources import (  # type: ignore[import-not-found]  # noqa: E402
+    LoaderToSourcesError,
+    run_loader_to_sources,
+)
+from make_data_artifacts import (  # type: ignore[import-not-found]  # noqa: E402
+    _sha256,
+    _write_manifest,
+    export_table_parquet,
+)
+
+
+def _seed_build_product(path: Path) -> None:
+    """A toy two-table build product: ``fact_sample`` (the loader's target)
+    and ``dim_untouched`` (proves the wrapper never touches un-affected
+    tables' sources)."""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE fact_sample (
+            id INTEGER NOT NULL,
+            label VARCHAR(20),
+            value NUMERIC(10, 2),
+            PRIMARY KEY (id)
+        );
+        INSERT INTO fact_sample VALUES (1, 'a', 1.25), (2, 'b', 2.5);
+        CREATE TABLE dim_untouched (
+            id INTEGER NOT NULL,
+            label VARCHAR(20),
+            PRIMARY KEY (id)
+        );
+        INSERT INTO dim_untouched VALUES (1, 'x'), (2, 'y');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _toy_loader_main(argv: list[str]) -> int:
+    """Synthetic legacy loader: parses ``--db-url`` (mirroring
+    ``ingest_bea_imports.main``'s real contract) and inserts one new row
+    into ``fact_sample`` via a plain sqlite3 connection."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db-url", required=True)
+    args = parser.parse_args(argv)
+    db_path = args.db_url.removeprefix("sqlite:///")
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("INSERT INTO fact_sample (id, label, value) VALUES (99, 'new', 9.9)")
+        conn.commit()
+    finally:
+        conn.close()
+    return 0
+
+
+def _noop_loader_main(argv: list[str]) -> int:
+    """A loader that touches nothing — proves the wrapper reports NO change
+    (not a spurious one) when the underlying content is identical."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db-url", required=True)
+    parser.parse_args(argv)
+    return 0
+
+
+def _failing_loader_main(argv: list[str]) -> int:
+    return 1
+
+
+@pytest.fixture
+def build_product(tmp_path: Path) -> Path:
+    path = tmp_path / "build" / "marxist-data-3NF.sqlite"
+    path.parent.mkdir(parents=True)
+    _seed_build_product(path)
+    return path
+
+
+@pytest.fixture
+def sources_root(tmp_path: Path) -> Path:
+    return tmp_path / "repo"
+
+
+@pytest.fixture
+def manifest_path(
+    tmp_path: Path,
+    build_product: Path,
+    sources_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    """A two-entry manifest, generated from the SAME build product, pointing
+    at real parquet sources under ``sources_root`` — the pre-condition the
+    wrapper is handed in production (manifest and sources in sync)."""
+    conn = sqlite3.connect(f"file:{build_product}?mode=ro", uri=True)
+    entries: list[dict[str, object]] = []
+    try:
+        for table in ("fact_sample", "dim_untouched"):
+            home = f"dist/data-artifacts/{table}.parquet"
+            dest = sources_root / home
+            rows, _size = export_table_parquet(conn, table, dest)
+            entries.append(
+                {
+                    "name": table,
+                    "format": "parquet",
+                    "source_table": table,
+                    "mode": "generate",
+                    "rows": rows,
+                    "sha256": _sha256(dest),
+                    "home": home,
+                    "material_relation": f"test fixture artifact for {table}.",
+                }
+            )
+    finally:
+        conn.close()
+    manifest = tmp_path / "data-artifacts.yaml"
+    _write_manifest(entries, path=manifest)
+    monkeypatch.setattr(make_data_artifacts, "MANIFEST_PATH", manifest)
+    return manifest
+
+
+@pytest.fixture
+def scratch_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An empty, dedicated tempdir — ``tempfile.tempdir`` is pointed here so
+    the test can assert the scratch copy left nothing behind."""
+    directory = tmp_path / "scratch"
+    directory.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(directory))
+    return directory
+
+
+class TestRunLoaderToSources:
+    def test_toy_loader_changes_only_the_affected_source(
+        self,
+        build_product: Path,
+        sources_root: Path,
+        manifest_path: Path,
+        scratch_dir: Path,
+    ) -> None:
+        before_product_hash = _sha256(build_product)
+        before = yaml.safe_load(manifest_path.read_text())
+        before_fact = next(e for e in before["artifacts"] if e["name"] == "fact_sample")
+        before_untouched = next(e for e in before["artifacts"] if e["name"] == "dim_untouched")
+
+        changed = run_loader_to_sources(
+            _toy_loader_main, ["fact_sample"], build_product, sources_root
+        )
+
+        assert changed == ["fact_sample"]
+
+        after = yaml.safe_load(manifest_path.read_text())
+        after_fact = next(e for e in after["artifacts"] if e["name"] == "fact_sample")
+        after_untouched = next(e for e in after["artifacts"] if e["name"] == "dim_untouched")
+
+        # Affected entry's hash + row count moved.
+        assert after_fact["rows"] == 3
+        assert after_fact["sha256"] != before_fact["sha256"]
+
+        # Every other entry is byte-for-byte untouched.
+        assert after_untouched == before_untouched
+
+        # The scratch copy is gone.
+        assert list(scratch_dir.iterdir()) == []
+
+        # The original build product was never opened for write.
+        assert _sha256(build_product) == before_product_hash
+
+        # The re-exported parquet actually carries the loader's new row.
+        import pyarrow.parquet as pq
+
+        table = pq.read_table(sources_root / "dist/data-artifacts/fact_sample.parquet")
+        assert table.num_rows == 3
+        assert sorted(table.column("id").to_pylist()) == [1, 2, 99]
+
+    def test_noop_loader_reports_no_change(
+        self,
+        build_product: Path,
+        sources_root: Path,
+        manifest_path: Path,
+        scratch_dir: Path,
+    ) -> None:
+        before = yaml.safe_load(manifest_path.read_text())
+
+        changed = run_loader_to_sources(
+            _noop_loader_main, ["fact_sample"], build_product, sources_root
+        )
+
+        assert changed == []
+        after = yaml.safe_load(manifest_path.read_text())
+        assert after == before
+        assert list(scratch_dir.iterdir()) == []
+
+    def test_missing_manifest_entry_is_loud(
+        self,
+        build_product: Path,
+        sources_root: Path,
+        manifest_path: Path,
+        scratch_dir: Path,
+    ) -> None:
+        with pytest.raises(LoaderToSourcesError, match="fact_nonexistent"):
+            run_loader_to_sources(
+                _toy_loader_main, ["fact_nonexistent"], build_product, sources_root
+            )
+        assert list(scratch_dir.iterdir()) == []  # never got as far as a scratch copy
+
+    def test_loader_failure_is_loud_and_still_cleans_up(
+        self,
+        build_product: Path,
+        sources_root: Path,
+        manifest_path: Path,
+        scratch_dir: Path,
+    ) -> None:
+        with pytest.raises(LoaderToSourcesError, match="exited 1"):
+            run_loader_to_sources(
+                _failing_loader_main, ["fact_sample"], build_product, sources_root
+            )
+        assert list(scratch_dir.iterdir()) == []
+
+    def test_missing_build_product_is_loud(
+        self,
+        tmp_path: Path,
+        sources_root: Path,
+        manifest_path: Path,
+    ) -> None:
+        missing = tmp_path / "nope.sqlite"
+        with pytest.raises(LoaderToSourcesError, match="build product not found"):
+            run_loader_to_sources(_toy_loader_main, ["fact_sample"], missing, sources_root)

--- a/tests/unit/reference/test_roundtrip.py
+++ b/tests/unit/reference/test_roundtrip.py
@@ -416,12 +416,15 @@ class TestFullPipelineRoundTrip:
         source_path = tmp_path / "src.sqlite"
         conn = sqlite3.connect(source_path)
         conn.executescript(
+            # Canonical contiguous-block DDL shape (tables, then indexes,
+            # then views) — the builder's replay contract hard-fails
+            # interleavings.
             "CREATE TABLE dim_k (id INTEGER PRIMARY KEY, name TEXT);\n"
             "CREATE TABLE fact_m (id INTEGER PRIMARY KEY, k_id INTEGER, v NUMERIC);\n"
-            "CREATE INDEX idx_fact_m_k ON fact_m (k_id);\n"
-            "CREATE VIEW view_m AS SELECT k_id, SUM(v) s FROM fact_m GROUP BY k_id;\n"
             "CREATE TABLE fact_flag (id INTEGER PRIMARY KEY, active BOOLEAN, seen_on DATE);\n"
             "CREATE TABLE dim_note (id INTEGER PRIMARY KEY, code TEXT, note TEXT, weight NUMERIC);\n"
+            "CREATE INDEX idx_fact_m_k ON fact_m (k_id);\n"
+            "CREATE VIEW view_m AS SELECT k_id, SUM(v) s FROM fact_m GROUP BY k_id;\n"
         )
         conn.executemany("INSERT INTO dim_k VALUES (?,?)", [(1, "a"), (2, "b")])
         conn.executemany("INSERT INTO fact_m VALUES (?,?,?)", [(1, 1, 2.5), (2, 2, 4.0)])

--- a/tools/build_reference_db.py
+++ b/tools/build_reference_db.py
@@ -401,11 +401,24 @@ def build_reference_db(
 
     table_statements = [s for s in statements if s.kind == "table"]
     table_names = {s.table for s in table_statements if s.table is not None}
-    indexes_by_table: dict[str, list[_Statement]] = {}
-    for stmt in statements:
-        if stmt.kind == "index" and stmt.table is not None:
-            indexes_by_table.setdefault(stmt.table, []).append(stmt)
+    index_statements = [s for s in statements if s.kind == "index"]
     trailing_statements = [s for s in statements if s.kind in ("view", "trigger")]
+
+    # Replay contract: the builder executes tables, then data, then indexes,
+    # then views/triggers — so it can only reproduce schema.sql's rowid order
+    # byte-for-byte when the file already has that contiguous-block shape
+    # (the real DB's is exactly TABLE* INDEX* VIEW*). An interleaved file
+    # would be silently reordered in the product; fail loud instead
+    # (Constitution III.11).
+    kind_rank = {"table": 0, "index": 1, "view": 2, "trigger": 2}
+    ranks = [kind_rank[s.kind] for s in statements]
+    if ranks != sorted(ranks):
+        msg = (
+            "schema.sql interleaves statement kinds (expected all tables, "
+            "then all indexes, then views/triggers) — the builder's replay "
+            "order cannot reproduce its sqlite_master rowid order"
+        )
+        raise SchemaParseError(msg)
 
     entry_source_tables = {str(entry["source_table"]) for entry in entries}
     missing_sources = sorted(name for name in table_names if name not in entry_source_tables)
@@ -435,8 +448,14 @@ def build_reference_db(
                 continue
             rows_inserted += _load_entry(conn, entry, sources_root)
             tables_built += 1
-            for index_stmt in indexes_by_table.get(table, []):
-                conn.execute(index_stmt.sql)
+
+        # All indexes AFTER all loads (bulk-load speed), in schema.sql
+        # statement order — sqlite_master rowid order is part of the schema
+        # fixed-point contract, and per-table creation in manifest (name-
+        # sorted) order broke it against the real DB's historical order
+        # (cutover Step 3, 2026-07-20).
+        for stmt in index_statements:
+            conn.execute(stmt.sql)
 
         for stmt in trailing_statements:
             conn.execute(stmt.sql)

--- a/tools/build_reference_db.py
+++ b/tools/build_reference_db.py
@@ -434,6 +434,14 @@ def build_reference_db(
     try:
         conn.execute(f"PRAGMA page_size={PAGE_SIZE}")
         conn.execute("PRAGMA journal_mode=DELETE")
+        # VACUUM spills a full copy of the DB to sqlite's temp dir, which
+        # defaults to /tmp — a 16G tmpfs on the dev box, where a ~4.6GB
+        # spill dies "database or disk is full" (cutover Step 4, 2026-07-20).
+        # Pin temp next to the output file instead: its filesystem must hold
+        # the product anyway. (Deprecated pragma, but it is the only
+        # per-connection control; SQLITE_TMPDIR proved unreliable through
+        # the mise->poetry->python chain.)
+        conn.execute(f"PRAGMA temp_store_directory = '{out_path.parent.resolve()}'")
 
         for stmt in table_statements:
             conn.execute(stmt.sql)

--- a/tools/extract_reference_schema.py
+++ b/tools/extract_reference_schema.py
@@ -45,7 +45,7 @@ HEADER = (
 
 
 def extract_schema_sql(conn: sqlite3.Connection) -> str:
-    """Extract canonical DDL text for every non-internal ``sqlite_master``
+    """Extract canonical DDL text for every governed ``sqlite_master``
     object, in rowid order.
 
     Per-statement canonicalization: strip trailing whitespace per line,
@@ -53,37 +53,50 @@ def extract_schema_sql(conn: sqlite3.Connection) -> str:
     newline on the whole file. ``sqlite_%`` internal objects (e.g.
     ``sqlite_sequence``) and NULL-``sql`` rows (auto-indexes from ``UNIQUE``/
     implicit rowid indexes) are excluded — neither is meaningful DDL to
-    replay.
+    replay. Objects outside the governed estate (utility bookkeeping like
+    ``ingest_checkpoint``, plus their indexes) are excluded by the shared
+    ``GOVERNED_PREFIXES`` boundary on ``tbl_name`` — the build product
+    contains exactly the governed estate; loaders recreate their own
+    bookkeeping DDL on demand via ``metadata.create_all``.
 
     :param conn: Open connection to the source DB.
     :returns: The full ``schema.sql`` text (header + statements).
     """
+    from babylon.sentinels.coverage.catalog import GOVERNED_PREFIXES
+
     rows = conn.execute(
-        "SELECT sql FROM sqlite_master "
+        "SELECT sql, tbl_name FROM sqlite_master "
         "WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%' ORDER BY rowid"
     ).fetchall()
     statements = []
-    for (sql,) in rows:
+    for sql, tbl_name in rows:
+        if not tbl_name.startswith(GOVERNED_PREFIXES):
+            continue
         body = "\n".join(line.rstrip() for line in sql.strip().splitlines())
         statements.append(body.rstrip(";") + ";")
     return HEADER + "\n" + "\n\n".join(statements) + "\n"
 
 
 def schema_census(conn: sqlite3.Connection) -> dict[str, int]:
-    """Count non-internal ``sqlite_master`` objects by type.
+    """Count governed ``sqlite_master`` objects by type.
 
     :param conn: Open connection to the source DB.
     :returns: ``{"tables": n, "views": n, "indexes": n}`` — the same
-        exclusions as :func:`extract_schema_sql` (``sqlite_%`` objects and
-        NULL-``sql`` auto-indexes never count).
+        exclusions as :func:`extract_schema_sql` (``sqlite_%`` objects,
+        NULL-``sql`` auto-indexes, and non-governed utility objects never
+        count).
     """
-    counts = dict(
-        conn.execute(
-            "SELECT type, COUNT(*) FROM sqlite_master "
-            "WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%' "
-            "GROUP BY type"
-        ).fetchall()
-    )
+    from babylon.sentinels.coverage.catalog import GOVERNED_PREFIXES
+
+    rows = conn.execute(
+        "SELECT type, tbl_name FROM sqlite_master "
+        "WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'"
+    ).fetchall()
+    counts: dict[str, int] = {}
+    for object_type, tbl_name in rows:
+        if not tbl_name.startswith(GOVERNED_PREFIXES):
+            continue
+        counts[object_type] = counts.get(object_type, 0) + 1
     return {
         "tables": counts.get("table", 0),
         "views": counts.get("view", 0),

--- a/tools/ingest_bea_imports.py
+++ b/tools/ingest_bea_imports.py
@@ -45,6 +45,17 @@ Usage::
 
     poetry run python tools/ingest_bea_imports.py \\
         --db-url "sqlite:////home/user/projects/game/babylon/data/sqlite/marxist-data-3NF.sqlite"
+
+.. note::
+   Post-cutover (parquet-canonical pipeline plan, Task 11), normal usage of
+   this loader goes through ``tools/loader_to_sources.py`` instead of calling
+   ``main`` here directly: the wrapper runs this module's ``main`` against a
+   SCRATCH COPY of the build product, then re-exports the affected tables
+   (``fact_bea_io_coefficient``, ``dim_bea_io_table_type``, ``dim_time``) as
+   parquet sources and regenerates the manifest — loaders produce sources,
+   only the builder produces the DB. This module's ``main(argv)`` signature
+   and direct-DB-write behavior are unchanged; they are exactly what the
+   wrapper calls against the scratch copy.
 """
 
 from __future__ import annotations

--- a/tools/loader_to_sources.py
+++ b/tools/loader_to_sources.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Loader-to-sources wrapper for legacy DB-writing loaders (parquet-canonical
+cutover plan, Task 11).
+
+Before the parquet-canonical cutover, a loader like ``ingest_bea_imports.py``
+opened the shared reference DB directly and wrote rows into it. Post-cutover,
+the DB is a build PRODUCT (``dist/build/marxist-data-3NF.sqlite``, rebuilt
+from the manifest + ``schema.sql`` + per-table parquet/CSV sources by
+``tools/build_reference_db.py``) — nothing is allowed to write it directly,
+loaders included.
+
+This wrapper is the seam: it runs a legacy loader's ``main(argv) -> int``
+against a throwaway SCRATCH COPY of the build product, then re-exports only
+the tables that loader is declared to affect as parquet sources (via
+``tools.make_data_artifacts.export_table_parquet``, the one parquet-writing
+path every other exporter uses) and regenerates the manifest (via
+``tools.make_data_artifacts._rewrite_manifest_preserving_blocks``, the Task 3
+writer that preserves any existing ``schema``/``product`` block). The scratch
+copy is always deleted; the shared build product and the working DB are never
+opened for write by this module.
+
+**The invariant:** loaders produce SOURCES; only the builder
+(``tools/build_reference_db.py``) produces the DB.
+
+Usage::
+
+    poetry run python tools/loader_to_sources.py \\
+        --loader ingest_bea_imports \\
+        --tables fact_bea_io_coefficient,dim_bea_io_table_type,dim_time
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import shutil
+import sqlite3
+import sys
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import make_data_artifacts as mda  # noqa: E402
+
+#: Default canonical locations (repo-root-relative), matching the builder's
+#: ``data:build-db`` mise task (``--out dist/build/marxist-data-3NF.sqlite``)
+#: and ``build_reference_db.py``'s ``DEFAULT_SOURCES_ROOT`` precedent.
+DEFAULT_BUILD_PRODUCT = Path("dist/build/marxist-data-3NF.sqlite")
+DEFAULT_SOURCES_ROOT = Path()
+
+
+class LoaderToSourcesError(Exception):
+    """A loader-to-sources run failed loudly — bad input, a loader that
+    reported failure, or a table this wrapper cannot re-export."""
+
+
+def run_loader_to_sources(
+    loader_main: Callable[[list[str]], int],
+    affected_tables: list[str],
+    build_product: Path,
+    sources_root: Path,
+) -> list[str]:
+    """Run a legacy DB-writing loader against a SCRATCH COPY of the build product,
+    then re-export the affected tables as parquet sources + regenerate the manifest.
+
+    The invariant this enforces: loaders produce SOURCES; only the builder produces
+    the DB. The scratch copy is deleted; the shared DB is never opened for write.
+    Returns the affected tables whose content actually changed.
+
+    :param loader_main: The legacy loader's ``main(argv) -> int`` entry point
+        (e.g. ``ingest_bea_imports.main``). Called exactly once, as
+        ``loader_main(["--db-url", f"sqlite:///{scratch}"])``.
+    :param affected_tables: Source-table names (``data-artifacts.yaml``
+        ``source_table`` values) the loader is declared to write. Each must
+        already have a ``format: parquet`` manifest entry — this wrapper only
+        re-exports via :func:`make_data_artifacts.export_table_parquet`.
+    :param build_product: The current build product to copy before handing
+        the scratch copy to ``loader_main`` (never opened for write itself).
+    :param sources_root: Base directory each manifest entry's ``home`` is
+        relative to (repo root in production; a temp dir in tests) — mirrors
+        ``build_reference_db.build_reference_db``'s ``sources_root`` contract.
+    :returns: The subset of ``affected_tables`` whose re-exported source
+        bytes differ from what was on disk before this run.
+    :raises LoaderToSourcesError: ``build_product`` is missing, the manifest
+        is missing, an affected table has no manifest entry or a non-parquet
+        one, or ``loader_main`` returns a non-zero exit code.
+    """
+    if not build_product.is_file():
+        msg = f"build product not found: {build_product}"
+        raise LoaderToSourcesError(msg)
+
+    manifest_path = mda.MANIFEST_PATH
+    manifest = mda._read_manifest(manifest_path)
+    if manifest is None:
+        msg = f"manifest missing: {manifest_path}"
+        raise LoaderToSourcesError(msg)
+    entries = cast("list[dict[str, object]]", manifest["artifacts"])
+    entry_by_table = {str(entry["source_table"]): entry for entry in entries}
+
+    missing = [t for t in affected_tables if t not in entry_by_table]
+    if missing:
+        msg = f"affected table(s) have no manifest entry: {missing}"
+        raise LoaderToSourcesError(msg)
+    non_parquet = [t for t in affected_tables if entry_by_table[t]["format"] != "parquet"]
+    if non_parquet:
+        msg = f"affected table(s) are not parquet-format manifest artifacts: {non_parquet}"
+        raise LoaderToSourcesError(msg)
+
+    changed: list[str] = []
+    with tempfile.NamedTemporaryFile(suffix=".sqlite") as scratch_handle:
+        scratch_path = Path(scratch_handle.name)
+        shutil.copyfile(build_product, scratch_path)
+
+        exit_code = loader_main(["--db-url", f"sqlite:///{scratch_path}"])
+        if exit_code != 0:
+            msg = f"loader_main exited {exit_code} against the scratch copy {scratch_path}"
+            raise LoaderToSourcesError(msg)
+
+        conn = sqlite3.connect(f"file:{scratch_path}?mode=ro", uri=True)
+        try:
+            for table in affected_tables:
+                entry = entry_by_table[table]
+                dest = sources_root / str(entry["home"])
+                before_hash = mda._sha256(dest) if dest.is_file() else None
+                rows, _size = mda.export_table_parquet(conn, table, dest)
+                after_hash = mda._sha256(dest)
+                entry["rows"] = rows
+                entry["sha256"] = after_hash
+                if after_hash != before_hash:
+                    changed.append(table)
+        finally:
+            conn.close()
+        # `with` block exit deletes scratch_path — no manual cleanup needed.
+
+    mda._rewrite_manifest_preserving_blocks(entries, manifest_path=manifest_path)
+    return changed
+
+
+def _resolve_loader_main(module_name: str) -> Callable[[list[str]], int]:
+    """Import ``module_name`` (resolved on ``tools/``'s own sys.path entry,
+    inserted above) and return its ``main(argv) -> int`` callable.
+
+    :raises LoaderToSourcesError: If the module has no callable ``main``.
+    """
+    module = importlib.import_module(module_name)
+    loader_main = getattr(module, "main", None)
+    if loader_main is None or not callable(loader_main):
+        msg = f"loader module {module_name!r} has no callable main(argv) -> int"
+        raise LoaderToSourcesError(msg)
+    return cast("Callable[[list[str]], int]", loader_main)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: run ``--loader``'s ``main`` against a scratch copy of
+    ``--build-product``, re-export ``--tables`` as parquet sources, and
+    regenerate the manifest."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--loader",
+        required=True,
+        help="tools/ module name exposing main(argv) -> int (e.g. ingest_bea_imports)",
+    )
+    parser.add_argument(
+        "--tables", required=True, help="comma-separated affected source_table names"
+    )
+    parser.add_argument("--build-product", type=Path, default=DEFAULT_BUILD_PRODUCT)
+    parser.add_argument("--sources-root", type=Path, default=DEFAULT_SOURCES_ROOT)
+    args = parser.parse_args(argv)
+
+    loader_main = _resolve_loader_main(args.loader)
+    affected_tables = [t.strip() for t in args.tables.split(",") if t.strip()]
+    if not affected_tables:
+        msg = "--tables produced an empty affected-table list"
+        raise LoaderToSourcesError(msg)
+
+    changed = run_loader_to_sources(
+        loader_main, affected_tables, args.build_product, args.sources_root
+    )
+
+    print(f"[loader-to-sources] loader={args.loader} affected={affected_tables}")
+    if changed:
+        print(f"[loader-to-sources] content changed: {changed}")
+    else:
+        print("[loader-to-sources] no affected table's content changed")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except LoaderToSourcesError as error:
+        print(f"[loader-to-sources] ABORT: {error}", file=sys.stderr)
+        sys.exit(2)

--- a/tools/make_data_artifacts.py
+++ b/tools/make_data_artifacts.py
@@ -94,8 +94,11 @@ ARTIFACTS: tuple[ArtifactSpec, ...] = (
         home="src/babylon/data/reference/bridge_county_bea_ea.csv",
         material_relation=(
             "county -> BEA Economic Area membership map — the regional-market "
-            "aggregation geography for cross-border metropolitan gravity."
+            "aggregation geography for cross-border metropolitan gravity. "
+            "R1 one-shot export (36f4cb98) then DB-table demotion; the CSV "
+            "has been canonical since (register, like babylon_ricci_final)."
         ),
+        mode="register",
     ),
     ArtifactSpec(
         name="dim_bea_economic_area",
@@ -104,8 +107,11 @@ ARTIFACTS: tuple[ArtifactSpec, ...] = (
         home="src/babylon/data/reference/dim_bea_economic_area.csv",
         material_relation=(
             "the 8 BEA Economic Areas (cross-border metro market regions) the "
-            "bridge maps counties onto."
+            "bridge maps counties onto. R1 one-shot export (36f4cb98) then "
+            "DB-table demotion; the CSV has been canonical since (register, "
+            "like babylon_ricci_final)."
         ),
+        mode="register",
     ),
     ArtifactSpec(
         name="babylon_ricci_final",

--- a/tools/make_data_artifacts.py
+++ b/tools/make_data_artifacts.py
@@ -298,15 +298,21 @@ def _column_array(values: list[object], field: pa.Field) -> pa.Array:
 
 
 def governed_db_tables(conn: sqlite3.Connection) -> list[str]:
-    """Every table this DB governs — the full sweep surface for the Phase-0
-    measurement CLI. Excludes sqlite's own internal bookkeeping tables
-    (``sqlite_sequence`` et al.)."""
+    """Every table this DB governs — the sweep surface for full-coverage
+    export, roundtrip verification and the Phase-0 measurement CLI. Excludes
+    sqlite's own internal bookkeeping tables (``sqlite_sequence`` et al.)
+    AND utility tables outside the governed estate (``ingest_checkpoint``,
+    ``staging_*`` — no catalog row, no parquet source, no place in the build
+    product; the boundary is ``GOVERNED_PREFIXES``, the same scope the
+    catalog sentinel probes)."""
+    from babylon.sentinels.coverage.catalog import GOVERNED_PREFIXES
+
     rows = conn.execute(
         "SELECT name FROM sqlite_master "
         "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' "
         "ORDER BY name"
     ).fetchall()
-    return [row[0] for row in rows]
+    return [row[0] for row in rows if row[0].startswith(GOVERNED_PREFIXES)]
 
 
 def _catalog_by_name() -> dict[str, CatalogTable]:

--- a/tools/make_data_artifacts.py
+++ b/tools/make_data_artifacts.py
@@ -150,15 +150,22 @@ ARTIFACTS: tuple[ArtifactSpec, ...] = (
         home="dist/data-artifacts/fact_energy_annual.parquet",
         material_relation=(
             "EIA MER annual energy series values 1949-2023 (series x year) — "
-            "national energy-metabolism history."
+            "national energy-metabolism history. R3 one-shot export then "
+            "DB-table demotion; the parquet has been canonical since."
         ),
+        mode="register",
     ),
     ArtifactSpec(
         name="dim_energy_series",
         format="parquet",
         source_table="dim_energy_series",
         home="dist/data-artifacts/dim_energy_series.parquet",
-        material_relation="EIA MER series definitions for fact_energy_annual.",
+        material_relation=(
+            "EIA MER series definitions for fact_energy_annual. R3 one-shot "
+            "export then DB-table demotion; the parquet has been canonical "
+            "since."
+        ),
+        mode="register",
     ),
     ArtifactSpec(
         name="dim_energy_table",
@@ -166,8 +173,11 @@ ARTIFACTS: tuple[ArtifactSpec, ...] = (
         source_table="dim_energy_table",
         home="dist/data-artifacts/dim_energy_table.parquet",
         material_relation=(
-            "EIA MER table taxonomy (with marxian_interpretation labels) for the energy series."
+            "EIA MER table taxonomy (with marxian_interpretation labels) for "
+            "the energy series. R3 one-shot export then DB-table demotion; "
+            "the parquet has been canonical since."
         ),
+        mode="register",
     ),
     ArtifactSpec(
         name="bridge_lodes_block",
@@ -177,8 +187,10 @@ ARTIFACTS: tuple[ArtifactSpec, ...] = (
         material_relation=(
             "census-block -> county/tract/CBSA/ZCTA crosswalk with block "
             "centroids (1,150,562 blocks) — the future hex-level commuter "
-            "disaggregation geography."
+            "disaggregation geography. R4 spike export then DB-table "
+            "demotion; the parquet has been canonical since."
         ),
+        mode="register",
     ),
     ArtifactSpec(
         name="staging_arcgis_feature",
@@ -188,8 +200,11 @@ ARTIFACTS: tuple[ArtifactSpec, ...] = (
         material_relation=(
             "facility-grain ArcGIS provenance rows (5,974 features: source, "
             "object id, county, type, capacity) behind fact_coercive_"
-            "infrastructure — kept as raw-provenance artifact."
+            "infrastructure — kept as raw-provenance artifact. R5 one-shot "
+            "export then DB-table demotion; the parquet has been canonical "
+            "since."
         ),
+        mode="register",
     ),
 )
 
@@ -709,7 +724,10 @@ def generate(db_path: Path, *, full_coverage: bool = False) -> list[dict[str, ob
                 if not out.exists():
                     msg = f"register-mode artifact missing: {out}"
                     raise ArtifactError(msg)
-                rows = _csv_data_rows(out)
+                if spec.format == "parquet":
+                    rows = pq.ParquetFile(out).metadata.num_rows
+                else:
+                    rows = _csv_data_rows(out)
             elif spec.format == "csv":
                 columns, pk, _schema = _table_layout(conn, spec.source_table)
                 data = _fetch_sorted(conn, spec.source_table, columns, pk)

--- a/tools/make_reference_subset.py
+++ b/tools/make_reference_subset.py
@@ -721,7 +721,9 @@ def find_unknown_tables(table_names: list[str], policy: dict[str, TablePolicy]) 
     :returns: Sorted names matching a classified prefix but missing a policy
         entry (``[]`` if none).
     """
-    prefixes = ("fact_", "dim_", "bridge_")
+    from babylon.sentinels.coverage.catalog import GOVERNED_PREFIXES
+
+    prefixes = tuple(p for p in GOVERNED_PREFIXES if p != "view_")
     return sorted(name for name in table_names if name.startswith(prefixes) and name not in policy)
 
 

--- a/tools/verify_reference_roundtrip.py
+++ b/tools/verify_reference_roundtrip.py
@@ -170,14 +170,17 @@ def view_content_hash(conn: sqlite3.Connection, view: str) -> tuple[int, str]:
 
 
 def _governed_db_views(conn: sqlite3.Connection) -> list[str]:
-    """Every non-internal view in ``conn`` — the view-side twin of
-    :func:`make_data_artifacts.governed_db_tables`."""
+    """Every governed view in ``conn`` — the view-side twin of
+    :func:`make_data_artifacts.governed_db_tables`, scoped by the same
+    ``GOVERNED_PREFIXES`` boundary (all reference views are ``view_*``)."""
+    from babylon.sentinels.coverage.catalog import GOVERNED_PREFIXES
+
     rows = conn.execute(
         "SELECT name FROM sqlite_master "
         "WHERE type = 'view' AND name NOT LIKE 'sqlite_%' "
         "ORDER BY name"
     ).fetchall()
-    return [row[0] for row in rows]
+    return [row[0] for row in rows if row[0].startswith(GOVERNED_PREFIXES)]
 
 
 def _compare_names(


### PR DESCRIPTION
## What

The reference DB is now a **build product**: parquet sources + `schema.sql` canonical, SQLite rebuilt deterministically on the pinned toolchain (sqlite 3.53.1, infra devshell). Executes the approved plan `docs/superpowers/plans/2026-07-19-parquet-reference-pipeline.md` Task 10 (runbook), with Tasks 11–12 to follow on this branch.

## Runbook evidence (Task 10)

- **Step 2 — export**: 84 manifest entries (80 full-coverage parquet incl. 14.7M-row `fact_qcew_annual` streamed + 4 in-repo register CSVs); `fact_commodity_flow` + `fact_hpms_road_segment` 0 rows = genuinely empty, catalog-declared.
- **Step 3 — schema fixed point**: rebuild-extract → `SCHEMA_FIXED_POINT=IDENTICAL` (75 tables, 8 views, 99 indexes, contiguous blocks); product block committed (5f1f23fe).
- **Step 4 — proofs**:
  - `data:verify-build`: ref-a `f760bab5c63ce879decd72cfe3bf51c569a5a4ba2a4a57e0ccbb5d90f5e6fa42` == ref-b (75 tables / 59,827,795 rows each) — **double-build byte identity**.
  - `data:verify-roundtrip`: 83/83 objects ok vs the live DB.
- **Step 5 — pre-flip sim gate**: `qa:regression` vs the rebuilt product: **6/6 byte-identical + two-process determinism leg PASS** (plan-spliced to the ADR090 modernized 6-scenario gate).
- **Step 6 — the flip**: old DB `a0cad5d1…` byte-verified into `backups/marxist-data-3NF.pre-parquet-20260720.sqlite`; canonical drive DB now hashes **exactly the manifest product sha** (extracted programmatically, no hand-typed hashes). Post-flip `qa:regression` 6/6 + determinism PASS via the normal symlink; `sentinel_check catalog --check` clean (83 rows, no dark objects).
- **Step 7 — release**: `ci-data-v7` (subset DERIVED from the product, 14,191,827 rows kept; 80 parquet + schema.sql all manifest-pinned; TIGER carried from v3 lineage); fetch action pins bumped, subset sha verified against the computed sidecar.
- **Step 8**: canonical source set archived to `backups/data-artifacts-v7` (273M).

## Owner-transparency flags

- **GOVERNED_PREFIXES** single SoT fix (three divergent governed-scope definitions found at first export; owner ruled Proceed) — `ingest_checkpoint` (47,339 rows) is OUT of the build product by design (pre-flip backup preserves it; loaders `create_all` on demand).
- **ADR076 demotion handoff completed**: 7 stale generate-mode curated specs flipped to register (R1/R3/R4/R5); new law: every generate-mode spec must name a catalogued table.
- **Builder index-order fix**: indexes replay post-load in schema.sql statement order + loud interleave precondition (first rebuild had deterministic-but-wrong index rowid order).
- **VACUUM temp pragma**: `temp_store_directory` pinned next to the output (tmpfs-/tmp boxes; the repeated 'disk full' was actually /home at 100% — documented for Task 12 docs).

## Remaining on this branch

- Task 11: `loader_to_sources` wrapper + IMPORT_USE lands as the first source-only ingest (pre-authorized ceremony if baselines drift).
- Task 12: ADR + docs + `ai/state.yaml`; nightly dispatch (Step 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)