### PR TITLE
fix(ci): submodule insteadOf must be --global — local config invisible to the spawned clone

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -174,7 +174,12 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "$INFRA_DEPLOY_KEY" > ~/.ssh/infra_deploy_key
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          git config url."git@github.com:percy-raskova/babylon-infra.git".insteadOf \
+          # --global, not local: `git submodule update` spawns a fresh clone
+          # subprocess that never reads the superproject's local config — a
+          # local insteadOf silently doesn't apply and the clone dies asking
+          # for https credentials (proven on the maiden run, job 88509068677).
+          git config --global \
+            url."git@github.com:percy-raskova/babylon-infra.git".insteadOf \
             "https://github.com/percy-raskova/babylon-infra.git"
           GIT_SSH_COMMAND="ssh -i ~/.ssh/infra_deploy_key -o IdentitiesOnly=yes" \
             git submodule update --init infra


### PR DESCRIPTION
One-hunk follow-up to #231: the maiden `rebuild-verify` run (job 88509068677) failed at the submodule fetch — `git submodule update` spawns a fresh `git clone` subprocess that never reads the superproject's **local** config, so the local `url.insteadOf` rewrite silently didn't apply and the clone attempted unauthenticated https. `GIT_SSH_COMMAND` (env-scoped) reached the subprocess; the config rewrite did not. Fix: `git config --global`, the documented pattern for submodule URL rewrites on ephemeral runners. Comment records the incident.

Will re-dispatch Nightly after merge and babysit the job to the sha-match verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)