### PR TITLE
feat(game): T5 — narrator lane wired, tick_summary lit, corpus manifest (U1–U3)

### DIFF
--- a/docs/reference/projection-registry.rst
+++ b/docs/reference/projection-registry.rst
@@ -79,6 +79,13 @@ it. This table is the normative registry; the code in
        FR-044 conservation view
      - ``session_id, tick``
      - ``GlobalPhiBalance``
+   * - ``v_national_trend``
+     - game_session tick-summary read-model (spec-037 bootstrap +
+       spec-061 FR-003 US4; single write path via
+       ``GameSession.advance_tick``'s ``persist_tick_summary`` commit,
+       T5 Unit U2 — "the wind is blowing")
+     - ``session_id, tick``
+     - ``NationalTrendView``
 
 The row-models ``CountyValueAggregate``, ``StateValueAggregate``,
 ``NationalValueAggregate``, and ``GlobalPhiBalance`` live in
@@ -86,6 +93,11 @@ The row-models ``CountyValueAggregate``, ``StateValueAggregate``,
 II.11-branded typed facade that the registry **generalizes rather than
 reinvents**. Their SQL definitions are canonical in
 ``src/babylon/persistence/migrations/0030_views_current.sql``.
+``NationalTrendView`` lives in :mod:`babylon.projection.view_models` instead
+— ``v_national_trend`` reads the game-session tick-summary tier, not the hex
+substrate, so its row-model joins the dossier module rather than the
+hex-aggregation facade. Its SQL definition is canonical in
+``src/babylon/persistence/migrations/0038_tick_summary_trend.sql``.
 
 Ambiguous ownership is recorded, never guessed
 ----------------------------------------------

--- a/src/babylon/cli/play.py
+++ b/src/babylon/cli/play.py
@@ -35,6 +35,18 @@ and the permanent endgame lock it enforces never engaged in the shipped game
 production callers). :func:`_driver_factory` itself is a thin adapter, not
 :func:`~babylon.game.pacing.paced_driver_for_session` directly — see its own
 docstring for why one is needed.
+
+T5 Unit U1 (the narrator lane) adds the ``--narrator/--no-narrator`` flag on
+:func:`play`, threaded through :func:`run` into :func:`_load_campaign`: ON
+(the default — the provider chain shipped by :mod:`babylon.intelligence.
+providers` ends in a mute lane, so ON is always legal, R4) constructs a real
+:class:`~babylon.projection.vault.narrator_cache.NarratorSideProcess` over
+this campaign's own vault root and threads it in as
+:func:`~babylon.game.session.create_new_campaign`/:func:`~babylon.game.
+session.resume_campaign`'s ``narrator=`` (previously wired to zero
+production callers); OFF passes ``narrator=None``, so
+:meth:`~babylon.game.session.GameSession.advance_tick` never calls
+``schedule()`` at all — the exact pre-Unit-U1 byte-identical path.
 """
 
 from __future__ import annotations
@@ -45,6 +57,8 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from uuid import UUID
+
+import typer
 
 if TYPE_CHECKING:
     from babylon.config.defines import GameDefines
@@ -124,7 +138,11 @@ def _bake_briefing(materializer: VaultMaterializer, session: GameSession) -> Non
 
 
 def _load_campaign(
-    runtime: PostgresRuntime, catalog: BabylonMetaStore, campaign_id: UUID
+    runtime: PostgresRuntime,
+    catalog: BabylonMetaStore,
+    campaign_id: UUID,
+    *,
+    narrator_enabled: bool = True,
 ) -> GameSession:
     """The lobby's ``CampaignLoader`` seam, fulfilled for real (Unit C2).
 
@@ -142,6 +160,13 @@ def _load_campaign(
         never again, so a resumed campaign's lobby row stayed stuck at
         ``Tick 0``).
     :param campaign_id: the lobby's chosen campaign UUID.
