### PR TITLE
feat(ci): nightly rebuild-verify runs in the dataBuild devshell (ADR098 follow-up)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -144,37 +144,69 @@ jobs:
           poetry run pytest tests -m requires_reference_db
           --ignore=tests/integration/web
           -o addopts="" -vv -ra -l --tb=long --durations=0
-      - name: Rebuild-verify reference DB (parquet-canonical gate)
+  # The byte-identity contract is defined ONLY under the pinned sqlite (the
+  # builder hard-gates on PINNED_SQLITE_VERSION), so this leg runs inside the
+  # infra flake's dataBuild devshell — the ADR098 declared follow-up, landed
+  # 2026-07-20; the old OFF-PIN warn-and-skip path is deleted with it. Its own
+  # job (not a refdata-tests step): the full rebuild took ~12 min on the dev
+  # box and hosted runners are slower — a 25-minute shared budget can't hold
+  # both it and the test suites, and a separate job gives clean attribution.
+  rebuild-verify:
+    name: Rebuild-Verify Reference DB (byte-identity, dataBuild devshell)
+    if: github.event.schedule != '0 4 * * 0' && vars.CI_REFDB_READY == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: dev
+      # babylon is public but the infra submodule is private — GITHUB_TOKEN is
+      # repo-scoped, so the fetch authenticates with a dedicated READ-ONLY
+      # deploy key (babylon-infra → settings → deploy keys, installed
+      # 2026-07-20). The key touches disk only for this fetch. The checked-out
+      # gitlink IS the environment pin: bumping it is the pin ceremony, and the
+      # flake's nixpkgs-data input remains the sole pinning authority.
+      - name: Fetch infra submodule (read-only deploy key)
+        env:
+          INFRA_DEPLOY_KEY: ${{ secrets.INFRA_SUBMODULE_DEPLOY_KEY }}
         run: |
-          # grep, not rg: ripgrep is NOT on the runner (proven 2026-07-20 run
-          # 29785321382 — 'rg: command not found' made this probe silently
-          # take the pre-cutover path AFTER the cutover had merged).
+          umask 077
+          mkdir -p ~/.ssh
+          printf '%s\n' "$INFRA_DEPLOY_KEY" > ~/.ssh/infra_deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          git config url."git@github.com:percy-raskova/babylon-infra.git".insteadOf \
+            "https://github.com/percy-raskova/babylon-infra.git"
+          GIT_SSH_COMMAND="ssh -i ~/.ssh/infra_deploy_key -o IdentitiesOnly=yes" \
+            git submodule update --init infra
+          rm -f ~/.ssh/infra_deploy_key
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      # Sources for the rebuild: the manifest-driven step of this action
+      # fetches every `artifacts:` entry + schema.sql into their dist/ homes —
+      # exactly what build_reference_db.py reads. (The subset DB and TIGER
+      # tarball it also installs are unused here; the shared action keeps the
+      # fetch logic single-sourced.)
+      - uses: ./.github/actions/fetch-reference-db
+      - name: Rebuild under the pinned devshell + compare product sha
+        run: |
+          # Post-cutover the product block is load-bearing — its absence is a
+          # manifest regression, not a pre-cutover state (III.11: fail loud).
           if ! grep -q '^product:' data-artifacts.yaml; then
-            echo "::notice::no product block in data-artifacts.yaml yet — rebuild-verify inert (pre-cutover)"
-            exit 0
-          fi
-          # The byte-identity contract is defined ONLY under the pinned sqlite
-          # (the builder hard-gates on PINNED_SQLITE_VERSION). Stock runners
-          # ship an older sqlite, so off-pin this leg warns LOUDLY and skips
-          # instead of hard-failing every nightly. Declared follow-up (ADR098):
-          # run this step inside the infra devshell on CI
-          # (cachix/install-nix-action, nix-release.yml prior art), then DELETE
-          # this warning path so the leg becomes the true remote identity proof.
-          RUNTIME=$(poetry run python -c 'import sqlite3; print(sqlite3.sqlite_version)')
-          PINNED=$(sed -n 's/^  sqlite_version: "\([0-9.]*\)"$/\1/p' data-artifacts.yaml | head -1)
-          if [ -z "$PINNED" ]; then
-            echo "::error::could not extract sqlite_version pin from data-artifacts.yaml — probe broken, failing loudly"
+            echo "::error::data-artifacts.yaml has no product block — manifest regression"
             exit 1
           fi
