### PR TITLE
feat(tui): T4-integration — live-campaign navigation over the baked vault (Unit U1+U2)

### DIFF
--- a/src/babylon/cli/play.py
+++ b/src/babylon/cli/play.py
@@ -143,11 +143,19 @@ def _load_campaign(
         ``Tick 0``).
     :param campaign_id: the lobby's chosen campaign UUID.
     :returns: the live, booted/resumed :class:`~babylon.game.session.GameSession`
-        (structurally satisfies ``babylon.tui.app.CampaignHandle``).
+        (structurally satisfies ``babylon.tui.app.CampaignHandle``, now
+        including its Unit U1 ``known_subjects`` seam via the same
+        ``vault_root`` :func:`~babylon.game.session.vault_known_subjects`
+        reads).
     """
     from babylon.engine.headless_runner.scopes import DETROIT_TRI_COUNTY_FIPS
     from babylon.engine.scenarios import WayneCountyScenario
-    from babylon.game.session import create_new_campaign, resume_campaign, vault_page_source
+    from babylon.game.session import (
+        create_new_campaign,
+        resume_campaign,
+        vault_known_subjects,
+        vault_page_source,
+    )
     from babylon.projection.vault.materializer import VaultMaterializer
     from babylon.projection.vault.tick_baker import ArchiveTickBaker
 
@@ -155,10 +163,16 @@ def _load_campaign(
     materializer = VaultMaterializer(vault_root)
     baker = ArchiveTickBaker(materializer, county_fips=tuple(DETROIT_TRI_COUNTY_FIPS))
     pages = vault_page_source(vault_root)
+    known_subjects = vault_known_subjects(vault_root)
 
     session = (
         resume_campaign(
-            runtime, campaign_id, tick_commit_observer=baker, pages=pages, progress_store=catalog
+            runtime,
+            campaign_id,
+            tick_commit_observer=baker,
+            pages=pages,
+            known_subjects=known_subjects,
+            progress_store=catalog,
         )
         if runtime.get_session(campaign_id) is not None
         else create_new_campaign(
@@ -167,6 +181,7 @@ def _load_campaign(
             session_id=campaign_id,
             tick_commit_observer=baker,
             pages=pages,
+            known_subjects=known_subjects,
             progress_store=catalog,
         )
     )

--- a/src/babylon/game/session.py
+++ b/src/babylon/game/session.py
@@ -78,7 +78,7 @@ import json
 import os
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Final, Protocol
 from uuid import UUID
 
 from babylon.config.defines import GameDefines
@@ -106,6 +106,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "GameRuntimeStore",
+    "KnownSubjectsSource",
     "PausePredicate",
     "ProgressStore",
     "VaultPageSource",
@@ -116,6 +117,7 @@ __all__ = [
     "resume_campaign",
     "ensure_schema",
     "open_runtime",
+    "vault_known_subjects",
     "vault_page_source",
 ]
 
@@ -229,6 +231,14 @@ VaultPageSource = Callable[[str], "str | None"]
 to :data:`babylon.tui.app.PageSource`; kept as a plain type alias here (not
 imported from ``babylon.tui.app``) so this module does not pull in Textual
 merely to describe :func:`vault_page_source`'s return shape."""
+
+KnownSubjectsSource = Callable[[], "frozenset[str]"]
+"""A zero-arg reader of every subject id a campaign's vault has baked so far.
+Structurally identical to the return shape of
+:data:`babylon.tui.app.CampaignHandle`'s ``known_subjects`` seam (Unit U1);
+kept as a plain type alias here for the same reason :data:`VaultPageSource`
+is — no Textual import merely to describe :func:`vault_known_subjects`'s
+return shape."""
 
 
 def default_pause_predicate(events: Sequence[Event]) -> bool:
@@ -364,6 +374,10 @@ class GameSession:
         :func:`vault_page_source` over its own vault root), read via
         :meth:`read_page`; ``None`` (the default) reads honestly absent for
         every subject — the pre-Unit-C2 no-vault path.
+    :param known_subjects: this campaign's own :data:`KnownSubjectsSource`
+        (typically :func:`vault_known_subjects` over its own vault root,
+        Unit U1), read via :meth:`known_subjects`; ``None`` (the default)
+        reads honestly empty — the pre-Unit-U1 no-vault path.
     :param progress_store: the lobby's :class:`ProgressStore` seam
         (typically the same ``BabylonMetaStore`` the composition root's
         ``CampaignMenu`` already holds); ``None`` (the default) runs with no
@@ -384,6 +398,7 @@ class GameSession:
         tick_commit_observer: TickCommitObserver | None = None,
         pause_predicate: PausePredicate = default_pause_predicate,
         pages: VaultPageSource | None = None,
+        known_subjects: KnownSubjectsSource | None = None,
         progress_store: ProgressStore | None = None,
     ) -> None:
         self.session_id = session_id
@@ -397,6 +412,7 @@ class GameSession:
         self._tick_commit_observer = tick_commit_observer
         self._pause_predicate = pause_predicate
         self._pages = pages
+        self._known_subjects = known_subjects
         self._progress_store = progress_store
 
     def read_page(self, subject: str) -> str | None:
