### PR TITLE
nightly.yml: rg-inertness fix + G1 refdata dependency + weekly Wednesday tempo

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,10 @@ name: Nightly
 
 on:
   schedule:
-    - cron: "0 6 * * *"   # daily deep legs, 06:00 UTC
+    # Owner ruling 2026-07-20: weekly tempo. The deep legs (formerly nightly)
+    # now run Wednesdays; the Sunday leg keeps its slot. workflow_dispatch
+    # remains the on-demand path (post-merge verification etc.).
+    - cron: "0 6 * * 3"   # weekly deep legs, Wednesday 06:00 UTC
     - cron: "0 4 * * 0"   # weekly leg, Sunday 04:00 UTC
   workflow_dispatch:
 
@@ -184,10 +187,14 @@ jobs:
     runs-on: ubuntu-latest
     # Measured: a 20-tick `us` sample cost 117.49s wall-clock on the dev box;
     # linear-fit extrapolation to 520 ticks ~= 49 minutes (see the test's
-    # docstring for the full model). No Postgres/reference-DB dependency —
-    # pacing_probe runs the engine's step() loop entirely in-memory and the
-    # `us` scenario's territories + seeded businesses come from H3 generation
-    # + a committed JSON artifact, not the data drive.
+    # docstring for the full model). No Postgres — but since PR #221 (#39,
+    # Amendment U) this leg DOES need the reference DB: SubstrateSystem's
+    # one-time ScaleAdjunction lattice build reads dim_county /
+    # bridge_county_metro / dim_metro_area (all shipped FULL in the ci-data
+    # subset). Without it, sqlalchemy auto-creates an empty sqlite and the
+    # run dies 'no such table: dim_county' at tick 0 (2026-07-20 red,
+    # run 29781894207). Territories/businesses still come from the
+    # committed JSON artifact, not the data drive.
     timeout-minutes: 75
     steps:
       - uses: actions/checkout@v7
@@ -196,6 +203,7 @@ jobs:
       - uses: ./.github/actions/bootstrap-python
         with:
           gdal: "true"
+      - uses: ./.github/actions/fetch-reference-db
       - name: G1 standing pacing gate (mise run qa:pacing)
         run: mise run qa:pacing
       - name: Upload test results

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -143,7 +143,10 @@ jobs:
           -o addopts="" -vv -ra -l --tb=long --durations=0
       - name: Rebuild-verify reference DB (parquet-canonical gate)
         run: |
-          if ! rg -q '^product:' data-artifacts.yaml; then
+          # grep, not rg: ripgrep is NOT on the runner (proven 2026-07-20 run
+          # 29785321382 — 'rg: command not found' made this probe silently
+          # take the pre-cutover path AFTER the cutover had merged).
+          if ! grep -q '^product:' data-artifacts.yaml; then
             echo "::notice::no product block in data-artifacts.yaml yet — rebuild-verify inert (pre-cutover)"
             exit 0
           fi
@@ -155,7 +158,11 @@ jobs:
           # (cachix/install-nix-action, nix-release.yml prior art), then DELETE
           # this warning path so the leg becomes the true remote identity proof.
           RUNTIME=$(poetry run python -c 'import sqlite3; print(sqlite3.sqlite_version)')
-          PINNED=$(rg -o 'sqlite_version: "([0-9.]+)"' -r '$1' data-artifacts.yaml | head -1)
+          PINNED=$(sed -n 's/^  sqlite_version: "\([0-9.]*\)"$/\1/p' data-artifacts.yaml | head -1)
+          if [ -z "$PINNED" ]; then
+            echo "::error::could not extract sqlite_version pin from data-artifacts.yaml — probe broken, failing loudly"
+            exit 1
+          fi
           if [ "$RUNTIME" != "$PINNED" ]; then
             MSG="runner sqlite ${RUNTIME} != pinned ${PINNED} — byte-identity leg"
             MSG="${MSG} skipped; CI-devshell pinning is the ADR098 declared follow-up"


### PR DESCRIPTION
Three nightly.yml repairs in one PR (same file, sequential discoveries):

1. **rg-inertness fix** (1593b884): the rebuild-verify probe used `rg`, absent on runners — 'rg: command not found' made the step silently take the pre-cutover-inert path AFTER the cutover merged (run 29781894207). Now grep/sed with a loud `::error` if pin extraction yields nothing.

2. **G1 pacing leg gains `fetch-reference-db`** (20303904): the 2026-07-20 G1 red (`no such table: dim_county`, tick 0) was **#221/#39 fallout** — SubstrateSystem's one-time ScaleAdjunction lattice build reads `dim_county`/`bridge_county_metro`/`dim_metro_area` via `get_reference_session`, and with no DB present sqlalchemy auto-creates an empty file (the auto-create-masks-absence class, sentinel = task #64). The morning-green/evening-red mystery resolves: #221 merged 16:56Z, between the runs. All three lattice tables ship FULL in the ci-data subset; the job's stale 'no reference-DB dependency' comment corrected.

3. **Weekly Wednesday tempo** (owner ruling 2026-07-20, verbatim: 'Nightly can become a weekly Wednesday thats a fine tempo for us'): deep-legs cron `0 6 * * *` → `0 6 * * 3`; Sunday leg keeps its slot; `workflow_dispatch` unchanged. Takes scheduled effect at the next dev→main promotion (schedules read the default branch); dispatches unaffected.

Post-merge verification: one `workflow_dispatch` of nightly.yml — expect G1 GREEN (~41 min) and the rebuild-verify OFF-PIN `::warning` actually firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)