-          if [ "$RUNTIME" != "$PINNED" ]; then
-            MSG="runner sqlite ${RUNTIME} != pinned ${PINNED} — byte-identity leg"
-            MSG="${MSG} skipped; CI-devshell pinning is the ADR098 declared follow-up"
-            echo "::warning title=rebuild-verify OFF-PIN::${MSG}"
-            exit 0
-          fi
-          poetry run python tools/build_reference_db.py --out /tmp/rebuilt.sqlite
-          poetry run python - <<'EOF'
-          import hashlib, pathlib, sys, yaml
+          nix develop ./infra#dataBuild --command \
+            python3 tools/build_reference_db.py --out /tmp/rebuilt.sqlite
+          nix develop ./infra#dataBuild --command python3 - <<'EOF'
+          import hashlib
+          import pathlib
+          import sys
+
+          import yaml
+
           want = yaml.safe_load(pathlib.Path("data-artifacts.yaml").read_text())["product"]["sha256"]
           got = hashlib.sha256(pathlib.Path("/tmp/rebuilt.sqlite").read_bytes()).hexdigest()
           print(f"registry={want}\nrebuilt ={got}")


### PR DESCRIPTION
## What

Closes the ADR098 declared follow-up (Task #65): the nightly `rebuild-verify` leg now runs inside the infra flake's `dataBuild` devshell, and the OFF-PIN warn-and-skip path is **deleted** — the leg becomes the true remote byte-identity proof instead of a probe that silently skipped on every stock runner (their sqlite ≠ pinned 3.53.1).

- **infra gitlink → `f3aaa9f0`** ([babylon-infra#4](https://github.com/percy-raskova/babylon-infra/pull/4), merged): adds `devShells.dataBuild` — the `pythonData` interpreter (sqlite 3.53.1 via the `nixpkgs-data` input, the flake's sole pinning authority) + pyarrow + pyyaml, BLAS determinism pins mirrored. The gitlink IS the environment pin; bumping it is the pin ceremony.
- **`rebuild-verify` is its own job** (was a `refdata-tests` step): the full rebuild took ~12 min on the dev box, hosted runners are slower, and a separate job gives clean failure attribution. `cachix/install-nix-action@v31` per the nix-release.yml prior art.
- **product-block absence → `::error` exit 1** (was a pre-cutover notice): post-cutover, a missing product block is a manifest regression (Constitution III.11, fail loud).

## Auth (owner-approved 2026-07-20)

babylon is public; babylon-infra is private; `GITHUB_TOKEN` is repo-scoped. The submodule fetch authenticates with a dedicated **read-only deploy key** on babylon-infra, private half stored as Actions secret `INFRA_SUBMODULE_DEPLOY_KEY`. Revocable anytime in both repos' settings; fork PRs never receive secrets; the key touches runner disk only for the fetch. Sops-migration of infra's plaintext `.envrc` keys remains the standing follow-up that would let infra go public and retire this key.

## Proof

Local rebuild under the same shell resolved from this exact gitlink:

```
dataBuild shell: python=Python 3.12.13 sqlite=3.53.1
[build] rebuilt.sqlite: 75 tables, 59827795 rows, sha256=f760bab5c63ce879decd72cfe3bf51c569a5a4ba2a4a57e0ccbb5d90f5e6fa42
BUILD_EXIT=0
```

Exact match with `product.sha256`. actionlint + yamllint clean (pre-commit hooks + local actionlint 1.7.12).

## Post-merge verification

nightly.yml executes from dev on schedule/dispatch — PR CI can't exercise it. After merge I will `workflow_dispatch` the Nightly workflow and babysit the `rebuild-verify` job to completion; the remote sha-match is the acceptance gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)