@@ -414,6 +430,21 @@ class GameSession:
             subject yet — never fabricated content (Constitution III.11).
         """
         return self._pages(subject) if self._pages is not None else None
+
+    def known_subjects(self) -> frozenset[str]:
+        """Every subject id this campaign's vault has baked so far (Unit U1).
+
+        Thin passthrough to the injected :data:`KnownSubjectsSource` (see
+        :attr:`known_subjects` on the constructor), read fresh on every
+        call; satisfies ``babylon.tui.app``'s ``CampaignHandle.
+        known_subjects`` seam the same way :meth:`read_page` satisfies
+        ``read_page`` — without either module importing the other.
+
+        :returns: the current baked-subject frozenset, or an empty one if
+            no vault reader is wired (constructor default) — never
+            fabricated (Constitution III.11).
+        """
+        return self._known_subjects() if self._known_subjects is not None else frozenset()
 
     def submit_verb(
         self,
@@ -533,6 +564,7 @@ def create_new_campaign(
     tick_commit_observer: TickCommitObserver | None = None,
     pause_predicate: PausePredicate = default_pause_predicate,
     pages: VaultPageSource | None = None,
+    known_subjects: KnownSubjectsSource | None = None,
     progress_store: ProgressStore | None = None,
 ) -> GameSession:
     """Boot a brand-new campaign: build the scenario, then bake tick 0.