+    :param narrator_enabled: T5 Unit U1's ``--narrator/--no-narrator`` flag
+        (see :func:`play`); ``True`` (the default) constructs a real
+        :class:`~babylon.projection.vault.narrator_cache.NarratorSideProcess`
+        over this campaign's own vault root, threaded through as
+        ``narrator=``; ``False`` threads ``narrator=None`` so
+        :meth:`~babylon.game.session.GameSession.advance_tick` never
+        schedules narration at all.
     :returns: the live, booted/resumed :class:`~babylon.game.session.GameSession`
         (structurally satisfies ``babylon.tui.app.CampaignHandle``, now
         including its Unit U1 ``known_subjects`` seam via the same
@@ -157,6 +182,7 @@ def _load_campaign(
         vault_page_source,
     )
     from babylon.projection.vault.materializer import VaultMaterializer
+    from babylon.projection.vault.narrator_cache import NarratorCache, NarratorSideProcess
     from babylon.projection.vault.tick_baker import ArchiveTickBaker
 
     vault_root = _campaign_vault_root(campaign_id)
@@ -164,6 +190,7 @@ def _load_campaign(
     baker = ArchiveTickBaker(materializer, county_fips=tuple(DETROIT_TRI_COUNTY_FIPS))
     pages = vault_page_source(vault_root)
     known_subjects = vault_known_subjects(vault_root)
+    narrator = NarratorSideProcess(NarratorCache(vault_root)) if narrator_enabled else None
 
     session = (
         resume_campaign(
@@ -173,6 +200,7 @@ def _load_campaign(
             pages=pages,
             known_subjects=known_subjects,
             progress_store=catalog,
+            narrator=narrator,
         )
         if runtime.get_session(campaign_id) is not None
         else create_new_campaign(
@@ -183,6 +211,7 @@ def _load_campaign(
             pages=pages,
             known_subjects=known_subjects,
             progress_store=catalog,
+            narrator=narrator,
         )
     )
     _bake_briefing(materializer, session)
@@ -215,10 +244,14 @@ def _driver_factory(campaign: CampaignHandle) -> PacedTickDriver:
     return paced_driver_for_session(cast("GameSession", campaign))
 
 
-def run() -> None:
+def run(*, narrator_enabled: bool = True) -> None:
     """Boot the REAL Archive TUI: campaign lobby -> briefing -> campaign shell.
 
     Requires a reachable Postgres — see :func:`babylon.game.session.open_runtime`.
+
+    :param narrator_enabled: T5 Unit U1's ``--narrator/--no-narrator`` flag
+        (see :func:`play`), threaded straight into every
+        :func:`_load_campaign` call this boot makes.
     """
     from functools import partial
 
@@ -242,12 +275,25 @@ def run() -> None:
 
     app = ArchiveApp(
         campaign_menu=menu,
-        campaign_loader=partial(_load_campaign, runtime, catalog),
+        campaign_loader=partial(
+            _load_campaign, runtime, catalog, narrator_enabled=narrator_enabled
+        ),
         driver_factory=_driver_factory,
     )
     app.run()
 
 
-def play() -> None:
+def play(
+    narrator: bool = typer.Option(
+        True,
+        "--narrator/--no-narrator",
+        help=(
+            "Enable the async narrator side-process, which writes prose into "
+            "the vault's narrative/ channel (T5 Unit U1). ON by default — the "
+            "shipped provider chain ends in a mute lane, so ON is always "
+            "legal (Constitution R4)."
+        ),
+    ),
+) -> None:
     """Play Babylon — the real campaign session, via the composition root."""
-    run()
+    run(narrator_enabled=narrator)

--- a/src/babylon/data/corpus/manifest.yaml
+++ b/src/babylon/data/corpus/manifest.yaml
@@ -18,11 +18,16 @@
 #                denied sub-path wins over whatever allow glob sweeps over it
 #                (the Trotsky-quoted-for-rebuttal case)
 #   flag_bd    - adversarial-only (Divergence Channel, ADR072). Never reachable
-#                from CorpusManifest.ingest_targets() — only allow rows ever
-#                populate that set
-#   apocryphal - kept deliberately, structurally fenced: CorpusRow's validator
-#                requires every row resolving into _apocrypha/ to declare this
-#                status, and forbids every other row from resolving there
+#                from CorpusManifest.ingest_targets() — that method excludes
+#                every non-allow row's matched files (not deny rows alone), so
+#                no allow glob, however broad, can sweep a flag_bd row's files
+#                back in
+#   apocryphal - kept deliberately, structurally fenced two ways: CorpusRow's
+#                validator requires every row resolving into _apocrypha/ to
+#                declare this status (and forbids every other row from
+#                resolving there), AND ingest_targets() independently drops any
+#                resolved file under _apocrypha/ regardless of which row
+#                matched it
 #
 # role is multi-valued (narrator, atlas_ru, atlas_cn, atlas_us, concept_card,
 # glossary, doctrine). It rides chunk metadata jsonb for `@>` retrieval
@@ -200,8 +205,10 @@ rows:
 
   # =========================================================================
   # adversarial-only (ADR072 Divergence Channel) — never the narrator's
-  # RagPipeline ingestion path; CorpusManifest.ingest_targets() only ever
-  # walks allow rows, so a flag_bd row can never leak into that set.
+  # RagPipeline ingestion path; CorpusManifest.ingest_targets() excludes this
+  # row's matched files from every allow row's results too (not just its own
+  # absence from allow_rows()), so a flag_bd row's files can never leak in
+  # via some broader, unrelated allow glob either.
   # =========================================================================
 
   - path_glob: "nitzan-bichler/capital-as-power/*.txt"

--- a/src/babylon/data/corpus/manifest.yaml
+++ b/src/babylon/data/corpus/manifest.yaml
@@ -1,0 +1,238 @@
+# Babylon corpus manifest — canon-as-data for the narrator's grounding corpus.
+#
+# Replaces the hardcoded MVP_CORPUS tuple in tools/ingest_corpus.py:58-108
+# (ADR107; loader: babylon.intelligence.corpus_manifest.CorpusManifest).
+#
+# Every path_glob is RELATIVE to a corpus_root supplied by the caller — the
+# durable OCR/extraction tree at ~/Documents/ocr/ (see that tree's own
+# MANIFEST.yaml for extraction provenance: method/quality/sha256/word counts).
+# This file never hardcodes an absolute, user-specific path. tools/ingest_corpus.py
+# defaults corpus_root to ~/Documents/ocr; unit tests inject a tmp fixture tree.
+#
+# canon_status (ADR107 widens the original allow|deny|flag_bd triad to four —
+# apocryphal could not otherwise be represented at all):
+#   allow      - canon; eligible for narrator/RAG ingestion
+#   deny       - ruled OUT (anti-MLM-TW positions). Honored even INSIDE an
+#                enclosing allow glob — computed as a set-difference over
+#                matched files, never a directory-level carve-out — so a
+#                denied sub-path wins over whatever allow glob sweeps over it
+#                (the Trotsky-quoted-for-rebuttal case)
+#   flag_bd    - adversarial-only (Divergence Channel, ADR072). Never reachable
+#                from CorpusManifest.ingest_targets() — only allow rows ever
+#                populate that set
+#   apocryphal - kept deliberately, structurally fenced: CorpusRow's validator
+#                requires every row resolving into _apocrypha/ to declare this
+#                status, and forbids every other row from resolving there
+#
+# role is multi-valued (narrator, atlas_ru, atlas_cn, atlas_us, concept_card,
+# glossary, doctrine). It rides chunk metadata jsonb for `@>` retrieval
+# filtering and is ORTHOGONAL to canon_status: role says WHERE a chunk can
+# surface once ingested, canon_status says WHETHER it is ever ingested at
+# all. Role assignments below are best-effort per theme, refined when the RAG
+# semantic-map port (T5: "port director.py SEMANTIC_MAP onto the vault
+# prompt-builder") lands.
+#
+# format is what every ~/Documents/ocr/ extraction normalizes to (txt) except
+# the one apocryphal row (content.jsonl).
+
+rows:
+  # =========================================================================
+  # v1 nine-work set (charter "V1 set: 9 works ~413k words ~2,900 chunks")
+  # =========================================================================
+
+  - path_glob: "fanon/the-wretched-of-the-earth/*.txt"
+    author: "Frantz Fanon"
+    work: "The Wretched of the Earth"
+    role: [narrator, doctrine]
+    format: txt
+    canon_status: allow
+    provenance: >-
+      Classical MLM-TW canon (BD ruling 2026-07-21, ADR107 base allow list).
+      Includes the "On National Culture" chapter. Public-domain marxists.org
+      mirror is the eventual source text; NOT YET extracted into
+      ~/Documents/ocr/ on this box — absence here is a MANIFEST fact, not an
+      error (program doc "step zero", line 283).
+
+  - path_glob: "zak-cope/divided-world-divided-class/*.txt"
+    author: "Zak Cope"
+    work: "Divided World, Divided Class"
+    role: [doctrine]
+    format: txt
+    canon_status: allow
+    provenance: >-
+      ADR107 ruling-8 canon extension (labor-aristocracy / unequal-exchange
+      line). Extracted 2026-07-21 (rescued-copy, clean_ocr, 122506 words) —
+      see ~/Documents/ocr/MANIFEST.yaml id
+      zak-cope/divided-world-divided-class, sha256
+      317faeee502a1f394fdd6f60097fec5ba40b32efb361e338bed24a7b5be97f07.
+
+  - path_glob: "samir-amin/the-law-of-worldwide-value/*.txt"
+    author: "Samir Amin"
+    work: "The Law of Worldwide Value"
+    role: [doctrine]
+    format: txt
+    canon_status: allow
+    provenance: >-
+      ADR107 base allow list (unequal-exchange theory). Extracted 2026-07-21
+      (pdftotext, born_digital, 38171 words) — see
+      ~/Documents/ocr/MANIFEST.yaml id samir-amin/the-law-of-worldwide-value,
+      sha256 600333fa17e1a5a0aa18552f7f2fffdb82c03c34374e55336aa6bae0804f7e38.
+
+  - path_glob: "mim-prisons/fundamental-political-line/*.txt"
+    author: "MIM(Prisons)"
+    work: "Fundamental Political Line"
+    role: [doctrine, glossary]
+    format: txt
+    canon_status: allow
+    provenance: >-
+      ADR107 base allow list (MIM / MIM(Prisons)); the "MIM(P) FPLmimp" of
+      the v1 nine-work set. Extracted 2026-07-21 (pdftotext, born_digital,
+      46046 words) — see ~/Documents/ocr/MANIFEST.yaml id
+      mim-prisons/fundamental-political-line, sha256
+      f89a92ffb3f3b2e171b4ae9a83a6eebce75f22e07f8d5744a4fdb1423400c6b8.
+
+  - path_glob: "mao/selected-works-curated/*.txt"
+    author: "Mao Zedong"
+    work: "Selected Works (curated essays)"
+    role: [narrator, doctrine, atlas_cn]
+    format: txt
+    canon_status: allow
+    provenance: >-
+      Classical MLM-TW canon (ADR107 base allow list). A curated subset of
+      the Selected Works volumes — successor to the two Mao essays in the
+      retired MVP_CORPUS ("On Contradiction", "Analysis of the Classes in
+      Chinese Society", tools/ingest_corpus.py:58-108 pre-T5). NOT YET
+      extracted into ~/Documents/ocr/ on this box.
+
+  - path_glob: "lenin/imperialism-highest-stage-of-capitalism/*.txt"
+    author: "V.I. Lenin"
+    work: "Imperialism, the Highest Stage of Capitalism"
+    role: [doctrine]
+    format: txt
+    canon_status: allow
+    provenance: >-
+      Classical MLM-TW canon (ADR107 base allow list); also the sole Lenin
+      text in the retired MVP_CORPUS. NOT YET extracted into
+      ~/Documents/ocr/ on this box.
+
+  - path_glob: "lenin/state-and-revolution/*.txt"
+    author: "V.I. Lenin"
+    work: "State and Revolution"
+    role: [doctrine, atlas_ru]
+    format: txt
+    canon_status: allow
+    provenance: >-
+      Classical MLM-TW canon (ADR107 base allow list). NOT YET extracted
+      into ~/Documents/ocr/ on this box.
+
+  - path_glob: "stalin/foundations-of-leninism/*.txt"
+    author: "Joseph Stalin"
+    work: "Foundations of Leninism"
+    role: [doctrine, atlas_ru]
+    format: txt
+    canon_status: allow
+    provenance: >-
+      Classical MLM-TW canon (ADR107 base allow list). NOT YET extracted
+      into ~/Documents/ocr/ on this box.
+
+  - path_glob: "che-guevara/1965-speeches-curated/*.txt"
+    author: 'Ernesto "Che" Guevara'
+    work: "Selected 1965 Speeches and Writings"
+    role: [narrator, doctrine]
+    format: txt
+    canon_status: allow
+    provenance: >-
+      Classical MLM-TW canon (ADR107 base allow list); a curated selection
+      (e.g. "Socialism and Man in Cuba"). NOT YET extracted into
+      ~/Documents/ocr/ on this box.
+
+  # =========================================================================
+  # ruled-out lines (ADR107 decision: "deny: CPUSA, Trotsky, Kautsky, Hoxha")
+  # =========================================================================
+
+  - path_glob: "trotsky/**/*.txt"
+    author: "Leon Trotsky"
+    work: "(all works — denied author)"
+    role: [doctrine]
+    format: txt
+    canon_status: deny
+    provenance: >-
+      ADR107 deny ruling: anti-Three-Worlds-Theory / anti-MLM-TW position.
+      Honored even if a future broad allow glob (e.g. a raw marxists.org
+      mirror import) would otherwise sweep this author in — the
+      Trotsky-quoted-for-rebuttal case the charter names explicitly (deny
+      rows win inside allow globs).
+
+  - path_glob: "kautsky/**/*.txt"
+    author: "Karl Kautsky"
+    work: "(all works — denied author)"
+    role: [doctrine]
+    format: txt
+    canon_status: deny
+    provenance: >-
+      ADR107 deny ruling: Second-International-revisionist position,
+      incompatible with the MLM-TW doctrinal spine.
+
+  - path_glob: "cpusa/**/*.txt"
+    author: "Communist Party USA"
+    work: "(all works — denied author)"
+    role: [doctrine]
+    format: txt
+    canon_status: deny
+    provenance: >-
+      ADR107 deny ruling. This deny is honored even where a CPUSA article is
+      quoted for rebuttal INSIDE an otherwise-allowed work (e.g.
+      miws/contemporary-services-draft — see that work's own note in
+      ~/Documents/ocr/MANIFEST.yaml) — the quote stays inside its allowed
+      host file; this row exists so a standalone CPUSA source is never
+      separately ingested as if it were doctrine.
+
+  - path_glob: "hoxha/**/*.txt"
+    author: "Enver Hoxha"
+    work: "(all works — denied author)"
+    role: [doctrine]
+    format: txt
+    canon_status: deny
+    provenance: >-
+      ADR107 deny ruling: anti-Mao, denies the Three Worlds Theory the
+      engine's imperial-rent math is built on (Fundamental Theorem, W_c vs
+      V_c) — specifically incompatible with this codebase's doctrinal spine.
+
+  # =========================================================================
+  # adversarial-only (ADR072 Divergence Channel) — never the narrator's
+  # RagPipeline ingestion path; CorpusManifest.ingest_targets() only ever
+  # walks allow rows, so a flag_bd row can never leak into that set.
+  # =========================================================================
+
+  - path_glob: "nitzan-bichler/capital-as-power/*.txt"
+    author: "Jonathan Nitzan and Shimshon Bichler"
+    work: "Capital as Power"
+    role: [doctrine]
+    format: txt
+    canon_status: flag_bd
+    provenance: >-
+      ADR107 flag_bd ruling: Divergence-Channel (ADR072) steelman opponent
+      only, never narrator-retrievable as doctrine. NOT extracted into
+      ~/Documents/ocr/ on this box. The Divergence-Channel adversarial
+      surface itself is Amendment T, still awaiting BD ratification — this
+      row is declarative only until that surface exists.
+
+  # =========================================================================
+  # apocrypha (ADR107 fourth canon_status) — glob-fenced, never bulk-ingested
+  # =========================================================================
+
+  - path_glob: "_apocrypha/content.jsonl"
+    author: "unknown (Moltbook scrape)"
+    work: "content.jsonl"
+    role: [narrator]
+    format: jsonl
+    canon_status: apocryphal
+    provenance: >-
+      ADR107: AI-generated Maoist pastiche (Moltbook scrape, Jan 2026), kept
+      as a personally significant BD artifact (ruling 2026-07-21). Canon-
+      excluded by construction: CorpusRow's apocrypha-fencing validator
+      requires this path to live under _apocrypha/, and forbids every other
+      row from resolving there. Eligible only for hand-curated,
+      author-selected easter-egg content — never bulk RAG ingestion. See
+      ~/Documents/ocr/_apocrypha/NOTES.md and MANIFEST.yaml, sha256
+      4b380fb853b981d88875711ac6269c9743b88b38dc31732df054376f4d1915af.

--- a/src/babylon/game/session.py
+++ b/src/babylon/game/session.py
@@ -107,6 +107,7 @@ if TYPE_CHECKING:
 __all__ = [
     "GameRuntimeStore",
     "KnownSubjectsSource",
+    "NarratorScheduler",
     "PausePredicate",
     "ProgressStore",
     "VaultPageSource",
@@ -217,6 +218,28 @@ class ProgressStore(Protocol):
         ...
 
 
+class NarratorScheduler(Protocol):
+    """Structural seam for the async narrator side-process (T5 Unit U1).
+
+    Satisfied by :class:`~babylon.projection.vault.narrator_cache.
+    NarratorSideProcess` (fire-and-forget: :meth:`schedule` never blocks and
+    never raises, per that class's own docstring) without this module
+    importing that concrete class — the same WO-37 trick
+    :class:`GameRuntimeStore`/:class:`ProgressStore` already use. ``None``
+    (the constructor default) means the narrator lane is OFF:
+    :meth:`GameSession.advance_tick` then never calls :meth:`schedule` at
+    all, so narrator-OFF stays the exact pre-Unit-U1 byte-identical path
+    (Constitution's determinism tiering — narrator-ON is non-reproducible
+    BY DESIGN and only ever touches the vault's ``narrative/`` subtree,
+    never a baked deterministic page).
+    """
+
+    def schedule(self, entity_id: str, tick: int, *, system: str, prompt: str) -> object:
+        """Submit one narration generation for ``(entity_id, tick)``; never
+        blocks, never raises (the implementation's own contract)."""
+        ...
+
+
 PausePredicate = Callable[[Sequence[Event]], bool]
 """The pacing driver's autopause SEAM: one tick's raw bus events -> pause?
 
@@ -270,6 +293,41 @@ def _replay_identity_hash(session_id: UUID, tick: int, rng_seed: int) -> str:
     convention rather than inventing a second.
     """
     return hashlib.sha256(f"{session_id}:{tick}:{rng_seed}".encode()).hexdigest()
+
+
+#: The one narration subject id :meth:`GameSession.advance_tick` schedules
+#: against per committed tick — mirrors ``tick_baker._NATIONAL_ID``'s
+#: ``"national/USA"`` sentinel/subject-id convention (the one nationwide
+#: "wind is blowing" beat), so its narrative page lands at
+#: ``narrative/national/USA/<tick>--<pin>.md`` alongside the deterministic
+#: ``national/USA.md`` dossier it narrates.
+_NARRATOR_SUBJECT: Final[str] = "national/USA"
+
+
+def _narrator_beat(tick: int, chronicle: tuple[ChronicleEvent, ...]) -> tuple[str, str]:
+    """The ``(system, prompt)`` pair one committed tick schedules narration with.
+
+    Minimal and honest by deliberate scope choice: built ONLY from this
+    tick's own committed chronicle (real per-event summaries from
+    :func:`~babylon.game.chronicle_adapter.chronicle_events_from_bus`),
+    never fabricated (Constitution III.11). Doctrine-conditioning of prompts
+    and the trend-view digest ("the wind is blowing" build, spine E) are
+    DEFERRED past this unit — :mod:`~babylon.projection.vault.narrator_cache`
+    already treats ``(system, prompt)`` as opaque caller-supplied text.
+
+    :param tick: the committed tick number.
+    :param chronicle: this tick's chronicle events, chronological (see
+        :attr:`TickAdvanceResult.chronicle`).
+    :returns: the ``(system, prompt)`` pair for :meth:`NarratorScheduler.schedule`.
+    """
+    system = (
+        "You are the Narrator: observe this committed tick's material state "
+        "and write one brief, grounded prose beat. Never invent facts beyond "
+        "what is given."
+    )
+    body = "; ".join(event.summary for event in chronicle) if chronicle else "no events recorded"
+    prompt = f"Tick {tick} committed. {body}."
+    return system, prompt
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
@@ -382,6 +440,12 @@ class GameSession:
         (typically the same ``BabylonMetaStore`` the composition root's
         ``CampaignMenu`` already holds); ``None`` (the default) runs with no
         lobby catalog to keep live — the pre-writeback no-op path.
+    :param narrator: this campaign's own :class:`NarratorScheduler` seam
+        (typically a real :class:`~babylon.projection.vault.narrator_cache.
+        NarratorSideProcess` over this campaign's own vault root, T5 Unit
+        U1); ``None`` (the default) means the narrator lane is OFF —
+        :meth:`advance_tick` never calls :meth:`~NarratorScheduler.schedule`
+        at all, the pre-Unit-U1 byte-identical path.
     """
 
     def __init__(
@@ -400,6 +464,7 @@ class GameSession:
         pages: VaultPageSource | None = None,
         known_subjects: KnownSubjectsSource | None = None,
         progress_store: ProgressStore | None = None,
+        narrator: NarratorScheduler | None = None,
     ) -> None:
         self.session_id = session_id
         self.graph = graph
@@ -414,6 +479,7 @@ class GameSession:
         self._pages = pages
         self._known_subjects = known_subjects
         self._progress_store = progress_store
+        self._narrator = narrator
 
     def read_page(self, subject: str) -> str | None:
         """Read one REAL baked vault page for this campaign (Unit C2).
@@ -503,6 +569,14 @@ class GameSession:
         a :class:`ProgressStore` is wired — the review fix for the gap where
         the catalog was written only at campaign creation and never again.
 
+        T5 Unit U1: when a :class:`NarratorScheduler` is wired, schedules
+        exactly ONE narration generation for this tick, AFTER the
+        deterministic bake (:attr:`_tick_commit_observer`) completes —
+        fire-and-forget, never blocking this method and never able to raise
+        into it (the side process's own isolation contract). ``narrator=None``
+        (the default) means :meth:`~NarratorScheduler.schedule` is never
+        called at all — the exact pre-Unit-U1 byte-identical path.
+
         Unit C6: also stamps :attr:`TickAdvanceResult.autosaved` via
         :func:`~babylon.persistence.delta.is_checkpoint_tick` — the same
         52-tick (one simulated year) cadence the hex-delta pipeline already
@@ -539,6 +613,9 @@ class GameSession:
             self._tick_commit_observer.on_tick_committed(
                 tick=next_tick, world=world, graph=self.graph
             )
+        if self._narrator is not None:
+            system, prompt = _narrator_beat(next_tick, chronicle)
+            self._narrator.schedule(_NARRATOR_SUBJECT, next_tick, system=system, prompt=prompt)
         if self._progress_store is not None:
             self._progress_store.record_progress(self.session_id, last_tick=next_tick)
 
@@ -566,6 +643,7 @@ def create_new_campaign(
     pages: VaultPageSource | None = None,
     known_subjects: KnownSubjectsSource | None = None,
     progress_store: ProgressStore | None = None,
+    narrator: NarratorScheduler | None = None,
 ) -> GameSession:
     """Boot a brand-new campaign: build the scenario, then bake tick 0.
 
@@ -596,6 +674,11 @@ def create_new_campaign(
         immediately (the lobby row already defaults to 0 at
         ``create_campaign``, so this is a harmless, honest sync rather than
         a required correction).
+    :param narrator: this campaign's :class:`NarratorScheduler` seam (T5 Unit
+        U1); ``None`` (the default) means the narrator lane is OFF for every
+        subsequent :meth:`GameSession.advance_tick`. Tick 0's bake above
+        never schedules narration itself — a stated non-goal of this unit
+        (there is no chronicle yet at boot; narration begins at tick 1).
     :returns: a fresh :class:`GameSession` at tick 0.
     """
     chosen: Scenario = scenario if scenario is not None else WayneCountyScenario()
@@ -643,6 +726,7 @@ def create_new_campaign(
         pages=pages,
         known_subjects=known_subjects,
         progress_store=progress_store,
+        narrator=narrator,
     )
 
 
@@ -655,6 +739,7 @@ def resume_campaign(
     pages: VaultPageSource | None = None,
     known_subjects: KnownSubjectsSource | None = None,
     progress_store: ProgressStore | None = None,
+    narrator: NarratorScheduler | None = None,
 ) -> GameSession:
     """Crash-resume a campaign from its last atomically-committed tick.
 
@@ -679,6 +764,8 @@ def resume_campaign(
         ``last_committed_tick`` right here — the fix for a campaign whose
         catalog row drifted (or never moved past its creation-time ``0``)
         while the Ledger kept advancing.
+    :param narrator: this campaign's :class:`NarratorScheduler` seam (see
+        :func:`create_new_campaign`'s identical parameter, T5 Unit U1).
     :raises ValueError: if ``session_id`` has no ``game_session`` row, or
         (a genuinely broken state — every session commits tick 0 at
         creation) has a row but no committed tick at all.
@@ -718,6 +805,7 @@ def resume_campaign(
         pages=pages,
         known_subjects=known_subjects,
         progress_store=progress_store,
+        narrator=narrator,
     )
 
 

--- a/src/babylon/game/session.py
+++ b/src/babylon/game/session.py
@@ -602,7 +602,12 @@ class GameSession:
         :func:`~babylon.projection.tick_summary.build_tick_summary_kwargs`
         over this tick's own ``world``/``graph`` — previously reachable only
         through the legacy web bridge, so a real Archive campaign wrote
-        nothing to ``tick_summary`` at all.
+        nothing to ``tick_summary`` at all. REVIEW FIX: also threads this
+        tick's own ``events`` (the SAME bus history collected above for the
+        Chronicle adapter) so ``uprising_count``/``repression_count`` count
+        REAL events, not the always-empty ``world.events``
+        (``WorldState.from_graph()`` never restamps ``graph.graph['events']``
+        per tick — see :func:`build_tick_summary_kwargs`'s own docstring).
         """
         next_tick = self.tick + 1
         pending = self._store.get_pending_turns(self.session_id, next_tick)
@@ -624,7 +629,7 @@ class GameSession:
         self._store.persist_tick(next_tick, self.graph, session_id=self.session_id)
         self._store.persist_tick_summary(
             next_tick,
-            build_tick_summary_kwargs(world, graph=self.graph),
+            build_tick_summary_kwargs(world, graph=self.graph, events=events),
             session_id=self.session_id,
         )
         self._store.persist_tick_atomic(

--- a/src/babylon/game/session.py
+++ b/src/babylon/game/session.py
@@ -95,6 +95,7 @@ from babylon.models.world_state import WorldState
 from babylon.persistence.delta import is_checkpoint_tick
 from babylon.persistence.envelope import PerTickTransactionEnvelope
 from babylon.persistence.postgres_schema import ensure_ddl_applied
+from babylon.projection.tick_summary import build_tick_summary_kwargs
 from babylon.projection.verbs.submit import TurnSink, build_player_actions, submit_verb
 from babylon.topology import BabylonGraph
 from babylon.tui.chronicle import ChronicleEvent
@@ -135,7 +136,9 @@ class GameRuntimeStore(TurnSink, Protocol):
     lifecycle named in the program plan (spine D): ``create_session`` /
     ``get_session`` / ``get_pending_turns`` / ``mark_turns_resolved`` /
     ``persist_tick`` / ``hydrate_graph`` / ``persist_tick_atomic`` /
-    ``get_last_committed_tick``.
+    ``get_last_committed_tick`` / ``persist_tick_summary`` (T5 Unit U2 — the
+    ``tick_summary`` read-model write, previously only reachable through the
+    legacy web bridge).
     """
 
     def create_session(
@@ -196,6 +199,16 @@ class GameRuntimeStore(TurnSink, Protocol):
 
     def get_last_committed_tick(self, session_id: UUID) -> int | None:
         """The largest tick with a committed ``tick_commit`` marker, or ``None``."""
+        ...
+
+    def persist_tick_summary(
+        self,
+        tick: int,
+        summary: dict[str, Any],
+        *,
+        session_id: UUID,
+    ) -> None:
+        """Persist one pre-aggregated ``tick_summary`` row (T5 Unit U2)."""
         ...
 
 
@@ -581,6 +594,15 @@ class GameSession:
         :func:`~babylon.persistence.delta.is_checkpoint_tick` — the same
         52-tick (one simulated year) cadence the hex-delta pipeline already
         checkpoints on.
+
+        T5 Unit U2: also persists this tick's ``tick_summary`` row (the
+        national trend read-model's source table — the ``v_national_trend``
+        declared view's ``LAG`` windows read this table) at the SAME commit
+        boundary as :meth:`~PostgresRuntime.persist_tick`, via
+        :func:`~babylon.projection.tick_summary.build_tick_summary_kwargs`
+        over this tick's own ``world``/``graph`` — previously reachable only
+        through the legacy web bridge, so a real Archive campaign wrote
+        nothing to ``tick_summary`` at all.
         """
         next_tick = self.tick + 1
         pending = self._store.get_pending_turns(self.session_id, next_tick)
@@ -600,6 +622,11 @@ class GameSession:
         determinism_hash = _replay_identity_hash(self.session_id, next_tick, self._rng_seed)
 
         self._store.persist_tick(next_tick, self.graph, session_id=self.session_id)
+        self._store.persist_tick_summary(
+            next_tick,
+            build_tick_summary_kwargs(world, graph=self.graph),
+            session_id=self.session_id,
+        )
         self._store.persist_tick_atomic(
             PerTickTransactionEnvelope(
                 session_id=self.session_id,

--- a/src/babylon/intelligence/corpus_manifest.py
+++ b/src/babylon/intelligence/corpus_manifest.py
@@ -1,0 +1,233 @@
+"""The corpus manifest — canon-as-data for the narrator's grounding corpus (ADR107, T5 U3).
+
+Replaces the hardcoded ``MVP_CORPUS`` tuple that used to live in
+``tools/ingest_corpus.py`` (a fuzzy-keyword-matching search against an
+arbitrary external mirror path) with a declarative manifest of rows —
+mirroring :mod:`babylon.intelligence.model_manifest`'s shape (frozen
+Pydantic models, closed ``StrEnum`` vocabularies, a pure ``parse_manifest``
+function, loud validation).
+
+Each row names a ``path_glob`` that resolves against a *corpus root* — the
+durable OCR/extraction tree at ``~/Documents/ocr/`` (see that tree's own
+``MANIFEST.yaml`` for extraction provenance) — supplied by the caller at
+load/resolve time. This module never hardcodes an absolute, user-specific
+path; production code passes the real tree, unit tests build tmp fixtures.
+
+Four canon dispositions (ADR107 widens the original allow/deny/flag_bd
+triad to four so the apocrypha row can even be represented):
+
+* ``allow`` — canon; eligible for narrator/RAG ingestion.
+* ``deny`` — ruled OUT. Honored even *inside* an enclosing allow glob: the
+  exclusion is computed as a set-difference over matched files, never a
+  directory-level carve-out, so a denied sub-path wins over whatever allow
+  glob happens to sweep over it (the "Trotsky-quoted-for-rebuttal" case).
+* ``flag_bd`` — adversarial-only (Divergence Channel, ADR072). Never
+  reachable from :meth:`CorpusManifest.ingest_targets` — only ``allow`` rows
+  ever populate that set.
+* ``apocryphal`` — kept deliberately, structurally fenced: a row may resolve
+  into an ``_apocrypha/`` directory only if it declares this status, and a
+  row declaring this status may resolve nowhere else. Enforced by
+  :meth:`CorpusRow._check_apocrypha_fencing`, not by trusting every future
+  ``path_glob`` author to remember a deny row (ADR107 consequences).
+
+Presence vs. validity: a row whose glob matches nothing on a given box is a
+MANIFEST fact (nothing has been extracted there yet), never a validation
+error — :meth:`CorpusManifest.ingest_targets` reports empty matches for such
+rows rather than raising.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, model_validator
+
+#: Directory name the apocrypha class is fenced to (ADR107). No non-apocryphal
+#: row's ``path_glob`` may resolve into it, and no apocryphal row may resolve
+#: anywhere else.
+APOCRYPHA_DIR_NAME = "_apocrypha"
+
+
+class CorpusRole(StrEnum):
+    """Where a chunk may surface — rides chunk ``metadata`` jsonb for ``@>`` retrieval.
+
+    Orthogonal to :class:`CanonStatus`: role says WHERE a chunk can surface
+    once ingested; canon_status says WHETHER it is ever ingested at all.
+    """
+
+    NARRATOR = "narrator"
+    ATLAS_RU = "atlas_ru"
+    ATLAS_CN = "atlas_cn"
+    ATLAS_US = "atlas_us"
+    CONCEPT_CARD = "concept_card"
+    GLOSSARY = "glossary"
+    DOCTRINE = "doctrine"
+
+
+class CanonStatus(StrEnum):
+    """The four canon dispositions (ADR107)."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+    FLAG_BD = "flag_bd"
+    APOCRYPHAL = "apocryphal"
+
+
+class CorpusFormat(StrEnum):
+    """Source format a ``path_glob``'s matched files are stored in."""
+
+    TXT = "txt"
+    HTML = "html"
+    MARKDOWN = "md"
+    JSONL = "jsonl"
+
+
+class CorpusRow(BaseModel):
+    """One row of the corpus manifest: a glob, its canon disposition, provenance."""
+
+    model_config = ConfigDict(frozen=True)
+
+    path_glob: str
+    author: str
+    work: str
+    role: tuple[CorpusRole, ...]
+    format: CorpusFormat
+    canon_status: CanonStatus
+    provenance: str
+
+    @model_validator(mode="after")
+    def _check_role_nonempty(self) -> CorpusRow:
+        if not self.role:
+            raise ValueError(f"row {self.work!r} ({self.author!r}) must declare at least one role")
+        return self
+
+    @model_validator(mode="after")
+    def _check_apocrypha_fencing(self) -> CorpusRow:
+        # ADR107: the _apocrypha/ directory is structurally fenced — a glob
+        # resolving into it must be tagged apocryphal, and nothing else may
+        # point there. This is enforced here (loud, at load time) rather than
+        # trusting every future path_glob author to remember a deny row.
+        points_into_apocrypha = APOCRYPHA_DIR_NAME in Path(self.path_glob).parts
+        if points_into_apocrypha and self.canon_status is not CanonStatus.APOCRYPHAL:
+            raise ValueError(
+                f"row {self.work!r} path_glob {self.path_glob!r} resolves into "
+                f"{APOCRYPHA_DIR_NAME}/ but canon_status is "
+                f"{self.canon_status.value!r}, not apocryphal (ADR107 glob-fencing)"
+            )
+        if self.canon_status is CanonStatus.APOCRYPHAL and not points_into_apocrypha:
+            raise ValueError(
+                f"row {self.work!r} is canon_status=apocryphal but path_glob "
+                f"{self.path_glob!r} does not resolve into {APOCRYPHA_DIR_NAME}/"
+            )
+        return self
+
+
+class ManifestTarget(BaseModel):
+    """One ``allow`` row plus its deny-subtracted, existing-only matched files.
+
+    ``files`` is already sorted (deterministic ordering). An empty tuple is a
+    MANIFEST fact — the row's work has not been extracted onto this box yet —
+    never an error.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    row: CorpusRow
+    files: tuple[Path, ...]
+
+    @property
+    def present(self) -> bool:
+        """Whether this row currently matches any file on disk."""
+        return len(self.files) > 0
+
+
+class CorpusManifest(BaseModel):
+    """A validated, ordered set of corpus rows."""
+
+    model_config = ConfigDict(frozen=True)
+
+    rows: tuple[CorpusRow, ...]
+
+    def allow_rows(self) -> tuple[CorpusRow, ...]:
+        return tuple(r for r in self.rows if r.canon_status is CanonStatus.ALLOW)
+
+    def deny_rows(self) -> tuple[CorpusRow, ...]:
+        return tuple(r for r in self.rows if r.canon_status is CanonStatus.DENY)
+
+    def flag_bd_rows(self) -> tuple[CorpusRow, ...]:
+        return tuple(r for r in self.rows if r.canon_status is CanonStatus.FLAG_BD)
+
+    def apocryphal_rows(self) -> tuple[CorpusRow, ...]:
+        return tuple(r for r in self.rows if r.canon_status is CanonStatus.APOCRYPHAL)
+
+    def ingest_targets(self, corpus_root: Path) -> tuple[ManifestTarget, ...]:
+        """Allow rows (in manifest order), each with deny-subtracted, existing files.
+
+        This is the enumeration contract that replaces ``MVP_CORPUS``: allow
+        minus deny, existing-files-only, deterministic ordering. Deny rows are
+        honored INSIDE allow globs — a denied sub-path's matched files are
+        removed from an allow row's matches by set difference, never by a
+        directory-level exclusion — so a deny row nested inside a broader
+        allow glob still wins (the Trotsky-quoted-for-rebuttal case).
+
+        A row whose matched-files tuple ends up empty is a MANIFEST fact
+        (nothing extracted onto this box yet), never an error.
+        """
+        deny_files: set[Path] = set()
+        for row in self.deny_rows():
+            deny_files.update(_glob_matches(corpus_root, row.path_glob))
+
+        targets: list[ManifestTarget] = []
+        for row in self.allow_rows():
+            matched = tuple(
+                f for f in _glob_matches(corpus_root, row.path_glob) if f not in deny_files
+            )
+            targets.append(ManifestTarget(row=row, files=matched))
+        return tuple(targets)
+
+    def resolve_ingestible_files(self, corpus_root: Path) -> tuple[Path, ...]:
+        """Flat, deterministically sorted union of every allow row's matched files."""
+        files: set[Path] = set()
+        for target in self.ingest_targets(corpus_root):
+            files.update(target.files)
+        return tuple(sorted(files))
+
+
+def _glob_matches(corpus_root: Path, path_glob: str) -> list[Path]:
+    """Resolve one ``path_glob`` against ``corpus_root``.
+
+    An absent corpus_root (or a glob matching nothing) returns an empty list
+    rather than raising — presence is reported separately from validity.
+    """
+    if not corpus_root.exists():
+        return []
+    return sorted(corpus_root.glob(path_glob))
+
+
+def parse_manifest(raw: dict[str, Any]) -> CorpusManifest:
+    """Parse a YAML mapping (a ``rows:`` list) into a validated manifest."""
+    return CorpusManifest(rows=tuple(raw.get("rows", [])))
+
+
+def load_manifest(path: Path) -> CorpusManifest:
+    """Load and validate a corpus manifest from an explicit YAML path.
+
+    Test-injectable by design: production code loads the bundled manifest via
+    :func:`load_bundled_manifest`; unit tests pass a tmp-fixture path instead
+    of ever touching the real ``~/Documents/ocr/`` tree.
+    """
+    with path.open("r", encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle)
+    return parse_manifest(raw or {})
+
+
+def load_bundled_manifest() -> CorpusManifest:
+    """Load the manifest shipped in the package (``babylon/data/corpus/manifest.yaml``)."""
+    from importlib import resources
+
+    data = resources.files("babylon.data.corpus").joinpath("manifest.yaml")
+    with resources.as_file(data) as path:
+        return load_manifest(path)

--- a/src/babylon/intelligence/corpus_manifest.py
+++ b/src/babylon/intelligence/corpus_manifest.py
@@ -17,18 +17,25 @@ Four canon dispositions (ADR107 widens the original allow/deny/flag_bd
 triad to four so the apocrypha row can even be represented):
 
 * ``allow`` — canon; eligible for narrator/RAG ingestion.
-* ``deny`` — ruled OUT. Honored even *inside* an enclosing allow glob: the
-  exclusion is computed as a set-difference over matched files, never a
-  directory-level carve-out, so a denied sub-path wins over whatever allow
-  glob happens to sweep over it (the "Trotsky-quoted-for-rebuttal" case).
-* ``flag_bd`` — adversarial-only (Divergence Channel, ADR072). Never
-  reachable from :meth:`CorpusManifest.ingest_targets` — only ``allow`` rows
-  ever populate that set.
+* ``deny`` — ruled OUT.
+* ``flag_bd`` — adversarial-only (Divergence Channel, ADR072).
 * ``apocryphal`` — kept deliberately, structurally fenced: a row may resolve
   into an ``_apocrypha/`` directory only if it declares this status, and a
-  row declaring this status may resolve nowhere else. Enforced by
-  :meth:`CorpusRow._check_apocrypha_fencing`, not by trusting every future
-  ``path_glob`` author to remember a deny row (ADR107 consequences).
+  row declaring this status may resolve nowhere else. Enforced at load time
+  by :meth:`CorpusRow._check_apocrypha_fencing` (rejects the glob *string*
+  itself), not by trusting every future ``path_glob`` author to remember a
+  deny row (ADR107 consequences).
+
+Every one of ``deny``/``flag_bd``/``apocryphal`` is honored even *inside* an
+enclosing allow glob: :meth:`CorpusManifest.ingest_targets` computes the
+exclusion as a set-difference over matched *files*, subtracting ALL non-allow
+rows' matches (not deny alone), never a directory-level carve-out — so a
+denied/flagged/apocryphal sub-path wins over whatever allow glob happens to
+sweep over it, however broad that glob is (the "Trotsky-quoted-for-rebuttal"
+case, and its ``_apocrypha``/``flag_bd`` analogues). The ``_apocrypha/``
+directory additionally gets a second, independent structural check at
+resolved-file granularity (:func:`_under_apocrypha`), so it stays unreachable
+from ``ingest_targets`` even if the per-row exclusion above were ever wrong.
 
 Presence vs. validity: a row whose glob matches nothing on a given box is a
 MANIFEST fact (nothing has been extracted there yet), never a validation
@@ -126,7 +133,7 @@ class CorpusRow(BaseModel):
 
 
 class ManifestTarget(BaseModel):
-    """One ``allow`` row plus its deny-subtracted, existing-only matched files.
+    """One ``allow`` row plus its excluded-and-existing-only matched files.
 
     ``files`` is already sorted (deterministic ordering). An empty tuple is a
     MANIFEST fact — the row's work has not been extracted onto this box yet —
@@ -164,26 +171,39 @@ class CorpusManifest(BaseModel):
         return tuple(r for r in self.rows if r.canon_status is CanonStatus.APOCRYPHAL)
 
     def ingest_targets(self, corpus_root: Path) -> tuple[ManifestTarget, ...]:
-        """Allow rows (in manifest order), each with deny-subtracted, existing files.
+        """Allow rows (in manifest order), each with excluded/existing files resolved.
 
         This is the enumeration contract that replaces ``MVP_CORPUS``: allow
-        minus deny, existing-files-only, deterministic ordering. Deny rows are
-        honored INSIDE allow globs — a denied sub-path's matched files are
-        removed from an allow row's matches by set difference, never by a
-        directory-level exclusion — so a deny row nested inside a broader
-        allow glob still wins (the Trotsky-quoted-for-rebuttal case).
+        minus every OTHER canon_status (deny, flag_bd, apocryphal) —
+        existing-files-only, deterministic ordering. The exclusion is a set
+        difference over matched files, never a directory-level carve-out, so
+        a narrower deny/flag_bd/apocryphal glob nested inside a broader allow
+        glob still wins (the Trotsky-quoted-for-rebuttal case) — and this
+        holds for a broad allow glob too (e.g. a raw marxists.org mirror
+        import, or ``**/*.jsonl``): it can never sweep a flag_bd or
+        apocryphal row's files back into the ingestible set, because ANY
+        non-allow row's matches are excluded, not just deny rows'.
+
+        On top of that per-row exclusion, every resolved file is also checked
+        structurally against :data:`APOCRYPHA_DIR_NAME` (see
+        :func:`_under_apocrypha`) — a second, independent fence so the
+        ``_apocrypha/`` directory stays unreachable even if the exclusion set
+        above were ever computed wrong.
 
         A row whose matched-files tuple ends up empty is a MANIFEST fact
         (nothing extracted onto this box yet), never an error.
         """
-        deny_files: set[Path] = set()
-        for row in self.deny_rows():
-            deny_files.update(_glob_matches(corpus_root, row.path_glob))
+        excluded_files: set[Path] = set()
+        for row in self.rows:
+            if row.canon_status is not CanonStatus.ALLOW:
+                excluded_files.update(_glob_matches(corpus_root, row.path_glob))
 
         targets: list[ManifestTarget] = []
         for row in self.allow_rows():
             matched = tuple(
-                f for f in _glob_matches(corpus_root, row.path_glob) if f not in deny_files
+                f
+                for f in _glob_matches(corpus_root, row.path_glob)
+                if f not in excluded_files and not _under_apocrypha(corpus_root, f)
             )
             targets.append(ManifestTarget(row=row, files=matched))
         return tuple(targets)
@@ -207,6 +227,19 @@ def _glob_matches(corpus_root: Path, path_glob: str) -> list[Path]:
     return sorted(corpus_root.glob(path_glob))
 
 
+def _under_apocrypha(corpus_root: Path, file_path: Path) -> bool:
+    """Whether ``file_path`` (a match under ``corpus_root``) lives under ``_apocrypha/``.
+
+    Structural fence (ADR107), applied unconditionally in
+    :meth:`CorpusManifest.ingest_targets` regardless of which row's glob
+    matched the file — the apocrypha directory is never bulk-ingestible via
+    any allow row, however broad. ``file_path`` always comes from
+    ``corpus_root.glob(...)`` (see :func:`_glob_matches`), so it is always
+    relative to ``corpus_root``.
+    """
+    return APOCRYPHA_DIR_NAME in file_path.relative_to(corpus_root).parts
+
+
 def parse_manifest(raw: dict[str, Any]) -> CorpusManifest:
     """Parse a YAML mapping (a ``rows:`` list) into a validated manifest."""
     return CorpusManifest(rows=tuple(raw.get("rows", [])))
@@ -225,9 +258,19 @@ def load_manifest(path: Path) -> CorpusManifest:
 
 
 def load_bundled_manifest() -> CorpusManifest:
-    """Load the manifest shipped in the package (``babylon/data/corpus/manifest.yaml``)."""
-    from importlib import resources
+    """Load the manifest shipped in the package (``babylon/data/corpus/manifest.yaml``).
 
-    data = resources.files("babylon.data.corpus").joinpath("manifest.yaml")
-    with resources.as_file(data) as path:
-        return load_manifest(path)
+    Loaded via a filesystem-relative path from this module's own location —
+    the same convention every other consumer under ``babylon/data/`` uses
+    (e.g. ``GameDefines.default_yaml_path`` in
+    :mod:`babylon.config.defines._assembler`), rather than
+    :mod:`importlib.resources`. ``babylon/data/`` and ``babylon/data/corpus/``
+    carry no ``__init__.py`` (unlike :mod:`babylon.intelligence.data`, the one
+    true ``importlib.resources`` package in this tree, which
+    :mod:`babylon.intelligence.model_manifest` reads from) — resolving them as
+    ``importlib.resources`` packages would lean on implicit namespace-package
+    behavior that the rest of ``babylon/data/`` deliberately does not depend
+    on for a real wheel / signed Nix-closure build.
+    """
+    manifest_path = Path(__file__).parent.parent / "data" / "corpus" / "manifest.yaml"
+    return load_manifest(manifest_path)

--- a/src/babylon/persistence/migrations/0038_tick_summary_trend.sql
+++ b/src/babylon/persistence/migrations/0038_tick_summary_trend.sql
@@ -1,0 +1,61 @@
+-- 0038_tick_summary_trend.sql
+-- T5 Unit U2: the national trend read-model — "the wind is blowing".
+--
+-- Declares v_national_trend (Constitution II.11) over tick_summary
+-- (spec-037 bootstrap; extended by migrations 0033/0034/0035):
+-- per-session, per-tick LAG-window deltas for the three headline series a
+-- real Archive campaign now actually writes
+-- (babylon.projection.tick_summary.build_tick_summary_kwargs, wired at
+-- GameSession's commit boundary, same unit) — imperial_rent (Phi), the
+-- Program 23 Market Scissors price<->value axis (price_log/fictitious_log,
+-- ADR077/078), and the correction-snap ledger's own foreshadowed increment
+-- read (market_corrections — migration 0034's own docstring: "the cockpit
+-- derives the snap ticks from increments"). Before this unit,
+-- persist_tick_summary's only caller was the legacy web bridge, so a real
+-- Archive campaign wrote nothing to tick_summary at all — any view over it
+-- was empty (the same dormant-construct pattern T3 closed for field-state).
+--
+-- tick_summary's remaining columns (year/total_c/total_v/total_s/
+-- exploitation_rate/profit_rate/co_optive_edge_count/conservation_check)
+-- carry no computed value from any engine system yet (see
+-- build_tick_summary_kwargs's own docstring) — a trend of a permanently
+-- NULL column is not a signal, so this view does not window them. Kept to
+-- ONE view: tick_summary has no per-scope (county/state) breakdown of its
+-- own to window separately.
+--
+-- Guarded: tick_summary is created by the spec-037 bootstrap
+-- (postgres_schema.py TICK_SUMMARY_DDL), not by any migration, so a
+-- database that only ran migrations must not hard-fail here. DROP VIEW
+-- IF EXISTS + CREATE (0030/0033's idiom) rather than CREATE OR REPLACE —
+-- Postgres forbids CREATE OR REPLACE VIEW from changing a view's declared
+-- column set.
+
+DO $tick_summary_trend$
+BEGIN
+    IF to_regclass('tick_summary') IS NOT NULL THEN
+        DROP VIEW IF EXISTS v_national_trend;
+
+        CREATE VIEW v_national_trend AS
+        SELECT
+            session_id,
+            tick,
+            imperial_rent,
+            imperial_rent - LAG(imperial_rent) OVER (
+                PARTITION BY session_id ORDER BY tick
+            ) AS imperial_rent_delta,
+            price_log,
+            price_log - LAG(price_log) OVER (
+                PARTITION BY session_id ORDER BY tick
+            ) AS price_log_delta,
+            fictitious_log,
+            fictitious_log - LAG(fictitious_log) OVER (
+                PARTITION BY session_id ORDER BY tick
+            ) AS fictitious_log_delta,
+            market_corrections,
+            market_corrections - LAG(market_corrections) OVER (
+                PARTITION BY session_id ORDER BY tick
+            ) AS market_corrections_delta
+        FROM tick_summary;
+    END IF;
+END
+$tick_summary_trend$;

--- a/src/babylon/projection/registry.py
+++ b/src/babylon/projection/registry.py
@@ -30,6 +30,7 @@ from babylon.persistence.postgres_aggregation import (
     NationalValueAggregate,
     StateValueAggregate,
 )
+from babylon.projection.view_models import NationalTrendView
 
 #: Sentinel prefix stamped on :attr:`DeclaredView.owning_subsystem` when a view
 #: reads tables from more than one subsystem and no single owner is declared by
@@ -228,6 +229,31 @@ _GLOBAL_PHI_BALANCE = DeclaredView(
     ownership_ambiguous=True,
 )
 
+_NATIONAL_TREND = DeclaredView(
+    name="v_national_trend",
+    owning_subsystem=(
+        "game_session tick-summary read-model (spec-037 bootstrap + "
+        "spec-061 FR-003 US4; single write path via GameSession.advance_tick's "
+        "persist_tick_summary commit, T5 Unit U2 — 'the wind is blowing')"
+    ),
+    sql_view="v_national_trend",
+    order_by="session_id, tick",
+    columns=(
+        "session_id",
+        "tick",
+        "imperial_rent",
+        "imperial_rent_delta",
+        "price_log",
+        "price_log_delta",
+        "fictitious_log",
+        "fictitious_log_delta",
+        "market_corrections",
+        "market_corrections_delta",
+    ),
+    fts_columns=(),
+    view_model=NationalTrendView,
+)
+
 #: The closed set of declared cross-subsystem read interfaces (Constitution
 #: II.11). Immutable by being a tuple of frozen models; new views join by
 #: adding an entry here and a row to the ownership table in
@@ -238,6 +264,7 @@ REGISTRY: Final[tuple[DeclaredView, ...]] = (
     _STATE_VALUE_AGGREGATE,
     _NATIONAL_VALUE_AGGREGATE,
     _GLOBAL_PHI_BALANCE,
+    _NATIONAL_TREND,
 )
 
 

--- a/src/babylon/projection/tick_summary.py
+++ b/src/babylon/projection/tick_summary.py
@@ -30,14 +30,29 @@ exactly matching the ported ``_build_tick_summary``'s own contract:
   ``None`` when its own axis is absent this tick.
 * ``solidarity_edge_count``/``antagonistic_edge_count`` count
   :class:`~babylon.models.entities.relationship.Relationship` rows by
-  ``edge_type``; ``uprising_count``/``repression_count`` count this tick's
-  ``WorldState.events`` by ``event_type`` (the ported source's own
-  ``_enum_val``-string comparison is replaced here by direct
-  :class:`~babylon.models.enums.topology.EdgeType`/
-  :class:`~babylon.models.enums.events.EventType` comparison — the SAME
-  counting rule, since ``Relationship.edge_type``/``SimulationEvent.
-  event_type`` are strictly-typed enum fields in this module's Pydantic
-  boundary, unlike the web bridge's own dict-serialized payloads).
+  ``edge_type`` (direct :class:`~babylon.models.enums.topology.EdgeType`
+  comparison — the SAME counting rule as the ported source's own
+  ``_enum_val``-string match, since ``Relationship.edge_type`` is a
+  strictly-typed enum field in this module's Pydantic boundary, unlike the
+  web bridge's own dict-serialized payloads).
+* ``uprising_count``/``repression_count`` count this tick's raw kernel
+  :class:`~babylon.kernel.event_bus.Event` history (the ``events=`` param)
+  by ``.type`` against :class:`~babylon.models.enums.events.EventType`
+  (REVIEW FIX, T5 U2: the first cut counted ``WorldState.events`` instead,
+  which is ALWAYS empty on the Archive path —
+  ``WorldState.from_graph()`` reconstructs ``.events`` from
+  ``graph.graph['events']``, a key only
+  :meth:`~babylon.models.world_state.WorldState.to_graph` ever writes
+  (once, at tick-0 boot); no engine system restamps it per tick, so every
+  ``advance_tick`` call was silently persisting a fabricated ``0`` instead
+  of the real count — exactly the invented-zero Constitution III.11
+  forbids. :meth:`~babylon.game.session.GameSession.advance_tick` already
+  collects the tick's real bus history via ``bus.get_history()`` for the
+  Chronicle adapter; this module reuses that SAME tuple rather than
+  inventing a second event source). ``events=None`` (no history threaded)
+  keeps both columns honestly ``None`` — a caller with no history is a
+  different state from "zero events happened this tick", so it is never
+  collapsed to the same ``0``.
 * ``org_count``/``player_org_count`` read ``WorldState.organizations``/
   ``player_org_id`` directly rather than the ported source's own
   already-``_serialize_organization``-ed ``organizations`` list — the same
@@ -54,12 +69,14 @@ are honest ``None`` — tick-0 has no TickDynamics output.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Final
 
 from babylon.models.enums.events import EventType
 from babylon.models.enums.topology import EdgeType, NodeType
 
 if TYPE_CHECKING:
+    from babylon.kernel.event_bus import Event
     from babylon.kernel.graph_protocol import GraphProtocol
     from babylon.models.world_state import WorldState
 
@@ -190,26 +207,38 @@ def build_tick_summary_kwargs(
     world: WorldState,
     *,
     graph: GraphProtocol | None = None,
+    events: Sequence[Event] | None = None,
 ) -> dict[str, Any]:
     """Aggregate one committed tick's ``tick_summary`` row from live state.
 
     Port of ``web/game/engine_bridge.py::_build_tick_summary`` (lines
     ~9341-9420) — same field semantics, no redesign (see this module's own
-    docstring for the field-by-field ruling and the two deliberate
-    mechanical simplifications: direct enum comparison in place of
-    ``_enum_val``-string matching, and reading ``org_count``/
-    ``player_org_count`` straight off ``WorldState`` rather than an
-    already-``_serialize_organization``-ed list).
+    docstring for the field-by-field ruling and the deliberate mechanical
+    simplifications: direct enum comparison in place of ``_enum_val``-string
+    matching, and reading ``org_count``/``player_org_count`` straight off
+    ``WorldState`` rather than an already-``_serialize_organization``-ed
+    list).
 
     :param world: The committed, post-tick ``WorldState``
         (``WorldState.from_graph(graph, tick=...)`` — never a bootstrap
         ``WorldState`` with a stale ``events`` list, since ``events`` is
-        per-tick, not cumulative).
+        per-tick, not cumulative). NOTE: ``world.events`` is NOT read for
+        ``uprising_count``/``repression_count`` (see ``events=`` below) —
+        ``WorldState.from_graph()`` never restamps it per tick, so it would
+        always be empty on this path.
     :param graph: The SAME committed post-tick graph ``world`` was built
         from, when the caller has one — unlocks the five county-deduped
         year-boundary aggregates via :func:`_county_tick_series_aggregates`.
         ``None`` (tick-0 bootstrap call sites) keeps those five honestly
         ``None`` rather than fabricating a step-function head.
+    :param events: This tick's raw kernel bus history (typically
+        ``tuple(bus.get_history())`` — the SAME tuple
+        :meth:`~babylon.game.session.GameSession.advance_tick` already
+        collects for the Chronicle adapter), used to count
+        ``uprising_count``/``repression_count`` by ``.type``. ``None`` (no
+        history threaded) keeps both columns honestly ``None`` rather than
+        a fabricated ``0`` (Constitution III.11; see this module's own
+        docstring, "REVIEW FIX, T5 U2").
     :returns: Kwargs dict for
         :meth:`~babylon.persistence.postgres_runtime.PostgresRuntime.
         persist_tick_summary`.
@@ -227,10 +256,14 @@ def build_tick_summary_kwargs(
     antagonistic_edge_count = sum(
         1 for rel in world.relationships if rel.edge_type == EdgeType.EXPLOITATION
     )
-    uprising_count = sum(1 for event in world.events if event.event_type == EventType.UPRISING)
-    repression_count = sum(
-        1 for event in world.events if event.event_type == EventType.STATE_REPRESSION
-    )
+    uprising_count: int | None
+    repression_count: int | None
+    if events is None:
+        uprising_count = None
+        repression_count = None
+    else:
+        uprising_count = sum(1 for event in events if event.type == EventType.UPRISING)
+        repression_count = sum(1 for event in events if event.type == EventType.STATE_REPRESSION)
     player_org_count = sum(
         1 for org in world.organizations.values() if org.id == world.player_org_id
     )

--- a/src/babylon/projection/tick_summary.py
+++ b/src/babylon/projection/tick_summary.py
@@ -1,0 +1,266 @@
+"""The ``tick_summary`` kwargs builder — ``build_tick_summary_kwargs`` (T5 Unit U2).
+
+Port of ``web/game/engine_bridge.py::_build_tick_summary`` (lines ~9341-9420)
+and its ``_county_tick_series_aggregates`` helper (lines ~8660-8737) into a
+pure projection helper — same read logic, no redesign. The web bridge's
+``persist_tick_summary`` caller (``_persist_snapshots_safe``,
+``web/game/engine_bridge.py:9486-9495``) is the only production caller of
+:meth:`~babylon.persistence.postgres_runtime.PostgresRuntime.
+persist_tick_summary` before this unit — a real Archive campaign
+(:class:`~babylon.game.session.GameSession`) wrote nothing to ``tick_summary``
+at all, so every trend read over it was empty (the same dormant-construct
+pattern T3 closed for field-state). This module supplies the SAME kwargs
+shape from :class:`~babylon.game.session.GameSession`'s own commit boundary,
+with no Django, no engine imports, and no database connection — the caller
+hands in the graph and world it already holds.
+
+Only values the engine actually computes are aggregated; everything else
+stays ``None`` — NULL columns over invented zeros (Constitution III.11),
+exactly matching the ported ``_build_tick_summary``'s own contract:
+
+* ``year`` / ``total_c`` / ``total_v`` / ``total_s`` / ``exploitation_rate``
+  / ``profit_rate`` / ``co_optive_edge_count`` / ``conservation_check`` are
+  ALWAYS ``None`` in the ported source too — no engine system computes them
+  yet, so this helper does not invent values for them either.
+* ``imperial_rent`` from :class:`~babylon.models.entities.economy.GlobalEconomy`'s
+  ``imperial_rent_pool``; ``avg_consciousness`` over
+  ``SocialClass.ideology.class_consciousness``; ``price_log``/
+  ``fictitious_log``/``market_corrections`` from the Program 23 Market
+  Scissors shadow axis (:class:`~babylon.models.market.MarketState`) — each
+  ``None`` when its own axis is absent this tick.
+* ``solidarity_edge_count``/``antagonistic_edge_count`` count
+  :class:`~babylon.models.entities.relationship.Relationship` rows by
+  ``edge_type``; ``uprising_count``/``repression_count`` count this tick's
+  ``WorldState.events`` by ``event_type`` (the ported source's own
+  ``_enum_val``-string comparison is replaced here by direct
+  :class:`~babylon.models.enums.topology.EdgeType`/
+  :class:`~babylon.models.enums.events.EventType` comparison — the SAME
+  counting rule, since ``Relationship.edge_type``/``SimulationEvent.
+  event_type`` are strictly-typed enum fields in this module's Pydantic
+  boundary, unlike the web bridge's own dict-serialized payloads).
+* ``org_count``/``player_org_count`` read ``WorldState.organizations``/
+  ``player_org_id`` directly rather than the ported source's own
+  already-``_serialize_organization``-ed ``organizations`` list — the same
+  ``_is_player_org`` single-source-of-truth comparison
+  (``org_id == player_org_id``, never a heuristic), since this module never
+  needs the fog-gated presentation fields ``_serialize_organization``
+  computes for a UI, only the two counts.
+
+Playability Spine Task 19 (spec-116 4d.5): when ``graph`` is supplied (the
+committed post-tick graph), five county-deduped year-boundary aggregates
+ride the row via :func:`_county_tick_series_aggregates`; without a graph they
+are honest ``None`` — tick-0 has no TickDynamics output.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
+
+from babylon.models.enums.events import EventType
+from babylon.models.enums.topology import EdgeType, NodeType
+
+if TYPE_CHECKING:
+    from babylon.kernel.graph_protocol import GraphProtocol
+    from babylon.models.world_state import WorldState
+
+__all__ = ["build_tick_summary_kwargs"]
+
+#: The three ``tick_crisis_phase`` values counted as "in crisis" by
+#: ``crisis_pop_share`` — verbatim from the ported
+#: ``_county_tick_series_aggregates``.
+_CRISIS_ACTIVE_PHASES: Final[frozenset[str]] = frozenset({"onset", "early", "deep"})
+
+#: The five ``tick_*`` territory attrs the county-dedup pass reads, in the
+#: order the ported source visits them.
+_TICK_SERIES_KEYS: Final[tuple[str, ...]] = (
+    "tick_crisis_phase",
+    "tick_bifurcation_score",
+    "tick_wage_compression",
+    "tick_capital_stock",
+    "tick_unemployment_rate",
+)
+
+#: The five aggregate columns' honest-absent shape when no graph is supplied
+#: (tick-0 bootstrap call sites) — verbatim from the ported
+#: ``_build_tick_summary``'s own no-graph branch.
+_EMPTY_TICK_SERIES: Final[dict[str, float | None]] = {
+    "crisis_pop_share": None,
+    "bifurcation_score_mean": None,
+    "wage_compression_mean": None,
+    "capital_stock_total": None,
+    "unemployment_rate_mean": None,
+}
+
+
+def _county_weighted_mean(rows: list[tuple[float, float]]) -> float | None:
+    """Population-weighted mean, falling back to a plain mean at zero weight.
+
+    Deliberately distinct from :func:`babylon.projection.national._weighted_mean`
+    (which returns ``None`` at zero total weight): the ported
+    ``_county_tick_series_aggregates`` instead falls back to an unweighted
+    mean across the counties present, so this helper preserves that EXACT
+    fallback rather than the different national.py contract.
+
+    :param rows: ``(value, population_weight)`` pairs, one per county that
+        carries the attr being averaged.
+    :returns: The weighted mean, or the plain mean when every weight is
+        zero, or ``None`` for an empty series.
+    """
+    if not rows:
+        return None
+    total_weight = sum(weight for _value, weight in rows)
+    if total_weight > 0:
+        return sum(value * weight for value, weight in rows) / total_weight
+    return sum(value for value, _weight in rows) / len(rows)
+
+
+def _county_tick_series_aggregates(graph: GraphProtocol) -> dict[str, float | None]:
+    """County-deduped aggregates of the year-boundary ``tick_*`` attrs.
+
+    Port of ``web/game/engine_bridge.py::_county_tick_series_aggregates``
+    (lines ~8660-8737): every territory in a county carries the SAME
+    county-level ``tick_*`` stamps, so aggregating per TERRITORY would
+    inflate every county quantity N-fold. This dedupes to one representative
+    value per ``county_fips`` (first non-``None`` seen per attr), weights
+    the intensive means by summed county population
+    (:func:`_county_weighted_mean`), and sums the extensive capital stock.
+
+    Honest-sparse by construction (Constitution III.11): ``tick_*`` attrs
+    stamp at year boundaries only and carry forward between them, so every
+    aggregate is ``None`` before the first boundary this session and a step
+    function after — never a fabricated 0.0, never smoothed.
+
+    :param graph: The committed post-tick graph whose territory nodes may
+        carry the ``tick_*`` attrs.
+    :returns: Dict with ``crisis_pop_share`` / ``bifurcation_score_mean`` /
+        ``wage_compression_mean`` / ``capital_stock_total`` /
+        ``unemployment_rate_mean``, each ``float | None``.
+    """
+    pops: dict[str, float] = {}
+    reps: dict[str, dict[str, Any]] = {}
+    for node in graph.query_nodes(node_type=NodeType.TERRITORY):
+        attrs = node.attributes
+        fips = attrs.get("county_fips")
+        if not fips:
+            continue
+        pops[fips] = pops.get(fips, 0.0) + max(0.0, float(attrs.get("population") or 0))
+        rep = reps.setdefault(fips, {})
+        for key in _TICK_SERIES_KEYS:
+            if rep.get(key) is None and attrs.get(key) is not None:
+                rep[key] = attrs[key]
+
+    def weighted_mean(key: str) -> float | None:
+        rows = [
+            (float(rep[key]), pops[fips]) for fips, rep in reps.items() if rep.get(key) is not None
+        ]
+        return _county_weighted_mean(rows)
+
+    phased = [
+        (rep["tick_crisis_phase"], pops[fips])
+        for fips, rep in reps.items()
+        if rep.get("tick_crisis_phase") is not None
+    ]
+    crisis_pop_share: float | None = None
+    if phased:
+        total = sum(weight for _phase, weight in phased)
+        if total > 0:
+            crisis_pop_share = (
+                sum(weight for phase, weight in phased if phase in _CRISIS_ACTIVE_PHASES) / total
+            )
+        else:
+            crisis_pop_share = sum(
+                1 for phase, _weight in phased if phase in _CRISIS_ACTIVE_PHASES
+            ) / len(phased)
+
+    capitals = [
+        float(rep["tick_capital_stock"])
+        for rep in reps.values()
+        if rep.get("tick_capital_stock") is not None
+    ]
+    return {
+        "crisis_pop_share": crisis_pop_share,
+        "bifurcation_score_mean": weighted_mean("tick_bifurcation_score"),
+        "wage_compression_mean": weighted_mean("tick_wage_compression"),
+        "capital_stock_total": sum(capitals) if capitals else None,
+        "unemployment_rate_mean": weighted_mean("tick_unemployment_rate"),
+    }
+
+
+def build_tick_summary_kwargs(
+    world: WorldState,
+    *,
+    graph: GraphProtocol | None = None,
+) -> dict[str, Any]:
+    """Aggregate one committed tick's ``tick_summary`` row from live state.
+
+    Port of ``web/game/engine_bridge.py::_build_tick_summary`` (lines
+    ~9341-9420) — same field semantics, no redesign (see this module's own
+    docstring for the field-by-field ruling and the two deliberate
+    mechanical simplifications: direct enum comparison in place of
+    ``_enum_val``-string matching, and reading ``org_count``/
+    ``player_org_count`` straight off ``WorldState`` rather than an
+    already-``_serialize_organization``-ed list).
+
+    :param world: The committed, post-tick ``WorldState``
+        (``WorldState.from_graph(graph, tick=...)`` — never a bootstrap
+        ``WorldState`` with a stale ``events`` list, since ``events`` is
+        per-tick, not cumulative).
+    :param graph: The SAME committed post-tick graph ``world`` was built
+        from, when the caller has one — unlocks the five county-deduped
+        year-boundary aggregates via :func:`_county_tick_series_aggregates`.
+        ``None`` (tick-0 bootstrap call sites) keeps those five honestly
+        ``None`` rather than fabricating a step-function head.
+    :returns: Kwargs dict for
+        :meth:`~babylon.persistence.postgres_runtime.PostgresRuntime.
+        persist_tick_summary`.
+    """
+    consciousness_values = [
+        float(sc.ideology.class_consciousness) for sc in world.entities.values()
+    ]
+    avg_consciousness = (
+        sum(consciousness_values) / len(consciousness_values) if consciousness_values else None
+    )
+
+    solidarity_edge_count = sum(
+        1 for rel in world.relationships if rel.edge_type == EdgeType.SOLIDARITY
+    )
+    antagonistic_edge_count = sum(
+        1 for rel in world.relationships if rel.edge_type == EdgeType.EXPLOITATION
+    )
+    uprising_count = sum(1 for event in world.events if event.event_type == EventType.UPRISING)
+    repression_count = sum(
+        1 for event in world.events if event.event_type == EventType.STATE_REPRESSION
+    )
+    player_org_count = sum(
+        1 for org in world.organizations.values() if org.id == world.player_org_id
+    )
+
+    return {
+        "year": None,
+        "total_c": None,
+        "total_v": None,
+        "total_s": None,
+        "exploitation_rate": None,
+        "profit_rate": None,
+        "imperial_rent": float(world.economy.imperial_rent_pool) if world.economy else None,
+        "avg_consciousness": avg_consciousness,
+        "solidarity_edge_count": solidarity_edge_count,
+        "antagonistic_edge_count": antagonistic_edge_count,
+        "co_optive_edge_count": None,
+        "org_count": len(world.organizations),
+        "player_org_count": player_org_count,
+        "uprising_count": uprising_count,
+        "repression_count": repression_count,
+        "conservation_check": None,
+        # Program 23 (ADR077): the Market Scissors shadow axis. NULL when the
+        # axis is absent this tick (no value substrate yet) — honest
+        # absence.
+        "price_log": float(world.market.price_log) if world.market else None,
+        "fictitious_log": float(world.market.fictitious_log) if world.market else None,
+        # ADR078: cumulative correction-snap count, same NULL contract.
+        "market_corrections": int(world.market.corrections) if world.market else None,
+        # Playability Spine Task 19 (spec-116 4d.5): county-deduped crisis/
+        # bifurcation history. NULL without a graph or before the first year
+        # boundary — honest sparse (step function), never smoothed.
+        **(_county_tick_series_aggregates(graph) if graph is not None else _EMPTY_TICK_SERIES),
+    }

--- a/src/babylon/projection/tick_summary.py
+++ b/src/babylon/projection/tick_summary.py
@@ -35,9 +35,11 @@ exactly matching the ported ``_build_tick_summary``'s own contract:
   ``_enum_val``-string match, since ``Relationship.edge_type`` is a
   strictly-typed enum field in this module's Pydantic boundary, unlike the
   web bridge's own dict-serialized payloads).
-* ``uprising_count``/``repression_count`` count this tick's raw kernel
+* ``uprising_count`` counts this tick's raw kernel
   :class:`~babylon.kernel.event_bus.Event` history (the ``events=`` param)
-  by ``.type`` against :class:`~babylon.models.enums.events.EventType`
+  by ``.type`` against :class:`~babylon.models.enums.events.EventType`;
+  ``repression_count`` is ALWAYS ``None`` — no production bus publisher
+  for STATE_REPRESSION exists (see the assignment-site comment)
   (REVIEW FIX, T5 U2: the first cut counted ``WorldState.events`` instead,
   which is ALWAYS empty on the Archive path —
   ``WorldState.from_graph()`` reconstructs ``.events`` from
@@ -235,10 +237,11 @@ def build_tick_summary_kwargs(
         ``tuple(bus.get_history())`` — the SAME tuple
         :meth:`~babylon.game.session.GameSession.advance_tick` already
         collects for the Chronicle adapter), used to count
-        ``uprising_count``/``repression_count`` by ``.type``. ``None`` (no
-        history threaded) keeps both columns honestly ``None`` rather than
-        a fabricated ``0`` (Constitution III.11; see this module's own
-        docstring, "REVIEW FIX, T5 U2").
+        ``uprising_count`` by ``.type``. ``None`` (no history threaded)
+        keeps it honestly ``None`` rather than a fabricated ``0``
+        (Constitution III.11). ``repression_count`` is ALWAYS ``None``
+        regardless — no production bus publisher for STATE_REPRESSION
+        exists (see the inline comment at its assignment).
     :returns: Kwargs dict for
         :meth:`~babylon.persistence.postgres_runtime.PostgresRuntime.
         persist_tick_summary`.
@@ -257,13 +260,20 @@ def build_tick_summary_kwargs(
         1 for rel in world.relationships if rel.edge_type == EdgeType.EXPLOITATION
     )
     uprising_count: int | None
-    repression_count: int | None
     if events is None:
         uprising_count = None
-        repression_count = None
     else:
         uprising_count = sum(1 for event in events if event.type == EventType.UPRISING)
-        repression_count = sum(1 for event in events if event.type == EventType.STATE_REPRESSION)
+    # repression_count is honestly NULL, never a bus count: NO production
+    # code publishes STATE_REPRESSION to the kernel bus (the OODA
+    # first-class-action gate covers only POGROM/LOCKOUT/VIGILANTISM; the
+    # type otherwise lives only as a string inside ActionResult.
+    # events_generated), so counting it over bus history is a structural
+    # fabricated 0 (Constitution III.11). The web-bridge reference is
+    # latently 0 for the same reason. Flip this to a real count only when
+    # an engine unit adds a STATE_REPRESSION bus publisher on the REPRESS
+    # path (declared drift ceremony).
+    repression_count: int | None = None
     player_org_count = sum(
         1 for org in world.organizations.values() if org.id == world.player_org_id
     )

--- a/src/babylon/projection/view_models.py
+++ b/src/babylon/projection/view_models.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Annotated, Any, Literal
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
@@ -1013,6 +1014,61 @@ class EconomyView(BaseModel):
     energy_beta_j: float | None = None
 
 
+class NationalTrendView(BaseModel):
+    """One row of ``v_national_trend`` — the declared trend read-model (T5 Unit U2).
+
+    Constitution II.11's declared cross-subsystem read interface over
+    ``tick_summary`` (spec-037; extended by migrations 0033-0035): per-tick
+    ``LAG``-window deltas for the series a real Archive campaign now
+    actually writes (:func:`~babylon.projection.tick_summary.
+    build_tick_summary_kwargs`, wired at :class:`~babylon.game.session.
+    GameSession`'s commit boundary, T5 Unit U2) — Φ (``imperial_rent``, the
+    Fundamental Theorem's Imperial Rent gap) and the Program 23 Market
+    Scissors price⟷value axis (``price_log``/``fictitious_log``,
+    ADR077/078), plus the correction-snap ledger's own foreshadowed
+    increment read (``market_corrections``, a cumulative counter —
+    migration ``0034_market_corrections.sql``'s own docstring: "the
+    cockpit derives the snap ticks from increments"). ``tick_summary``'s
+    remaining columns (``year``/``total_c``/``total_v``/``total_s``/
+    ``exploitation_rate``/``profit_rate``/``co_optive_edge_count``/
+    ``conservation_check``) carry no computed value from any engine system
+    yet (see :func:`~babylon.projection.tick_summary.
+    build_tick_summary_kwargs`'s own docstring) — a trend of a permanently
+    ``NULL`` column is not a signal, so this view does not window them.
+
+    Every ``*_delta`` is ``NULL`` at a session's first committed tick (no
+    prior row for ``LAG`` to read) and whenever either endpoint of the pair
+    is itself ``NULL`` (the axis was absent one side of the step) — honest
+    absence (Constitution III.11), never a fabricated zero.
+
+    :param session_id: The campaign session this row belongs to.
+    :param tick: The committed tick this row summarizes.
+    :param imperial_rent: ``GlobalEconomy.imperial_rent_pool`` this tick.
+    :param imperial_rent_delta: ``imperial_rent - LAG(imperial_rent)``.
+    :param price_log: The Market Scissors price-index log this tick.
+    :param price_log_delta: ``price_log - LAG(price_log)``.
+    :param fictitious_log: The Market Scissors fictitious-capitalization log.
+    :param fictitious_log_delta: ``fictitious_log - LAG(fictitious_log)``.
+    :param market_corrections: Cumulative correction-snap count as of this
+        tick.
+    :param market_corrections_delta: New correction snaps since the prior
+        tick — a positive value marks a snap tick this tick.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    session_id: UUID
+    tick: int = Field(ge=0)
+    imperial_rent: float | None = None
+    imperial_rent_delta: float | None = None
+    price_log: float | None = None
+    price_log_delta: float | None = None
+    fictitious_log: float | None = None
+    fictitious_log_delta: float | None = None
+    market_corrections: int | None = None
+    market_corrections_delta: int | None = None
+
+
 class FieldStateNodeView(BaseModel):
     """One social-class node's Systems #19/#20 field-stack reading (T3 U3).
 
@@ -1616,6 +1672,7 @@ __all__ = [
     "IndustryView",
     "InstitutionView",
     "KeyFigureView",
+    "NationalTrendView",
     "NationalView",
     "OrganizationView",
     "PrincipalFieldView",

--- a/tests/integration/persistence/test_tick_summary_trend_view.py
+++ b/tests/integration/persistence/test_tick_summary_trend_view.py
@@ -1,0 +1,236 @@
+"""Migration-applies proof for 0038 (T5 Unit U2's ``v_national_trend``).
+
+Database-backed leg of ``test_tick_summary_trend_migration.py``'s
+source-level pins — ADR074's test-estate law (Postgres-connected tests
+belong in the integration tier). Follows the ``ensure_ddl_applied`` idiom
+(``test_migration_idempotency.py``'s ``fresh_db_pool`` fixture pattern): a
+fresh, disposable database bootstrapped with the spec-037 schema, then
+migration 0038 applied directly (this test targets ONE migration, not the
+whole runner sequence) — proving the view creates and its ``LAG`` windows
+compute real per-session, per-tick deltas.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+import psycopg
+import pytest
+from psycopg import sql
+
+from babylon.persistence.postgres_schema import ensure_ddl_applied
+
+pytestmark = pytest.mark.integration
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "babylon"
+    / "persistence"
+    / "migrations"
+    / "0038_tick_summary_trend.sql"
+)
+
+
+@pytest.fixture()
+def fresh_db_pool(pg_dsn: str) -> Generator[Any, None, None]:
+    """A pool against a brand-new database, spec-037-bootstrapped then
+    migration-0038-applied — mirrors ``test_migration_idempotency.py``'s
+    own ``fresh_db_pool`` fixture (a disposable per-test database, never
+    the shared ``babylon_test``)."""
+    from psycopg_pool import ConnectionPool
+
+    db_name = f"trend_view_{uuid.uuid4().hex[:12]}"
+    try:
+        admin = psycopg.connect(pg_dsn, autocommit=True)
+    except psycopg.OperationalError:
+        pytest.skip("PostgreSQL not available (set BABYLON_TEST_PG_DSN)")
+    with admin:
+        admin.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(db_name)))
+
+    fresh_dsn = re.sub(r"dbname=\S+", f"dbname={db_name}", pg_dsn)
+    pool = ConnectionPool(conninfo=fresh_dsn, min_size=1, max_size=2, open=True)
+
+    from babylon.persistence.postgres_schema import POSTGRES_SCHEMA_DDL
+
+    with pool.connection() as conn:
+        conn.autocommit = True
+        for ddl in POSTGRES_SCHEMA_DDL:
+            conn.execute(ddl)
+        ensure_ddl_applied(conn, [_MIGRATION.read_text(encoding="utf8")])
+
+    try:
+        yield pool
+    finally:
+        pool.close()
+        with psycopg.connect(pg_dsn, autocommit=True) as admin2:
+            admin2.execute(sql.SQL("DROP DATABASE {} WITH (FORCE)").format(sql.Identifier(db_name)))
+
+
+def _insert_session(pool: Any) -> uuid.UUID:
+    session_id = uuid.uuid4()
+    with pool.connection() as conn:
+        conn.execute(
+            "INSERT INTO game_session (id, scenario) VALUES (%s, %s)",
+            (session_id, "test_scenario"),
+        )
+    return session_id
+
+
+def _insert_tick_summary_row(
+    pool: Any,
+    session_id: uuid.UUID,
+    tick: int,
+    *,
+    imperial_rent: float | None,
+    price_log: float | None,
+    fictitious_log: float | None,
+    market_corrections: int | None,
+) -> None:
+    with pool.connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO tick_summary
+                (session_id, tick, imperial_rent, price_log, fictitious_log, market_corrections)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            (session_id, tick, imperial_rent, price_log, fictitious_log, market_corrections),
+        )
+
+
+class TestViewCreates:
+    def test_view_exists_after_migration(self, fresh_db_pool: Any) -> None:
+        with fresh_db_pool.connection() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM pg_views WHERE viewname = 'v_national_trend'"
+            ).fetchone()
+        assert row is not None
+
+
+class TestLagDeltas:
+    def test_first_tick_has_null_deltas(self, fresh_db_pool: Any) -> None:
+        """No prior row to LAG against — honest NULL, never a fabricated zero."""
+        session_id = _insert_session(fresh_db_pool)
+        _insert_tick_summary_row(
+            fresh_db_pool,
+            session_id,
+            1,
+            imperial_rent=10.0,
+            price_log=0.1,
+            fictitious_log=0.2,
+            market_corrections=0,
+        )
+
+        with fresh_db_pool.connection() as conn:
+            row = conn.execute(
+                "SELECT imperial_rent_delta, price_log_delta, fictitious_log_delta, "
+                "market_corrections_delta FROM v_national_trend "
+                "WHERE session_id = %s AND tick = 1",
+                (session_id,),
+            ).fetchone()
+
+        assert row == (None, None, None, None)
+
+    def test_second_tick_computes_the_real_delta(self, fresh_db_pool: Any) -> None:
+        session_id = _insert_session(fresh_db_pool)
+        _insert_tick_summary_row(
+            fresh_db_pool,
+            session_id,
+            1,
+            imperial_rent=10.0,
+            price_log=0.1,
+            fictitious_log=0.2,
+            market_corrections=0,
+        )
+        _insert_tick_summary_row(
+            fresh_db_pool,
+            session_id,
+            2,
+            imperial_rent=12.5,
+            price_log=0.15,
+            fictitious_log=0.05,
+            market_corrections=1,
+        )
+
+        with fresh_db_pool.connection() as conn:
+            row = conn.execute(
+                "SELECT imperial_rent, imperial_rent_delta, price_log_delta, "
+                "fictitious_log_delta, market_corrections_delta FROM v_national_trend "
+                "WHERE session_id = %s AND tick = 2",
+                (session_id,),
+            ).fetchone()
+
+        assert row[0] == pytest.approx(12.5)
+        assert row[1] == pytest.approx(2.5)
+        assert row[2] == pytest.approx(0.05)
+        assert row[3] == pytest.approx(-0.15)
+        assert row[4] == 1  # one correction snapped between tick 1 and tick 2
+
+    def test_sessions_never_lag_across_each_other(self, fresh_db_pool: Any) -> None:
+        """``PARTITION BY session_id``: two campaigns' tick-1 rows never see
+        each other's history."""
+        session_a = _insert_session(fresh_db_pool)
+        session_b = _insert_session(fresh_db_pool)
+        _insert_tick_summary_row(
+            fresh_db_pool,
+            session_a,
+            1,
+            imperial_rent=100.0,
+            price_log=None,
+            fictitious_log=None,
+            market_corrections=None,
+        )
+        _insert_tick_summary_row(
+            fresh_db_pool,
+            session_b,
+            1,
+            imperial_rent=1.0,
+            price_log=None,
+            fictitious_log=None,
+            market_corrections=None,
+        )
+
+        with fresh_db_pool.connection() as conn:
+            row = conn.execute(
+                "SELECT imperial_rent_delta FROM v_national_trend "
+                "WHERE session_id = %s AND tick = 1",
+                (session_b,),
+            ).fetchone()
+
+        assert row == (None,)
+
+    def test_null_endpoint_yields_null_delta_never_a_fabricated_zero(
+        self, fresh_db_pool: Any
+    ) -> None:
+        session_id = _insert_session(fresh_db_pool)
+        _insert_tick_summary_row(
+            fresh_db_pool,
+            session_id,
+            1,
+            imperial_rent=None,
+            price_log=None,
+            fictitious_log=None,
+            market_corrections=None,
+        )
+        _insert_tick_summary_row(
+            fresh_db_pool,
+            session_id,
+            2,
+            imperial_rent=5.0,
+            price_log=None,
+            fictitious_log=None,
+            market_corrections=None,
+        )
+
+        with fresh_db_pool.connection() as conn:
+            row = conn.execute(
+                "SELECT imperial_rent_delta FROM v_national_trend "
+                "WHERE session_id = %s AND tick = 2",
+                (session_id,),
+            ).fetchone()
+
+        assert row == (None,)

--- a/tests/unit/cli/test_app.py
+++ b/tests/unit/cli/test_app.py
@@ -36,12 +36,25 @@ def test_play_subcommand_boots_the_composition_root(monkeypatch) -> None:  # typ
     """Since Unit C1, ``babylon play`` boots the real campaign session
     (``babylon.game.session``) through ``play_cmd.run``, not the legacy
     two-node demo — ``play_cmd.play_demo`` preserves the old behavior for
-    anyone scripting against it directly, but no entry point calls it."""
-    calls: list[str] = []
-    monkeypatch.setattr(play_cmd, "run", lambda: calls.append("ran"))
+    anyone scripting against it directly, but no entry point calls it.
+
+    T5 Unit U1: ``play`` now threads ``narrator_enabled=`` into ``run`` —
+    ON by default with no flag given."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(play_cmd, "run", lambda **kwargs: calls.append(kwargs))
     result = runner.invoke(app, ["play"])
     assert result.exit_code == 0
-    assert calls == ["ran"]
+    assert calls == [{"narrator_enabled": True}]
+
+
+def test_play_subcommand_no_narrator_flag_disables_the_narrator(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """T5 Unit U1: ``--no-narrator`` threads ``narrator_enabled=False``
+    through to ``run`` — OFF means ``schedule()`` is never called at all."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(play_cmd, "run", lambda **kwargs: calls.append(kwargs))
+    result = runner.invoke(app, ["play", "--no-narrator"])
+    assert result.exit_code == 0
+    assert calls == [{"narrator_enabled": False}]
 
 
 def test_play_demo_preserved_for_direct_scripting(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/unit/cli/test_play.py
+++ b/tests/unit/cli/test_play.py
@@ -143,3 +143,26 @@ def test_run_still_wires_campaign_menu_and_loader(_patched_composition_root: Non
     assert isinstance(runtime, _FakeRuntime)
     assert isinstance(catalog, _FakeMetaStore)
     assert catalog.pool is runtime.pool
+
+
+def test_run_threads_narrator_enabled_default_true_into_the_loader(
+    _patched_composition_root: None,
+) -> None:
+    """T5 Unit U1: ``run()`` with no argument threads ``narrator_enabled=True``
+    (the sensible ON default, R4) into ``_load_campaign``'s partial — never
+    silently dropped."""
+    play_cmd.run()
+
+    loader = _captured[0].kwargs["campaign_loader"]
+    assert loader.keywords == {"narrator_enabled": True}
+
+
+def test_run_threads_narrator_enabled_false_into_the_loader(
+    _patched_composition_root: None,
+) -> None:
+    """``run(narrator_enabled=False)`` — the ``--no-narrator`` path — threads
+    straight through, unweakened."""
+    play_cmd.run(narrator_enabled=False)
+
+    loader = _captured[0].kwargs["campaign_loader"]
+    assert loader.keywords == {"narrator_enabled": False}

--- a/tests/unit/game/test_pacing.py
+++ b/tests/unit/game/test_pacing.py
@@ -540,6 +540,15 @@ class _MinimalFakeStore:
             tick = max(t for sid, t in self._graphs if sid == session_id)
         return self._graphs[(session_id, tick)]
 
+    def persist_tick_summary(
+        self,
+        tick: int,
+        summary: dict[str, Any],
+        *,
+        session_id: Any,
+    ) -> None:
+        pass
+
     def persist_tick_atomic(self, envelope: Any, *, write_commit_marker: bool = True) -> None:
         pass
 

--- a/tests/unit/game/test_session.py
+++ b/tests/unit/game/test_session.py
@@ -442,39 +442,40 @@ def test_advance_tick_persists_tick_summary_in_the_same_batch_as_persist_tick() 
     assert order == ["persist_tick", "persist_tick_summary", "persist_tick_atomic"]
 
 
-class _EmitsUprisingAndRepressionSystem:
-    """Test-only ``System`` stub: publishes one real UPRISING + one real
-    STATE_REPRESSION bus event per tick — no struggle-system trigger
-    conditions (spark/agitation/hopelessness) required. Satisfies
-    ``babylon.kernel.system_protocol.System`` structurally (name + step)."""
+class _EmitsUprisingSystem:
+    """Test-only ``System`` stub: publishes one real UPRISING bus event per
+    tick — the same publication ``StruggleSystem`` performs in production
+    (struggle.py), minus its spark/agitation/hopelessness trigger
+    conditions. Satisfies ``babylon.kernel.system_protocol.System``
+    structurally (name + step). Deliberately does NOT publish
+    STATE_REPRESSION: no production code does, and stubbing a publisher
+    production never implements would green a permanently-dead wire."""
 
-    name = "test_emits_uprising_and_repression"
+    name = "test_emits_uprising"
 
     def step(self, graph: Any, services: Any, context: Any) -> None:  # noqa: ARG002
         services.event_bus.publish(Event(type=EventType.UPRISING, tick=context.tick, payload={}))
-        services.event_bus.publish(
-            Event(type=EventType.STATE_REPRESSION, tick=context.tick, payload={})
-        )
 
 
-def test_advance_tick_persists_real_uprising_and_repression_counts() -> None:
-    """Regression pin (T5 U2 review fix): drives a REAL ``advance_tick``
-    over a tick whose bus emits a real UPRISING + STATE_REPRESSION event,
-    and asserts the PERSISTED ``uprising_count``/``repression_count``
-    reflect them. Before the fix these were structurally always ``0``:
-    ``build_tick_summary_kwargs`` counted ``WorldState.events``, which
-    ``WorldState.from_graph()`` never restamps per tick (only ``to_graph()``
-    writes ``graph.graph['events']``, once, at tick-0 boot) — a fabricated
-    ``0`` where the truth was "not observed" (Constitution III.11)."""
+def test_advance_tick_persists_real_uprising_count_and_null_repression() -> None:
+    """Regression pin (T5 U2 review fix, both halves): drives a REAL
+    ``advance_tick`` over a tick whose bus emits a real UPRISING event and
+    asserts (a) the PERSISTED ``uprising_count`` reflects it — the first
+    cut counted ``WorldState.events``, which ``from_graph()`` never
+    restamps per tick, a fabricated ``0`` — and (b) ``repression_count``
+    is honestly ``None``, NOT a count: no production code publishes
+    STATE_REPRESSION to the bus (the OODA first-class-action gate covers
+    only POGROM/LOCKOUT/VIGILANTISM), so a bus count would be a
+    structurally fabricated ``0`` (Constitution III.11)."""
     store = _FakeStore()
     session = create_new_campaign(store, scenario=WayneCountyScenario())
-    session.engine = SimulationEngine([_EmitsUprisingAndRepressionSystem()])
+    session.engine = SimulationEngine([_EmitsUprisingSystem()])
 
     session.advance_tick()
 
     _tick, summary, _session_id = store.persist_tick_summary_calls[-1]
     assert summary["uprising_count"] == 1
-    assert summary["repression_count"] == 1
+    assert summary["repression_count"] is None
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/game/test_session.py
+++ b/tests/unit/game/test_session.py
@@ -51,6 +51,7 @@ class _FakeStore:
     def __init__(self) -> None:
         self.sessions: dict[UUID, dict[str, Any]] = {}
         self.persist_tick_calls: list[tuple[int, UUID | None]] = []
+        self.persist_tick_summary_calls: list[tuple[int, dict[str, Any], UUID | None]] = []
         self.persist_tick_atomic_calls: list[PerTickTransactionEnvelope] = []
         self.mark_resolved_calls: list[tuple[UUID, int]] = []
         self.get_pending_turns_calls: list[tuple[UUID, int]] = []
@@ -102,6 +103,15 @@ class _FakeStore:
     ) -> None:
         self.persist_tick_calls.append((tick, session_id))
         self._graphs[(session_id, tick)] = graph  # type: ignore[index]
+
+    def persist_tick_summary(
+        self,
+        tick: int,
+        summary: dict[str, Any],
+        *,
+        session_id: UUID,
+    ) -> None:
+        self.persist_tick_summary_calls.append((tick, summary, session_id))
 
     def hydrate_graph(
         self, tick: int | None = None, *, session_id: UUID | None = None
@@ -363,6 +373,70 @@ def test_advance_tick_runs_with_no_progress_store() -> None:
     session = create_new_campaign(store, scenario=WayneCountyScenario())
     result = session.advance_tick()
     assert result.tick == 1
+
+
+# --------------------------------------------------------------------------- #
+# persist_tick_summary wiring (T5 Unit U2) — the tick_summary read-model      #
+# write, previously reachable only through the legacy web bridge.            #
+# --------------------------------------------------------------------------- #
+
+
+def test_advance_tick_persists_tick_summary_at_the_persist_tick_commit_boundary() -> None:
+    """One ``persist_tick_summary`` call per committed tick, with the exact
+    kwargs :func:`~babylon.projection.tick_summary.build_tick_summary_kwargs`
+    computes over this SAME tick's ``world``/``graph`` — never a second,
+    independently-derived payload."""
+    from babylon.projection.tick_summary import build_tick_summary_kwargs
+
+    store = _FakeStore()
+    session = create_new_campaign(store, scenario=WayneCountyScenario())
+
+    result = session.advance_tick()
+
+    assert len(store.persist_tick_summary_calls) == 1
+    tick, summary, session_id = store.persist_tick_summary_calls[0]
+    assert tick == 1
+    assert session_id == session.session_id
+    assert summary == build_tick_summary_kwargs(result.world, graph=session.graph)
+
+
+def test_advance_tick_persists_tick_summary_once_per_further_tick() -> None:
+    store = _FakeStore()
+    session = create_new_campaign(store, scenario=WayneCountyScenario())
+
+    session.advance_tick()
+    session.advance_tick()
+
+    assert [tick for tick, _summary, _sid in store.persist_tick_summary_calls] == [1, 2]
+
+
+def test_advance_tick_persists_tick_summary_in_the_same_batch_as_persist_tick() -> None:
+    """ "Same commit boundary as persist_tick" pinned as call ORDER: the
+    summary write happens strictly between ``persist_tick`` and
+    ``persist_tick_atomic`` (the commit marker), never before the full
+    snapshot or after the tick is already marked committed."""
+    order: list[str] = []
+
+    class _OrderedStore(_FakeStore):
+        def persist_tick(self, *args: Any, **kwargs: Any) -> None:
+            order.append("persist_tick")
+            super().persist_tick(*args, **kwargs)
+
+        def persist_tick_summary(self, *args: Any, **kwargs: Any) -> None:
+            order.append("persist_tick_summary")
+            super().persist_tick_summary(*args, **kwargs)
+
+        def persist_tick_atomic(self, *args: Any, **kwargs: Any) -> None:
+            order.append("persist_tick_atomic")
+            super().persist_tick_atomic(*args, **kwargs)
+
+    store = _OrderedStore()
+    session = create_new_campaign(store, scenario=WayneCountyScenario())
+    order.clear()  # drop tick 0's own boot sequence
+
+    session.advance_tick()
+
+    assert order == ["persist_tick", "persist_tick_summary", "persist_tick_atomic"]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/game/test_session.py
+++ b/tests/unit/game/test_session.py
@@ -10,6 +10,7 @@ trick) — no Postgres required. The PG-reachable integration leg lives at
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -362,6 +363,206 @@ def test_advance_tick_runs_with_no_progress_store() -> None:
     session = create_new_campaign(store, scenario=WayneCountyScenario())
     result = session.advance_tick()
     assert result.tick == 1
+
+
+# --------------------------------------------------------------------------- #
+# NarratorScheduler seam (T5 Unit U1) — one schedule() per committed tick,    #
+# AFTER the deterministic bake, gated entirely on whether a narrator is       #
+# wired at all (narrator=None means schedule() is never called).             #
+# --------------------------------------------------------------------------- #
+
+
+class _RecordingNarrator:
+    """``NarratorScheduler`` double — records every ``schedule()`` call
+    (entity id, tick, and non-empty ``system``/``prompt``) without touching
+    any real provider or vault."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int, str, str]] = []
+
+    def schedule(self, entity_id: str, tick: int, *, system: str, prompt: str) -> None:
+        self.calls.append((entity_id, tick, system, prompt))
+
+
+def test_advance_tick_schedules_narration_exactly_once_per_tick_when_wired() -> None:
+    store = _FakeStore()
+    narrator = _RecordingNarrator()
+    session = create_new_campaign(store, scenario=WayneCountyScenario(), narrator=narrator)
+
+    session.advance_tick()
+    session.advance_tick()
+
+    assert [tick for _entity, tick, _system, _prompt in narrator.calls] == [1, 2]
+    assert all(entity == "national/USA" for entity, _t, _s, _p in narrator.calls)
+    # Real, non-empty (system, prompt) content — never a placeholder call.
+    assert all(system and prompt for _e, _t, system, prompt in narrator.calls)
+
+
+def test_advance_tick_never_schedules_narration_with_no_narrator_wired() -> None:
+    """``narrator=None`` (the default) — ``schedule()`` is never called at
+    all; the pre-Unit-U1 behavior and the narrator-OFF byte-identity
+    guarantee's actual mechanism (see ``TestNarratorVaultParity`` below for
+    the full vault-tree proof)."""
+    store = _FakeStore()
+    session = create_new_campaign(store, scenario=WayneCountyScenario())
+
+    result = session.advance_tick()  # must not raise with nothing wired
+
+    assert result.tick == 1
+
+
+def test_advance_tick_schedules_narration_after_the_deterministic_bake() -> None:
+    """Ordering: the vault's tick-commit observer (the deterministic bake)
+    runs strictly BEFORE narration is scheduled for the same tick."""
+    order: list[str] = []
+
+    class _OrderedObserver(_RecordingObserver):
+        def on_tick_committed(self, *, tick: int, world: Any, graph: Any) -> None:
+            order.append("bake")
+            super().on_tick_committed(tick=tick, world=world, graph=graph)
+
+    class _OrderedNarrator(_RecordingNarrator):
+        def schedule(self, entity_id: str, tick: int, *, system: str, prompt: str) -> None:
+            order.append("narrate")
+            super().schedule(entity_id, tick, system=system, prompt=prompt)
+
+    store = _FakeStore()
+    session = create_new_campaign(
+        store,
+        scenario=WayneCountyScenario(),
+        tick_commit_observer=_OrderedObserver(),
+        narrator=_OrderedNarrator(),
+    )
+    order.clear()  # drop tick 0's own bake (create_new_campaign never narrates tick 0)
+
+    session.advance_tick()
+
+    assert order == ["bake", "narrate"]
+
+
+def _vault_file_bytes(
+    vault_root: Path, *, exclude_top: frozenset[str] = frozenset()
+) -> dict[str, bytes]:
+    """Every real file byte-for-byte under ``vault_root``, excluding ``.git``
+    and any top-level directory named in ``exclude_top`` — the OFF/ON
+    deterministic-page parity comparison helper."""
+    result: dict[str, bytes] = {}
+    for path in sorted(vault_root.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(vault_root)
+        if ".git" in relative.parts or relative.parts[0] in exclude_top:
+            continue
+        result[relative.as_posix()] = path.read_bytes()
+    return result
+
+
+class TestNarratorVaultParity:
+    """T5 Unit U1's determinism-tiering contract, end to end through a real
+    vault: narrator-OFF stays byte-reproducible; narrator-ON schedules
+    exactly once per tick and never perturbs a single deterministic page —
+    only ``narrative/`` differs."""
+
+    @staticmethod
+    def _bake_two_ticks(vault_root: Path, *, narrator: object | None) -> None:
+        from babylon.projection.vault.materializer import VaultMaterializer
+        from babylon.projection.vault.tick_baker import ArchiveTickBaker
+
+        store = _FakeStore()
+        baker = ArchiveTickBaker(VaultMaterializer(vault_root), county_fips=("26163",))
+        session = create_new_campaign(
+            store,
+            scenario=WayneCountyScenario(),
+            tick_commit_observer=baker,
+            narrator=narrator,  # type: ignore[arg-type]
+        )
+        session.advance_tick()
+        session.advance_tick()
+
+    def test_narrator_off_two_independent_bakes_are_byte_identical(self, tmp_path: Path) -> None:
+        """(a) narrator OFF: two identical campaign advances produce
+        byte-identical vault trees."""
+        root_a, root_b = tmp_path / "a", tmp_path / "b"
+        self._bake_two_ticks(root_a, narrator=None)
+        self._bake_two_ticks(root_b, narrator=None)
+
+        assert _vault_file_bytes(root_a) == _vault_file_bytes(root_b)
+
+    def test_narrator_on_schedules_once_per_tick_and_deterministic_pages_match_off(
+        self, tmp_path: Path
+    ) -> None:
+        """(b) narrator ON + MockNarrator: schedule() fires exactly once per
+        committed tick, and every deterministic (non-narrative) page stays
+        byte-identical to the OFF run."""
+        from babylon.intelligence.providers import MockNarrator
+        from babylon.projection.vault.narrator_cache import NarratorCache, NarratorSideProcess
+
+        off_root = tmp_path / "off"
+        self._bake_two_ticks(off_root, narrator=None)
+
+        on_root = tmp_path / "on"
+        mock = MockNarrator(responses=["Beat one.", "Beat two."])
+        narrator = NarratorSideProcess(NarratorCache(on_root), provider=mock)
+        try:
+            self._bake_two_ticks(on_root, narrator=narrator)
+        finally:
+            narrator.close()  # drains the worker before any assertion below
+
+        assert mock.call_count == 2  # exactly one schedule()-driven narrate() per tick
+        assert (on_root / "narrative").is_dir()
+        assert _vault_file_bytes(off_root) == _vault_file_bytes(
+            on_root, exclude_top=frozenset({"narrative"})
+        )
+
+    def test_narrator_provider_failure_never_breaks_the_tick(self, tmp_path: Path) -> None:
+        """(c) a provider that raises does not break the tick — the side
+        process's own isolation (``NarratorSideProcess._run``'s broad
+        ``except Exception``) absorbs even an UNEXPECTED (non-
+        ``ProviderUnavailable``) failure, never propagating into
+        ``advance_tick``."""
+        from babylon.intelligence.providers import (
+            NarrationResult,
+            ProviderEndpoint,
+            ProviderHealth,
+            ProviderKind,
+            ProviderUnavailable,
+        )
+        from babylon.projection.vault.narrator_cache import NarratorCache, NarratorSideProcess
+
+        class _RaisingProvider:
+            endpoint = ProviderEndpoint(
+                kind=ProviderKind.MOCK,
+                base_url="about:mock",
+                chat_model="mock",
+                embed_model="mock",
+            )
+
+            def narrate(
+                self,
+                system: str,  # noqa: ARG002 — NarratorProvider shape
+                prompt: str,  # noqa: ARG002 — NarratorProvider shape
+                *,
+                max_tokens: int = 512,  # noqa: ARG002 — NarratorProvider shape
+                temperature: float = 0.7,  # noqa: ARG002 — NarratorProvider shape
+            ) -> NarrationResult:
+                raise RuntimeError("simulated unexpected narrator failure")
+
+            def embed(self, texts: object) -> object:  # noqa: ARG002
+                raise ProviderUnavailable("n/a")
+
+            def health(self) -> ProviderHealth:
+                return ProviderHealth(ok=True, kind=ProviderKind.MOCK, detail="raising")
+
+        store = _FakeStore()
+        narrator = NarratorSideProcess(
+            NarratorCache(tmp_path / "vault"), provider=_RaisingProvider()
+        )
+        session = create_new_campaign(store, scenario=WayneCountyScenario(), narrator=narrator)
+
+        result = session.advance_tick()  # must not raise
+        narrator.close()  # drains the worker; confirms the failure stayed contained
+
+        assert result.tick == 1
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/game/test_session.py
+++ b/tests/unit/game/test_session.py
@@ -19,6 +19,7 @@ import pytest
 import babylon.game.session as session_module
 from babylon.config.defines import GameDefines
 from babylon.engine.scenarios import WayneCountyScenario
+from babylon.engine.simulation_engine import SimulationEngine
 from babylon.game.chronicle_adapter import chronicle_events_from_bus
 from babylon.game.session import (
     TickAdvanceResult,
@@ -397,7 +398,9 @@ def test_advance_tick_persists_tick_summary_at_the_persist_tick_commit_boundary(
     tick, summary, session_id = store.persist_tick_summary_calls[0]
     assert tick == 1
     assert session_id == session.session_id
-    assert summary == build_tick_summary_kwargs(result.world, graph=session.graph)
+    assert summary == build_tick_summary_kwargs(
+        result.world, graph=session.graph, events=result.events
+    )
 
 
 def test_advance_tick_persists_tick_summary_once_per_further_tick() -> None:
@@ -437,6 +440,41 @@ def test_advance_tick_persists_tick_summary_in_the_same_batch_as_persist_tick() 
     session.advance_tick()
 
     assert order == ["persist_tick", "persist_tick_summary", "persist_tick_atomic"]
+
+
+class _EmitsUprisingAndRepressionSystem:
+    """Test-only ``System`` stub: publishes one real UPRISING + one real
+    STATE_REPRESSION bus event per tick — no struggle-system trigger
+    conditions (spark/agitation/hopelessness) required. Satisfies
+    ``babylon.kernel.system_protocol.System`` structurally (name + step)."""
+
+    name = "test_emits_uprising_and_repression"
+
+    def step(self, graph: Any, services: Any, context: Any) -> None:  # noqa: ARG002
+        services.event_bus.publish(Event(type=EventType.UPRISING, tick=context.tick, payload={}))
+        services.event_bus.publish(
+            Event(type=EventType.STATE_REPRESSION, tick=context.tick, payload={})
+        )
+
+
+def test_advance_tick_persists_real_uprising_and_repression_counts() -> None:
+    """Regression pin (T5 U2 review fix): drives a REAL ``advance_tick``
+    over a tick whose bus emits a real UPRISING + STATE_REPRESSION event,
+    and asserts the PERSISTED ``uprising_count``/``repression_count``
+    reflect them. Before the fix these were structurally always ``0``:
+    ``build_tick_summary_kwargs`` counted ``WorldState.events``, which
+    ``WorldState.from_graph()`` never restamps per tick (only ``to_graph()``
+    writes ``graph.graph['events']``, once, at tick-0 boot) — a fabricated
+    ``0`` where the truth was "not observed" (Constitution III.11)."""
+    store = _FakeStore()
+    session = create_new_campaign(store, scenario=WayneCountyScenario())
+    session.engine = SimulationEngine([_EmitsUprisingAndRepressionSystem()])
+
+    session.advance_tick()
+
+    _tick, summary, _session_id = store.persist_tick_summary_calls[-1]
+    assert summary["uprising_count"] == 1
+    assert summary["repression_count"] == 1
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/intelligence/test_corpus_manifest.py
+++ b/tests/unit/intelligence/test_corpus_manifest.py
@@ -1,0 +1,330 @@
+"""Behavioral contract for the corpus manifest (ADR107, T5 U3).
+
+Replaces the hardcoded ``MVP_CORPUS`` tuple in ``tools/ingest_corpus.py``
+with a declarative manifest (mirrors
+:mod:`babylon.intelligence.model_manifest`'s validation style). Unit tests
+never touch the real ``~/Documents/ocr/`` tree — every glob-resolution test
+below builds its own tmp fixture tree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from babylon.intelligence.corpus_manifest import (
+    APOCRYPHA_DIR_NAME,
+    CanonStatus,
+    CorpusFormat,
+    CorpusManifest,
+    CorpusRole,
+    load_bundled_manifest,
+    load_manifest,
+    parse_manifest,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _row(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "path_glob": "author-x/work-y/*.txt",
+        "author": "Author X",
+        "work": "Work Y",
+        "role": ["narrator"],
+        "format": "txt",
+        "canon_status": "allow",
+        "provenance": "test fixture row",
+    }
+    base.update(overrides)
+    return base
+
+
+# =============================================================================
+# 1. Loader validation — closed vocabularies red loudly (Do item 4)
+# =============================================================================
+
+
+class TestClosedVocabularies:
+    def test_valid_row_parses(self) -> None:
+        manifest = parse_manifest({"rows": [_row()]})
+        assert len(manifest.rows) == 1
+        row = manifest.rows[0]
+        assert row.canon_status is CanonStatus.ALLOW
+        assert row.role == (CorpusRole.NARRATOR,)
+        assert row.format is CorpusFormat.TXT
+
+    def test_bad_role_reds_loudly(self) -> None:
+        with pytest.raises(ValidationError):
+            parse_manifest({"rows": [_row(role=["not_a_real_role"])]})
+
+    def test_bad_canon_status_reds_loudly(self) -> None:
+        with pytest.raises(ValidationError):
+            parse_manifest({"rows": [_row(canon_status="maybe")]})
+
+    def test_bad_format_reds_loudly(self) -> None:
+        with pytest.raises(ValidationError):
+            parse_manifest({"rows": [_row(format="pdf")]})
+
+    def test_empty_role_list_reds_loudly(self) -> None:
+        with pytest.raises(ValidationError):
+            parse_manifest({"rows": [_row(role=[])]})
+
+    def test_multi_valued_role_accepted(self) -> None:
+        manifest = parse_manifest({"rows": [_row(role=["narrator", "doctrine", "atlas_cn"])]})
+        assert manifest.rows[0].role == (
+            CorpusRole.NARRATOR,
+            CorpusRole.DOCTRINE,
+            CorpusRole.ATLAS_CN,
+        )
+
+
+# =============================================================================
+# 2. Apocrypha glob-fencing (ADR107) — both directions
+# =============================================================================
+
+
+class TestApocryphaFencing:
+    def test_apocryphal_row_must_resolve_into_apocrypha_dir(self) -> None:
+        with pytest.raises(ValidationError, match="apocryphal"):
+            parse_manifest(
+                {"rows": [_row(path_glob="author-x/work-y/*.txt", canon_status="apocryphal")]}
+            )
+
+    def test_non_apocryphal_row_forbidden_inside_apocrypha_dir(self) -> None:
+        with pytest.raises(ValidationError, match=APOCRYPHA_DIR_NAME):
+            parse_manifest(
+                {
+                    "rows": [
+                        _row(path_glob=f"{APOCRYPHA_DIR_NAME}/content.jsonl", canon_status="allow")
+                    ]
+                }
+            )
+
+    def test_apocryphal_row_pointing_into_apocrypha_dir_is_valid(self) -> None:
+        manifest = parse_manifest(
+            {
+                "rows": [
+                    _row(
+                        path_glob=f"{APOCRYPHA_DIR_NAME}/content.jsonl",
+                        canon_status="apocryphal",
+                        format="jsonl",
+                    )
+                ]
+            }
+        )
+        assert manifest.rows[0].canon_status is CanonStatus.APOCRYPHAL
+
+
+# =============================================================================
+# 3. Deny-inside-allow precedence, presence, and deterministic ordering
+#    (Do item 4) — every test below builds its own tmp fixture tree.
+# =============================================================================
+
+
+class TestDenyInsideAllowPrecedence:
+    def test_deny_row_wins_inside_an_enclosing_allow_glob(self, tmp_path: Path) -> None:
+        # The "Trotsky-quoted-for-rebuttal" case: one broad allow glob sweeps
+        # over several authors' subdirectories; a deny row nested inside it
+        # must still exclude that author's files.
+        (tmp_path / "classics" / "marx").mkdir(parents=True)
+        (tmp_path / "classics" / "trotsky").mkdir(parents=True)
+        marx_file = tmp_path / "classics" / "marx" / "capital.txt"
+        marx_file.write_text("value theory")
+        trotsky_file = tmp_path / "classics" / "trotsky" / "permanent-revolution.txt"
+        trotsky_file.write_text("denied position")
+
+        manifest = parse_manifest(
+            {
+                "rows": [
+                    _row(path_glob="classics/**/*.txt", canon_status="allow"),
+                    _row(path_glob="classics/trotsky/**/*.txt", canon_status="deny"),
+                ]
+            }
+        )
+
+        resolved = manifest.resolve_ingestible_files(tmp_path)
+        assert marx_file in resolved
+        assert trotsky_file not in resolved
+
+    def test_flag_bd_row_never_appears_in_ingestible_files(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "nitzan-bichler" / "capital-as-power"
+        work_dir.mkdir(parents=True)
+        flagged_file = work_dir / "full.txt"
+        flagged_file.write_text("adversarial-only steelman text")
+
+        manifest = parse_manifest(
+            {
+                "rows": [
+                    _row(path_glob="nitzan-bichler/capital-as-power/*.txt", canon_status="flag_bd")
+                ]
+            }
+        )
+
+        assert manifest.resolve_ingestible_files(tmp_path) == ()
+
+    def test_apocryphal_row_never_appears_in_ingestible_files(self, tmp_path: Path) -> None:
+        (tmp_path / APOCRYPHA_DIR_NAME).mkdir(parents=True)
+        apocrypha_file = tmp_path / APOCRYPHA_DIR_NAME / "content.jsonl"
+        apocrypha_file.write_text('{"text": "pastiche"}\n')
+
+        manifest = parse_manifest(
+            {
+                "rows": [
+                    _row(
+                        path_glob=f"{APOCRYPHA_DIR_NAME}/content.jsonl",
+                        canon_status="apocryphal",
+                        format="jsonl",
+                    )
+                ]
+            }
+        )
+
+        assert manifest.resolve_ingestible_files(tmp_path) == ()
+
+
+class TestPresenceReporting:
+    def test_absent_row_reports_empty_files_not_an_error(self, tmp_path: Path) -> None:
+        # corpus_root exists but this row's work has not been extracted yet —
+        # a MANIFEST fact, never an exception.
+        manifest = parse_manifest(
+            {
+                "rows": [
+                    _row(path_glob="fanon/the-wretched-of-the-earth/*.txt", canon_status="allow")
+                ]
+            }
+        )
+
+        targets = manifest.ingest_targets(tmp_path)
+        assert len(targets) == 1
+        assert targets[0].files == ()
+        assert targets[0].present is False
+
+    def test_entirely_absent_corpus_root_reports_empty_without_error(self, tmp_path: Path) -> None:
+        missing_root = tmp_path / "does-not-exist"
+        manifest = parse_manifest(
+            {
+                "rows": [
+                    _row(path_glob="fanon/the-wretched-of-the-earth/*.txt", canon_status="allow")
+                ]
+            }
+        )
+
+        targets = manifest.ingest_targets(missing_root)
+        assert targets[0].files == ()
+
+    def test_present_row_reports_matched_files(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "author-x" / "work-y"
+        work_dir.mkdir(parents=True)
+        (work_dir / "full.txt").write_text("body")
+
+        manifest = parse_manifest({"rows": [_row()]})
+        targets = manifest.ingest_targets(tmp_path)
+        assert targets[0].present is True
+        assert len(targets[0].files) == 1
+
+
+class TestDeterministicOrdering:
+    def test_files_within_a_row_are_sorted_regardless_of_creation_order(
+        self, tmp_path: Path
+    ) -> None:
+        work_dir = tmp_path / "mao" / "selected-works-curated"
+        work_dir.mkdir(parents=True)
+        # Write chapters out of order on purpose.
+        (work_dir / "ch-03.txt").write_text("three")
+        (work_dir / "ch-01.txt").write_text("one")
+        (work_dir / "ch-02.txt").write_text("two")
+
+        manifest = parse_manifest(
+            {"rows": [_row(path_glob="mao/selected-works-curated/*.txt", canon_status="allow")]}
+        )
+
+        files = manifest.ingest_targets(tmp_path)[0].files
+        assert [f.name for f in files] == ["ch-01.txt", "ch-02.txt", "ch-03.txt"]
+
+    def test_rows_are_returned_in_manifest_declaration_order(self, tmp_path: Path) -> None:
+        manifest = parse_manifest(
+            {
+                "rows": [
+                    _row(path_glob="zebra/work/*.txt", work="Zebra Work", canon_status="allow"),
+                    _row(path_glob="apple/work/*.txt", work="Apple Work", canon_status="allow"),
+                ]
+            }
+        )
+
+        targets = manifest.ingest_targets(tmp_path)
+        assert [t.row.work for t in targets] == ["Zebra Work", "Apple Work"]
+
+
+# =============================================================================
+# 4. load_manifest — the test-injectable file loader (never the real tree)
+# =============================================================================
+
+
+class TestLoadManifestFromPath:
+    def test_load_manifest_reads_a_yaml_fixture(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text(
+            "rows:\n"
+            "  - path_glob: 'author-x/work-y/*.txt'\n"
+            "    author: 'Author X'\n"
+            "    work: 'Work Y'\n"
+            "    role: [narrator]\n"
+            "    format: txt\n"
+            "    canon_status: allow\n"
+            "    provenance: 'fixture'\n"
+        )
+
+        manifest = load_manifest(manifest_path)
+        assert isinstance(manifest, CorpusManifest)
+        assert len(manifest.rows) == 1
+        assert manifest.rows[0].author == "Author X"
+
+
+# =============================================================================
+# 5. The bundled production manifest — sanity checks against the real file
+#    this unit ships (src/babylon/data/corpus/manifest.yaml). Still no I/O
+#    against ~/Documents/ocr/ — glob resolution against the real corpus root
+#    is exercised only by the presence tests above, on tmp fixtures.
+# =============================================================================
+
+
+class TestBundledManifest:
+    def test_bundled_manifest_loads_and_validates(self) -> None:
+        manifest = load_bundled_manifest()
+        assert isinstance(manifest, CorpusManifest)
+        assert len(manifest.rows) > 0
+
+    def test_bundled_manifest_has_the_v1_nine_work_allow_set(self) -> None:
+        manifest = load_bundled_manifest()
+        assert len(manifest.allow_rows()) == 9
+
+    def test_bundled_manifest_denies_the_ruled_out_authors(self) -> None:
+        manifest = load_bundled_manifest()
+        denied_authors = {row.author for row in manifest.deny_rows()}
+        assert denied_authors == {
+            "Leon Trotsky",
+            "Karl Kautsky",
+            "Communist Party USA",
+            "Enver Hoxha",
+        }
+
+    def test_bundled_manifest_has_exactly_one_apocryphal_row_fenced(self) -> None:
+        manifest = load_bundled_manifest()
+        apocryphal = manifest.apocryphal_rows()
+        assert len(apocryphal) == 1
+        assert APOCRYPHA_DIR_NAME in Path(apocryphal[0].path_glob).parts
+
+    def test_bundled_manifest_has_a_flag_bd_row(self) -> None:
+        manifest = load_bundled_manifest()
+        assert len(manifest.flag_bd_rows()) >= 1
+
+    def test_bundled_manifest_no_row_glob_resolves_into_apocrypha_unless_apocryphal(
+        self,
+    ) -> None:
+        manifest = load_bundled_manifest()
+        for row in manifest.rows:
+            resolves_into_apocrypha = APOCRYPHA_DIR_NAME in Path(row.path_glob).parts
+            assert resolves_into_apocrypha == (row.canon_status is CanonStatus.APOCRYPHAL)

--- a/tests/unit/intelligence/test_corpus_manifest.py
+++ b/tests/unit/intelligence/test_corpus_manifest.py
@@ -185,6 +185,84 @@ class TestDenyInsideAllowPrecedence:
         assert manifest.resolve_ingestible_files(tmp_path) == ()
 
 
+class TestBroadAllowGlobDoesNotLeakNonAllowFiles:
+    """Reviewer-reproduced regression: a broad allow glob whose literal
+    string never mentions a non-allow row's directory still RESOLVES into it
+    at runtime. ``ingest_targets`` must exclude those files by set difference
+    over ALL non-allow rows (not deny rows alone) — a narrow per-row glob
+    check on the string is not enough.
+    """
+
+    def test_broad_allow_glob_does_not_leak_apocrypha_files(self, tmp_path: Path) -> None:
+        (tmp_path / APOCRYPHA_DIR_NAME).mkdir(parents=True)
+        apocrypha_file = tmp_path / APOCRYPHA_DIR_NAME / "content.jsonl"
+        apocrypha_file.write_text('{"text": "pastiche"}\n')
+        real_file = tmp_path / "real.jsonl"
+        real_file.write_text('{"text": "canon"}\n')
+
+        manifest = parse_manifest(
+            {
+                "rows": [
+                    _row(path_glob="**/*.jsonl", format="jsonl", canon_status="allow"),
+                    _row(
+                        path_glob=f"{APOCRYPHA_DIR_NAME}/content.jsonl",
+                        canon_status="apocryphal",
+                        format="jsonl",
+                    ),
+                ]
+            }
+        )
+
+        resolved = manifest.resolve_ingestible_files(tmp_path)
+        assert real_file in resolved
+        assert apocrypha_file not in resolved
+
+    def test_broad_allow_glob_does_not_leak_flag_bd_files(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "nitzan-bichler" / "capital-as-power"
+        work_dir.mkdir(parents=True)
+        flagged_file = work_dir / "full.txt"
+        flagged_file.write_text("adversarial-only steelman text")
+        real_dir = tmp_path / "zak-cope" / "divided-world-divided-class"
+        real_dir.mkdir(parents=True)
+        real_file = real_dir / "full.txt"
+        real_file.write_text("canon body")
+
+        manifest = parse_manifest(
+            {
+                "rows": [
+                    _row(path_glob="**/*.txt", canon_status="allow"),
+                    _row(
+                        path_glob="nitzan-bichler/capital-as-power/*.txt",
+                        canon_status="flag_bd",
+                    ),
+                ]
+            }
+        )
+
+        resolved = manifest.resolve_ingestible_files(tmp_path)
+        assert real_file in resolved
+        assert flagged_file not in resolved
+
+    def test_apocrypha_dir_excluded_structurally_even_without_a_matching_row(
+        self, tmp_path: Path
+    ) -> None:
+        # The independent structural fence (_under_apocrypha): even with NO
+        # row declaring canon_status=apocryphal for this exact path (so
+        # nothing exists in the per-row exclusion set for it), a resolved
+        # file under _apocrypha/ must still never surface.
+        (tmp_path / APOCRYPHA_DIR_NAME).mkdir(parents=True)
+        apocrypha_file = tmp_path / APOCRYPHA_DIR_NAME / "stray.txt"
+        apocrypha_file.write_text("should never surface")
+        real_file = tmp_path / "canon.txt"
+        real_file.write_text("canon body")
+
+        manifest = parse_manifest({"rows": [_row(path_glob="**/*.txt", canon_status="allow")]})
+
+        resolved = manifest.resolve_ingestible_files(tmp_path)
+        assert real_file in resolved
+        assert apocrypha_file not in resolved
+
+
 class TestPresenceReporting:
     def test_absent_row_reports_empty_files_not_an_error(self, tmp_path: Path) -> None:
         # corpus_root exists but this row's work has not been extracted yet —

--- a/tests/unit/persistence/test_tick_summary_trend_migration.py
+++ b/tests/unit/persistence/test_tick_summary_trend_migration.py
@@ -1,0 +1,108 @@
+"""Source-level pins for migration 0038 (T5 Unit U2's ``v_national_trend``).
+
+No database needed — pure text assertions on the migration file itself,
+mirroring ``test_no_stored_aggregate_rows.py``'s scan idiom. The
+database-backed proof (the view actually creates and its ``LAG`` windows
+compute correctly against real rows) lives in
+``tests/integration/persistence/test_tick_summary_trend_view.py`` per the
+test-estate law (ADR074: Postgres-connected tests are integration tier).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "babylon"
+    / "persistence"
+    / "migrations"
+    / "0038_tick_summary_trend.sql"
+)
+
+
+@pytest.fixture
+def sql() -> str:
+    return _MIGRATION.read_text(encoding="utf8")
+
+
+@pytest.fixture
+def view_body(sql: str) -> str:
+    """Just the ``CREATE VIEW ... FROM tick_summary;`` statement — excludes
+    the file's explanatory header comments (which legitimately NAME the
+    permanently-NULL columns while explaining why they are excluded)."""
+    start = sql.index("CREATE VIEW v_national_trend AS")
+    end = sql.index("FROM tick_summary;", start) + len("FROM tick_summary;")
+    return sql[start:end]
+
+
+class TestGuardedOnTickSummaryPresence:
+    """``tick_summary`` is a spec-037 bootstrap table, not migration-created —
+    a migrations-only database must not hard-fail here (0033's guard idiom)."""
+
+    def test_guarded_on_to_regclass(self, sql: str) -> None:
+        assert "to_regclass('tick_summary') IS NOT NULL" in sql
+
+    def test_view_ddl_lives_inside_the_guard(self, sql: str) -> None:
+        guard_start = sql.index("to_regclass('tick_summary') IS NOT NULL")
+        end_marker = sql.index("END", guard_start)
+        guarded_body = sql[guard_start:end_marker]
+        assert "DROP VIEW IF EXISTS v_national_trend" in guarded_body
+        assert "CREATE VIEW v_national_trend AS" in guarded_body
+
+
+class TestViewShape:
+    """``DROP VIEW IF EXISTS`` + ``CREATE VIEW`` — never ``CREATE OR REPLACE``
+    (which forbids changing a view's declared column set, the 0030 idiom)."""
+
+    def test_drop_then_create_never_create_or_replace(self, sql: str) -> None:
+        assert "DROP VIEW IF EXISTS v_national_trend" in sql
+        assert "CREATE VIEW v_national_trend AS" in sql
+        assert "CREATE OR REPLACE VIEW v_national_trend" not in sql
+
+    def test_reads_from_tick_summary(self, sql: str) -> None:
+        assert "FROM tick_summary" in sql
+
+    def test_one_view_only(self, sql: str) -> None:
+        """Kept to ONE view — tick_summary has no per-scope breakdown to
+        window separately (unlike the county/state/national hex aggregates)."""
+        assert sql.count("CREATE VIEW") == 1
+
+
+class TestLagWindows:
+    """Deterministic per-session, per-tick ``LAG`` deltas — the DeclaredView
+    ``order_by`` contract (Constitution III.13) lives on the registry entry,
+    not inside the view itself (matching 0030's own views)."""
+
+    def test_four_lag_windows_partitioned_and_ordered_correctly(self, view_body: str) -> None:
+        assert view_body.count("LAG(") == 4
+        assert view_body.count("PARTITION BY session_id ORDER BY tick") == 4
+
+    def test_windows_cover_imperial_rent_price_and_market_corrections(self, view_body: str) -> None:
+        for column in ("imperial_rent", "price_log", "fictitious_log", "market_corrections"):
+            assert column in view_body, column
+        for delta in (
+            "imperial_rent_delta",
+            "price_log_delta",
+            "fictitious_log_delta",
+            "market_corrections_delta",
+        ):
+            assert delta in view_body, delta
+
+    def test_never_windows_the_permanently_null_columns(self, view_body: str) -> None:
+        """A trend of a column no engine system computes yet is not a signal."""
+        for column in (
+            "total_c",
+            "total_v",
+            "total_s",
+            "exploitation_rate",
+            "profit_rate",
+            "co_optive_edge_count",
+            "conservation_check",
+        ):
+            assert column not in view_body, column

--- a/tests/unit/projection/test_registry.py
+++ b/tests/unit/projection/test_registry.py
@@ -20,6 +20,7 @@ _REQUIRED_VIEWS = frozenset(
         "v_state_value_aggregate",
         "v_national_value_aggregate",
         "v_global_phi_balance",
+        "v_national_trend",
     }
 )
 
@@ -60,6 +61,27 @@ def test_declared_view_looks_up_by_name() -> None:
     view = declared_view("v_county_value_aggregate")
     assert view.name == "v_county_value_aggregate"
     assert view.view_model.__name__ == "CountyValueAggregate"
+
+
+def test_national_trend_view_is_declared_correctly() -> None:
+    """T5 Unit U2: v_national_trend's contract — deterministic order, the
+    tick_summary-derived column set, and its own row-model."""
+    view = declared_view("v_national_trend")
+    assert view.order_by == "session_id, tick"
+    assert view.view_model.__name__ == "NationalTrendView"
+    assert view.columns == (
+        "session_id",
+        "tick",
+        "imperial_rent",
+        "imperial_rent_delta",
+        "price_log",
+        "price_log_delta",
+        "fictitious_log",
+        "fictitious_log_delta",
+        "market_corrections",
+        "market_corrections_delta",
+    )
+    assert view.ownership_ambiguous is False
 
 
 def test_declared_view_raises_loudly_on_unknown_name() -> None:

--- a/tests/unit/projection/test_tick_summary.py
+++ b/tests/unit/projection/test_tick_summary.py
@@ -1,0 +1,274 @@
+"""Contract tests for :func:`babylon.projection.tick_summary.build_tick_summary_kwargs`.
+
+Port of ``web/game/engine_bridge.py::_build_tick_summary`` (T5 Unit U2, the
+same dormant-construct pattern T3 closed for field-state): same field
+semantics, no redesign. The market-axis and county-series-aggregate cases
+below reuse the EXACT golden values from
+``tests/unit/web/test_engine_bridge.py``'s ``TestBuildTickSummaryMarketAxis``
+/ ``TestBuildTickSummarySeriesAggregates`` — the ported logic is checked
+against the SAME numbers, not independently re-derived ones.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from babylon.engine.factories import create_proletariat
+from babylon.models.entities.economy import GlobalEconomy
+from babylon.models.entities.organization import CivilSocietyOrg
+from babylon.models.entities.relationship import Relationship
+from babylon.models.entities.social_class import IdeologicalProfile
+from babylon.models.enums import ClassCharacter, EdgeType, EventType, ServiceType
+from babylon.models.enums.topology import NodeType
+from babylon.models.events import SimulationEvent
+from babylon.models.market import MarketState
+from babylon.models.world_state import WorldState
+from babylon.projection.tick_summary import build_tick_summary_kwargs
+from babylon.topology import BabylonGraph
+
+_ALWAYS_NULL_KEYS = (
+    "year",
+    "total_c",
+    "total_v",
+    "total_s",
+    "exploitation_rate",
+    "profit_rate",
+    "co_optive_edge_count",
+    "conservation_check",
+)
+
+
+class TestAlwaysNullColumns:
+    """No engine system computes these yet — the ported source's own honest gap."""
+
+    def test_never_fabricated(self) -> None:
+        summary = build_tick_summary_kwargs(WorldState(tick=1))
+        for key in _ALWAYS_NULL_KEYS:
+            assert summary[key] is None, key
+
+
+class TestImperialRent:
+    def test_reads_the_economy_pool(self) -> None:
+        world = WorldState(tick=5, economy=GlobalEconomy(imperial_rent_pool=1.25))
+        summary = build_tick_summary_kwargs(world)
+        assert summary["imperial_rent"] == pytest.approx(1.25)
+
+
+class TestAvgConsciousness:
+    def test_none_with_no_entities(self) -> None:
+        summary = build_tick_summary_kwargs(WorldState(tick=1))
+        assert summary["avg_consciousness"] is None
+
+    def test_averages_class_consciousness_across_entities(self) -> None:
+        e1 = create_proletariat(
+            id="C001",
+            ideology=IdeologicalProfile(class_consciousness=0.8, national_identity=0.2),
+        )
+        e2 = create_proletariat(
+            id="C002",
+            ideology=IdeologicalProfile(class_consciousness=0.4, national_identity=0.5),
+        )
+        world = WorldState(tick=1, entities={"C001": e1, "C002": e2})
+        summary = build_tick_summary_kwargs(world)
+        assert summary["avg_consciousness"] == pytest.approx(0.6)
+
+
+class TestEdgeCounts:
+    def test_counts_solidarity_and_exploitation_edges_only(self) -> None:
+        world = WorldState(
+            tick=1,
+            relationships=[
+                Relationship(source_id="C001", target_id="C002", edge_type=EdgeType.SOLIDARITY),
+                Relationship(source_id="C001", target_id="C003", edge_type=EdgeType.SOLIDARITY),
+                Relationship(source_id="C002", target_id="C003", edge_type=EdgeType.EXPLOITATION),
+                Relationship(source_id="C002", target_id="C001", edge_type=EdgeType.WAGES),
+            ],
+        )
+        summary = build_tick_summary_kwargs(world)
+        assert summary["solidarity_edge_count"] == 2
+        assert summary["antagonistic_edge_count"] == 1
+
+
+class TestOrgCounts:
+    @staticmethod
+    def _org(org_id: str) -> CivilSocietyOrg:
+        return CivilSocietyOrg(
+            id=org_id,
+            name=org_id,
+            class_character=ClassCharacter.PROLETARIAN,
+            service_type=ServiceType.RELIGIOUS,
+        )
+
+    def test_org_count_and_player_org_count(self) -> None:
+        world = WorldState(
+            tick=1,
+            organizations={"ORG1": self._org("ORG1"), "ORG2": self._org("ORG2")},
+            player_org_id="ORG2",
+        )
+        summary = build_tick_summary_kwargs(world)
+        assert summary["org_count"] == 2
+        assert summary["player_org_count"] == 1
+
+    def test_player_org_count_zero_with_no_player_org_set(self) -> None:
+        world = WorldState(tick=1, organizations={"ORG1": self._org("ORG1")})
+        summary = build_tick_summary_kwargs(world)
+        assert summary["org_count"] == 1
+        assert summary["player_org_count"] == 0
+
+
+class TestEventCounts:
+    def test_counts_uprising_and_repression_events_only(self) -> None:
+        world = WorldState(
+            tick=1,
+            events=[
+                SimulationEvent(event_type=EventType.UPRISING, tick=1),
+                SimulationEvent(event_type=EventType.UPRISING, tick=1),
+                SimulationEvent(event_type=EventType.STATE_REPRESSION, tick=1),
+                SimulationEvent(event_type=EventType.LIFECYCLE_TRANSITION, tick=1),
+            ],
+        )
+        summary = build_tick_summary_kwargs(world)
+        assert summary["uprising_count"] == 2
+        assert summary["repression_count"] == 1
+
+
+class TestMarketAxis:
+    """Golden parity with ``TestBuildTickSummaryMarketAxis`` (web bridge)."""
+
+    def test_market_axis_flows_into_summary_columns(self) -> None:
+        world = WorldState(
+            tick=3,
+            market=MarketState(
+                price_log=0.25,
+                price_velocity=0.0,
+                fictitious_log=-0.1,
+                fictitious_velocity=0.0,
+                surplus_ema=1.0,
+                value_ema=4.0,
+                tick=3,
+            ),
+        )
+        summary = build_tick_summary_kwargs(world)
+        assert summary["price_log"] == pytest.approx(0.25)
+        assert summary["fictitious_log"] == pytest.approx(-0.1)
+        assert summary["market_corrections"] == 0  # ledger present with the axis
+
+    def test_correction_ledger_flows_into_summary(self) -> None:
+        world = WorldState(
+            tick=12,
+            market=MarketState(
+                price_log=0.1,
+                price_velocity=0.0,
+                fictitious_log=0.2,
+                fictitious_velocity=0.0,
+                surplus_ema=1.0,
+                value_ema=4.0,
+                tick=12,
+                corrections=2,
+                last_correction_tick=11,
+            ),
+        )
+        summary = build_tick_summary_kwargs(world)
+        assert summary["market_corrections"] == 2
+
+    def test_absent_axis_is_honest_null(self) -> None:
+        summary = build_tick_summary_kwargs(WorldState(tick=1))
+        assert summary["price_log"] is None
+        assert summary["fictitious_log"] is None
+        assert summary["market_corrections"] is None
+
+
+class TestCountySeriesAggregates:
+    """Golden parity with ``TestBuildTickSummarySeriesAggregates`` (web bridge)."""
+
+    _SERIES_KEYS = (
+        "crisis_pop_share",
+        "bifurcation_score_mean",
+        "wage_compression_mean",
+        "capital_stock_total",
+        "unemployment_rate_mean",
+    )
+
+    @staticmethod
+    def _graph_with_two_counties() -> BabylonGraph:
+        graph = BabylonGraph()
+        # T1/T2 share one county and carry IDENTICAL county-level stamps —
+        # they must count ONCE (the _county_flow_snapshot N-fold-inflation
+        # hazard), never once per territory.
+        graph.add_node(
+            "T1",
+            NodeType.TERRITORY,
+            county_fips="26163",
+            population=1_000_000,
+            tick_crisis_phase="deep",
+            tick_bifurcation_score=-0.5,
+            tick_wage_compression=0.2,
+            tick_capital_stock=1e9,
+            tick_unemployment_rate=0.10,
+        )
+        graph.add_node(
+            "T2",
+            NodeType.TERRITORY,
+            county_fips="26163",
+            population=500_000,
+            tick_crisis_phase="deep",
+            tick_bifurcation_score=-0.5,
+            tick_wage_compression=0.2,
+            tick_capital_stock=1e9,
+            tick_unemployment_rate=0.10,
+        )
+        graph.add_node(
+            "T3",
+            NodeType.TERRITORY,
+            county_fips="26125",
+            population=500_000,
+            tick_crisis_phase="normal",
+            tick_bifurcation_score=0.3,
+            tick_wage_compression=0.0,
+            tick_capital_stock=2e9,
+            tick_unemployment_rate=0.05,
+        )
+        return graph
+
+    def test_aggregates_are_county_deduped_and_population_weighted(self) -> None:
+        summary = build_tick_summary_kwargs(
+            WorldState(tick=52), graph=self._graph_with_two_counties()
+        )
+
+        # Wayne pop 1.5M (deep) vs 26125 pop 0.5M (normal): 1.5/2.0.
+        assert summary["crisis_pop_share"] == pytest.approx(0.75)
+        # Weighted over COUNTIES: (-0.5 * 1.5e6 + 0.3 * 0.5e6) / 2e6.
+        assert summary["bifurcation_score_mean"] == pytest.approx(-0.3)
+        assert summary["wage_compression_mean"] == pytest.approx(0.15)
+        # Extensive sum, ONE term per county: 1e9 + 2e9 — never 1e9*2 + 2e9.
+        assert summary["capital_stock_total"] == pytest.approx(3e9)
+        assert summary["unemployment_rate_mean"] == pytest.approx(0.0875)
+
+    def test_no_graph_or_no_boundary_yet_is_honest_null(self) -> None:
+        no_graph = build_tick_summary_kwargs(WorldState(tick=1))
+        bare_graph = BabylonGraph()
+        bare_graph.add_node("T1", NodeType.TERRITORY, county_fips="26163", population=10)
+        pre_boundary = build_tick_summary_kwargs(WorldState(tick=1), graph=bare_graph)
+
+        for key in self._SERIES_KEYS:
+            assert no_graph[key] is None, f"{key} must be NULL without a graph"
+            assert pre_boundary[key] is None, f"{key} must be NULL before the first boundary"
+
+
+class TestDeterminism:
+    """Identical inputs yield identical kwargs dicts."""
+
+    def test_double_call_is_identical(self) -> None:
+        world = WorldState(
+            tick=1,
+            economy=GlobalEconomy(imperial_rent_pool=2.0),
+            relationships=[
+                Relationship(source_id="C001", target_id="C002", edge_type=EdgeType.SOLIDARITY),
+            ],
+        )
+        graph = TestCountySeriesAggregates._graph_with_two_counties()
+
+        first = build_tick_summary_kwargs(world, graph=graph)
+        second = build_tick_summary_kwargs(world, graph=graph)
+
+        assert first == second

--- a/tests/unit/projection/test_tick_summary.py
+++ b/tests/unit/projection/test_tick_summary.py
@@ -14,13 +14,13 @@ from __future__ import annotations
 import pytest
 
 from babylon.engine.factories import create_proletariat
+from babylon.kernel.event_bus import Event
 from babylon.models.entities.economy import GlobalEconomy
 from babylon.models.entities.organization import CivilSocietyOrg
 from babylon.models.entities.relationship import Relationship
 from babylon.models.entities.social_class import IdeologicalProfile
 from babylon.models.enums import ClassCharacter, EdgeType, EventType, ServiceType
 from babylon.models.enums.topology import NodeType
-from babylon.models.events import SimulationEvent
 from babylon.models.market import MarketState
 from babylon.models.world_state import WorldState
 from babylon.projection.tick_summary import build_tick_summary_kwargs
@@ -117,19 +117,47 @@ class TestOrgCounts:
 
 
 class TestEventCounts:
-    def test_counts_uprising_and_repression_events_only(self) -> None:
+    """REVIEW FIX (T5 U2): counts the ``events=`` kernel bus history, NEVER
+    ``WorldState.events`` — ``WorldState.from_graph()`` never restamps
+    ``graph.graph['events']`` per tick, so on the real Archive path
+    ``world.events`` is always ``[]`` and these two columns would silently
+    fabricate a ``0`` (Constitution III.11) instead of reporting the truth.
+    """
+
+    def test_counts_uprising_and_repression_bus_events_only(self) -> None:
+        events = [
+            Event(type=EventType.UPRISING, tick=1, payload={}),
+            Event(type=EventType.UPRISING, tick=1, payload={}),
+            Event(type=EventType.STATE_REPRESSION, tick=1, payload={}),
+            Event(type=EventType.LIFECYCLE_TRANSITION, tick=1, payload={}),
+        ]
+        summary = build_tick_summary_kwargs(WorldState(tick=1), events=events)
+        assert summary["uprising_count"] == 2
+        assert summary["repression_count"] == 1
+
+    def test_world_events_are_never_read_for_these_counts(self) -> None:
+        """A populated ``world.events`` must NOT leak into the count when a
+        real ``events=`` bus history is also supplied — the two counts come
+        from ONE source, never a union of both."""
+        from babylon.models.events import SimulationEvent
+
         world = WorldState(
             tick=1,
             events=[
                 SimulationEvent(event_type=EventType.UPRISING, tick=1),
-                SimulationEvent(event_type=EventType.UPRISING, tick=1),
                 SimulationEvent(event_type=EventType.STATE_REPRESSION, tick=1),
-                SimulationEvent(event_type=EventType.LIFECYCLE_TRANSITION, tick=1),
             ],
         )
-        summary = build_tick_summary_kwargs(world)
-        assert summary["uprising_count"] == 2
-        assert summary["repression_count"] == 1
+        summary = build_tick_summary_kwargs(
+            world, events=[Event(type=EventType.UPRISING, tick=1, payload={})]
+        )
+        assert summary["uprising_count"] == 1
+        assert summary["repression_count"] == 0
+
+    def test_no_events_threaded_is_honest_null_not_zero(self) -> None:
+        summary = build_tick_summary_kwargs(WorldState(tick=1))
+        assert summary["uprising_count"] is None
+        assert summary["repression_count"] is None
 
 
 class TestMarketAxis:

--- a/tests/unit/projection/test_tick_summary.py
+++ b/tests/unit/projection/test_tick_summary.py
@@ -124,20 +124,31 @@ class TestEventCounts:
     fabricate a ``0`` (Constitution III.11) instead of reporting the truth.
     """
 
-    def test_counts_uprising_and_repression_bus_events_only(self) -> None:
+    def test_counts_uprising_bus_events_only(self) -> None:
         events = [
             Event(type=EventType.UPRISING, tick=1, payload={}),
             Event(type=EventType.UPRISING, tick=1, payload={}),
-            Event(type=EventType.STATE_REPRESSION, tick=1, payload={}),
             Event(type=EventType.LIFECYCLE_TRANSITION, tick=1, payload={}),
         ]
         summary = build_tick_summary_kwargs(WorldState(tick=1), events=events)
         assert summary["uprising_count"] == 2
-        assert summary["repression_count"] == 1
+
+    def test_repression_count_is_always_null_even_with_bus_events(self) -> None:
+        """STATE_REPRESSION has NO production bus publisher (the OODA
+        first-class-action gate covers only POGROM/LOCKOUT/VIGILANTISM;
+        the type lives only as a string in ActionResult.events_generated),
+        so a bus count would be a structurally fabricated ``0``
+        (Constitution III.11). The column is honestly NULL until an engine
+        unit adds a real publisher — even a bus history that DOES carry
+        the type (only a non-production stub could produce one) must not
+        flip it to a count."""
+        events = [Event(type=EventType.STATE_REPRESSION, tick=1, payload={})]
+        summary = build_tick_summary_kwargs(WorldState(tick=1), events=events)
+        assert summary["repression_count"] is None
 
     def test_world_events_are_never_read_for_these_counts(self) -> None:
         """A populated ``world.events`` must NOT leak into the count when a
-        real ``events=`` bus history is also supplied — the two counts come
+        real ``events=`` bus history is also supplied — the count comes
         from ONE source, never a union of both."""
         from babylon.models.events import SimulationEvent
 
@@ -152,7 +163,7 @@ class TestEventCounts:
             world, events=[Event(type=EventType.UPRISING, tick=1, payload={})]
         )
         assert summary["uprising_count"] == 1
-        assert summary["repression_count"] == 0
+        assert summary["repression_count"] is None
 
     def test_no_events_threaded_is_honest_null_not_zero(self) -> None:
         summary = build_tick_summary_kwargs(WorldState(tick=1))

--- a/tests/unit/tools/test_ingest_corpus.py
+++ b/tests/unit/tools/test_ingest_corpus.py
@@ -1,0 +1,186 @@
+"""Behavioral contract for tools/ingest_corpus.py's manifest-driven rewire (T5 U3).
+
+The retired ``MVP_CORPUS`` tuple (fuzzy filename matching against an
+arbitrary external mirror) is replaced entirely by
+:class:`babylon.intelligence.corpus_manifest.CorpusManifest`-driven
+enumeration (allow minus deny, existing-files-only, deterministic
+ordering). Nothing here touches the real ``~/Documents/ocr/`` tree, calls
+an embedding model, or writes to a database — this unit ships file
+preparation only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from tools.ingest_corpus import (
+    _dest_filename,
+    import_corpus_files,
+    import_manifest_work,
+)
+
+from babylon.intelligence.corpus_manifest import parse_manifest
+
+pytestmark = pytest.mark.unit
+
+
+def _row(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "path_glob": "author-x/work-y/*.txt",
+        "author": "Author X",
+        "work": "Work Y",
+        "role": ["narrator"],
+        "format": "txt",
+        "canon_status": "allow",
+        "provenance": "test fixture row",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestNoMvpCorpusSymbolsRemain:
+    """Regression sentinel: the old hardcoded corpus must not creep back."""
+
+    def test_mvp_corpus_tuple_is_gone(self) -> None:
+        import tools.ingest_corpus as module
+
+        assert not hasattr(module, "MVP_CORPUS")
+        assert not hasattr(module, "CorpusText")
+        assert not hasattr(module, "fuzzy_match_score")
+
+
+class TestManifestDrivenEnumeration:
+    def test_allow_minus_deny_existing_files_only(self, tmp_path: Path) -> None:
+        corpus_root = tmp_path / "ocr"
+        corpus_dir = tmp_path / "prepared"
+
+        # Present allow row.
+        present_dir = corpus_root / "zak-cope" / "divided-world-divided-class"
+        present_dir.mkdir(parents=True)
+        (present_dir / "full.txt").write_text("labor aristocracy theory body")
+
+        # Allow row whose work has NOT been extracted onto this box yet.
+        absent_row = _row(
+            path_glob="fanon/the-wretched-of-the-earth/*.txt",
+            author="Frantz Fanon",
+            work="The Wretched of the Earth",
+            canon_status="allow",
+        )
+
+        # A broad allow glob that would sweep in a denied sub-path if the
+        # deny row were not honored — the Trotsky-quoted-for-rebuttal case.
+        (corpus_root / "classics" / "marx").mkdir(parents=True)
+        (corpus_root / "classics" / "trotsky").mkdir(parents=True)
+        (corpus_root / "classics" / "marx" / "capital.txt").write_text("value theory")
+        (corpus_root / "classics" / "trotsky" / "pr.txt").write_text("denied position")
+
+        manifest = parse_manifest(
+            {
+                "rows": [
+                    _row(
+                        path_glob="zak-cope/divided-world-divided-class/*.txt",
+                        author="Zak Cope",
+                        work="Divided World, Divided Class",
+                        canon_status="allow",
+                    ),
+                    absent_row,
+                    _row(
+                        path_glob="classics/**/*.txt",
+                        author="Karl Marx",
+                        work="Classics",
+                        canon_status="allow",
+                    ),
+                    _row(
+                        path_glob="classics/trotsky/**/*.txt",
+                        author="Leon Trotsky",
+                        work="(all works — denied author)",
+                        canon_status="deny",
+                    ),
+                ]
+            }
+        )
+
+        imported, missing = import_corpus_files(corpus_root, corpus_dir, manifest)
+
+        assert imported == 2  # Cope + Classics(marx-only); Fanon absent
+        assert "The Wretched of the Earth (Frantz Fanon)" in missing
+
+        cope_dest = corpus_dir / _dest_filename(manifest.allow_rows()[0])
+        assert cope_dest.exists()
+        assert "labor aristocracy theory body" in cope_dest.read_text()
+
+        classics_dest = corpus_dir / _dest_filename(manifest.allow_rows()[2])
+        classics_text = classics_dest.read_text()
+        assert "value theory" in classics_text
+        assert "denied position" not in classics_text
+
+        # No file was ever prepared for the absent Fanon row.
+        fanon_dest = corpus_dir / _dest_filename(manifest.allow_rows()[1])
+        assert not fanon_dest.exists()
+
+    def test_absent_row_reported_missing_not_raised(self, tmp_path: Path) -> None:
+        corpus_root = tmp_path / "ocr"  # never created — entirely absent tree
+        corpus_dir = tmp_path / "prepared"
+        manifest = parse_manifest(
+            {"rows": [_row(path_glob="stalin/foundations-of-leninism/*.txt", canon_status="allow")]}
+        )
+
+        imported, missing = import_corpus_files(corpus_root, corpus_dir, manifest)
+
+        assert imported == 0
+        assert len(missing) == 1
+
+    def test_deterministic_dest_filename(self) -> None:
+        manifest = parse_manifest(
+            {"rows": [_row(author="V.I. Lenin", work="State and Revolution")]}
+        )
+        assert _dest_filename(manifest.rows[0]) == "vi_lenin_state_and_revolution.md"
+
+
+class TestImportManifestWork:
+    def test_txt_format_is_read_verbatim(self, tmp_path: Path) -> None:
+        f = tmp_path / "full.txt"
+        f.write_text("plain extracted body")
+        manifest = parse_manifest({"rows": [_row(format="txt")]})
+        row = manifest.rows[0]
+        dest = tmp_path / "out.md"
+
+        assert import_manifest_work((f,), row, dest) is True
+        content = dest.read_text()
+        assert "plain extracted body" in content
+        assert f"# {row.work}" in content
+        assert f"**Author:** {row.author}" in content
+
+    def test_html_format_is_converted_via_markdownify(self, tmp_path: Path) -> None:
+        f = tmp_path / "ch01.htm"
+        f.write_text("<html><body><h1>Title</h1><p>Body text</p></body></html>")
+        manifest = parse_manifest({"rows": [_row(format="html")]})
+        row = manifest.rows[0]
+        dest = tmp_path / "out.md"
+
+        assert import_manifest_work((f,), row, dest) is True
+        content = dest.read_text()
+        assert "Body text" in content
+        assert "<html>" not in content
+
+    def test_multiple_files_joined_in_given_order(self, tmp_path: Path) -> None:
+        f1 = tmp_path / "ch-01.txt"
+        f1.write_text("chapter one")
+        f2 = tmp_path / "ch-02.txt"
+        f2.write_text("chapter two")
+        manifest = parse_manifest({"rows": [_row(format="txt")]})
+        row = manifest.rows[0]
+        dest = tmp_path / "out.md"
+
+        assert import_manifest_work((f1, f2), row, dest) is True
+        content = dest.read_text()
+        assert content.index("chapter one") < content.index("chapter two")
+
+    def test_empty_files_tuple_returns_false(self, tmp_path: Path) -> None:
+        manifest = parse_manifest({"rows": [_row()]})
+        row = manifest.rows[0]
+        dest = tmp_path / "out.md"
+
+        assert import_manifest_work((), row, dest) is False
+        assert not dest.exists()

--- a/tools/ingest_corpus.py
+++ b/tools/ingest_corpus.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
 """Corpus ingestion tool for Babylon's RAG pipeline.
 
-This tool imports texts from external libraries (like marxists.org) and
-prepares them as chunked Markdown files for RAG ingestion.
+This tool prepares texts from the durable OCR/extraction tree
+(``~/Documents/ocr/`` by default) as chunked Markdown files for RAG
+ingestion. Which works are eligible, and where their extracted text lives,
+is declared entirely in the corpus manifest
+(``src/babylon/data/corpus/manifest.yaml`` +
+:mod:`babylon.intelligence.corpus_manifest`, ADR107) — this tool no longer
+hardcodes a corpus list or fuzzy-matches filenames against an arbitrary
+external mirror (the retired ``MVP_CORPUS`` tuple / ``fuzzy_match_score``).
 
 NOTE: ChromaDB has been removed. Vector storage is now handled by
 pgvector via PgVectorStore (Feature 037). This tool can still import
 and prepare corpus files; ingestion into the vector store requires
-a running PostgreSQL instance with pgvector.
+a running PostgreSQL instance with pgvector and is NOT performed here
+(no embedding calls, no DB writes — file preparation only).
 
 Usage:
-    # Import texts from external library
-    poetry run python tools/ingest_corpus.py --import-from /media/user/marxists.org/
+    # Prepare corpus files from the OCR extraction tree
+    poetry run python tools/ingest_corpus.py --prepare
 
     # List corpus status
     poetry run python tools/ingest_corpus.py --list
@@ -23,123 +30,29 @@ import argparse
 import logging
 import re
 import sys
-from dataclasses import dataclass
-from difflib import SequenceMatcher
 from pathlib import Path
-from typing import Final
 
 from babylon.config.logging_config import setup_logging
+from babylon.intelligence.corpus_manifest import (
+    CorpusFormat,
+    CorpusManifest,
+    CorpusRow,
+    ManifestTarget,
+    load_bundled_manifest,
+)
 
 setup_logging(default_level="INFO")
 logger = logging.getLogger(__name__)
 
-
-# =============================================================================
-# MVP VERTICAL SLICE CORPUS
-# =============================================================================
-# These 7 texts form the minimal viable corpus for testing the RAG pipeline.
-# They cover the key theoretical foundations: exploitation, imperialism, and
-# revolutionary consciousness.
-
-
-@dataclass(frozen=True)
-class CorpusText:
-    """A text in the MVP corpus with metadata for fuzzy matching."""
-
-    title: str
-    author: str
-    keywords: tuple[str, ...]  # For fuzzy filename matching
-    year: int | None = None
-    # Subdirectories to search in (relative to source root) for targeted scanning
-    search_paths: tuple[str, ...] = ()
-
-
-MVP_CORPUS: Final[tuple[CorpusText, ...]] = (
-    CorpusText(
-        title="Wage Labour and Capital",
-        author="Marx",
-        keywords=("wage", "labour", "capital", "wage-labour"),
-        year=1849,
-        search_paths=("archive/marx/works/1847/wage-labour",),
-    ),
-    CorpusText(
-        title="Value, Price and Profit",
-        author="Marx",
-        keywords=("value", "price", "profit", "value-price-profit"),
-        year=1865,
-        search_paths=("archive/marx/works/1865/value-price-profit",),
-    ),
-    CorpusText(
-        title="Principles of Communism",
-        author="Engels",
-        keywords=("principles", "communism", "prin-com"),
-        year=1847,
-        search_paths=("archive/marx/works/1847/11",),
-    ),
-    CorpusText(
-        title="Imperialism, the Highest Stage of Capitalism",
-        author="Lenin",
-        keywords=("imperialism", "highest", "stage", "capitalism", "imp-hsc"),
-        year=1916,
-        search_paths=("archive/lenin/works/1916/imp-hsc",),
-    ),
-    CorpusText(
-        title="On National Culture",
-        author="Fanon",
-        keywords=("national", "culture", "national-culture"),
-        year=1961,
-        search_paths=("subject/africa/fanon",),
-    ),
-    CorpusText(
-        title="On Contradiction",
-        author="Mao",
-        keywords=("contradiction", "mswv1_17"),
-        year=1937,
-        search_paths=("reference/archive/mao/selected-works/volume-1",),
-    ),
-    CorpusText(
-        title="Analysis of the Classes in Chinese Society",
-        author="Mao",
-        keywords=("analysis", "classes", "chinese", "society", "mswv1_1"),
-        year=1926,
-        search_paths=("reference/archive/mao/selected-works/volume-1",),
-    ),
-)
+#: Default durable extraction tree root (ADR107 "step zero"). Manifest
+#: path_globs resolve against this; overridable via --corpus-root for
+#: alternate boxes (and always overridden in tests, which never touch it).
+DEFAULT_CORPUS_ROOT: Path = Path.home() / "Documents" / "ocr"
 
 
 # =============================================================================
 # FILE DISCOVERY AND IMPORT
 # =============================================================================
-
-
-def fuzzy_match_score(filename: str, text: CorpusText) -> float:
-    """Calculate fuzzy match score between filename and corpus text.
-
-    Args:
-        filename: The filename to check (lowercase, without extension)
-        text: The corpus text to match against
-
-    Returns:
-        A score between 0.0 and 1.0, higher is better match
-    """
-    filename_lower = filename.lower()
-
-    # Direct keyword match gets highest priority
-    for keyword in text.keywords:
-        if keyword.lower() in filename_lower:
-            return 0.9 + (0.1 * len(keyword) / len(filename_lower))
-
-    # Title similarity as fallback
-    title_lower = text.title.lower().replace(",", "").replace("'", "")
-    title_words = title_lower.split()
-
-    # Check how many title words appear in filename
-    word_matches = sum(1 for word in title_words if word in filename_lower)
-    if word_matches > 0:
-        return 0.5 * (word_matches / len(title_words))
-
-    # Sequence matcher for partial matches
-    return SequenceMatcher(None, filename_lower, title_lower).ratio() * 0.3
 
 
 def convert_html_to_markdown(html_content: str) -> str:
@@ -167,125 +80,99 @@ def convert_html_to_markdown(html_content: str) -> str:
     return markdown.strip()
 
 
-def import_multi_chapter_work(
-    search_dir: Path,
-    text: CorpusText,
-    dest_path: Path,
-) -> bool:
-    """Import a multi-chapter work by concatenating all chapter files.
+def import_manifest_work(files: tuple[Path, ...], row: CorpusRow, dest_path: Path) -> bool:
+    """Concatenate one manifest row's matched files into a single Markdown file.
+
+    HTML-format rows are converted via :func:`convert_html_to_markdown`
+    (REUSED unchanged); every other format (the ~/Documents/ocr/ convention:
+    plain ``.txt`` extraction output) is read as-is. Multiple matched files
+    (chapter splits) are joined in the deterministic order the manifest
+    already sorted them in.
 
     Args:
-        search_dir: Directory containing chapter files (ch01.htm, ch02.htm, etc.)
-        text: The corpus text metadata
-        dest_path: Destination path for the combined Markdown file
+        files: This row's existing, deny-subtracted matched files (already
+            sorted deterministically by :meth:`CorpusManifest.ingest_targets`).
+        row: The manifest row these files belong to.
+        dest_path: Destination path for the combined Markdown file.
 
     Returns:
-        True if successful, False otherwise
+        True if at least one file yielded non-empty content, False otherwise.
     """
-    chapter_files = sorted(search_dir.glob("ch*.htm"))
-    if not chapter_files:
-        chapter_files = sorted(search_dir.glob("ch*.html"))
-
-    if not chapter_files:
+    if not files:
         return False
 
-    logger.info(f"Found {len(chapter_files)} chapters for '{text.title}'")
-
-    # Also look for intro/preface files
-    intro_files: list[Path] = []
-    for name in ["intro.htm", "introduction.htm", "pref01.htm", "pref02.htm", "preface.htm"]:
-        intro_path = search_dir / name
-        if intro_path.exists():
-            intro_files.append(intro_path)
-
-    all_files = sorted(intro_files) + chapter_files
-    combined_content: list[str] = []
-
-    for file_path in all_files:
+    chunks: list[str] = []
+    for file_path in files:
         try:
             with open(file_path, encoding="utf-8", errors="replace") as f:
-                raw_html = f.read()
-            chapter_md = convert_html_to_markdown(raw_html)
-            if chapter_md.strip():
-                combined_content.append(chapter_md)
-        except Exception as e:
-            logger.warning(f"Failed to read chapter {file_path.name}: {e}")
+                raw = f.read()
+        except OSError as e:
+            logger.warning(f"Failed to read {file_path.name}: {e}")
+            continue
 
-    if not combined_content:
+        text = convert_html_to_markdown(raw) if row.format is CorpusFormat.HTML else raw.strip()
+        if text:
+            chunks.append(text)
+
+    if not chunks:
         return False
 
-    full_content = f"# {text.title}\n\n**Author:** {text.author}\n\n---\n\n"
-    full_content += "\n\n---\n\n".join(combined_content)
+    full_content = f"# {row.work}\n\n**Author:** {row.author}\n\n---\n\n"
+    full_content += "\n\n---\n\n".join(chunks)
 
     with open(dest_path, "w", encoding="utf-8") as f:
         f.write(full_content)
 
-    logger.info(f"Combined {len(all_files)} files -> {dest_path.name}")
+    logger.info(f"Imported {len(files)} file(s) for '{row.work}' -> {dest_path.name}")
     return True
 
 
-def import_corpus_files(source_dir: Path, corpus_dir: Path) -> tuple[int, list[str]]:
-    """Import matching files from external library to corpus directory.
+def _dest_filename(row: CorpusRow) -> str:
+    """Deterministic ``<author>_<work>.md`` destination filename for a row."""
+    safe_title = re.sub(r"[^\w\s-]", "", row.work).replace(" ", "_").lower()
+    safe_author = re.sub(r"[^\w\s-]", "", row.author).replace(" ", "_").lower()
+    return f"{safe_author}_{safe_title}.md"
+
+
+def import_corpus_files(
+    corpus_root: Path,
+    corpus_dir: Path,
+    manifest: CorpusManifest,
+) -> tuple[int, list[str]]:
+    """Prepare every allow-listed, existing manifest work as a Markdown file.
+
+    Enumeration is entirely manifest-driven: allow minus deny, existing-files
+    -only, in the manifest's declared (deterministic) row order — see
+    :meth:`CorpusManifest.ingest_targets`. A row whose work has not been
+    extracted onto this box yet is a MANIFEST fact, reported as missing,
+    never raised as an error.
 
     Args:
-        source_dir: External library path to import from
-        corpus_dir: Local corpus directory to copy files to
+        corpus_root: Durable extraction tree root manifest globs resolve
+            against (e.g. ``~/Documents/ocr``).
+        corpus_dir: Local corpus directory to write prepared Markdown into.
+        manifest: The loaded, validated corpus manifest.
 
     Returns:
-        Tuple of (number imported, list of missing text titles)
+        Tuple of (number imported, list of missing "work (author)" strings).
     """
     corpus_dir.mkdir(parents=True, exist_ok=True)
 
     imported = 0
     missing: list[str] = []
 
-    for text in MVP_CORPUS:
-        safe_title = re.sub(r"[^\w\s-]", "", text.title).replace(" ", "_").lower()
-        safe_author = text.author.lower()
-        dest_filename = f"{safe_author}_{safe_title}.md"
-        dest_path = corpus_dir / dest_filename
+    target: ManifestTarget
+    for target in manifest.ingest_targets(corpus_root):
+        row = target.row
+        if not target.present:
+            missing.append(f"{row.work} ({row.author})")
+            continue
 
-        success = False
-
-        for subpath in text.search_paths:
-            search_dir = source_dir / subpath
-            if not search_dir.exists():
-                continue
-
-            chapter_files = list(search_dir.glob("ch*.htm")) + list(search_dir.glob("ch*.html"))
-            if chapter_files:
-                success = import_multi_chapter_work(search_dir, text, dest_path)
-                if success:
-                    logger.info(f"Imported multi-chapter: {text.title}")
-                    break
-            else:
-                for ext in (".htm", ".html", ".txt", ".md"):
-                    for file_path in search_dir.glob(f"*{ext}"):
-                        filename = file_path.stem
-                        score = fuzzy_match_score(filename, text)
-                        if score > 0.5:
-                            try:
-                                with open(file_path, encoding="utf-8", errors="replace") as f:
-                                    raw_html = f.read()
-                                content = convert_html_to_markdown(raw_html)
-
-                                with open(dest_path, "w", encoding="utf-8") as f:
-                                    f.write(content)
-
-                                logger.info(f"Imported: {text.title} -> {dest_filename}")
-                                success = True
-                                break
-                            except Exception as e:
-                                logger.error(f"Failed to import {file_path}: {e}")
-                    if success:
-                        break
-            if success:
-                break
-
-        if success:
+        dest_path = corpus_dir / _dest_filename(row)
+        if import_manifest_work(target.files, row, dest_path):
             imported += 1
         else:
-            missing.append(f"{text.title} ({text.author})")
+            missing.append(f"{row.work} ({row.author})")
 
     return imported, missing
 
@@ -322,25 +209,27 @@ def list_corpus(corpus_dir: Path) -> None:
 def main() -> int:
     """Main entry point."""
     parser = argparse.ArgumentParser(
-        description="Import corpus texts for Babylon's RAG pipeline",
+        description="Prepare manifest-declared corpus texts for Babylon's RAG pipeline",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-    # Import from external library
-    %(prog)s --import-from /media/user/marxists.org/www.marxists.org/
+    # Prepare from the default OCR extraction tree (~/Documents/ocr)
+    %(prog)s --prepare
+
+    # Prepare from an alternate extraction tree
+    %(prog)s --prepare --corpus-root /path/to/ocr
 
     # List corpus status
     %(prog)s --list
 
-Note: Vector ingestion requires pgvector (Feature 037).
+Note: Vector ingestion requires pgvector (Feature 037) and is a separate step.
         """,
     )
 
     parser.add_argument(
-        "--import-from",
-        type=Path,
-        metavar="PATH",
-        help="External library path to import texts from",
+        "--prepare",
+        action="store_true",
+        help="Prepare manifest-declared, allow-listed works as Markdown from --corpus-root",
     )
 
     parser.add_argument(
@@ -350,11 +239,19 @@ Note: Vector ingestion requires pgvector (Feature 037).
     )
 
     parser.add_argument(
+        "--corpus-root",
+        type=Path,
+        default=DEFAULT_CORPUS_ROOT,
+        metavar="PATH",
+        help=f"Durable OCR extraction tree manifest globs resolve against (default: {DEFAULT_CORPUS_ROOT})",
+    )
+
+    parser.add_argument(
         "--corpus-dir",
         type=Path,
         default=Path(__file__).parent.parent / "data" / "corpus",
         metavar="PATH",
-        help="Local corpus directory (default: data/corpus/)",
+        help="Local corpus directory prepared Markdown is written to (default: data/corpus/)",
     )
 
     parser.add_argument(
@@ -369,31 +266,31 @@ Note: Vector ingestion requires pgvector (Feature 037).
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
-    # Print MVP corpus info
+    manifest = load_bundled_manifest()
+
     logger.info("=" * 60)
     logger.info("Babylon Corpus Tool")
     logger.info("=" * 60)
-    logger.info("\nMVP Vertical Slice Corpus (7 texts):")
-    for i, text in enumerate(MVP_CORPUS, 1):
-        logger.info(f"  {i}. {text.title} ({text.author}, {text.year})")
+    logger.info(f"\nManifest allow-listed works ({len(manifest.allow_rows())}):")
+    for i, row in enumerate(manifest.allow_rows(), 1):
+        logger.info(f"  {i}. {row.work} ({row.author})")
     logger.info("")
 
     if args.list:
         list_corpus(args.corpus_dir)
         return 0
 
-    # Import from external library if specified
-    if args.import_from:
-        logger.info(f"\nImporting from: {args.import_from}")
-        imported, missing = import_corpus_files(args.import_from, args.corpus_dir)
+    if args.prepare:
+        logger.info(f"\nPreparing from corpus root: {args.corpus_root}")
+        imported, missing = import_corpus_files(args.corpus_root, args.corpus_dir, manifest)
 
-        logger.info(f"\nImport Summary: Found {imported}/{len(MVP_CORPUS)} texts")
+        logger.info(f"\nPrepare summary: {imported}/{len(manifest.allow_rows())} works found")
         if missing:
-            logger.warning(f"Missing texts: {', '.join(missing)}")
+            logger.warning(f"Missing works (not yet extracted): {', '.join(missing)}")
         return 0
 
     # No action specified
-    logger.info("No action specified. Use --import-from to import, or --list to view status.")
+    logger.info("No action specified. Use --prepare to prepare files, or --list to view status.")
     logger.info("Vector ingestion requires pgvector backend (Feature 037).")
     return 0
 


### PR DESCRIPTION
## T5 — The narrator train (v1.0.0, post-T4-integration)

Wires the fully-built-but-dormant narrator lane into the live campaign loop, lights `tick_summary` on the Archive path, and replaces the hardcoded corpus tuple with canon-as-data.

### Units (opus-reviewed)
- **U1** `a4afb807` — **narrator wire** (first-pass APPROVE): `NarratorScheduler` structural Protocol; exactly one fire-and-forget `schedule()` per committed tick in `GameSession.advance_tick`, placed after the deterministic bake; `babylon play --narrator/--no-narrator` (default on — the provider chain ends in mute). Parity proven by tests: OFF byte-identical across independent bakes; ON leaves every deterministic page byte-identical with only `narrative/` differing; a raising provider never breaks the tick. No narrator→engine path exists (the reviewer verified all seven constitutional hunt items).
- **U2** `35c831a5` + `211e60f4` + `b7567a3c` — **tick_summary + trend view**: `build_tick_summary_kwargs` ports the web bridge's builder; `persist_tick_summary` now fires at the Archive commit boundary (its only caller was the legacy bridge — real campaigns wrote nothing); `v_national_trend` DeclaredView (LAG windows over Φ/price_log/fictitious_log/market_corrections, migration 0038, registry + view model + rst row). Review chain caught two honesty defects in sequence: `uprising_count` read the never-restamped `WorldState.events` (fixed — counts the real kernel bus history), then `repression_count` remained a fabricated 0 because **no production code publishes STATE_REPRESSION to the bus** — now honest NULL with a test pinning that even a stub-produced bus event cannot flip it (flip requires a real REPRESS-path publisher, a declared engine unit).
- **U3** `1c2d4346` + fix — **corpus manifest** (APPROVED after fix): `src/babylon/data/corpus/manifest.yaml` (v1 nine-work canon + deny rows for Trotsky/Kautsky/CPUSA/Hoxha + content.jsonl apocrypha per ADR107), frozen `CorpusManifest` loader, `tools/ingest_corpus.py` now manifest-driven (deny-inside-allow precedence — the review caught a broad-glob apocrypha bypass and it was fenced). No ingestion run.

### Battery (controller-run, single-flight)
- `mise run check` — **13,988 passed**
- `check:sentinels` — all green
- `qa:regression` — 6/6 byte-identical + two-process determinism PASS
- `qa:vault-regression` — byte-identical to the existing goldens (no bake-path change; narrative channel is live-campaign-only) — no ceremony needed

On this box the provider chain now has a real local lane: Ollama with the pinned `llama3.1:8b` + `embeddinggemma`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)