### PR TITLE
feat(render): ADR097 render seam — tiers, probe-once, [render] config, PalettePlate, §9b

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -483,6 +483,17 @@ uv run pytest tests/scenarios \
   --html=reports/test-results/scenario/report.html --self-contained-html
 """
 
+[tasks."test:render"]
+description = "Render seam unit + snapshot tests (ADR097) → reports/test-results/render/"
+run = """
+mkdir -p reports/test-results/render
+uv run pytest tests/unit/render \
+  -vv --tb=long --showlocals --show-capture=all --capture=tee-sys -r aR --durations=25 \
+  --junit-xml=reports/test-results/render/junit.xml \
+  --json-report --json-report-file=reports/test-results/render/report.json --json-report-indent=2 \
+  --html=reports/test-results/render/report.html --self-contained-html
+"""
+
 [tasks."test:all"]
 description = "All non-AI tests → reports/test-results/all/"
 run = """

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -167,6 +167,12 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
+        # __snapshots__/*.raw: pytest-textual-snapshot goldens (ADR097/ADR099, III.13
+        # determinism). Rich's SVG export template emits a static whitespace-only line
+        # unconditionally; trimming it here would desync the committed golden from every
+        # future --snapshot-update byte-for-byte, breaking the same-state-same-bytes
+        # contract. Excluded, not fixed: this is generated/vendored, not hand-authored.
+        exclude: ^tests/.*/__snapshots__/.*\.raw$
       - id: end-of-file-fixer
       - id: check-yaml
         args: [--unsafe]  # Allow custom tags in GitHub Actions

--- a/project/research/16-living-map/DESIGN_BIBLE.md
+++ b/project/research/16-living-map/DESIGN_BIBLE.md
@@ -313,6 +313,29 @@ Cold Collapse canon tokens REMAIN (contract add-only; wire/dialectic/data ramps 
 their language). The CHROME skin moves to ksbc: crimson borders, gold selection/action,
 near-black field. §6's "cyan on frames" clause is superseded for chrome.
 
+### Degraded palette (256-color, ADR097 D5)
+
+The crimson/gold truecolor canon has a DECLARED 256-color fallback (ADR097 D5): terminals without
+truecolor render the same roles at their nearest xterm-256 index. This is honest degradation, never
+silent — `babylon doctor` prints the palette verdict. The mapping is computed by
+`nearest_xterm256` and lives in `babylon.render.tiers.DEGRADED_256_PALETTE` (the single source of
+truth; `tests/unit/render/test_design_bible_parity.py` fails if this table drifts from the code).
+
+| Role token | Truecolor | xterm-256 |
+|---|---|---|
+| `field` | #1a0000 | 232 |
+| `text` | #e8e8e8 | 254 |
+| `accent_crimson` | #dc143c | 161 |
+| `accent_gold` | #ffd700 | 220 |
+| `selection_text` | #000000 | 16 |
+| `muted_dim` | #404040 | 238 |
+| `muted_light` | #c0c0c0 | 250 |
+| `muted_dark` | #202020 | 234 |
+| `green_dark` | #228b22 | 28 |
+| `green_bright` | #32cd32 | 77 |
+| `royal` | #4169e1 | 62 |
+| `cyan` | #008b8b | 30 |
+
 ### The dialog anatomy (newt idiom → FloatingPanel/modal reskin)
 
 - **Dead space is composition**: takeovers, lobby, login, scenario select, endgame =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ dependencies = [
     "jinja2>=3.1.6,<4.0.0",
     "markdown-it-py>=4.2.0,<5.0.0",
     "mdit-py-plugins>=0.6.1,<0.7.0",
+    "textual-plotext>=1.0.1",
+    "pillow>=12.3.0",
+    "tomlkit>=0.15.1",
 ]
 
 [project.optional-dependencies]

--- a/src/babylon/cli/__init__.py
+++ b/src/babylon/cli/__init__.py
@@ -11,6 +11,8 @@ import typer
 
 from babylon import __version__
 from babylon.cli import play as play_cmd
+from babylon.render.session import set_render_override
+from babylon.render.tiers import RenderTier
 
 app = typer.Typer(
     name="babylon",
@@ -53,8 +55,16 @@ def main(
         is_eager=True,
         help="Show the Babylon version and exit.",
     ),
+    # noqa: B008 below — typer's DI-style Option() default; ruff's bugbear allowlist for
+    # Option/Argument defaults doesn't cover Enum-typed params (verified: str/bool are exempt).
+    render: RenderTier | None = typer.Option(  # noqa: B008
+        None,
+        "--render",
+        help="Override the persisted render tier for this session (glyph|pixel).",
+    ),
 ) -> None:
     """Babylon CLI root. With no subcommand, launches the game (play)."""
+    set_render_override(render)
     if ctx.invoked_subcommand is None:
         play_cmd.run()
 

--- a/src/babylon/cli/doctor.py
+++ b/src/babylon/cli/doctor.py
@@ -21,6 +21,8 @@ from babylon.intelligence.providers import (
     resolve_provider,
 )
 from babylon.intelligence.provision import default_models_dir, provision_models
+from babylon.render.config import render_config_path
+from babylon.render.doctor import run_render_probe
 
 #: soft_wrap avoids Rich's default 80-column word-wrap splitting long config
 #: paths (e.g. deep tmp_path fixtures, nested XDG dirs) across lines; disabling