@@ -556,6 +588,9 @@ def create_new_campaign(
         :data:`PausePredicate`).
     :param pages: this campaign's :data:`VaultPageSource`, read via
         :meth:`GameSession.read_page` (Unit C2's ``CampaignHandle`` seam).
+    :param known_subjects: this campaign's :data:`KnownSubjectsSource`, read
+        via :meth:`GameSession.known_subjects` (Unit U1's ``CampaignHandle``
+        seam).
     :param progress_store: the lobby's :class:`ProgressStore` seam; when
         given, the freshly-minted campaign's ``last_tick`` is stamped ``0``
         immediately (the lobby row already defaults to 0 at
@@ -606,6 +641,7 @@ def create_new_campaign(
         tick_commit_observer=tick_commit_observer,
         pause_predicate=pause_predicate,
         pages=pages,
+        known_subjects=known_subjects,
         progress_store=progress_store,
     )
 
@@ -617,6 +653,7 @@ def resume_campaign(
     tick_commit_observer: TickCommitObserver | None = None,
     pause_predicate: PausePredicate = default_pause_predicate,
     pages: VaultPageSource | None = None,
+    known_subjects: KnownSubjectsSource | None = None,
     progress_store: ProgressStore | None = None,
 ) -> GameSession:
     """Crash-resume a campaign from its last atomically-committed tick.
@@ -634,6 +671,8 @@ def resume_campaign(
     :param tick_commit_observer: the vault's tick-commit observer.
     :param pause_predicate: the pacing driver's autopause SEAM.
     :param pages: this campaign's :data:`VaultPageSource` (see
+        :func:`create_new_campaign`'s identical parameter).
+    :param known_subjects: this campaign's :data:`KnownSubjectsSource` (see
         :func:`create_new_campaign`'s identical parameter).
     :param progress_store: the lobby's :class:`ProgressStore` seam; when
         given, the lobby row is synced to the Ledger's own
@@ -677,6 +716,7 @@ def resume_campaign(
         tick_commit_observer=tick_commit_observer,
         pause_predicate=pause_predicate,
         pages=pages,
+        known_subjects=known_subjects,
         progress_store=progress_store,
     )
 
@@ -754,3 +794,52 @@ def vault_page_source(vault_root: Path) -> VaultPageSource:
             return None
 
     return _read
+
+
+#: Repo loop-bound rule (CLAUDE.md Power-of-10 #2): the nationwide worst case
+#: is ~3,300 baked pages (``commit_pages``'s own "~3,156 pages per tick"
+#: figure, plus briefing/narrative pages); this cap sits generously above
+#: that, so slicing ``all_pages[:_MAX_VAULT_PAGES]`` below is a trivially
+#: bounded loop, not a runtime-dependent walk of the vault's actual size.
+_MAX_VAULT_PAGES: Final = 100_000
+
+
+def vault_known_subjects(vault_root: Path) -> KnownSubjectsSource:
+    """A reader enumerating every subject id a vault has baked (Unit U1).
+
+    Walks ``vault_root`` for the exact ``<subject>.md`` files
+    :class:`~babylon.projection.vault.tick_baker.ArchiveTickBaker` writes —
+    the same convention :func:`vault_page_source` reads in reverse: a
+    subject id is a baked file's vault-relative POSIX path, minus the
+    ``.md`` suffix. Excludes the vault's own ``.git/`` directory (never a
+    page) and a top-level ``narrative/`` subtree if present (the WO-42
+    narrator prose cache — attributed blocks a dossier page's
+    ``{narrative}`` fence pulls IN, never standalone navigable subjects in
+    their own right).
+
+    :param vault_root: the campaign's vault repository root.
+    :returns: a zero-arg callable producing the CURRENT known-subject
+        frozenset (:data:`KnownSubjectsSource`), read fresh on every call —
+        pages bake as ticks advance, so this is deliberately never cached.
+    """
+
+    def _known_subjects() -> frozenset[str]:
+        if not vault_root.is_dir():
+            return frozenset()
+        all_pages = sorted(vault_root.rglob("*.md"))
+        if len(all_pages) > _MAX_VAULT_PAGES:
+            # Loud refusal (Constitution III.11), never a silent truncation
+            # of the known-subject set.
+            raise RuntimeError(
+                f"vault at {vault_root} has grown past the "
+                f"{_MAX_VAULT_PAGES}-page static scan bound"
+            )
+        subjects: set[str] = set()
+        for page_path in all_pages[:_MAX_VAULT_PAGES]:
+            relative = page_path.relative_to(vault_root)
+            if ".git" in relative.parts or relative.parts[0] == "narrative":
+                continue
+            subjects.add(relative.with_suffix("").as_posix())
+        return frozenset(subjects)
+
+    return _known_subjects

--- a/src/babylon/tui/app.py
+++ b/src/babylon/tui/app.py
@@ -30,6 +30,21 @@ autopause-ack flow) instead of calling :attr:`ArchiveApp.campaign` directly
 With no ``driver_factory`` given (the default), :attr:`ArchiveApp.driver`
 stays ``None`` and ``t`` behaves exactly as it did before this unit —
 existing callers/tests are unaffected.
+
+Program v1.0.0 Unit U1 (live-campaign navigation) closes the gap left by
+Unit C2's own ``known_entities``/``_resolver`` docstrings: booting a live
+campaign used to swap :attr:`ArchiveApp._pages` but never the demo
+:data:`KNOWN_ENTITIES` fixture set, so wikilink classification and the
+command palette (:class:`~babylon.tui.palette.EntityNavigatorProvider`)
+kept speaking the demo entities on every real ``babylon play`` boot —
+real baked pages were unreachable except by direct ``Ctrl-O``/``Ctrl-I``
+jumplist replay. :meth:`CampaignHandle.known_subjects` is the new
+enumeration seam; :meth:`ArchiveApp._on_campaign_chosen` rebuilds
+``known_entities``/``_resolver`` from it right after swapping ``_pages``,
+and every successful ``t``/``r`` tick advance re-scans it again (cheap
+frozenset compare, skipped when unchanged) so pages baked mid-campaign
+become navigable immediately. The demo (no-``campaign_menu``) boot path is
+completely unaffected.
 """
 
 from __future__ import annotations
@@ -163,6 +178,18 @@ class CampaignHandle(Protocol):
 
     def read_page(self, subject: str) -> str | None:
         """Read one baked vault page for this campaign (see :data:`PageSource`)."""
+        ...
+
+    def known_subjects(self) -> frozenset[str]:
+        """Every subject id this campaign's vault has baked so far (Unit U1).
+
+        Replaces the demo :data:`KNOWN_ENTITIES` fixture set once a live
+        campaign boots — :meth:`ArchiveApp._on_campaign_chosen` reads this
+        to rebuild :attr:`ArchiveApp.known_entities`/``_resolver`` against
+        the REAL vault instead of the built-in fixture set, so wikilink
+        classification and the command palette speak the live campaign's
+        own baked pages.
+        """
         ...
 
     def advance_tick(self) -> TickOutcome:
@@ -380,7 +407,10 @@ class ArchiveApp(App[None]):
         ``{statblock}`` fences carry no baked body; defaults to the sample
         provider.
     :param known_entities: The palette/redlink known-entity set; defaults
-        to the sample set (:data:`KNOWN_ENTITIES`).
+        to the sample set (:data:`KNOWN_ENTITIES`). Ignored once a live
+        campaign boots (Unit U1): rebuilt from the booted
+        :class:`CampaignHandle`'s own :meth:`~CampaignHandle.known_subjects`
+        instead, same shape as ``pages`` below.
     :param pages: The page-content source navigation reads from; defaults
         to the sample-only source. Ignored once a live campaign boots
         (Unit C2): :attr:`_pages` is then replaced by the booted
@@ -528,6 +558,7 @@ class ArchiveApp(App[None]):
         self.campaign = campaign
         self.driver = self._driver_factory(campaign) if self._driver_factory is not None else None
         self._pages = campaign.read_page
+        self._refresh_known_entities(campaign)
         briefing_subject = f"briefing/{campaign_id}"
         page = self._pages(briefing_subject)
         markdown = page if page is not None else _absence_page(briefing_subject)
@@ -553,13 +584,46 @@ class ArchiveApp(App[None]):
         with VerticalScroll(id="page"):
             yield BabylonMarkdown(
                 self._page,
-                parser_factory=make_parser_factory(self._resolver),
+                parser_factory=self._current_parser,
                 open_links=False,
                 id="dossier",
                 statblocks=self._statblocks,
             )
         yield Label("status: — (click a link)", id="status")
         yield Footer()
+
+    def _current_parser(self) -> MarkdownIt:
+        """The dossier's zero-arg ``parser_factory``, rebuilt fresh every call.
+
+        ``BabylonMarkdown``/``Markdown.update()`` invokes its
+        ``parser_factory`` fresh on every render (never caching the
+        ``MarkdownIt`` instance), but a plain ``make_parser_factory(self.
+        _resolver)`` closure captures :attr:`_resolver`'s VALUE at
+        :meth:`compose` time — swapping the attribute later (Unit U1's
+        live-campaign known-set refresh) would never reach an already-built
+        closure. Passing this bound method instead means every render reads
+        :attr:`_resolver` fresh, so the very next navigation after a swap
+        classifies links against the live set — the same shape the existing
+        :attr:`_pages` swap already relies on.
+
+        :returns: a freshly configured parser.
+        """
+        return make_parser_factory(self._resolver)()
+
+    def _refresh_known_entities(self, campaign: CampaignHandle) -> None:
+        """Recompute :attr:`known_entities`/``_resolver`` from the live
+        campaign's vault, IF the baked subject set actually changed (Unit
+        U1). Pages bake once per committed tick, so most ticks contribute
+        no new subjects — comparing the frozensets first skips an
+        unnecessary resolver rebuild.
+
+        :param campaign: the live campaign to re-scan.
+        """
+        subjects = campaign.known_subjects()
+        if subjects == self.known_entities:
+            return
+        self.known_entities = subjects
+        self._resolver = known_target_resolver(self.known_entities)
 
     def _refresh_breadcrumbs(self) -> None:
         """Render the trail's newest entries into the breadcrumb bar."""
@@ -606,6 +670,11 @@ class ArchiveApp(App[None]):
         ``t`` past an autopause (or while ``r``'s worker is still running
         in the background) sees WHY nothing moved, not a crash or silence
         (Constitution III.11).
+
+        Unit U1: also re-scans :attr:`campaign`'s vault via
+        :meth:`_refresh_known_entities` after a successful advance, so a
+        page baked THIS tick becomes navigable/known immediately, not only
+        on the next lobby boot.
         """
         status = self.query_one("#status", Label)
         if self.campaign is None:
@@ -627,6 +696,7 @@ class ArchiveApp(App[None]):
             result: TickOutcome = self.driver.advance_once()
         else:
             result = self.campaign.advance_tick()
+        self._refresh_known_entities(self.campaign)
         subject = self.nav.current
         if subject is not None:
             await self._navigate(subject, record=False)
@@ -652,6 +722,9 @@ class ArchiveApp(App[None]):
         awaiting it; the executor thread underneath keeps running either
         way (cooperative-only cancellation), so refusing the SECOND press
         is the only choice that is actually honest about what is running.
+
+        Unit U1: re-scans :attr:`campaign`'s vault via
+        :meth:`_refresh_known_entities` once the run stops, same as ``t``.
         """
         status = self.query_one("#status", Label)
         if self.driver is None:
@@ -671,6 +744,8 @@ class ArchiveApp(App[None]):
             return
         results = await asyncio.to_thread(self.driver.run_until_paused)
         last = results[-1]
+        if self.campaign is not None:
+            self._refresh_known_entities(self.campaign)
         subject = self.nav.current
         if subject is not None:
             await self._navigate(subject, record=False)

--- a/tests/unit/game/test_session.py
+++ b/tests/unit/game/test_session.py
@@ -25,6 +25,7 @@ from babylon.game.session import (
     default_pause_predicate,
     open_runtime,
     resume_campaign,
+    vault_known_subjects,
     vault_page_source,
 )
 from babylon.kernel.event_bus import Event
@@ -627,6 +628,78 @@ def test_read_page_is_honestly_none_with_no_vault_wired() -> None:
     store = _FakeStore()
     session = create_new_campaign(store, scenario=WayneCountyScenario())
     assert session.read_page("county/26163") is None
+
+
+# --------------------------------------------------------------------------- #
+# vault_known_subjects — enumerates baked pages, honest empty for absence     #
+# (Program v1.0.0 Unit U1).                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_vault_known_subjects_enumerates_baked_pages(tmp_path: Any) -> None:
+    (tmp_path / "county").mkdir()
+    (tmp_path / "county" / "26163.md").write_text("# county/26163 — Wayne\n")
+    (tmp_path / "economy").mkdir()
+    (tmp_path / "economy" / "USA.md").write_text("# economy/USA\n")
+
+    known_subjects = vault_known_subjects(tmp_path)
+
+    assert known_subjects() == frozenset({"county/26163", "economy/USA"})
+
+
+def test_vault_known_subjects_excludes_git_and_narrative(tmp_path: Any) -> None:
+    """``.git/`` is the vault's own backend, never a page; ``narrative/`` is
+    the WO-42 narrator prose cache — attributed blocks a dossier's
+    ``{narrative}`` fence pulls IN, never a standalone navigable subject."""
+    (tmp_path / "county").mkdir()
+    (tmp_path / "county" / "26163.md").write_text("# county/26163\n")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "HEAD.md").write_text("not a page\n")
+    (tmp_path / "narrative" / "org").mkdir(parents=True)
+    (tmp_path / "narrative" / "org" / "cache-key.md").write_text("prose\n")
+
+    known_subjects = vault_known_subjects(tmp_path)
+
+    assert known_subjects() == frozenset({"county/26163"})
+
+
+def test_vault_known_subjects_reads_fresh_every_call(tmp_path: Any) -> None:
+    """Pages bake as ticks advance — no caching, unlike a one-shot scan."""
+    known_subjects = vault_known_subjects(tmp_path)
+    assert known_subjects() == frozenset()
+
+    (tmp_path / "county").mkdir()
+    (tmp_path / "county" / "26163.md").write_text("# county/26163\n")
+    assert known_subjects() == frozenset({"county/26163"})
+
+
+def test_vault_known_subjects_is_honestly_empty_for_a_nonexistent_root(tmp_path: Any) -> None:
+    known_subjects = vault_known_subjects(tmp_path / "does-not-exist")
+    assert known_subjects() == frozenset()
+
+
+# --------------------------------------------------------------------------- #
+# GameSession.known_subjects — the CampaignHandle.known_subjects seam        #
+# (Program v1.0.0 Unit U1).                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_known_subjects_wraps_the_injected_vault_known_subjects(tmp_path: Any) -> None:
+    (tmp_path / "county").mkdir()
+    (tmp_path / "county" / "26163.md").write_text("# county/26163\n")
+    store = _FakeStore()
+    session = create_new_campaign(
+        store, scenario=WayneCountyScenario(), known_subjects=vault_known_subjects(tmp_path)
+    )
+
+    assert session.known_subjects() == frozenset({"county/26163"})
+
+
+def test_known_subjects_is_honestly_empty_with_no_vault_wired() -> None:
+    """``known_subjects=None`` (the default) — never a fabricated set."""
+    store = _FakeStore()
+    session = create_new_campaign(store, scenario=WayneCountyScenario())
+    assert session.known_subjects() == frozenset()
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/tui/test_app_lobby_flow.py
+++ b/tests/unit/tui/test_app_lobby_flow.py
@@ -22,7 +22,7 @@ from uuid import UUID, uuid4
 import pytest
 from textual.widgets import Label, OptionList
 
