### PR TITLE
feat(sentinels): absence sentinel — auto-create must never mask a missing reference DB (task #64)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -104,7 +104,7 @@ description = "Run complexity gate (xenon) - fails if CC > 15"
 run = "poetry run xenon --max-absolute C src/"
 
 [tasks.check]
-description = "Fast CI gate: data-pathway + hygiene + ALL 13 sentinels + lint + imports + format + typecheck + unit tests"
+description = "Fast CI gate: data-pathway + hygiene + ALL 14 sentinels + lint + imports + format + typecheck + unit tests"
 depends = ["data:doctor", "check:hygiene", "check:sentinels", "lint", "lint:imports", "format", "typecheck", "test:unit"]
 
 [tasks."data:doctor"]
@@ -175,13 +175,17 @@ run = "poetry run python tools/sentinel_check.py partition --check"
 description = "Synthetic-data sentinel: every declared synthetic source's source + guard symbols exist (static gate)"
 run = "poetry run python tools/sentinel_check.py synthetic --check"
 
+[tasks."check:absence"]
+description = "Absence sentinel (task #64): every sqlite3.connect/create_engine(sqlite) site carries a cited disposition — auto-create must never mask a missing reference DB (static gate)"
+run = "poetry run python tools/sentinel_check.py absence --check"
+
 [tasks."check:sentinels"]
-description = "ALL 14 sentinels (owner ruling 2026-07-18: the whole family is fast-gate LOCALLY — the dev box has the reference DB): seam coverage vocabulary inert dangling unconsumed masked-arithmetic aggregation fog catalog partition synthetic defines-passthrough gate-coverage"
+description = "ALL 15 sentinels (owner ruling 2026-07-18: the whole family is fast-gate LOCALLY — the dev box has the reference DB): seam coverage vocabulary inert dangling unconsumed masked-arithmetic aggregation fog catalog partition synthetic defines-passthrough gate-coverage absence"
 depends = ["check:sentinels-static", "check:catalog"]
 
 [tasks."check:sentinels-static"]
-description = "The 13 static sentinels (no reference DB needed) — CI's fast-gate job runs THIS; the catalog DB-probe runs where the DB exists (locally via check:sentinels, in CI via nightly's requires_reference_db job)"
-depends = ["check:seams", "check:coverage", "check:vocabulary", "check:inert", "check:dangling", "check:unconsumed", "check:masked-arithmetic", "check:aggregation", "check:fog", "check:partition", "check:synthetic", "check:defines-passthrough", "check:gate-coverage"]
+description = "The 14 static sentinels (no reference DB needed) — CI's fast-gate job runs THIS; the catalog DB-probe runs where the DB exists (locally via check:sentinels, in CI via nightly's requires_reference_db job)"
+depends = ["check:seams", "check:coverage", "check:vocabulary", "check:inert", "check:dangling", "check:unconsumed", "check:masked-arithmetic", "check:aggregation", "check:fog", "check:partition", "check:synthetic", "check:defines-passthrough", "check:gate-coverage", "check:absence"]
 
 [tasks."check:surface"]
 description = "Sentinel: __all__ vs its pinned baseline frozenset (public-surface baseline blindness gate)"

--- a/src/babylon/reference/database.py
+++ b/src/babylon/reference/database.py
@@ -221,7 +221,22 @@ def get_reference_session() -> Iterator[Session]:
 
     Yields:
         Session: SQLAlchemy database session (read-only by convention).
+
+    Raises:
+        FileNotFoundError: If ``NORMALIZED_DB_PATH`` does not exist. Unlike
+            ``get_normalized_engine``, this entry point never auto-creates the
+            reference database (Constitution III.11 / task #64) -- an absent
+            file here means the DB was never built or the environment is
+            misconfigured, not that a fresh one should be silently opened.
     """
+    if not NORMALIZED_DB_PATH.is_file():
+        raise FileNotFoundError(
+            f"Reference database not found at {NORMALIZED_DB_PATH}. "
+            "get_reference_session() is read-only and will not create it. "
+            "Remedies: `mise run data:build-db` (rebuild from parquet sources, "
+            "ADR098), the CI `fetch-reference-db` action, or set "
+            "BABYLON_NORMALIZED_DB_PATH to an existing database."
+        )
     session_factory = get_normalized_session_factory()
     session = session_factory()
     try:

--- a/src/babylon/sentinels/absence/__init__.py
+++ b/src/babylon/sentinels/absence/__init__.py
@@ -1,0 +1,26 @@
+"""Absence sentinel: every sqlite connect site carries a cited disposition.
+
+Instance of the Sentinel pattern guarding the "auto-create masks absence"
+invariant (task #64, founding incident: 2026-07-20 G1 nightly --
+``get_reference_session()`` silently created an empty reference DB on a
+runner with none, surfacing as a baffling downstream ``no such table:
+dim_county``). Registry = one :class:`~babylon.sentinels.absence.registry.
+ConnectionDisposition` row per file containing a sqlite connect call under
+``src/babylon``; checks = three static AST rules (growth: every hit is
+registered; backslide: a readonly_uri file stays read-only; staleness: a
+registered file still has a hit). See :mod:`babylon.reference.database` for
+the runtime guard this static sentinel's registry documents (part A of the
+same task); see :mod:`babylon.sentinels.absence.checks` for the scan itself.
+"""
+
+from babylon.sentinels.absence.registry import (
+    CONNECTION_DISPOSITIONS,
+    ConnectionDisposition,
+    Disposition,
+)
+
+__all__ = [
+    "CONNECTION_DISPOSITIONS",
+    "ConnectionDisposition",
+    "Disposition",
+]

--- a/src/babylon/sentinels/absence/checks.py
+++ b/src/babylon/sentinels/absence/checks.py
@@ -1,0 +1,457 @@
+"""Absence sentinel: every sqlite connect site carries a cited disposition.
+
+Instance of the Sentinel pattern guarding the "auto-create masks absence"
+invariant (task #64): ``sqlite3.connect(path)``/SQLAlchemy's
+``create_engine("sqlite:///path")`` both silently CREATE an empty database
+when ``path`` does not exist, turning a loud, actionable absence into a
+baffling downstream ``no such table: X`` two systems later (the 2026-07-20
+G1 nightly incident this sentinel is named for). Part A of task #64 closed
+the one constitutional entry point this bit
+(``babylon.reference.database.get_reference_session``); this static scanner
+is the growth mechanism that keeps every OTHER sqlite connect site honest --
+:mod:`babylon.sentinels.absence.registry` is the declared-invariant registry,
+this module is the check.
+
+Three gating rules, all read statically from source (no engine import, no DB
+connection of its own -- cheap enough for the always-on fast gate):
+
+**(1) Growth gate.** Every file under ``src/babylon`` containing a
+non-memory sqlite connect site (:func:`find_connect_sites`) must have a
+:class:`~babylon.sentinels.absence.registry.ConnectionDisposition` row. An
+unregistered file is exactly how the founding incident happened: nobody
+looked at the site, so nobody noticed it could silently create an empty DB.
+
+**(2) Backslide gate.** A file registered ``"readonly_uri"`` must have
+EVERY one of its connect sites classified read-only (a resolved ``mode=ro``
+URI literal). A new writable call added to an otherwise-read-only file is a
+silent regression of the declared safety property.
+
+**(3) Stale-row gate.** A registry row whose file no longer contains ANY
+connect site (the code moved, was deleted, or was refactored away) is a
+violation -- the row describes a call site that no longer exists, the same
+"declaration outlived its target" drift the vocabulary/unconsumed families
+already guard against for their own registries.
+
+Classification (per connect site, :func:`find_connect_sites`):
+
+- ``:memory:`` (an exact literal) -- auto-pass, never counted as a "hit" for
+  gates (1)/(2), though it still counts toward gate (3)'s "does this file
+  still have ANY site" liveness check.
+- a resolved literal/f-string containing ``"mode=ro"`` -- ``"readonly"``.
+- everything else (an unresolvable dynamic argument, or a resolved literal
+  without ``mode=ro``) -- ``"writable"``, the disposition-requiring case.
+
+Scope note: only ``sqlite3.connect(...)`` calls and ``create_engine(...)``
+calls whose first argument is PROVABLY sqlite (a literal/f-string containing
+``"sqlite"``, or a bare module-level Name resolved to one) are considered --
+a ``create_engine(url)`` call over an opaque parameter (e.g.
+``persistence/database.py``'s generic ``DatabaseConnection`` wrapper, whose
+default is a sqlite URL but whose actual argument at any call site is an
+unresolvable parameter) is invisible to this static scan by design, the same
+"cannot resolve without value-flow analysis" limitation the dangling/inert
+sentinels document for their own computed-name cases.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import Final, Literal, NamedTuple
+
+from babylon.sentinels._ast import parse_module
+from babylon.sentinels.absence.registry import CONNECTION_DISPOSITIONS, ConnectionDisposition
+from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.report import finding
+
+__all__ = [
+    "ConnectSite",
+    "check_readonly_backslide",
+    "check_stale_dispositions",
+    "check_unregistered_connections",
+    "find_connect_sites",
+    "main",
+]
+
+#: Repo root (this file is ``<root>/src/babylon/sentinels/absence/checks.py``,
+#: the same nesting depth as ``aggregation/checks.py``).
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[4]
+
+#: The one tree this sentinel scans -- narrower than vocabulary/inert's
+#: ``src``/``web``/``tests`` sweep, because every sqlite connect site in this
+#: codebase lives under ``src/babylon`` (verified by the ``rg`` census the
+#: registry cites).
+_SCAN_ROOT: Final[str] = "src/babylon"
+
+#: The exact-literal argument that marks a connect call as memory-only --
+#: never a disposition risk (nothing to create on disk).
+_MEMORY_LITERAL: Final[str] = ":memory:"
+
+#: Substring that marks a resolved literal/f-string as opening a read-only URI.
+_READONLY_MARKER: Final[str] = "mode=ro"
+
+
+class ConnectSite(NamedTuple):
+    """One AST-detected sqlite connection call site.
+
+    :ivar file: Repo-relative POSIX path of the source file.
+    :ivar line: 1-indexed source line of the call.
+    :ivar kind: Which call form matched.
+    :ivar classification: ``"memory"`` (auto-pass), ``"readonly"`` (a
+        resolved ``mode=ro`` literal), or ``"writable"`` (everything else --
+        the case a registry row must account for).
+    """
+
+    file: str
+    line: int
+    kind: Literal["sqlite3.connect", "create_engine"]
+    classification: Literal["memory", "readonly", "writable"]
+
+
+def _literal_text(node: ast.expr) -> str | None:
+    """Best-effort literal text of an expression.
+
+    Handles a bare string constant and an f-string's constant parts (joined,
+    skipping any interpolated ``{...}`` placeholders) -- the same two forms
+    every sqlite connect site in this tree actually uses.
+
+    :param node: The expression to resolve.
+    :returns: The literal text, or ``None`` if ``node`` is not one of the two
+        recognized literal forms.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        return "".join(
+            part.value
+            for part in node.values
+            if isinstance(part, ast.Constant) and isinstance(part.value, str)
+        )
+    return None
+
+
+def _module_level_literals(tree: ast.Module) -> dict[str, str]:
+    """Module-level ``NAME = <literal>`` bindings, resolved to literal text.
+
+    A single-hop resolution (module top-level assignments only, never a
+    function-local or a chained alias) -- exactly what
+    ``reference/database.py``'s own ``NORMALIZED_DATABASE_URL``/
+    ``SOURCE_DATABASE_URL`` module constants need to be visible as sqlite
+    ``create_engine`` arguments.
+
+    :param tree: A parsed module.
+    :returns: Every module-level Name bound to a resolvable literal.
+    """
+    literals: dict[str, str] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        text = _literal_text(node.value)
+        if text is None:
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                literals[target.id] = text
+    return literals
+
+
+def _resolve_first_arg(call: ast.Call, module_literals: dict[str, str]) -> str | None:
+    """Resolve a call's first positional argument to literal text, if possible.
+
+    :param call: The call node (must have at least one positional arg).
+    :param module_literals: This file's :func:`_module_level_literals` map.
+    :returns: The resolved literal text, or ``None`` if the argument is
+        neither a literal itself nor a Name bound to one at module level.
+    """
+    arg = call.args[0]
+    text = _literal_text(arg)
+    if text is not None:
+        return text
+    if isinstance(arg, ast.Name):
+        return module_literals.get(arg.id)
+    return None
+
+
+def _classify(text: str | None) -> Literal["memory", "readonly", "writable"]:
+    """Classify a connect site by its resolved argument text.
+
+    :param text: The resolved literal text, or ``None`` if unresolvable.
+    :returns: ``"memory"`` for the exact ``:memory:`` literal, ``"readonly"``
+        when the resolved text carries a ``mode=ro`` marker, ``"writable"``
+        otherwise (including every unresolvable argument -- absence of proof
+        of safety is not proof of safety).
+    """
+    if text == _MEMORY_LITERAL:
+        return "memory"
+    if text is not None and _READONLY_MARKER in text:
+        return "readonly"
+    return "writable"
+
+
+def _is_sqlite3_connect(call: ast.Call) -> bool:
+    """True iff ``call`` is ``sqlite3.connect(...)``.
+
+    :param call: The call node to inspect.
+    :returns: Whether the call's function is the ``connect`` attribute of a
+        bare ``sqlite3`` name.
+    """
+    return (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr == "connect"
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "sqlite3"
+    )
+
+
+def _is_create_engine(call: ast.Call) -> bool:
+    """True iff ``call`` is a bare ``create_engine(...)`` call.
+
+    :param call: The call node to inspect.
+    :returns: Whether the call's function is the bare name ``create_engine``.
+    """
+    return isinstance(call.func, ast.Name) and call.func.id == "create_engine"
+
+
+def _iter_scanned_files(repo_root: Path, scan_root: str) -> Iterator[Path]:
+    """Yield every ``.py`` file under ``repo_root / scan_root``, sorted.
+
+    :param repo_root: Repository root the scan is relative to.
+    :param scan_root: Repo-relative root directory to walk.
+    :returns: Source files in a stable order, ``__pycache__`` excluded.
+    :raises SentinelCheckError: If the scan root is missing.
+    """
+    base = repo_root / scan_root
+    if not base.is_dir():
+        raise SentinelCheckError(f"scan root missing: {base} (cannot verify sqlite connect sites)")
+    for path in sorted(base.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        yield path
+
+
+def find_connect_sites(
+    repo_root: Path = _REPO_ROOT, scan_root: str = _SCAN_ROOT
+) -> tuple[ConnectSite, ...]:
+    """Scan for every sqlite connect call site under ``repo_root / scan_root``.
+
+    :param repo_root: Repository root (injectable so tests can point this at
+        a synthetic tree under ``tmp_path``).
+    :param scan_root: Repo-relative root directory to walk.
+    :returns: Every matched site, sorted (file, then line).
+    :raises SentinelCheckError: If the scan root is missing, or a scanned
+        file is missing/unparseable when read.
+    """
+    sites: list[ConnectSite] = []
+    for path in _iter_scanned_files(repo_root, scan_root):
+        rel = path.relative_to(repo_root).as_posix()
+        tree = parse_module(path)
+        module_literals = _module_level_literals(tree)
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and node.args):
+                continue
+            if _is_sqlite3_connect(node):
+                text = _resolve_first_arg(node, module_literals)
+                sites.append(ConnectSite(rel, node.lineno, "sqlite3.connect", _classify(text)))
+            elif _is_create_engine(node):
+                text = _resolve_first_arg(node, module_literals)
+                if text is None or "sqlite" not in text:
+                    continue
+                sites.append(ConnectSite(rel, node.lineno, "create_engine", _classify(text)))
+    return tuple(sorted(sites))
+
+
+def _sites_by_file(sites: Iterable[ConnectSite]) -> dict[str, tuple[ConnectSite, ...]]:
+    """Group connect sites by their file.
+
+    :param sites: Sites to group.
+    :returns: Each file mapped to its sites, in the order they were given.
+    """
+    by_file: dict[str, list[ConnectSite]] = {}
+    for site in sites:
+        by_file.setdefault(site.file, []).append(site)
+    return {file: tuple(group) for file, group in by_file.items()}
+
+
+def check_unregistered_connections(
+    sites: tuple[ConnectSite, ...] | None = None,
+    dispositions: dict[str, ConnectionDisposition] | None = None,
+) -> list[str]:
+    """Growth gate: every file with a non-memory connect site must be registered.
+
+    :param sites: Connect sites to check (defaults to a fresh
+        :func:`find_connect_sites` scan of the real tree; injectable so tests
+        can supply a synthetic scan).
+    :param dispositions: The registry to check against (defaults to the real
+        :data:`~babylon.sentinels.absence.registry.CONNECTION_DISPOSITIONS`).
+    :returns: One finding per unregistered file (empty when every file with a
+        non-memory hit is registered).
+    :raises SentinelCheckError: If the scan root is missing/unparseable.
+    """
+    if sites is None:
+        sites = find_connect_sites()
+    if dispositions is None:
+        dispositions = CONNECTION_DISPOSITIONS
+    by_file = _sites_by_file(site for site in sites if site.classification != "memory")
+    findings: list[str] = []
+    for file, file_sites in sorted(by_file.items()):
+        if file in dispositions:
+            continue
+        first = min(file_sites, key=lambda site: site.line)
+        findings.append(
+            finding(
+                error_class="unregistered-connection",
+                symbol=first.kind,
+                file=file,
+                line=first.line,
+                problem=(
+                    "opens a sqlite connection with no ConnectionDisposition row -- an "
+                    "absent database file here would silently auto-create instead of "
+                    "failing loudly"
+                ),
+                remedy=(
+                    "add a ConnectionDisposition row to "
+                    "src/babylon/sentinels/absence/registry.py naming the disposition "
+                    "(readonly_uri/guarded/creates_own_store/canonical/declared_debt) and "
+                    "citing the evidence"
+                ),
+            )
+        )
+    return sorted(findings)
+
+
+def check_readonly_backslide(
+    sites: tuple[ConnectSite, ...] | None = None,
+    dispositions: dict[str, ConnectionDisposition] | None = None,
+) -> list[str]:
+    """Backslide gate: a ``readonly_uri`` file's connect sites must ALL be read-only.
+
+    :param sites: Connect sites to check (see :func:`check_unregistered_connections`).
+    :param dispositions: The registry to check against.
+    :returns: One finding per writable site inside a ``readonly_uri`` file.
+    :raises SentinelCheckError: If the scan root is missing/unparseable.
+    """
+    if sites is None:
+        sites = find_connect_sites()
+    if dispositions is None:
+        dispositions = CONNECTION_DISPOSITIONS
+    by_file = _sites_by_file(sites)
+    findings: list[str] = []
+    for file, row in sorted(dispositions.items()):
+        if row.disposition != "readonly_uri":
+            continue
+        for site in by_file.get(file, ()):
+            if site.classification != "writable":
+                continue
+            findings.append(
+                finding(
+                    error_class="readonly-backslide",
+                    symbol=site.kind,
+                    file=file,
+                    line=site.line,
+                    problem=(
+                        "registered readonly_uri but this connect call cannot be proven "
+                        "read-only (no resolvable mode=ro literal) -- a backslide from the "
+                        "declared disposition"
+                    ),
+                    remedy=(
+                        "open with a `file:...?mode=ro` URI, matching this file's other "
+                        "connect sites, or update the registry disposition if this call is "
+                        "legitimately writable"
+                    ),
+                )
+            )
+    return sorted(findings)
+
+
+def check_stale_dispositions(
+    sites: tuple[ConnectSite, ...] | None = None,
+    dispositions: dict[str, ConnectionDisposition] | None = None,
+) -> list[str]:
+    """Stale-row gate: a registered file must still contain a connect site.
+
+    :param sites: Connect sites to check (see :func:`check_unregistered_connections`;
+        memory sites count here -- ANY site keeps a row live).
+    :param dispositions: The registry to check against.
+    :returns: One finding per registry row whose file no longer has any site.
+    :raises SentinelCheckError: If the scan root is missing/unparseable.
+    """
+    if sites is None:
+        sites = find_connect_sites()
+    if dispositions is None:
+        dispositions = CONNECTION_DISPOSITIONS
+    files_with_any_site = {site.file for site in sites}
+    findings: list[str] = []
+    for file, row in sorted(dispositions.items()):
+        if file in files_with_any_site:
+            continue
+        findings.append(
+            finding(
+                error_class="stale-disposition",
+                symbol=row.disposition,
+                file=file,
+                line=0,
+                problem=(
+                    "registry declares a disposition but the file no longer contains any "
+                    "sqlite3.connect/create_engine(sqlite) call -- the row has drifted stale"
+                ),
+                remedy=(
+                    "remove the stale ConnectionDisposition row from registry.py, or verify "
+                    "whether the connection moved to another file and register it there instead"
+                ),
+            )
+        )
+    return sorted(findings)
+
+
+#: All three rules gate (task #64: this is the "grows with the codebase"
+#: mechanism -- an unregistered/backslid/stale row is a live defect, not
+#: advisory noise).
+_GATING_CHECKS: Final[tuple[LabelledCheck, ...]] = (
+    ("unregistered sqlite connect site", check_unregistered_connections),
+    ("readonly_uri backslide", check_readonly_backslide),
+    ("stale disposition row", check_stale_dispositions),
+)
+
+#: Nothing advisory -- all three rules gate.
+_ADVISORY_CHECKS: Final[tuple[LabelledCheck, ...]] = ()
+
+
+def _summary(advisory_count: int) -> str:
+    """Build the clean one-line summary printed when nothing gated.
+
+    :param advisory_count: Number of advisory findings (0 -- no advisory tier).
+    :returns: The summary line naming the scan size.
+    """
+    _ = advisory_count  # This sentinel declares no advisory tier.
+    sites = find_connect_sites()
+    non_memory_files = {site.file for site in sites if site.classification != "memory"}
+    return (
+        f"Absence clean: {len(non_memory_files)} file(s) with a non-memory sqlite connect "
+        f"site, {len(CONNECTION_DISPOSITIONS)} declared disposition(s) -- every hit is "
+        "registered, every readonly_uri file stays read-only, no stale rows."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the absence gate and return the process exit code.
+
+    :param argv: CLI args (``--check`` accepted for family symmetry; this
+        sensor always gates regardless).
+    :returns: 0 clean, 1 gating violations found, 2 infrastructure failure.
+    """
+    parser = argparse.ArgumentParser(
+        description="Absence -- every sqlite connect site carries a cited disposition.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="CI-mode alias; the tool always gates (exit 1 on violations).",
+    )
+    parser.parse_args(argv)
+    return run_sensor("ABSENCE", _GATING_CHECKS, _ADVISORY_CHECKS, _summary)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/babylon/sentinels/absence/registry.py
+++ b/src/babylon/sentinels/absence/registry.py
@@ -1,0 +1,239 @@
+"""Declared invariants of the ``absence`` sentinel — every sqlite connect
+site carries a cited disposition.
+
+Founding incident (2026-07-20, G1 nightly): ``SubstrateSystem``'s lattice
+build called ``get_reference_session()`` on a CI runner with no reference
+database. ``sqlite3.connect``/SQLAlchemy's ``create_engine("sqlite:///path")``
+both silently CREATE an empty file when the path is missing — the runner got
+a lattice build against a brand-new, table-less SQLite file instead of a
+loud "database not found", and the real failure only surfaced two systems
+later as a baffling ``no such table: dim_county``. Part A of task #64 closed
+the one constitutional entry point (``get_reference_session``, see
+:mod:`babylon.reference.database`); this registry is the family-wide audit
+trail that every OTHER sqlite connect site in ``src/babylon`` has been looked
+at and classified, so a new unguarded site can never join the tree silently
+again.
+
+Every ``sqlite3.connect``/``create_engine("sqlite:///...")`` call site under
+``src/babylon`` (found by :func:`babylon.sentinels.absence.checks.
+find_connect_sites`) must be accounted for by exactly one row here, keyed by
+its repo-relative file path. :data:`Disposition` is a closed taxonomy:
+
+- ``"canonical"``: the file OWNS the constitutional absence guard (currently
+  just ``reference/database.py`` — ``get_reference_session`` per part A).
+- ``"guarded"``: an explicit ``if not path.exists(): raise FileNotFoundError``
+  precedes every connect in this file (model:
+  ``engine/headless_runner/scopes.py:170``).
+- ``"readonly_uri"``: every connect in this file opens a ``file:...?mode=ro``
+  URI — SQLite refuses to create a database file under a read-only-mode URI,
+  so an absent file fails loudly on its own even without an explicit guard.
+- ``"creates_own_store"``: creation IS the correct behavior here — this is
+  the file's own runtime state, not immutable reference data (ADR030/031).
+- ``"declared_debt"``: neither guarded nor read-only — a real, open absence
+  risk, held here by name (Constitution III.11: loud, not silently fixed or
+  silently ignored) with the remediation named in ``reason``.
+
+Layer 0.5: imports nothing above the stdlib — no row here needs a live model
+import (unlike the vocabulary sentinel's ``NodeType``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal, get_args
+
+#: The closed disposition taxonomy — see the module docstring for what each
+#: value asserts and what evidence it demands.
+Disposition = Literal["readonly_uri", "guarded", "creates_own_store", "canonical", "declared_debt"]
+
+_VALID_DISPOSITIONS: Final[frozenset[str]] = frozenset(get_args(Disposition))
+
+
+@dataclass(frozen=True)
+class ConnectionDisposition:
+    """One file's declared, evidence-cited sqlite-connection disposition.
+
+    :ivar file: Repo-relative ``.py`` path — must equal the
+        :data:`CONNECTION_DISPOSITIONS` dict key it is stored under.
+    :ivar disposition: The disposition category, see :data:`Disposition`.
+    :ivar reason: The cited evidence — line numbers, why this is safe (or
+        not), and for ``declared_debt`` rows, the named remediation.
+    """
+
+    file: str
+    disposition: Disposition
+    reason: str
+
+    def __post_init__(self) -> None:
+        """Reject a malformed row loudly at import (Constitution III.11).
+
+        :raises ValueError: If ``file``/``reason`` is blank, ``file`` is not
+            a ``.py`` path, or ``disposition`` is not a member of
+            :data:`Disposition`.
+        """
+        if not self.file.strip():
+            raise ValueError("ConnectionDisposition.file must be non-empty")
+        if not self.file.endswith(".py"):
+            raise ValueError(f"{self.file!r}: file must be a .py path")
+        if not self.reason.strip():
+            raise ValueError(f"{self.file!r}: reason must be non-empty")
+        if self.disposition not in _VALID_DISPOSITIONS:
+            raise ValueError(
+                f"{self.file!r}: disposition {self.disposition!r} not one of "
+                f"{sorted(_VALID_DISPOSITIONS)}"
+            )
+
+
+def _build_registry(
+    rows: tuple[ConnectionDisposition, ...],
+) -> dict[str, ConnectionDisposition]:
+    """Key declared rows by file, failing loudly on a duplicate.
+
+    :param rows: The declared rows (single source of truth order).
+    :returns: The rows keyed by :attr:`ConnectionDisposition.file`.
+    :raises ValueError: If two rows declare the same file.
+    """
+    registry: dict[str, ConnectionDisposition] = {}
+    for row in rows:
+        if row.file in registry:
+            raise ValueError(f"absence sentinel: duplicate registry row for {row.file!r}")
+        registry[row.file] = row
+    return registry
+
+
+#: One row per audited file (task #64 census, 2026-07-20). Every claim below
+#: was re-verified against the tree with ``rg`` before being written here —
+#: three files a prior draft census reasoned were "unguarded writable"
+#: (``hex_hydrator.py``, ``county_aggregation.py``, ``tiger_ingestion.py``)
+#: turned out, on inspection, to carry the exact same
+#: ``if not path.exists(): raise FileNotFoundError`` guard as
+#: ``scopes.py`` — they are filed ``guarded``, not ``declared_debt`` (see
+#: each row's own ``reason`` for the correction). Two files absent from that
+#: draft census (``reference_data_cache.py``, ``natural_earth_reader.py``)
+#: were found by the ``rg`` sweep and are filed here too.
+_ROWS: Final[tuple[ConnectionDisposition, ...]] = (
+    ConnectionDisposition(
+        file="src/babylon/reference/database.py",
+        disposition="canonical",
+        reason=(
+            "get_reference_session() (task #64 part A) raises FileNotFoundError before "
+            "opening a session when NORMALIZED_DB_PATH is absent -- this file OWNS the "
+            "constitutional reference-DB absence guard. get_normalized_engine()/"
+            "get_source_engine() (create_engine at ~lines 100/127) legitimately auto-create "
+            "via SQLAlchemy for loader tools (init_normalized_db, migration scripts) -- "
+            "ADR098 loader doctrine: a loader writing the DB for the first time is supposed "
+            "to create it."
+        ),
+    ),
+    ConnectionDisposition(
+        file="src/babylon/engine/headless_runner/scopes.py",
+        disposition="guarded",
+        reason=(
+            "_load_national_fips raises FileNotFoundError at ~line 169 "
+            "(`if not sqlite_path.exists(): raise ...`) immediately before "
+            "sqlite3.connect at ~line 173 -- the model case part A's runtime guard is "
+            "patterned on."
+        ),
+    ),
+    ConnectionDisposition(
+        file="src/babylon/engine/headless_runner/reference_data_cache.py",
+        disposition="guarded",
+        reason=(
+            "Not in the original task census -- found by the rg sweep (task #64). "
+            "ReferenceDataCache.hydrate() raises FileNotFoundError at ~line 178 "
+            "(`if not self._sqlite_path.exists(): raise ...`) immediately before "
+            "sqlite3.connect at ~line 204 -- the same in-function guard shape as scopes.py."
+        ),
+    ),
+    ConnectionDisposition(
+        file="src/babylon/domain/geography/natural_earth_reader.py",
+        disposition="guarded",
+        reason=(
+            "Not in the original task census -- found by the rg sweep (task #64). "
+            "NaturalEarthReader.__init__ raises FileNotFoundError at ~line 149 "
+            "(`if not self._db_path.exists(): raise ...`) before any instance can call "
+            "_connect() (~line 156); _connect() also opens a `file:...?mode=ro` URI, though "
+            "that literal is one variable assignment away from the connect call and "
+            "therefore invisible to this sentinel's own single-hop literal resolution -- the "
+            "constructor guard is what this row rests on, not the (real but "
+            "statically-unprovable) read-only mode."
+        ),
+    ),
+    ConnectionDisposition(
+        file="src/babylon/persistence/runtime_db.py",
+        disposition="creates_own_store",
+        reason=(
+            "RuntimeDatabase creates a per-simulation-run tick-store SQLite file (or "
+            ":memory: for tests) at ~lines 79/83 -- this is the RUN's own state (ADR030/031 "
+            "Unified SQLite Runtime), never immutable reference data. Creation-on-first-use "
+            "is the correct, intended behavior here, not an absence bug."
+        ),
+    ),
+    ConnectionDisposition(
+        file="src/babylon/persistence/postgres_initialization.py",
+        disposition="declared_debt",
+        reason=(
+            "Four sqlite3.connect calls (~lines 136, 217, 276, 398) use `file:...?mode=ro` "
+            "URIs -- safe, cannot auto-create. The bea_engine "
+            "`create_engine(f'sqlite:///{sqlite_path}')` at ~line 850 is an unguarded, "
+            "writable-mode read path (no existence check, no mode=ro) -- genuine debt. "
+            "Remediation: convert to a read-only URI, mirroring this file's own four "
+            "sqlite3.connect siblings."
+        ),
+    ),
+    ConnectionDisposition(
+        file="src/babylon/persistence/sqlite_hydrator.py",
+        disposition="readonly_uri",
+        reason="sqlite3.connect opens a `file:...?mode=ro` URI at ~line 45.",
+    ),
+    ConnectionDisposition(
+        file="src/babylon/domain/economics/county_exposure.py",
+        disposition="readonly_uri",
+        reason="sqlite3.connect opens a `file:...?mode=ro` URI at ~line 105.",
+    ),
+    ConnectionDisposition(
+        file="src/babylon/sentinels/coverage/db_probe.py",
+        disposition="readonly_uri",
+        reason="sqlite3.connect opens a `file:...?mode=ro` URI at ~line 75.",
+    ),
+    ConnectionDisposition(
+        file="src/babylon/persistence/hex_hydrator.py",
+        disposition="guarded",
+        reason=(
+            "Corrected from the original task census's 'declared_debt' (unguarded writable) "
+            "-- rg verification (task #64) found hydrate_hex_state raises FileNotFoundError "
+            "at ~line 161 (`if not sqlite_path_resolved.exists(): raise ...`) immediately "
+            "before sqlite3.connect at ~line 175, the same guard shape as scopes.py. Still "
+            "lacks a mode=ro URI (a real defense-in-depth gap), but the existence guard "
+            "already prevents the auto-create-masks-absence bug this sentinel targets."
+        ),
+    ),
+    ConnectionDisposition(
+        file="src/babylon/persistence/county_aggregation.py",
+        disposition="guarded",
+        reason=(
+            "Corrected from the original task census's 'declared_debt' (unguarded writable) "
+            "-- rg verification (task #64) found BOTH sqlite3.connect call sites "
+            "(~lines 303, 386) directly preceded, in the same function, by "
+            "`if not sqlite_path.exists(): raise FileNotFoundError(...)` (~lines 298, 381) -- "
+            "the same guard shape as scopes.py. Still lacks a mode=ro URI, same "
+            "defense-in-depth note as hex_hydrator.py."
+        ),
+    ),
+    ConnectionDisposition(
+        file="src/babylon/persistence/tiger_ingestion.py",
+        disposition="guarded",
+        reason=(
+            "Corrected from the original task census's 'declared_debt' (unguarded writable) "
+            "-- rg verification (task #64) found the TIGER-geometry reader raises "
+            "FileNotFoundError at ~lines 198-202 (`if not path.exists(): raise ...`) "
+            "immediately before sqlite3.connect at ~line 219, the same guard shape as "
+            "scopes.py -- this is a loader-ADJACENT reader (loads existing TIGER rows to "
+            "insert into Postgres), not itself a table-creating loader, so ADR098 loader "
+            "doctrine does not apply here; the existence guard is what makes this safe."
+        ),
+    ),
+)
+
+#: The audited registry, keyed by repo-relative file path.
+CONNECTION_DISPOSITIONS: Final[dict[str, ConnectionDisposition]] = _build_registry(_ROWS)

--- a/tests/unit/reference/test_reference_db_absence.py
+++ b/tests/unit/reference/test_reference_db_absence.py
@@ -1,0 +1,118 @@
+"""Tests for ``get_reference_session``'s absence guard (task #64).
+
+Founding incident (2026-07-20, G1 nightly): ``SubstrateSystem``'s lattice
+build called ``get_reference_session()`` on a runner with no reference
+database. ``sqlite3.connect()``/SQLAlchemy's
+``create_engine("sqlite:///path")`` both silently CREATE an empty file when
+the path is missing -- the runner got a lattice build against a brand-new,
+table-less SQLite file instead of a loud "database not found", and the real
+failure only surfaced two systems later as a baffling
+``no such table: dim_county``.
+
+These tests pin the RED->GREEN fix: ``get_reference_session()`` must raise
+``FileNotFoundError`` BEFORE ever opening a connection, and must never create
+the missing file as a side effect. Every test that needs to prove the file
+was (or was not) touched forces a real connection with a trivial
+``SELECT 1`` -- ``create_engine()``/``sessionmaker()`` are both lazy in
+SQLAlchemy and never open the underlying file on their own, so a test that
+never executes anything would pass "by accident" whether or not the guard
+exists.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+
+import babylon.reference.database as db_module
+from babylon.reference.database import get_reference_session
+
+pytestmark = pytest.mark.unit
+
+
+def _point_at(monkeypatch: pytest.MonkeyPatch, db_path: Path) -> None:
+    """Point the module at ``db_path`` and clear its lazily-cached globals.
+
+    ``get_reference_session`` resolves its DB through four module globals
+    that are each read/created only ONCE and then cached:
+    ``NORMALIZED_DB_PATH`` (read by the absence guard itself, at call time),
+    ``NORMALIZED_DATABASE_URL`` (the SQLAlchemy URL ``get_normalized_engine``
+    builds ``create_engine`` from), and the ``_normalized_engine`` /
+    ``_NormalizedSessionLocal`` memoization slots. All four must move
+    together, or a stale cached engine from an earlier test/import would
+    silently keep pointing at the OLD path while the guard checks the NEW
+    one.
+
+    :param monkeypatch: The test's monkeypatch fixture.
+    :param db_path: The path to point the module at.
+    """
+    monkeypatch.setattr(db_module, "NORMALIZED_DB_PATH", db_path)
+    monkeypatch.setattr(db_module, "NORMALIZED_DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(db_module, "_normalized_engine", None)
+    monkeypatch.setattr(db_module, "_NormalizedSessionLocal", None)
+
+
+def test_get_reference_session_raises_loudly_on_absent_db(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No auto-create: an absent reference DB is a loud ``FileNotFoundError``."""
+    missing = tmp_path / "does-not-exist.sqlite"
+    _point_at(monkeypatch, missing)
+
+    with (
+        pytest.raises(FileNotFoundError, match=r"does-not-exist\.sqlite"),
+        get_reference_session() as session,
+    ):
+        session.execute(text("SELECT 1"))
+
+
+def test_get_reference_session_error_names_the_documented_remedies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The error names every documented remedy, not just "it's missing"."""
+    missing = tmp_path / "does-not-exist.sqlite"
+    _point_at(monkeypatch, missing)
+
+    with pytest.raises(FileNotFoundError) as exc_info, get_reference_session() as session:
+        session.execute(text("SELECT 1"))
+
+    message = str(exc_info.value)
+    assert "mise run data:build-db" in message
+    assert "fetch-reference-db" in message
+    assert "BABYLON_NORMALIZED_DB_PATH" in message
+
+
+def test_get_reference_session_does_not_create_the_missing_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The auto-create IS the bug: the guard must fire before any sqlite touch."""
+    missing = tmp_path / "does-not-exist.sqlite"
+    _point_at(monkeypatch, missing)
+
+    with pytest.raises(FileNotFoundError), get_reference_session() as session:
+        session.execute(text("SELECT 1"))
+
+    assert not missing.exists(), (
+        "get_reference_session() created the missing DB file as a side effect -- "
+        "the guard must run BEFORE any sqlite3/create_engine call"
+    )
+
+
+def test_get_reference_session_opens_fine_when_db_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A real (even minimal) DB file at the resolved path still opens normally."""
+    present = tmp_path / "present.sqlite"
+    conn = sqlite3.connect(present)
+    conn.execute("CREATE TABLE dim_county (fips TEXT PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+
+    _point_at(monkeypatch, present)
+
+    with get_reference_session() as session:
+        result = session.execute(text("SELECT COUNT(*) FROM dim_county")).scalar()
+        assert result == 0

--- a/tests/unit/sentinels/test_absence_sentinel.py
+++ b/tests/unit/sentinels/test_absence_sentinel.py
@@ -1,0 +1,336 @@
+"""Tests for the absence sentinel (task #64): every sqlite connect site
+carries a cited disposition.
+
+Founding incident (2026-07-20, G1 nightly): ``SubstrateSystem``'s lattice
+build called ``get_reference_session()`` on a runner with no reference
+database. ``sqlite3.connect``/SQLAlchemy's ``create_engine("sqlite:///path")``
+both silently CREATE an empty file when the path is missing, so the absence
+surfaced two systems later as a baffling ``no such table: dim_county``
+instead of a loud error at the point of connection. Part A of task #64 fixed
+the one entry point that bit; this file tests the STATIC scanner that keeps
+every OTHER sqlite connect site under ``src/babylon`` honest.
+
+Three tiers, mirroring the family's own established shape
+(``test_dangling.py``):
+
+- **Efficacy** (:func:`find_connect_sites` against synthetic ``tmp_path``
+  trees) — the scanner correctly classifies each syntactic form.
+- **Regression** (injected registry rows against synthetic sites) — proves
+  each of the three gating rules actually reds on a genuine violation and
+  stays clean on a genuine pass, independent of the live registry's state.
+- **Liveness** (the real, shipped registry against the real tree) — the
+  scan is clean on the integrated repo, proving the sentinel actually
+  functions against production source, not only synthetic fixtures.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from babylon.sentinels.absence.checks import (
+    ConnectSite,
+    check_readonly_backslide,
+    check_stale_dispositions,
+    check_unregistered_connections,
+    find_connect_sites,
+    main,
+)
+from babylon.sentinels.absence.registry import (
+    CONNECTION_DISPOSITIONS,
+    ConnectionDisposition,
+    _build_registry,
+)
+from babylon.sentinels.base import SentinelCheckError
+
+pytestmark = pytest.mark.unit
+
+_TOOLS_DIR = Path(__file__).resolve().parents[3] / "tools"
+_TOOL_PATH = _TOOLS_DIR / "sentinel_check.py"
+
+
+def _write_src(tmp_path: Path, source: str, name: str = "sample.py") -> Path:
+    """Write a synthetic module under ``tmp_path/src/babylon/<name>``.
+
+    :param tmp_path: The pytest tmp_path fixture root.
+    :param source: The module source to write.
+    :param name: The filename (may include subdirectories).
+    :returns: The written file's path.
+    """
+    path = tmp_path / "src" / "babylon" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# find_connect_sites -- scanner efficacy
+# ---------------------------------------------------------------------------
+
+
+def test_memory_literal_is_classified_memory(tmp_path: Path) -> None:
+    """MUTATION: an exact `:memory:` literal auto-passes."""
+    _write_src(tmp_path, "import sqlite3\nsqlite3.connect(':memory:')\n")
+    sites = find_connect_sites(repo_root=tmp_path)
+    assert sites == (ConnectSite("src/babylon/sample.py", 2, "sqlite3.connect", "memory"),)
+
+
+def test_readonly_uri_literal_is_classified_readonly(tmp_path: Path) -> None:
+    """MUTATION: a `mode=ro` f-string URI is classified readonly."""
+    _write_src(
+        tmp_path,
+        "import sqlite3\n"
+        "sqlite_path = '/tmp/x.sqlite'\n"
+        "sqlite3.connect(f'file:{sqlite_path}?mode=ro', uri=True)\n",
+    )
+    sites = find_connect_sites(repo_root=tmp_path)
+    assert sites == (ConnectSite("src/babylon/sample.py", 3, "sqlite3.connect", "readonly"),)
+
+
+def test_unresolvable_argument_is_classified_writable(tmp_path: Path) -> None:
+    """MUTATION: a bare Name argument (no literal to resolve) defaults writable --
+    absence of proof of safety is not proof of safety."""
+    _write_src(
+        tmp_path,
+        "import sqlite3\ndef f(path):\n    return sqlite3.connect(path)\n",
+    )
+    sites = find_connect_sites(repo_root=tmp_path)
+    assert sites == (ConnectSite("src/babylon/sample.py", 3, "sqlite3.connect", "writable"),)
+
+
+def test_create_engine_sqlite_literal_is_a_hit(tmp_path: Path) -> None:
+    """MUTATION: create_engine with an inline sqlite f-string literal is a hit."""
+    _write_src(
+        tmp_path,
+        "from sqlalchemy import create_engine\n"
+        "path = '/tmp/x.sqlite'\n"
+        "create_engine(f'sqlite:///{path}')\n",
+    )
+    sites = find_connect_sites(repo_root=tmp_path)
+    assert sites == (ConnectSite("src/babylon/sample.py", 3, "create_engine", "writable"),)
+
+
+def test_create_engine_resolves_module_level_name_binding(tmp_path: Path) -> None:
+    """MUTATION: create_engine(NAME) resolves NAME through a module-level
+    assignment -- the exact reference/database.py NORMALIZED_DATABASE_URL shape."""
+    _write_src(
+        tmp_path,
+        "from sqlalchemy import create_engine\n"
+        "DB_URL = f'sqlite:///{1}'\n"
+        "def get_engine():\n"
+        "    return create_engine(DB_URL)\n",
+    )
+    sites = find_connect_sites(repo_root=tmp_path)
+    assert sites == (ConnectSite("src/babylon/sample.py", 4, "create_engine", "writable"),)
+
+
+def test_create_engine_over_non_sqlite_literal_is_not_a_hit(tmp_path: Path) -> None:
+    """create_engine("postgresql://...") is out of this sentinel's scope entirely."""
+    _write_src(
+        tmp_path,
+        "from sqlalchemy import create_engine\ncreate_engine('postgresql:///db')\n",
+    )
+    assert find_connect_sites(repo_root=tmp_path) == ()
+
+
+def test_create_engine_over_unresolvable_name_is_not_a_hit(tmp_path: Path) -> None:
+    """create_engine(url) over an opaque parameter cannot be proven sqlite --
+    the persistence/database.py DatabaseConnection wrapper shape."""
+    _write_src(
+        tmp_path,
+        "from sqlalchemy import create_engine\ndef f(url):\n    return create_engine(url)\n",
+    )
+    assert find_connect_sites(repo_root=tmp_path) == ()
+
+
+def test_scan_raises_on_missing_scan_root(tmp_path: Path) -> None:
+    with pytest.raises(SentinelCheckError):
+        find_connect_sites(repo_root=tmp_path, scan_root="nowhere")
+
+
+def test_scan_raises_on_unparseable_source(tmp_path: Path) -> None:
+    _write_src(tmp_path, "def (:\n", name="broken.py")
+    with pytest.raises(SentinelCheckError):
+        find_connect_sites(repo_root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Regression: the three gating rules against synthetic sites + registries
+# ---------------------------------------------------------------------------
+
+
+def test_unregistered_writable_connection_is_flagged() -> None:
+    """Growth gate: a file with a writable hit and no registry row reds."""
+    sites = (ConnectSite("src/babylon/unregistered.py", 10, "sqlite3.connect", "writable"),)
+    violations = check_unregistered_connections(sites=sites, dispositions={})
+    assert len(violations) == 1
+    assert "src/babylon/unregistered.py" in violations[0]
+    assert "unregistered-connection" in violations[0]
+
+
+def test_memory_only_file_needs_no_registration() -> None:
+    """A file whose only site is `:memory:` is never required to register."""
+    sites = (ConnectSite("src/babylon/scratch.py", 5, "sqlite3.connect", "memory"),)
+    assert check_unregistered_connections(sites=sites, dispositions={}) == []
+
+
+def test_registered_file_is_not_flagged_as_unregistered() -> None:
+    sites = (ConnectSite("src/babylon/known.py", 5, "sqlite3.connect", "writable"),)
+    dispositions = {
+        "src/babylon/known.py": ConnectionDisposition(
+            file="src/babylon/known.py", disposition="declared_debt", reason="test row"
+        )
+    }
+    assert check_unregistered_connections(sites=sites, dispositions=dispositions) == []
+
+
+def test_readonly_uri_file_with_a_writable_site_backslides() -> None:
+    """Backslide gate: a readonly_uri-registered file must have EVERY hit read-only."""
+    sites = (
+        ConnectSite("src/babylon/reader.py", 8, "sqlite3.connect", "readonly"),
+        ConnectSite("src/babylon/reader.py", 20, "sqlite3.connect", "writable"),
+    )
+    dispositions = {
+        "src/babylon/reader.py": ConnectionDisposition(
+            file="src/babylon/reader.py", disposition="readonly_uri", reason="test row"
+        )
+    }
+    violations = check_readonly_backslide(sites=sites, dispositions=dispositions)
+    assert len(violations) == 1
+    assert "src/babylon/reader.py:20" in violations[0]
+    assert "readonly-backslide" in violations[0]
+
+
+def test_readonly_uri_file_all_readonly_passes() -> None:
+    sites = (ConnectSite("src/babylon/reader.py", 8, "sqlite3.connect", "readonly"),)
+    dispositions = {
+        "src/babylon/reader.py": ConnectionDisposition(
+            file="src/babylon/reader.py", disposition="readonly_uri", reason="test row"
+        )
+    }
+    assert check_readonly_backslide(sites=sites, dispositions=dispositions) == []
+
+
+def test_non_readonly_uri_disposition_is_never_checked_for_backslide() -> None:
+    """A declared_debt/guarded/etc row's writable sites are its own documented
+    debt, not a backslide from a readonly_uri promise that was never made."""
+    sites = (ConnectSite("src/babylon/debt.py", 8, "sqlite3.connect", "writable"),)
+    dispositions = {
+        "src/babylon/debt.py": ConnectionDisposition(
+            file="src/babylon/debt.py", disposition="declared_debt", reason="test row"
+        )
+    }
+    assert check_readonly_backslide(sites=sites, dispositions=dispositions) == []
+
+
+def test_stale_registry_row_is_flagged() -> None:
+    """Stale-row gate: a registered file with zero remaining hits reds."""
+    dispositions = {
+        "src/babylon/gone.py": ConnectionDisposition(
+            file="src/babylon/gone.py", disposition="guarded", reason="test row"
+        )
+    }
+    violations = check_stale_dispositions(sites=(), dispositions=dispositions)
+    assert len(violations) == 1
+    assert "src/babylon/gone.py" in violations[0]
+    assert "stale-disposition" in violations[0]
+
+
+def test_registered_file_with_a_remaining_hit_is_not_stale() -> None:
+    sites = (ConnectSite("src/babylon/live.py", 3, "sqlite3.connect", "writable"),)
+    dispositions = {
+        "src/babylon/live.py": ConnectionDisposition(
+            file="src/babylon/live.py", disposition="declared_debt", reason="test row"
+        )
+    }
+    assert check_stale_dispositions(sites=sites, dispositions=dispositions) == []
+
+
+def test_memory_only_site_still_keeps_a_registered_row_live() -> None:
+    """Unlike the growth gate, staleness counts a :memory: site as "still here"."""
+    sites = (ConnectSite("src/babylon/scratch.py", 3, "sqlite3.connect", "memory"),)
+    dispositions = {
+        "src/babylon/scratch.py": ConnectionDisposition(
+            file="src/babylon/scratch.py", disposition="creates_own_store", reason="test row"
+        )
+    }
+    assert check_stale_dispositions(sites=sites, dispositions=dispositions) == []
+
+
+# ---------------------------------------------------------------------------
+# Registry shape teeth
+# ---------------------------------------------------------------------------
+
+
+def test_connection_disposition_rejects_blank_file() -> None:
+    with pytest.raises(ValueError, match="file"):
+        ConnectionDisposition(file="", disposition="guarded", reason="x")
+
+
+def test_connection_disposition_rejects_non_py_file() -> None:
+    with pytest.raises(ValueError, match="\\.py"):
+        ConnectionDisposition(file="src/babylon/x.txt", disposition="guarded", reason="x")
+
+
+def test_connection_disposition_rejects_blank_reason() -> None:
+    with pytest.raises(ValueError, match="reason"):
+        ConnectionDisposition(file="src/babylon/x.py", disposition="guarded", reason="  ")
+
+
+def test_connection_disposition_rejects_unknown_disposition() -> None:
+    with pytest.raises(ValueError, match="disposition"):
+        ConnectionDisposition(
+            file="src/babylon/x.py",
+            disposition="not_a_real_disposition",  # type: ignore[arg-type]
+            reason="x",
+        )
+
+
+def test_build_registry_rejects_duplicate_file_rows() -> None:
+    rows = (
+        ConnectionDisposition(file="src/babylon/x.py", disposition="guarded", reason="a"),
+        ConnectionDisposition(file="src/babylon/x.py", disposition="readonly_uri", reason="b"),
+    )
+    with pytest.raises(ValueError, match="duplicate"):
+        _build_registry(rows)
+
+
+def test_real_registry_has_no_duplicate_files() -> None:
+    """The shipped registry already passed this guard at import time -- this
+    test just makes that fact independently assertable, mirroring the
+    dangling sentinel's own `_unknown_member_classes` liveness pin."""
+    assert len(CONNECTION_DISPOSITIONS) > 0
+
+
+# ---------------------------------------------------------------------------
+# Liveness: the real, shipped registry against the current tree
+# ---------------------------------------------------------------------------
+
+
+def test_real_tree_is_clean() -> None:
+    """No unregistered/backslid/stale rows against the actual repo."""
+    assert check_unregistered_connections() == []
+    assert check_readonly_backslide() == []
+    assert check_stale_dispositions() == []
+
+
+def test_main_check_exits_zero_on_the_real_tree() -> None:
+    assert main(["--check"]) == 0
+
+
+def test_cli_entry_point_clean_on_live_tree() -> None:
+    """`sentinel_check.py absence --check` exits 0 on the integrated tree."""
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell, trusted path
+        [sys.executable, str(_TOOL_PATH), "absence", "--check"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        "expected the ABSENCE sensor to be clean on the integrated tree:\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "Absence clean" in result.stdout

--- a/tools/sentinel_check.py
+++ b/tools/sentinel_check.py
@@ -18,6 +18,7 @@ import argparse
 import sys
 from collections.abc import Callable
 
+from babylon.sentinels.absence.checks import main as absence_main
 from babylon.sentinels.aggregation.checks import main as aggregation_intensive_main
 from babylon.sentinels.coupling.checks import main as coupling_main
 from babylon.sentinels.coverage.checks import main as coverage_main
@@ -110,6 +111,7 @@ def _partition_main(argv: list[str] | None) -> int:
 
 #: Registered sentinels: name -> its ``main(argv)`` entry point.
 _SENSORS: dict[str, Callable[[list[str] | None], int]] = {
+    "absence": absence_main,
     "seam": seam_main,
     "coverage": coverage_main,
     "gate-coverage": gate_coverage_main,


### PR DESCRIPTION
## Founding incident

2026-07-20 G1 nightly (run 29781894207): `SubstrateSystem`'s lattice build called `get_reference_session()` on a runner with no reference DB. `sqlite3.connect()` / `create_engine("sqlite:///…")` silently **create an empty database** when the path is missing, so the failure surfaced two systems later as a baffling `no such table: dim_county`. This is the ADR098-declared `auto-create-masks-absence` follow-up (Task #64), executed as a Part A runtime fix + Part B sentinel family per the standing "sentinel every error CLASS" rule.

## Part A — `fix(reference)`: the constitutional entry point fails loudly

`get_reference_session()` now raises `FileNotFoundError` **before** any engine/session creation when `NORMALIZED_DB_PATH` is absent, naming three remedies (`mise run data:build-db`, the `fetch-reference-db` CI action, `BABYLON_NORMALIZED_DB_PATH`). `get_normalized_engine()`/`init_normalized_db()` untouched — loaders legitimately create the DB (ADR098 loader doctrine). 4 runtime tests force a real `SELECT 1` (SQLAlchemy engines are lazy — a test that never executes would pass with or without the guard) and pin the no-side-effect-creation property.

## Part B — `feat(sentinels)`: the absence family (15th sentinel)

`babylon.sentinels.absence` (house pattern: registry + checks + CLI + `check:sentinels-static` membership, so it gates in CI's fast lane): a closed-taxonomy `ConnectionDisposition` registry (canonical / guarded / readonly_uri / creates_own_store / declared_debt) over **every** `sqlite3.connect` / `create_engine(sqlite)` site under `src/babylon`, with three gating rules — growth (unregistered file = red), readonly-backslide (a `readonly_uri` file gaining a writable call = red), stale-row (registry row outliving its call sites = red; also catches scanner blindness regressions). Unresolvable arguments classify as *writable*: absence of proof of safety is not proof of safety.

## Census corrections (evidence over transcription)

The draft census called `hex_hydrator.py`, `county_aggregation.py`, `tiger_ingestion.py` "unguarded writable" — reading each file showed all three carry the identical `if not path.exists(): raise FileNotFoundError` guard as the model case (`scopes.py`). Corrected to `guarded` with line citations in each row's `reason`. Two files the census missed (`reference_data_cache.py`, `natural_earth_reader.py`) found by the sweep and registered. Final: 12 files, 12 dispositions, 0 violations.

**Open debt held loudly (owner-gated):** `postgres_initialization.py`'s `bea_engine` `create_engine(f"sqlite:///…")` is genuinely unguarded+writable — registered `declared_debt` with the remediation named (convert to `mode=ro` URI like its four sibling connects in the same file).

## Verification

- `mise run check` green post-rebase: **11,847 passed**, mypy strict clean (690 files), ruff clean, all 15 sentinels pass.
- **Mutation validation ×2:** (1) planted an unregistered `sqlite3.connect` in `capacity.py` → sentinel RED with correct file:line + remedy → reverted byte-identical → clean. (2) commented out Part A's guard → 3/4 runtime tests RED (`DID NOT RAISE`) → reverted → 4/4 green.
- Full report: `.superpowers/sdd/task-64-report.md` (local working notes — `.superpowers/` is gitignored); registry rows carry the citations.

## Reviewer notes (non-blocking, documented static limits)

The scanner resolves literals/f-strings + one module-level Name hop only. Bare-name `create_engine(...)` calls are matched; attribute-form `sqlalchemy.create_engine(...)` and kwarg-only `sqlite3.connect(database=…)` would be invisible — **no such forms exist in tree** (rg census), and the stale-row gate turns scanner blindness into a red row rather than silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)