### PR TITLE
feat(projection): T3 gap projections — economy dossier, field-state, balkanization, anchoring, habitability (ADR125)

### DIFF
--- a/ai/decisions/ADR125_t3_gap_projections.yaml
+++ b/ai/decisions/ADR125_t3_gap_projections.yaml
@@ -1,0 +1,111 @@
+id: ADR125
+title: >-
+  T3 Gap Projections (Program 24 spine-C, v1.0.0 Playable Archive): five new
+  Archive projection modules — economy, field-state, balkanization faction,
+  chronicle event-territory anchoring, and hex habitability — close the four
+  remaining WO-52b/test-port-ledger LOUD gap rows
+  (TestEconomyDashboardFundamentalTheorem, TestEconomyDashboardChipContract,
+  TestGetFieldState, TestBalkanizationMapFields) and light two wiring motions
+  the Vol I/Vol II cascade left declared-dormant (the fundamental_theorem
+  graph stash, W-P; the value_form Phi tri-decomposition builders, W-C/W-P),
+  plus a small U1 completion publishing the last two SurplusValueDistribution
+  terms (W-C). One gap is found, not closed, and explicitly handed off: no
+  engine scenario stamps NodeType.FACTION, so the balkanization dossier is
+  honest-empty on every real campaign until the RED_OGV repair program seeds
+  it.
+status: accepted
+date: '2026-07-22'
+context: >-
+  specs/24-archive/test-port-ledger.md's WO-52 cutover-gate pass (§"LOUD —
+  coverage gaps") left four classes from the disabled legacy
+  tests/unit/web/test_engine_bridge.py suite with no landed successor and no
+  owning work order: TestEconomyDashboardFundamentalTheorem/
+  TestEconomyDashboardChipContract (the graph-wide Wc-Vc verdict and the
+  Volume III surplus-split/matter-book chips), TestGetFieldState (the
+  dialectical field-stack "Weather Layer"), and TestBalkanizationMapFields
+  (faction enumeration + INFLUENCES-derived contested territory). Separately,
+  two Vol I/Vol II cascade ADRs had left real state on the graph with no
+  consumer: ADR117 (Vol I U2) stashed a per-class fundamental_theorem report
+  on a graph attribute each tick with only a liveness-registry dormant row to
+  show for it, and the value_form module's Phi tri-decomposition builders
+  (unequal-exchange/reproduction/domestic components) had zero callers tree-
+  wide. domain/economics/tick/graph_bridge.py also published 5 of 6
+  SurplusValueDistribution terms as tick_-prefixed territory attrs, silently
+  omitting taxes_on_surplus and total_surplus_produced — the two terms needed
+  to reconstruct the Marxian identity s = p + i + r + t from the graph at
+  all. T3 U1-U6 closed all of the above except the FACTION-node seeding gap,
+  which U4's own commit note explicitly deferred and named as "owed to U7" —
+  this ADR.
+decision: >-
+  U1 (surplus-publisher, W-C): graph_bridge.py's write_tick_state_to_graph
+  gains tick_taxes_on_surplus and tick_total_surplus, same 0.0-when-None
+  defaulting idiom as the other four SurplusValueDistribution terms — no new
+  read path, a genuine dataflow-wire completion. U2 (economy dossier, W-P +
+  W-C/W-P): new babylon.projection.economy.project_economy /
+  render_economy.py / economy.md.j2 read the Fundamental Theorem verdict
+  verbatim off opposition_states["wage"].balance (never a parallel Phi), the
+  per-class Phi readings off the fundamental_theorem graph stash (closing
+  ADR117's declared-dormant liveness row — a genuine W-P motion, confirmed in
+  the row's own updated material_relation text), the Volume III surplus split
+  s = p+i+r+t as an extensive ratio-of-sums off U1's new tick_ attrs, and the
+  matter-book overshoot O = C/B honestly (None on a zero denominator, never
+  WorldState.overshoot_ratio's fabricated 999.0 sentinel). A reviewer finding
+  on the same unit caught the Phi tri-decomposition components hardcoded to
+  five None literals with no actual graph read behind them (a false
+  "wired to light up" claim) — fixed by giving each component (unequal
+  exchange, reproduction, domestic, the report-only Phi_III term, and the
+  total) its own named graph.get_graph_attr reads and a call into the
+  matching value_form builder only when every required input resolves; every
+  input is still genuinely absent tree-wide today, so behavior is unchanged,
+  but the read sites are now real (W-C dataflow declaration) feeding a real
+  projection consumer (W-P) — a future producer lights the component with no
+  further change to this module. U3 (field-state dossier, W-P): new
+  project_field_state ports web/game/engine_bridge.py's get_field_state read
+  logic verbatim (contradiction_fields, field_derivatives laplacian/df_dt
+  only, fascist_alignment, TENANCY-anchored field_gradients, graph-level
+  principal_field/dialectical_regime) into a pure projection, reading the
+  live post-tick graph directly, never a from_graph() round-trip. U4
+  (balkanization dossier, W-P found / W-C deferred): new project_faction
+  mirrors project_sovereign's recipe exactly, deriving territory_influence
+  from outgoing INFLUENCES edges; verified honest-empty on every real
+  headless campaign because no engine scenario seeds NodeType.FACTION today
+  (only the legacy web bridge's _seed_balkanization_layer does) — porting
+  that seed is a physics change out of this program's scope, EXPLICITLY
+  DEFERRED to the RED_OGV sovereignty-inert repair program (see
+  ai/wiring-doctrine.md's gap ledger, new OPEN row). U5 (event-anchoring,
+  W-C): the TENANCY-inversion primitive duplicated in web/game/
+  engine_bridge.py and projection/verbs/plate.py is hoisted into one shared
+  babylon.projection.territory_anchor home; chronicle_events_from_bus gains
+  an optional graph= parameter so class-scoped chronicle events (UPRISING
+  and the reactionary-verb family) resolve a real territory anchor when the
+  session's live graph is threaded through, never a from_graph() round-trip
+  (which drops TENANCY edges). U6 (habitability, W-G-shaped broadcast):
+  CountyView gains an Optional habitability field read straight off the live
+  graph (MetabolismSystem's transient territory attr, excluded from
+  WorldState.from_graph() by TERRITORY_EXCLUDED_FIELDS); a new
+  hex_habitability_by_county_inheritance helper gives every hex its parent
+  county's live reading — documented explicitly as county-grain broadcast
+  (one number inherited, not a sum partitioned), NOT hex-native, because no
+  dynamic_hex_state column stores hex-resolution habitability; a real
+  substrate column remains the pending prerequisite for a hex-native
+  reading.
+consequences: >-
+  specs/24-archive/test-port-ledger.md's four LOUD gap rows (192-195) and
+  their numbered closure items (1-4) are now all CLOSED — WO-52's cutover
+  gate has zero open rows from the original disabled test_engine_bridge.py
+  sweep. The liveness registry's fundamental_theorem row moves from
+  zero-consumer dormant to a real consumer_files entry
+  (src/babylon/projection/economy.py); its wire fields still need the same
+  projection/veil.py TIER1_VALUE_RELATION_FIELDS forward-pin as any other
+  value-relation field before they'd reach a web-facing endpoint — unchanged
+  by this unit. No qa:regression baseline drift: every change is either a
+  projection-layer (read-only, vault-materialized) addition, or in U1's
+  case a new tick_-prefixed graph attribute confirmed unread by any
+  dense-trace/gate-coverage registry column. The balkanization FACTION-node
+  seeding gap is recorded, not fixed, as a new OPEN row in
+  ai/wiring-doctrine.md's §4 gap ledger citing the RED_OGV repair program
+  (red-ogv-sovereignty-inert-repair) as its owner; per-hex habitability
+  stays an honest county-grain inheritance until a dynamic_hex_state column
+  exists to store a real hex-native reading. This ADR is a governance
+  close-out: no production code changes ship with it.
+file: ADR125_t3_gap_projections.yaml

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -1,6 +1,6 @@
 meta:
-  version: 1.52.0
-  updated: '2026-07-21'
+  version: 1.53.0
+  updated: '2026-07-22'
   description: Architecture Decision Records Index
   format: See individual ADR files in this directory
   # ADR NUMBER ALLOCATION (controller ruling 2026-07-21, v1.0.0 parallel lanes —
@@ -8,8 +8,15 @@ meta:
   # volume lanes). Blocks: mainline/controller = 109 + anything unallocated;
   # Vol I lane = ADR110-119; Vol II lane = ADR120-129; T1.1 = ADR130-134;
   # T1.2 = ADR135-139; T4 = ADR140-144; T7-beta = ADR145-149. Lanes never mint
-  # outside their block; blocks dissolve when the lane merges.
+  # outside their block; blocks dissolve when the lane merges. ADR125 = T3
+  # gap-projections (post-cascade, next free slot >= 125 per controller
+  # ruling 2026-07-22 — does not fill the reserved Vol I 119 hole).
 decisions:
+  ADR125_t3_gap_projections:
+    title: 'T3 Gap Projections (Program 24 spine-C): five new Archive projection modules (economy, field-state, balkanization faction, chronicle event-anchoring, hex habitability) close the four remaining WO-52b/test-port-ledger LOUD gap rows; two Vol I/Vol II cascade dormancy gaps lit (fundamental_theorem graph stash consumed by the economy dossier — W-P; the value_form Phi tri-decomposition builders wired to real graph-input reads — W-C/W-P); U1 completes the SurplusValueDistribution graph publication (taxes_on_surplus + total_surplus — W-C). One gap found, not closed, and explicitly deferred: no engine scenario stamps NodeType.FACTION, so the balkanization dossier is honest-empty on every real campaign until the RED_OGV repair program seeds it (new OPEN row in ai/wiring-doctrine.md). Per-hex habitability ships as a county-grain inheritance (broadcast, not aggregation), pending a real dynamic_hex_state substrate column for a hex-native reading. Governance close-out ADR: no production code changes.'
+    status: accepted
+    date: '2026-07-22'
+    file: ADR125_t3_gap_projections.yaml
   ADR124_vol2_u8_monitoring:
     title: 'Vol II Circulation program U8 (Monitoring, lane/vol2-circulation): audited what the program''s new opposition bindings/GraphInputs fields/catalog artifact/gate satisfiers actually have on a wire today — the four shadow GraphInputs ratios and the gate-satisfiers have no persisted graph-attr home or wire path at all (recomputed fresh each tick purely to feed the opposition step; the LODES artifact is already cataloged in data-artifacts.yaml, not the seam registry''s remit) and building bespoke exposure for them was judged disproportionate to one unit, deferred to the T1.1 seam_algebra cascade this lane''s own merge-runbook already names for that. What DID have a concrete gap: U3''s compute_disproportionality output was computed but never reached a graph attr (a computed-but-unserialized silent no-op, Constitution VIII.12/III.11) — fixed: write_tick_state_to_graph now stamps tick_disproportionality (signed imbalance, honest None absent tensor data), _serialize_territory reads it through, and it is gated Tier >= 1 in babylon.projection.veil (same family as profit_rate/occ) — the other 13 pre-existing Group C/D fields deliberately stay out of that registry, a separate already-flagged gap not retroactively closed here. Also corrected the shared _CIRCULATION_LIVE seam-registry note (feeding all 7 pre-existing Group C rows) to record U3''s full fix (real reproduction calculators + genuine cross-tick accumulation), not just the turnover_profile_source wiring it previously described alone. New TestWriteDisproportionality (2 tests) red->green; full seam sentinel suite (63 tests) + veil suites (45 tests) re-run green; real-registry CLI gate exit 0, 124 observables, zero new advisories. No baseline drift (additive-only graph attr, no golden scenario reads it).'
     status: accepted

--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -2,9 +2,40 @@
 # What exists vs what's planned - KEEP THIS UPDATED
 
 meta:
-  version: "2.51.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
-  updated: "2026-07-21"
+  version: "2.52.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
+  updated: "2026-07-22"
   truth_status: |
+    (2026-07-22 T3 U7 governance close-out, ADR125) T3 GAP PROJECTIONS
+    PROGRAM COMPLETE (feature/t3-gap-projections, post-cascade spine-C):
+    U1-U6 all APPROVED (U2 APPROVED_AFTER_FIX; the PhiDecomposition
+    hardcoded-None finding fixed same session). Five new projection modules
+    ship: economy.py (Fundamental Theorem verdict off
+    opposition_states["wage"].balance, per-class Phi off the
+    fundamental_theorem graph stash, Volume III surplus split s=p+i+r+t as
+    extensive ratio-of-sums, matter-book overshoot honest-None), field_state
+    .py (Weather Layer — direct port of EngineBridge.get_field_state's read
+    logic), faction.py (balkanization dossier mirroring project_sovereign's
+    recipe), territory_anchor.py (TENANCY-inversion primitive deduped out of
+    web bridge + plate.py into one shared home, feeding chronicle event
+    anchoring), and topology/hex_habitability.py (county-grain broadcast to
+    hexes, pending a real dynamic_hex_state column for hex-native data).
+    Plus U1's graph_bridge.py completion publishing tick_taxes_on_surplus/
+    tick_total_surplus (the last 2 of 6 SurplusValueDistribution terms).
+    Closes all four remaining WO-52b/test-port-ledger LOUD gap rows
+    (TestEconomyDashboardFundamentalTheorem, TestEconomyDashboardChipContract,
+    TestGetFieldState, TestBalkanizationMapFields — rows 192-195 + items
+    1-4 all now CLOSED/REWRITTEN); lights the fundamental_theorem
+    liveness-registry row (ADR117's declared-dormant graph stash, a W-P
+    wiring motion) and the value_form Phi tri-decomposition builders'
+    read-side (W-C/W-P, still honest-None tree-wide — no producer exists
+    yet). One gap found, not fixed, and formally handed off: no engine
+    scenario stamps NodeType.FACTION (only the legacy web bridge's
+    _seed_balkanization_layer), so the balkanization dossier is honest-empty
+    on every real campaign — recorded as a new OPEN row in
+    ai/wiring-doctrine.md's §4 gap ledger citing the RED_OGV repair program
+    as owner. ADR125 written (governance close-out, no production code);
+    index.yaml bumped 1.52.0->1.53.0. tests/baselines/** untouched (docs +
+    ledgers only, per the controller's ceremony-ownership ruling).
     (2026-07-21 CASCADE) THE v1.0.0 FIVE-LANE MERGE CASCADE EXECUTED AND
     GREEN on merge/v1-cascade: T1.1 seam-severity (derived severity catalog
     single-sourced across web+Archive, seam-algebra dL sentinel, wall-clock

--- a/ai/wiring-doctrine.md
+++ b/ai/wiring-doctrine.md
@@ -107,6 +107,10 @@ budget L-MAT-1, population conservation (F-3 warn→alarm), the carbon register.
 | Divergence Channel (ADR072) | 𝕊 — correctly BLOCKED on Amendment T | — |
 | energy vertex J | 𝕊 (Amendment AB) then W-C/W-𝔇 | EIA/USWTDB/USPVDB keyless [V per §VI.11]; `energy/` thin (13M) |
 | hex biocapacity estate | W-G (ScaleAdjunction) or retire-with-record | NLCD/NASS/FIA/gSSURGO [V per §VI.11] |
+| fundamental_theorem dormancy (Vol I ADR117 graph stash, zero consumers) | W-P — **CLOSED** (T3 U2; `babylon.projection.economy.project_economy` consumes the stash's per-class Phi readings; liveness-registry row updated) | none needed (existing wage-opposition + `contradiction.py` feed) |
+| Phi tri-decomposition (value_form builders, zero callers tree-wide) | W-C read-side **CLOSED** (T3 U2 fix) / W-P consumer live; every component input still genuinely absent | `gamma_basket`+`consumption`; `p_g2_labor_value`+`wage_paid_for_d_g2`; `l_unpaid`+national MELT; `gamma_iii`+tau — none published tree-wide [U — unresearched producer] |
+| SurplusValueDistribution taxes_on_surplus/total_surplus unpublished (2 of 6 terms) | W-C — **CLOSED** (T3 U1; `graph_bridge.py` tick_taxes_on_surplus/tick_total_surplus) | none needed (already-computed field) |
+| balkanization FACTION-node seeding (no engine scenario stamps `NodeType.FACTION`; only the legacy web bridge's `_seed_balkanization_layer`) | W-C — **OPEN**, deferred to the RED_OGV repair program (T3 U4 finding; distinct from the Θ_data sovereignty-seed row above) | LODES ON DRIVE (7.9G), shared estate with the row above |
 
 ## 5. Data-estate posture
 

--- a/specs/24-archive/test-port-ledger.md
+++ b/specs/24-archive/test-port-ledger.md
@@ -192,7 +192,7 @@ judged legacy-web-only. Branch scanned: `feature/archive-p2-p4 @ 5474c44e`
 | `TestEconomyDashboardFundamentalTheorem` | graph-wide Wc−Vc imperial-rent gap + per-region population-weighted per-capita breakdown | the T3 spine-C economy dossier reads the SAME verdict the engine already adjudicates (`opposition_states["wage"].balance`, never a parallel Φ) + per-class Φ readings off the `fundamental_theorem` graph stash — `babylon.projection.economy.project_economy`, `tests/unit/projection/test_economy.py::TestEconomyDashboardFundamentalTheorem` | REWRITTEN (T3 U2) |
 | `TestEconomyDashboardChipContract` | economy dashboard emits an exact key set of aggregate quantities | the chip key-SET itself was web-shape and retires; the underlying quantities (Volume III surplus split s=p+i+r+t + the metabolic matter-book) are now projected, extensive RATIO-OF-SUMS — `babylon.projection.economy.project_economy`, `tests/unit/projection/test_economy.py::TestEconomyDashboardChipContract` | REWRITTEN (T3 U2) |
 | `TestGetFieldState` | dialectical field-stack projection: contradiction_fields + field_derivatives (laplacian/df_dt) honest-omitted, id-sorted, TENANCY-anchored edges, principal_field/dialectical_regime | the T3 U3 field-state dossier ports `EngineBridge.get_field_state`'s exact read logic — `babylon.projection.field_state.project_field_state`, `tests/unit/projection/test_field_state.py::TestGetFieldStateNodes`/`TestGetFieldStateEdges`/`TestGetFieldStatePrincipalFieldAndRegime` | REWRITTEN (T3 U3) |
-| `TestBalkanizationMapFields` | balkanization block: faction enumeration + per-territory contested/dominant_faction from INFLUENCES reads | single sovereign IS covered (`project_sovereign`/county `sovereign_id`); **faction enumeration + contested-territory derivation are not projected** (no `FactionView`, no INFLUENCES read); no WO | GAP (LOUD) |
+| `TestBalkanizationMapFields` | balkanization block: faction enumeration + per-territory contested/dominant_faction from INFLUENCES reads | the T3 U4 balkanization dossier adds `FactionView` + `territory_influence` (outgoing INFLUENCES edges, edge weight/channel + target `county_fips`) mirroring `project_sovereign`'s recipe — `babylon.projection.faction.project_faction`, `tests/unit/projection/test_faction.py`; no engine scenario seeds `NodeType.FACTION` today (only the legacy web bridge's `_seed_balkanization_layer`) — the honest all-absent dossier is correct on a real campaign; porting the seed is deferred to the RED_OGV repair program (`ai/wiring-doctrine.md` gap ledger, OPEN row) | REWRITTEN (T3 U4) |
 
 ### LOUD — coverage gaps the main loop must close before cutover
 
@@ -224,11 +224,20 @@ clearly owns. These block the WO-52 cutover gate:
    `dialectical_regime`) into a pure projection read-model, singleton page
    `field_state/USA.md` (`ArchiveTickBaker`/`IncrementalArchiveTickBaker`
    dispatch). See row 194 above.
-4. **`TestBalkanizationMapFields` → faction enumeration + contested-territory
-   derivation.** spec-070 balkanization (factions, INFLUENCES influence_level,
-   per-territory contested/dominant_faction) feeds RED_SETTLER_TRAP / secession.
-   Single-sovereign CLAIMS is projected; the faction/contested half is not, and no
-   WO owns it. **Owner needed: NEW balkanization projection, or extend map-room WO-33.**
+4. **CLOSED (T3 U4).** ~~`TestBalkanizationMapFields` → faction enumeration +
+   contested-territory derivation.~~ Closed by
+   `babylon.projection.faction.project_faction` + `render_faction.py` —
+   `territory_influence` derives from outgoing INFLUENCES edges (mirroring
+   `project_sovereign._claimed_county_fips`'s query pattern), sorted
+   influence-level-descending/territory-id-ascending to match
+   `GraphProtocol.query_faction_influence_by_territory`'s own ordering.
+   Honest-empty verified: no engine scenario seeds `NodeType.FACTION` (only
+   the legacy web bridge's `_seed_balkanization_layer` does), so a real
+   headless campaign's graph has zero faction nodes and `project_faction`
+   correctly returns a valid all-absent dossier for it — porting the seed
+   into engine scenarios is a physics change EXPLICITLY DEFERRED to the
+   RED_OGV repair program, tracked as an OPEN row in `ai/wiring-doctrine.md`'s
+   gap ledger (ADR125). See row 195 above.
 
 Secondary / borderline (surface for a ruling, not hard cutover blockers):
 - **Event→territory anchoring** (`TestSerializeEventUprisingTerritoryAnchoring`,

--- a/specs/24-archive/test-port-ledger.md
+++ b/specs/24-archive/test-port-ledger.md
@@ -191,7 +191,7 @@ judged legacy-web-only. Branch scanned: `feature/archive-p2-p4 @ 5474c44e`
 | `TestGroupCDDocstringsHonest` | web/game/engine_bridge.py docstrings say "CORRECTED 2026-07-18", not "both gating services are unwired" | docstring-accuracy meta-test on web-bridge source that dies at cutover; pins no runtime behavior | RETIRED |
 | `TestEconomyDashboardFundamentalTheorem` | graph-wide Wc−Vc imperial-rent gap + per-region population-weighted per-capita breakdown | the T3 spine-C economy dossier reads the SAME verdict the engine already adjudicates (`opposition_states["wage"].balance`, never a parallel Φ) + per-class Φ readings off the `fundamental_theorem` graph stash — `babylon.projection.economy.project_economy`, `tests/unit/projection/test_economy.py::TestEconomyDashboardFundamentalTheorem` | REWRITTEN (T3 U2) |
 | `TestEconomyDashboardChipContract` | economy dashboard emits an exact key set of aggregate quantities | the chip key-SET itself was web-shape and retires; the underlying quantities (Volume III surplus split s=p+i+r+t + the metabolic matter-book) are now projected, extensive RATIO-OF-SUMS — `babylon.projection.economy.project_economy`, `tests/unit/projection/test_economy.py::TestEconomyDashboardChipContract` | REWRITTEN (T3 U2) |
-| `TestGetFieldState` | dialectical field-stack projection: contradiction_fields + field_derivatives (laplacian/df_dt) honest-omitted, id-sorted, TENANCY-anchored edges, principal_field/dialectical_regime | engine-produced + engine-tested, but **no projection read-model** (grep-confirmed zero hits in `src/babylon/projection/`) and **no P2–P4 WO** names the Weather Layer | GAP (LOUD) |
+| `TestGetFieldState` | dialectical field-stack projection: contradiction_fields + field_derivatives (laplacian/df_dt) honest-omitted, id-sorted, TENANCY-anchored edges, principal_field/dialectical_regime | the T3 U3 field-state dossier ports `EngineBridge.get_field_state`'s exact read logic — `babylon.projection.field_state.project_field_state`, `tests/unit/projection/test_field_state.py::TestGetFieldStateNodes`/`TestGetFieldStateEdges`/`TestGetFieldStatePrincipalFieldAndRegime` | REWRITTEN (T3 U3) |
 | `TestBalkanizationMapFields` | balkanization block: faction enumeration + per-territory contested/dominant_faction from INFLUENCES reads | single sovereign IS covered (`project_sovereign`/county `sovereign_id`); **faction enumeration + contested-territory derivation are not projected** (no `FactionView`, no INFLUENCES read); no WO | GAP (LOUD) |
 
 ### LOUD — coverage gaps the main loop must close before cutover
@@ -215,13 +215,15 @@ clearly owns. These block the WO-52 cutover gate:
    `biocapacity_ceiling`) — `wealth_by_class_role`/`county_flow` specifically
    have no successor (no `FactionView`/per-role rollup exists; not this
    unit's scope). See row 192 above.
-3. **`TestGetFieldState` → dialectical field-stack / "Weather Layer" projection.**
-   `contradiction_fields`, `field_derivatives` (laplacian/df_dt), `principal_field`,
-   `dialectical_regime`, TENANCY-anchored field edges — engine-produced and
-   engine-tested (`test_contradiction_field_system.py`, `test_field_derivative_system.py`)
-   but with no projection read-model and no WO. **Owner needed: NEW field-state
-   dossier / topology-surface WO** (or an explicit RETIRE ruling if the Weather
-   Layer is out of scope for the TUI).
+3. **CLOSED (T3 U3).** ~~`TestGetFieldState` → dialectical field-stack /
+   "Weather Layer" projection.~~ Closed by
+   `babylon.projection.field_state.project_field_state` — a direct port of
+   `EngineBridge.get_field_state`'s read logic (`contradiction_fields`,
+   `field_derivatives` laplacian/df_dt only, `fascist_alignment`,
+   TENANCY-anchored `field_gradients`, graph-level `principal_field`/
+   `dialectical_regime`) into a pure projection read-model, singleton page
+   `field_state/USA.md` (`ArchiveTickBaker`/`IncrementalArchiveTickBaker`
+   dispatch). See row 194 above.
 4. **`TestBalkanizationMapFields` → faction enumeration + contested-territory
    derivation.** spec-070 balkanization (factions, INFLUENCES influence_level,
    per-territory contested/dominant_faction) feeds RED_SETTLER_TRAP / secession.

--- a/specs/24-archive/test-port-ledger.md
+++ b/specs/24-archive/test-port-ledger.md
@@ -39,7 +39,8 @@ these are the cutover blockers enumerated in the LOUD list.
 | RE-GUARDED (new) | 3 |
 | CARRIED — P3 (new) | 8 |
 | RETIRED (new) | 21 |
-| GAP — uncovered, unowned (new) | 4 |
+| REWRITTEN (new — T3 U2 closure) | 2 |
+| GAP — uncovered, unowned (new) | 2 |
 | **Total** | **63** |
 
 ## Ledger
@@ -188,8 +189,8 @@ judged legacy-web-only. Branch scanned: `feature/archive-p2-p4 @ 5474c44e`
 | `TestBridgeEconomicsOverridesWiresCirculationAndFinancialServices` | `_bridge_economics_overrides` wires FRED circulation/financial services | web-bridge-local DUPLICATE of the headless-runner wiring (`domain/economics/factory.py`); Archive runs the engine via the runner; durable behavior covered by `tests/unit/economics/test_create_financial_services.py` + `tests/integration/test_circulation_one_tick.py` | RETIRED |
 | `TestBridgeEconomicsOverridesWiresVol1ReserveArmyServices` | `_bridge_economics_overrides` wires Vol I reserve-army services | same — web duplicate of the runner's `create_vol1_services`; durable behavior covered by `tests/integration/test_volume_i_integration.py` | RETIRED |
 | `TestGroupCDDocstringsHonest` | web/game/engine_bridge.py docstrings say "CORRECTED 2026-07-18", not "both gating services are unwired" | docstring-accuracy meta-test on web-bridge source that dies at cutover; pins no runtime behavior | RETIRED |
-| `TestEconomyDashboardFundamentalTheorem` | graph-wide Wc−Vc imperial-rent gap + per-region population-weighted per-capita breakdown | **NO projection module computes this** (county `imperial_rent_phi`=`tick_phi_hour` is different math); **no WO owns it** — the Fundamental Theorem is THE core game theorem | GAP (LOUD) |
-| `TestEconomyDashboardChipContract` | economy dashboard emits an exact key set of aggregate quantities | the aggregates (wage_flow_total/tribute_flow_total/rent_extracted/wealth_by_class_role/county_flow/imperial_rent_gap) are **not projected anywhere**; no WO | GAP (LOUD) |
+| `TestEconomyDashboardFundamentalTheorem` | graph-wide Wc−Vc imperial-rent gap + per-region population-weighted per-capita breakdown | the T3 spine-C economy dossier reads the SAME verdict the engine already adjudicates (`opposition_states["wage"].balance`, never a parallel Φ) + per-class Φ readings off the `fundamental_theorem` graph stash — `babylon.projection.economy.project_economy`, `tests/unit/projection/test_economy.py::TestEconomyDashboardFundamentalTheorem` | REWRITTEN (T3 U2) |
+| `TestEconomyDashboardChipContract` | economy dashboard emits an exact key set of aggregate quantities | the chip key-SET itself was web-shape and retires; the underlying quantities (Volume III surplus split s=p+i+r+t + the metabolic matter-book) are now projected, extensive RATIO-OF-SUMS — `babylon.projection.economy.project_economy`, `tests/unit/projection/test_economy.py::TestEconomyDashboardChipContract` | REWRITTEN (T3 U2) |
 | `TestGetFieldState` | dialectical field-stack projection: contradiction_fields + field_derivatives (laplacian/df_dt) honest-omitted, id-sorted, TENANCY-anchored edges, principal_field/dialectical_regime | engine-produced + engine-tested, but **no projection read-model** (grep-confirmed zero hits in `src/babylon/projection/`) and **no P2–P4 WO** names the Weather Layer | GAP (LOUD) |
 | `TestBalkanizationMapFields` | balkanization block: faction enumeration + per-territory contested/dominant_faction from INFLUENCES reads | single sovereign IS covered (`project_sovereign`/county `sovereign_id`); **faction enumeration + contested-territory derivation are not projected** (no `FactionView`, no INFLUENCES read); no WO | GAP (LOUD) |
 
@@ -198,17 +199,22 @@ judged legacy-web-only. Branch scanned: `feature/archive-p2-p4 @ 5474c44e`
 Engine/projection behavior that (a) no landed test covers, (b) no in-flight WO
 clearly owns. These block the WO-52 cutover gate:
 
-1. **`TestEconomyDashboardFundamentalTheorem` → graph-wide Wc−Vc imperial-rent gap
-   + per-region population-weighted per-capita breakdown.** THE core theorem
-   (`W_c > V_c`). No projection module computes `value_produced`/`rent_extracted`/
-   `wage_flow_total`/`imperial_rent_gap[_by_region]`; the per-county `tick_phi_hour`
-   (rows 35) is Leontief Φ, a different quantity. **Owner needed: NEW economy-dossier
-   projection WO** (also reconciles the row-35 scope note above).
-2. **`TestEconomyDashboardChipContract` → economy aggregate quantities.** The
-   dashboard's `wealth_by_class_role`/`county_flow`/`rent_extracted`/
-   `tribute_flow_total`/`current_super_wage_rate` are projected nowhere. Same
-   owner as #1 (the chip key-SET contract itself is web-shape and can retire; the
-   quantities are the gap).
+1. **CLOSED (T3 U2).** ~~`TestEconomyDashboardFundamentalTheorem` → graph-wide
+   Wc−Vc imperial-rent gap + per-region population-weighted per-capita
+   breakdown.~~ Closed by `babylon.projection.economy.project_economy` — the
+   verdict reads `opposition_states["wage"].balance` verbatim (never a
+   parallel Φ) plus the `fundamental_theorem` graph stash's per-class Φ
+   readings. Row 35's `tick_phi_hour` remains a distinct quantity (per-county
+   Leontief Φ, not the Fundamental Theorem) — the reconciling note that scope
+   boundary still stands. See row 191 above.
+2. **CLOSED (T3 U2).** ~~`TestEconomyDashboardChipContract` → economy
+   aggregate quantities.~~ The chip key-SET contract itself was web-shape and
+   retires with the web client; the underlying aggregates are now the
+   economy dossier's Volume III surplus split (`s = p + i + r + t`, extensive
+   ratio-of-sums) + metabolic matter-book (`overshoot_ratio`,
+   `biocapacity_ceiling`) — `wealth_by_class_role`/`county_flow` specifically
+   have no successor (no `FactionView`/per-role rollup exists; not this
+   unit's scope). See row 192 above.
 3. **`TestGetFieldState` → dialectical field-stack / "Weather Layer" projection.**
    `contradiction_fields`, `field_derivatives` (laplacian/df_dt), `principal_field`,
    `dialectical_regime`, TENANCY-anchored field edges — engine-produced and

--- a/specs/24-archive/test-port-ledger.md
+++ b/specs/24-archive/test-port-ledger.md
@@ -39,8 +39,7 @@ these are the cutover blockers enumerated in the LOUD list.
 | RE-GUARDED (new) | 3 |
 | CARRIED — P3 (new) | 8 |
 | RETIRED (new) | 21 |
-| REWRITTEN (new — T3 U2 closure) | 2 |
-| GAP — uncovered, unowned (new) | 2 |
+| REWRITTEN (new — T3 U2/U3/U4 closure) | 4 |
 | **Total** | **63** |
 
 ## Ledger

--- a/src/babylon/domain/economics/tick/graph_bridge.py
+++ b/src/babylon/domain/economics/tick/graph_bridge.py
@@ -234,6 +234,20 @@ def write_tick_state_to_graph(  # pragma: no mutate — data serialization
                 if county.surplus_distribution is not None  # pragma: no mutate
                 else 0.0  # pragma: no mutate
             ),  # pragma: no mutate
+            # U1 (surplus-split publication completion): the remaining 2 of
+            # the 6 SurplusValueDistribution terms — without these the
+            # Marxian identity s = p + i + r + t could not be reconstructed
+            # from the graph (5 of 6 terms were already published above).
+            tick_taxes_on_surplus=(  # pragma: no mutate
+                county.surplus_distribution.taxes_on_surplus  # pragma: no mutate
+                if county.surplus_distribution is not None  # pragma: no mutate
+                else 0.0  # pragma: no mutate
+            ),  # pragma: no mutate
+            tick_total_surplus=(  # pragma: no mutate
+                county.surplus_distribution.total_surplus_produced  # pragma: no mutate
+                if county.surplus_distribution is not None  # pragma: no mutate
+                else 0.0  # pragma: no mutate
+            ),  # pragma: no mutate
             tick_accumulated_debt=(  # pragma: no mutate
                 county.debt_accumulation.accumulated_debt  # pragma: no mutate
                 if county.debt_accumulation is not None  # pragma: no mutate

--- a/src/babylon/game/chronicle_adapter.py
+++ b/src/babylon/game/chronicle_adapter.py
@@ -53,6 +53,30 @@ never dropped, never guessed at, always loud about the gap.
 the pilot's own coercion discipline: a bus ``Event`` whose ``.type`` is not
 a real ``EventType`` value raises (a bug elsewhere — a malformed event is
 never silently absorbed into the Chronicle).
+
+**Event-to-territory anchoring (Unit U5).** Several verified payload shapes
+carry a bare social_class node id with no place to report — e.g. struggle.py's
+``EventType.UPRISING``/``EXCESSIVE_FORCE``/``SOLIDARITY_SPIKE`` all publish
+the SAME struggling class's ``node.id``; ``reactionary.py`` does the same
+for ``FASCIST_DRIFT``; the reactionary-verb family (``POGROM``/``LOCKOUT``/
+``VIGILANTISM``) publishes the victim class as ``target_id`` — the SAME
+``target_id`` the legacy ``web/game/engine_bridge.py::
+_TERRITORY_ANCHORED_VERB_EVENTS`` precedent already anchors for the map
+layer. :data:`_CLASS_ANCHOR_FIELD` names, per ``EventType``, which payload
+key holds that resolvable social_class id; when a live ``graph`` is threaded
+through (:func:`chronicle_events_from_bus`'s ``graph=`` parameter —
+``GameSession.advance_tick`` threads its own live, post-tick graph, never a
+``WorldState.from_graph()`` round trip, which drops the TENANCY edges this
+resolution reads), the resolved :class:`~babylon.projection.
+territory_anchor.TerritoryAnchor` is added as ``data["anchor"]`` and
+appended to the human summary. The TENANCY-inversion primitive itself
+(:func:`~babylon.projection.territory_anchor.tenancy_members_by_territory` /
+:func:`~babylon.projection.territory_anchor.class_to_territory`) is the ONE
+shared home :mod:`babylon.projection.verbs.plate` also consumes — no third
+copy. An event whose payload never carries the field, or whose class id
+carries no live TENANCY edge into any territory, resolves to no anchor at
+all (Constitution III.11: honest absence, never a fabricated territory);
+``graph=None`` (the default) reproduces the exact pre-U5 behavior.
 """
 
 from __future__ import annotations
@@ -62,6 +86,13 @@ from typing import Any, Final
 
 from babylon.kernel.event_bus import Event
 from babylon.models.enums.events import EventType
+from babylon.projection.territory_anchor import (
+    TerritoryAnchor,
+    class_to_territory,
+    resolve_class_territory_anchor,
+    tenancy_members_by_territory,
+)
+from babylon.topology import BabylonGraph
 from babylon.tui.chronicle import ChronicleEvent
 
 __all__ = [
@@ -69,6 +100,23 @@ __all__ = [
     "summarize_event",
     "chronicle_events_from_bus",
 ]
+
+_CLASS_ANCHOR_FIELD: Final[dict[EventType, str]] = {
+    EventType.EXCESSIVE_FORCE: "node_id",
+    EventType.UPRISING: "node_id",
+    EventType.SOLIDARITY_SPIKE: "node_id",
+    EventType.FASCIST_DRIFT: "node_id",
+    EventType.POGROM: "target_id",
+    EventType.LOCKOUT: "target_id",
+    EventType.VIGILANTISM: "target_id",
+}
+"""``EventType`` -> the payload key holding a resolvable social_class node id
+(see the module docstring's "Event-to-territory anchoring" section for the
+per-EventType provenance). Deliberately narrow: only EventTypes this module
+could VERIFY carry a social_class id here — the same "ground truth, not
+invention" discipline :data:`_SUMMARY_BUILDERS` already applies. An
+``EventType`` absent from this table never gains an anchor, even when a
+live ``graph`` is supplied."""
 
 SummaryBuilder = Callable[[Mapping[str, Any]], str]
 """A pure function: one event's raw ``payload`` -> its one-line summary."""
@@ -467,7 +515,37 @@ def summarize_event(event_type: EventType, tick: int, payload: Mapping[str, Any]
     return _generic_summary(event_type, tick, payload)
 
 
-def chronicle_events_from_bus(raw_events: Sequence[Event]) -> tuple[ChronicleEvent, ...]:
+def _resolve_event_anchor(
+    event_type: EventType,
+    payload: Mapping[str, Any],
+    class_to_territory_map: Mapping[str, str],
+    graph: BabylonGraph,
+) -> TerritoryAnchor | None:
+    """Resolve one event's :class:`TerritoryAnchor`, or ``None`` if it has none.
+
+    :param event_type: the event's coerced, real :class:`EventType`.
+    :param payload: the event's raw payload dict.
+    :param class_to_territory_map: this tick's precomputed
+        :func:`~babylon.projection.territory_anchor.class_to_territory` map
+        (computed once per :func:`chronicle_events_from_bus` call, never
+        recomputed per-event).
+    :param graph: the live world graph (for the territory's display name).
+    :returns: the resolved anchor, or ``None`` when ``event_type`` carries no
+        anchor-eligible field (:data:`_CLASS_ANCHOR_FIELD`), the field is
+        absent/malformed, or the class id resolves to no territory.
+    """
+    field = _CLASS_ANCHOR_FIELD.get(event_type)
+    if field is None:
+        return None
+    class_id = payload.get(field)
+    if not isinstance(class_id, str) or not class_id:
+        return None
+    return resolve_class_territory_anchor(graph, dict(class_to_territory_map), class_id)
+
+
+def chronicle_events_from_bus(
+    raw_events: Sequence[Event], *, graph: BabylonGraph | None = None
+) -> tuple[ChronicleEvent, ...]:
     """Promote one tick's real bus events into real :class:`ChronicleEvent`\\ s.
 
     The PRODUCTION replacement for the WO-50 pilot test's own documented
@@ -485,19 +563,36 @@ def chronicle_events_from_bus(raw_events: Sequence[Event]) -> tuple[ChronicleEve
     ``len(raw_events)``.
 
     :param raw_events: one tick's raw event-bus history, in emission order.
+    :param graph: the live, post-tick world graph (see the module
+        docstring's "Event-to-territory anchoring" section) —
+        :meth:`~babylon.game.session.GameSession.advance_tick`'s OWN live
+        graph object, never a ``WorldState.from_graph()`` round trip (which
+        drops the TENANCY edges this resolution reads). ``None`` (the
+        default) reproduces the exact pre-U5 behavior: no event gains an
+        ``anchor``.
     :returns: one :class:`ChronicleEvent` per input event, same order.
     :raises ValueError: if any event's ``.type`` is not a real
         :class:`EventType` value.
     """
+    class_to_territory_map: dict[str, str] = (
+        class_to_territory(tenancy_members_by_territory(graph)) if graph is not None else {}
+    )
     chronicle: list[ChronicleEvent] = []
     for event in raw_events:  # loop bound: len(raw_events)
         event_type = EventType(event.type)
+        summary = summarize_event(event_type, event.tick, event.payload)
+        data = dict(event.payload)
+        if graph is not None:
+            anchor = _resolve_event_anchor(event_type, event.payload, class_to_territory_map, graph)
+            if anchor is not None:
+                summary = f"{summary} (in {anchor.territory_name})"
+                data["anchor"] = anchor.model_dump()
         chronicle.append(
             ChronicleEvent(
                 tick=event.tick,
                 event_type=event_type,
-                summary=summarize_event(event_type, event.tick, event.payload),
-                data=dict(event.payload),
+                summary=summary,
+                data=data,
             )
         )
     return tuple(chronicle)

--- a/src/babylon/game/session.py
+++ b/src/babylon/game/session.py
@@ -293,6 +293,10 @@ class TickAdvanceResult:
         :func:`~babylon.game.chronicle_adapter.chronicle_events_from_bus`
         (Unit C4) — same order, one-to-one with ``events``. The Chronicle
         client's real content source; never re-derived from ``world``.
+        Class-scoped events (e.g. UPRISING) carry a resolved territory
+        ``anchor`` when the graph's TENANCY edges make one resolvable
+        (Unit U5), since ``chronicle`` is built from :attr:`graph` itself,
+        not ``world``.
     :param paused: the pacing driver's pause-predicate verdict for this tick.
     :param autosaved: ``True`` iff this tick is a checkpoint tick under
         :func:`~babylon.persistence.delta.is_checkpoint_tick` (Unit C6 —
@@ -482,7 +486,10 @@ class GameSession:
         bus.clear_history()
         self.engine.run_tick(self.graph, self.services, context)
         events = tuple(bus.get_history())
-        chronicle = chronicle_events_from_bus(events)
+        # Unit U5: threads the session's OWN live, post-tick graph so the
+        # adapter can resolve event-to-territory anchors (TENANCY edges) —
+        # never a WorldState.from_graph() round trip, which drops them.
+        chronicle = chronicle_events_from_bus(events, graph=self.graph)
 
         world = WorldState.from_graph(self.graph, tick=next_tick)
         determinism_hash = _replay_identity_hash(self.session_id, next_tick, self._rng_seed)

--- a/src/babylon/projection/county.py
+++ b/src/babylon/projection/county.py
@@ -39,6 +39,13 @@ choice is recorded here):
      - ``aggregate_survival_for_county`` pop-weighted means.
    * - ``bifurcation_score``
      - ``tick_bifurcation_score`` territory attribute.
+   * - ``habitability``
+     - ``habitability`` territory attribute (MetabolismSystem,
+       engine/systems/metabolism.py — Sovereign-driven metabolic impact +
+       biocapacity-derived ecological viability). A graph-only transient:
+       ``TERRITORY_EXCLUDED_FIELDS`` drops it from ``WorldState.from_graph()``
+       (world_state.py:88), so it is read straight off the LIVE post-tick
+       graph node handed to this function, never through ``world``.
    * - ``sovereign_id``
      - The single incoming CLAIMS edge on the county's territory node
        (spec-070); zero or contested (>1) claims project as ``None``.
@@ -179,5 +186,6 @@ def project_county(
         p_acquiescence=survival[0],
         p_revolution=survival[1],
         bifurcation_score=attrs.get("tick_bifurcation_score"),
+        habitability=attrs.get("habitability"),
         sovereign_id=_single_claimant(graph, territory.id) if territory else None,
     )

--- a/src/babylon/projection/economy.py
+++ b/src/babylon/projection/economy.py
@@ -3,12 +3,16 @@
 Assembles a :class:`~babylon.projection.view_models.EconomyView` from the
 post-tick world: the Fundamental Theorem verdict read verbatim off the
 ``wage`` opposition's Balance, the per-class/county Φ readings the
-``fundamental_theorem`` graph stash carries, Φ's tri-decomposition (wired
-here as a pure read of graph inputs — genuinely absent tree-wide today), the
-Volume III surplus split aggregated RATIO-OF-SUMS across territories, and
-the metabolic matter-book. Transport-neutral by construction — no Django, no
-engine imports, no database connection; callers hand in the graph and world
-they already hold.
+``fundamental_theorem`` graph stash carries, Φ's tri-decomposition (each
+component's own named graph inputs are attempted at project time and fed
+straight into the matching :mod:`~babylon.domain.dialectics.instances.
+value_form` builder — genuinely absent tree-wide today, so every attempt
+currently resolves ``None``, but the read sites are real: the first future
+unit to publish a component's inputs makes that component light up with no
+change to this module), the Volume III surplus split aggregated
+RATIO-OF-SUMS across territories, and the metabolic matter-book.
+Transport-neutral by construction — no Django, no engine imports, no
+database connection; callers hand in the graph and world they already hold.
 
 **One producer per field** (mirrors the WO-3 ruling
 :mod:`babylon.projection.county` records):
@@ -38,19 +42,30 @@ they already hold.
        ``phi_iii_report`` / ``phi_decomposition_total``
      - Φ's tri-decomposition (:mod:`~babylon.domain.dialectics.instances.
        value_form`'s ``phi_unequal_exchange``/``phi_reproduction``/
-       ``phi_domestic``/``phi_iii_report`` builders, §9.3). Wired here as a
-       pure read of graph inputs at project time — NOT engine computation.
-       Each component needs its own raw input (``γ_basket`` + consumption
-       for unequal exchange; ``p_g2_labor_value`` + wages-for-rearing for
-       reproduction; unpaid reproductive labor-hours for domestic) and
-       **none of these five inputs is published to the graph anywhere in
-       the engine today** (verified tree-wide, 2026-07-22 — not even the
-       national MELT τ alone, itself live on
-       ``tick_dynamics.tick_summary.national_melt``, can complete
-       ``τ · L_unpaid`` without ``L_unpaid``). All five project as honest
-       ``None`` until a future unit lands the first missing input, one
-       component at a time (Constitution III.11) — this module never
-       fabricates them and never adds the missing engine-side computation.
+       ``phi_domestic``/``phi_iii_report``/``PhiDecomposition`` builders,
+       §9.3). Each component attempts its own named graph reads at project
+       time — NOT engine computation — and calls the matching builder only
+       when every one of its inputs resolves:
+       ``phi_unequal_exchange`` reads the ``"gamma_basket"`` (a
+       :class:`~babylon.domain.economics.gamma.types.GammaBasket` dump) and
+       ``"consumption"`` graph attrs; ``phi_reproduction`` reads
+       ``"p_g2_labor_value"`` and ``"wage_paid_for_d_g2"``; ``phi_domestic``
+       reads ``"l_unpaid"`` plus the national MELT τ already live on
+       ``tick_dynamics.tick_summary.national_melt``; ``phi_iii_report``
+       reads ``"gamma_iii"`` (a
+       :class:`~babylon.domain.economics.gamma.types.GammaIII` dump) plus
+       the same τ. ``phi_decomposition_total`` builds a real
+       :class:`~babylon.domain.dialectics.instances.value_form.
+       PhiDecomposition` and reads its ``total`` — but only once all THREE
+       conservation components (unequal exchange, reproduction, domestic)
+       resolve; ``phi_iii_report`` is report-only and never gates it.
+       **None of these six graph attrs is published anywhere in the engine
+       today** (verified tree-wide, 2026-07-22), so every read attempt
+       currently resolves ``None`` and every component projects honest
+       ``None`` (Constitution III.11) — this module never fabricates an
+       input and never adds the missing engine-side computation. The read
+       sites are real, though: the first future unit to publish any one
+       input lights up that component with no change to this module.
    * - ``surplus_produced`` / ``profit_of_enterprise`` / ``interest_burden``
        / ``ground_rent`` / ``taxes_on_surplus`` / ``rentier_share`` /
        ``financialization_share``
@@ -93,6 +108,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from babylon.domain.dialectics.instances.value_form import (
+    PhiDecomposition,
+    phi_domestic,
+    phi_iii_report,
+    phi_reproduction,
+    phi_unequal_exchange,
+)
+from babylon.domain.economics.gamma.types import GammaBasket, GammaIII
 from babylon.models.enums.topology import NodeType
 from babylon.projection.view_models import ClassPhiReadingView, EconomyView
 
@@ -137,6 +160,140 @@ def _class_phi_readings(graph: GraphProtocol) -> tuple[ClassPhiReadingView, ...]
     if raw is None:
         return None
     return tuple(ClassPhiReadingView(**data) for _, data in sorted(raw.items()))
+
+
+def _national_melt(graph: GraphProtocol) -> float | None:
+    """Read the national MELT (τ) off the live ``tick_dynamics`` graph stash.
+
+    ``TickDynamicsSystem`` writes ``state.tick_summary`` (a
+    :class:`~babylon.domain.economics.tick.types.TickSummary` instance, not a
+    dump) verbatim into the ``"tick_dynamics"`` graph attr's ``"tick_summary"``
+    key (:func:`~babylon.domain.economics.tick.graph_bridge.
+    write_tick_state_to_graph`) — read here via ``graph.get_graph_attr``
+    through the SAME live in-memory graph object, never a round-tripped copy.
+
+    :param graph: The post-tick graph.
+    :returns: ``tick_dynamics.tick_summary.national_melt``, or ``None`` when
+        the ``tick_dynamics`` stash or its ``tick_summary`` sub-object is
+        absent this tick.
+    """
+    tick_dynamics = graph.get_graph_attr("tick_dynamics", None)
+    if not isinstance(tick_dynamics, dict):
+        return None
+    tick_summary = tick_dynamics.get("tick_summary")
+    if tick_summary is None:
+        return None
+    return float(tick_summary.national_melt)
+
+
+def _phi_unequal_exchange(graph: GraphProtocol) -> float | None:
+    """Emmanuel/Amin Φ_unequal_exchange, from its two named graph inputs.
+
+    :param graph: The post-tick graph.
+    :returns: :func:`~babylon.domain.dialectics.instances.value_form.
+        phi_unequal_exchange` over the ``"gamma_basket"``/``"consumption"``
+        graph attrs, or ``None`` when either is absent this tick.
+    :raises pydantic.ValidationError: if a present ``"gamma_basket"`` dump is
+        malformed.
+    """
+    raw_gamma_basket = graph.get_graph_attr("gamma_basket", None)
+    consumption = graph.get_graph_attr("consumption", None)
+    if raw_gamma_basket is None or consumption is None:
+        return None
+    gamma_basket = GammaBasket(**raw_gamma_basket)
+    return phi_unequal_exchange(gamma_basket, float(consumption))
+
+
+def _phi_reproduction(graph: GraphProtocol) -> float | None:
+    """Meillassoux Φ_reproduction, from its two named graph inputs.
+
+    :param graph: The post-tick graph.
+    :returns: :func:`~babylon.domain.dialectics.instances.value_form.
+        phi_reproduction` over the ``"p_g2_labor_value"``/
+        ``"wage_paid_for_d_g2"`` graph attrs, or ``None`` when either is
+        absent this tick.
+    """
+    p_g2_labor_value = graph.get_graph_attr("p_g2_labor_value", None)
+    wage_paid_for_d_g2 = graph.get_graph_attr("wage_paid_for_d_g2", None)
+    if p_g2_labor_value is None or wage_paid_for_d_g2 is None:
+        return None
+    return phi_reproduction(
+        p_g2_labor_value=float(p_g2_labor_value),
+        wage_paid_for_d_g2=float(wage_paid_for_d_g2),
+    )
+
+
+def _phi_domestic(graph: GraphProtocol) -> float | None:
+    """Fortunati Φ_domestic (``τ · L_unpaid``), from its named graph inputs.
+
+    :param graph: The post-tick graph.
+    :returns: :func:`~babylon.domain.dialectics.instances.value_form.
+        phi_domestic` over the ``"l_unpaid"`` graph attr and
+        :func:`_national_melt`, or ``None`` when either is absent this tick.
+    """
+    l_unpaid = graph.get_graph_attr("l_unpaid", None)
+    tau = _national_melt(graph)
+    if l_unpaid is None or tau is None:
+        return None
+    return phi_domestic(tau, float(l_unpaid))
+
+
+def _phi_iii_report(graph: GraphProtocol) -> float | None:
+    """The kernel's narrower Φ_III report term, from its named graph inputs.
+
+    :param graph: The post-tick graph.
+    :returns: :func:`~babylon.domain.dialectics.instances.value_form.
+        phi_iii_report` over the ``"gamma_iii"`` graph attr and
+        :func:`_national_melt`, or ``None`` when either is absent this tick.
+    :raises pydantic.ValidationError: if a present ``"gamma_iii"`` dump is
+        malformed.
+    """
+    raw_gamma_iii = graph.get_graph_attr("gamma_iii", None)
+    tau = _national_melt(graph)
+    if raw_gamma_iii is None or tau is None:
+        return None
+    gamma_iii = GammaIII(**raw_gamma_iii)
+    return phi_iii_report(gamma_iii, tau)
+
+
+#: One Φ tri-decomposition tuple:
+#: (unequal_exchange, reproduction, domestic, iii_report, decomposition_total).
+_PhiTriDecomposition = tuple[float | None, float | None, float | None, float | None, float | None]
+
+
+def _phi_tri_decomposition(graph: GraphProtocol) -> _PhiTriDecomposition:
+    """Attempt every Φ tri-decomposition component's own named graph read.
+
+    Each component is read and, where possible, built independently — a
+    present ``phi_unequal_exchange`` does not require ``phi_domestic`` to
+    also be present. ``phi_decomposition_total`` is the odd one out: it
+    builds a real :class:`~babylon.domain.dialectics.instances.value_form.
+    PhiDecomposition` and reads its ``total`` computed field, so it requires
+    all THREE conservation components (unequal exchange, reproduction,
+    domestic) to resolve — ``phi_iii_report`` is report-only (D2 kernel-fork
+    resolution) and never gates it, matching
+    :attr:`~babylon.domain.dialectics.instances.value_form.PhiDecomposition.total`'s
+    own exclusion.
+
+    :param graph: The post-tick graph.
+    :returns: ``(phi_unequal_exchange, phi_reproduction, phi_domestic,
+        phi_iii_report, phi_decomposition_total)`` — each independently
+        ``None`` when its own inputs are absent this tick.
+    """
+    unequal_exchange = _phi_unequal_exchange(graph)
+    reproduction = _phi_reproduction(graph)
+    domestic = _phi_domestic(graph)
+    iii_report = _phi_iii_report(graph)
+    total: float | None = None
+    if unequal_exchange is not None and reproduction is not None and domestic is not None:
+        decomposition = PhiDecomposition(
+            phi_unequal_exchange=unequal_exchange,
+            phi_reproduction=reproduction,
+            phi_domestic=domestic,
+            phi_iii_report=iii_report if iii_report is not None else 0.0,
+        )
+        total = decomposition.total
+    return (unequal_exchange, reproduction, domestic, iii_report, total)
 
 
 #: One RATIO-OF-SUMS tuple: (s, p, i, r, t, rentier_share, financialization_share).
@@ -246,6 +403,13 @@ def project_economy(
     wage_balance, labor_aristocracy_verdict = _fundamental_theorem_verdict(graph)
     class_phi_readings = _class_phi_readings(graph)
     (
+        phi_unequal_exchange_reading,
+        phi_reproduction_reading,
+        phi_domestic_reading,
+        phi_iii_report_reading,
+        phi_decomposition_total_reading,
+    ) = _phi_tri_decomposition(graph)
+    (
         surplus_produced,
         profit_of_enterprise,
         interest_burden,
@@ -267,19 +431,18 @@ def project_economy(
         wage_balance=wage_balance,
         labor_aristocracy_verdict=labor_aristocracy_verdict,
         class_phi_readings=class_phi_readings,
-        # Φ's tri-decomposition (§9.3): genuinely absent tree-wide today —
-        # no engine producer publishes gamma_basket/consumption (unequal
-        # exchange), p_g2_labor_value/wage_paid_for_d_g2 (reproduction), or
-        # l_unpaid (domestic labor's unpaid-hours half; national MELT tau
-        # IS live elsewhere, but alone cannot complete tau * l_unpaid).
-        # Wired to light up the moment any ONE producer lands, one
-        # component at a time (Constitution III.11) — never engine
-        # computation added here (see this module's own docstring table).
-        phi_unequal_exchange=None,
-        phi_reproduction=None,
-        phi_domestic=None,
-        phi_iii_report=None,
-        phi_decomposition_total=None,
+        # Φ's tri-decomposition (§9.3): each component reads its own named
+        # graph inputs at project time (see :func:`_phi_tri_decomposition`
+        # and this module's own docstring table) — genuinely absent
+        # tree-wide today, so every attempt currently resolves None, but the
+        # read sites are real and light up the moment a future unit
+        # publishes the first input (Constitution III.11) — never engine
+        # computation added here.
+        phi_unequal_exchange=phi_unequal_exchange_reading,
+        phi_reproduction=phi_reproduction_reading,
+        phi_domestic=phi_domestic_reading,
+        phi_iii_report=phi_iii_report_reading,
+        phi_decomposition_total=phi_decomposition_total_reading,
         surplus_produced=surplus_produced,
         profit_of_enterprise=profit_of_enterprise,
         interest_burden=interest_burden,

--- a/src/babylon/projection/economy.py
+++ b/src/babylon/projection/economy.py
@@ -1,0 +1,298 @@
+"""The economy read-model — ``project_economy``, the T3 spine-C dossier.
+
+Assembles a :class:`~babylon.projection.view_models.EconomyView` from the
+post-tick world: the Fundamental Theorem verdict read verbatim off the
+``wage`` opposition's Balance, the per-class/county Φ readings the
+``fundamental_theorem`` graph stash carries, Φ's tri-decomposition (wired
+here as a pure read of graph inputs — genuinely absent tree-wide today), the
+Volume III surplus split aggregated RATIO-OF-SUMS across territories, and
+the metabolic matter-book. Transport-neutral by construction — no Django, no
+engine imports, no database connection; callers hand in the graph and world
+they already hold.
+
+**One producer per field** (mirrors the WO-3 ruling
+:mod:`babylon.projection.county` records):
+
+.. list-table:: Field-producer rulings
+   :header-rows: 1
+
+   * - Field
+     - Producer
+   * - ``wage_balance`` / ``labor_aristocracy_verdict``
+     - The ``wage`` opposition's ``balance`` on the ``opposition_states``
+       graph attribute (``ContradictionSystem``,
+       ``OPPOSITION_STATES_ATTR`` = ``"opposition_states"``) — ``balance =
+       (value_produced − price_of_labor_power) / (value_produced +
+       price_of_labor_power)`` (catalog.py's ``_wage_value_reading``).
+       ``balance > 0`` IS ``W_c > V_c`` BY CONSTRUCTION; this module never
+       recomputes a parallel theorem.
+   * - ``class_phi_readings``
+     - The ``fundamental_theorem`` graph attribute
+       (``ContradictionSystem._stash_fundamental_theorem``,
+       ``FUNDAMENTAL_THEOREM_ATTR`` = ``"fundamental_theorem"``), a
+       ``{entity_id: ClassPhiReading.model_dump()}`` dump computed by
+       :func:`~babylon.domain.dialectics.instances.value_form.
+       compute_fundamental_theorem`, hydrated verbatim and sorted by
+       ``entity_id``.
+   * - ``phi_unequal_exchange`` / ``phi_reproduction`` / ``phi_domestic`` /
+       ``phi_iii_report`` / ``phi_decomposition_total``
+     - Φ's tri-decomposition (:mod:`~babylon.domain.dialectics.instances.
+       value_form`'s ``phi_unequal_exchange``/``phi_reproduction``/
+       ``phi_domestic``/``phi_iii_report`` builders, §9.3). Wired here as a
+       pure read of graph inputs at project time — NOT engine computation.
+       Each component needs its own raw input (``γ_basket`` + consumption
+       for unequal exchange; ``p_g2_labor_value`` + wages-for-rearing for
+       reproduction; unpaid reproductive labor-hours for domestic) and
+       **none of these five inputs is published to the graph anywhere in
+       the engine today** (verified tree-wide, 2026-07-22 — not even the
+       national MELT τ alone, itself live on
+       ``tick_dynamics.tick_summary.national_melt``, can complete
+       ``τ · L_unpaid`` without ``L_unpaid``). All five project as honest
+       ``None`` until a future unit lands the first missing input, one
+       component at a time (Constitution III.11) — this module never
+       fabricates them and never adds the missing engine-side computation.
+   * - ``surplus_produced`` / ``profit_of_enterprise`` / ``interest_burden``
+       / ``ground_rent`` / ``taxes_on_surplus`` / ``rentier_share`` /
+       ``financialization_share``
+     - The Volume III surplus split's ``tick_``-prefixed territory
+       attributes (``domain/economics/tick/graph_bridge.py``,
+       ``write_tick_state_to_graph`` — U1's surplus-split publication
+       completion). The five dollar terms are RATIO-OF-SUMS (extensive
+       sums across territories, presented directly); the two shares are
+       re-derived as ``Σr/Σs``/``Σi/Σs`` from those SAME sums — never by
+       averaging the per-territory ``tick_rentier_share``/
+       ``tick_financialization_share`` readings (the named
+       intensive-aggregation error class).
+   * - ``total_consumption`` / ``total_biocapacity`` / ``overshoot_ratio`` /
+       ``biocapacity_ceiling``
+     - ``WorldState.total_consumption``/``total_biocapacity`` (the
+       extensive-sum shape ``world_state.py`` already computes over
+       ``Territory.biocapacity``/entity ``consumption_needs``) plus a
+       locally-summed ``Territory.max_biocapacity`` ceiling. NEVER the
+       ``v_*_value_aggregate`` views' ``biocapacity_sum`` column — that is
+       a STATIC seed placeholder never ticked (``hex_hydrator.py``).
+       ``overshoot_ratio`` is computed HONESTLY here (``None`` on a
+       non-positive denominator), never via
+       ``WorldState.overshoot_ratio``'s own fabricated ``999.0`` sentinel.
+   * - ``energy_beta_j``
+     - No producer. Always ``None`` — the energy vertex is genuinely absent
+       tree-wide (no EROI/joule/power-density accounting anywhere in the
+       engine, per ``ai/_inbox/math/metabolic-calculus.md``'s own
+       tree-wide verification). Never derived from the money-form
+       quantities above.
+
+Absence discipline (Constitution III.11): every quantity above projects as
+``None`` when its own graph input is absent this tick — never a defaulted
+zero. A present-but-malformed source value fails loud through the relevant
+Pydantic validation (:class:`~babylon.projection.view_models.
+ClassPhiReadingView`, the constrained field types) — only a *missing* value
+is absence.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from babylon.models.enums.topology import NodeType
+from babylon.projection.view_models import ClassPhiReadingView, EconomyView
+
+if TYPE_CHECKING:
+    from babylon.kernel.graph_protocol import GraphProtocol
+    from babylon.models.world_state import WorldState
+
+__all__ = ["project_economy"]
+
+
+def _fundamental_theorem_verdict(graph: GraphProtocol) -> tuple[float | None, bool | None]:
+    """Read the ``wage`` opposition's Balance verdict verbatim off the graph.
+
+    Never recomputes W_c/V_c independently — the Balance IS the theorem
+    (``opposition_states["wage"].balance``, positive meaning the wage
+    exceeds value produced).
+
+    :param graph: The post-tick graph.
+    :returns: ``(wage_balance, labor_aristocracy_verdict)`` — both ``None``
+        when the opposition registry is unwired or ``wage`` is not a
+        registered key this run.
+    """
+    states = graph.get_graph_attr("opposition_states", {}) or {}
+    wage_state = states.get("wage") if isinstance(states, dict) else None
+    if not isinstance(wage_state, dict) or "balance" not in wage_state:
+        return (None, None)
+    balance = float(wage_state["balance"])
+    return (balance, balance > 0.0)
+
+
+def _class_phi_readings(graph: GraphProtocol) -> tuple[ClassPhiReadingView, ...] | None:
+    """Hydrate the ``fundamental_theorem`` graph stash into sorted readings.
+
+    :param graph: The post-tick graph.
+    :returns: readings sorted by ``entity_id``, or ``None`` when the graph
+        attribute itself is absent (the registry never ran this tick). An
+        attributed-but-empty dict yields an empty tuple — a real, different
+        fact from "never computed".
+    :raises pydantic.ValidationError: if a present reading is malformed.
+    """
+    raw = graph.get_graph_attr("fundamental_theorem", None)
+    if raw is None:
+        return None
+    return tuple(ClassPhiReadingView(**data) for _, data in sorted(raw.items()))
+
+
+#: One RATIO-OF-SUMS tuple: (s, p, i, r, t, rentier_share, financialization_share).
+_SurplusSplit = tuple[
+    float | None, float | None, float | None, float | None, float | None, float | None, float | None
+]
+
+
+def _surplus_split(graph: GraphProtocol) -> _SurplusSplit:
+    """Territory-wide Vol III surplus split, RATIO-OF-SUMS (U1's tick_ attrs).
+
+    Sums the five extensive dollar terms (s, p, i, r, t) across every
+    territory that carries ``tick_total_surplus`` this tick, then derives
+    the two intensive shares as genuine ratios of the summed totals
+    (``Σr/Σs``, ``Σi/Σs``) — never by averaging the per-territory
+    ``tick_rentier_share``/``tick_financialization_share`` readings (a
+    territory producing a sliver of national surplus must not swing the
+    national share as hard as one producing the bulk of it).
+
+    Territories are visited in sorted-id order so the float summation order
+    is fixed (Constitution III.7).
+
+    :param graph: The post-tick graph.
+    :returns: ``(s, p, i, r, t, rentier_share, financialization_share)`` —
+        all seven ``None`` when no territory carries ``tick_total_surplus``
+        (the economics tick bridge never ran this tick); the two shares
+        independently ``None`` when Σs is not positive.
+    """
+    sum_s = sum_p = sum_i = sum_r = sum_t = 0.0
+    saw_any = False
+    for territory in sorted(graph.query_nodes(node_type=NodeType.TERRITORY), key=lambda n: n.id):
+        attrs = territory.attributes
+        if "tick_total_surplus" not in attrs:
+            continue
+        saw_any = True
+        sum_s += float(attrs.get("tick_total_surplus", 0.0))
+        sum_p += float(attrs.get("tick_profit_of_enterprise", 0.0))
+        sum_i += float(attrs.get("tick_interest_burden", 0.0))
+        sum_r += float(attrs.get("tick_ground_rent", 0.0))
+        sum_t += float(attrs.get("tick_taxes_on_surplus", 0.0))
+    if not saw_any:
+        return (None, None, None, None, None, None, None)
+    rentier_share = sum_r / sum_s if sum_s > 0.0 else None
+    financialization_share = sum_i / sum_s if sum_s > 0.0 else None
+    return (sum_s, sum_p, sum_i, sum_r, sum_t, rentier_share, financialization_share)
+
+
+#: One matter-book tuple: (total_consumption, total_biocapacity, overshoot, ceiling).
+_MatterBook = tuple[float | None, float | None, float | None, float | None]
+
+
+def _matter_book(world: WorldState) -> _MatterBook:
+    """The metabolic matter-book: consumption, biocapacity, overshoot, ceiling.
+
+    Reuses ``WorldState.total_consumption``/``total_biocapacity`` verbatim
+    — the same extensive-sum shape (Σ ``Territory.biocapacity``, Σ entity
+    ``consumption_needs``) rather than re-deriving it — but computes
+    ``overshoot_ratio`` honestly here rather than reusing
+    ``WorldState.overshoot_ratio``'s own ``999.0`` fabricated sentinel on a
+    zero-biocapacity denominator (Constitution III.11 forbids a substituted
+    default standing in for absence). The monotone ceiling M̄ has no
+    existing ``WorldState`` property, so it is summed directly here.
+
+    LANDMINE avoided: the ``v_*_value_aggregate`` views' ``biocapacity_sum``
+    column is a STATIC seed placeholder never ticked (``hex_hydrator.py``)
+    — this reads the LIVE ``Territory.biocapacity``/``max_biocapacity``
+    model fields instead, which do survive the post-tick round trip.
+
+    :param world: The post-tick world state.
+    :returns: ``(total_consumption, total_biocapacity, overshoot_ratio,
+        biocapacity_ceiling)`` — all four ``None`` when the world carries no
+        territory; ``overshoot_ratio`` independently ``None`` when total
+        biocapacity is not positive.
+    """
+    if not world.territories:
+        return (None, None, None, None)
+    total_consumption = float(world.total_consumption)
+    total_biocapacity = float(world.total_biocapacity)
+    overshoot = total_consumption / total_biocapacity if total_biocapacity > 0.0 else None
+    ceiling = float(sum(t.max_biocapacity for t in world.territories.values()))
+    return (total_consumption, total_biocapacity, overshoot, ceiling)
+
+
+def project_economy(
+    economy_id: str,
+    *,
+    graph: GraphProtocol,
+    world: WorldState,
+    tick: int,
+) -> EconomyView:
+    """Project the whole economy's post-tick state into an :class:`EconomyView`.
+
+    Read strictly *post-tick*, exactly like :func:`~babylon.projection.
+    county.project_county`/:func:`~babylon.projection.national.
+    project_national`. See :class:`~babylon.projection.view_models.
+    EconomyView`'s docstring for the full field-by-field producer ruling.
+
+    :param economy_id: The economy's identity (``"USA"`` today).
+    :param graph: The committed post-tick graph.
+    :param world: The committed post-tick world state.
+    :param tick: The committed tick this dossier is projected from.
+    :returns: The frozen, validated economy dossier.
+    :raises pydantic.ValidationError: when a present source value violates
+        its constrained type — a wrong value fails loud, only a *missing*
+        one is absence.
+    """
+    wage_balance, labor_aristocracy_verdict = _fundamental_theorem_verdict(graph)
+    class_phi_readings = _class_phi_readings(graph)
+    (
+        surplus_produced,
+        profit_of_enterprise,
+        interest_burden,
+        ground_rent,
+        taxes_on_surplus,
+        rentier_share,
+        financialization_share,
+    ) = _surplus_split(graph)
+    (
+        total_consumption,
+        total_biocapacity,
+        overshoot_ratio,
+        biocapacity_ceiling,
+    ) = _matter_book(world)
+
+    return EconomyView(
+        economy_id=economy_id,
+        verified_tick=tick,
+        wage_balance=wage_balance,
+        labor_aristocracy_verdict=labor_aristocracy_verdict,
+        class_phi_readings=class_phi_readings,
+        # Φ's tri-decomposition (§9.3): genuinely absent tree-wide today —
+        # no engine producer publishes gamma_basket/consumption (unequal
+        # exchange), p_g2_labor_value/wage_paid_for_d_g2 (reproduction), or
+        # l_unpaid (domestic labor's unpaid-hours half; national MELT tau
+        # IS live elsewhere, but alone cannot complete tau * l_unpaid).
+        # Wired to light up the moment any ONE producer lands, one
+        # component at a time (Constitution III.11) — never engine
+        # computation added here (see this module's own docstring table).
+        phi_unequal_exchange=None,
+        phi_reproduction=None,
+        phi_domestic=None,
+        phi_iii_report=None,
+        phi_decomposition_total=None,
+        surplus_produced=surplus_produced,
+        profit_of_enterprise=profit_of_enterprise,
+        interest_burden=interest_burden,
+        ground_rent=ground_rent,
+        taxes_on_surplus=taxes_on_surplus,
+        rentier_share=rentier_share,
+        financialization_share=financialization_share,
+        total_consumption=total_consumption,
+        total_biocapacity=total_biocapacity,
+        overshoot_ratio=overshoot_ratio,
+        biocapacity_ceiling=biocapacity_ceiling,
+        # The energy vertex beta_J: always None, genuinely absent tree-wide
+        # (no EROI/joule/power-density accounting anywhere in the engine).
+        # Never derived from the money-form quantities above.
+        energy_beta_j=None,
+    )

--- a/src/babylon/projection/faction.py
+++ b/src/babylon/projection/faction.py
@@ -1,0 +1,221 @@
+"""The faction read-model — ``project_faction``, Program 24 T3 U4.
+
+Assembles a :class:`~babylon.projection.view_models.FactionView` dossier from
+the post-tick graph's ``faction`` node (spec-070). Faction is the political
+coalition a sovereign's ``ruling_faction_id`` names
+(:mod:`babylon.projection.sovereign`) and the source of every INFLUENCES edge
+contesting a territory; this module is what makes a sovereign page's
+``ruling_faction_id`` resolvable to a real page, plus the forward direction —
+every territory this faction influences, with its edge weight and channel.
+
+Transport-neutral by construction, exactly like ``sovereign.py``: no Django,
+no engine imports, no database connection — the caller hands in the graph
+and world it already holds.
+
+**One producer per field:**
+
+.. list-table:: Field-producer rulings
+   :header-rows: 1
+
+   * - Field
+     - Producer
+   * - ``name``, ``ideology``, ``colonial_stance``, ``is_settler_formation``,
+       ``extraction_modifier``, ``violence_modifier``, ``class_reduction``,
+       ``metabolic_reduction``, ``color_hex``, ``founded_tick``,
+       ``dissolved_tick``
+     - The ``faction`` graph node's own attributes —
+       ``BalkanizationFaction.model_dump()`` written by
+       ``WorldState.to_graph()`` (spec-070 / spec-109 A6).
+   * - ``territory_influence``
+     - Derived: one entry per outgoing INFLUENCES edge from this faction,
+       carrying the edge's ``influence_level``/``support_type`` and the
+       target territory's ``county_fips`` (resolved the same way
+       ``project_sovereign`` resolves a capital/claim) — the *reverse* of
+       ``GraphProtocol.query_faction_influence_by_territory``, which walks
+       INFLUENCES edges *into* one territory to find its influencing
+       factions.
+
+Absence discipline (Constitution III.11): a faction id with no matching
+graph node projects every field as ``None`` — including
+``territory_influence``, which is otherwise a *present* (possibly empty)
+tuple the instant the faction node exists. An empty tuple ("influences
+nothing right now") and ``None`` ("this faction doesn't exist in this run")
+are deliberately distinct: the former is real data, the latter is honest
+absence.
+
+**Fixture-harvest finding (documented, not silently worked around):** no
+``babylon.engine.scenarios`` builder ever constructs a
+``BalkanizationFaction`` or populates ``WorldState.factions`` (confirmed by
+grep: zero ``BalkanizationFaction(`` / ``factions=`` call sites under
+``src/babylon/engine/``) — the only production writer of ``NodeType.FACTION``
+graph nodes today is the legacy web bridge's
+``web/game/engine_bridge.py::_seed_balkanization_layer`` (Bridge-layer only,
+owner item 8). This is not a dead node type — ``NodeType.FACTION`` is real,
+production-stamped graph vocabulary (``WorldState.to_graph()`` writes it,
+``FactionInfluenceSystem`` reads it) — it is a scenario-coverage gap: every
+real headless campaign bakes zero faction pages today, and that is correct
+behavior, not a bug. Porting the seed into engine scenarios is a physics
+change out of this unit's scope (belongs to the RED_OGV repair program); the
+gap itself is recorded as a wiring-doctrine ledger row separately.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from babylon.models.enums.topology import EdgeType, NodeType
+from babylon.projection.sovereign import _county_fips_of
+from babylon.projection.vault.render_faction import faction_statblock_rows
+from babylon.projection.view_models import FactionTerritoryInfluence, FactionView
+
+if TYPE_CHECKING:
+    from babylon.kernel.graph_protocol import GraphProtocol
+    from babylon.models.graph import GraphNode
+    from babylon.models.world_state import WorldState
+
+__all__ = ["project_faction", "faction_statblocks"]
+
+
+def _resolve_faction(graph: GraphProtocol, faction_id: str) -> GraphNode | None:
+    """Look up the faction node by its stable id.
+
+    :param graph: The post-tick graph.
+    :param faction_id: The faction's node id (``FAC_*``, spec-070).
+    :returns: The matching node, or ``None`` when no such node exists — the
+        faction hasn't been instantiated in this run, or the caller passed
+        an id nobody has minted.
+    """
+    node = graph.get_node(faction_id)
+    if node is None or node.node_type != NodeType.FACTION.value:
+        return None
+    return node
+
+
+def _territory_influence(
+    graph: GraphProtocol, faction_id: str
+) -> tuple[FactionTerritoryInfluence, ...]:
+    """Every INFLUENCES edge this faction casts, resolved to territory + county.
+
+    Mirrors ``project_sovereign._claimed_county_fips``'s generic-query
+    pattern — walking ``graph.query_edges(edge_type=EdgeType.INFLUENCES)``
+    rather than the dedicated ``query_faction_influence_by_territory``
+    (which resolves the opposite direction: influences *at* one territory).
+
+    :param graph: The post-tick graph.
+    :param faction_id: The influencing faction's node id.
+    :returns: Rows sorted by ``influence_level`` descending, ``territory_id``
+        ascending on ties — matching
+        ``GraphProtocol.query_faction_influence_by_territory``'s own
+        ordering convention. Empty when the faction influences nothing.
+    """
+    rows: list[FactionTerritoryInfluence] = []
+    for edge in graph.query_edges(edge_type=EdgeType.INFLUENCES):
+        if edge.source_id != faction_id:
+            continue
+        rows.append(
+            FactionTerritoryInfluence(
+                territory_id=edge.target_id,
+                county_fips=_county_fips_of(graph, edge.target_id),
+                influence_level=edge.attributes.get("influence_level", 0.0),
+                support_type=edge.attributes.get("support_type", "ideological"),
+            )
+        )
+    rows.sort(key=lambda row: (-row.influence_level, row.territory_id))
+    return tuple(rows)
+
+
+def project_faction(
+    faction_id: str,
+    *,
+    graph: GraphProtocol,
+    world: WorldState,
+    tick: int,
+) -> FactionView:
+    """Project one faction's post-tick state into a :class:`FactionView`.
+
+    Read strictly *post-tick*, for the same reason ``project_sovereign`` is:
+    systems mutate the shared graph in-place in strict order, so a mid-tick
+    read would see a partially-applied world.
+
+    :param faction_id: The faction's node id (e.g. ``"FAC_RESTORATIONIST"``).
+    :param graph: The committed post-tick graph.
+    :param world: Unused — every ``FactionView`` field is graph-node sourced
+        (spec-070's ``BalkanizationFaction`` carries no world-entity
+        aggregation). Accepted anyway for signature parity with the Lane P
+        ``project_<kind>(id, *, graph, world, tick)`` recipe every sibling
+        projector (``project_sovereign`` et al.) shares.
+    :param tick: The committed tick this dossier is projected from —
+        becomes the dossier's ``verified_tick`` staleness anchor.
+    :returns: The frozen, validated faction dossier. Every unattributed or
+        nonexistent quantity is ``None``.
+    :raises pydantic.ValidationError: when a present source value violates
+        its constrained type — a wrong value fails loud, only a *missing*
+        one is absence.
+    """
+    del world  # unused: see docstring above.
+    node = _resolve_faction(graph, faction_id)
+    attrs: dict[str, Any] = dict(node.attributes) if node else {}
+
+    return FactionView(
+        faction_id=faction_id,
+        verified_tick=tick,
+        name=attrs.get("name"),
+        ideology=attrs.get("ideology"),
+        colonial_stance=attrs.get("colonial_stance"),
+        is_settler_formation=attrs.get("is_settler_formation"),
+        extraction_modifier=attrs.get("extraction_modifier"),
+        violence_modifier=attrs.get("violence_modifier"),
+        class_reduction=attrs.get("class_reduction"),
+        metabolic_reduction=attrs.get("metabolic_reduction"),
+        color_hex=attrs.get("color_hex"),
+        founded_tick=attrs.get("founded_tick"),
+        dissolved_tick=attrs.get("dissolved_tick"),
+        territory_influence=_territory_influence(graph, faction_id) if node else None,
+    )
+
+
+def faction_statblocks(
+    *,
+    graph: GraphProtocol,
+    world: WorldState,
+    tick: int,
+) -> Callable[[str], list[tuple[str, str]] | None]:
+    """Build a live ``{statblock}`` provider for ``faction/<id>`` subjects.
+
+    The per-kind statblock provider the shared-file-discipline design rule
+    requires (``specs/24-archive/work-orders-p2-p4.md``): this module
+    registers nothing in ``babylon.tui.app`` itself — the single serial
+    WO-45 composes every Lane P kind's provider into the app's kind-dispatch
+    ``StatblockProvider`` registry. Live, not baked (design canon S3): a
+    page whose ``{statblock}`` fence carries no baked body defers to
+    exactly this kind of provider, by subject id
+    (``tui.directives.BabylonFence._directive_statblock``).
+
+    Deliberately does not import :mod:`babylon.tui` — the projection layer
+    must not depend on its own client — so the returned callable matches
+    ``tui.directives.StatblockProvider``'s shape *structurally*
+    (``Callable[[str], Sequence[tuple[str, str]] | None]``) rather than by
+    importing that type alias.
+
+    :param graph: The live post-tick graph the caller already holds.
+    :param world: Unused; see :func:`project_faction`. Accepted for
+        signature parity with the other Lane P statblock-provider factories.
+    :param tick: The tick this provider's projections are verified as of.
+    :returns: A provider callable: for a ``"faction/<id>"`` subject whose id
+        names a real faction node, the flattened statblock rows of its live
+        projection; ``None`` for any other subject or an unknown id (the
+        honest-absence path the ``{statblock}`` directive itself renders).
+    """
+
+    def provider(subject: str) -> list[tuple[str, str]] | None:
+        prefix = "faction/"
+        if not subject.startswith(prefix):
+            return None
+        faction_id = subject[len(prefix) :]
+        if _resolve_faction(graph, faction_id) is None:
+            return None
+        view = project_faction(faction_id, graph=graph, world=world, tick=tick)
+        return list(faction_statblock_rows(view))
+
+    return provider

--- a/src/babylon/projection/field_state.py
+++ b/src/babylon/projection/field_state.py
@@ -1,0 +1,275 @@
+"""The field-state read-model — ``project_field_state``, the Weather Layer.
+
+Port of ``web/game/engine_bridge.py::EngineBridge.get_field_state`` (and its
+``_build_field_state_nodes``/``_build_field_state_edges`` helpers) into a
+pure projection: same read logic — ContradictionFieldSystem @19's
+``contradiction_fields``, FieldDerivativeSystem @20's ``field_derivatives``
+(``laplacian``/``df_dt`` sub-keys only, ``d2f_dt2`` excluded, matching the
+ported endpoint's own declared contract) and ``field_gradients``,
+FascistFactionSystem's ``fascist_alignment``, plus the graph-level
+``principal_field``/``dialectical_regime`` attrs — never a redesign.
+Transport-neutral by construction — no Django, no engine imports, no
+database connection; callers hand in the graph they already hold.
+
+**Read the LIVE graph, never a round trip.** ``WorldState.from_graph()``
+drops every ``tick_``/``flow_`` node attr via its wildcard filter and the
+graph-level ``principal_field``/``dialectical_regime`` attrs outright
+(``world_state.py``); the ``field_stack`` graph attr exists specifically to
+survive THAT round trip (``FieldDerivativeSystem._build_field_stack`` +
+``WorldState._restamp_field_stack``) for callers who only have a
+reconstructed graph. This module never reads ``field_stack`` — the vault
+tick-baker (``ArchiveTickBaker.on_tick_committed``) always hands this
+projection the SAME live graph object the engine just ticked, exactly like
+every other projection in this package, so the direct per-node/edge/graph
+reads below are always the freshest available.
+
+**One producer per field** (mirrors the WO-3 ruling
+:mod:`babylon.projection.county` records):
+
+.. list-table:: Field-producer rulings
+   :header-rows: 1
+
+   * - Field
+     - Producer
+   * - ``nodes``
+     - Every ``social_class`` node carrying ``contradiction_fields``
+       (ContradictionFieldSystem @19), ``field_derivatives``
+       (FieldDerivativeSystem @20), or ``fascist_alignment``
+       (FascistFactionSystem), sorted by node id. A node carrying none of
+       the three is omitted entirely (never a fabricated empty entry).
+   * - ``edges``
+     - Every ``(edge, field)`` pair with a ``field_gradients`` entry
+       (FieldDerivativeSystem @20's ``_compute_edge_gradients``),
+       territory-anchored via the live TENANCY edges (the same Occupant ->
+       Territory link ``ProductionSystem._find_tenancy_target`` reads),
+       sorted by ``(source, target, field)``.
+   * - ``principal_field``
+     - The ``principal_field`` graph attribute
+       (``FieldDerivativeSystem._identify_principal_contradiction``),
+       hydrated verbatim.
+   * - ``dialectical_regime``
+     - The ``dialectical_regime`` graph attribute
+       (``ContradictionSystem._classify_regime`` @18), hydrated verbatim.
+
+Absence discipline (Constitution III.11): every quantity above projects as
+``None`` when its own graph input is absent this tick — never a defaulted
+zero. A present-but-malformed source value fails loud through the relevant
+Pydantic validation (:class:`~babylon.projection.view_models.
+FieldStateNodeView`/:class:`~babylon.projection.view_models.
+FieldStateEdgeView`/the constrained field types) — only a *missing* value is
+absence.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+from babylon.models.enums.topology import EdgeType, NodeType
+from babylon.projection.view_models import (
+    DialecticalRegimeView,
+    FieldStateEdgeView,
+    FieldStateNodeView,
+    FieldStateView,
+    PrincipalFieldView,
+)
+
+if TYPE_CHECKING:
+    from babylon.kernel.graph_protocol import GraphProtocol
+
+__all__ = ["project_field_state"]
+
+
+def _node_field_derivatives(
+    raw: Mapping[str, object],
+) -> tuple[dict[str, float] | None, dict[str, float] | None]:
+    """Split a node's ``field_derivatives`` dict into laplacian/df_dt sub-maps.
+
+    ``d2f_dt2`` is deliberately never read — out of this dossier's declared
+    contract, matching the ported ``_build_field_state_nodes`` endpoint.
+
+    :param raw: One node's ``field_derivatives`` attribute
+        (``{field_name: {"laplacian": ..., "df_dt": ..., "d2f_dt2": ...}}``).
+    :returns: ``(laplacian, df_dt)``, each ``None`` when no field carries
+        that sub-key (a ``None`` sub-value — under 2/3 ticks of history — is
+        excluded from its map, not zero-filled).
+    """
+    laplacian: dict[str, float] = {}
+    df_dt: dict[str, float] = {}
+    for field_name, entry in raw.items():
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("laplacian") is not None:
+            laplacian[field_name] = float(entry["laplacian"])
+        if entry.get("df_dt") is not None:
+            df_dt[field_name] = float(entry["df_dt"])
+    return (laplacian or None, df_dt or None)
+
+
+def _field_state_nodes(graph: GraphProtocol) -> tuple[FieldStateNodeView, ...] | None:
+    """Every social_class node's field-stack reading, sorted by id.
+
+    :param graph: The post-tick graph.
+    :returns: Sorted node readings, or ``None`` when no social_class node
+        carries ``contradiction_fields``, ``field_derivatives``, or
+        ``fascist_alignment`` this tick.
+    """
+    entries: list[FieldStateNodeView] = []
+    for node in graph.query_nodes(node_type=NodeType.SOCIAL_CLASS):
+        attrs = node.attributes
+
+        fields_raw = attrs.get("contradiction_fields")
+        fields = (
+            {name: float(value) for name, value in fields_raw.items()}
+            if isinstance(fields_raw, dict) and fields_raw
+            else None
+        )
+
+        derivatives_raw = attrs.get("field_derivatives")
+        laplacian, df_dt = (
+            _node_field_derivatives(derivatives_raw)
+            if isinstance(derivatives_raw, dict) and derivatives_raw
+            else (None, None)
+        )
+
+        fascist_alignment = attrs.get("fascist_alignment")
+        fascist_alignment_value = (
+            float(fascist_alignment) if fascist_alignment is not None else None
+        )
+
+        if (
+            fields is None
+            and laplacian is None
+            and df_dt is None
+            and fascist_alignment_value is None
+        ):
+            continue
+
+        entries.append(
+            FieldStateNodeView(
+                node_id=node.id,
+                name=str(attrs.get("name", node.id)),
+                fields=fields,
+                laplacian=laplacian,
+                df_dt=df_dt,
+                fascist_alignment=fascist_alignment_value,
+            )
+        )
+
+    entries.sort(key=lambda entry: entry.node_id)
+    return tuple(entries) if entries else None
+
+
+def _class_territory(graph: GraphProtocol) -> dict[str, str]:
+    """social_class node id -> territory node id, via TENANCY edges.
+
+    Deterministic tie-break: TENANCY edges are visited sorted by
+    ``(territory, class)``, so the lexicographically smallest territory wins
+    if a class somehow carries TENANCY edges into more than one territory.
+
+    :param graph: The post-tick graph.
+    :returns: Map of social_class node id to its resolved territory. A class
+        with no live TENANCY edge is simply absent — callers must treat a
+        missing entry as unresolved, never a fabricated territory.
+    """
+    edges = sorted(
+        graph.query_edges(edge_type=EdgeType.TENANCY),
+        key=lambda edge: (edge.target_id, edge.source_id),
+    )
+    mapping: dict[str, str] = {}
+    for edge in edges:
+        mapping.setdefault(edge.source_id, edge.target_id)
+    return mapping
+
+
+def _field_state_edges(
+    graph: GraphProtocol, class_territory: Mapping[str, str]
+) -> tuple[FieldStateEdgeView, ...] | None:
+    """Every ``(edge, field)`` gradient entry, territory-anchored, sorted.
+
+    :param graph: The post-tick graph.
+    :param class_territory: :func:`_class_territory`'s result.
+    :returns: Sorted gradient entries, or ``None`` when no edge carries a
+        ``field_gradients`` entry this tick.
+    """
+    entries: list[FieldStateEdgeView] = []
+    for edge in graph.query_edges():
+        gradients = edge.attributes.get("field_gradients")
+        if not isinstance(gradients, dict) or not gradients:
+            continue
+        source_territory = class_territory.get(edge.source_id)
+        target_territory = class_territory.get(edge.target_id)
+        for field_name in sorted(gradients):
+            entries.append(
+                FieldStateEdgeView(
+                    source=edge.source_id,
+                    target=edge.target_id,
+                    source_territory=source_territory,
+                    target_territory=target_territory,
+                    field=field_name,
+                    gradient=float(gradients[field_name]),
+                )
+            )
+    entries.sort(key=lambda entry: (entry.source, entry.target, entry.field))
+    return tuple(entries) if entries else None
+
+
+def _principal_field(graph: GraphProtocol) -> PrincipalFieldView | None:
+    """The ``principal_field`` graph attribute, hydrated verbatim.
+
+    :param graph: The post-tick graph.
+    :returns: The hydrated reading, or ``None`` when the attribute is absent
+        (FieldDerivativeSystem never ran with a nonempty field registry).
+    :raises pydantic.ValidationError: if a present attribute is malformed.
+    """
+    raw = graph.get_graph_attr("principal_field", None)
+    if raw is None:
+        return None
+    return PrincipalFieldView(**raw)
+
+
+def _dialectical_regime(graph: GraphProtocol) -> DialecticalRegimeView | None:
+    """The ``dialectical_regime`` graph attribute, hydrated verbatim.
+
+    :param graph: The post-tick graph.
+    :returns: The hydrated reading, or ``None`` when the attribute is absent
+        (no ``capital_labor``/principal opposition state existed yet).
+    :raises pydantic.ValidationError: if a present attribute is malformed.
+    """
+    raw = graph.get_graph_attr("dialectical_regime", None)
+    if raw is None:
+        return None
+    return DialecticalRegimeView(**raw)
+
+
+def project_field_state(
+    field_state_id: str,
+    *,
+    graph: GraphProtocol,
+    tick: int,
+) -> FieldStateView:
+    """Project the post-tick field stack into a :class:`FieldStateView`.
+
+    Read strictly *post-tick*, exactly like :func:`~babylon.projection.
+    county.project_county`. Takes no ``world`` parameter — every field this
+    dossier carries is read straight off the graph (matching the ported
+    ``get_field_state``, which never consults a ``WorldState`` either).
+
+    :param field_state_id: The dossier's identity (``"USA"`` today, the
+        singleton the field stack is national-scale by construction).
+    :param graph: The committed post-tick graph.
+    :param tick: The committed tick this dossier is projected from.
+    :returns: The frozen, validated field-state dossier.
+    :raises pydantic.ValidationError: when a present source value violates
+        its constrained type — a wrong value fails loud, only a *missing*
+        one is absence.
+    """
+    class_territory = _class_territory(graph)
+    return FieldStateView(
+        field_state_id=field_state_id,
+        verified_tick=tick,
+        nodes=_field_state_nodes(graph),
+        edges=_field_state_edges(graph, class_territory),
+        principal_field=_principal_field(graph),
+        dialectical_regime=_dialectical_regime(graph),
+    )

--- a/src/babylon/projection/territory_anchor.py
+++ b/src/babylon/projection/territory_anchor.py
@@ -1,0 +1,124 @@
+"""Social-class -> territory resolution — the shared tenancy-inversion seam.
+
+The engine gives a social-class node no direct spatial field (``SocialClass``
+carries no ``territory_ids`` — see the CLAUDE.md gotcha on stamped attribute
+shape); its one live spatial link is the Occupant -> Territory ``TENANCY``
+edge. Two independent call sites already needed the inversion of that edge
+into a lookup table: the legacy web bridge's own
+``web/game/engine_bridge.py::_tenancy_members_by_territory`` /
+``_class_to_territory`` (event-anchoring for the map layer), and
+:mod:`babylon.projection.verbs.plate`'s ``_tenancy_members_by_territory``
+(verb-plate target-existence eligibility). This module is the ONE shared,
+non-underscore home for that primitive (DRY) — :mod:`babylon.projection.
+verbs.plate` and :mod:`babylon.game.chronicle_adapter` both consume it
+rather than each carrying their own copy.
+
+:func:`tenancy_members_by_territory` is the ported twin of ``plate.py``'s
+own private implementation (byte-identical logic, hoisted here); the
+inversion, :func:`class_to_territory`, follows the deterministic
+sorted-first tie-break the legacy bridge's own ``_class_to_territory``
+docstring establishes: territories and their members are walked in sorted
+order, so the lexicographically smallest territory wins for the (currently
+unseeded) case of a class carrying TENANCY edges into more than one
+territory.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from babylon.models.enums.topology import EdgeType, NodeType
+from babylon.topology import BabylonGraph
+
+__all__ = [
+    "TerritoryAnchor",
+    "tenancy_members_by_territory",
+    "class_to_territory",
+    "resolve_class_territory_anchor",
+]
+
+
+class TerritoryAnchor(BaseModel):
+    """One resolved social-class -> territory anchor.
+
+    :param territory_id: the resolved territory node id.
+    :param territory_name: the territory's human-readable display name
+        (``Territory.name``, or the raw ``territory_id`` itself when a
+        fixture graph never stamped a name — an honest fallback, never a
+        fabricated one).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    territory_id: str = Field(min_length=1)
+    territory_name: str = Field(min_length=1)
+
+
+def tenancy_members_by_territory(graph: BabylonGraph) -> dict[str, list[str]]:
+    """Map territory id -> social-class occupants via TENANCY edges.
+
+    Social classes carry no ``territory_ids`` field — their spatial link is
+    the Occupant -> Territory TENANCY edge (Track 1 / Task 8b). Ported
+    verbatim from :mod:`babylon.projection.verbs.plate`'s own prior
+    implementation (now hoisted here so both callers share one copy).
+
+    :param graph: World graph (read-only).
+    :returns: Territory id to occupant social-class ids, insertion-ordered.
+    """
+    members: dict[str, list[str]] = {}
+    for source, target, data in graph.edges(data=True):
+        if data.get("_edge_type") == EdgeType.TENANCY:
+            source_type = graph.nodes[source].get("_node_type")
+            if source_type == NodeType.SOCIAL_CLASS:
+                members.setdefault(str(target), []).append(str(source))
+    return members
+
+
+def class_to_territory(tenancy_members: dict[str, list[str]]) -> dict[str, str]:
+    """Invert :func:`tenancy_members_by_territory` to social_class -> territory.
+
+    Deterministic tie-break: territories and their members are walked in
+    sorted order, so the lexicographically smallest territory wins if a
+    class somehow carries TENANCY edges into more than one territory (not
+    seeded by any current scenario, but not structurally forbidden either)
+    — the same convention ``web/game/engine_bridge.py::_class_to_territory``
+    already established for the legacy map layer.
+
+    :param tenancy_members: Output of :func:`tenancy_members_by_territory`
+        (territory node id -> list of tenant social_class node ids).
+    :returns: Map of social_class node id -> territory node id. A class with
+        no TENANCY edge into any territory is simply absent — callers must
+        treat a missing entry as unresolved, never a fabricated territory.
+    """
+    mapping: dict[str, str] = {}
+    for territory_id in sorted(tenancy_members):
+        for class_id in sorted(tenancy_members[territory_id]):
+            mapping.setdefault(class_id, territory_id)
+    return mapping
+
+
+def resolve_class_territory_anchor(
+    graph: BabylonGraph,
+    class_to_territory_map: dict[str, str],
+    class_id: str,
+) -> TerritoryAnchor | None:
+    """Resolve one social_class node id to its :class:`TerritoryAnchor`.
+
+    :param graph: World graph (read-only) — read for the territory's
+        display name only; membership itself comes from
+        ``class_to_territory_map``.
+    :param class_to_territory_map: Output of :func:`class_to_territory`,
+        computed once per caller (never recomputed per-event).
+    :param class_id: the social_class node id to resolve.
+    :returns: the resolved anchor, or ``None`` when ``class_id`` carries no
+        TENANCY edge into any territory (honest absence — never a
+        fabricated territory).
+    """
+    territory_id = class_to_territory_map.get(class_id)
+    if territory_id is None:
+        return None
+    territory_name = graph.nodes.get(territory_id, {}).get("name")
+    return TerritoryAnchor(
+        territory_id=territory_id,
+        territory_name=str(territory_name) if territory_name else territory_id,
+    )

--- a/src/babylon/projection/topology/hex_habitability.py
+++ b/src/babylon/projection/topology/hex_habitability.py
@@ -1,0 +1,143 @@
+"""Hex-grain habitability by county inheritance — T3 U6, the habitability signal.
+
+There is no hex-native habitability column anywhere in the substrate:
+``dynamic_hex_state``/``v_hex_state_asof`` (:class:`~babylon.persistence.
+hex_state.DynamicHexState`) carry ``c``/``v``/``s``/``k`` and the three
+substrate stocks, never ``habitability``. ``habitability`` lives ONLY on the
+live in-memory graph, written onto ``territory`` node attrs by
+``MetabolismSystem`` (``engine/systems/metabolism.py``) — a graph-only
+transient ``TERRITORY_EXCLUDED_FIELDS`` (``world_state.py:88``) drops on
+every ``WorldState.from_graph()`` reconstruction. Adding a per-hex column is
+a physics/persistence change, out of T3 scope (see the county dossier's own
+``habitability`` field, :func:`babylon.projection.county.project_county`,
+for the same live-graph-only read one scale up).
+
+This module fills the gap the *only* honest way available today: **G-inherited
+county-grain read, read-only.** Each hex row already carries its parent
+``county_fips`` (the crosswalk the hex substrate ships on every row); this
+function resolves that county's territory node on the LIVE graph and hands
+every hex under it the SAME value — the ``allocate`` leg of
+:class:`~babylon.domain.dialectics.instances.scale.ScaleAdjunction`'s
+``allocate ⊣ aggregate`` adjunction, broadcasting one parent reading down to
+its children, not splitting a divisible quantity by share (there is only one
+number to inherit, not a sum to partition, so no ``ScaleAdjunction`` instance
+is actually constructed here — the analogy is the adjunction's *shape*, not
+its extensive-quantity machinery). The result is explicitly labelled
+county-grain, not hex-native: two hexes in the same county read identically
+today, and will keep doing so until a real per-hex habitability physics
+lands.
+
+Absence discipline (Constitution III.11): a hex whose county has no
+territory node, or whose territory has never had ``habitability`` written
+onto it (tick 0 / MetabolismSystem has not run this session), projects
+``None`` — never a fabricated ``0.0`` (nor the ``1.0`` some aggregators, e.g.
+``endgame_detector.py``, default an unattributed *mean* reading to; that
+convention belongs to that aggregator, not this per-hex honest read).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from babylon.models.enums.topology import NodeType
+from babylon.models.types import Probability
+from babylon.persistence.hex_state import DynamicHexState
+
+if TYPE_CHECKING:
+    from babylon.kernel.graph_protocol import GraphProtocol
+    from babylon.models.graph import GraphNode
+
+__all__ = ["HexHabitabilityCell", "hex_habitability_by_county_inheritance"]
+
+
+class HexHabitabilityCell(BaseModel):
+    """One hex's county-inherited habitability read.
+
+    :param h3_index: The hex's stable H3 identifier (``v_hex_state_asof``'s
+        ``h3_index`` column).
+    :param county_fips: The hex's parent county FIPS, read straight off the
+        hex row itself — never re-derived spatially by this function.
+    :param habitability: The parent county's territory node's LIVE
+        ``habitability`` graph attribute, inherited verbatim (G-inherited
+        county-grain read, not hex-native data) — or ``None`` when the county
+        has no territory node, or the territory carries no ``habitability``
+        attribute yet. Honest absence, never a fabricated ``0.0``.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    h3_index: str = Field(min_length=15, max_length=15)
+    county_fips: str = Field(pattern=r"^\d{5}$")
+    habitability: Probability | None = None
+
+
+def _territory_by_county_fips(graph: GraphProtocol, county_fips: str) -> GraphNode | None:
+    """Resolve the territory node carrying ``county_fips``, deterministically.
+
+    Mirrors :func:`babylon.projection.county._resolve_territory`'s
+    lexicographically-smallest tie-break for the (currently unseeded)
+    multi-territory-per-county case. A small module-local copy rather than
+    reaching into ``county.py``'s private helper, matching this codebase's
+    existing per-module resolver convention (:mod:`babylon.projection.
+    social_class` and :mod:`babylon.projection.state` each carry their own
+    equivalent instead of sharing one).
+
+    :param graph: The live post-tick graph.
+    :param county_fips: Five-digit county FIPS code.
+    :returns: The matching territory node, or ``None`` if none carries the code.
+    """
+    matches = [
+        node
+        for node in graph.query_nodes(node_type=NodeType.TERRITORY)
+        if node.attributes.get("county_fips") == county_fips
+    ]
+    if not matches:
+        return None
+    return min(matches, key=lambda node: node.id)
+
+
+def hex_habitability_by_county_inheritance(
+    rows: Sequence[DynamicHexState],
+    *,
+    graph: GraphProtocol,
+) -> tuple[HexHabitabilityCell, ...]:
+    """Hex-grain habitability, G-inherited from each hex's parent county.
+
+    Reads ``habitability`` straight off the LIVE ``graph`` object's territory
+    nodes — never through a ``WorldState`` round-trip, since
+    ``TERRITORY_EXCLUDED_FIELDS`` drops the attribute on reconstruction
+    (world_state.py:88). Every distinct ``county_fips`` among ``rows`` is
+    resolved to its territory node at most once (cached), so a caller handing
+    in thousands of hexes under a handful of counties pays one graph query
+    per county, not one per hex.
+
+    :param rows: Hex-level rows carrying ``h3_index``/``county_fips`` — any
+        ``v_hex_state_asof`` as-of read. Unlike
+        :func:`~babylon.projection.topology.choropleth_aggregation.
+        state_choropleth_cells_from_hex_rows`, this function never reads
+        ``row.tick`` and does no cross-hex summation (it is a 1:1 per-hex
+        map, not an aggregation), so it places no single-tick constraint on
+        ``rows``.
+    :param graph: The live post-tick graph, read directly.
+    :returns: One cell per input row, sorted by ``h3_index`` ascending
+        (Constitution III.13: every projection ends in an explicit order).
+    """
+    territory_by_county: dict[str, GraphNode | None] = {}
+    cells: list[HexHabitabilityCell] = []
+    for row in sorted(rows, key=lambda row: row.h3_index):
+        county_fips = row.county_fips
+        if county_fips not in territory_by_county:
+            territory_by_county[county_fips] = _territory_by_county_fips(graph, county_fips)
+        territory = territory_by_county[county_fips]
+        habitability = territory.attributes.get("habitability") if territory is not None else None
+        cells.append(
+            HexHabitabilityCell(
+                h3_index=row.h3_index,
+                county_fips=county_fips,
+                habitability=habitability,
+            )
+        )
+    return tuple(cells)

--- a/src/babylon/projection/vault/incremental_baker.py
+++ b/src/babylon/projection/vault/incremental_baker.py
@@ -20,12 +20,13 @@ DB envelope" to "which dossier pages are worth re-baking this tick":
   re-baked only when the backing node's attribute snapshot changed since
   its last bake (:class:`~babylon.projection.vault.dirty_tracker.
   NodeSnapshotTracker`, the generalized ``hex_value_key`` comparison).
-* **Derived dirtiness for rollups** — ``state``/``national`` have no
-  single backing node (they aggregate every territory in scope); they are
-  dirty whenever ANY constituent county is (:class:`~babylon.projection.
-  vault.dirty_tracker.PendingDirtySet`, which — unlike a same-tick
-  derivation — survives a budget-clamped tick so a rollup is never
-  silently left stale).
+* **Derived dirtiness for rollups** — ``state``/``national``/``economy``
+  have no single backing node (they aggregate every territory in scope, and
+  ``economy`` additionally reads the graph-wide ``opposition_states``
+  attribute); they are dirty whenever ANY constituent county is
+  (:class:`~babylon.projection.vault.dirty_tracker.PendingDirtySet`, which
+  — unlike a same-tick derivation — survives a budget-clamped tick so a
+  rollup is never silently left stale).
 * **Cross-node dependency** — a social class's ``county_class_composition``
   field reads its *containing* territory (:mod:`babylon.projection.
   social_class`'s own field-producer table), so a social class is ALSO
@@ -74,6 +75,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from babylon.models.enums.topology import NodeType
 from babylon.projection.community import project_community
 from babylon.projection.county import project_county
+from babylon.projection.economy import project_economy
 from babylon.projection.industry import project_industry
 from babylon.projection.institution import project_institution
 from babylon.projection.national import project_national
@@ -83,13 +85,14 @@ from babylon.projection.sovereign import project_sovereign
 from babylon.projection.state import project_state
 from babylon.projection.vault.dirty_tracker import NodeSnapshotTracker, PendingDirtySet
 from babylon.projection.vault.render import render_county, render_sovereign
+from babylon.projection.vault.render_economy import render_economy
 from babylon.projection.vault.render_industry import render_industry
 from babylon.projection.vault.render_institution import render_institution
 from babylon.projection.vault.render_national import render_national
 from babylon.projection.vault.render_organization import render_organization
 from babylon.projection.vault.render_social_class import render_social_class
 from babylon.projection.vault.render_state import render_state
-from babylon.projection.vault.tick_baker import _NATIONAL_ID, _node_ids
+from babylon.projection.vault.tick_baker import _ECONOMY_ID, _NATIONAL_ID, _node_ids
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -114,6 +117,7 @@ class BakeBudgets(BaseModel):
     county: int | None = Field(default=None, ge=0)
     state: int | None = Field(default=None, ge=0)
     national: int | None = Field(default=None, ge=0)
+    economy: int | None = Field(default=None, ge=0)
     organization: int | None = Field(default=None, ge=0)
     institution: int | None = Field(default=None, ge=0)
     sovereign: int | None = Field(default=None, ge=0)
@@ -270,6 +274,7 @@ class IncrementalArchiveTickBaker:
         for fips in county_dirty_raw:
             self._pending.mark("state", fips[:2])
             self._pending.mark("national", _NATIONAL_ID)
+            self._pending.mark("economy", _ECONOMY_ID)
 
         state_prefixes = sorted({fips[:2] for fips in self._county_fips})
         state_dirty = [p for p in state_prefixes if self._pending.is_dirty("state", p)]
@@ -283,6 +288,12 @@ class IncrementalArchiveTickBaker:
             national = project_national(national_id, graph=graph, world=world, tick=tick)
             pages[f"national/{national_id}.md"] = render_national(national, verified_tick=tick)
             self._pending.clear("national", national_id)
+
+        economy_dirty = [_ECONOMY_ID] if self._pending.is_dirty("economy", _ECONOMY_ID) else []
+        for economy_id in _clamp(economy_dirty, self._budgets.economy):
+            economy = project_economy(economy_id, graph=graph, world=world, tick=tick)
+            pages[f"economy/{economy_id}.md"] = render_economy(economy, verified_tick=tick)
+            self._pending.clear("economy", economy_id)
 
     def _bake_simple_kind(
         self,

--- a/src/babylon/projection/vault/incremental_baker.py
+++ b/src/babylon/projection/vault/incremental_baker.py
@@ -20,13 +20,21 @@ DB envelope" to "which dossier pages are worth re-baking this tick":
   re-baked only when the backing node's attribute snapshot changed since
   its last bake (:class:`~babylon.projection.vault.dirty_tracker.
   NodeSnapshotTracker`, the generalized ``hex_value_key`` comparison).
-* **Derived dirtiness for rollups** — ``state``/``national``/``economy``
-  have no single backing node (they aggregate every territory in scope, and
-  ``economy`` additionally reads the graph-wide ``opposition_states``
-  attribute); they are dirty whenever ANY constituent county is
+* **Derived dirtiness for rollups** — ``state``/``national``/``economy``/
+  ``field_state`` have no single backing node (they aggregate every
+  territory in scope, and ``economy``/``field_state`` additionally read
+  graph-wide attributes — ``opposition_states``, and
+  ``contradiction_fields``/``field_derivatives``/``field_gradients``/
+  ``principal_field``/``dialectical_regime`` respectively); they are dirty
+  whenever ANY constituent county is
   (:class:`~babylon.projection.vault.dirty_tracker.PendingDirtySet`, which
   — unlike a same-tick derivation — survives a budget-clamped tick so a
-  rollup is never silently left stale).
+  rollup is never silently left stale). This is the SAME documented
+  approximation ``economy``'s own ``opposition_states`` read already
+  accepts (see the scope-boundary paragraph below) — ``field_state``'s true
+  drivers are social_class/edge state, not territory state, but no cheaper
+  sound signal exists yet, so it piggybacks on county dirtiness exactly
+  like ``economy`` rather than silently going untracked.
 * **Cross-node dependency** — a social class's ``county_class_composition``
   field reads its *containing* territory (:mod:`babylon.projection.
   social_class`'s own field-producer table), so a social class is ALSO
@@ -76,6 +84,7 @@ from babylon.models.enums.topology import NodeType
 from babylon.projection.community import project_community
 from babylon.projection.county import project_county
 from babylon.projection.economy import project_economy
+from babylon.projection.field_state import project_field_state
 from babylon.projection.industry import project_industry
 from babylon.projection.institution import project_institution
 from babylon.projection.national import project_national
@@ -86,13 +95,19 @@ from babylon.projection.state import project_state
 from babylon.projection.vault.dirty_tracker import NodeSnapshotTracker, PendingDirtySet
 from babylon.projection.vault.render import render_county, render_sovereign
 from babylon.projection.vault.render_economy import render_economy
+from babylon.projection.vault.render_field_state import render_field_state
 from babylon.projection.vault.render_industry import render_industry
 from babylon.projection.vault.render_institution import render_institution
 from babylon.projection.vault.render_national import render_national
 from babylon.projection.vault.render_organization import render_organization
 from babylon.projection.vault.render_social_class import render_social_class
 from babylon.projection.vault.render_state import render_state
-from babylon.projection.vault.tick_baker import _ECONOMY_ID, _NATIONAL_ID, _node_ids
+from babylon.projection.vault.tick_baker import (
+    _ECONOMY_ID,
+    _FIELD_STATE_ID,
+    _NATIONAL_ID,
+    _node_ids,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -118,6 +133,7 @@ class BakeBudgets(BaseModel):
     state: int | None = Field(default=None, ge=0)
     national: int | None = Field(default=None, ge=0)
     economy: int | None = Field(default=None, ge=0)
+    field_state: int | None = Field(default=None, ge=0)
     organization: int | None = Field(default=None, ge=0)
     institution: int | None = Field(default=None, ge=0)
     sovereign: int | None = Field(default=None, ge=0)
@@ -275,6 +291,7 @@ class IncrementalArchiveTickBaker:
             self._pending.mark("state", fips[:2])
             self._pending.mark("national", _NATIONAL_ID)
             self._pending.mark("economy", _ECONOMY_ID)
+            self._pending.mark("field_state", _FIELD_STATE_ID)
 
         state_prefixes = sorted({fips[:2] for fips in self._county_fips})
         state_dirty = [p for p in state_prefixes if self._pending.is_dirty("state", p)]
@@ -294,6 +311,16 @@ class IncrementalArchiveTickBaker:
             economy = project_economy(economy_id, graph=graph, world=world, tick=tick)
             pages[f"economy/{economy_id}.md"] = render_economy(economy, verified_tick=tick)
             self._pending.clear("economy", economy_id)
+
+        field_state_dirty = (
+            [_FIELD_STATE_ID] if self._pending.is_dirty("field_state", _FIELD_STATE_ID) else []
+        )
+        for field_state_id in _clamp(field_state_dirty, self._budgets.field_state):
+            field_state = project_field_state(field_state_id, graph=graph, tick=tick)
+            pages[f"field_state/{field_state_id}.md"] = render_field_state(
+                field_state, verified_tick=tick
+            )
+            self._pending.clear("field_state", field_state_id)
 
     def _bake_simple_kind(
         self,

--- a/src/babylon/projection/vault/render.py
+++ b/src/babylon/projection/vault/render.py
@@ -56,6 +56,7 @@ _REMEDY_BY_FIELD: Final[dict[str, str]] = {
     "p_acquiescence": "Assess(SurvivalCalculus) to attribute P(S|A)",
     "p_revolution": "Assess(SurvivalCalculus) to attribute P(S|R)",
     "bifurcation_score": "Observe(Bifurcation) to attribute the axis",
+    "habitability": "Assess(Metabolism) to attribute the habitability index",
     "sovereign_id": "Claim(Sovereignty) to attribute a CLAIMS edge",
 }
 
@@ -102,6 +103,8 @@ def _statblock_rows(view: CountyView) -> tuple[tuple[str, str], ...]:
         rows.append(("p_revolution", f"{view.p_revolution:.6f}"))
     if view.bifurcation_score is not None:
         rows.append(("bifurcation_score", f"{view.bifurcation_score:.6f}"))
+    if view.habitability is not None:
+        rows.append(("habitability", f"{view.habitability:.6f}"))
     if view.sovereign_id is not None:
         rows.append(("sovereign_id", view.sovereign_id))
     return tuple(rows)

--- a/src/babylon/projection/vault/render_economy.py
+++ b/src/babylon/projection/vault/render_economy.py
@@ -1,0 +1,277 @@
+"""Sandboxed deterministic economy-page rendering (Constitution III.13).
+
+Mirrors :mod:`babylon.projection.vault.render`'s county pipeline exactly —
+same :class:`~jinja2.sandbox.ImmutableSandboxedEnvironment` construction (no
+custom filters/globals/finalizers, templates loaded only from this package's
+own ``templates/`` directory, :class:`~jinja2.StrictUndefined`), same
+precompute-then-hand-to-template discipline for
+:class:`~babylon.projection.view_models.EconomyView`'s ``Optional`` fields
+(Jinja renders a defined-but-``None`` attribute as the literal text
+``"None"`` rather than raising, so the template never dereferences an
+``Optional`` field directly).
+
+``class_phi_readings`` (a tuple of :class:`~babylon.projection.view_models.
+ClassPhiReadingView`) is rendered as its own section, exactly like
+:mod:`~babylon.projection.vault.render_community`'s ``roster``/``overlaps``
+— a collection is not flattened into dotted statblock rows the way the
+scalar-composite fields (:class:`~babylon.projection.view_models.
+ClassComposition`) are.
+
+Lives in its own module rather than appending to ``render.py``, matching
+the sanctioned per-kind pattern (``render_national.py``, ``render_
+community.py``, ...): that module's helper names are all County-shaped, and
+a dedicated module per kind keeps each WO's diff collision-free.
+
+jinja2 is imported lazily (function-local), matching ``render.py``, so
+importing this module never pulls jinja2 into ``sys.modules`` merely by
+being on the import path.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from babylon.projection.view_models import EconomyView
+
+if TYPE_CHECKING:
+    from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+#: EconomyView fields that are always present (identity/provenance) — every
+#: other declared field is walked for statblock/absence resolution.
+_IDENTITY_FIELDS: Final[frozenset[str]] = frozenset({"kind", "economy_id", "verified_tick"})
+
+#: ``class_phi_readings`` is a collection, rendered as its own section (see
+#: :func:`_class_phi_rows`) — excluded from the generic scalar statblock walk
+#: the same way ``render_community.py`` excludes ``roster``/``overlaps``.
+_COLLECTION_FIELDS: Final[frozenset[str]] = frozenset({"class_phi_readings"})
+
+#: Remedy text for each optional EconomyView field, in the "Verb(Noun) to
+#: <goal>" register the county spike established for {absence} blocks.
+#: ``energy_beta_j`` deliberately breaks that register — no verb can ever
+#: resolve it (there is no producer to invoke, not merely one this run
+#: didn't attribute; the same reasoning ``render_community.py``'s
+#: ``formation_tick`` entry documents). Keyed by the exact EconomyView field
+#: name so a field added without a remedy entry fails loudly in
+#: :func:`_absent_fields` rather than silently rendering no block.
+_REMEDY_BY_FIELD: Final[dict[str, str]] = {
+    "wage_balance": "Step(OppositionRegistry) to attribute the wage opposition's Balance",
+    "labor_aristocracy_verdict": (
+        "Step(OppositionRegistry) to attribute the wage opposition's Balance"
+    ),
+    "class_phi_readings": "Wire(FundamentalTheorem) to attribute per-class Φ readings",
+    "phi_unequal_exchange": (
+        "Meter(GammaBasket) + Track(Consumption) to attribute Φ_unequal_exchange "
+        "(genuinely absent tree-wide — no producer publishes either input)"
+    ),
+    "phi_reproduction": (
+        "Meter(ReproductionSubsidy) to attribute Φ_reproduction (genuinely absent "
+        "tree-wide — no producer publishes p_g2_labor_value or wage_paid_for_d_g2)"
+    ),
+    "phi_domestic": (
+        "Meter(DomesticLabor) to attribute Φ_domestic (genuinely absent tree-wide "
+        "— no producer publishes unpaid reproductive labor-hours, though national "
+        "MELT τ is itself live)"
+    ),
+    "phi_iii_report": (
+        "Meter(GammaIII) to attribute the Φ_III report term (genuinely absent tree-wide)"
+    ),
+    "phi_decomposition_total": (
+        "Meter(GammaBasket) + Meter(ReproductionSubsidy) + Meter(DomesticLabor) to "
+        "attribute all three Φ conservation components"
+    ),
+    "surplus_produced": "Distribute(Surplus) to attribute the territory-wide split",
+    "profit_of_enterprise": "Distribute(Surplus) to attribute the territory-wide split",
+    "interest_burden": "Distribute(Surplus) to attribute the territory-wide split",
+    "ground_rent": "Distribute(Surplus) to attribute the territory-wide split",
+    "taxes_on_surplus": "Distribute(Surplus) to attribute the territory-wide split",
+    "rentier_share": "Distribute(Surplus) to attribute the territory-wide split",
+    "financialization_share": "Distribute(Surplus) to attribute the territory-wide split",
+    "total_consumption": "Survey(Territory) to attribute consumption nationwide",
+    "total_biocapacity": "Survey(Territory) to attribute biocapacity nationwide",
+    "overshoot_ratio": "Survey(Territory) to attribute biocapacity nationwide",
+    "biocapacity_ceiling": "Survey(Territory) to attribute biocapacity nationwide",
+    "energy_beta_j": (
+        "no producer exists — the energy vertex β_J is genuinely absent tree-wide "
+        "(no EROI/joule/power-density accounting anywhere in the engine); wire the "
+        "energy split first (see EconomyView docstring)"
+    ),
+}
+
+
+def _optional_field_names() -> tuple[str, ...]:
+    """Return EconomyView's optional (non-identity) field names, in declared order.
+
+    :returns: field names in :class:`~babylon.projection.view_models.
+        EconomyView` declaration order, excluding the always-present
+        identity fields.
+    """
+    return tuple(name for name in EconomyView.model_fields if name not in _IDENTITY_FIELDS)
+
+
+def _statblock_rows(view: EconomyView) -> tuple[tuple[str, str], ...]:
+    """Resolve every present scalar field of ``view`` into a statblock row.
+
+    ``class_phi_readings`` is skipped here (see :func:`_class_phi_rows`);
+    every remaining optional field is either a ``float`` (formatted to six
+    decimal places, matching the county/national convention) or a ``bool``
+    (formatted via ``str``).
+
+    :param view: the economy projection to walk.
+    :returns: ``(label, value)`` pairs in EconomyView declaration order.
+    """
+    rows: list[tuple[str, str]] = []
+    for name in _optional_field_names():
+        if name in _COLLECTION_FIELDS:
+            continue
+        value = getattr(view, name)
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            rows.append((name, str(value)))
+        else:
+            rows.append((name, f"{value:.6f}"))
+    return tuple(rows)
+
+
+def _class_phi_rows(view: EconomyView) -> tuple[str, ...]:
+    """Format each class/county Φ reading as one line, for its own section.
+
+    Sub-fields that are honestly absent within a *present* reading (a class
+    with ``v_produced <= 0`` carries no ``phi_relative``/
+    ``labor_aristocracy_ratio``/``is_labor_aristocracy``) render as ``n/a``
+    — a deliberate, controlled literal chosen precisely so the page never
+    carries the bare text ``"None"``.
+
+    :param view: the economy projection to walk.
+    :returns: one formatted line per reading in ``class_phi_readings``
+        (already sorted by ``entity_id`` at project time), or empty when
+        ``class_phi_readings`` is ``None`` or an attributed-but-empty tuple.
+    """
+    if not view.class_phi_readings:
+        return ()
+    lines: list[str] = []
+    for reading in view.class_phi_readings:
+        relative = "n/a" if reading.phi_relative is None else f"{reading.phi_relative:.6f}"
+        ratio = (
+            "n/a"
+            if reading.labor_aristocracy_ratio is None
+            else f"{reading.labor_aristocracy_ratio:.6f}"
+        )
+        aristocracy = (
+            "n/a" if reading.is_labor_aristocracy is None else str(reading.is_labor_aristocracy)
+        )
+        lines.append(
+            f"{reading.entity_id}: w_paid={reading.w_paid:.6f} v_produced={reading.v_produced:.6f} "
+            f"phi_absolute={reading.phi_absolute:.6f} phi_relative={relative} "
+            f"labor_aristocracy_ratio={ratio} is_labor_aristocracy={aristocracy}"
+        )
+    return tuple(lines)
+
+
+def _surplus_identity_line(view: EconomyView) -> str | None:
+    """Format the ``s = p + i + r + t`` conservation identity, numbers filled in.
+
+    :param view: the economy projection to walk.
+    :returns: the formatted identity line, or ``None`` when any one of the
+        four surplus-split terms is absent (they are always co-present with
+        ``surplus_produced`` by construction — see
+        :func:`babylon.projection.economy._surplus_split`'s single presence
+        gate — but each is checked independently here defensively).
+    """
+    if (
+        view.surplus_produced is None
+        or view.profit_of_enterprise is None
+        or view.interest_burden is None
+        or view.ground_rent is None
+        or view.taxes_on_surplus is None
+    ):
+        return None
+    return (
+        f"s = p + i + r + t  →  {view.surplus_produced:.6f} = "
+        f"{view.profit_of_enterprise:.6f} + {view.interest_burden:.6f} + "
+        f"{view.ground_rent:.6f} + {view.taxes_on_surplus:.6f}"
+    )
+
+
+def _absent_fields(view: EconomyView) -> tuple[tuple[str, str], ...]:
+    """Resolve every ``None`` field of ``view`` into a named remedy entry.
+
+    An attributed-but-empty ``class_phi_readings`` (``()``, not ``None``) is
+    NOT absent — "computed and found none" is a real, different fact from
+    "not computed" (mirrors ``CommunityView``'s ``roster``/``overlaps``
+    discipline).
+
+    :param view: the economy projection to walk.
+    :returns: ``(field_name, remedy)`` pairs, one per ``None`` optional
+        field, in EconomyView declaration order.
+    :raises KeyError: if an absent field has no entry in
+        :data:`_REMEDY_BY_FIELD` — an EconomyView field added without a
+        registered remedy is a loud failure, never a silently-skipped
+        absence block.
+    """
+    entries: list[tuple[str, str]] = []
+    for field_name in _optional_field_names():
+        if getattr(view, field_name) is not None:
+            continue
+        try:
+            remedy = _REMEDY_BY_FIELD[field_name]
+        except KeyError as exc:
+            msg = f"no remedy text registered for absent EconomyView field {field_name!r}"
+            raise KeyError(msg) from exc
+        entries.append((field_name, remedy))
+    return tuple(entries)
+
+
+def _build_environment() -> ImmutableSandboxedEnvironment:
+    """Construct the vault's Jinja2 environment.
+
+    Identical construction to :func:`babylon.projection.vault.render._build_environment`
+    (ADR099: construction is code, never data) — duplicated rather than
+    imported so this module has zero dependency on ``render.py``'s
+    County-shaped internals, matching ``render_community.py``'s precedent.
+
+    :returns: a sandboxed environment with StrictUndefined, autoescape off
+        (the output is Markdown, not HTML), and templates resolved from this
+        package's ``templates/`` directory only.
+    """
+    from jinja2 import PackageLoader, StrictUndefined
+    from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+    return ImmutableSandboxedEnvironment(
+        loader=PackageLoader("babylon.projection.vault", "templates"),
+        undefined=StrictUndefined,
+        autoescape=False,
+        keep_trailing_newline=True,
+    )
+
+
+def render_economy(view: EconomyView, *, verified_tick: int) -> str:
+    """Render an economy dossier page from a projection view-model.
+
+    Pure function of ``(view, verified_tick)`` — no wall-clock, no
+    randomness, no filesystem reads inside the template — so two calls with
+    identical arguments yield byte-identical output (Constitution III.13's
+    determinism contract).
+
+    :param view: the economy projection to materialize.
+    :param verified_tick: the tick stamped into the page's frontmatter as
+        its staleness anchor. Passed explicitly rather than read from
+        ``view.verified_tick`` so the caller (the materializer) declares
+        the bake tick once and unambiguously.
+    :returns: the rendered Markdown page text.
+    :raises jinja2.exceptions.UndefinedError: if the template references a
+        field this module does not resolve (a template/model shape drift).
+    """
+    environment = _build_environment()
+    template = environment.get_template("economy.md.j2")
+    return template.render(
+        economy=view,
+        verified_tick=verified_tick,
+        statblock_rows=_statblock_rows(view),
+        class_phi_rows=_class_phi_rows(view),
+        surplus_identity_line=_surplus_identity_line(view),
+        absent_fields=_absent_fields(view),
+    )
+
+
+__all__ = ["render_economy"]

--- a/src/babylon/projection/vault/render_faction.py
+++ b/src/babylon/projection/vault/render_faction.py
@@ -1,0 +1,178 @@
+"""Sandboxed deterministic faction-page rendering (Constitution III.13).
+
+Sibling of :mod:`babylon.projection.vault.render` (the county/sovereign
+renderer) for :class:`~babylon.projection.view_models.FactionView` — T3 U4.
+Reuses :func:`~babylon.projection.vault.render._build_environment` rather
+than duplicating it: that module's own docstring declares itself "the only
+place the environment is built" (ADR099, construction-is-code), so this
+renderer imports the same factory instead of growing a second one (matching
+``render_institution.py``'s precedent).
+
+Follows the identical discipline ``render.py`` documents: a present-but-
+``None`` field is different from a missing template name (Jinja's
+``StrictUndefined`` only fires on the latter), so this module walks the view
+once, resolving every scalar-identity field to a formatted statblock row,
+every ``territory_influence`` entry to its own prose line (an INFLUENCES
+reading names TWO subjects — faction and territory — which a single-subject
+statblock row cannot express, matching ``render_field_state.py``'s ``edges``
+precedent), and every absent field to a named ``{absence}`` block with
+remedy text.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from babylon.projection.vault.render import _build_environment
+from babylon.projection.view_models import FactionView
+
+#: FactionView fields that are always present (identity/provenance) — every
+#: other declared field is walked for statblock/absence resolution.
+_IDENTITY_FIELDS: Final[frozenset[str]] = frozenset({"kind", "faction_id", "verified_tick"})
+
+#: Remedy verb for each optional FactionView field, in the "Verb(Noun) to
+#: <goal>" register the spike established for {absence} blocks (matches
+#: ``render.py``'s ``_REMEDY_BY_FIELD``). Keyed by the exact FactionView
+#: field name so a field added without a remedy entry fails loudly in
+#: :func:`_absent_fields` rather than silently rendering no block.
+_REMEDY_BY_FIELD: Final[dict[str, str]] = {
+    "name": "Survey(Faction) to attribute a name",
+    "ideology": "Classify(Faction) to attribute its ideological label",
+    "colonial_stance": "Classify(Faction) to attribute its colonial stance",
+    "is_settler_formation": "Investigate(Faction) to attribute settler-formation status",
+    "extraction_modifier": "Audit(Faction) to attribute its extraction multiplier",
+    "violence_modifier": "Audit(Faction) to attribute its violence multiplier",
+    "class_reduction": "Assess(ClassStruggle) to attribute the faction's class-reduction effect",
+    "metabolic_reduction": "Audit(Metabolism) to attribute the faction's metabolic effect",
+    "color_hex": "Survey(Faction) to attribute a UI color",
+    "founded_tick": "Investigate(Faction) to attribute the founding tick",
+    "dissolved_tick": "Investigate(Faction) to attribute a dissolution tick",
+    "territory_influence": "Observe(Influence) to attribute INFLUENCES-edge territory anchors",
+}
+
+
+def _optional_field_names() -> tuple[str, ...]:
+    """Return FactionView's optional (non-identity) field names, in declared order.
+
+    :returns: field names in :class:`~babylon.projection.view_models.FactionView`
+        declaration order, excluding the always-present identity fields.
+    """
+    return tuple(name for name in FactionView.model_fields if name not in _IDENTITY_FIELDS)
+
+
+def faction_statblock_rows(view: FactionView) -> tuple[tuple[str, str], ...]:
+    """Resolve every present scalar field of ``view`` into a statblock row.
+
+    ``territory_influence`` is deliberately excluded — it renders as its own
+    prose section via :func:`_influence_rows`, matching
+    ``render_field_state.py``'s ``edges`` precedent. Public (unlike
+    ``render_institution.py``'s private ``_statblock_rows``) because
+    :func:`babylon.projection.faction.faction_statblocks`'s live provider
+    reuses it — one row-format definition serving both the baked template
+    path and the live ``{statblock}`` directive path, so they can never
+    drift apart.
+
+    :param view: the faction projection to walk.
+    :returns: ``(label, value)`` pairs in FactionView declaration order.
+    """
+    rows: list[tuple[str, str]] = []
+    if view.name is not None:
+        rows.append(("name", view.name))
+    if view.ideology is not None:
+        rows.append(("ideology", view.ideology))
+    if view.colonial_stance is not None:
+        rows.append(("colonial_stance", view.colonial_stance.value))
+    if view.is_settler_formation is not None:
+        rows.append(("is_settler_formation", str(view.is_settler_formation)))
+    if view.extraction_modifier is not None:
+        rows.append(("extraction_modifier", f"{view.extraction_modifier:.6f}"))
+    if view.violence_modifier is not None:
+        rows.append(("violence_modifier", f"{view.violence_modifier:.6f}"))
+    if view.class_reduction is not None:
+        rows.append(("class_reduction", f"{view.class_reduction:.6f}"))
+    if view.metabolic_reduction is not None:
+        rows.append(("metabolic_reduction", f"{view.metabolic_reduction:.6f}"))
+    if view.color_hex is not None:
+        rows.append(("color_hex", view.color_hex))
+    if view.founded_tick is not None:
+        rows.append(("founded_tick", str(view.founded_tick)))
+    if view.dissolved_tick is not None:
+        rows.append(("dissolved_tick", str(view.dissolved_tick)))
+    return tuple(rows)
+
+
+def _influence_rows(view: FactionView) -> tuple[str, ...]:
+    """Format each ``territory_influence`` entry as its own line.
+
+    :param view: the faction projection to walk.
+    :returns: one formatted line per entry in ``territory_influence``, or
+        empty when it is ``None`` or an attributed-but-empty tuple. An
+        unresolved ``county_fips`` renders as the deliberate literal
+        ``"n/a"`` (matching ``render_field_state.py``'s ``_edge_rows``
+        convention), never the bare text ``"None"``.
+    """
+    if not view.territory_influence:
+        return ()
+    lines: list[str] = []
+    for entry in view.territory_influence:
+        county_fips = "n/a" if entry.county_fips is None else entry.county_fips
+        lines.append(
+            f"{entry.territory_id} county={county_fips} "
+            f"influence_level={entry.influence_level:.6f} support_type={entry.support_type}"
+        )
+    return tuple(lines)
+
+
+def _absent_fields(view: FactionView) -> tuple[tuple[str, str], ...]:
+    """Resolve every ``None`` field of ``view`` into a named remedy entry.
+
+    :param view: the faction projection to walk.
+    :returns: ``(field_name, remedy)`` pairs, one per absent optional field,
+        in FactionView declaration order.
+    :raises KeyError: if an absent field has no entry in
+        :data:`_REMEDY_BY_FIELD` — a FactionView field added without a
+        registered remedy is a loud failure, never a silently-skipped
+        absence block.
+    """
+    entries: list[tuple[str, str]] = []
+    for field_name in _optional_field_names():
+        if getattr(view, field_name) is not None:
+            continue
+        try:
+            remedy = _REMEDY_BY_FIELD[field_name]
+        except KeyError as exc:
+            msg = f"no remedy text registered for absent FactionView field {field_name!r}"
+            raise KeyError(msg) from exc
+        entries.append((field_name, remedy))
+    return tuple(entries)
+
+
+def render_faction(view: FactionView, *, verified_tick: int) -> str:
+    """Render a faction dossier page from a projection view-model.
+
+    Pure function of ``(view, verified_tick)`` — no wall-clock, no
+    randomness, no filesystem reads inside the template — so two calls with
+    identical arguments yield byte-identical output (Constitution III.13's
+    determinism contract).
+
+    :param view: the faction projection to materialize.
+    :param verified_tick: the tick stamped into the page's frontmatter as
+        its staleness anchor. Passed explicitly rather than read from
+        ``view.verified_tick`` so the caller (the materializer) declares the
+        bake tick once and unambiguously.
+    :returns: the rendered Markdown page text.
+    :raises jinja2.exceptions.UndefinedError: if the template references a
+        field this module does not resolve (a template/model shape drift).
+    """
+    environment = _build_environment()
+    template = environment.get_template("faction.md.j2")
+    return template.render(
+        faction=view,
+        verified_tick=verified_tick,
+        statblock_rows=faction_statblock_rows(view),
+        influence_rows=_influence_rows(view),
+        absent_fields=_absent_fields(view),
+    )
+
+
+__all__ = ["render_faction", "faction_statblock_rows"]

--- a/src/babylon/projection/vault/render_field_state.py
+++ b/src/babylon/projection/vault/render_field_state.py
@@ -1,0 +1,227 @@
+"""Sandboxed deterministic field-state-page rendering (Constitution III.13).
+
+Mirrors :mod:`babylon.projection.vault.render`'s county pipeline exactly —
+same :class:`~jinja2.sandbox.ImmutableSandboxedEnvironment` construction (no
+custom filters/globals/finalizers, templates loaded only from this package's
+own ``templates/`` directory, :class:`~jinja2.StrictUndefined`), same
+precompute-then-hand-to-template discipline for
+:class:`~babylon.projection.view_models.FieldStateView`'s ``Optional``
+fields (Jinja renders a defined-but-``None`` attribute as the literal text
+``"None"`` rather than raising, so the template never dereferences an
+``Optional`` field directly).
+
+``principal_field``/``dialectical_regime`` and each node's ``fields``/
+``laplacian``/``df_dt``/``fascist_alignment`` readings render as dotted
+statblock rows keyed by class id (small N — a handful of social classes
+per run) — unlike :mod:`~babylon.projection.vault.render_economy`'s
+``class_phi_readings``, this collection is shallow enough that flattening it
+into the statblock (matching :mod:`~babylon.projection.national`'s
+``class_composition.<field>``/``consciousness.<field>`` nesting convention)
+reads better than a dedicated prose section. ``edges`` gets its own section
+instead — a gradient reading names TWO subjects (source/target), which a
+single-subject statblock row cannot express.
+
+Lives in its own module rather than appending to ``render.py``, matching
+the sanctioned per-kind pattern (``render_national.py``, ``render_
+economy.py``, ...): a dedicated module per kind keeps each unit's diff
+collision-free.
+
+jinja2 is imported lazily (function-local), matching ``render.py``, so
+importing this module never pulls jinja2 into ``sys.modules`` merely by
+being on the import path.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from babylon.projection.view_models import FieldStateView
+
+if TYPE_CHECKING:
+    from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+#: FieldStateView fields that are always present (identity/provenance) —
+#: every other declared field is walked for statblock/absence resolution.
+_IDENTITY_FIELDS: Final[frozenset[str]] = frozenset({"kind", "field_state_id", "verified_tick"})
+
+#: Remedy text for each optional FieldStateView field, in the "Verb(Noun) to
+#: <goal>" register the county spike established for {absence} blocks.
+#: Keyed by the exact FieldStateView field name so a field added without a
+#: remedy entry fails loudly in :func:`_absent_fields` rather than silently
+#: rendering no block.
+_REMEDY_BY_FIELD: Final[dict[str, str]] = {
+    "nodes": "Step(ContradictionFieldSystem) to attribute per-class field readings",
+    "edges": "Step(FieldDerivativeSystem) to attribute field gradients",
+    "principal_field": "Step(FieldDerivativeSystem) to identify the principal field",
+    "dialectical_regime": "Step(ContradictionSystem) to classify the dialectical regime",
+}
+
+
+def _optional_field_names() -> tuple[str, ...]:
+    """Return FieldStateView's optional (non-identity) field names, in declared order.
+
+    :returns: field names in :class:`~babylon.projection.view_models.
+        FieldStateView` declaration order, excluding the always-present
+        identity fields.
+    """
+    return tuple(name for name in FieldStateView.model_fields if name not in _IDENTITY_FIELDS)
+
+
+def _statblock_rows(view: FieldStateView) -> tuple[tuple[str, str], ...]:
+    """Resolve principal_field/dialectical_regime/per-node readings into rows.
+
+    A present-but-``None`` sub-field (``principal_field.field_name`` before
+    any principal is identified) renders as the deliberate, controlled
+    literal ``"n/a"`` — never the bare text ``"None"`` — the same convention
+    :mod:`~babylon.projection.vault.render_economy`'s per-class Φ rows use.
+
+    :param view: the field-state projection to walk.
+    :returns: ``(label, value)`` pairs: principal_field's three sub-fields,
+        dialectical_regime's three sub-fields, then each node's name/
+        fields.*/laplacian.*/df_dt.*/fascist_alignment, in that order.
+    """
+    rows: list[tuple[str, str]] = []
+
+    principal = view.principal_field
+    if principal is not None:
+        field_name = "n/a" if principal.field_name is None else principal.field_name
+        rows.append(("principal_field.field_name", field_name))
+        rows.append(("principal_field.max_abs_df_dt", f"{principal.max_abs_df_dt:.6f}"))
+        rows.append(("principal_field.changed", str(principal.changed)))
+
+    regime = view.dialectical_regime
+    if regime is not None:
+        rows.append(("dialectical_regime.regime", regime.regime))
+        rows.append(("dialectical_regime.opposition", regime.opposition))
+        rows.append(("dialectical_regime.rate", f"{regime.rate:.6f}"))
+
+    for node in view.nodes or ():
+        rows.append((f"node.{node.node_id}.name", node.name))
+        node_fields = node.fields or {}
+        for field_name in sorted(node_fields):
+            rows.append(
+                (f"node.{node.node_id}.fields.{field_name}", f"{node_fields[field_name]:.6f}")
+            )
+        node_laplacian = node.laplacian or {}
+        for field_name in sorted(node_laplacian):
+            rows.append(
+                (
+                    f"node.{node.node_id}.laplacian.{field_name}",
+                    f"{node_laplacian[field_name]:.6f}",
+                )
+            )
+        node_df_dt = node.df_dt or {}
+        for field_name in sorted(node_df_dt):
+            rows.append(
+                (f"node.{node.node_id}.df_dt.{field_name}", f"{node_df_dt[field_name]:.6f}")
+            )
+        if node.fascist_alignment is not None:
+            rows.append((f"node.{node.node_id}.fascist_alignment", f"{node.fascist_alignment:.6f}"))
+
+    return tuple(rows)
+
+
+def _edge_rows(view: FieldStateView) -> tuple[str, ...]:
+    """Format each field-gradient edge entry as its own line.
+
+    :param view: the field-state projection to walk.
+    :returns: one formatted line per entry in ``edges``, or empty when
+        ``edges`` is ``None`` or an attributed-but-empty tuple. An
+        unresolved territory renders as the deliberate literal ``"n/a"``,
+        never the bare text ``"None"``.
+    """
+    if not view.edges:
+        return ()
+    lines: list[str] = []
+    for edge in view.edges:
+        source_territory = "n/a" if edge.source_territory is None else edge.source_territory
+        target_territory = "n/a" if edge.target_territory is None else edge.target_territory
+        lines.append(
+            f"{edge.source} -> {edge.target} field={edge.field} "
+            f"gradient={edge.gradient:.6f} source_territory={source_territory} "
+            f"target_territory={target_territory}"
+        )
+    return tuple(lines)
+
+
+def _absent_fields(view: FieldStateView) -> tuple[tuple[str, str], ...]:
+    """Resolve every ``None`` field of ``view`` into a named remedy entry.
+
+    An attributed-but-empty ``nodes``/``edges`` never occurs today (both
+    projection-side helpers return ``None`` rather than ``()`` for "nothing
+    to show" — see :mod:`babylon.projection.field_state`'s own docstring),
+    so both are simply walked like every other optional field here.
+
+    :param view: the field-state projection to walk.
+    :returns: ``(field_name, remedy)`` pairs, one per ``None`` optional
+        field, in FieldStateView declaration order.
+    :raises KeyError: if an absent field has no entry in
+        :data:`_REMEDY_BY_FIELD` — a FieldStateView field added without a
+        registered remedy is a loud failure, never a silently-skipped
+        absence block.
+    """
+    entries: list[tuple[str, str]] = []
+    for field_name in _optional_field_names():
+        if getattr(view, field_name) is not None:
+            continue
+        try:
+            remedy = _REMEDY_BY_FIELD[field_name]
+        except KeyError as exc:
+            msg = f"no remedy text registered for absent FieldStateView field {field_name!r}"
+            raise KeyError(msg) from exc
+        entries.append((field_name, remedy))
+    return tuple(entries)
+
+
+def _build_environment() -> ImmutableSandboxedEnvironment:
+    """Construct the vault's Jinja2 environment.
+
+    Identical construction to :func:`babylon.projection.vault.render._build_environment`
+    (ADR099: construction is code, never data) — duplicated rather than
+    imported so this module has zero dependency on ``render.py``'s
+    County-shaped internals, matching ``render_economy.py``'s precedent.
+
+    :returns: a sandboxed environment with StrictUndefined, autoescape off
+        (the output is Markdown, not HTML), and templates resolved from this
+        package's ``templates/`` directory only.
+    """
+    from jinja2 import PackageLoader, StrictUndefined
+    from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+    return ImmutableSandboxedEnvironment(
+        loader=PackageLoader("babylon.projection.vault", "templates"),
+        undefined=StrictUndefined,
+        autoescape=False,
+        keep_trailing_newline=True,
+    )
+
+
+def render_field_state(view: FieldStateView, *, verified_tick: int) -> str:
+    """Render a field-state dossier page from a projection view-model.
+
+    Pure function of ``(view, verified_tick)`` — no wall-clock, no
+    randomness, no filesystem reads inside the template — so two calls with
+    identical arguments yield byte-identical output (Constitution III.13's
+    determinism contract).
+
+    :param view: the field-state projection to materialize.
+    :param verified_tick: the tick stamped into the page's frontmatter as
+        its staleness anchor. Passed explicitly rather than read from
+        ``view.verified_tick`` so the caller (the materializer) declares
+        the bake tick once and unambiguously.
+    :returns: the rendered Markdown page text.
+    :raises jinja2.exceptions.UndefinedError: if the template references a
+        field this module does not resolve (a template/model shape drift).
+    """
+    environment = _build_environment()
+    template = environment.get_template("field_state.md.j2")
+    return template.render(
+        field_state=view,
+        verified_tick=verified_tick,
+        statblock_rows=_statblock_rows(view),
+        edge_rows=_edge_rows(view),
+        absent_fields=_absent_fields(view),
+    )
+
+
+__all__ = ["render_field_state"]

--- a/src/babylon/projection/vault/templates/economy.md.j2
+++ b/src/babylon/projection/vault/templates/economy.md.j2
@@ -1,0 +1,50 @@
+{#-
+Economy dossier page skeleton (Constitution III.13 / Amendment W; T3 spine-C).
+
+Deliberately prose-free: this is a scaffold page, not narrative copy. Every
+value interpolated here is a plain string already resolved by
+babylon.projection.vault.render_economy (never a raw Optional EconomyView
+field — Jinja's StrictUndefined only fires on genuinely *absent* names, and a
+present-but-None field renders the literal text "None" rather than raising,
+so render_economy.py precomputes statblock_rows/class_phi_rows/
+surplus_identity_line/absent_fields and the template only ever touches those
+and the three always-present identity fields).
+
+Money and matter are never rendered as interconvertible — the Surplus Split
+($) and the Matter-Book (biocapacity) live in separate sections below, and
+the energy vertex beta_J is its own UNPOSITIONED {absence} fence, never
+derived from either.
+
+Fenced directives only ({statblock}/{absence}), matching
+babylon.tui.directives.BabylonFence dispatch (ADR099: paired containers
+break the 8.2.8 markdown walker).
+-#}
+---
+id: economy/{{ economy.economy_id }}
+name: Economy {{ economy.economy_id }}
+verified_tick: {{ verified_tick }}
+staleness: verified as of tick {{ verified_tick }} — always regenerable, never authoritative
+---
+
+# economy/{{ economy.economy_id }} — Dossier
+
+```{statblock} economy/{{ economy.economy_id }}
+{% for label, value in statblock_rows -%}
+{{ label }}: {{ value }}
+{% endfor -%}
+```
+
+## Fundamental Theorem — Per-Class Φ Readings
+
+{% for line in class_phi_rows -%}
+{{ line }}
+{% endfor %}
+## Surplus Split
+
+{% if surplus_identity_line is not none -%}
+{{ surplus_identity_line }}
+{% endif %}
+{% for field, remedy in absent_fields -%}
+```{absence} {{ field }} — {{ remedy }}
+```
+{% endfor %}

--- a/src/babylon/projection/vault/templates/faction.md.j2
+++ b/src/babylon/projection/vault/templates/faction.md.j2
@@ -1,0 +1,45 @@
+{#-
+Faction dossier page skeleton (Constitution III.13 / Amendment W; T3 U4).
+
+Deliberately prose-free: this is a scaffold page, not narrative copy. Every
+value interpolated here is a plain string already resolved by
+babylon.projection.vault.render_faction (never a raw Optional FactionView
+field — Jinja's StrictUndefined only fires on genuinely *absent* names, and
+a present-but-None field renders the literal text "None" rather than
+raising, so render_faction.py precomputes statblock_rows/influence_rows/
+absent_fields and the template only ever touches those and the three
+always-present identity fields).
+
+territory_influence gets its own section rather than folding into the
+statblock — an INFLUENCES reading names TWO subjects (faction and
+territory), which a single-subject statblock row cannot express (matching
+field_state.md.j2's "Field Gradients" section for the same reason).
+
+Fenced directives only ({statblock}/{absence}), matching
+babylon.tui.directives.BabylonFence dispatch (ADR099: paired containers
+break the 8.2.8 markdown walker).
+-#}
+---
+id: faction/{{ faction.faction_id }}
+name: Faction {{ faction.faction_id }}
+verified_tick: {{ verified_tick }}
+staleness: verified as of tick {{ verified_tick }} — always regenerable, never authoritative
+---
+
+# faction/{{ faction.faction_id }} — Dossier
+
+```{statblock} faction/{{ faction.faction_id }}
+{% for label, value in statblock_rows -%}
+{{ label }}: {{ value }}
+{% endfor -%}
+```
+
+## Influence
+
+{% for line in influence_rows -%}
+{{ line }}
+{% endfor %}
+{% for field, remedy in absent_fields -%}
+```{absence} {{ field }} — {{ remedy }}
+```
+{% endfor %}

--- a/src/babylon/projection/vault/templates/field_state.md.j2
+++ b/src/babylon/projection/vault/templates/field_state.md.j2
@@ -1,0 +1,47 @@
+{#-
+Field-state dossier page skeleton (Constitution III.13 / Amendment W; T3 U3
+— the Weather Layer).
+
+Deliberately prose-free: this is a scaffold page, not narrative copy. Every
+value interpolated here is a plain string already resolved by
+babylon.projection.vault.render_field_state (never a raw Optional
+FieldStateView field — Jinja's StrictUndefined only fires on genuinely
+*absent* names, and a present-but-None field renders the literal text
+"None" rather than raising, so render_field_state.py precomputes
+statblock_rows/edge_rows/absent_fields and the template only ever touches
+those and the three always-present identity fields).
+
+principal_field/dialectical_regime and each node's field/laplacian/df_dt/
+fascist_alignment readings render as statblock rows (small N — a handful of
+social classes) keyed by class id; field_gradients get their own section,
+one line per (edge, field) pair, since an edge reading is relational rather
+than a single subject's statblock.
+
+Fenced directives only ({statblock}/{absence}), matching
+babylon.tui.directives.BabylonFence dispatch (ADR099: paired containers
+break the 8.2.8 markdown walker).
+-#}
+---
+id: field_state/{{ field_state.field_state_id }}
+name: Field State {{ field_state.field_state_id }}
+verified_tick: {{ verified_tick }}
+staleness: verified as of tick {{ verified_tick }} — always regenerable, never authoritative
+---
+
+# field_state/{{ field_state.field_state_id }} — The Weather Layer
+
+```{statblock} field_state/{{ field_state.field_state_id }}
+{% for label, value in statblock_rows -%}
+{{ label }}: {{ value }}
+{% endfor -%}
+```
+
+## Field Gradients
+
+{% for line in edge_rows -%}
+{{ line }}
+{% endfor %}
+{% for field, remedy in absent_fields -%}
+```{absence} {{ field }} — {{ remedy }}
+```
+{% endfor %}

--- a/src/babylon/projection/vault/tick_baker.py
+++ b/src/babylon/projection/vault/tick_baker.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 from babylon.models.enums.topology import NodeType
 from babylon.projection.community import project_community
 from babylon.projection.county import project_county
+from babylon.projection.economy import project_economy
 from babylon.projection.industry import project_industry
 from babylon.projection.institution import project_institution
 from babylon.projection.national import project_national
@@ -25,6 +26,7 @@ from babylon.projection.sovereign import project_sovereign
 from babylon.projection.state import project_state
 from babylon.projection.vault.render import render_county, render_sovereign
 from babylon.projection.vault.render_community import render_community
+from babylon.projection.vault.render_economy import render_economy
 from babylon.projection.vault.render_industry import render_industry
 from babylon.projection.vault.render_institution import render_institution
 from babylon.projection.vault.render_national import render_national
@@ -39,6 +41,9 @@ __all__ = ["ArchiveTickBaker", "CountyTickBaker"]
 
 #: The one national dossier id (NATIONWIDE canonical scale, Amendment R/S).
 _NATIONAL_ID = "USA"
+
+#: The one economy dossier id (T3 spine-C singleton, mirrors _NATIONAL_ID).
+_ECONOMY_ID = "USA"
 
 
 def _node_ids(graph: Any, node_type: NodeType) -> list[str]:
@@ -144,6 +149,8 @@ class ArchiveTickBaker:
             pages[f"state/{state_fips}.md"] = render_state(state, verified_tick=tick)
         national = project_national(_NATIONAL_ID, graph=graph, world=world, tick=tick)
         pages[f"national/{_NATIONAL_ID}.md"] = render_national(national, verified_tick=tick)
+        economy = project_economy(_ECONOMY_ID, graph=graph, world=world, tick=tick)
+        pages[f"economy/{_ECONOMY_ID}.md"] = render_economy(economy, verified_tick=tick)
         for org_id in _node_ids(graph, NodeType.ORGANIZATION):
             org = project_organization(org_id, graph=graph, world=world, tick=tick)
             pages[f"organization/{org_id}.md"] = render_organization(org, verified_tick=tick)

--- a/src/babylon/projection/vault/tick_baker.py
+++ b/src/babylon/projection/vault/tick_baker.py
@@ -17,6 +17,7 @@ from babylon.models.enums.topology import NodeType
 from babylon.projection.community import project_community
 from babylon.projection.county import project_county
 from babylon.projection.economy import project_economy
+from babylon.projection.field_state import project_field_state
 from babylon.projection.industry import project_industry
 from babylon.projection.institution import project_institution
 from babylon.projection.national import project_national
@@ -27,6 +28,7 @@ from babylon.projection.state import project_state
 from babylon.projection.vault.render import render_county, render_sovereign
 from babylon.projection.vault.render_community import render_community
 from babylon.projection.vault.render_economy import render_economy
+from babylon.projection.vault.render_field_state import render_field_state
 from babylon.projection.vault.render_industry import render_industry
 from babylon.projection.vault.render_institution import render_institution
 from babylon.projection.vault.render_national import render_national
@@ -44,6 +46,9 @@ _NATIONAL_ID = "USA"
 
 #: The one economy dossier id (T3 spine-C singleton, mirrors _NATIONAL_ID).
 _ECONOMY_ID = "USA"
+
+#: The one field-state dossier id (T3 U3 singleton, mirrors _ECONOMY_ID).
+_FIELD_STATE_ID = "USA"
 
 
 def _node_ids(graph: Any, node_type: NodeType) -> list[str]:
@@ -151,6 +156,10 @@ class ArchiveTickBaker:
         pages[f"national/{_NATIONAL_ID}.md"] = render_national(national, verified_tick=tick)
         economy = project_economy(_ECONOMY_ID, graph=graph, world=world, tick=tick)
         pages[f"economy/{_ECONOMY_ID}.md"] = render_economy(economy, verified_tick=tick)
+        field_state = project_field_state(_FIELD_STATE_ID, graph=graph, tick=tick)
+        pages[f"field_state/{_FIELD_STATE_ID}.md"] = render_field_state(
+            field_state, verified_tick=tick
+        )
         for org_id in _node_ids(graph, NodeType.ORGANIZATION):
             org = project_organization(org_id, graph=graph, world=world, tick=tick)
             pages[f"organization/{org_id}.md"] = render_organization(org, verified_tick=tick)

--- a/src/babylon/projection/vault/tick_baker.py
+++ b/src/babylon/projection/vault/tick_baker.py
@@ -17,6 +17,7 @@ from babylon.models.enums.topology import NodeType
 from babylon.projection.community import project_community
 from babylon.projection.county import project_county
 from babylon.projection.economy import project_economy
+from babylon.projection.faction import project_faction
 from babylon.projection.field_state import project_field_state
 from babylon.projection.industry import project_industry
 from babylon.projection.institution import project_institution
@@ -28,6 +29,7 @@ from babylon.projection.state import project_state
 from babylon.projection.vault.render import render_county, render_sovereign
 from babylon.projection.vault.render_community import render_community
 from babylon.projection.vault.render_economy import render_economy
+from babylon.projection.vault.render_faction import render_faction
 from babylon.projection.vault.render_field_state import render_field_state
 from babylon.projection.vault.render_industry import render_industry
 from babylon.projection.vault.render_institution import render_institution
@@ -120,11 +122,19 @@ class ArchiveTickBaker:
     The per-kind composition over the Lane P estate: counties from the
     configured scope, states from the scope's FIPS prefixes, the national
     dossier, graph-enumerated organizations / institutions / sovereigns /
-    industries / social classes, and membership-enumerated communities —
-    all rendered into ONE pages dict and landed as ONE content-hash-skipped
-    commit per tick (:meth:`~babylon.projection.vault.materializer.
-    VaultMaterializer.bake_tick`). Key figures bake nothing: the kind has
-    no producer, so there are no ids to enumerate (honest absence).
+    factions / industries / social classes, and membership-enumerated
+    communities — all rendered into ONE pages dict and landed as ONE
+    content-hash-skipped commit per tick (:meth:`~babylon.projection.vault.
+    materializer.VaultMaterializer.bake_tick`). Key figures bake nothing: the
+    kind has no producer, so there are no ids to enumerate (honest absence).
+    Factions bake nothing in every current scenario for a related but
+    distinct reason: the node type has a real producer
+    (``WorldState.to_graph()``), but no ``babylon.engine.scenarios`` builder
+    populates ``WorldState.factions`` — only the legacy web bridge's
+    ``_seed_balkanization_layer`` does (Bridge-layer only) — so
+    ``_node_ids(graph, NodeType.FACTION)`` is honestly empty for a headless
+    campaign today; that is a scenario-coverage gap, not a bug (see
+    :mod:`babylon.projection.faction`'s module docstring).
 
     Read-only over ``world``/``graph`` per the observer contract; page
     ordering inside the commit is sorted-path (the materializer's own
@@ -171,6 +181,9 @@ class ArchiveTickBaker:
         for sovereign_id in _node_ids(graph, NodeType.SOVEREIGN):
             sovereign = project_sovereign(sovereign_id, graph=graph, world=world, tick=tick)
             pages[f"sovereign/{sovereign_id}.md"] = render_sovereign(sovereign, verified_tick=tick)
+        for faction_id in _node_ids(graph, NodeType.FACTION):
+            faction = project_faction(faction_id, graph=graph, world=world, tick=tick)
+            pages[f"faction/{faction_id}.md"] = render_faction(faction, verified_tick=tick)
         for industry_id in _node_ids(graph, NodeType.INDUSTRY):
             industry = project_industry(industry_id, graph=graph, world=world, tick=tick)
             pages[f"industry/{industry_id}.md"] = render_industry(industry, verified_tick=tick)

--- a/src/babylon/projection/verbs/plate.py
+++ b/src/babylon/projection/verbs/plate.py
@@ -20,32 +20,13 @@ territories non-empty) — eligibility must never launder a fixture into
 from __future__ import annotations
 
 from babylon.config.defines import GameDefines
-from babylon.models.enums.topology import EdgeType, NodeType
+from babylon.models.enums.topology import NodeType
 from babylon.models.vanguard_resources import VanguardResources, check_can_afford
+from babylon.projection.territory_anchor import tenancy_members_by_territory
 from babylon.projection.verbs.copy import VERB_INELIGIBILITY_COPY
 from babylon.projection.verbs.preview import VERB_TO_ACTION_TYPE, preview_verb
 from babylon.projection.verbs.view_models import VerbPlateView, VerbRow
 from babylon.topology import BabylonGraph
-
-
-def _tenancy_members_by_territory(graph: BabylonGraph) -> dict[str, list[str]]:
-    """Map territory id -> social-class occupants via TENANCY edges.
-
-    Social classes carry no ``territory_ids`` field — their spatial link is
-    the Occupant -> Territory TENANCY edge (Track 1 / Task 8b). This is the
-    same resolution the educate/aid target lists apply, so the plate's
-    predicate can never disagree with them.
-
-    :param graph: World graph (read-only).
-    :returns: Territory id to occupant social-class ids, insertion-ordered.
-    """
-    members: dict[str, list[str]] = {}
-    for source, target, data in graph.edges(data=True):
-        if data.get("_edge_type") == EdgeType.TENANCY:
-            source_type = graph.nodes[source].get("_node_type")
-            if source_type == NodeType.SOCIAL_CLASS:
-                members.setdefault(str(target), []).append(str(source))
-    return members
 
 
 def build_verb_plate(
@@ -71,7 +52,7 @@ def build_verb_plate(
     org_data = graph.nodes[org_id]
     own_tids = {str(t) for t in org_data.get("territory_ids", [])}
 
-    tenancy_members = _tenancy_members_by_territory(graph)
+    tenancy_members = tenancy_members_by_territory(graph)
     has_social_class = any(tid in tenancy_members for tid in own_tids)
 
     # One bounded pass over the graph gathers every remaining predicate input.

--- a/src/babylon/projection/view_models.py
+++ b/src/babylon/projection/view_models.py
@@ -30,6 +30,7 @@ from babylon.models.enums import (
     ApparatusType,
     ClassCharacter,
     ClassInscription,
+    ColonialStance,
     CommunityType,
     ConsciousnessTendency,
     ExtractionPolicy,
@@ -1275,6 +1276,109 @@ class CommunityView(BaseModel):
     overlaps: tuple[CommunityOverlap, ...] | None = None
 
 
+class FactionTerritoryInfluence(BaseModel):
+    """One INFLUENCES edge from a faction into a territory (spec-070 FR-014).
+
+    The reverse-direction sibling of :class:`FieldStateEdgeView`'s territory
+    anchoring: a faction's influence is inherently relational (a faction, a
+    territory, and how strongly/by what channel), so it gets its own
+    per-entry composite rather than collapsing to a bare id the way
+    :attr:`SovereignView.claimed_county_fips` does for weight-free CLAIMS.
+
+    :param territory_id: The raw territory node id the faction influences
+        (the INFLUENCES edge's target).
+    :param county_fips: The territory's ``county_fips`` attribute, resolved
+        the same way :func:`babylon.projection.sovereign._county_fips_of`
+        resolves a sovereign's capital/claims, or ``None`` when the
+        territory node doesn't exist or carries no ``county_fips``.
+    :param influence_level: The edge's influence intensity in ``[0, 1]``.
+    :param support_type: The edge's support channel (e.g.
+        labor/ideological/material).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    territory_id: str = Field(min_length=1)
+    county_fips: str | None = Field(default=None, pattern=r"^\d{5}$")
+    influence_level: Probability
+    support_type: str = Field(min_length=1)
+
+
+class FactionView(BaseModel):
+    """A balkanization-faction dossier — the projected read-model for one
+    political coalition (T3 U4).
+
+    Mirrors :func:`~babylon.projection.sovereign.project_sovereign`'s recipe:
+    faction IS a graph node (spec-070's ``BalkanizationFaction``, stamped
+    whole-cloth by ``WorldState.to_graph()``), so every identity field beyond
+    provenance is that node's own attribute. ``territory_influence`` is the
+    reverse of :attr:`SovereignView.claimed_county_fips` — carrying the
+    INFLUENCES edge's weight/channel, not just the anchored id, per FR-014.
+
+    Every field beyond identity and provenance is ``Optional`` because the
+    faction either doesn't exist in this run (a stale/unminted id) or one of
+    its attributes genuinely isn't attributed; in both cases the honest
+    projection is ``None``, never a defaulted value. ``territory_influence``
+    is the one field where an *empty* tuple ("influences nothing right now")
+    and ``None`` ("this faction doesn't exist") are deliberately distinct.
+
+    Extra keys are rejected (``extra="forbid"``): a payload carrying a field
+    this model does not declare is a shape mismatch to surface loudly, not to
+    swallow.
+
+    :param kind: The discriminator literal ``"faction"`` tagging this record
+        in :data:`ProjectionRecord`.
+    :param faction_id: The faction's stable node id (``FAC_*``, spec-070).
+    :param verified_tick: The committed tick this dossier was projected from
+        (``tick_commit``), the staleness anchor for any materialization.
+    :param name: Display name, or ``None`` if the faction node doesn't exist
+        / carries none.
+    :param ideology: Free-text ideological label, or ``None``.
+    :param colonial_stance: The principal political axis (UPHOLD / IGNORE /
+        ABOLISH), or ``None``.
+    :param is_settler_formation: Whether the faction is a settler-formation
+        coalition, or ``None``.
+    :param extraction_modifier: Mechanical multiplier on extraction, or
+        ``None``.
+    :param violence_modifier: Mechanical multiplier on state violence, or
+        ``None``.
+    :param class_reduction: The faction's effect on class contradiction in
+        ``[0, 1]``, or ``None``.
+    :param metabolic_reduction: The faction's effect on metabolic impact in
+        ``[-1, +1]``, or ``None``.
+    :param color_hex: UI color in ``#RRGGBB`` form, or ``None``.
+    :param founded_tick: The tick the faction was instantiated, or ``None``.
+    :param dissolved_tick: The tick the faction dissolved, or ``None`` (the
+        common case for a still-active faction, not necessarily an
+        attribution gap).
+    :param territory_influence: Every INFLUENCES edge this faction casts,
+        sorted by influence level descending then territory id ascending
+        (matching ``GraphProtocol.query_faction_influence_by_territory``'s
+        own ordering). ``None`` when the faction node itself doesn't exist;
+        an empty tuple is a real, present value ("this faction currently
+        influences nothing"), never conflated with absence.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: Literal["faction"] = "faction"
+    faction_id: str = Field(pattern=r"^FAC_[A-Z][A-Z0-9_]*$")
+    verified_tick: int = Field(ge=0)
+
+    name: str | None = None
+    ideology: str | None = Field(default=None, min_length=1, max_length=64)
+    colonial_stance: ColonialStance | None = None
+    is_settler_formation: bool | None = None
+    extraction_modifier: float | None = Field(default=None, ge=0.0)
+    violence_modifier: float | None = Field(default=None, ge=0.0)
+    class_reduction: Probability | None = None
+    metabolic_reduction: float | None = Field(default=None, ge=-1.0, le=1.0)
+    color_hex: str | None = Field(default=None, pattern=r"^#[0-9A-Fa-f]{6}$")
+    founded_tick: int | None = Field(default=None, ge=0)
+    dissolved_tick: int | None = Field(default=None, ge=0)
+    territory_influence: tuple[FactionTerritoryInfluence, ...] | None = None
+
+
 #: A projected record of any scale, keyed on ``kind``. Widened by
 #: Program 24 P2 as each entity-kind page lands; the hydrate helpers
 #: below need no change as the union grows.
@@ -1282,6 +1386,7 @@ ProjectionRecord = Annotated[
     CountyView
     | CommunityView
     | EconomyView
+    | FactionView
     | FieldStateView
     | IndustryView
     | InstitutionView
@@ -1300,6 +1405,7 @@ _NATIONAL_ADAPTER: TypeAdapter[NationalView] = TypeAdapter(NationalView)
 _ORGANIZATION_ADAPTER: TypeAdapter[OrganizationView] = TypeAdapter(OrganizationView)
 _INSTITUTION_ADAPTER: TypeAdapter[InstitutionView] = TypeAdapter(InstitutionView)
 _SOVEREIGN_ADAPTER: TypeAdapter[SovereignView] = TypeAdapter(SovereignView)
+_FACTION_ADAPTER: TypeAdapter[FactionView] = TypeAdapter(FactionView)
 _KEY_FIGURE_ADAPTER: TypeAdapter[KeyFigureView] = TypeAdapter(KeyFigureView)
 _INDUSTRY_ADAPTER: TypeAdapter[IndustryView] = TypeAdapter(IndustryView)
 _SOCIAL_CLASS_ADAPTER: TypeAdapter[SocialClassView] = TypeAdapter(SocialClassView)
@@ -1407,6 +1513,18 @@ def hydrate_sovereign(data: Mapping[str, Any]) -> SovereignView:
     return _SOVEREIGN_ADAPTER.validate_python(data)
 
 
+def hydrate_faction(data: Mapping[str, Any]) -> FactionView:
+    """Validate an untyped mapping into a :class:`FactionView`.
+
+    :param data: A mapping shaped like a ``FactionView`` — a recorded
+        fixture, a JSON payload, or an assembled row dict. Missing optional
+        keys become ``None``; unknown keys are rejected.
+    :returns: The validated, frozen :class:`FactionView`.
+    :raises pydantic.ValidationError: on a shape or constraint violation.
+    """
+    return _FACTION_ADAPTER.validate_python(data)
+
+
 def hydrate_key_figure(data: Mapping[str, Any]) -> KeyFigureView:
     """Validate an untyped mapping into a :class:`KeyFigureView`.
 
@@ -1483,6 +1601,8 @@ __all__ = [
     "DialecticalRegimeView",
     "EconomyView",
     "FactionalComposition",
+    "FactionTerritoryInfluence",
+    "FactionView",
     "FieldStateEdgeView",
     "FieldStateNodeView",
     "FieldStateView",
@@ -1499,6 +1619,7 @@ __all__ = [
     "hydrate_community",
     "hydrate_county",
     "hydrate_economy",
+    "hydrate_faction",
     "hydrate_field_state",
     "hydrate_industry",
     "hydrate_institution",

--- a/src/babylon/projection/view_models.py
+++ b/src/babylon/projection/view_models.py
@@ -39,7 +39,14 @@ from babylon.models.enums import (
     SocialRole,
     SovereigntyType,
 )
-from babylon.models.types import Coefficient, Currency, Ideology, Probability, SignedLaborHours
+from babylon.models.types import (
+    Coefficient,
+    Currency,
+    Ideology,
+    Intensity,
+    Probability,
+    SignedLaborHours,
+)
 
 #: Tolerance for the simplex/share sum invariants — matches the engine-side
 #: ``ClassDistribution`` and ternary-consciousness tolerance so a record that
@@ -998,6 +1005,188 @@ class EconomyView(BaseModel):
     energy_beta_j: float | None = None
 
 
+class FieldStateNodeView(BaseModel):
+    """One social-class node's Systems #19/#20 field-stack reading (T3 U3).
+
+    Projection-side mirror of the shape
+    ``web/game/engine_bridge.py::_build_field_state_nodes`` serializes —
+    ContradictionFieldSystem @19's ``contradiction_fields`` (per-field
+    value), FieldDerivativeSystem @20's ``field_derivatives`` (only its
+    ``laplacian``/``df_dt`` sub-keys — ``d2f_dt2`` is deliberately out of
+    this dossier's declared contract, matching the ported endpoint), and
+    FascistFactionSystem's ``fascist_alignment``. A node contributes only
+    the keys it actually carries this tick — never a fabricated zero for a
+    field the engine did not compute.
+
+    :param node_id: The social_class graph node id.
+    :param name: The node's ``name`` attribute, or ``node_id`` itself when
+        unattributed (matches the ported helper's own fallback).
+    :param fields: ``{field_name: value}`` from ``contradiction_fields``, or
+        ``None`` when the node carries none this tick.
+    :param laplacian: ``{field_name: value}``, the ``laplacian`` sub-key of
+        every field in ``field_derivatives`` that has one, or ``None``.
+    :param df_dt: ``{field_name: value}``, the ``df_dt`` sub-key of every
+        field in ``field_derivatives`` that has one (``None`` df_dt entries
+        — fewer than 2 ticks of history — are excluded, not zero-filled), or
+        ``None`` when no field has one yet.
+    :param fascist_alignment: The node's ``fascist_alignment`` (a required
+        ``Intensity`` ``SocialClass`` field, default 0.0 — so this is
+        ``None`` only when the node itself carries no such attribute at
+        all, never when the true value happens to be zero).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    node_id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    fields: dict[str, float] | None = None
+    laplacian: dict[str, float] | None = None
+    df_dt: dict[str, float] | None = None
+    fascist_alignment: Intensity | None = None
+
+
+class FieldStateEdgeView(BaseModel):
+    """One field-gradient edge entry (T3 U3), one per ``(edge, field)`` pair.
+
+    Projection-side mirror of
+    ``web/game/engine_bridge.py::_build_field_state_edges`` — an edge
+    carrying gradients for N fields contributes N entries, one per field
+    name, sorted. Territory anchoring reuses the TENANCY membership the
+    engine's own ``ProductionSystem._find_tenancy_target`` establishes
+    (Occupant -> Territory); an endpoint with no resolvable territory keeps
+    its entry with that key present but ``None`` — never omitted or
+    fabricated (the same keep-key-use-null convention the ported helper's
+    own docstring documents).
+
+    :param source: The edge's source social_class node id.
+    :param target: The edge's target social_class node id.
+    :param source_territory: The territory ``source`` holds a TENANCY edge
+        into, or ``None`` when unresolved.
+    :param target_territory: The territory ``target`` holds a TENANCY edge
+        into, or ``None`` when unresolved.
+    :param field: The field name this gradient reading is for.
+    :param gradient: ``f(target) - f(source)`` for :attr:`field`.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    source: str = Field(min_length=1)
+    target: str = Field(min_length=1)
+    source_territory: str | None = None
+    target_territory: str | None = None
+    field: str = Field(min_length=1)
+    gradient: float
+
+
+class PrincipalFieldView(BaseModel):
+    """FieldDerivativeSystem @20's principal-FIELD identification (T3 U3).
+
+    Deliberately distinct from ContradictionSystem @18's Maoist principal
+    OPPOSITION (E0 rename) — this is the field-stack's fastest-developing
+    contradiction FIELD (max ``|df/dt|`` across every node), never the
+    opposition-layer's own principal.
+
+    :param field_name: The identified principal field's name, or ``None``
+        when no field has yet shown any nonzero ``df/dt`` (legitimately
+        null under 2 ticks of history — never a fabricated first field).
+    :param max_abs_df_dt: The winning field's max ``|df/dt|`` across every
+        node (``0.0`` when :attr:`field_name` is ``None``).
+    :param changed: Whether the principal field differs from the previous
+        tick's.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    field_name: str | None = None
+    max_abs_df_dt: float = Field(ge=0.0)
+    changed: bool
+
+
+class DialecticalRegimeView(BaseModel):
+    """ContradictionSystem @18's fixed-point regime classification (T3 U3).
+
+    Classifies the capital_labor opposition (falling back to whichever
+    opposition is principal) into one of three regimes from its trajectory
+    — reproduction (converged or contained), crisis (rising, no Aufhebung),
+    or sublation (rising, level transition available).
+
+    :param regime: ``"reproduction"``, ``"crisis"``, or ``"sublation"``.
+    :param opposition: The classified opposition's key (``"capital_labor"``
+        today, or its principal fallback).
+    :param rate: The classified opposition's own rate this tick.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    regime: Literal["reproduction", "crisis", "sublation"]
+    opposition: str = Field(min_length=1)
+    rate: float
+
+
+class FieldStateView(BaseModel):
+    """The field-state dossier — the Weather Layer, Systems #19/#20's field stack (T3 U3).
+
+    Port of ``web/game/engine_bridge.py::EngineBridge.get_field_state`` (the
+    ``{tick, nodes, edges, principal_field, dialectical_regime}`` shape) into
+    a pure projection read-model — same read logic, no redesign. Transport-
+    neutral by construction — no Django, no engine imports, no database
+    connection; the caller hands in the LIVE post-tick graph it already
+    holds (never a ``WorldState.from_graph()`` round trip, which drops the
+    graph-level ``principal_field``/``dialectical_regime`` attrs and every
+    node/edge attr this dossier reads outside its own ``field_stack`` carrier
+    — see :func:`~babylon.projection.field_state.project_field_state`).
+
+    **One producer per field:**
+
+    .. list-table:: Field-producer rulings
+       :header-rows: 1
+
+       * - Field
+         - Producer
+       * - ``nodes``
+         - :class:`FieldStateNodeView` per social_class node carrying
+           ``contradiction_fields`` (ContradictionFieldSystem @19),
+           ``field_derivatives`` (FieldDerivativeSystem @20 — ``laplacian``/
+           ``df_dt`` sub-keys only), or ``fascist_alignment``
+           (FascistFactionSystem), sorted by ``node_id``. ``None`` when no
+           social_class node carries any of the three this tick (the field
+           stack never ran).
+       * - ``edges``
+         - :class:`FieldStateEdgeView` per ``(edge, field)`` pair carrying a
+           ``field_gradients`` entry (FieldDerivativeSystem @20), territory-
+           anchored via the live TENANCY edges, sorted by ``(source, target,
+           field)``. ``None`` when no edge carries a gradient this tick.
+       * - ``principal_field``
+         - The ``principal_field`` graph attribute
+           (``FieldDerivativeSystem._identify_principal_contradiction``),
+           hydrated verbatim. ``None`` when the attribute itself is absent
+           (the field stack never ran this tick — it is otherwise always
+           written once ``FieldDerivativeSystem`` runs with a nonempty field
+           registry).
+       * - ``dialectical_regime``
+         - The ``dialectical_regime`` graph attribute
+           (``ContradictionSystem._classify_regime`` @18), hydrated
+           verbatim. ``None`` when no ``capital_labor``/principal
+           ``OppositionState`` existed yet this tick — the classifier
+           returns without writing the attribute in that case.
+
+    Absence discipline (Constitution III.11): a fresh graph with neither
+    system having run yet (tick 0) projects every field ``None`` — an
+    honest "the weather has not formed" reading, never a fabricated calm.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: Literal["field_state"] = "field_state"
+    field_state_id: str = Field(min_length=1)
+    verified_tick: int = Field(ge=0)
+
+    nodes: tuple[FieldStateNodeView, ...] | None = None
+    edges: tuple[FieldStateEdgeView, ...] | None = None
+    principal_field: PrincipalFieldView | None = None
+    dialectical_regime: DialecticalRegimeView | None = None
+
+
 class CommunityOverlap(BaseModel):
     """One other community sharing at least one roster member with the queried one.
 
@@ -1093,6 +1282,7 @@ ProjectionRecord = Annotated[
     CountyView
     | CommunityView
     | EconomyView
+    | FieldStateView
     | IndustryView
     | InstitutionView
     | KeyFigureView
@@ -1115,6 +1305,7 @@ _INDUSTRY_ADAPTER: TypeAdapter[IndustryView] = TypeAdapter(IndustryView)
 _SOCIAL_CLASS_ADAPTER: TypeAdapter[SocialClassView] = TypeAdapter(SocialClassView)
 _COMMUNITY_ADAPTER: TypeAdapter[CommunityView] = TypeAdapter(CommunityView)
 _ECONOMY_ADAPTER: TypeAdapter[EconomyView] = TypeAdapter(EconomyView)
+_FIELD_STATE_ADAPTER: TypeAdapter[FieldStateView] = TypeAdapter(FieldStateView)
 _RECORD_ADAPTER: TypeAdapter[CountyView | NationalView | OrganizationView | StateView] = (
     TypeAdapter(ProjectionRecord)
 )
@@ -1142,6 +1333,18 @@ def hydrate_economy(data: Mapping[str, Any]) -> EconomyView:
     :raises pydantic.ValidationError: on a shape or constraint violation.
     """
     return _ECONOMY_ADAPTER.validate_python(data)
+
+
+def hydrate_field_state(data: Mapping[str, Any]) -> FieldStateView:
+    """Validate an untyped mapping into a :class:`FieldStateView`.
+
+    :param data: A mapping shaped like a ``FieldStateView`` — a recorded
+        fixture, a JSON payload, or an assembled row dict. Missing optional
+        keys become ``None``; unknown keys are rejected.
+    :returns: The validated, frozen :class:`FieldStateView`.
+    :raises pydantic.ValidationError: on a shape or constraint violation.
+    """
+    return _FIELD_STATE_ADAPTER.validate_python(data)
 
 
 def hydrate_state(data: Mapping[str, Any]) -> StateView:
@@ -1277,13 +1480,18 @@ __all__ = [
     "ConsciousnessSimplex",
     "CountyView",
     "DepartmentComposition",
+    "DialecticalRegimeView",
     "EconomyView",
     "FactionalComposition",
+    "FieldStateEdgeView",
+    "FieldStateNodeView",
+    "FieldStateView",
     "IndustryView",
     "InstitutionView",
     "KeyFigureView",
     "NationalView",
     "OrganizationView",
+    "PrincipalFieldView",
     "ProjectionRecord",
     "SocialClassView",
     "SovereignView",
@@ -1291,6 +1499,7 @@ __all__ = [
     "hydrate_community",
     "hydrate_county",
     "hydrate_economy",
+    "hydrate_field_state",
     "hydrate_industry",
     "hydrate_institution",
     "hydrate_key_figure",

--- a/src/babylon/projection/view_models.py
+++ b/src/babylon/projection/view_models.py
@@ -837,6 +837,167 @@ class SocialClassView(BaseModel):
     county_class_composition: ClassComposition | None = None
 
 
+class ClassPhiReadingView(BaseModel):
+    """One class/county's Fundamental Theorem reading (Vol I U2).
+
+    Projection-side mirror of
+    :class:`~babylon.domain.dialectics.instances.value_form.ClassPhiReading`
+    — the projection layer declares its own wire shape rather than importing
+    the domain model (WO-22's no-engine-no-domain-import discipline, the
+    same choice :class:`DepartmentComposition` makes for
+    ``DepartmentMapper.DepartmentAllocation``). Hydrated verbatim from the
+    ``fundamental_theorem`` graph-attribute dump
+    (``ContradictionSystem._stash_fundamental_theorem``), never recomputed.
+
+    :param entity_id: The class/county graph node id this reading is for.
+    :param w_paid: W_c — total wages paid this tick.
+    :param v_produced: V_c — productivity value captured this tick.
+    :param phi_absolute: Phi = W_c − V_c in dollars. Always defined.
+    :param phi_relative: ``(W_c − V_c)/V_c``, or ``None`` when ``v_produced
+        <= 0`` (a class that produced nothing has no defined ratio).
+    :param labor_aristocracy_ratio: ``W_c / V_c``, or ``None`` under the
+        same guard.
+    :param is_labor_aristocracy: ``W_c > V_c`` (strict), or ``None`` under
+        the same guard.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    entity_id: str = Field(min_length=1)
+    w_paid: float
+    v_produced: float
+    phi_absolute: float
+    phi_relative: float | None = None
+    labor_aristocracy_ratio: float | None = None
+    is_labor_aristocracy: bool | None = None
+
+
+class EconomyView(BaseModel):
+    """The economy dossier — the singleton national Φ/surplus/matter read-model.
+
+    T3 spine-C prescription (``ai/_inbox/PROGRAM_v1_0_0_playable_archive.md``
+    §C): (1) the Fundamental Theorem verdict read off the SAME
+    ``opposition_states["wage"].balance`` the engine's own contradiction
+    registry adjudicates — never a parallel Φ; (2) the per-class/county Φ
+    readings the ``fundamental_theorem`` graph stash carries (Vol I U2);
+    (3) Φ's tri-decomposition (unequal exchange + reproduction + domestic,
+    excluding the report-only Φ_III term from the total); (4) the Volume
+    III surplus split ``s = p + i + r + t``, aggregated RATIO-OF-SUMS across
+    territories, never mean-of-ratios; (5) the metabolic "matter-book"
+    (overshoot ``O = C/B``, the monotone ceiling ``M̄``); (6) the energy
+    vertex β_J, an UNPOSITIONED honest absence (genuinely absent tree-wide —
+    no EROI/joule accounting anywhere in the engine). Money and matter are
+    never rendered as interconvertible — see
+    :func:`~babylon.projection.economy.project_economy` for the full
+    field-by-field producer ruling.
+
+    Extra keys are rejected (``extra="forbid"``): a payload carrying a field
+    this model does not declare is a shape mismatch to surface loudly, not
+    to swallow.
+
+    :param kind: The discriminator literal ``"economy"`` tagging this record
+        in :data:`ProjectionRecord`.
+    :param economy_id: The economy's identity (``"USA"`` today, matching
+        :attr:`NationalView.national_id`'s singleton convention) — not a
+        FIPS code.
+    :param verified_tick: The committed tick this dossier was projected from.
+    :param wage_balance: The ``wage`` opposition's signed Balance
+        ``(W_c − V_c)/(W_c + V_c)`` read verbatim off ``opposition_states``
+        — positive means the wage exceeds value produced (the imperial
+        bribe). ``None`` when the opposition registry is unwired or the
+        ``wage`` key is not registered this run.
+    :param labor_aristocracy_verdict: ``wage_balance > 0``, the Fundamental
+        Theorem verdict BY CONSTRUCTION (never recomputed from a parallel
+        feed). ``None`` under the same guard as :attr:`wage_balance`.
+    :param class_phi_readings: Every class/county's
+        :class:`ClassPhiReadingView`, sorted by ``entity_id`` for
+        deterministic ordering, or ``None`` when the ``fundamental_theorem``
+        graph attribute itself is absent (the opposition registry never
+        ran). An attributed-but-empty tuple means the registry ran but no
+        node carried both ``w_paid``/``v_produced`` this tick — a real,
+        different fact from "never computed".
+    :param phi_unequal_exchange: Emmanuel/Amin international transfer
+        (``(1 − γ_basket)·Consumption``), or ``None`` — genuinely absent
+        tree-wide: no engine producer publishes ``γ_basket`` or aggregate
+        consumption to the graph today.
+    :param phi_reproduction: Meillassoux externalized reproduction
+        (``max(0, P_g2 − wage)``), or ``None`` — genuinely absent tree-wide.
+    :param phi_domestic: Fortunati domestic shadow labor (``τ · L_unpaid``),
+        or ``None`` — genuinely absent tree-wide (unpaid/reproductive
+        labor-hours have no producer, even though national MELT τ is itself
+        live elsewhere).
+    :param phi_iii_report: The kernel's narrower invisible-fraction Φ_III
+        (report only, excluded from any total), or ``None`` — same absence.
+    :param phi_decomposition_total: The sum of :attr:`phi_unequal_exchange`
+        + :attr:`phi_reproduction` + :attr:`phi_domestic` (excluding
+        :attr:`phi_iii_report` by design — the domain model's own ``total``
+        computed-field rule), or ``None`` unless all three conservation
+        components are present.
+    :param surplus_produced: Σ ``tick_total_surplus`` (s) across territories
+        this tick, or ``None`` when no territory carries the attribute.
+    :param profit_of_enterprise: Σ ``tick_profit_of_enterprise`` (p) —
+        signed; may be negative in a debt spiral.
+    :param interest_burden: Σ ``tick_interest_burden`` (i).
+    :param ground_rent: Σ ``tick_ground_rent`` (r).
+    :param taxes_on_surplus: Σ ``tick_taxes_on_surplus`` (t).
+    :param rentier_share: The national ``Σr / Σs`` — a genuine RATIO OF
+        SUMS, never a mean of the per-territory ``tick_rentier_share``
+        readings (the intensive-aggregation error class). ``None`` when
+        Σs is not positive.
+    :param financialization_share: The national ``Σi / Σs``, same
+        ratio-of-sums discipline.
+    :param total_consumption: Σ ``consumption_needs`` nationwide (C, the
+        ``WorldState.total_consumption`` extensive sum), or ``None`` when
+        the world carries no territory.
+    :param total_biocapacity: Σ ``Territory.biocapacity`` nationwide (B),
+        or ``None`` under the same guard.
+    :param overshoot_ratio: ``C / B``, or ``None`` when B is not positive —
+        never the ``WorldState.overshoot_ratio`` computed-field's own
+        fabricated ``999.0`` sentinel (Constitution III.11 forbids a
+        substituted default standing in for absence).
+    :param biocapacity_ceiling: Σ ``Territory.max_biocapacity`` nationwide
+        (the monotone ceiling M̄), or ``None`` when the world carries no
+        territory.
+    :param energy_beta_j: The energy vertex β_J — always ``None``.
+        Genuinely absent tree-wide (verified: no EROI, fossil,
+        power-density, or joule accounting anywhere in the engine); an
+        UNPOSITIONED {absence} fence naming the energy-split prerequisite.
+        Never derived from the money-form quantities above — money and
+        matter are not interconvertible.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: Literal["economy"] = "economy"
+    economy_id: str = Field(min_length=1)
+    verified_tick: int = Field(ge=0)
+
+    wage_balance: Ideology | None = None
+    labor_aristocracy_verdict: bool | None = None
+    class_phi_readings: tuple[ClassPhiReadingView, ...] | None = None
+
+    phi_unequal_exchange: float | None = None
+    phi_reproduction: float | None = None
+    phi_domestic: float | None = None
+    phi_iii_report: float | None = None
+    phi_decomposition_total: float | None = None
+
+    surplus_produced: Currency | None = None
+    profit_of_enterprise: float | None = None
+    interest_burden: Currency | None = None
+    ground_rent: Currency | None = None
+    taxes_on_surplus: Currency | None = None
+    rentier_share: float | None = None
+    financialization_share: float | None = None
+
+    total_consumption: Currency | None = None
+    total_biocapacity: Currency | None = None
+    overshoot_ratio: float | None = Field(default=None, ge=0.0)
+    biocapacity_ceiling: Currency | None = None
+
+    energy_beta_j: float | None = None
+
+
 class CommunityOverlap(BaseModel):
     """One other community sharing at least one roster member with the queried one.
 
@@ -931,6 +1092,7 @@ class CommunityView(BaseModel):
 ProjectionRecord = Annotated[
     CountyView
     | CommunityView
+    | EconomyView
     | IndustryView
     | InstitutionView
     | KeyFigureView
@@ -952,6 +1114,7 @@ _KEY_FIGURE_ADAPTER: TypeAdapter[KeyFigureView] = TypeAdapter(KeyFigureView)
 _INDUSTRY_ADAPTER: TypeAdapter[IndustryView] = TypeAdapter(IndustryView)
 _SOCIAL_CLASS_ADAPTER: TypeAdapter[SocialClassView] = TypeAdapter(SocialClassView)
 _COMMUNITY_ADAPTER: TypeAdapter[CommunityView] = TypeAdapter(CommunityView)
+_ECONOMY_ADAPTER: TypeAdapter[EconomyView] = TypeAdapter(EconomyView)
 _RECORD_ADAPTER: TypeAdapter[CountyView | NationalView | OrganizationView | StateView] = (
     TypeAdapter(ProjectionRecord)
 )
@@ -967,6 +1130,18 @@ def hydrate_county(data: Mapping[str, Any]) -> CountyView:
     :raises pydantic.ValidationError: on a shape or constraint violation.
     """
     return _COUNTY_ADAPTER.validate_python(data)
+
+
+def hydrate_economy(data: Mapping[str, Any]) -> EconomyView:
+    """Validate an untyped mapping into an :class:`EconomyView`.
+
+    :param data: A mapping shaped like an ``EconomyView`` — a recorded
+        fixture, a JSON payload, or an assembled row dict. Missing optional
+        keys become ``None``; unknown keys are rejected.
+    :returns: The validated, frozen :class:`EconomyView`.
+    :raises pydantic.ValidationError: on a shape or constraint violation.
+    """
+    return _ECONOMY_ADAPTER.validate_python(data)
 
 
 def hydrate_state(data: Mapping[str, Any]) -> StateView:
@@ -1096,11 +1271,13 @@ def hydrate_record(
 
 __all__ = [
     "ClassComposition",
+    "ClassPhiReadingView",
     "CommunityOverlap",
     "CommunityView",
     "ConsciousnessSimplex",
     "CountyView",
     "DepartmentComposition",
+    "EconomyView",
     "FactionalComposition",
     "IndustryView",
     "InstitutionView",
@@ -1113,6 +1290,7 @@ __all__ = [
     "StateView",
     "hydrate_community",
     "hydrate_county",
+    "hydrate_economy",
     "hydrate_industry",
     "hydrate_institution",
     "hydrate_key_figure",

--- a/src/babylon/projection/view_models.py
+++ b/src/babylon/projection/view_models.py
@@ -171,6 +171,12 @@ class CountyView(BaseModel):
         ``None``.
     :param bifurcation_score: The county bifurcation axis in ``[-1, +1]``
         (revolutionary at ``-1``, fascist at ``+1``), or ``None``.
+    :param habitability: Territory ecological viability in ``[0, 1]``
+        (MetabolismSystem's biocapacity/Sovereign-metabolic-impact index), or
+        ``None`` before MetabolismSystem has ever run this session (tick 0)
+        or when no territory carries this county's FIPS — never a fabricated
+        ``0.0`` or the ``1.0`` some aggregators default an unattributed
+        reading to.
     :param sovereign_id: The id of the sovereign claiming this county via a
         CLAIMS edge, or ``None`` when unclaimed (no CLAIMS edge projected).
     """
@@ -190,6 +196,7 @@ class CountyView(BaseModel):
     p_acquiescence: Probability | None = None
     p_revolution: Probability | None = None
     bifurcation_score: Ideology | None = None
+    habitability: Probability | None = None
     sovereign_id: str | None = None
 
 

--- a/src/babylon/sentinels/liveness/registry.py
+++ b/src/babylon/sentinels/liveness/registry.py
@@ -136,26 +136,18 @@ LIVENESS_ROWS: tuple[LivenessRow, ...] = (
         producer_file=f"{_ENGINE_SYSTEMS}/contradiction.py",
         producer_symbol="ContradictionSystem",
         output_symbol="fundamental_theorem",
-        consumer_files=(),
-        dormant_reason=(
-            "Written to the graph every tick (ContradictionSystem._stash_fundamental_theorem, "
-            "Vol I U2/ADR117) and read by nothing in production today — a deliberate scope "
-            "boundary, not an oversight: U2 stopped at graph-attribute-only observability, the "
-            "SAME Phase-1-shadow precedent pole_readings/market_balance above already "
-            "establish. Declared dormant pending a future unit surfacing it through "
-            "WorldState/persistence or a narrator/dashboard reader (ADR117 names this as "
-            "U9's/a later unit's open scope); until then it is a live producer with zero "
-            "production readers, recorded rather than hidden. If a future unit does surface "
-            "it on a web-facing endpoint, its wire fields (phi_absolute, phi_relative, "
-            "labor_aristocracy_ratio, is_labor_aristocracy) must be added to "
-            "projection/veil.py's TIER1_VALUE_RELATION_FIELDS before exposure, the same "
-            "forward-pin discipline that module's docstring already applies to "
-            "profit_rate/occ/surplus_denied (Vol I U9/ADR115)."
-        ),
+        consumer_files=("src/babylon/projection/economy.py",),
         material_relation=(
             "Phi = W_c - V_c per class/county, the Fundamental Theorem computed "
             "(compute_fundamental_theorem, domain/dialectics/instances/value_form.py) — "
-            "the named comparison Ch. 25's imperial-rent thesis rests on."
+            "the named comparison Ch. 25's imperial-rent thesis rests on. Surfaced "
+            "(T3 spine-C, ADR109 W-P wiring motion) by "
+            "babylon.projection.economy.project_economy's class_phi_readings field — "
+            "the dossier this row's original dormant_reason named as its open scope. "
+            "Its wire fields (phi_absolute, phi_relative, labor_aristocracy_ratio, "
+            "is_labor_aristocracy) are projection-layer read-only today; adding a "
+            "web-facing endpoint still requires the same forward-pin into "
+            "projection/veil.py's TIER1_VALUE_RELATION_FIELDS this row's prior note flagged."
         ),
     ),
     LivenessRow(

--- a/tests/baselines/vault/detroit_tri_county/manifest.json
+++ b/tests/baselines/vault/detroit_tri_county/manifest.json
@@ -1,8 +1,10 @@
 {
   "files": {
-    "county/26099.md": "e37de3777ddf4289fa7f29c36f36d69b62cf940b0bd1eb7e34a19370b8d672e8",
-    "county/26125.md": "d55938a5d63da4abb4ab3ee87199c8a3fd00e1e93fe0771f7c9720a3e99804cb",
-    "county/26163.md": "e72b0c5ae4e284e4565d602118d3648c6fb8045fedfe84b2a88acffdbf7b03ac",
+    "county/26099.md": "940f91cb7e170f51f24f81e7a215f4d1353dbad71676ebadf35767602fb065fc",
+    "county/26125.md": "6826fb0e9c1e001f254263318ca05c34c71b405aeea11f840d9519700d1196b9",
+    "county/26163.md": "a3f8d7ea8cc31d213b82add40de0d660aad4ffb6a592d48ae20a20ff7e546ca9",
+    "economy/USA.md": "d47d4fb45ee0f76448d147278feb20511b95aa863b34c15cdb1acdd12ecb54c2",
+    "field_state/USA.md": "5d23f41dc15debf593805506aaf7f95038901d371dff8cc55888cb6cd2456af6",
     "national/USA.md": "5038d4628ab3ab4515ddbcb098cd76800ac65b29b4b8ce71605fa79a9e186893",
     "social_class/C001.md": "a646fd6e7529f768500cd1463eabb1930c1f747ad8e8e22fa2f72f27dc466acf",
     "social_class/C002.md": "3fe47ad2aa1ba06e1cdd9b88e97424bca16a4568a26a0deb834810baa8296483",
@@ -12,8 +14,8 @@
     "social_class/C503.md": "f4900a44b391b4c59b88fa7ff94f71c0bee83e87a3695e08a061478a8365f3e5",
     "state/26.md": "8a0d5fabaa8ce242e8fdc83d6e4b6616eb595d1e9c46ff18905f8fc4a629c0ad"
   },
-  "head_sha": "aa7d73a7669efdc105f3a7f821edc70434427181",
-  "page_count": 11,
+  "head_sha": "a58230d3df37153572fce6abb3e2b0d9076b68a4",
+  "page_count": 13,
   "scenario": "detroit_tri_county",
   "ticks": 3
 }

--- a/tests/baselines/vault/single_county/manifest.json
+++ b/tests/baselines/vault/single_county/manifest.json
@@ -1,13 +1,15 @@
 {
   "files": {
-    "county/26163.md": "c97d1e6ab8596731f3dd3f21094b386b1f99ff255a6fa25445ceff2eb2bfee2b",
+    "county/26163.md": "67798bedf2c759ebc271f70a7030940536648ccac928cad145bb14bd370a33ee",
+    "economy/USA.md": "f2513e276ac6368e6a7c4528ec5cc5d7148ca996343103cdd30117b4c1c0edba",
+    "field_state/USA.md": "7e956bda57f5b7356fff984986af571f399386c180412cfb90eb366167439d19",
     "national/USA.md": "0f8b82b66090b09d100b82ebe4138acb69b9b32568734562c5d89547335f89b6",
     "social_class/C003.md": "e624872b95ad3b5bb6e95b4b1e798a87818a00625f491bcc86fb6951ff19d52d",
     "social_class/C004.md": "d01adc9f27150109c79b4a217cc4c43faafad51a46274cf1390dfc79260c24e4",
     "state/26.md": "4dd8aeff285a12bcd0cd9fe8b6ccb314cef5ec467560d138711ebf3675776697"
   },
-  "head_sha": "26fa622d0d6208a02f1fd2cea1589b9b6aa504fd",
-  "page_count": 5,
+  "head_sha": "3b293d0f637c1e5bf2e60a774e1c82269e70dbb0",
+  "page_count": 7,
   "scenario": "single_county",
   "ticks": 5
 }

--- a/tests/unit/archive/test_ledger_closed.py
+++ b/tests/unit/archive/test_ledger_closed.py
@@ -14,10 +14,13 @@ the claim mechanically checked instead:
 3. Every disposition cell across the ledger's three per-item tables uses the
    closed vocabulary the ledger itself declares: ``PORTED`` / ``REWRITTEN``
    / ``RE-GUARDED`` / ``CARRIED(...)`` / ``RETIRED`` / ``GAP``.
-4. The four ``GAP`` rows (cutover blockers: the economy Wc-Vc aggregates,
-   the economy chip contract, the field-state read-model, and balkanization
-   factions) stay visible — these must survive until a BD ruling closes
-   them, not vanish in a ledger edit.
+4. The four former ``GAP`` rows (cutover blockers: the economy Wc-Vc
+   aggregates, the economy chip contract, the field-state read-model, and
+   balkanization factions) were CLOSED by the T3 gap-projections train
+   (U2/U3/U4, ADR125) under the BD ruling "4 LOUD ledger gaps -> BUILD all"
+   (ratified master plan, 2026-07-21). The check now pins the closed state:
+   the four classes stay NAMED (as ``REWRITTEN (T3 ...)`` rows) and ZERO
+   ``GAP`` cells remain — a reappearing ``GAP`` is a regression.
 5. The checker is itself mutation-tested: each check is proven to fail on a
    ledger copy with the fact it depends on removed.
 
@@ -51,8 +54,8 @@ _CLASS_RE = re.compile(r"^class (Test\w+)")
 # The ledger's own declared vocabulary (test-port-ledger.md lines 10-13).
 _DISPOSITION_RE = re.compile(r"^(PORTED|REWRITTEN|RE-GUARDED|RETIRED|GAP)\b|^CARRIED\s*\(")
 
-# The four cutover blockers (test-port-ledger.md "LOUD" section) — must stay
-# both NAMED and tagged GAP.
+# The four former cutover blockers (test-port-ledger.md "LOUD" section) —
+# closed by T3 U2/U3/U4 (ADR125); must stay NAMED as REWRITTEN (T3 ...) rows.
 _LOUD_GAP_CLASSES = (
     "TestEconomyDashboardFundamentalTheorem",
     "TestEconomyDashboardChipContract",
@@ -190,21 +193,29 @@ class TestDispositionVocabularyClosed:
 
 
 # ---------------------------------------------------------------------------
-# 4. The four LOUD GAP rows stay visible.
+# 4. The four LOUD rows are CLOSED (T3 U2/U3/U4) and stay that way.
 # ---------------------------------------------------------------------------
 
 
-class TestLoudGapsStayVisible:
-    def test_all_four_gap_classes_are_named(self) -> None:
+class TestLoudGapsClosed:
+    def test_all_four_former_gap_classes_stay_named(self) -> None:
         ledger_text = _LEDGER.read_text(encoding="utf-8")
         missing = _missing_names(list(_LOUD_GAP_CLASSES), ledger_text)
-        assert missing == [], f"a GAP cutover-blocker silently vanished: {missing}"
+        assert missing == [], f"a closed cutover-blocker silently vanished: {missing}"
 
-    def test_exactly_four_rows_are_tagged_gap(self) -> None:
+    def test_zero_rows_are_tagged_gap(self) -> None:
+        # T3 closed all four LOUD gaps (ADR125); the honest-GAP vocabulary
+        # stays legal for FUTURE rows, but today a GAP cell reappearing means
+        # either a regression or an undispositioned new gap — both loud.
         ledger_text = _LEDGER.read_text(encoding="utf-8")
         cells = _all_disposition_cells(ledger_text)
         gap_cells = [cell for cell in cells if cell.startswith("GAP")]
-        assert len(gap_cells) == 4, f"expected exactly 4 GAP rows, found {len(gap_cells)}"
+        assert gap_cells == [], f"expected zero GAP rows post-T3, found: {gap_cells}"
+
+    def test_all_four_closures_are_tagged_rewritten_t3(self) -> None:
+        ledger_text = _LEDGER.read_text(encoding="utf-8")
+        for marker in ("REWRITTEN (T3 U2)", "REWRITTEN (T3 U3)", "REWRITTEN (T3 U4)"):
+            assert marker in ledger_text, f"missing closure disposition: {marker}"
 
 
 # ---------------------------------------------------------------------------
@@ -236,26 +247,24 @@ class TestSentinelCatchesMutation:
         bad = [cell for cell in cells if not _DISPOSITION_RE.match(cell)]
         assert bad == ["SHIPPED (WO-27)"]
 
-    def test_gap_visibility_check_reds_when_a_gap_row_is_deleted(self) -> None:
+    def test_closure_check_reds_when_a_closed_row_regresses_to_gap(self) -> None:
+        # Mutate on the disposition CELL, not the row's full prose (the prose
+        # drifted once already and broke the old fixture) — flipping the
+        # balkanization closure back to GAP must red the zero-GAP check.
         real_ledger = _LEDGER.read_text(encoding="utf-8")
-        gap_row = (
-            "| `TestBalkanizationMapFields` | balkanization block: faction enumeration + "
-            "per-territory contested/dominant_faction from INFLUENCES reads | single "
-            "sovereign IS covered (`project_sovereign`/county `sovereign_id`); **faction "
-            "enumeration + contested-territory derivation are not projected** (no "
-            "`FactionView`, no INFLUENCES read); no WO | GAP (LOUD) |"
-        )
-        assert gap_row in real_ledger, "the GAP row's exact text drifted — update the fixture"
-        # The class name is ALSO named a second time, in the "LOUD" prose list
-        # below the table (a deliberate redundancy) — both mentions must be
-        # gone for the class to genuinely vanish from the ledger, so the row
-        # deletion is followed by scrubbing the remaining name occurrence too.
-        assert real_ledger.count("TestBalkanizationMapFields") == 2
-        mutated = real_ledger.replace(gap_row, "").replace("TestBalkanizationMapFields", "")
-
-        missing = _missing_names(["TestBalkanizationMapFields"], mutated)
-        assert missing == ["TestBalkanizationMapFields"]
-
+        closed_cell = "| REWRITTEN (T3 U4) |"
+        assert closed_cell in real_ledger, "the U4 closure cell drifted — update the fixture"
+        mutated = real_ledger.replace(closed_cell, "| GAP (LOUD) |")
         cells = _all_disposition_cells(mutated)
         gap_cells = [cell for cell in cells if cell.startswith("GAP")]
-        assert len(gap_cells) == 3, "deleting one GAP row must drop the count from 4 to 3"
+        assert gap_cells == ["GAP (LOUD)"], "a regressed GAP cell must be seen by the checker"
+
+    def test_containment_check_reds_when_a_closed_class_vanishes(self) -> None:
+        # The class name appears in its REWRITTEN row AND the struck-through
+        # LOUD prose item (deliberate redundancy) — scrub every mention and
+        # the containment check must red.
+        real_ledger = _LEDGER.read_text(encoding="utf-8")
+        assert real_ledger.count("TestBalkanizationMapFields") >= 2
+        mutated = real_ledger.replace("TestBalkanizationMapFields", "")
+        missing = _missing_names(["TestBalkanizationMapFields"], mutated)
+        assert missing == ["TestBalkanizationMapFields"]

--- a/tests/unit/economics/tick/test_graph_bridge.py
+++ b/tests/unit/economics/tick/test_graph_bridge.py
@@ -365,6 +365,10 @@ class TestWriteFinancialState:
         assert node_data["tick_rentier_share"] == 0.0
         assert node_data["tick_profit_of_enterprise"] == 0.0
         assert node_data["tick_financialization_share"] == 0.0
+        # U1 (surplus-split publication completion): the remaining 2 of the
+        # 6 SurplusValueDistribution terms (s = p + i + r + t).
+        assert node_data["tick_taxes_on_surplus"] == 0.0
+        assert node_data["tick_total_surplus"] == 0.0
         assert node_data["tick_accumulated_debt"] == 0.0
         assert node_data["tick_claims_exceed_surplus"] is False
         assert node_data["tick_housing_fictitious_fraction"] is None
@@ -440,11 +444,54 @@ class TestWriteFinancialState:
         assert node_data["tick_rentier_share"] == 0.1  # 100 / 1000
         assert node_data["tick_profit_of_enterprise"] == 650.0
         assert node_data["tick_financialization_share"] == 0.2  # 200 / 1000
+        # U1 (surplus-split publication completion): the remaining 2 of the
+        # 6 SurplusValueDistribution terms (s = p + i + r + t).
+        assert node_data["tick_taxes_on_surplus"] == 50.0
+        assert node_data["tick_total_surplus"] == 1000.0
         assert node_data["tick_accumulated_debt"] == 500.0
         assert node_data["tick_claims_exceed_surplus"] is False  # 200+100+50 < 1000
         expected_fict = (50000.0 + 30000.0) / 180000.0
         assert abs(node_data["tick_housing_fictitious_fraction"] - expected_fict) < 1e-9
         assert node_data["tick_financial_crisis_signals"] == 4
+
+    def test_surplus_split_identity_holds_on_node_attrs(
+        self,
+        sample_tick_state: SimulationTickState,
+    ) -> None:
+        """Verify s = p + i + r + t on the graph's published node attrs.
+
+        U1 (surplus-split publication completion): the bridge now publishes
+        all 6 :class:`SurplusValueDistribution` terms as ``tick_`` node
+        attrs (previously 5 of 6 — ``taxes_on_surplus`` and
+        ``total_surplus_produced`` were missing), so the Marxian identity
+        is reconstructible from the LIVE graph object alone, without a
+        ``WorldState`` round-trip (which drops every ``tick_*``/``flow_*``
+        node attr, ``world_state.py:241``).
+        """
+        svd = SurplusValueDistribution(
+            fips_code="26163",
+            year=2015,
+            total_surplus_produced=1000.0,
+            interest_payments=200.0,
+            ground_rent=100.0,
+            taxes_on_surplus=50.0,
+        )
+        original_county = sample_tick_state.county_states[WAYNE_FIPS]
+        modified_county = original_county.model_copy(update={"surplus_distribution": svd})
+        modified_state = sample_tick_state.model_copy(
+            update={"county_states": {WAYNE_FIPS: modified_county}}
+        )
+
+        graph = build_territory_graph()
+        write_tick_state_to_graph(graph, modified_state)
+
+        node_data = graph.nodes[WAYNE_FIPS]
+        p = node_data["tick_profit_of_enterprise"]
+        i = node_data["tick_interest_burden"]
+        r = node_data["tick_ground_rent"]
+        t = node_data["tick_taxes_on_surplus"]
+        s = node_data["tick_total_surplus"]
+        assert p + i + r + t == pytest.approx(s)
 
     def test_credit_cycle_phase_in_metadata(
         self,

--- a/tests/unit/game/test_chronicle_adapter.py
+++ b/tests/unit/game/test_chronicle_adapter.py
@@ -25,6 +25,8 @@ from babylon.game.chronicle_adapter import (
 )
 from babylon.kernel.event_bus import Event
 from babylon.models.enums.events import EventType
+from babylon.models.enums.topology import EdgeType, NodeType
+from babylon.topology import BabylonGraph
 
 pytestmark = [pytest.mark.unit]
 
@@ -310,3 +312,116 @@ def test_chronicle_events_from_bus_is_per_tick_not_cumulative() -> None:
     # exact same result — determinism, not first-call-wins caching.
     replayed_tick1 = chronicle_events_from_bus(tick1_events)
     assert replayed_tick1 == first_call
+
+
+# --------------------------------------------------------------------------- #
+# Event-to-territory anchoring (Unit U5): a class/org node_id in the payload  #
+# gains a resolved territory anchor when a live graph is threaded through.    #
+# --------------------------------------------------------------------------- #
+
+
+def _graph_with_tenancy(class_id: str = "C001", territory_id: str = "T001") -> BabylonGraph:
+    """A minimal live graph: one social_class TENANCY-linked to one territory."""
+    graph = BabylonGraph()
+    graph.add_node(territory_id, NodeType.TERRITORY, name="Wayne County")
+    graph.add_node(class_id, NodeType.SOCIAL_CLASS, name="Periphery Proletariat")
+    graph.add_edge(class_id, territory_id, EdgeType.TENANCY)
+    return graph
+
+
+def test_uprising_on_a_tenancy_linked_class_resolves_its_territory_anchor() -> None:
+    """UPRISING's ``node_id`` is a social_class id (``struggle.py``'s own
+    ``node.id``) — with a live graph carrying that class's TENANCY edge, the
+    ChronicleEvent gains a real ``data["anchor"]`` AND the human summary
+    stops showing a bare, unanchored node id."""
+    graph = _graph_with_tenancy()
+    raw = [
+        Event(
+            type=EventType.UPRISING.value,
+            tick=9,
+            payload={"node_id": "C001", "trigger": "spark", "agitation": 0.8, "repression": 0.3},
+        )
+    ]
+    result = chronicle_events_from_bus(raw, graph=graph)
+    assert result[0].data["anchor"] == {"territory_id": "T001", "territory_name": "Wayne County"}
+    assert "Wayne County" in result[0].summary
+    # The raw payload is preserved verbatim alongside the anchor, not replaced.
+    assert result[0].data["node_id"] == "C001"
+
+
+def test_uprising_with_no_node_id_stays_clean() -> None:
+    """A payload that never carries the anchor-eligible key resolves to no
+    anchor at all — honest absence, not a fabricated one."""
+    graph = _graph_with_tenancy()
+    raw = [Event(type=EventType.UPRISING.value, tick=9, payload={"trigger": "spark"})]
+    result = chronicle_events_from_bus(raw, graph=graph)
+    assert "anchor" not in result[0].data
+
+
+def test_uprising_on_a_class_with_no_tenancy_edge_stays_unanchored() -> None:
+    """A real node_id with NO TENANCY edge into any territory resolves to no
+    anchor — Constitution III.11, never a guessed territory."""
+    graph = _graph_with_tenancy()
+    raw = [Event(type=EventType.UPRISING.value, tick=9, payload={"node_id": "C999"})]
+    result = chronicle_events_from_bus(raw, graph=graph)
+    assert "anchor" not in result[0].data
+
+
+def test_anchoring_is_deterministic_over_repeated_calls() -> None:
+    """The SAME graph + SAME events always resolve the SAME anchor —
+    Constitution III.7 determinism, not a first-call-wins cache."""
+    graph = _graph_with_tenancy()
+    raw = [Event(type=EventType.UPRISING.value, tick=9, payload={"node_id": "C001"})]
+    first = chronicle_events_from_bus(raw, graph=graph)
+    second = chronicle_events_from_bus(raw, graph=graph)
+    assert first == second
+    assert first[0].data["anchor"] == second[0].data["anchor"]
+
+
+def test_no_graph_threaded_preserves_the_pre_existing_unanchored_behavior() -> None:
+    """Callers that never thread a graph through (the default) get exactly
+    the pre-U5 behavior — no ``anchor`` key, no crash. Backward compatible
+    with every pre-existing call site/test."""
+    raw = [Event(type=EventType.UPRISING.value, tick=9, payload={"node_id": "C001"})]
+    result = chronicle_events_from_bus(raw)
+    assert "anchor" not in result[0].data
+
+
+def test_event_type_with_no_anchor_field_never_gains_one_even_with_a_graph() -> None:
+    """An EventType outside the anchor-field registry (e.g.
+    ORGANIZATIONAL_ACTION, which has no class/org subject at all) never
+    gains a fabricated anchor just because a graph happens to be present."""
+    graph = _graph_with_tenancy()
+    raw = [
+        Event(
+            type=EventType.ORGANIZATIONAL_ACTION.value,
+            tick=9,
+            payload={"org_count": 2, "action_count": 3, "layer0_count": 1},
+        )
+    ]
+    result = chronicle_events_from_bus(raw, graph=graph)
+    assert "anchor" not in result[0].data
+
+
+@pytest.mark.parametrize(
+    ("event_type", "field"),
+    [
+        (EventType.EXCESSIVE_FORCE, "node_id"),
+        (EventType.SOLIDARITY_SPIKE, "node_id"),
+        (EventType.FASCIST_DRIFT, "node_id"),
+        (EventType.POGROM, "target_id"),
+        (EventType.LOCKOUT, "target_id"),
+        (EventType.VIGILANTISM, "target_id"),
+    ],
+)
+def test_other_class_scoped_event_types_also_anchor(event_type: EventType, field: str) -> None:
+    """Every other verified class-scoped ``EventType`` (struggle.py's
+    EXCESSIVE_FORCE/SOLIDARITY_SPIKE sharing UPRISING's own ``node.id``;
+    ``reactionary.py``'s FASCIST_DRIFT; the reactionary-verb family's
+    ``target_id`` — the SAME ``target_id`` the legacy
+    ``web/game/engine_bridge.py::_TERRITORY_ANCHORED_VERB_EVENTS`` precedent
+    already anchors) resolves through the same mechanism, not just UPRISING."""
+    graph = _graph_with_tenancy()
+    raw = [Event(type=event_type.value, tick=9, payload={field: "C001"})]
+    result = chronicle_events_from_bus(raw, graph=graph)
+    assert result[0].data["anchor"] == {"territory_id": "T001", "territory_name": "Wayne County"}

--- a/tests/unit/game/test_session.py
+++ b/tests/unit/game/test_session.py
@@ -314,7 +314,7 @@ def test_advance_tick_wires_the_real_chronicle_adapter_not_a_dead_seam() -> None
 
     result = session.advance_tick()
 
-    expected = chronicle_events_from_bus(result.events)
+    expected = chronicle_events_from_bus(result.events, graph=session.graph)
     assert result.chronicle == expected
     for chronicle_event, raw_event in zip(result.chronicle, result.events, strict=True):
         assert chronicle_event.tick == raw_event.tick

--- a/tests/unit/projection/test_county.py
+++ b/tests/unit/projection/test_county.py
@@ -73,6 +73,7 @@ def _full_graph() -> BabylonGraph:
         tick_bifurcation_score=-0.32,
         tick_class_distribution=dict(_DISTRIBUTION),
         legitimation_index=0.71,
+        habitability=0.83,
     )
     graph.add_node("SOV_USA", NodeType.SOVEREIGN, name="United States")
     graph.add_edge("SOV_USA", "T001", EdgeType.CLAIMS)
@@ -113,6 +114,7 @@ class TestFullDossier:
         assert view.imperial_rent_phi == pytest.approx(412.7)
         assert view.bifurcation_score == pytest.approx(-0.32)
         assert view.legitimacy == pytest.approx(0.71)
+        assert view.habitability == pytest.approx(0.83)
         assert view.sovereign_id == "SOV_USA"
         assert view.class_composition is not None
         assert view.class_composition.proletariat == pytest.approx(0.382)
@@ -166,6 +168,7 @@ class TestHonestAbsence:
         assert view.bifurcation_score is None
         assert view.legitimacy is None
         assert view.class_composition is None
+        assert view.habitability is None
         assert view.sovereign_id is None
 
     def test_unattributed_county_has_no_consciousness(self) -> None:
@@ -192,6 +195,7 @@ class TestHonestAbsence:
         assert view.population == 250
         assert view.p_acquiescence is not None
         assert view.median_wage is None
+        assert view.habitability is None
         assert view.sovereign_id is None
 
     def test_contested_claims_project_no_single_sovereign(self) -> None:
@@ -216,6 +220,13 @@ class TestLoudFailure:
             county_fips=WAYNE,
             tick_class_distribution={"proletariat": 1.0},
         )
+        with pytest.raises(ValidationError):
+            project_county(WAYNE, graph=graph, world=_world(), tick=1)
+
+    def test_out_of_range_habitability_raises(self) -> None:
+        """A present ``habitability`` outside ``[0, 1]`` fails validation loudly."""
+        graph = BabylonGraph()
+        graph.add_node("T001", NodeType.TERRITORY, county_fips=WAYNE, habitability=1.5)
         with pytest.raises(ValidationError):
             project_county(WAYNE, graph=graph, world=_world(), tick=1)
 

--- a/tests/unit/projection/test_economy.py
+++ b/tests/unit/projection/test_economy.py
@@ -1,0 +1,366 @@
+"""Contract tests for :func:`babylon.projection.economy.project_economy`.
+
+The economy dossier's behavioral contract (T3 spine-C prescription,
+``ai/_inbox/PROGRAM_v1_0_0_playable_archive.md`` §C): the Fundamental
+Theorem verdict read verbatim off the ``wage`` opposition's Balance (never a
+parallel Φ), the per-class Φ readings from the ``fundamental_theorem`` graph
+stash, Φ's tri-decomposition (genuinely absent tree-wide today), the Volume
+III surplus split aggregated RATIO-OF-SUMS, and the metabolic matter-book.
+Fixture-fed — no engine tick, no database — per the keel's fixture-first
+discipline. Test class names mirror the intent of the retired
+``TestEconomyDashboardFundamentalTheorem``/``TestEconomyDashboardChipContract``
+GAP rows (``specs/24-archive/test-port-ledger.md`` rows 191-192).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from babylon.models.entities.social_class import IdeologicalProfile, SocialClass
+from babylon.models.entities.territory import Territory
+from babylon.models.enums import SocialRole
+from babylon.models.enums.territory import SectorType
+from babylon.models.enums.topology import NodeType
+from babylon.models.world_state import WorldState
+from babylon.projection.economy import project_economy
+from babylon.topology import BabylonGraph
+
+WAYNE = "26163"
+
+_WAYNE_SURPLUS_ATTRS = {
+    "tick_total_surplus": 1000.0,
+    "tick_profit_of_enterprise": 400.0,
+    "tick_interest_burden": 100.0,
+    "tick_ground_rent": 300.0,
+    "tick_taxes_on_surplus": 200.0,
+}
+_OAKLAND_SURPLUS_ATTRS = {
+    "tick_total_surplus": 500.0,
+    "tick_profit_of_enterprise": 200.0,
+    "tick_interest_burden": 50.0,
+    "tick_ground_rent": 150.0,
+    "tick_taxes_on_surplus": 100.0,
+}
+
+
+def _territory(node_id: str, *, biocapacity: float, max_biocapacity: float) -> Territory:
+    """Build a minimal Territory entity for matter-book tests."""
+    return Territory(
+        id=node_id,
+        name=f"Test {node_id}",
+        sector_type=SectorType.RESIDENTIAL,
+        biocapacity=biocapacity,
+        max_biocapacity=max_biocapacity,
+    )
+
+
+def _make_entity(
+    eid: str,
+    *,
+    county_fips: str | None = None,
+    population: int = 100,
+) -> SocialClass:
+    """Build a minimal SocialClass (default s_bio/s_class => consumption_needs=0.01)."""
+    return SocialClass(
+        id=eid,
+        name=f"Test {eid}",
+        role=SocialRole.PERIPHERY_PROLETARIAT,
+        wealth=1.0,
+        ideology=IdeologicalProfile(class_consciousness=0.5, national_identity=0.5),
+        population=population,
+        county_fips=county_fips,
+    )
+
+
+class TestEconomyDashboardFundamentalTheorem:
+    """The verdict is read verbatim off opposition_states['wage'].balance — never a parallel Φ."""
+
+    def test_positive_balance_is_the_labor_aristocracy_verdict(self) -> None:
+        graph = BabylonGraph()
+        graph.set_graph_attr(
+            "opposition_states",
+            {
+                "wage": {
+                    "key": "wage",
+                    "tick": 1,
+                    "gap": 0.4,
+                    "balance": 0.25,
+                    "rate": 0.0,
+                    "leading_pole": "b",
+                }
+            },
+        )
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.wage_balance == pytest.approx(0.25)
+        assert view.labor_aristocracy_verdict is True
+
+    def test_negative_balance_is_not_the_labor_aristocracy_verdict(self) -> None:
+        graph = BabylonGraph()
+        graph.set_graph_attr(
+            "opposition_states",
+            {
+                "wage": {
+                    "key": "wage",
+                    "tick": 1,
+                    "gap": 0.4,
+                    "balance": -0.1,
+                    "rate": 0.0,
+                    "leading_pole": "a",
+                }
+            },
+        )
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.wage_balance == pytest.approx(-0.1)
+        assert view.labor_aristocracy_verdict is False
+
+    def test_unwired_registry_is_honest_absence(self) -> None:
+        view = project_economy("USA", graph=BabylonGraph(), world=WorldState(), tick=1)
+
+        assert view.wage_balance is None
+        assert view.labor_aristocracy_verdict is None
+
+    def test_wage_key_absent_from_a_populated_opposition_states_is_honest_absence(self) -> None:
+        graph = BabylonGraph()
+        graph.set_graph_attr(
+            "opposition_states",
+            {"capital_labor": {"key": "capital_labor", "tick": 1, "gap": 0.1, "balance": 0.0}},
+        )
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.wage_balance is None
+        assert view.labor_aristocracy_verdict is None
+
+    def test_per_class_phi_readings_hydrate_sorted_by_entity_id(self) -> None:
+        graph = BabylonGraph()
+        graph.set_graph_attr(
+            "fundamental_theorem",
+            {
+                "C002": {
+                    "entity_id": "C002",
+                    "w_paid": 50.0,
+                    "v_produced": 60.0,
+                    "phi_absolute": -10.0,
+                    "phi_relative": -1.0 / 6.0,
+                    "labor_aristocracy_ratio": 50.0 / 60.0,
+                    "is_labor_aristocracy": False,
+                },
+                "C001": {
+                    "entity_id": "C001",
+                    "w_paid": 120.0,
+                    "v_produced": 100.0,
+                    "phi_absolute": 20.0,
+                    "phi_relative": 0.2,
+                    "labor_aristocracy_ratio": 1.2,
+                    "is_labor_aristocracy": True,
+                },
+            },
+        )
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.class_phi_readings is not None
+        assert [r.entity_id for r in view.class_phi_readings] == ["C001", "C002"]
+        assert view.class_phi_readings[0].is_labor_aristocracy is True
+        assert view.class_phi_readings[1].phi_absolute == pytest.approx(-10.0)
+
+    def test_zero_production_class_projects_none_ratio_subfields(self) -> None:
+        graph = BabylonGraph()
+        graph.set_graph_attr(
+            "fundamental_theorem",
+            {
+                "C001": {
+                    "entity_id": "C001",
+                    "w_paid": 10.0,
+                    "v_produced": 0.0,
+                    "phi_absolute": 10.0,
+                }
+            },
+        )
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.class_phi_readings is not None
+        reading = view.class_phi_readings[0]
+        assert reading.phi_relative is None
+        assert reading.labor_aristocracy_ratio is None
+        assert reading.is_labor_aristocracy is None
+
+    def test_fundamental_theorem_attr_absent_is_honest_none(self) -> None:
+        view = project_economy("USA", graph=BabylonGraph(), world=WorldState(), tick=1)
+
+        assert view.class_phi_readings is None
+
+    def test_fundamental_theorem_present_but_empty_dict_is_a_real_empty_tuple(self) -> None:
+        graph = BabylonGraph()
+        graph.set_graph_attr("fundamental_theorem", {})
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.class_phi_readings == ()
+
+    def test_phi_tri_decomposition_is_honest_absence_tree_wide(self) -> None:
+        """Wired-but-genuinely-absent: every conservation component and the total."""
+        view = project_economy("USA", graph=BabylonGraph(), world=WorldState(), tick=1)
+
+        assert view.phi_unequal_exchange is None
+        assert view.phi_reproduction is None
+        assert view.phi_domestic is None
+        assert view.phi_iii_report is None
+        assert view.phi_decomposition_total is None
+
+
+class TestEconomyDashboardChipContract:
+    """Surplus-split + matter-book aggregate quantities: extensive ratio-of-sums."""
+
+    def test_surplus_split_sums_extensively_across_territories(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node("T001", NodeType.TERRITORY, county_fips=WAYNE, **_WAYNE_SURPLUS_ATTRS)
+        graph.add_node("T002", NodeType.TERRITORY, county_fips="26125", **_OAKLAND_SURPLUS_ATTRS)
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.surplus_produced == pytest.approx(1500.0)
+        assert view.profit_of_enterprise == pytest.approx(600.0)
+        assert view.interest_burden == pytest.approx(150.0)
+        assert view.ground_rent == pytest.approx(450.0)
+        assert view.taxes_on_surplus == pytest.approx(300.0)
+
+    def test_surplus_identity_holds_on_the_summed_totals(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node("T001", NodeType.TERRITORY, county_fips=WAYNE, **_WAYNE_SURPLUS_ATTRS)
+        graph.add_node("T002", NodeType.TERRITORY, county_fips="26125", **_OAKLAND_SURPLUS_ATTRS)
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        total = (
+            view.profit_of_enterprise
+            + view.interest_burden
+            + view.ground_rent
+            + view.taxes_on_surplus
+        )
+        assert total == pytest.approx(view.surplus_produced)
+
+    def test_shares_are_ratio_of_sums_not_mean_of_ratios(self) -> None:
+        """A tiny territory's extreme per-territory ratio must not swing the national share."""
+        graph = BabylonGraph()
+        graph.add_node("T001", NodeType.TERRITORY, **_WAYNE_SURPLUS_ATTRS)
+        graph.add_node(
+            "T002",
+            NodeType.TERRITORY,
+            tick_total_surplus=1.0,
+            tick_profit_of_enterprise=0.0,
+            tick_interest_burden=1.0,
+            tick_ground_rent=0.0,
+            tick_taxes_on_surplus=0.0,
+        )
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        expected = (100.0 + 1.0) / (1000.0 + 1.0)
+        assert view.financialization_share == pytest.approx(expected)
+        # A naive mean of per-territory ratios would be (0.10 + 1.0) / 2 = 0.55.
+        assert view.financialization_share < 0.5
+
+    def test_profit_of_enterprise_may_be_negative_in_a_debt_spiral(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node(
+            "T001",
+            NodeType.TERRITORY,
+            tick_total_surplus=100.0,
+            tick_profit_of_enterprise=-50.0,
+            tick_interest_burden=80.0,
+            tick_ground_rent=50.0,
+            tick_taxes_on_surplus=20.0,
+        )
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.profit_of_enterprise == pytest.approx(-50.0)
+
+    def test_no_territory_carries_the_attr_is_honest_absence(self) -> None:
+        view = project_economy("USA", graph=BabylonGraph(), world=WorldState(), tick=1)
+
+        assert view.surplus_produced is None
+        assert view.profit_of_enterprise is None
+        assert view.interest_burden is None
+        assert view.ground_rent is None
+        assert view.taxes_on_surplus is None
+        assert view.rentier_share is None
+        assert view.financialization_share is None
+
+    def test_zero_surplus_is_honest_absence_for_the_two_shares_only(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node(
+            "T001",
+            NodeType.TERRITORY,
+            tick_total_surplus=0.0,
+            tick_profit_of_enterprise=0.0,
+            tick_interest_burden=0.0,
+            tick_ground_rent=0.0,
+            tick_taxes_on_surplus=0.0,
+        )
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.surplus_produced == pytest.approx(0.0)
+        assert view.rentier_share is None
+        assert view.financialization_share is None
+
+    def test_matter_book_extensive_sums(self) -> None:
+        world = WorldState(
+            territories={
+                "T001": _territory("T001", biocapacity=40.0, max_biocapacity=100.0),
+                "T002": _territory("T002", biocapacity=60.0, max_biocapacity=120.0),
+            },
+            entities={"C001": _make_entity("C001")},
+        )
+        view = project_economy("USA", graph=BabylonGraph(), world=world, tick=1)
+
+        assert view.total_biocapacity == pytest.approx(100.0)
+        assert view.biocapacity_ceiling == pytest.approx(220.0)
+        assert view.total_consumption == pytest.approx(0.01)
+        assert view.overshoot_ratio == pytest.approx(0.01 / 100.0)
+
+    def test_zero_biocapacity_yields_honest_none_overshoot(self) -> None:
+        world = WorldState(
+            territories={"T001": _territory("T001", biocapacity=0.0, max_biocapacity=0.0)}
+        )
+        view = project_economy("USA", graph=BabylonGraph(), world=world, tick=1)
+
+        assert view.total_biocapacity == pytest.approx(0.0)
+        assert view.overshoot_ratio is None
+
+    def test_no_territories_is_honest_absence_for_the_whole_matter_book(self) -> None:
+        view = project_economy("USA", graph=BabylonGraph(), world=WorldState(), tick=1)
+
+        assert view.total_consumption is None
+        assert view.total_biocapacity is None
+        assert view.overshoot_ratio is None
+        assert view.biocapacity_ceiling is None
+
+    def test_matter_book_never_reads_the_static_biocapacity_sum_seed(self) -> None:
+        """Regression: the matter-book must never source from a Postgres view row."""
+        world = WorldState(
+            territories={"T001": _territory("T001", biocapacity=5.0, max_biocapacity=5.0)}
+        )
+        view = project_economy("USA", graph=BabylonGraph(), world=world, tick=1)
+
+        assert view.total_biocapacity == pytest.approx(5.0)
+
+    def test_energy_beta_j_is_always_absent(self) -> None:
+        view = project_economy("USA", graph=BabylonGraph(), world=WorldState(), tick=1)
+
+        assert view.energy_beta_j is None
+
+
+class TestDeterminism:
+    """Identical inputs yield identical frozen dossiers."""
+
+    def test_double_projection_is_identical(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node("T001", NodeType.TERRITORY, county_fips=WAYNE, **_WAYNE_SURPLUS_ATTRS)
+        graph.set_graph_attr(
+            "opposition_states",
+            {"wage": {"key": "wage", "tick": 1, "gap": 0.4, "balance": 0.25, "rate": 0.0}},
+        )
+        world = WorldState(entities={"C001": _make_entity("C001", county_fips=WAYNE)})
+
+        first = project_economy("USA", graph=graph, world=world, tick=847)
+        second = project_economy("USA", graph=graph, world=world, tick=847)
+
+        assert first == second
+        assert first.model_dump() == second.model_dump()

--- a/tests/unit/projection/test_economy.py
+++ b/tests/unit/projection/test_economy.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import pytest
 
+from babylon.domain.economics.tick.types import TickSummary
 from babylon.models.entities.social_class import IdeologicalProfile, SocialClass
 from babylon.models.entities.territory import Territory
 from babylon.models.enums import SocialRole
@@ -40,6 +41,29 @@ _OAKLAND_SURPLUS_ATTRS = {
     "tick_interest_burden": 50.0,
     "tick_ground_rent": 150.0,
     "tick_taxes_on_surplus": 100.0,
+}
+
+#: A minimal valid TickSummary carrying national_melt=65.0 — the ONE input
+#: phi_domestic/phi_iii_report share, already live on the graph independent
+#: of the Φ tri-decomposition wiring (see project_economy's own docstring).
+_NATIONAL_MELT_SUMMARY = TickSummary(
+    year=2020,
+    counties_processed=1,
+    phi_aggregate=0.0,
+    national_melt=65.0,
+    mean_profit_rate=0.1,
+    mean_occ=1.0,
+    mean_exploitation_rate=1.0,
+    national_class_distribution={},
+)
+
+_GAMMA_BASKET_DUMP = {"year": 2022, "alpha": 0.35, "gamma_import": 0.65, "gamma_basket": 0.74}
+_GAMMA_III_DUMP = {
+    "year": 2022,
+    "paid_care_hours": 16.5,
+    "unpaid_care_hours": 33.0,
+    "gamma_iii": 0.333,
+    "fortunati_exploitation": 2.003,
 }
 
 
@@ -206,6 +230,124 @@ class TestEconomyDashboardFundamentalTheorem:
         assert view.phi_domestic is None
         assert view.phi_iii_report is None
         assert view.phi_decomposition_total is None
+
+
+class TestPhiTriDecomposition:
+    """Each Φ tri-decomposition component reads its OWN named graph inputs.
+
+    Fix-commit regression coverage: the tri-decomposition must have a real
+    read site per component (each attempting ``graph.get_graph_attr`` for
+    its own named inputs and calling the matching ``value_form`` builder
+    only when all of them resolve) rather than five hardcoded ``None``
+    literals — a future producer publishing any ONE component's inputs must
+    make that component light up with no change to ``project_economy``.
+    These tests exercise the lit-up path directly, giving the previously
+    zero-caller ``value_form`` builders (and ``PhiDecomposition`` itself) a
+    real call site.
+    """
+
+    def test_unequal_exchange_lights_up_from_gamma_basket_and_consumption(self) -> None:
+        graph = BabylonGraph()
+        graph.set_graph_attr("gamma_basket", _GAMMA_BASKET_DUMP)
+        graph.set_graph_attr("consumption", 1000.0)
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.phi_unequal_exchange == pytest.approx((1.0 - 0.74) * 1000.0)
+        # The other components still lack THEIR OWN inputs — each reads
+        # independently, so one lighting up must not fabricate the rest.
+        assert view.phi_reproduction is None
+        assert view.phi_domestic is None
+        assert view.phi_iii_report is None
+        assert view.phi_decomposition_total is None
+
+    def test_reproduction_lights_up_from_p_g2_and_wage_paid(self) -> None:
+        graph = BabylonGraph()
+        graph.set_graph_attr("p_g2_labor_value", 60000.0)
+        graph.set_graph_attr("wage_paid_for_d_g2", 12000.0)
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.phi_reproduction == pytest.approx(48000.0)
+        assert view.phi_unequal_exchange is None
+        assert view.phi_decomposition_total is None
+
+    def test_domestic_lights_up_from_l_unpaid_and_national_melt(self) -> None:
+        graph = BabylonGraph()
+        graph.set_graph_attr("l_unpaid", 1000.0)
+        graph.set_graph_attr("tick_dynamics", {"tick_summary": _NATIONAL_MELT_SUMMARY})
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.phi_domestic == pytest.approx(65.0 * 1000.0)
+        assert view.phi_decomposition_total is None
+
+    def test_domestic_stays_absent_without_national_melt_even_with_l_unpaid(self) -> None:
+        """One input alone is not both inputs — τ must ALSO resolve."""
+        graph = BabylonGraph()
+        graph.set_graph_attr("l_unpaid", 1000.0)
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.phi_domestic is None
+
+    def test_iii_report_lights_up_from_gamma_iii_and_national_melt(self) -> None:
+        graph = BabylonGraph()
+        graph.set_graph_attr("gamma_iii", _GAMMA_III_DUMP)
+        graph.set_graph_attr("tick_dynamics", {"tick_summary": _NATIONAL_MELT_SUMMARY})
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.phi_iii_report == pytest.approx((1.0 - 0.333) * 33.0 * 65.0)
+        # phi_iii_report is report-only (D2 kernel-fork resolution) — it
+        # never gates phi_decomposition_total on its own.
+        assert view.phi_decomposition_total is None
+
+    def test_decomposition_total_requires_all_three_conservation_components(self) -> None:
+        graph = BabylonGraph()
+        graph.set_graph_attr("gamma_basket", _GAMMA_BASKET_DUMP)
+        graph.set_graph_attr("consumption", 1000.0)
+        graph.set_graph_attr("p_g2_labor_value", 60000.0)
+        graph.set_graph_attr("wage_paid_for_d_g2", 12000.0)
+        graph.set_graph_attr("l_unpaid", 1000.0)
+        graph.set_graph_attr("tick_dynamics", {"tick_summary": _NATIONAL_MELT_SUMMARY})
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        expected_unequal_exchange = (1.0 - 0.74) * 1000.0
+        expected_reproduction = 48000.0
+        expected_domestic = 65.0 * 1000.0
+        assert view.phi_unequal_exchange == pytest.approx(expected_unequal_exchange)
+        assert view.phi_reproduction == pytest.approx(expected_reproduction)
+        assert view.phi_domestic == pytest.approx(expected_domestic)
+        assert view.phi_decomposition_total == pytest.approx(
+            expected_unequal_exchange + expected_reproduction + expected_domestic
+        )
+
+    def test_decomposition_total_missing_one_conservation_component_is_none(self) -> None:
+        """Two of three conservation components present is still not enough."""
+        graph = BabylonGraph()
+        graph.set_graph_attr("gamma_basket", _GAMMA_BASKET_DUMP)
+        graph.set_graph_attr("consumption", 1000.0)
+        graph.set_graph_attr("p_g2_labor_value", 60000.0)
+        graph.set_graph_attr("wage_paid_for_d_g2", 12000.0)
+        # l_unpaid / national_melt deliberately absent — phi_domestic stays None.
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.phi_unequal_exchange is not None
+        assert view.phi_reproduction is not None
+        assert view.phi_domestic is None
+        assert view.phi_decomposition_total is None
+
+    def test_decomposition_total_excludes_iii_report(self) -> None:
+        """Adding phi_iii_report's OWN inputs must not change the total (D2 fork)."""
+        graph = BabylonGraph()
+        graph.set_graph_attr("gamma_basket", _GAMMA_BASKET_DUMP)
+        graph.set_graph_attr("consumption", 1000.0)
+        graph.set_graph_attr("p_g2_labor_value", 60000.0)
+        graph.set_graph_attr("wage_paid_for_d_g2", 12000.0)
+        graph.set_graph_attr("l_unpaid", 1000.0)
+        graph.set_graph_attr("gamma_iii", _GAMMA_III_DUMP)
+        graph.set_graph_attr("tick_dynamics", {"tick_summary": _NATIONAL_MELT_SUMMARY})
+        view = project_economy("USA", graph=graph, world=WorldState(), tick=1)
+
+        assert view.phi_iii_report is not None
+        without_iii_report = view.phi_unequal_exchange + view.phi_reproduction + view.phi_domestic
+        assert view.phi_decomposition_total == pytest.approx(without_iii_report)
 
 
 class TestEconomyDashboardChipContract:

--- a/tests/unit/projection/test_faction.py
+++ b/tests/unit/projection/test_faction.py
@@ -1,0 +1,281 @@
+"""Contract tests for :func:`babylon.projection.faction.project_faction`.
+
+The faction read-model's behavioral contract: one producer per field,
+honest ``None`` for every unattributed or nonexistent quantity, deterministic
+output. Fixture-fed — no engine tick, no database — per the keel's
+fixture-first discipline. Mirrors ``tests/unit/projection/test_sovereign.py``
+exactly (T3 U4 shares the same recipe as WO-20's ``project_sovereign``).
+
+The HONEST-EMPTY case (``TestNoScenarioSeedsFactions``) pins down a real
+production fact: no ``babylon.engine.scenarios`` builder ever constructs a
+``BalkanizationFaction`` or populates ``WorldState.factions`` today — only
+the legacy web bridge's ``_seed_balkanization_layer`` does (Bridge-layer
+only). A graph with zero faction nodes is exactly what every real headless
+campaign bakes, and ``project_faction`` must still return a valid,
+all-absent dossier for it — never a crash.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from babylon.models.enums.topology import EdgeType, NodeType
+from babylon.models.world_state import WorldState
+from babylon.projection.faction import faction_statblocks, project_faction
+from babylon.topology import BabylonGraph
+
+FAC_RESTORATIONIST = "FAC_RESTORATIONIST"
+
+
+def _full_graph() -> BabylonGraph:
+    """A faction influencing two territories, at differing intensities."""
+    graph = BabylonGraph()
+    graph.add_node(
+        FAC_RESTORATIONIST,
+        NodeType.FACTION,
+        name="Restorationist Coalition",
+        ideology="settler-restorationism",
+        colonial_stance="uphold",
+        is_settler_formation=True,
+        extraction_modifier=1.2,
+        violence_modifier=1.1,
+        class_reduction=0.3,
+        metabolic_reduction=-0.2,
+        color_hex="#AA0000",
+        founded_tick=0,
+    )
+    graph.add_node("T001", NodeType.TERRITORY, county_fips="26163")
+    graph.add_node("T002", NodeType.TERRITORY, county_fips="26125")
+    graph.add_edge(
+        FAC_RESTORATIONIST,
+        "T001",
+        EdgeType.INFLUENCES,
+        influence_level=0.7,
+        support_type="labor",
+    )
+    graph.add_edge(
+        FAC_RESTORATIONIST,
+        "T002",
+        EdgeType.INFLUENCES,
+        influence_level=0.4,
+        support_type="ideological",
+    )
+    return graph
+
+
+def _world() -> WorldState:
+    """Faction fields are all graph-sourced; the world is never consulted."""
+    return WorldState()
+
+
+class TestFullDossier:
+    """Every field populated when every producer has attributed data."""
+
+    def test_projects_every_field(self) -> None:
+        """A fully-attributed faction yields a dossier with no absences."""
+        view = project_faction(FAC_RESTORATIONIST, graph=_full_graph(), world=_world(), tick=847)
+
+        assert view.faction_id == FAC_RESTORATIONIST
+        assert view.verified_tick == 847
+        assert view.name == "Restorationist Coalition"
+        assert view.ideology == "settler-restorationism"
+        assert view.colonial_stance is not None
+        assert view.colonial_stance.value == "uphold"
+        assert view.is_settler_formation is True
+        assert view.extraction_modifier == pytest.approx(1.2)
+        assert view.violence_modifier == pytest.approx(1.1)
+        assert view.class_reduction == pytest.approx(0.3)
+        assert view.metabolic_reduction == pytest.approx(-0.2)
+        assert view.color_hex == "#AA0000"
+        assert view.founded_tick == 0
+        assert view.dissolved_tick is None
+
+    def test_territory_influence_is_sorted_by_level_descending(self) -> None:
+        """INFLUENCES-derived rows come back highest-influence-first."""
+        view = project_faction(FAC_RESTORATIONIST, graph=_full_graph(), world=_world(), tick=1)
+
+        assert view.territory_influence is not None
+        assert [row.territory_id for row in view.territory_influence] == ["T001", "T002"]
+        assert view.territory_influence[0].influence_level == pytest.approx(0.7)
+        assert view.territory_influence[0].county_fips == "26163"
+        assert view.territory_influence[0].support_type == "labor"
+        assert view.territory_influence[1].county_fips == "26125"
+        assert view.territory_influence[1].support_type == "ideological"
+
+    def test_territory_influence_ignores_other_factions_edges(self) -> None:
+        """Only this faction's own INFLUENCES edges are counted."""
+        graph = _full_graph()
+        graph.add_node("FAC_RIVAL", NodeType.FACTION, name="Rival")
+        graph.add_node("T003", NodeType.TERRITORY, county_fips="26099")
+        graph.add_edge("FAC_RIVAL", "T003", EdgeType.INFLUENCES, influence_level=0.9)
+
+        view = project_faction(FAC_RESTORATIONIST, graph=graph, world=_world(), tick=1)
+
+        assert view.territory_influence is not None
+        territory_ids = [row.territory_id for row in view.territory_influence]
+        assert "T003" not in territory_ids
+        assert territory_ids == ["T001", "T002"]
+
+
+class TestHonestAbsence:
+    """Missing producers project as None — never a default (III.11)."""
+
+    def test_unknown_faction_id_yields_all_none(self) -> None:
+        """A faction id with no matching graph node projects every field None."""
+        graph = _full_graph()
+        view = project_faction("FAC_NOPE", graph=graph, world=_world(), tick=5)
+
+        assert view.name is None
+        assert view.ideology is None
+        assert view.colonial_stance is None
+        assert view.is_settler_formation is None
+        assert view.extraction_modifier is None
+        assert view.violence_modifier is None
+        assert view.class_reduction is None
+        assert view.metabolic_reduction is None
+        assert view.color_hex is None
+        assert view.founded_tick is None
+        assert view.dissolved_tick is None
+        # territory_influence is None here -- "this faction doesn't exist" --
+        # never confused with the empty-tuple "exists but influences nothing".
+        assert view.territory_influence is None
+
+    def test_empty_graph_yields_all_none(self) -> None:
+        """No territory node at all still projects a valid, all-absent dossier."""
+        view = project_faction(FAC_RESTORATIONIST, graph=BabylonGraph(), world=_world(), tick=9)
+
+        assert view.faction_id == FAC_RESTORATIONIST
+        assert view.name is None
+        assert view.territory_influence is None
+
+    def test_faction_with_no_influence_has_empty_but_present_tuple(self) -> None:
+        """A real faction that currently influences nothing gets () -- not None."""
+        graph = BabylonGraph()
+        graph.add_node(FAC_RESTORATIONIST, NodeType.FACTION, name="Restorationist Coalition")
+
+        view = project_faction(FAC_RESTORATIONIST, graph=graph, world=_world(), tick=5)
+
+        assert view.name == "Restorationist Coalition"
+        assert view.territory_influence == ()
+        assert view.territory_influence is not None
+
+    def test_influenced_territory_with_no_county_fips_projects_none_county(self) -> None:
+        """An influenced territory carrying no county_fips yields None, not KeyError."""
+        graph = BabylonGraph()
+        graph.add_node(FAC_RESTORATIONIST, NodeType.FACTION)
+        graph.add_node("T_BARE", NodeType.TERRITORY)
+        graph.add_edge(FAC_RESTORATIONIST, "T_BARE", EdgeType.INFLUENCES, influence_level=0.5)
+
+        view = project_faction(FAC_RESTORATIONIST, graph=graph, world=_world(), tick=5)
+
+        assert view.territory_influence is not None
+        assert view.territory_influence[0].territory_id == "T_BARE"
+        assert view.territory_influence[0].county_fips is None
+
+    def test_a_node_id_collision_with_a_non_faction_type_projects_absence(self) -> None:
+        """An id that resolves to a node of a different type is not this faction."""
+        graph = BabylonGraph()
+        graph.add_node(FAC_RESTORATIONIST, NodeType.TERRITORY, county_fips="26163")
+
+        view = project_faction(FAC_RESTORATIONIST, graph=graph, world=_world(), tick=5)
+
+        assert view.name is None
+        assert view.territory_influence is None
+
+
+class TestNoScenarioSeedsFactions:
+    """The HONEST-EMPTY case: no engine scenario seeds FACTION nodes today.
+
+    Only the legacy web bridge's ``_seed_balkanization_layer`` does
+    (Bridge-layer only, owner item 8) -- a real headless campaign's graph
+    has zero faction nodes, and this projector must handle that gracefully
+    rather than assume at least one faction always exists.
+    """
+
+    def test_empty_graph_with_no_faction_nodes_at_all(self) -> None:
+        """A graph with no faction node whatsoever still yields a valid dossier."""
+        graph = BabylonGraph()
+        graph.add_node("T001", NodeType.TERRITORY, county_fips="26163")
+
+        view = project_faction("FAC_ANY", graph=graph, world=_world(), tick=520)
+
+        assert view.faction_id == "FAC_ANY"
+        assert view.verified_tick == 520
+        assert view.name is None
+        assert view.territory_influence is None
+
+
+class TestLoudFailure:
+    """A present-but-wrong value raises; only a missing one is absence."""
+
+    def test_malformed_colonial_stance_raises(self) -> None:
+        """An unrecognized colonial_stance string fails validation loudly."""
+        graph = BabylonGraph()
+        graph.add_node(FAC_RESTORATIONIST, NodeType.FACTION, colonial_stance="not_a_real_stance")
+
+        with pytest.raises(ValidationError):
+            project_faction(FAC_RESTORATIONIST, graph=graph, world=_world(), tick=1)
+
+    def test_class_reduction_out_of_probability_range_raises(self) -> None:
+        """A class_reduction outside [0, 1] fails validation loudly."""
+        graph = BabylonGraph()
+        graph.add_node(FAC_RESTORATIONIST, NodeType.FACTION, class_reduction=1.5)
+
+        with pytest.raises(ValidationError):
+            project_faction(FAC_RESTORATIONIST, graph=graph, world=_world(), tick=1)
+
+    def test_malformed_color_hex_raises(self) -> None:
+        """A color_hex not matching #RRGGBB fails validation loudly."""
+        graph = BabylonGraph()
+        graph.add_node(FAC_RESTORATIONIST, NodeType.FACTION, color_hex="not-a-color")
+
+        with pytest.raises(ValidationError):
+            project_faction(FAC_RESTORATIONIST, graph=graph, world=_world(), tick=1)
+
+
+class TestDeterminism:
+    """Identical inputs yield identical frozen dossiers."""
+
+    def test_double_projection_is_identical(self) -> None:
+        """Two projections of the same state compare equal."""
+        graph = _full_graph()
+
+        first = project_faction(FAC_RESTORATIONIST, graph=graph, world=_world(), tick=847)
+        second = project_faction(FAC_RESTORATIONIST, graph=graph, world=_world(), tick=847)
+
+        assert first == second
+        assert first.model_dump() == second.model_dump()
+
+
+class TestFactionStatblocks:
+    """The WO-45 composition seam: a live, per-kind statblock provider."""
+
+    def test_it_resolves_a_known_faction_subject_to_rows(self) -> None:
+        provider = faction_statblocks(graph=_full_graph(), world=_world(), tick=5)
+
+        rows = provider("faction/FAC_RESTORATIONIST")
+
+        assert rows is not None
+        assert ("name", "Restorationist Coalition") in rows
+
+    def test_it_returns_none_for_an_unknown_faction_id(self) -> None:
+        provider = faction_statblocks(graph=_full_graph(), world=_world(), tick=5)
+
+        assert provider("faction/FAC_NOPE") is None
+
+    def test_it_returns_none_for_a_non_faction_subject(self) -> None:
+        """A ``sovereign/*`` (or any other kind's) subject is not this provider's concern."""
+        provider = faction_statblocks(graph=_full_graph(), world=_world(), tick=5)
+
+        assert provider("sovereign/SOV_USA_FED") is None
+
+    def test_rows_match_the_baked_render_pathway(self) -> None:
+        """The live provider and render_faction never disagree on row content."""
+        from babylon.projection.vault.render_faction import faction_statblock_rows
+
+        graph = _full_graph()
+        provider = faction_statblocks(graph=graph, world=_world(), tick=5)
+        view = project_faction(FAC_RESTORATIONIST, graph=graph, world=_world(), tick=5)
+
+        assert provider("faction/FAC_RESTORATIONIST") == list(faction_statblock_rows(view))

--- a/tests/unit/projection/test_field_state.py
+++ b/tests/unit/projection/test_field_state.py
@@ -1,0 +1,268 @@
+"""Contract tests for :func:`babylon.projection.field_state.project_field_state`.
+
+The field-state dossier's behavioral contract (T3 U3, the Weather Layer):
+port of ``web/game/engine_bridge.py::EngineBridge.get_field_state`` into a
+pure projection read-model — Systems #19/#20's per-social_class
+``contradiction_fields``/``field_derivatives`` (laplacian/df_dt only,
+d2f_dt2 excluded), FascistFactionSystem's ``fascist_alignment``,
+FieldDerivativeSystem's per-edge ``field_gradients`` (TENANCY-anchored to a
+territory), and the graph-level ``principal_field``/``dialectical_regime``
+attrs. Fixture-fed — no engine tick, no database — per the keel's
+fixture-first discipline. Test class name mirrors the retired
+``TestGetFieldState`` GAP row (``specs/24-archive/test-port-ledger.md`` row
+193).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from babylon.models.enums import EdgeType
+from babylon.models.enums.topology import NodeType
+from babylon.projection.field_state import project_field_state
+from babylon.topology import BabylonGraph
+
+
+class TestGetFieldStateNodes:
+    """Per-social_class node readings: honest omission, id-sorted."""
+
+    def test_no_node_carries_any_attr_is_honest_absence(self) -> None:
+        view = project_field_state("USA", graph=BabylonGraph(), tick=1)
+
+        assert view.nodes is None
+
+    def test_node_carrying_only_fascist_alignment_is_included(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node("C001", NodeType.SOCIAL_CLASS, fascist_alignment=0.3)
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.nodes is not None
+        assert len(view.nodes) == 1
+        node = view.nodes[0]
+        assert node.node_id == "C001"
+        assert node.fascist_alignment == pytest.approx(0.3)
+        assert node.fields is None
+        assert node.laplacian is None
+        assert node.df_dt is None
+
+    def test_nodes_are_sorted_by_id_independent_of_insertion_order(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node("C002", NodeType.SOCIAL_CLASS, fascist_alignment=0.1)
+        graph.add_node("C001", NodeType.SOCIAL_CLASS, fascist_alignment=0.2)
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.nodes is not None
+        assert [n.node_id for n in view.nodes] == ["C001", "C002"]
+
+    def test_node_name_falls_back_to_id_when_unattributed(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node("C001", NodeType.SOCIAL_CLASS, fascist_alignment=0.0)
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.nodes is not None
+        assert view.nodes[0].name == "C001"
+
+    def test_node_name_reads_the_attributed_name(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node(
+            "C001", NodeType.SOCIAL_CLASS, name="Periphery Proletariat", fascist_alignment=0.0
+        )
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.nodes is not None
+        assert view.nodes[0].name == "Periphery Proletariat"
+
+    def test_fields_hydrate_from_contradiction_fields(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node(
+            "C001",
+            NodeType.SOCIAL_CLASS,
+            contradiction_fields={"exploitation": 0.523, "atomization": 0.1},
+        )
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.nodes is not None
+        assert view.nodes[0].fields == {"exploitation": 0.523, "atomization": 0.1}
+
+    def test_laplacian_and_df_dt_only_include_present_sub_keys(self) -> None:
+        """d2f_dt2 is deliberately excluded — out of this dossier's contract."""
+        graph = BabylonGraph()
+        graph.add_node(
+            "C001",
+            NodeType.SOCIAL_CLASS,
+            field_derivatives={
+                "exploitation": {"laplacian": 0.4, "df_dt": None, "d2f_dt2": None},
+                "atomization": {"laplacian": 0.0, "df_dt": 0.05, "d2f_dt2": 0.01},
+            },
+        )
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.nodes is not None
+        node = view.nodes[0]
+        assert node.laplacian == {"exploitation": 0.4, "atomization": 0.0}
+        assert node.df_dt == {"atomization": 0.05}
+
+    def test_empty_field_derivatives_dict_yields_no_laplacian_or_df_dt(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node("C001", NodeType.SOCIAL_CLASS, field_derivatives={})
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.nodes is None
+
+
+class TestGetFieldStateEdges:
+    """Per-(edge, field) gradient entries, TENANCY-territory-anchored, sorted."""
+
+    def test_no_edge_carries_a_gradient_is_honest_absence(self) -> None:
+        graph = BabylonGraph()
+        graph.add_edge("C001", "C002", edge_type=EdgeType.SOLIDARITY, strength=0.5)
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.edges is None
+
+    def test_one_entry_per_field_name_sorted(self) -> None:
+        graph = BabylonGraph()
+        graph.add_edge(
+            "C001",
+            "C002",
+            edge_type=EdgeType.SOLIDARITY,
+            field_gradients={"exploitation": 0.2, "atomization": -0.1},
+        )
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.edges is not None
+        assert len(view.edges) == 2
+        assert [e.field for e in view.edges] == ["atomization", "exploitation"]
+        atomization_entry = next(e for e in view.edges if e.field == "atomization")
+        assert atomization_entry.gradient == pytest.approx(-0.1)
+
+    def test_edges_sorted_by_source_target_field(self) -> None:
+        graph = BabylonGraph()
+        graph.add_edge(
+            "C002", "C003", edge_type=EdgeType.SOLIDARITY, field_gradients={"exploitation": 0.1}
+        )
+        graph.add_edge(
+            "C001", "C002", edge_type=EdgeType.SOLIDARITY, field_gradients={"exploitation": 0.2}
+        )
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.edges is not None
+        assert [(e.source, e.target) for e in view.edges] == [("C001", "C002"), ("C002", "C003")]
+
+    def test_territory_anchored_via_tenancy_edges(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node("T001", NodeType.TERRITORY)
+        graph.add_edge("C001", "T001", edge_type=EdgeType.TENANCY)
+        graph.add_edge("C002", "T001", edge_type=EdgeType.TENANCY)
+        graph.add_edge(
+            "C001", "C002", edge_type=EdgeType.SOLIDARITY, field_gradients={"exploitation": 0.2}
+        )
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.edges is not None
+        entry = view.edges[0]
+        assert entry.source_territory == "T001"
+        assert entry.target_territory == "T001"
+
+    def test_unresolved_territory_is_none_not_omitted(self) -> None:
+        graph = BabylonGraph()
+        graph.add_edge(
+            "C001", "C002", edge_type=EdgeType.SOLIDARITY, field_gradients={"exploitation": 0.2}
+        )
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.edges is not None
+        entry = view.edges[0]
+        assert entry.source_territory is None
+        assert entry.target_territory is None
+
+    def test_tenancy_tiebreak_prefers_lexicographically_smallest_territory(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node("T002", NodeType.TERRITORY)
+        graph.add_node("T001", NodeType.TERRITORY)
+        graph.add_edge("C001", "T002", edge_type=EdgeType.TENANCY)
+        graph.add_edge("C001", "T001", edge_type=EdgeType.TENANCY)
+        graph.add_edge(
+            "C001", "C002", edge_type=EdgeType.SOLIDARITY, field_gradients={"exploitation": 0.2}
+        )
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.edges is not None
+        assert view.edges[0].source_territory == "T001"
+
+
+class TestGetFieldStatePrincipalFieldAndRegime:
+    """Graph-level principal_field/dialectical_regime, hydrated verbatim."""
+
+    def test_principal_field_absent_when_graph_attr_unset(self) -> None:
+        view = project_field_state("USA", graph=BabylonGraph(), tick=1)
+
+        assert view.principal_field is None
+
+    def test_principal_field_hydrates_verbatim(self) -> None:
+        graph = BabylonGraph()
+        graph.set_graph_attr(
+            "principal_field",
+            {"field_name": "exploitation", "max_abs_df_dt": 0.42, "changed": True},
+        )
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.principal_field is not None
+        assert view.principal_field.field_name == "exploitation"
+        assert view.principal_field.max_abs_df_dt == pytest.approx(0.42)
+        assert view.principal_field.changed is True
+
+    def test_principal_field_present_with_null_field_name_is_legitimate(self) -> None:
+        """< 2 ticks of history: the attr is written but no principal chosen yet."""
+        graph = BabylonGraph()
+        graph.set_graph_attr(
+            "principal_field", {"field_name": None, "max_abs_df_dt": 0.0, "changed": False}
+        )
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.principal_field is not None
+        assert view.principal_field.field_name is None
+
+    def test_dialectical_regime_absent_when_graph_attr_unset(self) -> None:
+        view = project_field_state("USA", graph=BabylonGraph(), tick=1)
+
+        assert view.dialectical_regime is None
+
+    def test_dialectical_regime_hydrates_verbatim(self) -> None:
+        graph = BabylonGraph()
+        graph.set_graph_attr(
+            "dialectical_regime",
+            {"regime": "crisis", "opposition": "capital_labor", "rate": 0.07},
+        )
+        view = project_field_state("USA", graph=graph, tick=1)
+
+        assert view.dialectical_regime is not None
+        assert view.dialectical_regime.regime == "crisis"
+        assert view.dialectical_regime.opposition == "capital_labor"
+        assert view.dialectical_regime.rate == pytest.approx(0.07)
+
+
+class TestDeterminism:
+    """Identical inputs yield identical frozen dossiers."""
+
+    def test_double_projection_is_identical(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node(
+            "C001",
+            NodeType.SOCIAL_CLASS,
+            contradiction_fields={"exploitation": 0.5},
+            fascist_alignment=0.2,
+        )
+        graph.add_edge(
+            "C001", "C002", edge_type=EdgeType.SOLIDARITY, field_gradients={"exploitation": 0.1}
+        )
+        graph.set_graph_attr(
+            "principal_field",
+            {"field_name": "exploitation", "max_abs_df_dt": 0.1, "changed": False},
+        )
+
+        first = project_field_state("USA", graph=graph, tick=847)
+        second = project_field_state("USA", graph=graph, tick=847)
+
+        assert first == second
+        assert first.model_dump() == second.model_dump()

--- a/tests/unit/projection/test_territory_anchor.py
+++ b/tests/unit/projection/test_territory_anchor.py
@@ -1,0 +1,102 @@
+"""Unit tests for the shared tenancy-inversion seam (WO-52b, Unit T3/U5).
+
+Covers the three functions hoisted/added to
+:mod:`babylon.projection.territory_anchor` — the single non-underscore home
+:mod:`babylon.projection.verbs.plate` and
+:mod:`babylon.game.chronicle_adapter` both consume, replacing what used to
+be two independent private copies (this one, and the legacy
+``web/game/engine_bridge.py`` twin, which stays legacy/out of scope).
+"""
+
+from __future__ import annotations
+
+from babylon.models.enums.topology import EdgeType, NodeType
+from babylon.projection.territory_anchor import (
+    TerritoryAnchor,
+    class_to_territory,
+    resolve_class_territory_anchor,
+    tenancy_members_by_territory,
+)
+from babylon.topology import BabylonGraph
+
+
+def _graph_with_tenancy() -> BabylonGraph:
+    graph = BabylonGraph()
+    graph.add_node("T001", NodeType.TERRITORY, name="Wayne County")
+    graph.add_node("C001", NodeType.SOCIAL_CLASS, name="Periphery Proletariat")
+    graph.add_edge("C001", "T001", EdgeType.TENANCY)
+    return graph
+
+
+def test_tenancy_members_by_territory_groups_social_class_occupants() -> None:
+    """A TENANCY edge from a social_class node groups under its territory."""
+    graph = _graph_with_tenancy()
+    members = tenancy_members_by_territory(graph)
+    assert members == {"T001": ["C001"]}
+
+
+def test_tenancy_members_by_territory_ignores_non_tenancy_edges() -> None:
+    """A non-TENANCY edge between a class and a territory-shaped node never
+    contributes an entry — only the real TENANCY edge type counts."""
+    graph = BabylonGraph()
+    graph.add_node("T001", NodeType.TERRITORY, name="Wayne County")
+    graph.add_node("C001", NodeType.SOCIAL_CLASS, name="Periphery Proletariat")
+    graph.add_edge("C001", "T001", EdgeType.SOLIDARITY)
+    assert tenancy_members_by_territory(graph) == {}
+
+
+def test_tenancy_members_by_territory_ignores_non_social_class_sources() -> None:
+    """A TENANCY-typed edge from a non-social_class source is not counted —
+    the primitive is Occupant(social_class) -> Territory specifically."""
+    graph = BabylonGraph()
+    graph.add_node("T001", NodeType.TERRITORY, name="Wayne County")
+    graph.add_node("org-1", NodeType.ORGANIZATION, name="A Union", territory_ids=["T001"])
+    graph.add_edge("org-1", "T001", EdgeType.TENANCY)
+    assert tenancy_members_by_territory(graph) == {}
+
+
+def test_class_to_territory_inverts_one_to_one() -> None:
+    """A single tenant class inverts cleanly to its one territory."""
+    assert class_to_territory({"T001": ["C001"]}) == {"C001": "T001"}
+
+
+def test_class_to_territory_deterministic_tie_break_lowest_territory_wins() -> None:
+    """A class TENANCY-linked to more than one territory resolves to the
+    lexicographically smallest territory id — deterministic, not
+    insertion-order-dependent (mirrors the legacy bridge's own convention)."""
+    tenancy_members = {"T002": ["C001"], "T001": ["C001"]}
+    assert class_to_territory(tenancy_members) == {"C001": "T001"}
+
+
+def test_class_to_territory_empty_when_no_tenancy() -> None:
+    """No TENANCY edges at all inverts to an empty map — honest absence."""
+    assert class_to_territory({}) == {}
+
+
+def test_resolve_class_territory_anchor_resolves_real_name() -> None:
+    """A resolvable class id yields a TerritoryAnchor carrying the
+    territory's real display name."""
+    graph = _graph_with_tenancy()
+    mapping = class_to_territory(tenancy_members_by_territory(graph))
+    anchor = resolve_class_territory_anchor(graph, mapping, "C001")
+    assert anchor == TerritoryAnchor(territory_id="T001", territory_name="Wayne County")
+
+
+def test_resolve_class_territory_anchor_falls_back_to_id_without_a_name() -> None:
+    """A territory node with no stamped ``name`` falls back to its own id —
+    honest, never a fabricated human name."""
+    graph = BabylonGraph()
+    graph.add_node("T001", NodeType.TERRITORY, county_fips="26163")
+    graph.add_node("C001", NodeType.SOCIAL_CLASS)
+    graph.add_edge("C001", "T001", EdgeType.TENANCY)
+    mapping = class_to_territory(tenancy_members_by_territory(graph))
+    anchor = resolve_class_territory_anchor(graph, mapping, "C001")
+    assert anchor == TerritoryAnchor(territory_id="T001", territory_name="T001")
+
+
+def test_resolve_class_territory_anchor_none_when_unresolvable() -> None:
+    """A class id with no TENANCY edge into any territory yields ``None`` —
+    never a fabricated anchor."""
+    graph = _graph_with_tenancy()
+    mapping = class_to_territory(tenancy_members_by_territory(graph))
+    assert resolve_class_territory_anchor(graph, mapping, "C999") is None

--- a/tests/unit/projection/topology/test_hex_habitability.py
+++ b/tests/unit/projection/topology/test_hex_habitability.py
@@ -1,0 +1,158 @@
+"""Contract tests for :mod:`babylon.projection.topology.hex_habitability` (T3 U6).
+
+Fixture-fed: a hand-built ``BabylonGraph`` with ``territory`` nodes plus
+hand-constructed :class:`~babylon.persistence.hex_state.DynamicHexState` rows
+shaped exactly like ``test_choropleth.py``'s own fixture helper — no engine
+tick, no database.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from babylon.models.enums.topology import NodeType
+from babylon.persistence.hex_state import DynamicHexState
+from babylon.projection.topology.hex_habitability import (
+    HexHabitabilityCell,
+    hex_habitability_by_county_inheritance,
+)
+from babylon.topology import BabylonGraph
+
+_SESSION = UUID("00000000-0000-0000-0000-000000000001")
+WAYNE = "26163"
+OTHER = "26125"
+
+
+def _hex_row(h3_index: str, *, county_fips: str, tick: int = 847) -> DynamicHexState:
+    """Build a hex row shaped like one ``v_hex_state_asof`` result row."""
+    return DynamicHexState(
+        session_id=_SESSION,
+        tick=tick,
+        h3_index=h3_index,
+        county_fips=county_fips,
+        state_fips=county_fips[:2],
+        region_id="detroit-metro",
+        c=1.0,
+        v=1.0,
+        s=1.0,
+        k=1.0,
+        biocapacity_stock=1.0,
+        energy_stock=1.0,
+        raw_material_stock=1.0,
+        internet_access_pct=0.5,
+        surveillance_coupling=0.1,
+    )
+
+
+def _graph_with_habitability(county_fips: str, habitability: float) -> BabylonGraph:
+    graph = BabylonGraph()
+    graph.add_node("T001", NodeType.TERRITORY, county_fips=county_fips, habitability=habitability)
+    return graph
+
+
+class TestCountyInheritance:
+    """A hex's habitability is its parent county territory's LIVE reading."""
+
+    def test_hex_inherits_its_parent_countys_live_habitability(self) -> None:
+        graph = _graph_with_habitability(WAYNE, 0.83)
+        rows = [_hex_row("8a2a1072b59ffff", county_fips=WAYNE)]
+
+        cells = hex_habitability_by_county_inheritance(rows, graph=graph)
+
+        assert cells == (
+            HexHabitabilityCell(h3_index="8a2a1072b59ffff", county_fips=WAYNE, habitability=0.83),
+        )
+
+    def test_every_hex_under_the_same_county_gets_the_same_broadcast_value(self) -> None:
+        graph = _graph_with_habitability(WAYNE, 0.6)
+        rows = [
+            _hex_row("8a2a1072b5bffff", county_fips=WAYNE),
+            _hex_row("8a2a1072b59ffff", county_fips=WAYNE),
+        ]
+
+        cells = hex_habitability_by_county_inheritance(rows, graph=graph)
+
+        assert [cell.habitability for cell in cells] == [pytest.approx(0.6), pytest.approx(0.6)]
+
+    def test_two_different_counties_do_not_leak_into_each_other(self) -> None:
+        graph = BabylonGraph()
+        graph.add_node("T001", NodeType.TERRITORY, county_fips=WAYNE, habitability=0.9)
+        graph.add_node("T002", NodeType.TERRITORY, county_fips=OTHER, habitability=0.2)
+        rows = [
+            _hex_row("8a2a1072b59ffff", county_fips=WAYNE),
+            _hex_row("8a2a1072b5bffff", county_fips=OTHER),
+        ]
+
+        cells = hex_habitability_by_county_inheritance(rows, graph=graph)
+        by_hex = {cell.h3_index: cell.habitability for cell in cells}
+
+        assert by_hex["8a2a1072b59ffff"] == pytest.approx(0.9)
+        assert by_hex["8a2a1072b5bffff"] == pytest.approx(0.2)
+
+    def test_sorted_by_h3_index_regardless_of_input_order(self) -> None:
+        graph = _graph_with_habitability(WAYNE, 0.5)
+        rows = [
+            _hex_row("8a2a1072b5bffff", county_fips=WAYNE),
+            _hex_row("8a2a1072b59ffff", county_fips=WAYNE),
+        ]
+
+        cells = hex_habitability_by_county_inheritance(rows, graph=graph)
+
+        assert [cell.h3_index for cell in cells] == ["8a2a1072b59ffff", "8a2a1072b5bffff"]
+
+    def test_empty_rows_yield_empty_cells(self) -> None:
+        assert hex_habitability_by_county_inheritance([], graph=BabylonGraph()) == ()
+
+
+class TestHonestAbsence:
+    """Absent county habitability propagates as None, never a fabricated zero."""
+
+    def test_no_territory_for_the_county_projects_none(self) -> None:
+        """The no-such-county case: no territory node carries this FIPS at all."""
+        graph = BabylonGraph()
+        rows = [_hex_row("8a2a1072b59ffff", county_fips=WAYNE)]
+
+        cells = hex_habitability_by_county_inheritance(rows, graph=graph)
+
+        assert cells[0].habitability is None
+
+    def test_territory_present_but_no_habitability_attr_yet_projects_none(self) -> None:
+        """Tick 0 / MetabolismSystem has never run this session — honest
+        absence, never a fabricated 0.0 (nor the 1.0 some mean-aggregators,
+        e.g. endgame_detector.py, default an unattributed reading to)."""
+        graph = BabylonGraph()
+        graph.add_node("T001", NodeType.TERRITORY, county_fips=WAYNE)
+        rows = [_hex_row("8a2a1072b59ffff", county_fips=WAYNE)]
+
+        cells = hex_habitability_by_county_inheritance(rows, graph=graph)
+
+        assert cells[0].habitability is None
+
+
+class TestHexHabitabilityCellModel:
+    """Frozen, extra-forbid view-model — matches the keel's ChoroplethCell discipline."""
+
+    def test_is_frozen(self) -> None:
+        cell = HexHabitabilityCell(h3_index="8a2a1072b59ffff", county_fips=WAYNE, habitability=0.5)
+        with pytest.raises(ValidationError):
+            cell.habitability = 0.9  # type: ignore[misc]
+
+    def test_rejects_unknown_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            HexHabitabilityCell(
+                h3_index="8a2a1072b59ffff",
+                county_fips=WAYNE,
+                habitability=0.5,
+                bogus=1,  # type: ignore[call-arg]
+            )
+
+    def test_out_of_range_habitability_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            HexHabitabilityCell(h3_index="8a2a1072b59ffff", county_fips=WAYNE, habitability=1.5)
+
+    def test_absence_is_a_real_none_not_a_default_zero(self) -> None:
+        cell = HexHabitabilityCell(h3_index="8a2a1072b59ffff", county_fips=WAYNE)
+        assert cell.habitability is None

--- a/tests/unit/projection/vault/conftest.py
+++ b/tests/unit/projection/vault/conftest.py
@@ -54,6 +54,7 @@ def wayne_county_view() -> CountyView:
             "p_acquiescence": 0.7,
             "p_revolution": 0.25,
             "bifurcation_score": -0.35,
+            "habitability": 0.83,
             "sovereign_id": "SOV_USA",
         }
     )

--- a/tests/unit/projection/vault/conftest.py
+++ b/tests/unit/projection/vault/conftest.py
@@ -13,10 +13,12 @@ import pytest
 
 from babylon.projection.view_models import (
     CountyView,
+    EconomyView,
     IndustryView,
     NationalView,
     SocialClassView,
     hydrate_county,
+    hydrate_economy,
     hydrate_industry,
     hydrate_national,
     hydrate_social_class,
@@ -128,6 +130,69 @@ def usa_national_view_with_absences() -> NationalView:
             "population": 331000000,
             "median_wage": 22.0,
             "imperial_rent_pool": 100.0,
+        }
+    )
+
+
+@pytest.fixture
+def usa_economy_view() -> EconomyView:
+    """A fully-populated ``EconomyView`` (T3 U2 spine-C economy dossier).
+
+    ``energy_beta_j`` is the ONE field that is never present, even here —
+    genuinely absent tree-wide by design (see ``EconomyView``'s docstring).
+    """
+    return hydrate_economy(
+        {
+            "kind": "economy",
+            "economy_id": "USA",
+            "verified_tick": 500,
+            "wage_balance": 0.18,
+            "labor_aristocracy_verdict": True,
+            "class_phi_readings": [
+                {
+                    "entity_id": "C001",
+                    "w_paid": 120.0,
+                    "v_produced": 100.0,
+                    "phi_absolute": 20.0,
+                    "phi_relative": 0.2,
+                    "labor_aristocracy_ratio": 1.2,
+                    "is_labor_aristocracy": True,
+                }
+            ],
+            "phi_unequal_exchange": 12.0,
+            "phi_reproduction": 8.0,
+            "phi_domestic": 5.0,
+            "phi_iii_report": 2.0,
+            "phi_decomposition_total": 25.0,
+            "surplus_produced": 1500.0,
+            "profit_of_enterprise": 600.0,
+            "interest_burden": 150.0,
+            "ground_rent": 450.0,
+            "taxes_on_surplus": 300.0,
+            "rentier_share": 0.3,
+            "financialization_share": 0.1,
+            "total_consumption": 900.0,
+            "total_biocapacity": 1000.0,
+            "overshoot_ratio": 0.9,
+            "biocapacity_ceiling": 1200.0,
+        }
+    )
+
+
+@pytest.fixture
+def usa_economy_view_with_absences() -> EconomyView:
+    """The same economy with only the Fundamental Theorem verdict attributed.
+
+    Only ``wage_balance``/``labor_aristocracy_verdict`` are present; every
+    other optional field hydrates to ``None``.
+    """
+    return hydrate_economy(
+        {
+            "kind": "economy",
+            "economy_id": "USA",
+            "verified_tick": 500,
+            "wage_balance": 0.18,
+            "labor_aristocracy_verdict": True,
         }
     )
 

--- a/tests/unit/projection/vault/conftest.py
+++ b/tests/unit/projection/vault/conftest.py
@@ -14,11 +14,13 @@ import pytest
 from babylon.projection.view_models import (
     CountyView,
     EconomyView,
+    FieldStateView,
     IndustryView,
     NationalView,
     SocialClassView,
     hydrate_county,
     hydrate_economy,
+    hydrate_field_state,
     hydrate_industry,
     hydrate_national,
     hydrate_social_class,
@@ -193,6 +195,60 @@ def usa_economy_view_with_absences() -> EconomyView:
             "verified_tick": 500,
             "wage_balance": 0.18,
             "labor_aristocracy_verdict": True,
+        }
+    )
+
+
+@pytest.fixture
+def usa_field_state_view() -> FieldStateView:
+    """A fully-populated ``FieldStateView`` (T3 U3 Weather Layer dossier)."""
+    return hydrate_field_state(
+        {
+            "kind": "field_state",
+            "field_state_id": "USA",
+            "verified_tick": 500,
+            "nodes": [
+                {
+                    "node_id": "C001",
+                    "name": "Periphery Proletariat",
+                    "fields": {"exploitation": 0.523, "atomization": 0.1},
+                    "laplacian": {"exploitation": 0.4},
+                    "df_dt": {"exploitation": 0.05},
+                    "fascist_alignment": 0.2,
+                }
+            ],
+            "edges": [
+                {
+                    "source": "C001",
+                    "target": "C002",
+                    "source_territory": "T001",
+                    "target_territory": "T001",
+                    "field": "exploitation",
+                    "gradient": 0.2,
+                }
+            ],
+            "principal_field": {
+                "field_name": "exploitation",
+                "max_abs_df_dt": 0.42,
+                "changed": True,
+            },
+            "dialectical_regime": {
+                "regime": "crisis",
+                "opposition": "capital_labor",
+                "rate": 0.07,
+            },
+        }
+    )
+
+
+@pytest.fixture
+def usa_field_state_view_with_absences() -> FieldStateView:
+    """The same field state with every optional field honestly unattributed."""
+    return hydrate_field_state(
+        {
+            "kind": "field_state",
+            "field_state_id": "USA",
+            "verified_tick": 500,
         }
     )
 

--- a/tests/unit/projection/vault/test_archive_tick_baker.py
+++ b/tests/unit/projection/vault/test_archive_tick_baker.py
@@ -4,7 +4,7 @@
 committed tick it composes ONE pages dict across every bakeable kind —
 counties from the configured scope, states derived from the scope's FIPS
 prefixes, the national dossier, graph-enumerated organizations /
-institutions / sovereigns / industries / social classes, and
+institutions / sovereigns / factions / industries / social classes, and
 membership-enumerated communities — and lands them as ONE
 content-hash-skipped commit (the WO-44 vault-at-scale contract).
 Key figures are deliberately absent: the kind has no producer, so there
@@ -54,6 +54,7 @@ def _graph(world: WorldState):  # type: ignore[no-untyped-def]
         legitimation_index=0.71,
     )
     graph.add_node("ORG1", NodeType.ORGANIZATION, name="Rev Workers Party")
+    graph.add_node("FAC_REV1", NodeType.FACTION, name="Rev Workers Faction")
     return graph
 
 
@@ -74,6 +75,7 @@ class TestArchiveTickBaker:
             "economy/USA.md",
             "field_state/USA.md",
             "organization/ORG1.md",
+            "faction/FAC_REV1.md",
             "social_class/C001.md",
             "community/settler.md",
         ):

--- a/tests/unit/projection/vault/test_archive_tick_baker.py
+++ b/tests/unit/projection/vault/test_archive_tick_baker.py
@@ -72,6 +72,7 @@ class TestArchiveTickBaker:
             "state/26.md",
             "national/USA.md",
             "economy/USA.md",
+            "field_state/USA.md",
             "organization/ORG1.md",
             "social_class/C001.md",
             "community/settler.md",

--- a/tests/unit/projection/vault/test_archive_tick_baker.py
+++ b/tests/unit/projection/vault/test_archive_tick_baker.py
@@ -71,6 +71,7 @@ class TestArchiveTickBaker:
             f"county/{WAYNE}.md",
             "state/26.md",
             "national/USA.md",
+            "economy/USA.md",
             "organization/ORG1.md",
             "social_class/C001.md",
             "community/settler.md",

--- a/tests/unit/projection/vault/test_incremental_baker.py
+++ b/tests/unit/projection/vault/test_incremental_baker.py
@@ -84,6 +84,7 @@ def _all_page_paths() -> tuple[str, ...]:
         "state/26.md",
         "state/17.md",
         "national/USA.md",
+        "economy/USA.md",
         "organization/ORG1.md",
         "social_class/C001.md",
     )

--- a/tests/unit/projection/vault/test_render.py
+++ b/tests/unit/projection/vault/test_render.py
@@ -14,6 +14,7 @@ _ABSENT_FIELDS_WHEN_ONLY_CORE_STATS_KNOWN = (
     "p_acquiescence",
     "p_revolution",
     "bifurcation_score",
+    "habitability",
     "sovereign_id",
 )
 
@@ -38,6 +39,7 @@ class TestRenderCounty:
         assert "median_wage: 18.500000" in page
         assert "class_composition.proletariat: 0.550000" in page
         assert "consciousness.liberal: 0.600000" in page
+        assert "habitability: 0.830000" in page
         assert "sovereign_id: SOV_USA" in page
 
     def test_it_renders_one_absence_block_per_absent_field_with_remedy_text(

--- a/tests/unit/projection/vault/test_render_economy.py
+++ b/tests/unit/projection/vault/test_render_economy.py
@@ -1,0 +1,114 @@
+"""Tests for babylon.projection.vault.render_economy: sandboxed deterministic rendering."""
+
+from __future__ import annotations
+
+import jinja2
+import pytest
+
+from babylon.projection.vault.render import _build_environment
+from babylon.projection.vault.render_economy import render_economy
+
+_ABSENT_FIELDS_WHEN_ONLY_VERDICT_KNOWN = (
+    "class_phi_readings",
+    "phi_unequal_exchange",
+    "phi_reproduction",
+    "phi_domestic",
+    "phi_iii_report",
+    "phi_decomposition_total",
+    "surplus_produced",
+    "profit_of_enterprise",
+    "interest_burden",
+    "ground_rent",
+    "taxes_on_surplus",
+    "rentier_share",
+    "financialization_share",
+    "total_consumption",
+    "total_biocapacity",
+    "overshoot_ratio",
+    "biocapacity_ceiling",
+    "energy_beta_j",
+)
+
+
+class TestRenderEconomy:
+    """Content contract: frontmatter, statblock, per-class Φ, surplus identity, absences."""
+
+    def test_it_renders_frontmatter_with_the_stable_id_slug_and_verified_tick(
+        self, usa_economy_view
+    ) -> None:
+        page = render_economy(usa_economy_view, verified_tick=500)
+        assert page.startswith("---\n")
+        assert "id: economy/USA" in page
+        assert "verified_tick: 500" in page
+
+    def test_it_renders_a_statblock_carrying_the_economy_view_numbers(
+        self, usa_economy_view
+    ) -> None:
+        page = render_economy(usa_economy_view, verified_tick=500)
+        assert "{statblock} economy/USA" in page
+        assert "wage_balance: 0.180000" in page
+        assert "labor_aristocracy_verdict: True" in page
+        assert "surplus_produced: 1500.000000" in page
+        assert "financialization_share: 0.100000" in page
+        assert "biocapacity_ceiling: 1200.000000" in page
+
+    def test_it_renders_per_class_phi_readings_as_their_own_section(self, usa_economy_view) -> None:
+        page = render_economy(usa_economy_view, verified_tick=500)
+        assert "C001:" in page
+        assert "phi_absolute=20.000000" in page
+        assert "is_labor_aristocracy=True" in page
+
+    def test_it_renders_the_surplus_identity_line(self, usa_economy_view) -> None:
+        page = render_economy(usa_economy_view, verified_tick=500)
+        assert "s = p + i + r + t" in page
+        assert "1500.000000 = 600.000000 + 150.000000 + 450.000000 + 300.000000" in page
+
+    def test_it_always_renders_the_energy_vertex_as_an_unpositioned_absence(
+        self, usa_economy_view
+    ) -> None:
+        """Even a fully-populated dossier still carries the one permanent absence."""
+        page = render_economy(usa_economy_view, verified_tick=500)
+        assert page.count("{absence}") == 1
+        assert "{absence} energy_beta_j —" in page
+        assert "energy split" in page
+
+    def test_it_renders_one_absence_block_per_absent_field_with_remedy_text(
+        self, usa_economy_view_with_absences
+    ) -> None:
+        page = render_economy(usa_economy_view_with_absences, verified_tick=500)
+        assert page.count("{absence}") == len(_ABSENT_FIELDS_WHEN_ONLY_VERDICT_KNOWN)
+        for field in _ABSENT_FIELDS_WHEN_ONLY_VERDICT_KNOWN:
+            assert f"{{absence}} {field} —" in page
+        # Every absence block names a remedy, never a bare field name.
+        assert "Wire(FundamentalTheorem)" in page
+        assert "Distribute(Surplus)" in page
+        assert "Survey(Territory)" in page
+
+    def test_it_never_renders_the_surplus_identity_line_when_absent(
+        self, usa_economy_view_with_absences
+    ) -> None:
+        page = render_economy(usa_economy_view_with_absences, verified_tick=500)
+        assert "s = p + i + r + t" not in page
+
+    def test_it_never_renders_a_bare_none_for_an_absent_field(
+        self, usa_economy_view_with_absences
+    ) -> None:
+        """A present-but-None field must never leak through as the literal
+        text 'None' — every absence is a named {absence} block instead."""
+        page = render_economy(usa_economy_view_with_absences, verified_tick=500)
+        assert "None" not in page
+
+    def test_it_is_a_pure_function_of_its_inputs(self, usa_economy_view) -> None:
+        first = render_economy(usa_economy_view, verified_tick=500)
+        second = render_economy(usa_economy_view, verified_tick=500)
+        assert first == second
+
+
+class TestSandboxedEnvironmentReuse:
+    """render_economy reuses render.py's sandboxed environment factory, not a copy."""
+
+    def test_strict_undefined_raises_on_a_nonexistent_field(self, usa_economy_view) -> None:
+        environment = _build_environment()
+        template = environment.from_string("{{ economy.this_field_does_not_exist }}")
+        with pytest.raises(jinja2.exceptions.UndefinedError):
+            template.render(economy=usa_economy_view)

--- a/tests/unit/projection/vault/test_render_faction.py
+++ b/tests/unit/projection/vault/test_render_faction.py
@@ -1,0 +1,185 @@
+"""Tests for babylon.projection.vault.render_faction's faction-page rendering.
+
+Local fixtures only — deliberately NOT added to the shared
+``tests/unit/projection/vault/conftest.py`` (not a listed shared-file-zipper
+point per ``specs/24-archive/work-orders-p2-p4.md``, and every parallel Lane
+P WO would otherwise collide on the same conftest lines). Mirrors
+``test_render_sovereign.py`` exactly.
+"""
+
+from __future__ import annotations
+
+import jinja2
+import pytest
+
+from babylon.projection.vault.render_faction import _build_environment, render_faction
+from babylon.projection.view_models import FactionView, hydrate_faction
+
+_ABSENT_FIELDS_WHEN_ONLY_NAME_KNOWN = (
+    "ideology",
+    "colonial_stance",
+    "is_settler_formation",
+    "extraction_modifier",
+    "violence_modifier",
+    "class_reduction",
+    "metabolic_reduction",
+    "color_hex",
+    "founded_tick",
+    "dissolved_tick",
+    "territory_influence",
+)
+
+
+@pytest.fixture
+def restorationist_view() -> FactionView:
+    """A fully-populated ``FactionView`` shaped like FAC_RESTORATIONIST."""
+    return hydrate_faction(
+        {
+            "kind": "faction",
+            "faction_id": "FAC_RESTORATIONIST",
+            "verified_tick": 500,
+            "name": "Restorationist Coalition",
+            "ideology": "settler-restorationism",
+            "colonial_stance": "uphold",
+            "is_settler_formation": True,
+            "extraction_modifier": 1.2,
+            "violence_modifier": 1.1,
+            "class_reduction": 0.3,
+            "metabolic_reduction": -0.2,
+            "color_hex": "#AA0000",
+            "founded_tick": 0,
+            "dissolved_tick": None,
+            "territory_influence": [
+                {
+                    "territory_id": "T001",
+                    "county_fips": "26163",
+                    "influence_level": 0.7,
+                    "support_type": "labor",
+                },
+                {
+                    "territory_id": "T002",
+                    "county_fips": None,
+                    "influence_level": 0.4,
+                    "support_type": "ideological",
+                },
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def restorationist_view_with_absences() -> FactionView:
+    """The same faction with only its name attributed.
+
+    ``territory_influence`` is deliberately ``None`` here (not ``()``): this
+    fixture represents "the faction node itself carries almost nothing", not
+    "a real faction known to influence zero territories".
+    """
+    return hydrate_faction(
+        {
+            "kind": "faction",
+            "faction_id": "FAC_RESTORATIONIST",
+            "verified_tick": 500,
+            "name": "Restorationist Coalition",
+        }
+    )
+
+
+class TestRenderFaction:
+    """Content contract: frontmatter, statblock, Influence lines, absence blocks."""
+
+    def test_it_renders_frontmatter_with_the_stable_id_slug_and_verified_tick(
+        self, restorationist_view: FactionView
+    ) -> None:
+        page = render_faction(restorationist_view, verified_tick=500)
+        assert page.startswith("---\n")
+        assert "id: faction/FAC_RESTORATIONIST" in page
+        assert "verified_tick: 500" in page
+
+    def test_it_renders_a_statblock_carrying_the_faction_view_numbers(
+        self, restorationist_view: FactionView
+    ) -> None:
+        page = render_faction(restorationist_view, verified_tick=500)
+        assert "{statblock} faction/FAC_RESTORATIONIST" in page
+        assert "name: Restorationist Coalition" in page
+        assert "ideology: settler-restorationism" in page
+        assert "colonial_stance: uphold" in page
+        assert "is_settler_formation: True" in page
+        assert "extraction_modifier: 1.200000" in page
+        assert "violence_modifier: 1.100000" in page
+        assert "class_reduction: 0.300000" in page
+        assert "metabolic_reduction: -0.200000" in page
+        assert "color_hex: #AA0000" in page
+        assert "founded_tick: 0" in page
+
+    def test_the_statblock_does_not_carry_territory_influence_rows(
+        self, restorationist_view: FactionView
+    ) -> None:
+        """territory_influence gets its own section, not statblock rows (edge-shaped)."""
+        page = render_faction(restorationist_view, verified_tick=500)
+        statblock, _, rest = page.partition("```")
+        del statblock
+        fence_body = rest.split("```", 1)[0]
+        assert "territory_influence" not in fence_body
+
+    def test_it_renders_one_line_per_influenced_territory(
+        self, restorationist_view: FactionView
+    ) -> None:
+        page = render_faction(restorationist_view, verified_tick=500)
+        assert "T001 county=26163 influence_level=0.700000 support_type=labor" in page
+        assert "T002 county=n/a influence_level=0.400000 support_type=ideological" in page
+
+    def test_it_renders_no_influence_lines_when_none_are_known(
+        self, restorationist_view_with_absences: FactionView
+    ) -> None:
+        page = render_faction(restorationist_view_with_absences, verified_tick=500)
+        assert "influence_level=" not in page
+
+    def test_it_renders_one_absence_block_per_absent_field_with_remedy_text(
+        self, restorationist_view_with_absences: FactionView
+    ) -> None:
+        page = render_faction(restorationist_view_with_absences, verified_tick=500)
+        assert page.count("{absence}") == len(_ABSENT_FIELDS_WHEN_ONLY_NAME_KNOWN)
+        for field in _ABSENT_FIELDS_WHEN_ONLY_NAME_KNOWN:
+            assert f"{{absence}} {field} —" in page
+        assert "Survey(Faction)" in page
+        assert "Observe(Influence)" in page
+
+    def test_it_never_renders_a_bare_none_for_an_absent_field(
+        self, restorationist_view_with_absences: FactionView
+    ) -> None:
+        """A present-but-None field must never leak through as the literal
+        text 'None' — every absence is a named {absence} block instead."""
+        page = render_faction(restorationist_view_with_absences, verified_tick=500)
+        assert "None" not in page
+
+    def test_a_faction_present_but_influencing_nothing_renders_no_absence_for_it(self) -> None:
+        """territory_influence=() is present data — no absence block for it."""
+        view = hydrate_faction(
+            {
+                "kind": "faction",
+                "faction_id": "FAC_RESTORATIONIST",
+                "verified_tick": 500,
+                "name": "Restorationist Coalition",
+                "territory_influence": [],
+            }
+        )
+        page = render_faction(view, verified_tick=500)
+        assert "{absence} territory_influence" not in page
+
+    def test_it_is_a_pure_function_of_its_inputs(self, restorationist_view: FactionView) -> None:
+        first = render_faction(restorationist_view, verified_tick=500)
+        second = render_faction(restorationist_view, verified_tick=500)
+        assert first == second
+
+
+class TestSandboxedEnvironmentFactionTemplate:
+    """The shared sandboxed environment renders the faction template safely."""
+
+    def test_strict_undefined_raises_on_a_nonexistent_field(
+        self, restorationist_view: FactionView
+    ) -> None:
+        environment = _build_environment()
+        template = environment.from_string("{{ faction.this_field_does_not_exist }}")
+        with pytest.raises(jinja2.exceptions.UndefinedError):
+            template.render(faction=restorationist_view)

--- a/tests/unit/projection/vault/test_render_field_state.py
+++ b/tests/unit/projection/vault/test_render_field_state.py
@@ -1,0 +1,85 @@
+"""Tests for babylon.projection.vault.render_field_state: sandboxed deterministic rendering."""
+
+from __future__ import annotations
+
+import jinja2
+import pytest
+
+from babylon.projection.vault.render import _build_environment
+from babylon.projection.vault.render_field_state import render_field_state
+
+_ABSENT_FIELDS_WHEN_NOTHING_KNOWN = (
+    "nodes",
+    "edges",
+    "principal_field",
+    "dialectical_regime",
+)
+
+
+class TestRenderFieldState:
+    """Content contract: frontmatter, statblock, edge section, absences."""
+
+    def test_it_renders_frontmatter_with_the_stable_id_slug_and_verified_tick(
+        self, usa_field_state_view
+    ) -> None:
+        page = render_field_state(usa_field_state_view, verified_tick=500)
+        assert page.startswith("---\n")
+        assert "id: field_state/USA" in page
+        assert "verified_tick: 500" in page
+
+    def test_it_renders_principal_field_and_dialectical_regime_as_statblock_rows(
+        self, usa_field_state_view
+    ) -> None:
+        page = render_field_state(usa_field_state_view, verified_tick=500)
+        assert "{statblock} field_state/USA" in page
+        assert "principal_field.field_name: exploitation" in page
+        assert "principal_field.max_abs_df_dt: 0.420000" in page
+        assert "principal_field.changed: True" in page
+        assert "dialectical_regime.regime: crisis" in page
+        assert "dialectical_regime.opposition: capital_labor" in page
+        assert "dialectical_regime.rate: 0.070000" in page
+
+    def test_it_renders_per_class_field_readings_as_statblock_rows_keyed_by_class_id(
+        self, usa_field_state_view
+    ) -> None:
+        page = render_field_state(usa_field_state_view, verified_tick=500)
+        assert "node.C001.name: Periphery Proletariat" in page
+        assert "node.C001.fields.exploitation: 0.523000" in page
+        assert "node.C001.laplacian.exploitation: 0.400000" in page
+        assert "node.C001.df_dt.exploitation: 0.050000" in page
+        assert "node.C001.fascist_alignment: 0.200000" in page
+
+    def test_it_renders_the_field_gradients_section(self, usa_field_state_view) -> None:
+        page = render_field_state(usa_field_state_view, verified_tick=500)
+        assert "## Field Gradients" in page
+        assert "C001 -> C002 field=exploitation gradient=0.200000" in page
+        assert "source_territory=T001 target_territory=T001" in page
+
+    def test_it_renders_one_absence_block_per_absent_field_with_remedy_text(
+        self, usa_field_state_view_with_absences
+    ) -> None:
+        page = render_field_state(usa_field_state_view_with_absences, verified_tick=500)
+        assert page.count("{absence}") == len(_ABSENT_FIELDS_WHEN_NOTHING_KNOWN)
+        for field in _ABSENT_FIELDS_WHEN_NOTHING_KNOWN:
+            assert f"{{absence}} {field} —" in page
+
+    def test_it_never_renders_a_bare_none_for_an_absent_field(
+        self, usa_field_state_view_with_absences
+    ) -> None:
+        page = render_field_state(usa_field_state_view_with_absences, verified_tick=500)
+        assert "None" not in page
+
+    def test_it_is_a_pure_function_of_its_inputs(self, usa_field_state_view) -> None:
+        first = render_field_state(usa_field_state_view, verified_tick=500)
+        second = render_field_state(usa_field_state_view, verified_tick=500)
+        assert first == second
+
+
+class TestSandboxedEnvironmentReuse:
+    """render_field_state reuses render.py's sandboxed environment factory, not a copy."""
+
+    def test_strict_undefined_raises_on_a_nonexistent_field(self, usa_field_state_view) -> None:
+        environment = _build_environment()
+        template = environment.from_string("{{ field_state.this_field_does_not_exist }}")
+        with pytest.raises(jinja2.exceptions.UndefinedError):
+            template.render(field_state=usa_field_state_view)

--- a/tests/unit/sentinels/test_liveness_registry.py
+++ b/tests/unit/sentinels/test_liveness_registry.py
@@ -46,16 +46,17 @@ def test_pole_readings_is_the_declared_dormant_row() -> None:
     assert "sentinel" in row.dormant_reason.lower()
 
 
-def test_fundamental_theorem_is_the_vol1_u2_dormant_row() -> None:
-    """``fundamental_theorem`` (Vol I U2) is graph-attribute-only, same as
+def test_fundamental_theorem_is_consumed_by_the_economy_projection() -> None:
+    """``fundamental_theorem`` (Vol I U2) is surfaced by the T3 economy dossier.
 
-    ``pole_readings``/``market_balance`` — a declared, reasoned dormancy, not
-    a silent one (ADR117's own recorded scope boundary, closed out by U9).
+    Formerly a declared, reasoned dormancy (graph-attribute-only, same as
+    ``pole_readings``/``market_balance``); closed out by T3 U2's ADR109 W-P
+    wiring motion — ``babylon.projection.economy.project_economy`` is now a
+    genuine production reader, not merely a dev-time probe.
     """
     row = next(r for r in LIVENESS_ROWS if r.name == "fundamental_theorem")
-    assert row.consumer_files == ()
-    assert "u2" in row.dormant_reason.lower() or "phase-1-shadow" in row.dormant_reason.lower()
-    assert "veil" in row.dormant_reason.lower()
+    assert row.consumer_files == ("src/babylon/projection/economy.py",)
+    assert "veil" in row.material_relation.lower()
 
 
 def test_vol1_u6_ratio_rows_are_consumed_by_the_opposition_catalog() -> None:


### PR DESCRIPTION
## T3 — Gap projections (v1.0.0 train, post-cascade)

Closes the four LOUD test-port-ledger gaps (BD ruling: "4 LOUD ledger gaps → BUILD all") plus the borderline pair, per the ratified master plan §C and ADR125.

### Units (each opus-reviewed at its boundary)
- **U1** `e2ef6642` — graph bridge publishes `tick_taxes_on_surplus` + `tick_total_surplus`; the 6-term identity s = p+i+r+t is now reconstructible on the live graph (W-C motion). Verified outside every declared trace column — qa baselines byte-identical.
- **U2** `391ad2b8` + fixes — **economy dossier** (`economy/USA.md`): Fundamental-Theorem verdict read off `opposition_states["wage"].balance` (never a parallel Φ); per-class Φ readings off the `fundamental_theorem` stash (declared dormancy CLOSED — W-P motion); Φ tri-decomposition wired to the real `value_form` builders (W-C/W-P; review caught a hardcoded-None first cut and it was rewired for real); surplus split as extensive ratio-of-sums; matter-book off `Territory.biocapacity`/`max_biocapacity` (NOT the static `biocapacity_sum` seed); β_J as UNPOSITIONED honest absence.
- **U3** `c2433746` — **field-state / Weather Layer** (`field_state/USA.md`): ports the web bridge's `get_field_state` read logic — per-class contradiction fields, derivatives, `principal_field` + `dialectical_regime`.
- **U4** `9e3cd4ad` — **balkanization faction dossier**: `FactionView` + INFLUENCES reads mirroring `project_sovereign`; honest-empty on real campaigns (no scenario seeds `NodeType.FACTION` — OPEN gap-ledger row, deferred to the RED_OGV repair program).
- **U5** `04c3ee34` — chronicle events anchored to their TENANCY territory (reuses the plate.py inversion primitive; no engine/EventType change).
- **U6** `fc8e0f6f` — habitability in the county dossier + county-inherited hex map-lens (G-inherited read; hex-native honest-absent pending a substrate column).
- **U7** `91d4af52` — ADR125, wiring-doctrine ledger rows (3 CLOSED + 1 OPEN), test-port-ledger closures, state.yaml.
- `320a2a21` — ledger-closure sentinel re-pinned to the closed state (zero-GAP + REWRITTEN pins, cell-level mutation legs).

### Battery (controller-run, single-flight)
- `mise run check` — **13,898 passed**, 303 skipped, 1 xfailed
- `check:sentinels` — all green (incl. vocabulary, seam-algebra, liveness)
- `qa:regression` — **6/6 byte-identical** + two-process determinism PASS (dense baselines untouched)
- `qa:vault-regression` — two independent bakes byte-identical to the new goldens (single_county 7 pages, detroit_tri_county 13)

### Ceremony
`Baselines: blessed(t3-gap-projections)` — `0188fdcf` (vault manifests only: 2 new singleton pages per scenario + county-page habitability row).

Known non-blocking carry-forward for T4-integration: the incremental baker's economy/field-state dirtiness keys on county-node snapshots, not graph-level attrs (same pre-existing pattern as the national rollup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)