-from babylon.tui.app import ArchiveApp, BabylonMarkdown, CampaignHandle, TickOutcome
+from babylon.tui.app import KNOWN_ENTITIES, ArchiveApp, BabylonMarkdown, CampaignHandle, TickOutcome
 from babylon.tui.campaign_menu import CampaignMenu, InMemoryCampaign, InMemoryCampaignCatalog
 
 pytestmark = pytest.mark.unit
@@ -47,6 +47,12 @@ class _FakeCampaign:
 
     def read_page(self, subject: str) -> str | None:
         return self._pages.get(subject)
+
+    def known_subjects(self) -> frozenset[str]:
+        """Every subject currently baked into ``self._pages`` — a test can
+        mutate that dict directly (simulating a mid-campaign bake) and the
+        next call here picks it up, same as the real vault-backed reader."""
+        return frozenset(self._pages)
 
     def advance_tick(self) -> _FakeTickOutcome:
         self.advance_calls += 1
@@ -226,3 +232,75 @@ class TestLobbyToCampaignShellFlow:
 
             assert app._exit is True
             assert loader.calls == []
+
+
+class TestLiveVaultKnownEntities:
+    """Program v1.0.0 Unit U1: the palette/resolver's known-entity set is
+    rebuilt from the live campaign's own vault instead of staying frozen on
+    the demo :data:`KNOWN_ENTITIES` fixture — see ``babylon.tui.app``'s
+    module docstring for the gap this closes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_choosing_a_campaign_rebuilds_known_entities_from_its_vault(self) -> None:
+        menu, campaign_id = _seeded_menu()
+        briefing_subject = f"briefing/{campaign_id}"
+        campaign = _FakeCampaign(
+            campaign_id,
+            {briefing_subject: "# OPERATION TEST\n", "county/26163": "# Wayne — LIVE\n"},
+        )
+        loader = _FakeLoader(campaign)
+        app = ArchiveApp(campaign_menu=menu, campaign_loader=loader)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("#campaigns", OptionList).focus()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            # A real, baked subject is now known...
+            assert "county/26163" in app.known_entities
+            assert app._resolver("county/26163") is True
+            # ...and a fixture-only demo entity the live vault never baked
+            # is no longer known — no more speaking the demo set.
+            assert "national/USA" not in app.known_entities
+            assert app._resolver("national/USA") is False
+
+    @pytest.mark.asyncio
+    async def test_an_advance_that_bakes_a_new_page_is_picked_up(self) -> None:
+        menu, campaign_id = _seeded_menu()
+        briefing_subject = f"briefing/{campaign_id}"
+        campaign = _FakeCampaign(
+            campaign_id,
+            {briefing_subject: "# OPERATION TEST\n", "county/26163": "# Wayne\n"},
+        )
+        loader = _FakeLoader(campaign)
+        app = ArchiveApp(campaign_menu=menu, campaign_loader=loader)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("#campaigns", OptionList).focus()
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.press("enter")  # "Begin Operation"
+            await pilot.pause()
+
+            assert "economy/USA" not in app.known_entities
+
+            # Simulate the vault baking a new page as part of this tick.
+            campaign._pages["economy/USA"] = "# economy/USA\n"
+            await pilot.press("t")
+            await pilot.pause()
+
+            assert "economy/USA" in app.known_entities
+            assert app._resolver("economy/USA") is True
+
+    @pytest.mark.asyncio
+    async def test_demo_path_still_resolves_the_fixture_sample_set(self) -> None:
+        """No ``campaign_menu`` at all — zero behavior change without a
+        live campaign (ground rule 4)."""
+        app = ArchiveApp()
+        assert app.known_entities == KNOWN_ENTITIES
+        assert app._resolver("county/26163") is True
+        assert app._resolver("org/tenants-un") is True
+        assert app._resolver("org/uaw-9999") is False

--- a/tests/unit/tui/test_app_pacing_driver.py
+++ b/tests/unit/tui/test_app_pacing_driver.py
@@ -41,6 +41,9 @@ class _FakeCampaign:
     def read_page(self, subject: str) -> str | None:
         return self._pages.get(subject)
 
+    def known_subjects(self) -> frozenset[str]:
+        return frozenset(self._pages)
+
     def advance_tick(self) -> _FakeTickOutcome:  # pragma: no cover - unused once a driver is wired
         raise AssertionError("campaign.advance_tick() called directly while a driver was wired")
 

--- a/tests/unit/tui/test_t3_live_reachability.py
+++ b/tests/unit/tui/test_t3_live_reachability.py
@@ -1,0 +1,389 @@
+"""Program v1.0.0 Unit U2: end-to-end reachability proof for the T3 pages
+(``economy/USA``, ``field_state/USA``) in the live shell.
+
+Builds directly on Unit U1 (``babylon.tui.app._refresh_known_entities``,
+``CampaignHandle.known_subjects``): U1 proved the resolver/known-set gets
+rebuilt from a live campaign's vault; this unit proves the FULL integration
+seam a real ``babylon play`` boot depends on, using the T3 gap-projection
+singletons (ADR125) as the concrete subjects:
+
+1. the command palette's ``EntityNavigatorProvider`` surfaces
+   ``economy/USA``/``field_state/USA`` once a live campaign whose vault has
+   baked them is chosen;
+2. navigating to each renders through ``BabylonFence`` with no "UNKNOWN
+   DIRECTIVE" refusal and no "MALFORMED STATBLOCK BODY" refusal — the real
+   statblock/absence numbers show up in the rendered widget tree;
+3. a wikilink to ``economy/USA`` written into another page (the campaign's
+   home dossier) classifies as a known wikilink span, not a redlink.
+
+The fixture pages are never hand-typed markdown lookalikes: both are built
+by calling the REAL renderers
+(:func:`~babylon.projection.vault.render_economy.render_economy`,
+:func:`~babylon.projection.vault.render_field_state.render_field_state`)
+over REAL, fully-hydrated view-models
+(:class:`~babylon.projection.view_models.EconomyView`/
+:class:`~babylon.projection.view_models.FieldStateView`), the same pipeline
+:mod:`babylon.projection.vault.tick_baker` uses to bake them into a
+campaign's vault — so a template/renderer regression that broke the
+``{statblock}``/``{absence}`` fence shape would fail THIS test, not just
+``tests/unit/projection/vault/test_render_economy.py`` in isolation.
+
+Drives ``ArchiveApp`` with Textual's ``Pilot`` through the same
+lobby -> briefing -> campaign-shell flow as
+``tests/unit/tui/test_app_lobby_flow.py``'s ``TestLiveVaultKnownEntities``
+(a local, minimal ``_FakeCampaign``/``_FakeLoader`` double — no engine, no
+Postgres), and inspects rendered widget content the same way
+``tests/unit/tui/test_directives_hardening.py`` does for fence Labels and
+``tests/unit/tui/test_wikilinks.py`` does for wikilink content spans.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from textual.content import Content
+from textual.pilot import Pilot
+from textual.widgets import Label, OptionList
+
+from babylon.projection.vault.render_economy import render_economy
+from babylon.projection.vault.render_field_state import render_field_state
+from babylon.projection.view_models import hydrate_economy, hydrate_field_state
+from babylon.tui.app import ArchiveApp, BabylonMarkdown, TickOutcome
+from babylon.tui.campaign_menu import CampaignMenu, InMemoryCampaign, InMemoryCampaignCatalog
+from babylon.tui.palette import EntityNavigated, EntityNavigatorProvider
+from babylon.tui.router import parse_babylon_uri
+from babylon.tui.wikilinks import REDLINK_COLOR, WIKILINK_COLOR, BabylonParagraph
+
+pytestmark = pytest.mark.unit
+
+_VERIFIED_TICK = 520
+_HOME_SUBJECT = "county/26163"
+_ECONOMY_SUBJECT = "economy/USA"
+_FIELD_STATE_SUBJECT = "field_state/USA"
+
+_HOME_PAGE = f"""\
+# {_HOME_SUBJECT} — Wayne
+
+Nationwide context: [[{_ECONOMY_SUBJECT}]] and [[{_FIELD_STATE_SUBJECT}]].
+"""
+"""The campaign's home dossier (the WO-47/Unit-C2 ``_SAMPLE_SUBJECT``): a
+hand-written link source, NOT one of the T3 pages under test — only
+``economy/USA``/``field_state/USA`` need come from the real renderers."""
+
+
+def _economy_usa_page() -> str:
+    """``economy/USA``, baked via the real T3 renderer over a fully-hydrated
+    ``EconomyView`` — mirrors ``tests/unit/projection/vault/conftest.py``'s
+    ``usa_economy_view`` fixture shape (``energy_beta_j`` stays the one
+    field that is genuinely absent tree-wide even here)."""
+    view = hydrate_economy(
+        {
+            "kind": "economy",
+            "economy_id": "USA",
+            "verified_tick": _VERIFIED_TICK,
+            "wage_balance": 0.18,
+            "labor_aristocracy_verdict": True,
+            "class_phi_readings": [
+                {
+                    "entity_id": "C001",
+                    "w_paid": 120.0,
+                    "v_produced": 100.0,
+                    "phi_absolute": 20.0,
+                    "phi_relative": 0.2,
+                    "labor_aristocracy_ratio": 1.2,
+                    "is_labor_aristocracy": True,
+                }
+            ],
+            "phi_unequal_exchange": 12.0,
+            "phi_reproduction": 8.0,
+            "phi_domestic": 5.0,
+            "phi_iii_report": 2.0,
+            "phi_decomposition_total": 25.0,
+            "surplus_produced": 1500.0,
+            "profit_of_enterprise": 600.0,
+            "interest_burden": 150.0,
+            "ground_rent": 450.0,
+            "taxes_on_surplus": 300.0,
+            "rentier_share": 0.3,
+            "financialization_share": 0.1,
+            "total_consumption": 900.0,
+            "total_biocapacity": 1000.0,
+            "overshoot_ratio": 0.9,
+            "biocapacity_ceiling": 1200.0,
+        }
+    )
+    return render_economy(view, verified_tick=_VERIFIED_TICK)
+
+
+def _field_state_usa_page() -> str:
+    """``field_state/USA``, baked via the real T3 renderer over a
+    fully-hydrated ``FieldStateView`` — mirrors ``tests/unit/projection/
+    vault/conftest.py``'s ``usa_field_state_view`` fixture shape."""
+    view = hydrate_field_state(
+        {
+            "kind": "field_state",
+            "field_state_id": "USA",
+            "verified_tick": _VERIFIED_TICK,
+            "nodes": [
+                {
+                    "node_id": "C001",
+                    "name": "Periphery Proletariat",
+                    "fields": {"exploitation": 0.523, "atomization": 0.1},
+                    "laplacian": {"exploitation": 0.4},
+                    "df_dt": {"exploitation": 0.05},
+                    "fascist_alignment": 0.2,
+                }
+            ],
+            "edges": [
+                {
+                    "source": "C001",
+                    "target": "C002",
+                    "source_territory": "T001",
+                    "target_territory": "T001",
+                    "field": "exploitation",
+                    "gradient": 0.2,
+                }
+            ],
+            "principal_field": {
+                "field_name": "exploitation",
+                "max_abs_df_dt": 0.42,
+                "changed": True,
+            },
+            "dialectical_regime": {
+                "regime": "crisis",
+                "opposition": "capital_labor",
+                "rate": 0.07,
+            },
+        }
+    )
+    return render_field_state(view, verified_tick=_VERIFIED_TICK)
+
+
+class _FakeCampaign:
+    """A minimal ``CampaignHandle`` double whose vault already carries the
+    T3 singletons — no engine, no Postgres (matches ``test_app_lobby_flow.
+    py``'s ``_FakeCampaign`` shape)."""
+
+    def __init__(self, session_id: UUID, pages: dict[str, str]) -> None:
+        self.session_id = session_id
+        self.tick = 0
+        self._pages = pages
+
+    def read_page(self, subject: str) -> str | None:
+        return self._pages.get(subject)
+
+    def known_subjects(self) -> frozenset[str]:
+        return frozenset(self._pages)
+
+    def advance_tick(self) -> TickOutcome:
+        """Unused by this unit — proving the T3 pages are already
+        vault-reachable never requires advancing a tick."""
+        raise NotImplementedError("this unit never advances the tick")
+
+
+class _FakeLoader:
+    """The ``CampaignLoader`` double."""
+
+    def __init__(self, campaign: _FakeCampaign) -> None:
+        self._campaign = campaign
+
+    def __call__(self, campaign_id: UUID) -> _FakeCampaign:
+        return self._campaign
+
+
+def _seeded_menu() -> tuple[CampaignMenu, UUID]:
+    """One seeded ACTIVE campaign, ready for the lobby to list/choose."""
+    campaign_id = UUID(int=1)
+    catalog = InMemoryCampaignCatalog(
+        seed=(
+            InMemoryCampaign(
+                campaign_id=campaign_id,
+                slug="campaign-t3",
+                engine_version="0.1.0",
+                defines_hash="d" * 16,
+            ),
+        )
+    )
+    return CampaignMenu(catalog, engine_version="0.1.0", defines_hash="d" * 16), campaign_id
+
+
+def _live_campaign_app() -> tuple[ArchiveApp, UUID]:
+    """A booted ``ArchiveApp`` wired to a campaign whose vault already
+    carries the briefing, the home dossier, and both T3 pages."""
+    menu, campaign_id = _seeded_menu()
+    briefing_subject = f"briefing/{campaign_id}"
+    campaign = _FakeCampaign(
+        campaign_id,
+        {
+            briefing_subject: "# OPERATION T3\n",
+            _HOME_SUBJECT: _HOME_PAGE,
+            _ECONOMY_SUBJECT: _economy_usa_page(),
+            _FIELD_STATE_SUBJECT: _field_state_usa_page(),
+        },
+    )
+    loader = _FakeLoader(campaign)
+    return ArchiveApp(campaign_menu=menu, campaign_loader=loader), campaign_id
+
+
+async def _boot_into_campaign_shell(pilot: Pilot[None]) -> None:
+    """Walk the lobby -> briefing -> campaign-shell flow (``TestLobbyToCampaignShellFlow``'s
+    own idiom, ``tests/unit/tui/test_app_lobby_flow.py``)."""
+    await pilot.pause()
+    pilot.app.screen.query_one("#campaigns", OptionList).focus()
+    await pilot.press("enter")  # choose the seeded campaign
+    await pilot.pause()
+    await pilot.press("enter")  # "Begin Operation" on the briefing
+    await pilot.pause()
+
+
+def _dossier_text(app: ArchiveApp) -> str:
+    """Every fence-rendered ``Label``'s plain text under ``#dossier``, joined.
+
+    Runs each label back through the real ``Content`` markup parser (the
+    same oracle ``test_directives_hardening.py``'s ``_plain_text`` uses) —
+    checking a substring against the raw, unparsed ``label.content`` would
+    pass even for a bug where markup silently ate part of the text.
+
+    :param app: the live app, already navigated to the page under test.
+    :returns: the concatenated plain text of every dossier Label.
+    """
+    dossier = app.query_one("#dossier", BabylonMarkdown)
+    parts: list[str] = []
+    for label in dossier.query(Label):
+        if label._render_markup:
+            parts.append(Content.from_markup(label.content).plain)
+        else:
+            parts.append(str(label.content))
+    return "\n".join(parts)
+
+
+class TestCommandPaletteSurfacesT3Pages:
+    """Requirement 1: the palette's ``EntityNavigatorProvider`` offers both
+    T3 singletons once the live campaign that baked them is chosen."""
+
+    @pytest.mark.asyncio
+    async def test_discover_lists_both_t3_pages(self) -> None:
+        app, _campaign_id = _live_campaign_app()
+        async with app.run_test() as pilot:
+            await _boot_into_campaign_shell(pilot)
+
+            provider = EntityNavigatorProvider(app.screen)
+            hits = [hit async for hit in provider.discover()]
+            texts = {hit.text for hit in hits}
+            assert _ECONOMY_SUBJECT in texts
+            assert _FIELD_STATE_SUBJECT in texts
+
+    @pytest.mark.asyncio
+    async def test_search_finds_economy_usa(self) -> None:
+        app, _campaign_id = _live_campaign_app()
+        async with app.run_test() as pilot:
+            await _boot_into_campaign_shell(pilot)
+
+            provider = EntityNavigatorProvider(app.screen)
+            hits = [hit async for hit in provider.search("economy")]
+            assert any(hit.text == _ECONOMY_SUBJECT for hit in hits)
+
+    @pytest.mark.asyncio
+    async def test_search_finds_field_state_usa(self) -> None:
+        app, _campaign_id = _live_campaign_app()
+        async with app.run_test() as pilot:
+            await _boot_into_campaign_shell(pilot)
+
+            provider = EntityNavigatorProvider(app.screen)
+            hits = [hit async for hit in provider.search("field_state")]
+            assert any(hit.text == _FIELD_STATE_SUBJECT for hit in hits)
+
+
+class TestT3PagesRenderCleanly:
+    """Requirement 2: navigating to each T3 page renders through
+    ``BabylonFence`` with no loud-refusal directive and the real
+    renderer-produced numbers visible in the mounted widget tree."""
+
+    @pytest.mark.asyncio
+    async def test_economy_usa_renders_its_real_numbers_with_no_refusal(self) -> None:
+        app, _campaign_id = _live_campaign_app()
+        async with app.run_test() as pilot:
+            await _boot_into_campaign_shell(pilot)
+
+            app.post_message(EntityNavigated(parse_babylon_uri(f"babylon://{_ECONOMY_SUBJECT}")))
+            await pilot.pause()
+
+            assert app.nav.current == _ECONOMY_SUBJECT
+            text = _dossier_text(app)
+            assert "UNKNOWN DIRECTIVE" not in text
+            assert "MALFORMED STATBLOCK BODY" not in text
+            # Real EconomyView-derived numbers, not a fixture lookalike.
+            assert "wage_balance" in text
+            assert "0.180000" in text
+            assert "phi_decomposition_total" in text
+            assert "25.000000" in text
+            # The one field genuinely absent tree-wide renders as an honest
+            # absence block, not a refusal.
+            assert "energy_beta_j" in text
+            assert "ABSENT" in text
+
+    @pytest.mark.asyncio
+    async def test_field_state_usa_renders_its_real_numbers_with_no_refusal(self) -> None:
+        app, _campaign_id = _live_campaign_app()
+        async with app.run_test() as pilot:
+            await _boot_into_campaign_shell(pilot)
+
+            app.post_message(
+                EntityNavigated(parse_babylon_uri(f"babylon://{_FIELD_STATE_SUBJECT}"))
+            )
+            await pilot.pause()
+
+            assert app.nav.current == _FIELD_STATE_SUBJECT
+            text = _dossier_text(app)
+            assert "UNKNOWN DIRECTIVE" not in text
+            assert "MALFORMED STATBLOCK BODY" not in text
+            # Real FieldStateView-derived numbers, not a fixture lookalike.
+            assert "dialectical_regime.regime" in text
+            assert "crisis" in text
+            assert "node.C001.fields.exploitation" in text
+            assert "0.523000" in text
+
+
+class TestWikilinkToEconomyUsaClassifiesAsKnown:
+    """Requirement 3: a wikilink to ``economy/USA`` written into another
+    page (the campaign's home dossier) classifies as known — a gold
+    wikilink span, never a crimson redlink."""
+
+    @pytest.mark.asyncio
+    async def test_home_page_wikilink_to_economy_usa_is_known(self) -> None:
+        app, _campaign_id = _live_campaign_app()
+        async with app.run_test() as pilot:
+            await _boot_into_campaign_shell(pilot)
+
+            assert app.nav.current == _HOME_SUBJECT
+            dossier = app.query_one("#dossier", BabylonMarkdown)
+            paragraph = next(
+                p for p in dossier.query(BabylonParagraph) if _ECONOMY_SUBJECT in p.content.plain
+            )
+            span = next(
+                s
+                for s in paragraph.content.spans
+                if s.style.meta.get("@click") == f"link('babylon://{_ECONOMY_SUBJECT}')"
+            )
+            assert span.style.foreground == WIKILINK_COLOR
+            assert span.style.foreground != REDLINK_COLOR
+
+    @pytest.mark.asyncio
+    async def test_home_page_wikilink_to_field_state_usa_is_known(self) -> None:
+        app, _campaign_id = _live_campaign_app()
+        async with app.run_test() as pilot:
+            await _boot_into_campaign_shell(pilot)
+
+            dossier = app.query_one("#dossier", BabylonMarkdown)
+            paragraph = next(
+                p
+                for p in dossier.query(BabylonParagraph)
+                if _FIELD_STATE_SUBJECT in p.content.plain
+            )
+            span = next(
+                s
+                for s in paragraph.content.spans
+                if s.style.meta.get("@click") == f"link('babylon://{_FIELD_STATE_SUBJECT}')"
+            )
+            assert span.style.foreground == WIKILINK_COLOR