@@ -92,5 +94,9 @@ def doctor(
         for result in results:
             style = "yellow" if result.status == "gated" else "green"
             console.print(f"  [{style}]{result.name}: {result.status}[/{style}] — {result.detail}")
+
+    # --- ADR097: render capability probe (probe-once; runtime never re-probes) ---
+    for render_line in run_render_probe(os.environ, config_path=render_config_path(os.environ)):
+        console.print(render_line)
 
     raise typer.Exit(code=0)

--- a/src/babylon/render/__init__.py
+++ b/src/babylon/render/__init__.py
@@ -1,0 +1,1 @@
+"""The render seam (ADR097): tier model, capability probe, config, widgets."""

--- a/src/babylon/render/capability.py
+++ b/src/babylon/render/capability.py
@@ -1,0 +1,139 @@
+"""Probe-once terminal capability detection (ADR097 D4).
+
+``probe`` is a pure function over an environment mapping plus an injected
+``TerminalQuerier``; it is run exactly once by ``babylon doctor`` and its verdict
+is persisted to config. Runtime never re-probes (no silent tier switches). The
+concrete ``TextualImageQuerier`` is the only part that touches a real terminal and
+is therefore not unit-tested; the pure core is fully covered by env-dict cases.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from collections.abc import Mapping
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict
+
+from babylon.render.tiers import PaletteTier, RenderTier
+
+logger = logging.getLogger("babylon.render.capability")
+
+_TRUECOLOR_TOKENS = frozenset({"truecolor", "24bit"})
+
+
+class CapabilityReport(BaseModel):
+    """Frozen record of one probe. Persisted (as evidence) into ``[render]``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    term: str
+    colorterm: str
+    truecolor: bool
+    has_256: bool
+    in_tmux: bool
+    is_tty: bool
+    pixel_protocol: str | None
+
+
+@runtime_checkable
+class TerminalQuerier(Protocol):
+    """Injection seam for the two facts a probe cannot read from env alone."""
+
+    def is_a_tty(self) -> bool: ...
+
+    def detect_pixel_protocol(self) -> str | None: ...
+
+
+def probe(env: Mapping[str, str], queries: TerminalQuerier) -> CapabilityReport:
+    """Derive a single capability verdict from env + the injected querier."""
+    term = env.get("TERM", "")
+    colorterm = env.get("COLORTERM", "")
+    truecolor = colorterm.strip().lower() in _TRUECOLOR_TOKENS
+    has_256 = truecolor or "256color" in term
+    in_tmux = "TMUX" in env or term.startswith(("tmux", "screen"))
+    is_tty = queries.is_a_tty()
+
+    # Guard: only consult the pixel query on a real TTY outside tmux. Non-TTY
+    # (CI/pipes) and tmux passthrough are treated as honest glyph (III.11).
+    pixel_protocol: str | None = None
+    if is_tty and not in_tmux:
+        pixel_protocol = queries.detect_pixel_protocol()
+
+    return CapabilityReport(
+        term=term,
+        colorterm=colorterm,
+        truecolor=truecolor,
+        has_256=has_256,
+        in_tmux=in_tmux,
+        is_tty=is_tty,
+        pixel_protocol=pixel_protocol,
+    )
+
+
+def derive_tiers(report: CapabilityReport) -> tuple[RenderTier, PaletteTier]:
+    """Map a report to the persisted (render tier, palette tier) pair."""
+    tier = RenderTier.PIXEL if report.pixel_protocol else RenderTier.GLYPH
+    palette = PaletteTier.TRUECOLOR if report.truecolor else PaletteTier.DEGRADED_256
+    return tier, palette
+
+
+def verdict_lines(report: CapabilityReport, tier: RenderTier, palette: PaletteTier) -> list[str]:
+    """Human-readable doctor verdict — degradation is always stated aloud."""
+    lines = [
+        f"render tier: {tier.value}",
+        f"palette: {palette.value}",
+        (
+            f"evidence: TERM={report.term or '(unset)'} "
+            f"COLORTERM={report.colorterm or '(unset)'} "
+            f"tty={report.is_tty} tmux={report.in_tmux} "
+            f"pixel-protocol={report.pixel_protocol or 'none'}"
+        ),
+    ]
+    if palette is PaletteTier.DEGRADED_256:
+        lines.append(
+            "note: degraded — no truecolor detected; using the declared 256-color "
+            "palette (DESIGN_BIBLE §9b)."
+        )
+    if tier is RenderTier.GLYPH and report.pixel_protocol is None and report.is_tty:
+        lines.append(
+            "note: degraded — no pixel protocol; Tier-0 glyph canon carries all "
+            "information (ADR097 D1)."
+        )
+    return lines
+
+
+class TextualImageQuerier:
+    """Production querier. Wraps textual-image's terminal detection.
+
+    NOT unit-tested (requires a live TTY). Any detection failure degrades to
+    glyph honestly rather than raising into the CLI.
+
+    Deviation from the original brief: the resolved textual-image version
+    (0.13.2) has no ``textual_image._terminal.get_tgp_output_format`` symbol.
+    The actual detection entry points in this version are the module-level
+    ``query_terminal_support() -> bool`` probes in
+    ``textual_image.renderable.tgp`` (Kitty Terminal Graphics Protocol) and
+    ``textual_image.renderable.sixel`` (Sixel) — both real escape-sequence
+    round trips against the live terminal, hence still only exercised here.
+    """
+
+    def is_a_tty(self) -> bool:
+        return sys.stdout.isatty()
+
+    def detect_pixel_protocol(self) -> str | None:
+        try:
+            from textual_image.renderable import sixel, tgp
+
+            if tgp.query_terminal_support():
+                return "kitty"
+            if sixel.query_terminal_support():
+                return "sixel"
+        except ImportError:
+            logger.debug("textual-image not importable; treating as glyph")
+            return None
+        except Exception:  # noqa: BLE001 - detection must never crash the CLI
+            logger.debug("pixel-protocol detection failed; treating as glyph", exc_info=True)
+            return None
+        return None

--- a/src/babylon/render/config.py
+++ b/src/babylon/render/config.py
@@ -1,0 +1,76 @@
+"""The ``[render]`` config contract (ADR097 D4).
+
+``babylon doctor`` persists the probed tier here; runtime only ever reads it.
+Writes are read-modify-write via tomlkit so ADR096's ``babylon doctor
+--provision`` tables (and any hand-added config) survive untouched.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from collections.abc import Mapping
+from pathlib import Path
+
+import tomlkit
+from pydantic import BaseModel, ConfigDict
+
+from babylon.intelligence.providers import _config_dir
+from babylon.render.capability import CapabilityReport
+from babylon.render.tiers import PaletteTier, RenderTier
+
+
+class RenderConfig(BaseModel):
+    """The runtime-visible slice of ``[render]``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    tier: RenderTier = RenderTier.GLYPH
+    palette: PaletteTier = PaletteTier.DEGRADED_256
+
+
+def render_config_path(env: Mapping[str, str]) -> Path:
+    """``config.toml`` under the shared config dir (providers precedence)."""
+    return _config_dir(env) / "config.toml"
+
+
+def read_render_config(config_path: Path) -> RenderConfig:
+    """Read the persisted tier, falling back to glyph/256 defaults."""
+    try:
+        with config_path.open("rb") as handle:
+            data = tomllib.load(handle)
+    except FileNotFoundError:
+        return RenderConfig()
+    render = data.get("render", {})
+    tier_raw = render.get("tier", RenderTier.GLYPH.value)
+    palette_raw = render.get("palette", PaletteTier.DEGRADED_256.value)
+    return RenderConfig(tier=RenderTier(tier_raw), palette=PaletteTier(palette_raw))
+
+
+def write_render_section(
+    config_path: Path,
+    report: CapabilityReport,
+    tier: RenderTier,
+    palette: PaletteTier,
+) -> None:
+    """Read-modify-write only the ``[render]`` table; preserve every other table."""
+    if config_path.exists():
+        document = tomlkit.parse(config_path.read_text(encoding="utf-8"))
+    else:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        document = tomlkit.document()
+
+    render = tomlkit.table()
+    render["tier"] = tier.value
+    render["palette"] = palette.value
+    render["probed_term"] = report.term
+    render["truecolor"] = report.truecolor
+    render["pixel_protocol"] = report.pixel_protocol or ""
+    render["in_tmux"] = report.in_tmux
+    document["render"] = render
+
+    config_path.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+
+def resolve_active_tier(override: RenderTier | None, cfg: RenderConfig) -> RenderTier:
+    """A ``--render`` override wins for the session; else the persisted tier."""
+    return override if override is not None else cfg.tier

--- a/src/babylon/render/doctor.py
+++ b/src/babylon/render/doctor.py
@@ -1,0 +1,33 @@
+"""The render half of ``babylon doctor`` — probe once, persist, hand back lines.
+
+Kept out of the Typer command so it is testable without a CLI runner; the CLI
+``doctor`` command imports and prints these lines (ADR097 D4).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from babylon.render.capability import (
+    TerminalQuerier,
+    TextualImageQuerier,
+    derive_tiers,
+    probe,
+    verdict_lines,
+)
+from babylon.render.config import write_render_section
+
+
+def run_render_probe(
+    env: Mapping[str, str],
+    queries: TerminalQuerier | None = None,
+    config_path: Path | None = None,
+) -> list[str]:
+    """Probe the terminal once, persist ``[render]``, return verdict lines."""
+    querier = queries if queries is not None else TextualImageQuerier()
+    report = probe(env, querier)
+    tier, palette = derive_tiers(report)
+    if config_path is not None:
+        write_render_section(config_path, report, tier, palette)
+    return verdict_lines(report, tier, palette)

--- a/src/babylon/render/session.py
+++ b/src/babylon/render/session.py
@@ -1,0 +1,31 @@
+"""Per-session render override (ADR097 D4).
+
+``babylon --render=glyph|pixel`` sets a process-wide override; runtime resolves
+the active tier as override-else-persisted. The override never re-probes and is
+never written back to config (it is a session-only decision).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from babylon.render.config import read_render_config, render_config_path, resolve_active_tier
+from babylon.render.tiers import RenderTier
+
+_SESSION_OVERRIDE: RenderTier | None = None
+
+
+def set_render_override(tier: RenderTier | None) -> None:
+    """Record the ``--render`` choice for this process (None clears it)."""
+    global _SESSION_OVERRIDE
+    _SESSION_OVERRIDE = tier
+
+
+def get_render_override() -> RenderTier | None:
+    return _SESSION_OVERRIDE
+
+
+def active_render_tier(override: RenderTier | None, env: Mapping[str, str]) -> RenderTier:
+    """Resolve the tier a session should render at: override else persisted config."""
+    cfg = read_render_config(render_config_path(env))
+    return resolve_active_tier(override, cfg)

--- a/src/babylon/render/tiers.py
+++ b/src/babylon/render/tiers.py
@@ -1,0 +1,106 @@
+"""Render tiers and the crimson/gold palette (ADR097 D1/D5).
+
+Tier 0 (GLYPH) is the design target and the sole information carrier; Tier 1
+(PIXEL) re-renders Tier-0 content. ``TRUECOLOR_PALETTE`` is the §9b canon; its
+256-color fallback ``DEGRADED_256_PALETTE`` is computed here — the single source
+of truth the DESIGN_BIBLE §9b row cites, so doc and code cannot drift.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Final
+
+
+class RenderTier(StrEnum):
+    GLYPH = "glyph"
+    PIXEL = "pixel"
+
+
+class PaletteTier(StrEnum):
+    TRUECOLOR = "truecolor"
+    DEGRADED_256 = "256"
+
+
+class RoleToken(StrEnum):
+    FIELD = "field"
+    TEXT = "text"
+    ACCENT_CRIMSON = "accent_crimson"
+    ACCENT_GOLD = "accent_gold"
+    SELECTION_TEXT = "selection_text"
+    MUTED_DIM = "muted_dim"
+    MUTED_LIGHT = "muted_light"
+    MUTED_DARK = "muted_dark"
+    GREEN_DARK = "green_dark"
+    GREEN_BRIGHT = "green_bright"
+    ROYAL = "royal"
+    CYAN = "cyan"
+
+
+# §9b "Kitty ksbc-new, verbatim" (DESIGN_BIBLE §9b, lines 302-310).
+TRUECOLOR_PALETTE: Final[dict[RoleToken, str]] = {
+    RoleToken.FIELD: "#1a0000",
+    RoleToken.TEXT: "#e8e8e8",
+    RoleToken.ACCENT_CRIMSON: "#dc143c",
+    RoleToken.ACCENT_GOLD: "#ffd700",
+    RoleToken.SELECTION_TEXT: "#000000",
+    RoleToken.MUTED_DIM: "#404040",
+    RoleToken.MUTED_LIGHT: "#c0c0c0",
+    RoleToken.MUTED_DARK: "#202020",
+    RoleToken.GREEN_DARK: "#228b22",
+    RoleToken.GREEN_BRIGHT: "#32cd32",
+    RoleToken.ROYAL: "#4169e1",
+    RoleToken.CYAN: "#008b8b",
+}
+
+# xterm-256 6x6x6 colour cube levels and grayscale ramp (indices 16-255).
+_CUBE_LEVELS: Final[tuple[int, ...]] = (0x00, 0x5F, 0x87, 0xAF, 0xD7, 0xFF)
+_CUBE_START: Final[int] = 16
+_CUBE_END: Final[int] = 231
+_GRAY_START: Final[int] = 232
+_GRAY_END: Final[int] = 255
+
+
+def _index_rgb(index: int) -> tuple[int, int, int]:
+    """RGB of an xterm-256 index in the cube (16-231) or grayscale (232-255) range."""
+    if _CUBE_START <= index <= _CUBE_END:
+        offset = index - _CUBE_START
+        return (
+            _CUBE_LEVELS[offset // 36],
+            _CUBE_LEVELS[(offset // 6) % 6],
+            _CUBE_LEVELS[offset % 6],
+        )
+    if _GRAY_START <= index <= _GRAY_END:
+        value = 8 + 10 * (index - _GRAY_START)
+        return (value, value, value)
+    raise ValueError(f"index {index} outside the searchable 16-255 range")
+
+
+def nearest_xterm256(hex_color: str) -> int:
+    """Nearest xterm-256 index (16-255) to a ``#rrggbb`` colour by squared RGB distance.
+
+    System colours 0-15 are excluded so the mapping is stable across terminal themes.
+    """
+    if len(hex_color) != 7 or not hex_color.startswith("#"):
+        raise ValueError(f"expected a 6-digit hex like '#dc143c', got {hex_color!r}")
+    try:
+        red = int(hex_color[1:3], 16)
+        green = int(hex_color[3:5], 16)
+        blue = int(hex_color[5:7], 16)
+    except ValueError as exc:
+        raise ValueError(f"expected a 6-digit hex like '#dc143c', got {hex_color!r}") from exc
+
+    best_index = _CUBE_START
+    best_distance: int | None = None
+    for index in range(_CUBE_START, _GRAY_END + 1):  # bounded: 240 iterations
+        pr, pg, pb = _index_rgb(index)
+        distance = (red - pr) ** 2 + (green - pg) ** 2 + (blue - pb) ** 2
+        if best_distance is None or distance < best_distance:
+            best_distance = distance
+            best_index = index
+    return best_index
+
+
+DEGRADED_256_PALETTE: Final[dict[RoleToken, int]] = {
+    token: nearest_xterm256(hex_color) for token, hex_color in TRUECOLOR_PALETTE.items()
+}

--- a/src/babylon/render/widgets/__init__.py
+++ b/src/babylon/render/widgets/__init__.py
@@ -1,0 +1,1 @@
+"""Render-seam Textual widgets (Tier-0 glyph canon)."""

--- a/src/babylon/render/widgets/palette_plate.py
+++ b/src/babylon/render/widgets/palette_plate.py
@@ -1,0 +1,76 @@
+"""Seed widget (ADR097 D1/D2/D3): the §9b palette swatch table at Tier 0.
+
+The minimal real deliverable that proves the render estate — one static Textual
+widget over a tier-INDEPENDENT plate model (the parity rule: Tier 1 may add no
+data Tier 0 lacks), snapshot-tested so it joins the III.13 golden estate.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from babylon.render.tiers import (
+    DEGRADED_256_PALETTE,
+    TRUECOLOR_PALETTE,
+    PaletteTier,
+    RoleToken,
+)
+
+
+class PaletteRow(BaseModel):
+    """One §9b role, carrying BOTH representations (parity: no tier-specific data)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    token: RoleToken
+    truecolor_hex: str
+    xterm256: int
+
+
+def plate_model() -> tuple[PaletteRow, ...]:
+    """The tier-independent plate data — identical for glyph and pixel paths."""
+    return tuple(
+        PaletteRow(
+            token=token,
+            truecolor_hex=TRUECOLOR_PALETTE[token],
+            xterm256=DEGRADED_256_PALETTE[token],
+        )
+        for token in RoleToken
+    )
+
+
+def swatch_cell(row: PaletteRow, palette: PaletteTier) -> str:
+    """The cell label for the active palette — selects a representation, not data."""
+    if palette is PaletteTier.TRUECOLOR:
+        return f"{row.token.value:<16} {row.truecolor_hex}"
+    return f"{row.token.value:<16} xterm-{row.xterm256}"
+
+
+class PalettePlate(Static):
+    """Static glyph-canon render of the §9b swatch table (Tier 0)."""
+
+    def __init__(self, palette: PaletteTier = PaletteTier.TRUECOLOR) -> None:
+        super().__init__()
+        self._palette = palette
+
+    def render(self) -> Text:
+        text = Text()
+        for row in plate_model():
+            color = (
+                row.truecolor_hex
+                if self._palette is PaletteTier.TRUECOLOR
+                else f"color({row.xterm256})"
+            )
+            text.append("  ██  ", style=color)
+            text.append(swatch_cell(row, self._palette) + "\n")
+        return text
+
+
+class PalettePlateApp(App[None]):
+    """Snapshot host for the seed widget (deterministic, fixed 80x24 in tests)."""
+
+    def compose(self) -> ComposeResult:
+        yield PalettePlate(PaletteTier.TRUECOLOR)

--- a/tests/unit/cli/test_doctor_render.py
+++ b/tests/unit/cli/test_doctor_render.py
@@ -1,0 +1,19 @@
+"""Smoke: ``babylon doctor`` emits the render verdict (ADR097 D4, consumes ADR095)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from babylon.cli import app
+
+runner = CliRunner()
+
+
+def test_doctor_prints_render_tier(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("BABYLON_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("TERM", "dumb")
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0
+    assert "render tier:" in result.stdout

--- a/tests/unit/cli/test_doctor_render.py
+++ b/tests/unit/cli/test_doctor_render.py
@@ -17,3 +17,10 @@ def test_doctor_prints_render_tier(tmp_path: Path, monkeypatch) -> None:  # type
     result = runner.invoke(app, ["doctor"])
     assert result.exit_code == 0
     assert "render tier:" in result.stdout
+
+
+def test_render_override_option_parses(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("BABYLON_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("TERM", "dumb")
+    result = runner.invoke(app, ["--render", "pixel", "doctor"])
+    assert result.exit_code == 0

--- a/tests/unit/render/__snapshots__/test_palette_plate/test_palette_plate_snapshot.raw
+++ b/tests/unit/render/__snapshots__/test_palette_plate/test_palette_plate_snapshot.raw
@@ -1,0 +1,162 @@
+<svg class="rich-terminal" viewBox="0 0 994 635.5999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #1a0000 }
+.terminal-r2 { fill: #e0e0e0 }
+.terminal-r3 { fill: #c5c8c6 }
+.terminal-r4 { fill: #e8e8e8 }
+.terminal-r5 { fill: #dc143c }
+.terminal-r6 { fill: #ffd700 }
+.terminal-r7 { fill: #000000 }
+.terminal-r8 { fill: #404040 }
+.terminal-r9 { fill: #c0c0c0 }
+.terminal-r10 { fill: #202020 }
+.terminal-r11 { fill: #228b22 }
+.terminal-r12 { fill: #32cd32 }
+.terminal-r13 { fill: #4169e1 }
+.terminal-r14 { fill: #008b8b }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="584.5999999999999" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="633.6" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">PalettePlateApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#121212" x="0" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="1.5" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="1.5" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="25.9" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="25.9" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="50.3" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="50.3" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="74.7" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="74.7" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="99.1" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="99.1" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="123.5" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="123.5" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="147.9" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="147.9" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="172.3" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="172.3" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="196.7" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="196.7" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="221.1" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="221.1" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="245.5" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="245.5" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="73.2" y="269.9" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="366" y="269.9" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r1" x="0" y="20" textLength="73.2" clip-path="url(#terminal-line-0)">&#160;&#160;██&#160;&#160;</text><text class="terminal-r2" x="73.2" y="20" textLength="292.8" clip-path="url(#terminal-line-0)">field&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;#1a0000</text><text class="terminal-r3" x="976" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r4" x="0" y="44.4" textLength="73.2" clip-path="url(#terminal-line-1)">&#160;&#160;██&#160;&#160;</text><text class="terminal-r2" x="73.2" y="44.4" textLength="292.8" clip-path="url(#terminal-line-1)">text&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;#e8e8e8</text><text class="terminal-r3" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r5" x="0" y="68.8" textLength="73.2" clip-path="url(#terminal-line-2)">&#160;&#160;██&#160;&#160;</text><text class="terminal-r2" x="73.2" y="68.8" textLength="292.8" clip-path="url(#terminal-line-2)">accent_crimson&#160;&#160;&#160;#dc143c</text><text class="terminal-r3" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r6" x="0" y="93.2" textLength="73.2" clip-path="url(#terminal-line-3)">&#160;&#160;██&#160;&#160;</text><text class="terminal-r2" x="73.2" y="93.2" textLength="292.8" clip-path="url(#terminal-line-3)">accent_gold&#160;&#160;&#160;&#160;&#160;&#160;#ffd700</text><text class="terminal-r3" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r7" x="0" y="117.6" textLength="73.2" clip-path="url(#terminal-line-4)">&#160;&#160;██&#160;&#160;</text><text class="terminal-r2" x="73.2" y="117.6" textLength="292.8" clip-path="url(#terminal-line-4)">selection_text&#160;&#160;&#160;#000000</text><text class="terminal-r3" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r8" x="0" y="142" textLength="73.2" clip-path="url(#terminal-line-5)">&#160;&#160;██&#160;&#160;</text><text class="terminal-r2" x="73.2" y="142" textLength="292.8" clip-path="url(#terminal-line-5)">muted_dim&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;#404040</text><text class="terminal-r3" x="976" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r9" x="0" y="166.4" textLength="73.2" clip-path="url(#terminal-line-6)">&#160;&#160;██&#160;&#160;</text><text class="terminal-r2" x="73.2" y="166.4" textLength="292.8" clip-path="url(#terminal-line-6)">muted_light&#160;&#160;&#160;&#160;&#160;&#160;#c0c0c0</text><text class="terminal-r3" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r10" x="0" y="190.8" textLength="73.2" clip-path="url(#terminal-line-7)">&#160;&#160;██&#160;&#160;</text><text class="terminal-r2" x="73.2" y="190.8" textLength="292.8" clip-path="url(#terminal-line-7)">muted_dark&#160;&#160;&#160;&#160;&#160;&#160;&#160;#202020</text><text class="terminal-r3" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r11" x="0" y="215.2" textLength="73.2" clip-path="url(#terminal-line-8)">&#160;&#160;██&#160;&#160;</text><text class="terminal-r2" x="73.2" y="215.2" textLength="292.8" clip-path="url(#terminal-line-8)">green_dark&#160;&#160;&#160;&#160;&#160;&#160;&#160;#228b22</text><text class="terminal-r3" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r12" x="0" y="239.6" textLength="73.2" clip-path="url(#terminal-line-9)">&#160;&#160;██&#160;&#160;</text><text class="terminal-r2" x="73.2" y="239.6" textLength="292.8" clip-path="url(#terminal-line-9)">green_bright&#160;&#160;&#160;&#160;&#160;#32cd32</text><text class="terminal-r3" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r13" x="0" y="264" textLength="73.2" clip-path="url(#terminal-line-10)">&#160;&#160;██&#160;&#160;</text><text class="terminal-r2" x="73.2" y="264" textLength="292.8" clip-path="url(#terminal-line-10)">royal&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;#4169e1</text><text class="terminal-r3" x="976" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r14" x="0" y="288.4" textLength="73.2" clip-path="url(#terminal-line-11)">&#160;&#160;██&#160;&#160;</text><text class="terminal-r2" x="73.2" y="288.4" textLength="292.8" clip-path="url(#terminal-line-11)">cyan&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;#008b8b</text><text class="terminal-r3" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r3" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r3" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r3" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r3" x="976" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r3" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r3" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r3" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r3" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
+</text><text class="terminal-r3" x="976" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
+</text><text class="terminal-r3" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
+</text><text class="terminal-r3" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/tests/unit/render/conftest.py
+++ b/tests/unit/render/conftest.py
@@ -1,0 +1,21 @@
+"""Env pinning for render-seam snapshot goldens.
+
+The repo-wide mise ``[env]`` exports ``NO_COLOR=1`` (agent ergonomics —
+uncolored tool output). Textual honors ``NO_COLOR`` even under the headless
+snapshot harness by desaturating every theme color to grayscale, which
+would (a) make the SVG goldens blind to ksbc-palette regressions and
+(b) split rendering into two incompatible lanes — mise/CI (grayscale) vs a
+direct venv pytest call (truecolor) — so a golden could only ever match one
+lane. Snapshot tests own this knob explicitly instead: colors are always
+on, and all lanes produce identical bytes. Mirrors ``tests/unit/tui/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _truecolor_snapshots(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Render snapshot goldens in full color regardless of the host env."""
+    monkeypatch.delenv("NO_COLOR", raising=False)

--- a/tests/unit/render/test_capability.py
+++ b/tests/unit/render/test_capability.py
@@ -1,0 +1,105 @@
+"""Probe-once capability contract (ADR097 D4).
+
+Pure env-dict cases with an injected querier: no real terminal is touched. The
+probe never re-runs mid-session; these tests pin what a single probe concludes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from babylon.render.capability import (
+    CapabilityReport,
+    TerminalQuerier,
+    derive_tiers,
+    probe,
+    verdict_lines,
+)
+from babylon.render.tiers import PaletteTier, RenderTier
+
+
+class FakeQuerier:
+    """Stand-in for a real terminal: fully caller-controlled."""
+
+    def __init__(self, *, is_tty: bool, protocol: str | None) -> None:
+        self._is_tty = is_tty
+        self._protocol = protocol
+
+    def is_a_tty(self) -> bool:
+        return self._is_tty
+
+    def detect_pixel_protocol(self) -> str | None:
+        return self._protocol
+
+
+def _probe(env: Mapping[str, str], *, is_tty: bool, protocol: str | None) -> CapabilityReport:
+    querier: TerminalQuerier = FakeQuerier(is_tty=is_tty, protocol=protocol)
+    return probe(env, querier)
+
+
+def test_kitty_truecolor_tty_is_pixel_truecolor() -> None:
+    report = _probe(
+        {"TERM": "xterm-kitty", "COLORTERM": "truecolor"}, is_tty=True, protocol="kitty"
+    )
+    assert report.truecolor is True
+    assert report.pixel_protocol == "kitty"
+    assert derive_tiers(report) == (RenderTier.PIXEL, PaletteTier.TRUECOLOR)
+
+
+def test_gnome_vte_256_no_pixel_is_glyph_truecolor() -> None:
+    # VTE reports truecolor via COLORTERM but has no pixel protocol.
+    report = _probe(
+        {"TERM": "xterm-256color", "COLORTERM": "truecolor"}, is_tty=True, protocol=None
+    )
+    assert report.has_256 is True
+    assert report.pixel_protocol is None
+    assert derive_tiers(report) == (RenderTier.GLYPH, PaletteTier.TRUECOLOR)
+
+
+def test_tmux_forces_glyph_even_if_querier_claims_pixel() -> None:
+    # Inside tmux, passthrough is not assumed: honest glyph, protocol suppressed.
+    report = _probe(
+        {"TERM": "tmux-256color", "TMUX": "/tmp/tmux-1000/default,1,0"},
+        is_tty=True,
+        protocol="kitty",
+    )
+    assert report.in_tmux is True
+    assert report.pixel_protocol is None
+    assert derive_tiers(report)[0] is RenderTier.GLYPH
+
+
+def test_dumb_terminal_is_glyph_degraded() -> None:
+    report = _probe({"TERM": "dumb"}, is_tty=True, protocol=None)
+    assert report.truecolor is False
+    assert report.has_256 is False
+    assert derive_tiers(report) == (RenderTier.GLYPH, PaletteTier.DEGRADED_256)
+
+
+def test_non_tty_ci_never_reports_pixel() -> None:
+    # CI / piped output: no TTY, so the pixel query is not even consulted.
+    report = _probe(
+        {"TERM": "xterm-256color", "COLORTERM": "truecolor", "CI": "true"},
+        is_tty=False,
+        protocol="sixel",
+    )
+    assert report.is_tty is False
+    assert report.pixel_protocol is None
+    assert derive_tiers(report)[0] is RenderTier.GLYPH
+
+
+def test_report_is_frozen() -> None:
+    report = _probe({"TERM": "dumb"}, is_tty=False, protocol=None)
+    with pytest.raises(Exception):  # noqa: B017 - pydantic frozen raises ValidationError
+        report.truecolor = True  # type: ignore[misc]
+
+
+def test_verdict_lines_declare_degradation() -> None:
+    report = _probe({"TERM": "xterm-256color"}, is_tty=True, protocol=None)
+    tier, palette = derive_tiers(report)
+    lines = verdict_lines(report, tier, palette)
+    joined = "\n".join(lines)
+    assert "render tier: glyph" in joined
+    assert "palette: 256" in joined
+    assert "degraded" in joined.lower()

--- a/tests/unit/render/test_config.py
+++ b/tests/unit/render/test_config.py
@@ -1,0 +1,86 @@
+"""Render config contract (ADR097 D4).
+
+Runtime reads the persisted tier; doctor writes it. The writer must be a
+read-modify-write that preserves 096's tables (both are ``babylon doctor``
+extensions and must never clobber each other).
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from babylon.render.capability import CapabilityReport
+from babylon.render.config import (
+    RenderConfig,
+    read_render_config,
+    render_config_path,
+    resolve_active_tier,
+    write_render_section,
+)
+from babylon.render.tiers import PaletteTier, RenderTier
+
+
+def _report(**kw: object) -> CapabilityReport:
+    base: dict[str, object] = {
+        "term": "xterm-256color",
+        "colorterm": "",
+        "truecolor": False,
+        "has_256": True,
+        "in_tmux": False,
+        "is_tty": True,
+        "pixel_protocol": None,
+    }
+    base.update(kw)
+    return CapabilityReport(**base)  # type: ignore[arg-type]
+
+
+def test_read_missing_config_returns_defaults(tmp_path: Path) -> None:
+    cfg = read_render_config(tmp_path / "config.toml")
+    assert cfg.tier is RenderTier.GLYPH
+    assert cfg.palette is PaletteTier.DEGRADED_256
+
+
+def test_round_trip_write_then_read(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    write_render_section(path, _report(truecolor=True), RenderTier.PIXEL, PaletteTier.TRUECOLOR)
+    cfg = read_render_config(path)
+    assert cfg.tier is RenderTier.PIXEL
+    assert cfg.palette is PaletteTier.TRUECOLOR
+
+
+def test_write_preserves_foreign_tables(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        '[intelligence]\nmode = "auto"\ntimeout_s = 30.0\n\n[provision]\nmodel = "qwen"\n',
+        encoding="utf-8",
+    )
+    write_render_section(path, _report(), RenderTier.GLYPH, PaletteTier.DEGRADED_256)
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    # 096's tables survive untouched.
+    assert data["intelligence"] == {"mode": "auto", "timeout_s": 30.0}
+    assert data["provision"] == {"model": "qwen"}
+    # Ours landed with evidence fields.
+    assert data["render"]["tier"] == "glyph"
+    assert data["render"]["palette"] == "256"
+    assert data["render"]["probed_term"] == "xterm-256color"
+
+
+def test_rewrite_updates_render_only(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    write_render_section(path, _report(), RenderTier.GLYPH, PaletteTier.DEGRADED_256)
+    write_render_section(path, _report(truecolor=True), RenderTier.PIXEL, PaletteTier.TRUECOLOR)
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    assert data["render"]["tier"] == "pixel"
+    assert data["render"]["palette"] == "truecolor"
+
+
+def test_render_config_path_honors_override(tmp_path: Path) -> None:
+    path = render_config_path({"BABYLON_CONFIG_DIR": str(tmp_path)})
+    assert path == tmp_path / "config.toml"
+
+
+def test_resolve_active_tier_prefers_override() -> None:
+    cfg = RenderConfig(tier=RenderTier.GLYPH, palette=PaletteTier.DEGRADED_256)
+    assert resolve_active_tier(RenderTier.PIXEL, cfg) is RenderTier.PIXEL
+    assert resolve_active_tier(None, cfg) is RenderTier.GLYPH

--- a/tests/unit/render/test_deps.py
+++ b/tests/unit/render/test_deps.py
@@ -1,0 +1,20 @@
+"""The Tier-1 pixel lane and snapshot mechanism must be importable (ADR097 D2/D3)."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+RUNTIME_MODULES = ["textual", "textual_plotext", "textual_image", "PIL", "tomlkit"]
+
+
+@pytest.mark.parametrize("module_name", RUNTIME_MODULES)
+def test_runtime_dependency_importable(module_name: str) -> None:
+    assert importlib.import_module(module_name) is not None
+
+
+def test_snapshot_plugin_available() -> None:
+    # pytest-textual-snapshot registers the ``snap_compare`` fixture as a plugin.
+    plugin = importlib.import_module("pytest_textual_snapshot")
+    assert plugin is not None

--- a/tests/unit/render/test_design_bible_parity.py
+++ b/tests/unit/render/test_design_bible_parity.py
@@ -1,0 +1,42 @@
+"""DESIGN_BIBLE §9b degraded row must equal the code constant (ADR097 D5).
+
+The doc cites ``DEGRADED_256_PALETTE`` as the single source of truth; this test is
+the enforcement — a drift in either side fails here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from babylon.render.tiers import DEGRADED_256_PALETTE, TRUECOLOR_PALETTE, RoleToken
+
+DESIGN_BIBLE = (
+    Path(__file__).resolve().parents[3]
+    / "project"
+    / "research"
+    / "16-living-map"
+    / "DESIGN_BIBLE.md"
+)
+_ROW = re.compile(r"^\|\s*`([a-z_]+)`\s*\|\s*(#[0-9a-fA-F]{6})\s*\|\s*(\d+)\s*\|")
+
+
+def _parse_degraded_rows() -> dict[str, tuple[str, int]]:
+    text = DESIGN_BIBLE.read_text(encoding="utf-8")
+    marker = "Degraded palette (256-color, ADR097 D5)"
+    assert marker in text, f"missing §9b subsection heading: {marker!r}"
+    section = text.split(marker, 1)[1]
+    rows: dict[str, tuple[str, int]] = {}
+    for line in section.splitlines():
+        match = _ROW.match(line.strip())
+        if match:
+            rows[match.group(1)] = (match.group(2).lower(), int(match.group(3)))
+    return rows
+
+
+def test_design_bible_degraded_row_matches_code() -> None:
+    rows = _parse_degraded_rows()
+    expected = {
+        token.value: (TRUECOLOR_PALETTE[token], DEGRADED_256_PALETTE[token]) for token in RoleToken
+    }
+    assert rows == expected

--- a/tests/unit/render/test_doctor.py
+++ b/tests/unit/render/test_doctor.py
@@ -1,0 +1,40 @@
+"""The render half of ``babylon doctor`` (ADR097 D4): probe once, persist, report."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from babylon.render.capability import TerminalQuerier
+from babylon.render.doctor import run_render_probe
+
+
+class _Q:
+    def __init__(self, *, is_tty: bool, protocol: str | None) -> None:
+        self._is_tty = is_tty
+        self._protocol = protocol
+
+    def is_a_tty(self) -> bool:
+        return self._is_tty
+
+    def detect_pixel_protocol(self) -> str | None:
+        return self._protocol
+
+
+def test_run_render_probe_persists_and_reports(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    queries: TerminalQuerier = _Q(is_tty=True, protocol="kitty")
+    lines = run_render_probe({"TERM": "xterm-kitty", "COLORTERM": "truecolor"}, queries, path)
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    assert data["render"]["tier"] == "pixel"
+    assert data["render"]["palette"] == "truecolor"
+    assert any("render tier: pixel" in line for line in lines)
+
+
+def test_run_render_probe_declares_glyph_degradation(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    queries: TerminalQuerier = _Q(is_tty=False, protocol=None)
+    lines = run_render_probe({"TERM": "dumb"}, queries, path)
+    joined = "\n".join(lines)
+    assert "render tier: glyph" in joined
+    assert "degraded" in joined.lower()

--- a/tests/unit/render/test_palette_plate.py
+++ b/tests/unit/render/test_palette_plate.py
@@ -1,0 +1,63 @@
+"""Seed widget: parity (D2) + determinism (D3) contracts for ADR097.
+
+Parity: the plate data model is tier-independent — the pixel path exposes no data
+field the glyph path lacks (asserted on the model, not screenshots). Determinism:
+the committed SVG snapshot is the III.13 same-state-same-bytes contract, via
+pytest-textual-snapshot (Textual's native SVG export).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from babylon.render.tiers import (
+    DEGRADED_256_PALETTE,
+    TRUECOLOR_PALETTE,
+    PaletteTier,
+    RoleToken,
+)
+from babylon.render.widgets.palette_plate import (
+    PalettePlateApp,
+    PaletteRow,
+    plate_model,
+    swatch_cell,
+)
+
+
+def test_plate_model_covers_every_role_token() -> None:
+    tokens = [row.token for row in plate_model()]
+    assert tokens == list(RoleToken)
+
+
+def test_plate_model_rows_carry_both_representations() -> None:
+    for row in plate_model():
+        assert row.truecolor_hex == TRUECOLOR_PALETTE[row.token]
+        assert row.xterm256 == DEGRADED_256_PALETTE[row.token]
+
+
+def test_information_parity_model_is_tier_independent() -> None:
+    # The parity rule (D2): the model is one object for BOTH tiers — there is no
+    # tier parameter and no tier-specific field. Tier only selects which cell text
+    # is drawn (swatch_cell), never which data exists.
+    fields = (
+        {f.name for f in dataclasses.fields(PaletteRow.__pydantic_dataclass__)}
+        if hasattr(PaletteRow, "__pydantic_dataclass__")
+        else set(PaletteRow.model_fields)
+    )
+    assert fields == {"token", "truecolor_hex", "xterm256"}
+    # Same rows regardless of which palette a caller intends to display.
+    assert plate_model() == plate_model()
+
+
+def test_swatch_cell_selects_representation_by_palette() -> None:
+    row = next(r for r in plate_model() if r.token is RoleToken.ACCENT_CRIMSON)
+    truecolor = swatch_cell(row, PaletteTier.TRUECOLOR)
+    degraded = swatch_cell(row, PaletteTier.DEGRADED_256)
+    assert "#dc143c" in truecolor
+    assert "161" in degraded  # the computed nearest index for crimson
+
+
+def test_palette_plate_snapshot(snap_compare) -> None:  # type: ignore[no-untyped-def]
+    # III.13 determinism: same state -> byte-identical SVG. First run generates the
+    # baseline with --snapshot-update; thereafter this asserts it never drifts.
+    assert snap_compare(PalettePlateApp())

--- a/tests/unit/render/test_session.py
+++ b/tests/unit/render/test_session.py
@@ -1,0 +1,29 @@
+"""Session override resolution (ADR097 D4): --render wins over persisted config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from babylon.render.session import active_render_tier
+from babylon.render.tiers import RenderTier
+
+
+def test_override_wins_over_config(tmp_path: Path) -> None:
+    (tmp_path / "config.toml").write_text(
+        '[render]\ntier = "glyph"\npalette = "256"\n', encoding="utf-8"
+    )
+    env = {"BABYLON_CONFIG_DIR": str(tmp_path)}
+    assert active_render_tier(RenderTier.PIXEL, env) is RenderTier.PIXEL
+
+
+def test_no_override_uses_persisted_tier(tmp_path: Path) -> None:
+    (tmp_path / "config.toml").write_text(
+        '[render]\ntier = "pixel"\npalette = "truecolor"\n', encoding="utf-8"
+    )
+    env = {"BABYLON_CONFIG_DIR": str(tmp_path)}
+    assert active_render_tier(None, env) is RenderTier.PIXEL
+
+
+def test_no_override_no_config_defaults_glyph(tmp_path: Path) -> None:
+    env = {"BABYLON_CONFIG_DIR": str(tmp_path)}
+    assert active_render_tier(None, env) is RenderTier.GLYPH

--- a/tests/unit/render/test_tiers.py
+++ b/tests/unit/render/test_tiers.py
@@ -1,0 +1,72 @@
+"""Tier model + palette contract (ADR097 D1/D5).
+
+The 256-index map is a behavioral golden: it pins the nearest-color math so the
+DESIGN_BIBLE §9b row (Task 8) and the widget (Task 7) can cite one source of truth.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from babylon.render.tiers import (
+    DEGRADED_256_PALETTE,
+    TRUECOLOR_PALETTE,
+    PaletteTier,
+    RenderTier,
+    RoleToken,
+    nearest_xterm256,
+)
+
+# Nearest xterm-256 index over the 6x6x6 cube + 24-step grayscale (indices 16-255,
+# system colors 0-15 excluded), computed from the §9b truecolor hexes.
+EXPECTED_256: dict[RoleToken, int] = {
+    RoleToken.FIELD: 232,
+    RoleToken.TEXT: 254,
+    RoleToken.ACCENT_CRIMSON: 161,
+    RoleToken.ACCENT_GOLD: 220,
+    RoleToken.SELECTION_TEXT: 16,
+    RoleToken.MUTED_DIM: 238,
+    RoleToken.MUTED_LIGHT: 250,
+    RoleToken.MUTED_DARK: 234,
+    RoleToken.GREEN_DARK: 28,
+    RoleToken.GREEN_BRIGHT: 77,
+    RoleToken.ROYAL: 62,
+    RoleToken.CYAN: 30,
+}
+
+
+def test_render_tier_values() -> None:
+    assert RenderTier.GLYPH.value == "glyph"
+    assert RenderTier.PIXEL.value == "pixel"
+
+
+def test_palette_tier_values() -> None:
+    assert PaletteTier.TRUECOLOR.value == "truecolor"
+    assert PaletteTier.DEGRADED_256.value == "256"
+
+
+def test_truecolor_palette_matches_design_bible_9b() -> None:
+    assert TRUECOLOR_PALETTE[RoleToken.FIELD] == "#1a0000"
+    assert TRUECOLOR_PALETTE[RoleToken.TEXT] == "#e8e8e8"
+    assert TRUECOLOR_PALETTE[RoleToken.ACCENT_CRIMSON] == "#dc143c"
+    assert TRUECOLOR_PALETTE[RoleToken.ACCENT_GOLD] == "#ffd700"
+    assert set(TRUECOLOR_PALETTE) == set(RoleToken)
+
+
+@pytest.mark.parametrize("token", list(RoleToken))
+def test_degraded_index_is_nearest(token: RoleToken) -> None:
+    assert DEGRADED_256_PALETTE[token] == EXPECTED_256[token]
+    assert DEGRADED_256_PALETTE[token] == nearest_xterm256(TRUECOLOR_PALETTE[token])
+
+
+@pytest.mark.parametrize(
+    ("hex_color", "index"),
+    [("#000000", 16), ("#ffffff", 231), ("#808080", 244)],
+)
+def test_nearest_xterm256_known_points(hex_color: str, index: int) -> None:
+    assert nearest_xterm256(hex_color) == index
+
+
+def test_nearest_xterm256_rejects_bad_input() -> None:
+    with pytest.raises(ValueError, match="6-digit hex"):
+        nearest_xterm256("dc143c")  # missing leading '#'

--- a/uv.lock
+++ b/uv.lock
@@ -427,6 +427,7 @@ dependencies = [
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "pgvector" },
+    { name = "pillow" },
     { name = "polars" },
     { name = "psycopg" },
     { name = "psycopg-pool" },
@@ -446,7 +447,9 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "textual" },
     { name = "textual-image" },
+    { name = "textual-plotext" },
     { name = "tokenizers" },
+    { name = "tomlkit" },
     { name = "tqdm" },
     { name = "typer" },
     { name = "xgi" },
@@ -543,6 +546,7 @@ requires-dist = [
     { name = "openpyxl", specifier = ">=3.1.5,<4.0.0" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pgvector", specifier = ">=0.5.0,<0.6.0" },
+    { name = "pillow", specifier = ">=12.3.0" },
     { name = "polars", specifier = ">=1.38.1,<2.0.0" },
     { name = "psycopg", specifier = ">=3.3.3,<4.0.0" },
     { name = "psycopg-pool", specifier = ">=3.3.0,<4.0.0" },
@@ -563,7 +567,9 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.36" },
     { name = "textual", specifier = ">=8.2,<8.3" },
     { name = "textual-image", specifier = ">=0.13,<0.14" },
+    { name = "textual-plotext", specifier = ">=1.0.1" },
     { name = "tokenizers", specifier = ">=0.19.1" },
+    { name = "tomlkit", specifier = ">=0.15.1" },
     { name = "tqdm", specifier = ">=4.66.0,<5.0.0" },
     { name = "typer", specifier = ">=0.15.1" },
     { name = "xgi", specifier = ">=0.10.0,<0.11.0" },
@@ -3467,6 +3473,15 @@ wheels = [
 ]
 
 [[package]]
+name = "plotext"
+version = "5.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/d7/f75f397af966fe252d0d34ffd3cae765317fce2134f925f95e7d6725d1ce/plotext-5.3.2.tar.gz", hash = "sha256:52d1e932e67c177bf357a3f0fe6ce14d1a96f7f7d5679d7b455b929df517068e", size = 61967, upload-time = "2024-09-24T15:13:37.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/1e/12fe7c40cd2099a1f454518754ed229b01beaf3bbb343127f0cc13ce6c22/plotext-5.3.2-py3-none-any.whl", hash = "sha256:394362349c1ddbf319548cfac17ca65e6d5dfc03200c40dfdc0503b3e95a2283", size = 64047, upload-time = "2024-09-24T15:13:36.296Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5348,6 +5363,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/10/77/b2128ced69556bfbb8e1c19d8f013e621cf12531eaba4e9b09e1cfa81e37/textual_image-0.13.2.tar.gz", hash = "sha256:8ca0cee2bfcd7734de5b16a1936da226b77b745e28830d9cf2bc202cb70e43ee", size = 2185178, upload-time = "2026-05-30T21:42:33.563Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/be/60aafd7263a6daa8cc4017e8bd4452c85b63ccd82a64f02636ca46e073b7/textual_image-0.13.2-py3-none-any.whl", hash = "sha256:41635f545ce2d0b3544763a2d10f25ada7f64c51acef77483b80fbfcf7ab22ee", size = 118469, upload-time = "2026-05-30T21:42:31.964Z" },
+]
+
+[[package]]
+name = "textual-plotext"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "plotext" },
+    { name = "textual" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/b0/e4e0f38df057db778252db0dd2c08522d7222b8537b6a0181d797b9044bd/textual_plotext-1.0.1.tar.gz", hash = "sha256:836f53a3316756609e194129a35c2875638e7958c261f541e0a794f7c98011be", size = 16489, upload-time = "2024-11-30T19:25:56.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/53/fba7da208f9d3f59254413660fa0aa6599f2aca806f3ae356670455fd4ea/textual_plotext-1.0.1-py3-none-any.whl", hash = "sha256:6b6bfd00b29f121ddf216eaaf9bdac9d688ed72f40028484d279a10cbbb169ed", size = 16558, upload-time = "2024-11-30T19:25:32.208Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Lands the ADR097 render *seam* (9 tasks, zero fix rounds, final whole-branch review: ready) — the last member of the ADR094-097 packet. Seam only: the unratified TUI program is NOT built (verified: zero `babylon/tui` files touched).

- **Tier model + palettes** (`render/tiers.py`): glyph canon Tier 0 / pixel plates Tier 1; `DEGRADED_256_PALETTE` computed from `TRUECOLOR_PALETTE` via `nearest_xterm256` — single source of truth for the DESIGN_BIBLE §9b row (drift-guard test pins doc↔code parity).
- **Probe-once capability detector** (`render/capability.py`): pure core with injected `TerminalQuerier`, frozen `CapabilityReport`; live-TTY probing isolated in `TextualImageQuerier` (adapted to textual-image 0.13.2's actual API — the plan's cited symbol doesn't exist in the resolved version; deviation documented in-code).
- **`[render]` config contract** (`render/config.py`): tomlkit read-modify-write, round-trip test proves ADR096's `[intelligence]`/`[provision]` tables survive.
- **Doctor wiring + session override**: `babylon doctor` probes once and prints a declared-degradation verdict (III.11); `babylon --render=glyph|pixel` overrides per-session and never persists (no config write in `session.py`).
- **`PalettePlate` seed widget**: Amendment W parity (Tier 1 renders Tier-0 content only, no unique data); snapshot golden joins the III.13 estate — re-run twice, byte-identical; pre-commit now excludes `__snapshots__/*.raw` from whitespace-fixing to protect the golden.
- **`test:render` mise task** wired.

## Gates (independently re-run by the final reviewer)

- pytest render + cli selection: 51 passed; `mise run test:render`: 49 passed
- lint-imports: 9 contracts kept, 0 broken (812 files) — tui + 096 seam contracts intact
- mypy clean on all new/touched modules; ruff clean; all pre-commit hooks passed on every commit (no `--no-verify`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)