### PR DESCRIPTION
## T4-integration (v1.0.0 train, post-T3)

Fixes the one real navigation defect the post-cascade recon found: `ArchiveApp.known_entities`/`_resolver` were frozen at `__init__` to the demo fixture set, so a live campaign could not wikilink or palette-navigate to ANY baked page.

### Units (opus-reviewed, both first-pass APPROVE)
- **U1** `961d0023` — `CampaignHandle.known_subjects()` Protocol seam; `vault_known_subjects()` factory in the composition root (bounded `*.md` walk, excludes `.git/`+`narrative/`, loud RuntimeError over the static cap); `_on_campaign_chosen` rebuilds `known_entities`/`_resolver`; parser factory now reads the resolver fresh per render; `t`/`r` actions refresh after ticks (frozenset-compare skip). Demo path byte-untouched. `lint:imports` 9/9 kept (tui projection-purity intact).
- **U2** `75dccb2f` — end-to-end reachability proof: fixture pages built by calling the REAL `render_economy`/`render_field_state`, driven through lobby → campaign shell with Pilot; palette surfaces both T3 singletons, both render with zero directive refusals, wikilinks classify as known. Proof mutation-validated: disabling U1's refresh wire fails 5/7 tests.

### Battery (controller-run, single-flight)
- `mise run check` — **13,914 passed**, 26 snapshots unchanged (no golden re-bake)
- `check:sentinels` — all green
- `qa:regression` — 6/6 byte-identical + two-process determinism PASS
- No vault manifest drift (no bake-path changes) — no ceremony needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)