### PR TITLE
feat(game): T6 — the tutorial IS the BDD suite (U1–U4)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -221,16 +221,20 @@ description = "Absence sentinel (task #64): every sqlite3.connect/create_engine(
 run = "uv run python tools/sentinel_check.py absence --check"
 
 [tasks."check:sentinels"]
-description = "ALL 17 sentinels (owner ruling 2026-07-18: the whole family is fast-gate LOCALLY — the dev box has the reference DB): seam seam-algebra coverage vocabulary inert dangling unconsumed masked-arithmetic aggregation fog catalog partition synthetic defines-passthrough gate-coverage absence formula-registration"
+description = "ALL 18 sentinels (owner ruling 2026-07-18: the whole family is fast-gate LOCALLY — the dev box has the reference DB): seam seam-algebra coverage vocabulary inert dangling unconsumed masked-arithmetic aggregation fog catalog partition synthetic defines-passthrough gate-coverage absence formula-registration tutorial-coverage"
 depends = ["check:sentinels-static", "check:catalog"]
 
 [tasks."check:sentinels-static"]
-description = "The 16 static sentinels (no reference DB needed) — CI's fast-gate job runs THIS; the catalog DB-probe runs where the DB exists (locally via check:sentinels, in CI via nightly's requires_reference_db job)"
-depends = ["check:seams", "check:seam-algebra", "check:coverage", "check:vocabulary", "check:inert", "check:dangling", "check:unconsumed", "check:masked-arithmetic", "check:aggregation", "check:fog", "check:partition", "check:synthetic", "check:defines-passthrough", "check:gate-coverage", "check:absence", "check:formula-registration"]
+description = "The 17 static sentinels (no reference DB needed) — CI's fast-gate job runs THIS; the catalog DB-probe runs where the DB exists (locally via check:sentinels, in CI via nightly's requires_reference_db job)"
+depends = ["check:seams", "check:seam-algebra", "check:coverage", "check:vocabulary", "check:inert", "check:dangling", "check:unconsumed", "check:masked-arithmetic", "check:aggregation", "check:fog", "check:partition", "check:synthetic", "check:defines-passthrough", "check:gate-coverage", "check:absence", "check:formula-registration", "check:tutorial-coverage"]
 
 [tasks."check:surface"]
 description = "Sentinel: __all__ vs its pinned baseline frozenset (public-surface baseline blindness gate)"
 run = "uv run python tools/sentinel_check.py surface --check"
+
+[tasks."check:tutorial-coverage"]
+description = "Tutorial option-coverage sentinel (T6): every declared TUI Binding is exercised by an authored TutorialStep or carries a cited exemption (static gate)"
+run = "uv run python tools/sentinel_check.py tutorial-coverage --check"
 
 [tasks."check:gate-coverage"]
 description = "Sentinel: qa:regression estate declaration is complete over all 30 engine systems (gate-blindness gate)"

--- a/src/babylon/cli/play.py
+++ b/src/babylon/cli/play.py
@@ -47,6 +47,21 @@ session.resume_campaign`'s ``narrator=`` (previously wired to zero
 production callers); OFF passes ``narrator=None``, so
 :meth:`~babylon.game.session.GameSession.advance_tick` never calls
 ``schedule()`` at all — the exact pre-Unit-U1 byte-identical path.
+
+T6 Unit U4 (the guided opening-arc overlay) adds the ``--tutorial/--no-
+tutorial`` flag on :func:`play`, threaded through :func:`run` into
+:func:`_tutorial_progress_factory`. Deliberately TRI-STATE (``bool | None``,
+default ``None``) rather than the narrator flag's plain bool — the ruling's
+own default is "ON for a new campaign, OFF for a resumed one," a decision
+that cannot be resolved until a specific campaign is chosen in the lobby,
+long after Typer has already parsed the CLI. ``None`` (no flag given) defers
+to :func:`_tutorial_progress_factory`'s own first-session heuristic
+(``campaign.tick == 0``, an HONEST, DOCUMENTED approximation of "was this
+campaign just minted" — see that function's own docstring for the precise
+signal it would need instead, and why threading it here would ripple into
+``LobbyScreen``'s dismiss contract); ``True``/``False`` (an explicit flag)
+always overrides the heuristic outright, for either a fresh or a resumed
+campaign.
 """
 
 from __future__ import annotations
@@ -61,13 +76,17 @@ from uuid import UUID
 import typer
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+
     from babylon.config.defines import GameDefines
     from babylon.game.pacing import PacedTickDriver
     from babylon.game.session import GameSession
     from babylon.persistence import PostgresRuntime
     from babylon.persistence.babylon_meta import BabylonMetaStore
     from babylon.projection.vault.materializer import VaultMaterializer
-    from babylon.tui.app import CampaignHandle
+    from babylon.tui.app import CampaignHandle, PacedDriverHandle
+    from babylon.tui.tutorial_overlay import TutorialProgress
 
 
 def play_demo() -> None:
@@ -244,7 +263,94 @@ def _driver_factory(campaign: CampaignHandle) -> PacedTickDriver:
     return paced_driver_for_session(cast("GameSession", campaign))
 
 
-def run(*, narrator_enabled: bool = True) -> None:
+def _tutorial_steps() -> tuple[Any, ...]:
+    """The guided opening-arc's step slice the campaign shell can teach.
+
+    Skips the authored arc's first TWO beats (lobby mint + briefing begin):
+    the overlay only ever mounts once the campaign shell itself is visible
+    (:meth:`~babylon.tui.app.ArchiveApp._on_briefing_dismissed`), by which
+    point both are already necessarily true (reaching the shell requires
+    having done them), and their own completion (``VerbIssued``) is not
+    observable from inside the shell anyway (see
+    :class:`~babylon.game.tutorial_runtime.TutorialRuntimeProgress`'s own
+    docstring). Computed ONCE and reused as BOTH ``ArchiveApp``'s
+    ``tutorial_steps=`` and the same steps :func:`_tutorial_progress_factory`
+    builds its evaluator against — a single source of the slice keeps the
+    overlay's rendering list and its evaluator's index space identical by
+    construction (see :data:`~babylon.tui.app.TutorialProgressFactory`'s own
+    docstring on why that alignment matters).
+
+    :returns: the sliced step sequence, typed loosely (``Any``) in this
+        function's own signature to avoid importing ``babylon.game.tutorial``
+        (and transitively ``babylon.engine``) at module scope — this
+        composition root already imports it lazily elsewhere in this file for
+        the same reason.
+    """
+    from babylon.game.tutorial import WAYNE_OPENING_ARC
+
+    return WAYNE_OPENING_ARC.steps[2:]
+
+
+def _tutorial_progress_factory(
+    tutorial_enabled: bool | None, steps: tuple[Any, ...]
+) -> Callable[
+    [CampaignHandle, PacedDriverHandle | None, Callable[[], str | None]], TutorialProgress | None
+]:
+    """Build ``ArchiveApp``'s ``tutorial_progress_factory=`` seam (Unit U4).
+
+    Returns a closure fulfilling :data:`~babylon.tui.app.TutorialProgressFactory`:
+    given the just-booted campaign, its paced driver (or ``None``), and a
+    nav-subject query, decide whether the T6 opening-arc overlay should show
+    for THIS campaign, and if so build its
+    :class:`~babylon.tui.tutorial_overlay.TutorialProgress` evaluator.
+
+    :param tutorial_enabled: the resolved ``--tutorial``/``--no-tutorial``
+        tri-state flag (see :func:`play`); ``True``/``False`` always wins;
+        ``None`` (no flag given) falls back to ``campaign.tick == 0`` — an
+        HONEST, DOCUMENTED APPROXIMATION of "this campaign was just minted,"
+        not a precise new-vs-resumed signal. The precise signal
+        (``runtime.get_session(campaign_id) is None``, computed inside
+        :func:`_load_campaign`) does not survive past that function's own
+        return (``ArchiveApp`` only ever sees the resulting ``GameSession``,
+        never the fact that produced it), and threading it through would mean
+        either widening :class:`~babylon.tui.app.CampaignHandle` with a new
+        REQUIRED member (breaking every existing fake in
+        ``tests/unit/tui/test_app_lobby_flow.py``/``test_app_pacing_driver.
+        py``) or changing :class:`~babylon.tui.campaign_menu.LobbyScreen`'s
+        own ``dismiss`` contract (rippling into ``test_campaign_menu.py`` and
+        ``test_tutorial_pilot.py`` too) — both a far larger blast radius than
+        this ruling's own "first-session semantics" asks for. Wayne's own
+        material state means a genuinely-resumed campaign realistically sits
+        at tick >= 1 (it autopauses every tick from tick 1 onward — see
+        ``tests/unit/tui/test_tutorial_pilot.py``'s own HONEST GAP docstring),
+        so the one false-positive this approximation admits (a resumed
+        campaign that was minted but never advanced past tick 0 in its prior
+        session) is narrow and self-correcting: the player sees the tutorial
+        once more, never a crash or a wrong answer.
+    :param steps: the exact step sequence to build the evaluator against —
+        :func:`_tutorial_steps`'s own return, so it stays index-aligned with
+        whatever ``ArchiveApp`` was given as ``tutorial_steps=``.
+    :returns: the ``tutorial_progress_factory`` closure.
+    """
+
+    def _factory(
+        campaign: CampaignHandle,
+        driver: PacedDriverHandle | None,
+        current_subject: Callable[[], str | None],
+    ) -> TutorialProgress | None:
+        from babylon.game.tutorial_runtime import TutorialRuntimeProgress
+
+        show = tutorial_enabled if tutorial_enabled is not None else campaign.tick == 0
+        if not show:
+            return None
+        return TutorialRuntimeProgress(
+            steps=steps, campaign=campaign, driver=driver, current_subject=current_subject
+        )
+
+    return _factory
+
+
+def run(*, narrator_enabled: bool = True, tutorial_enabled: bool | None = None) -> None:
     """Boot the REAL Archive TUI: campaign lobby -> briefing -> campaign shell.
 
     Requires a reachable Postgres — see :func:`babylon.game.session.open_runtime`.
@@ -252,6 +358,10 @@ def run(*, narrator_enabled: bool = True) -> None:
     :param narrator_enabled: T5 Unit U1's ``--narrator/--no-narrator`` flag
         (see :func:`play`), threaded straight into every
         :func:`_load_campaign` call this boot makes.
+    :param tutorial_enabled: T6 Unit U4's ``--tutorial/--no-tutorial``
+        tri-state flag (see :func:`play`), threaded into
+        :func:`_tutorial_progress_factory` (see its own docstring for the
+        ``None`` default's first-session heuristic).
     """
     from functools import partial
 
@@ -273,12 +383,15 @@ def run(*, narrator_enabled: bool = True) -> None:
         defines_hash=_defines_hash(GameDefines.load_default()),
     )
 
+    steps = _tutorial_steps()
     app = ArchiveApp(
         campaign_menu=menu,
         campaign_loader=partial(
             _load_campaign, runtime, catalog, narrator_enabled=narrator_enabled
         ),
         driver_factory=_driver_factory,
+        tutorial_steps=steps,
+        tutorial_progress_factory=_tutorial_progress_factory(tutorial_enabled, steps),
     )
     app.run()
 
@@ -294,6 +407,16 @@ def play(
             "legal (Constitution R4)."
         ),
     ),
+    tutorial: bool | None = typer.Option(
+        None,
+        "--tutorial/--no-tutorial",
+        help=(
+            "Show the guided opening-arc overlay (T6 Unit U4). Unset (the "
+            "default) shows it for a freshly-minted campaign only, never a "
+            "resumed one (first-session semantics); an explicit flag always "
+            "wins either way."
+        ),
+    ),
 ) -> None:
     """Play Babylon — the real campaign session, via the composition root."""
-    run(narrator_enabled=narrator)
+    run(narrator_enabled=narrator, tutorial_enabled=tutorial)

--- a/src/babylon/game/tutorial.py
+++ b/src/babylon/game/tutorial.py
@@ -23,16 +23,33 @@ Completion predicates are DATA, never callables (the ruling: "no prose
 duplication anywhere, ever" generalizes to "no hidden behavior anywhere
 either" — a lambda could not serialize into the overlay/docs the way a
 Pydantic model does). The closed vocabulary below is deliberately small —
-exactly the four kinds an opening-arc teaching script needs:
+exactly the five kinds an opening-arc teaching script needs:
 
 * :class:`OnPage` — the player is viewing a named dossier subject.
 * :class:`TickAtLeast` — the campaign has resolved at least a given tick.
+* :class:`PausePending` — an autopause has become pending — the paced
+  driver actually STOPPED, not merely that a run was requested. The
+  load-bearing symmetric counterpart to :class:`EventAcked` below,
+  grounded on the live :attr:`~babylon.game.pacing.PacedTickDriver.
+  awaiting_ack`/:attr:`~babylon.game.pacing.PacedTickDriver.
+  pending_pause` state (the same primitives
+  :class:`~babylon.tui.app.PacedDriverHandle` already crosses the
+  tui/game seam with). Added in this unit's fix pass: a step whose
+  ``then`` advertises "the driver ... stops" must be verified by a
+  predicate that actually checks the stop — :class:`VerbIssued` alone
+  cannot distinguish "ran and stopped as designed" from "ran and kept
+  going".
 * :class:`EventAcked` — a pending autopause has been acknowledged.
 * :class:`VerbIssued` — a named verb/binding action has been issued (this
   covers BOTH a TUI keybinding's action name — ``"advance_tick"``,
   ``"run_until_paused"`` — and, in a future script, an Article-V player
   verb string; the ruling's own anchor phrasing, "the page/binding/verb it
-  exercises", already treats bindings and verbs as one family).
+  exercises", already treats bindings and verbs as one family). This is
+  the HONEST FLOOR only where no outcome-shaped predicate is queryable
+  yet (e.g. ``boot_into_lobby`` below, pre-campaign — there is no page or
+  tick to read FROM yet); it proves dispatch, never the advertised
+  outcome, and must not stand in for an outcome predicate where one is
+  available (the fix pass's ``begin_the_operation`` correction).
 
 :data:`CompletionPredicateAdapter` validates against exactly this closed set
 — an unrecognized ``kind`` raises :class:`pydantic.ValidationError` loudly
@@ -95,6 +112,7 @@ from babylon.engine.scenarios.wayne_county import WayneCountyScenario
 __all__ = [
     "EventAcked",
     "OnPage",
+    "PausePending",
     "TickAtLeast",
     "VerbIssued",
     "CompletionPredicate",
@@ -135,6 +153,30 @@ class TickAtLeast(BaseModel):
     tick: int = Field(ge=0)
 
 
+class PausePending(BaseModel):
+    """Then: the paced driver has actually STOPPED at a pending autopause.
+
+    Grounds on :attr:`~babylon.game.pacing.PacedTickDriver.awaiting_ack`
+    being ``True`` (equivalently, :attr:`~babylon.game.pacing.
+    PacedTickDriver.pending_pause` being non-``None``) — the same two
+    primitives :class:`~babylon.tui.app.PacedDriverHandle` already
+    exposes across the tui/game structural seam, so a later executor unit
+    can check this predicate without importing ``babylon.game.pacing``
+    itself. Deliberately unconditional (no ``tick`` filter), mirroring
+    :class:`EventAcked`'s own YAGNI reasoning: the opening-arc script only
+    ever teaches ONE run-until-autopause beat.
+
+    Reviewer finding (T6 U1 fix pass): ``VerbIssued(verb="run_until_paused")``
+    proves only that the keypress dispatched, never that the driver
+    actually stopped — a step whose ``then`` advertises the STOP behavior
+    needs a predicate that checks the stop, not the dispatch.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: Literal["pause_pending"] = "pause_pending"
+
+
 class EventAcked(BaseModel):
     """Then: the pending autopause has been acknowledged.
 
@@ -168,16 +210,16 @@ class VerbIssued(BaseModel):
 
 
 CompletionPredicate = Annotated[
-    OnPage | TickAtLeast | EventAcked | VerbIssued,
+    OnPage | TickAtLeast | PausePending | EventAcked | VerbIssued,
     Field(discriminator="kind"),
 ]
 """The closed completion-predicate vocabulary (module docstring). Every
 :class:`TutorialStep` carries exactly one — DATA, never a callable, so the
 same script serializes for the overlay, the Pilot executor, and the docs."""
 
-CompletionPredicateAdapter: TypeAdapter[OnPage | TickAtLeast | EventAcked | VerbIssued] = (
-    TypeAdapter(CompletionPredicate)
-)
+CompletionPredicateAdapter: TypeAdapter[
+    OnPage | TickAtLeast | PausePending | EventAcked | VerbIssued
+] = TypeAdapter(CompletionPredicate)
 """Validates a raw ``{"kind": ..., ...}`` payload against the closed set
 above. An unrecognized ``kind`` (or one missing it) raises
 :class:`pydantic.ValidationError` loudly (Constitution III.11) — there is
@@ -288,6 +330,16 @@ WAYNE_OPENING_ARC: Final[TutorialScript] = TutorialScript(
             when="the player presses 'n' to mint a new campaign",
             then="a freshly minted campaign row appears in the lobby, ready to be loaded",
             anchor="binding:LobbyScreen:n",
+            # Honest gap (reviewer finding, T6 U1 fix pass): no page/tick
+            # outcome predicate is queryable pre-campaign — there is no
+            # campaign yet to read a page or a tick FROM — so VerbIssued
+            # is the honest floor here, not a shortcut. This proves ONLY
+            # that the keypress dispatched; the advertised "row appears"
+            # outcome is left unverified by this step. A future
+            # rendered-text predicate (module docstring's OBSERVATION on
+            # the closed vocabulary) is the eventual fix; until then the
+            # executor must not over-certify this step's `then` from a
+            # green run of this predicate alone.
             completion=VerbIssued(verb="new_campaign"),
         ),
         TutorialStep(
@@ -296,7 +348,12 @@ WAYNE_OPENING_ARC: Final[TutorialScript] = TutorialScript(
             when="the player presses Enter to begin the operation",
             then="the campaign shell reveals Wayne County's own home dossier",
             anchor="binding:BriefingScreen:enter",
-            completion=VerbIssued(verb="begin"),
+            # Verifies the advertised OUTCOME (the dossier reveal), not
+            # merely the keypress dispatch — unlike boot_into_lobby above,
+            # an outcome predicate IS queryable here (reviewer finding,
+            # T6 U1 fix pass): self-contained rather than relying on the
+            # next step's OnPage to cover it after the fact.
+            completion=OnPage(subject="county/26163"),
         ),
         TutorialStep(
             id="read_the_county_dossier",
@@ -326,7 +383,13 @@ WAYNE_OPENING_ARC: Final[TutorialScript] = TutorialScript(
                 "instant a critical event or the endgame pattern fires"
             ),
             anchor="binding:ArchiveApp:r",
-            completion=VerbIssued(verb="run_until_paused"),
+            # Verifies the advertised STOP itself (reviewer finding, T6 U1
+            # fix pass) — VerbIssued would prove only that the keypress
+            # dispatched, not that the driver actually stopped, which is
+            # the whole point of this Then. See PausePending's own
+            # docstring for the grounding (PacedTickDriver.awaiting_ack /
+            # .pending_pause).
+            completion=PausePending(),
         ),
         TutorialStep(
             id="acknowledge_the_pause",

--- a/src/babylon/game/tutorial.py
+++ b/src/babylon/game/tutorial.py
@@ -1,0 +1,374 @@
+"""The tutorial step script — the T6 unification (Program v1.0.0, Unit U1).
+
+Per ``ai/_inbox/t6-tutorial-bdd-ruling.md`` (BD, 2026-07-21): the opening-arc
+tutorial IS the BDD acceptance suite. ONE data artifact —
+:class:`TutorialScript` — is meant to be consumed three ways: the player
+overlay renders each :class:`TutorialStep`'s Given/When/Then as instruction
+text over the live campaign; a headless Textual-Pilot executor drives the
+When and hard-asserts the Then; the developer-facing docs read the same
+steps as living specification. Because all three consumers read the SAME
+fields, "the strings the player reads ARE the scenario definitions CI
+runs" — there is no second, separately-authored copy of this prose anywhere
+(:attr:`TutorialStep.scenario_name` / :attr:`TutorialStep.overlay_text`
+below both derive verbatim from ``given``/``when``/``then``; nothing else
+in this module, or any future consumer, is licensed to hardcode a parallel
+description).
+
+This unit ships ONLY the model + the authored opening-arc script (the
+ruling's own placement note: the overlay consumer, the Pilot executor, the
+option-coverage sentinel, and the transcript emitter are separate T6 units
+building on this one).
+
+Completion predicates are DATA, never callables (the ruling: "no prose
+duplication anywhere, ever" generalizes to "no hidden behavior anywhere
+either" — a lambda could not serialize into the overlay/docs the way a
+Pydantic model does). The closed vocabulary below is deliberately small —
+exactly the four kinds an opening-arc teaching script needs:
+
+* :class:`OnPage` — the player is viewing a named dossier subject.
+* :class:`TickAtLeast` — the campaign has resolved at least a given tick.
+* :class:`EventAcked` — a pending autopause has been acknowledged.
+* :class:`VerbIssued` — a named verb/binding action has been issued (this
+  covers BOTH a TUI keybinding's action name — ``"advance_tick"``,
+  ``"run_until_paused"`` — and, in a future script, an Article-V player
+  verb string; the ruling's own anchor phrasing, "the page/binding/verb it
+  exercises", already treats bindings and verbs as one family).
+
+:data:`CompletionPredicateAdapter` validates against exactly this closed set
+— an unrecognized ``kind`` raises :class:`pydantic.ValidationError` loudly
+(Constitution III.11), never a silently-ignored predicate.
+
+**Anchor grammar** (a plain string field, not its own typed union — the
+ruling names anchor as a single field; the option-coverage sentinel, a
+later unit, is where matching anchors against live registries belongs, not
+here). Three prefixes, used consistently by the authored script below:
+
+* ``"binding:<ClassName>:<key>"`` — a :class:`~textual.binding.Binding`
+  entry's key on that Textual class's own ``BINDINGS`` (qualified by class
+  name because the same key means different things on different
+  screens — ``"a"`` is ``LobbyScreen``'s archive-toggle but
+  ``ArchiveApp``'s acknowledge-pause).
+* ``"page:<subject>"`` — a vault-baked dossier subject id (the
+  ``babylon.tui.app.PageSource``/``CampaignHandle.read_page`` convention).
+* ``"palette:<subject>"`` — a command-palette
+  (:class:`~babylon.tui.palette.EntityNavigatorProvider`) pick of that
+  known subject.
+
+Every anchor below was verified against the LIVE registries before
+authoring (Constitution: no fiction) — ``babylon.tui.app.ArchiveApp.
+BINDINGS`` (``t``/``r``/``a``/``ctrl+o``/``ctrl+i``), ``babylon.tui.
+app.BriefingScreen.BINDINGS`` (``enter``), ``babylon.tui.campaign_menu.
+LobbyScreen.BINDINGS`` (``n``/``a``/``d``/``escape``), and the real baked
+subjects ``county/26163`` (Wayne — ruling 3, "Wayne stays in lobby"),
+``economy/USA`` (:mod:`babylon.projection.vault.tick_baker`'s singleton
+economy dossier, carrying the real Fundamental Theorem verdict —
+:attr:`~babylon.projection.view_models.EconomyView.labor_aristocracy_verdict`)
+via ``tests/unit/tui/test_t3_live_reachability.py``'s own
+``TestCommandPaletteSurfacesT3Pages`` (a palette search for ``"economy"``
+finds ``"economy/USA"`` on a live campaign, proving the ``palette:``
+anchor below is real, not aspirational).
+
+**Deviation from the task brief's literal beat list** ("... advance a tick
+-> read the chronicle -> run to autopause -> ..."): there is today no live
+Chronicle screen wired into :class:`~babylon.tui.app.ArchiveApp` —
+:mod:`babylon.tui.chronicle`'s ``render_chronicle``/``chronicle_stream`` are
+real, tested, and fed real per-tick content by
+:func:`~babylon.game.chronicle_adapter.chronicle_events_from_bus`, but no
+production caller mounts them as a screen or widget yet (verified by
+grepping every non-test caller). Authoring a "read the chronicle" STEP
+would be exactly the fiction the ruling forbids ("do NOT author steps for
+verbs/options that do not exist in the shell today"). The tick's real
+outcome — what the chronicle would show — is instead folded into
+``advance_a_tick``'s own Then-clause (the status line reports it); wiring a
+live Chronicle screen and giving it its own step is a future unit's honest
+gap to close, not this one's to fabricate.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Final, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
+
+from babylon.engine.scenarios.wayne_county import WayneCountyScenario
+
+__all__ = [
+    "EventAcked",
+    "OnPage",
+    "TickAtLeast",
+    "VerbIssued",
+    "CompletionPredicate",
+    "CompletionPredicateAdapter",
+    "TutorialStep",
+    "TutorialScript",
+    "WAYNE_OPENING_ARC",
+]
+
+#: Shared id-slug shape for both a step's own id and a script's id: lowercase,
+#: starts with a letter, ``[a-z0-9_]`` after — a stable machine key, never a
+#: free-text title (that lives in ``given``/``when``/``then`` instead).
+_ID_PATTERN: Final[str] = r"^[a-z][a-z0-9_]*$"
+
+
+class OnPage(BaseModel):
+    """Then: the player is viewing ``subject``'s dossier page.
+
+    :param subject: the vault-relative subject id (e.g. ``"county/26163"``),
+        matching :data:`babylon.tui.app.PageSource`'s own convention.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: Literal["on_page"] = "on_page"
+    subject: str = Field(min_length=1)
+
+
+class TickAtLeast(BaseModel):
+    """Then: the campaign has resolved at least tick ``tick``.
+
+    :param tick: the minimum committed tick this predicate is satisfied by.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: Literal["tick_at_least"] = "tick_at_least"
+    tick: int = Field(ge=0)
+
+
+class EventAcked(BaseModel):
+    """Then: the pending autopause has been acknowledged.
+
+    Unconditional by design (no ``event_type``/``tick`` filter): the
+    opening-arc script only ever teaches ONE acknowledge beat, and a later
+    script needing to distinguish which pending pause it acks can widen
+    this predicate kind then — never with an ad hoc field this unit does
+    not exercise (YAGNI, CLAUDE.md "no features beyond what was asked").
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: Literal["event_acked"] = "event_acked"
+
+
+class VerbIssued(BaseModel):
+    """Then: the named verb/binding action has been issued.
+
+    :param verb: an action name — either a TUI binding's own
+        ``Binding(key, action, ...)`` action string (e.g.
+        ``"advance_tick"``, ``"run_until_paused"``, ``"begin"``,
+        ``"new_campaign"``) or, in a future script, an Article-V player
+        verb string (e.g. ``"educate"``). Never the raw KEY (``"t"``) —
+        the action name is what a remapped keybinding would still share.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: Literal["verb_issued"] = "verb_issued"
+    verb: str = Field(min_length=1)
+
+
+CompletionPredicate = Annotated[
+    OnPage | TickAtLeast | EventAcked | VerbIssued,
+    Field(discriminator="kind"),
+]
+"""The closed completion-predicate vocabulary (module docstring). Every
+:class:`TutorialStep` carries exactly one — DATA, never a callable, so the
+same script serializes for the overlay, the Pilot executor, and the docs."""
+
+CompletionPredicateAdapter: TypeAdapter[OnPage | TickAtLeast | EventAcked | VerbIssued] = (
+    TypeAdapter(CompletionPredicate)
+)
+"""Validates a raw ``{"kind": ..., ...}`` payload against the closed set
+above. An unrecognized ``kind`` (or one missing it) raises
+:class:`pydantic.ValidationError` loudly (Constitution III.11) — there is
+no silent fallback predicate kind."""
+
+#: Generous static bound on ``anchor``'s length (Power-of-10 rule: every
+#: bounded thing gets a named, provable ceiling, not an implicit one) —
+#: anchors are short identifiers (``"binding:ArchiveApp:ctrl+o"``), never
+#: prose; this sits far above any real anchor string.
+_MAX_ANCHOR_LEN: Final[int] = 256
+
+
+class TutorialStep(BaseModel):
+    """One Given/When/Then teaching beat, keyed to one real UI anchor.
+
+    :param id: a stable machine key, unique within its
+        :class:`TutorialScript` (validated there, not here — uniqueness is
+        a property of the SET of steps, not of one step in isolation).
+    :param given: the precondition sentence fragment.
+    :param when: the player's action sentence fragment.
+    :param then: the observable-result sentence fragment.
+    :param anchor: the page/binding/verb this step exercises (module
+        docstring's anchor grammar).
+    :param completion: the DATA predicate (:data:`CompletionPredicate`)
+        proving ``then`` actually happened.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: str = Field(min_length=1, pattern=_ID_PATTERN)
+    given: str = Field(min_length=1)
+    when: str = Field(min_length=1)
+    then: str = Field(min_length=1)
+    anchor: str = Field(min_length=1, max_length=_MAX_ANCHOR_LEN)
+    completion: CompletionPredicate
+
+    @property
+    def scenario_name(self) -> str:
+        """The step's scenario-name sentence — the developer-docs title.
+
+        Derives VERBATIM from :attr:`given`/:attr:`when`/:attr:`then` (the
+        rendering contract this module's docstring names): there is no
+        second, separately-authored title string anywhere for this step.
+        Mirrors :class:`~babylon.tui.campaign_menu.LobbyRow`'s own
+        ``label`` property — a frozen model's derived display string.
+        """
+        return f"Given {self.given}, when {self.when}, then {self.then}."
+
+    @property
+    def overlay_text(self) -> str:
+        """The player-facing overlay block — the SAME fields,
+        :attr:`scenario_name`'s sibling rendering (module docstring: "no
+        prose duplication anywhere, ever"). A future opening-arc overlay
+        consumer renders exactly this, never a separately-authored copy.
+        """
+        return f"GIVEN: {self.given}\nWHEN: {self.when}\nTHEN: {self.then}"
+
+
+#: Generous static bound on a script's step count (Power-of-10 rule 2): the
+#: authored Wayne arc below has 9; this sits far above any teaching arc a
+#: single opening session would plausibly need.
+_MAX_SCRIPT_STEPS: Final[int] = 64
+
+
+class TutorialScript(BaseModel):
+    """An ordered, uniquely-keyed sequence of :class:`TutorialStep`\\ s.
+
+    :param id: the script's own stable machine key.
+    :param scenario: the engine scenario this script is authored against
+        (e.g. ``"wayne_county"`` — :attr:`~babylon.engine.scenarios.
+        wayne_county.WayneCountyScenario.name`, reused rather than
+        re-typed, so the two never drift). The headless Pilot executor
+        (a later T6 unit) boots exactly this scenario before driving the
+        script — never an unstated implicit one.
+    :param steps: the ordered beats; length bounded by
+        :data:`_MAX_SCRIPT_STEPS` (Power-of-10 rule 2).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: str = Field(min_length=1, pattern=_ID_PATTERN)
+    scenario: str = Field(min_length=1)
+    steps: tuple[TutorialStep, ...] = Field(min_length=1, max_length=_MAX_SCRIPT_STEPS)
+
+    @model_validator(mode="after")
+    def _unique_step_ids(self) -> Self:
+        """Reject a script whose steps do not carry pairwise-distinct ids.
+
+        :raises ValueError: on the first duplicate id found (loud, not a
+            silently-deduplicated script — Constitution III.11).
+        """
+        seen: set[str] = set()
+        for step in self.steps:  # loop bound: len(self.steps) <= _MAX_SCRIPT_STEPS
+            if step.id in seen:
+                msg = f"TutorialScript {self.id!r}: duplicate step id {step.id!r}"
+                raise ValueError(msg)
+            seen.add(step.id)
+        return self
+
+
+WAYNE_OPENING_ARC: Final[TutorialScript] = TutorialScript(
+    id="wayne_opening_arc",
+    scenario=WayneCountyScenario.name,
+    steps=(
+        TutorialStep(
+            id="boot_into_lobby",
+            given="a fresh boot with no campaign chosen yet, the campaign lobby showing",
+            when="the player presses 'n' to mint a new campaign",
+            then="a freshly minted campaign row appears in the lobby, ready to be loaded",
+            anchor="binding:LobbyScreen:n",
+            completion=VerbIssued(verb="new_campaign"),
+        ),
+        TutorialStep(
+            id="begin_the_operation",
+            given="the freshly minted campaign is chosen and its Scenario Briefing dossier is showing",
+            when="the player presses Enter to begin the operation",
+            then="the campaign shell reveals Wayne County's own home dossier",
+            anchor="binding:BriefingScreen:enter",
+            completion=VerbIssued(verb="begin"),
+        ),
+        TutorialStep(
+            id="read_the_county_dossier",
+            given="the campaign shell has just revealed Wayne County's home dossier at tick 0",
+            when="the player reads county/26163's page",
+            then="the county dossier's statblock renders Wayne's own material state, not a fixture",
+            anchor="page:county/26163",
+            completion=OnPage(subject="county/26163"),
+        ),
+        TutorialStep(
+            id="advance_a_tick",
+            given="Wayne County's dossier is showing at tick 0",
+            when="the player presses 't' to advance one tick",
+            then=(
+                "the campaign resolves tick 1 through the full 30-system engine and "
+                "the status line reports the tick just committed"
+            ),
+            anchor="binding:ArchiveApp:t",
+            completion=TickAtLeast(tick=1),
+        ),
+        TutorialStep(
+            id="run_until_autopause",
+            given="the campaign has resolved at least one tick",
+            when="the player presses 'r' to run until an autopause or the endgame lock",
+            then=(
+                "the paced driver auto-advances through uneventful ticks and stops the "
+                "instant a critical event or the endgame pattern fires"
+            ),
+            anchor="binding:ArchiveApp:r",
+            completion=VerbIssued(verb="run_until_paused"),
+        ),
+        TutorialStep(
+            id="acknowledge_the_pause",
+            given="an autopause is pending after a run",
+            when="the player presses 'a' to acknowledge it",
+            then="the pending autopause clears and further 't'/'r' presses are permitted again",
+            anchor="binding:ArchiveApp:a",
+            completion=EventAcked(),
+        ),
+        TutorialStep(
+            id="palette_to_the_economy_dossier",
+            given="the campaign shell is showing any dossier page",
+            when="the player opens the command palette with Ctrl-P and picks economy/USA",
+            then="the dossier pane navigates to the national economy dossier",
+            anchor="palette:economy/USA",
+            completion=OnPage(subject="economy/USA"),
+        ),
+        TutorialStep(
+            id="read_the_theorem_verdict",
+            given="the economy dossier is showing",
+            when="the player reads its Fundamental Theorem verdict",
+            then=(
+                "the wage balance and the labor-aristocracy verdict render as real numbers "
+                "read off the SAME opposition the engine itself adjudicates, never a "
+                "fabricated parallel feed"
+            ),
+            anchor="page:economy/USA",
+            completion=OnPage(subject="economy/USA"),
+        ),
+        TutorialStep(
+            id="jump_back_to_wayne",
+            given="the player has navigated away from Wayne County's dossier to economy/USA",
+            when="the player presses Ctrl-O to walk back one jumplist step",
+            then="the dossier pane returns to county/26163, the campaign's own home page",
+            anchor="binding:ArchiveApp:ctrl+o",
+            completion=OnPage(subject="county/26163"),
+        ),
+    ),
+)
+"""The Wayne first-session opening arc (Program v1.0.0 T6, Unit U1) — the
+core loop end-to-end over what the shell actually does today: lobby ->
+briefing -> the county dossier -> a tick -> a run to autopause ->
+acknowledge -> the command palette -> the economy dossier's theorem verdict
+-> jump back. Every anchor and subject id above was checked against the
+live registries before authoring (module docstring)."""

--- a/src/babylon/game/tutorial_runtime.py
+++ b/src/babylon/game/tutorial_runtime.py
@@ -1,0 +1,120 @@
+"""The T6 tutorial's completion-predicate evaluator (Program v1.0.0 T6, Unit U4).
+
+Fulfills :class:`~babylon.tui.tutorial_overlay.TutorialProgress` for real —
+the composition root's concrete answer to "is this step complete right now?",
+built over the SAME closed :data:`~babylon.game.tutorial.CompletionPredicate`
+vocabulary the headless Pilot executor (Unit U2, :mod:`tests.unit.tui.
+test_tutorial_pilot`) already asserts against, so the player-facing overlay
+and CI never diverge on what "complete" means for a given step.
+
+**Never handed a ``VerbIssued``-completion step.** Unlike the Pilot
+executor (which can wrap a step's own ``action_<verb>`` in a
+``mock.patch.object`` spy — see :func:`tests.unit.tui.test_tutorial_pilot.
+_drive_verb_issued`), this evaluator runs inside the REAL, shipped game: it
+has no license to instrument production action dispatch just to observe
+whether a keypress fired. :meth:`TutorialRuntimeProgress.is_step_complete`
+therefore raises loudly (Constitution III.11) if it is ever asked to
+evaluate a ``VerbIssued`` step — never a silent ``False`` masquerading as
+"not yet complete" forever. This is why :mod:`babylon.cli.play`'s own
+composition root only ever hands this evaluator the authored arc's SLICE
+starting after its two ``VerbIssued`` beats (``boot_into_lobby``,
+``begin_the_operation``) — both already necessarily true by the time the
+campaign shell (and this overlay) exist, since reaching the shell requires
+having done them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Protocol, runtime_checkable
+
+from babylon.game.tutorial import (
+    EventAcked,
+    OnPage,
+    PausePending,
+    TickAtLeast,
+    TutorialStep,
+    VerbIssued,
+)
+
+__all__ = ["TutorialRuntimeProgress"]
+
+
+@runtime_checkable
+class _TickSource(Protocol):
+    """Structural shape this module needs from the live campaign: only its
+    committed tick (:class:`~babylon.tui.app.CampaignHandle` satisfies this)."""
+
+    @property
+    def tick(self) -> int: ...
+
+
+@runtime_checkable
+class _PausedDriverSource(Protocol):
+    """Structural shape this module needs from the paced driver: only
+    ``awaiting_ack`` (:class:`~babylon.tui.app.PacedDriverHandle` satisfies
+    this)."""
+
+    @property
+    def awaiting_ack(self) -> bool: ...
+
+
+class TutorialRuntimeProgress:
+    """The live evaluator: closed dispatch over :data:`~babylon.game.
+    tutorial.CompletionPredicate`, reading the campaign's tick, the paced
+    driver's ``awaiting_ack``, and the nav shell's current subject.
+
+    :param steps: the exact step sequence :class:`~babylon.tui.
+        tutorial_overlay.TutorialOverlay` was ALSO constructed with — indices
+        must line up between the two (the composition root's job to keep
+        them so; see ``babylon.cli.play``'s own wiring).
+    :param campaign: the live campaign (only its ``tick`` is read).
+    :param driver: the live paced driver, or ``None`` when no
+        ``driver_factory`` was wired — ``PausePending``/``EventAcked`` then
+        never hold (there is no driver to have ever paused).
+    :param current_subject: reads the nav shell's CURRENT subject at call
+        time — a plain callable rather than a nav-shell import, so this
+        module never needs to know :class:`~babylon.tui.nav.NavShell` exists.
+    """
+
+    def __init__(
+        self,
+        *,
+        steps: Sequence[TutorialStep],
+        campaign: _TickSource,
+        driver: _PausedDriverSource | None,
+        current_subject: Callable[[], str | None],
+    ) -> None:
+        self._steps: tuple[TutorialStep, ...] = tuple(steps)
+        self._campaign = campaign
+        self._driver = driver
+        self._current_subject = current_subject
+
+    def is_step_complete(self, step_index: int) -> bool:
+        """See :meth:`~babylon.tui.tutorial_overlay.TutorialProgress.is_step_complete`.
+
+        :raises AssertionError: ``step_index`` names a ``VerbIssued``-completion
+            step (module docstring), or the completion is outside the closed
+            vocabulary entirely — never silently ``False``.
+        """
+        if not 0 <= step_index < len(self._steps):
+            return False
+        predicate = self._steps[step_index].completion
+        if isinstance(predicate, OnPage):
+            return self._current_subject() == predicate.subject
+        if isinstance(predicate, TickAtLeast):
+            return self._campaign.tick >= predicate.tick
+        if isinstance(predicate, PausePending):
+            return self._driver is not None and self._driver.awaiting_ack
+        if isinstance(predicate, EventAcked):
+            return self._driver is not None and not self._driver.awaiting_ack
+        if isinstance(predicate, VerbIssued):
+            msg = (
+                f"TutorialRuntimeProgress: step {self._steps[step_index].id!r}'s "
+                f"VerbIssued({predicate.verb!r}) completion is not observable from "
+                "inside the live campaign shell (see module docstring) — the "
+                "composition root must never hand this evaluator a VerbIssued step"
+            )
+            raise AssertionError(msg)
+        msg = f"TutorialRuntimeProgress: unrecognized completion predicate kind {predicate!r}"
+        raise AssertionError(msg)

--- a/src/babylon/sentinels/_ast.py
+++ b/src/babylon/sentinels/_ast.py
@@ -1661,3 +1661,81 @@ def wallclock_call_lines(path: Path) -> list[tuple[int, str]]:
         if symbol is not None:
             hits.add((node.lineno, symbol))
     return sorted(hits)
+
+
+def declared_bindings(path: Path) -> tuple[tuple[str, str, str, int], ...]:
+    """Extract every class's own declared ``BINDINGS = [Binding(...), ...]``.
+
+    Reads a Textual client module statically — :mod:`babylon.sentinels` never
+    imports :mod:`textual` or ``babylon.tui`` (layer 0.5) — and returns each
+    class's OWN ``BINDINGS`` list literal (never an inherited/merged one; a
+    subclass that does not redeclare ``BINDINGS`` contributes nothing here,
+    matching Textual's own "class attribute, not accumulated" semantics). Only
+    ``Binding(key, action, ...)`` calls whose first two positional args are
+    string constants are extracted; a computed key or action is not a
+    *declared* one and is skipped, mirroring :func:`coupling_edges`.
+
+    :param path: The module to scan.
+    :returns: ``(class_name, key, action, line)`` tuples, in source order.
+    :raises SentinelCheckError: If the file is missing or unparseable.
+    """
+    tree = parse_module(path)
+    found: list[tuple[str, str, str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for stmt in node.body:  # own body only -- never a nested/inherited list
+            if not (
+                isinstance(stmt, ast.Assign)
+                and any(isinstance(t, ast.Name) and t.id == "BINDINGS" for t in stmt.targets)
+                and isinstance(stmt.value, ast.List)
+            ):
+                continue
+            for element in stmt.value.elts:
+                if not (
+                    isinstance(element, ast.Call)
+                    and isinstance(element.func, ast.Name)
+                    and element.func.id == "Binding"
+                    and len(element.args) >= 2
+                    and isinstance(element.args[0], ast.Constant)
+                    and isinstance(element.args[0].value, str)
+                    and isinstance(element.args[1], ast.Constant)
+                    and isinstance(element.args[1].value, str)
+                ):
+                    continue
+                found.append(
+                    (node.name, element.args[0].value, element.args[1].value, element.lineno)
+                )
+    return tuple(found)
+
+
+def tutorial_step_anchors(path: Path) -> tuple[str, ...]:
+    """Extract every declared ``TutorialStep(..., anchor="...", ...)`` literal.
+
+    Reads a tutorial-script-authoring module statically -- the option-coverage
+    sentinel never imports :mod:`babylon.game.tutorial` itself (it transitively
+    pulls in the engine layer, which ``babylon.sentinels`` may not import).
+
+    :param path: The module to scan.
+    :returns: The declared ``anchor`` string literals, in source order
+        (duplicates preserved -- a script may legitimately exercise the same
+        anchor from two different steps).
+    :raises SentinelCheckError: If the file is missing or unparseable.
+    """
+    tree = parse_module(path)
+    anchors: list[str] = []
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "TutorialStep"
+        ):
+            continue
+        for kw in node.keywords:
+            if (
+                kw.arg == "anchor"
+                and isinstance(kw.value, ast.Constant)
+                and isinstance(kw.value.value, str)
+            ):
+                anchors.append(kw.value.value)
+    return tuple(anchors)

--- a/src/babylon/sentinels/tutorial_coverage/__init__.py
+++ b/src/babylon/sentinels/tutorial_coverage/__init__.py
@@ -1,0 +1,27 @@
+"""The tutorial option-coverage sentinel — every player-facing option is taught.
+
+Per ``ai/_inbox/t6-tutorial-bdd-ruling.md`` (BD, 2026-07-21): the tutorial IS
+the BDD acceptance suite, and "an option with no scenario is a seam" — this
+sensor makes that a gate. Every class's own declared
+:class:`~textual.binding.Binding` in ``babylon.tui``/``babylon.game`` must be
+exercised by an authored :class:`~babylon.game.tutorial.TutorialStep` or carry
+a cited :class:`~babylon.sentinels.exemptions.SentinelExemption`.
+
+Gating and local/on-demand:
+``poetry run python tools/sentinel_check.py tutorial-coverage --check``.
+
+Layer 0.5: reads ``babylon.tui``/``babylon.game`` statically via :mod:`ast` —
+it may not import them (import-linter contract, ``pyproject.toml``).
+"""
+
+from babylon.sentinels.tutorial_coverage.checks import (
+    check_every_binding_covered_or_exempted,
+    check_every_exemption_still_names_a_real_binding,
+    main,
+)
+
+__all__ = [
+    "check_every_binding_covered_or_exempted",
+    "check_every_exemption_still_names_a_real_binding",
+    "main",
+]

--- a/src/babylon/sentinels/tutorial_coverage/checks.py
+++ b/src/babylon/sentinels/tutorial_coverage/checks.py
@@ -1,0 +1,208 @@
+"""The tutorial option-coverage sentinel (static, gating).
+
+Per ``ai/_inbox/t6-tutorial-bdd-ruling.md`` (BD, 2026-07-21): "an option with no
+scenario is a seam (∂L boundary node) — red." This sensor is that check made
+real: every player-facing :class:`~textual.binding.Binding` a Babylon TUI class
+declares on its own ``BINDINGS`` must be exercised by some authored
+:class:`~babylon.game.tutorial.TutorialStep`'s ``anchor`` (``"binding:<Class>:
+<key>"`` — :mod:`babylon.game.tutorial`'s own anchor grammar) or carry a cited
+:class:`~babylon.sentinels.exemptions.SentinelExemption` in
+:data:`~babylon.sentinels.tutorial_coverage.registry.TUTORIAL_COVERAGE_EXEMPTIONS`.
+
+A companion direction closes the reverse hole (an exemption that no longer
+matches any live binding — the same "declared-but-absent" failure mode
+:mod:`babylon.sentinels.coupling` checks for its own registry): every declared
+exemption's key must still name a real, currently-declared binding.
+
+Scope -- STATIC coherence only: reads source with :mod:`ast`; never imports
+:mod:`textual`, ``babylon.tui``, or ``babylon.game.tutorial`` (layer 0.5, same
+rank as every other sentinel).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from babylon.sentinels._ast import declared_bindings, tutorial_step_anchors
+from babylon.sentinels.base import LabelledCheck, run_sensor
+from babylon.sentinels.exemptions import SentinelExemption, is_exempt
+from babylon.sentinels.report import finding
+from babylon.sentinels.tutorial_coverage.registry import TUTORIAL_COVERAGE_EXEMPTIONS
+
+#: Repo root (this file is ``<root>/src/babylon/sentinels/tutorial_coverage/checks.py``).
+_REPO_ROOT: Path = Path(__file__).resolve().parents[4]
+
+#: Where player-facing ``BINDINGS`` may be declared -- the live TUI shell and
+#: its composition root (a future ``TutorialOverlay`` may land in either).
+_BINDING_SCAN_ROOTS: tuple[str, ...] = ("src/babylon/tui", "src/babylon/game")
+
+#: Where authored :class:`~babylon.game.tutorial.TutorialStep` scripts live.
+_SCRIPT_SCAN_ROOT: str = "src/babylon/game"
+
+
+def _scan(root: str) -> list[Path]:
+    """List a scan root's Python files, deterministically ordered.
+
+    :param root: Repo-relative directory to scan.
+    :returns: Sorted absolute paths.
+    """
+    return sorted((_REPO_ROOT / root).rglob("*.py"))
+
+
+def _declared_options(
+    scan_roots: tuple[str, ...] = _BINDING_SCAN_ROOTS,
+) -> tuple[tuple[str, str, str, str, int], ...]:
+    """Every class's own declared binding, as an anchor plus its provenance.
+
+    :param scan_roots: Repo-relative directories to scan (injectable for tests).
+    :returns: ``(anchor, class_name, key, file, line)`` tuples, in scan order.
+    :raises SentinelCheckError: If a scanned file is unparseable.
+    """
+    options: list[tuple[str, str, str, str, int]] = []
+    for root in scan_roots:
+        for path in _scan(root):
+            rel = str(path.relative_to(_REPO_ROOT))
+            for class_name, key, _action, line in declared_bindings(path):
+                anchor = f"binding:{class_name}:{key}"
+                options.append((anchor, class_name, key, rel, line))
+    return tuple(options)
+
+
+def _exercised_anchors(script_scan_root: str = _SCRIPT_SCAN_ROOT) -> frozenset[str]:
+    """Every anchor exercised by some authored tutorial script.
+
+    :param script_scan_root: Repo-relative directory to scan (injectable).
+    :returns: The set of declared ``anchor=`` literals.
+    :raises SentinelCheckError: If a scanned file is unparseable.
+    """
+    anchors: set[str] = set()
+    for path in _scan(script_scan_root):
+        anchors.update(tutorial_step_anchors(path))
+    return frozenset(anchors)
+
+
+def check_every_binding_covered_or_exempted(
+    options: tuple[tuple[str, str, str, str, int], ...] | None = None,
+    exercised: frozenset[str] | None = None,
+    exemptions: tuple[SentinelExemption, ...] = TUTORIAL_COVERAGE_EXEMPTIONS,
+) -> list[str]:
+    """Every declared binding is exercised by a script or carries an exemption.
+
+    :param options: Declared bindings to judge (defaults to the live scan;
+        injectable so the efficacy test can supply an injected defect).
+    :param exercised: Anchors the authored scripts exercise (defaults to the
+        live scan; injectable).
+    :param exemptions: Declared exemption rows (injectable).
+    :returns: Sorted agent-legible finding strings (empty when every binding is
+        covered or exempted).
+    :raises SentinelCheckError: If a scanned file is missing or unparseable.
+    """
+    live_options = _declared_options() if options is None else options
+    live_exercised = _exercised_anchors() if exercised is None else exercised
+    findings: list[str] = []
+    for anchor, class_name, key, file, line in live_options:
+        if anchor in live_exercised:
+            continue
+        if is_exempt(("binding", class_name, key), exemptions):
+            continue
+        findings.append(
+            finding(
+                error_class="tutorial-option-uncovered",
+                symbol=anchor,
+                file=file,
+                line=line,
+                problem=(
+                    f"{class_name}'s {key!r} binding is a real player-facing option "
+                    "with no TutorialStep exercising it and no cited exemption"
+                ),
+                remedy=(
+                    "either author a TutorialStep whose anchor is "
+                    f"{anchor!r} (ai/_inbox/t6-tutorial-bdd-ruling.md) or add a dated "
+                    "SentinelExemption to "
+                    "babylon.sentinels.tutorial_coverage.registry."
+                    "TUTORIAL_COVERAGE_EXEMPTIONS keyed "
+                    f'("binding", {class_name!r}, {key!r})'
+                ),
+            )
+        )
+    return sorted(findings)
+
+
+def check_every_exemption_still_names_a_real_binding(
+    options: tuple[tuple[str, str, str, str, int], ...] | None = None,
+    exemptions: tuple[SentinelExemption, ...] = TUTORIAL_COVERAGE_EXEMPTIONS,
+) -> list[str]:
+    """Every declared exemption's key still names a currently-declared binding.
+
+    The dual of :func:`check_every_binding_covered_or_exempted` -- an
+    exemption whose binding was renamed or removed is dead weight that would
+    silently mask a FUTURE binding coincidentally reusing the same class/key
+    (:mod:`babylon.sentinels.exemptions`'s own exact-tuple-match design does
+    not protect against a stale row being *reused* by a new, unrelated finding
+    unless something keeps the registry honest against the live source).
+
+    :param options: Declared bindings (defaults to the live scan; injectable).
+    :param exemptions: Declared exemption rows (injectable).
+    :returns: Sorted agent-legible finding strings for exemptions with no
+        matching live binding (empty when every exemption is still grounded).
+    :raises SentinelCheckError: If a scanned file is missing or unparseable.
+    """
+    live_options = _declared_options() if options is None else options
+    live_keys = {(class_name, key) for _anchor, class_name, key, _file, _line in live_options}
+    findings: list[str] = []
+    for exemption in exemptions:
+        if exemption.key[0] != "binding" or len(exemption.key) != 3:
+            continue
+        _kind, class_name, key = exemption.key
+        if (class_name, key) in live_keys:
+            continue
+        findings.append(
+            finding(
+                error_class="tutorial-exemption-stale",
+                symbol=".".join(exemption.key),
+                file="src/babylon/sentinels/tutorial_coverage/registry.py",
+                line=0,
+                problem=(
+                    f"exemption keyed {exemption.key!r} names no currently-declared "
+                    f"{class_name}.BINDINGS entry for key {key!r}"
+                ),
+                remedy="delete the stale row from TUTORIAL_COVERAGE_EXEMPTIONS",
+            )
+        )
+    return sorted(findings)
+
+
+def _summary(advisory_count: int) -> str:
+    """Build the clean-run summary line.
+
+    :param advisory_count: Number of advisory findings (always ``0`` -- this
+        sensor has no advisory tier today).
+    :returns: The one-line summary.
+    """
+    del advisory_count
+    return "TUTORIAL-COVERAGE: every declared binding is covered or exempted; every exemption is grounded"
+
+
+_GATING: tuple[LabelledCheck, ...] = (
+    ("covered-or-exempted", check_every_binding_covered_or_exempted),
+    ("exemption-grounded", check_every_exemption_still_names_a_real_binding),
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point -- ``tools/sentinel_check.py tutorial-coverage [--check]``.
+
+    :param argv: Forwarded CLI args (``--check`` is accepted for the
+        dispatcher's uniform contract; this sensor always gates).
+    :returns: 0 clean, 1 gating violation found, 2 infrastructure failure.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="CI mode (no-op alias)")
+    parser.parse_args(argv)
+    return run_sensor("TUTORIAL-COVERAGE", _GATING, (), _summary)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/babylon/sentinels/tutorial_coverage/registry.py
+++ b/src/babylon/sentinels/tutorial_coverage/registry.py
@@ -1,0 +1,71 @@
+"""Declared exemptions for the tutorial option-coverage sentinel.
+
+Every option row this gate finds uncovered by the authored tutorial scripts is
+either wired into a future step or recorded here, dated and owned, per
+:mod:`babylon.sentinels.exemptions`'s standard shape. A key is
+``("binding", <class_name>, <textual-key>)`` -- matching
+:func:`babylon.sentinels._ast.declared_bindings`'s own triple, so an exemption
+can never collide across two different classes' same key (``LobbyScreen``'s
+``"a"`` and ``ArchiveApp``'s ``"a"`` are two distinct keys, by design --
+:mod:`babylon.game.tutorial`'s own anchor-grammar docstring).
+"""
+
+from __future__ import annotations
+
+from babylon.sentinels.exemptions import SentinelExemption
+
+TUTORIAL_COVERAGE_EXEMPTIONS: tuple[SentinelExemption, ...] = (
+    SentinelExemption(
+        key=("binding", "ArchiveApp", "ctrl+i"),
+        reason=(
+            "ArchiveApp.jump_forward (ctrl+i) is the jumplist-forward half of a "
+            "pair whose backward half (ctrl+o, jump_back) IS exercised by "
+            "wayne_opening_arc's jump_back_to_wayne step. The opening arc teaches "
+            "one jumplist round-trip (navigate away, then walk back) -- teaching "
+            "the forward walk too is a natural next beat for a follow-up script, "
+            "not a gap in the first-session arc's own scope."
+        ),
+        owner="Persephone Raskova",
+        date="2026-07-22",
+        tracking_task="N/A (future opening-arc-extension unit per "
+        "ai/_inbox/t6-tutorial-bdd-ruling.md; not a wired gap)",
+    ),
+    SentinelExemption(
+        key=("binding", "LobbyScreen", "a"),
+        reason=(
+            "LobbyScreen.toggle_archive (a) reveals ARCHIVED campaign rows -- an "
+            "administrative lobby action the first-session opening arc has no "
+            "reason to teach (wayne_opening_arc's own boot_into_lobby step mints "
+            "a fresh campaign and moves on; there is nothing archived yet to "
+            "toggle into view)."
+        ),
+        owner="Persephone Raskova",
+        date="2026-07-22",
+        tracking_task="N/A (secondary lobby chrome, not a game-loop verb)",
+    ),
+    SentinelExemption(
+        key=("binding", "LobbyScreen", "d"),
+        reason=(
+            "LobbyScreen.delete_step (d) is a destructive campaign-deletion "
+            "action -- deliberately not exercised by a teaching script whose own "
+            "job is to mint and enter a campaign, never to delete the one it just "
+            "made."
+        ),
+        owner="Persephone Raskova",
+        date="2026-07-22",
+        tracking_task="N/A (destructive administrative action, out of scope for "
+        "a first-session teaching arc)",
+    ),
+    SentinelExemption(
+        key=("binding", "LobbyScreen", "escape"),
+        reason=(
+            "LobbyScreen.leave (escape) exits the lobby without choosing a "
+            "campaign -- the opening arc's own point is to choose one "
+            "(boot_into_lobby's 'n' -> begin_the_operation), so the abandon path "
+            "is intentionally untaught, not overlooked."
+        ),
+        owner="Persephone Raskova",
+        date="2026-07-22",
+        tracking_task="N/A (the arc teaches choosing a campaign, not abandoning the lobby)",
+    ),
+)

--- a/src/babylon/sentinels/tutorial_coverage/registry.py
+++ b/src/babylon/sentinels/tutorial_coverage/registry.py
@@ -68,4 +68,15 @@ TUTORIAL_COVERAGE_EXEMPTIONS: tuple[SentinelExemption, ...] = (
         date="2026-07-22",
         tracking_task="N/A (the arc teaches choosing a campaign, not abandoning the lobby)",
     ),
+    SentinelExemption(
+        key=("binding", "TutorialOverlay", "escape"),
+        reason=(
+            "TutorialOverlay.dismiss_tutorial lets the player close the guided "
+            "overlay early -- tutorial-system chrome, not a game-loop verb the "
+            "opening arc itself teaches."
+        ),
+        owner="Persephone Raskova",
+        date="2026-07-22",
+        tracking_task="N/A (tutorial-chrome dismiss action, not a wired gap)",
+    ),
 )

--- a/src/babylon/tui/app.py
+++ b/src/babylon/tui/app.py
@@ -45,6 +45,23 @@ and every successful ``t``/``r`` tick advance re-scans it again (cheap
 frozenset compare, skipped when unchanged) so pages baked mid-campaign
 become navigable immediately. The demo (no-``campaign_menu``) boot path is
 completely unaffected.
+
+Program v1.0.0 T6 Unit U4 (the guided opening-arc overlay — not to be
+confused with the earlier, unrelated "Unit U1" above) adds
+``tutorial_steps``/``tutorial_progress_factory``: when both are given,
+:meth:`ArchiveApp._on_campaign_chosen` builds this campaign's
+:class:`~babylon.tui.tutorial_overlay.TutorialProgress` seam, and
+:meth:`ArchiveApp._on_briefing_dismissed` mounts a
+:class:`~babylon.tui.tutorial_overlay.TutorialOverlay` over the freshly-
+revealed campaign shell IFF that seam is not ``None`` (the composition
+root's own new-vs-resumed gating — see ``babylon.cli.play``). Every
+committed-tick action (``t``/``r``/``a``) and every navigation event
+(``Ctrl-O``/``Ctrl-I``/palette pick/wikilink follow — all of which route
+through :meth:`ArchiveApp._navigate`) re-polls the mounted overlay via
+:meth:`ArchiveApp._refresh_tutorial_progress`. With no
+``tutorial_progress_factory`` given (the default), nothing here runs at
+all — every pre-Unit-U4 caller/test, and the demo boot path, is completely
+unaffected.
 """
 
 from __future__ import annotations
@@ -73,6 +90,7 @@ from babylon.tui.nav import InMemoryNavPersistence, NavShell, subject_for
 from babylon.tui.palette import EntityNavigated, EntityNavigatorProvider
 from babylon.tui.router import InvalidBabylonUri, parse_babylon_uri
 from babylon.tui.theme import KSBC
+from babylon.tui.tutorial_overlay import TutorialOverlay, TutorialProgress, TutorialStepView
 from babylon.tui.wikilinks import (
     BabylonH1,
     BabylonH2,
@@ -276,6 +294,21 @@ needs — the composition root holds the real
 :class:`~babylon.game.session.GameSession`, this module only ever sees it
 through the narrower seam types)."""
 
+TutorialProgressFactory = Callable[
+    [CampaignHandle, "PacedDriverHandle | None", Callable[[], "str | None"]],
+    "TutorialProgress | None",
+]
+"""The booted campaign's tutorial-progress seam (Program v1.0.0 T6, Unit U4)
+— one layer up from :data:`DriverFactory`, same shape. Takes the just-booted
+:class:`CampaignHandle`, the just-built :class:`PacedDriverHandle` (or
+``None`` when no ``driver_factory`` was wired), and a zero-arg callable
+reading :attr:`ArchiveApp.nav`'s current subject at call time; returns
+``None`` to mean "the tutorial should not show for this campaign" — the
+composition root's own new-vs-resumed gating decision (see
+``babylon.cli.play``'s own docstring for the honest first-session heuristic
+it uses), in which case :meth:`ArchiveApp._on_briefing_dismissed` never
+mounts a :class:`~babylon.tui.tutorial_overlay.TutorialOverlay` at all."""
+
 #: The sample page's own subject — the nav shell's seed position, and
 #: (Unit C2) the live campaign's own home dossier subject too: Wayne County
 #: is the only scenario wired today (ruling 3, "Wayne stays in lobby").
@@ -435,6 +468,23 @@ class ArchiveApp(App[None]):
         same pattern as ``campaign_menu``/``campaign_loader``). ``None``
         (the default) leaves :attr:`driver` ``None`` forever — the pre-
         Unit-C3 behavior, unchanged.
+    :param tutorial_steps: The guided opening-arc step sequence to render
+        (Program v1.0.0 T6, Unit U4) — MUST be the exact same sequence
+        ``tutorial_progress_factory`` builds its evaluator against (same
+        length, same order; see :data:`TutorialProgressFactory`). ``None``
+        (the default) never mounts a tutorial overlay, unchanged from every
+        pre-Unit-U4 caller/test.
+    :param tutorial_progress_factory: The tutorial-progress seam
+        (:data:`TutorialProgressFactory`, Unit U4); when given (and
+        ``tutorial_steps`` too — REQUIRED together, raised loudly otherwise,
+        same pattern as ``campaign_menu``/``campaign_loader``),
+        :meth:`_on_campaign_chosen` builds this campaign's
+        :class:`~babylon.tui.tutorial_overlay.TutorialProgress`, and
+        :meth:`_on_briefing_dismissed` mounts a
+        :class:`~babylon.tui.tutorial_overlay.TutorialOverlay` over the
+        campaign shell IFF the factory did not return ``None``. ``None``
+        (the default) never mounts one — the pre-Unit-U4 behavior,
+        unchanged.
     """
 
     COMMANDS = App.COMMANDS | {EntityNavigatorProvider}
@@ -486,6 +536,8 @@ class ArchiveApp(App[None]):
         campaign_menu: CampaignMenu | None = None,
         campaign_loader: CampaignLoader | None = None,
         driver_factory: DriverFactory | None = None,
+        tutorial_steps: Sequence[TutorialStepView] | None = None,
+        tutorial_progress_factory: TutorialProgressFactory | None = None,
     ) -> None:
         super().__init__()
         if campaign_menu is not None and campaign_loader is None:
@@ -498,6 +550,12 @@ class ArchiveApp(App[None]):
             msg = (
                 "ArchiveApp: driver_factory was given but no campaign_loader — "
                 "there would never be a booted campaign to wrap in a driver"
+            )
+            raise ValueError(msg)
+        if tutorial_progress_factory is not None and tutorial_steps is None:
+            msg = (
+                "ArchiveApp: tutorial_progress_factory was given but no tutorial_steps — "
+                "there would be nothing for a TutorialOverlay to render"
             )
             raise ValueError(msg)
         self._page = page if page is not None else SAMPLE_COUNTY_PAGE
@@ -513,6 +571,8 @@ class ArchiveApp(App[None]):
         self._campaign_menu = campaign_menu
         self._campaign_loader = campaign_loader
         self._driver_factory = driver_factory
+        self._tutorial_steps = tutorial_steps
+        self._tutorial_progress_factory = tutorial_progress_factory
         self.campaign: CampaignHandle | None = None
         """The live, booted campaign (Unit C2) — ``None`` until the lobby
         dismisses and :func:`CampaignLoader` returns one; stays ``None``
@@ -523,6 +583,16 @@ class ArchiveApp(App[None]):
         ``None`` forever in the no-``driver_factory`` boot path (``t``
         then falls back to calling :attr:`campaign` directly, unchanged
         from before this unit)."""
+        self._tutorial_progress: TutorialProgress | None = None
+        """This campaign's tutorial-progress seam (Unit U4) — ``None``
+        until :attr:`campaign` boots AND ``tutorial_progress_factory``
+        both was given AND itself returned non-``None`` (its own new-vs-
+        resumed gating); stays ``None`` forever otherwise."""
+        self._tutorial_overlay: TutorialOverlay | None = None
+        """The mounted :class:`~babylon.tui.tutorial_overlay.TutorialOverlay`
+        (Unit U4) — ``None`` until :meth:`_on_briefing_dismissed` mounts one
+        (only when :attr:`_tutorial_progress` is not ``None``); stays
+        ``None`` forever otherwise."""
 
     def on_mount(self) -> None:
         self.register_theme(KSBC)
@@ -557,6 +627,10 @@ class ArchiveApp(App[None]):
         campaign = self._campaign_loader(campaign_id)
         self.campaign = campaign
         self.driver = self._driver_factory(campaign) if self._driver_factory is not None else None
+        if self._tutorial_progress_factory is not None:
+            self._tutorial_progress = self._tutorial_progress_factory(
+                campaign, self.driver, lambda: self.nav.current
+            )
         self._pages = campaign.read_page
         self._refresh_known_entities(campaign)
         briefing_subject = f"briefing/{campaign_id}"
@@ -578,6 +652,32 @@ class ArchiveApp(App[None]):
             signature (unused either way — there is no decline branch).
         """
         await self._navigate(_SAMPLE_SUBJECT)
+        await self._mount_tutorial_overlay_if_active()
+
+    async def _mount_tutorial_overlay_if_active(self) -> None:
+        """Mount :attr:`_tutorial_overlay` over the freshly-revealed campaign
+        shell, IFF :attr:`_tutorial_progress` is not ``None`` (Unit U4).
+
+        A no-op with no ``tutorial_progress_factory`` wired, or when the
+        factory itself decided not to show the tutorial for THIS campaign
+        (its own new-vs-resumed gating) — every pre-Unit-U4 caller/test is
+        unaffected either way.
+        """
+        if self._tutorial_progress is None or self._tutorial_steps is None:
+            return
+        overlay = TutorialOverlay(self._tutorial_steps, self._tutorial_progress)
+        self._tutorial_overlay = overlay
+        await self.mount(overlay)
+
+    def _refresh_tutorial_progress(self) -> None:
+        """Re-poll the mounted overlay's current step (Unit U4) — called
+        at the tail of every committed-tick action and navigation event
+        (:meth:`action_advance_tick`, :meth:`action_run_until_paused`,
+        :meth:`action_acknowledge_pause`, :meth:`_navigate`). A no-op with
+        no overlay mounted.
+        """
+        if self._tutorial_overlay is not None:
+            self._tutorial_overlay.check_progress()
 
     def compose(self) -> ComposeResult:
         yield Label("", id="breadcrumbs")
@@ -645,6 +745,7 @@ class ArchiveApp(App[None]):
         self._refresh_breadcrumbs()
         marker = " [ABSENT]" if page is None else ""
         self.query_one("#status", Label).update(f"status: {subject}{marker}")
+        self._refresh_tutorial_progress()
 
     async def action_jump_back(self) -> None:
         """``Ctrl-O``: walk back one jumplist step, if there is one."""
@@ -702,6 +803,7 @@ class ArchiveApp(App[None]):
             await self._navigate(subject, record=False)
         paused_marker = " [PAUSED]" if result.paused else ""
         status.update(f"status: tick {result.tick}{paused_marker}")
+        self._refresh_tutorial_progress()
 
     @work()
     async def action_run_until_paused(self) -> None:
@@ -757,6 +859,7 @@ class ArchiveApp(App[None]):
             status.update(f"status: ran to tick {last.tick} [PAUSED] ({self.driver.pause_summary})")
         else:
             status.update(f"status: ran to tick {last.tick} (stopped at the run limit)")
+        self._refresh_tutorial_progress()
 
     def action_acknowledge_pause(self) -> None:
         """``a``: acknowledge a pending autopause (Program v1.0.0 Unit C3),
@@ -771,6 +874,7 @@ class ArchiveApp(App[None]):
             return
         self.driver.acknowledge_pause()
         status.update("status: autopause acknowledged — ready to advance")
+        self._refresh_tutorial_progress()
 
     async def on_entity_navigated(self, event: EntityNavigated) -> None:
         """Open the page a palette hit chose.

--- a/src/babylon/tui/app.py
+++ b/src/babylon/tui/app.py
@@ -726,9 +726,27 @@ class ArchiveApp(App[None]):
         self._resolver = known_target_resolver(self.known_entities)
 
     def _refresh_breadcrumbs(self) -> None:
-        """Render the trail's newest entries into the breadcrumb bar."""
+        """Render the trail's newest entries into the breadcrumb bar.
+
+        Tolerant of a transient-absent breadcrumb widget. This runs from
+        the briefing-dismiss ``call_next`` callback via :meth:`_navigate` —
+        a window in which the campaign shell's compose can still be
+        settling under concurrent load (the source of the CI-only
+        ``NoMatches`` this guard closes). ``#breadcrumbs`` is yielded
+        unconditionally in :meth:`compose`, so an empty query here is only
+        ever a transition artifact, never a structural absence — and the
+        bar is chrome (the tutorial-BDD transcript asserts semantic text,
+        never chrome, per the T6 ruling), so a skipped repaint self-heals
+        on the next navigation. ``#dossier``/``#status`` deliberately stay
+        loud ``query_one`` calls in :meth:`_navigate`: those ARE asserted
+        behavior. This never masks a real absence — only the transition
+        window can empty a query on an unconditionally-composed widget.
+        """
+        bar = self.query("#breadcrumbs")
+        if not bar:
+            return
         crumbs = self.nav.trail.entries[-_BREADCRUMB_DISPLAY:]
-        self.query_one("#breadcrumbs", Label).update(" › ".join(crumbs))
+        bar.first(Label).update(" › ".join(crumbs))
 
     async def _navigate(self, subject: str, *, record: bool = True) -> None:
         """Show ``subject``'s page (or its loud absence page).

--- a/src/babylon/tui/tutorial_overlay.py
+++ b/src/babylon/tui/tutorial_overlay.py
@@ -1,0 +1,243 @@
+"""The guided opening-arc overlay — the PLAYER-facing consumer of the T6
+tutorial step script (Program v1.0.0 T6, Unit U4).
+
+Per ``ai/_inbox/t6-tutorial-bdd-ruling.md``: ONE data artifact —
+:class:`~babylon.game.tutorial.TutorialStep` — is consumed three ways. Units
+U1/U2 shipped the model and the headless Pilot executor; this unit ships the
+THIRD consumer, the live overlay a player actually sees, rendered over the
+campaign shell. Because "the strings the player reads ARE the scenario
+definitions CI runs," this widget renders :attr:`~babylon.game.tutorial.
+TutorialStep.scenario_name`/:attr:`~babylon.game.tutorial.TutorialStep.
+overlay_text` VERBATIM — it never reconstructs its own copy of the
+given/when/then prose.
+
+**Projection-pure, by construction (import-linter: ``babylon.tui`` may never
+reach ``babylon.engine``).** :mod:`babylon.game.tutorial` imports
+``babylon.engine.scenarios.wayne_county`` directly, so this module — a real
+``babylon.tui`` package member — must never import it either (a direct
+import here would create the exact forbidden ``tui -> game -> engine`` chain
+import-linter's "tui client reads projections only" contract exists to
+catch). The WO-37 trick applies one more time: :data:`TutorialStepView` and
+:data:`TutorialProgress` below are STRUCTURAL protocols describing only the
+handful of members this widget actually touches;
+:class:`~babylon.game.tutorial.TutorialStep` and the composition-root's
+concrete predicate evaluator (:class:`~babylon.game.tutorial_runtime.
+TutorialRuntimeProgress`) satisfy them without either module importing the
+other — the exact shape :class:`~babylon.tui.app.CampaignHandle`/
+:class:`~babylon.tui.app.PacedDriverHandle` already establish for the
+engine/game seam.
+
+**The widget renders and advances; it never evaluates a predicate itself.**
+:meth:`TutorialOverlay.check_progress` is a dumb poll: ask
+:attr:`TutorialProgress.is_step_complete` whether the CURRENT step's
+completion holds, and if so, advance — the actual predicate logic (reading
+the live campaign's tick, the paced driver's ``awaiting_ack``, the nav
+shell's current subject) lives entirely in the composition root's evaluator,
+never here. The composition root is responsible for calling
+:meth:`check_progress` after whatever it considers a "committed tick or
+navigation event" (:class:`~babylon.tui.app.ArchiveApp` does this at the tail
+of ``action_advance_tick``/``action_run_until_paused``/
+``action_acknowledge_pause``/``_navigate``).
+
+**Consecutive same-target steps can collapse in one poll.** :meth:`check_progress`
+loops forward through every consecutive TRUE predicate starting at the
+current index (bounded by :data:`len(steps)`, Power-of-10 rule 2) — so two
+adjacent steps sharing the identical completion (e.g. the authored arc's
+``palette_to_the_economy_dossier``/``read_the_theorem_verdict``, both
+``OnPage(subject="economy/USA")``) both advance in the SAME poll, and the
+first of the pair's own instruction text is never separately shown. This is
+an honest consequence of steps being GATE conditions rather than
+individually-timed beats, not a bug this unit works around — flagged here
+per this repo's own "surface the gap, don't silently smooth it" culture
+(Constitution III.11), mirroring the executor unit's own documented
+``run_until_autopause`` no-op finding.
+
+**Dismiss is a binding on the widget itself**, not on
+:class:`~babylon.tui.app.ArchiveApp` (unlike ``t``/``r``/``a``, which are App
+actions) — deliberately, so the overlay's own lifecycle (mount, advance,
+dismiss) stays fully encapsulated wherever it is mounted, never requiring its
+host to know its internals beyond "mount me, poll me." Because Textual
+resolves a widget's own ``BINDINGS`` only via the FOCUS chain (a sibling that
+never has focus never sees its own bindings fire), :meth:`on_mount` gives the
+widget focus so ``escape`` reaches it; the App's own ``ctrl+o``/``t``/``r``/
+``a`` bindings are unaffected either way (``App`` is always in the bubble
+chain regardless of which descendant currently holds focus).
+
+**A NEW player-facing option — declared, not silently exempt-by-omission.**
+``TutorialOverlay.BINDINGS``'s own ``escape`` entry is exactly the kind of
+option the T6 ruling's option-coverage sentinel (Unit U3,
+:mod:`babylon.sentinels.tutorial_coverage`) polices: every real ``Binding`` a
+Babylon TUI class declares must be exercised by a ``TutorialStep`` or carry a
+cited :class:`~babylon.sentinels.exemptions.SentinelExemption`. This one is
+cited, not scripted — ``babylon.sentinels.tutorial_coverage.registry.
+TUTORIAL_COVERAGE_EXEMPTIONS`` keyed ``("binding", "TutorialOverlay",
+"escape")`` — because dismissing the tutorial is the tutorial system's own
+chrome, never a beat the opening arc itself teaches.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Final, Protocol, runtime_checkable
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container
+from textual.widgets import Label
+
+__all__ = ["TutorialOverlay", "TutorialProgress", "TutorialStepView"]
+
+
+@runtime_checkable
+class TutorialStepView(Protocol):
+    """Structural shape of one rendered step (:class:`~babylon.game.tutorial.
+    TutorialStep` satisfies this without either module importing the other).
+
+    Deliberately narrow: only the two DERIVED rendering properties the
+    overlay actually paints, never the raw ``given``/``when``/``then``
+    fields directly — rendering through the model's own properties (rather
+    than reassembling the fields here) is what keeps this widget's output a
+    verbatim, zero-copy-divergence render of U1's own rendering contract.
+    """
+
+    @property
+    def scenario_name(self) -> str:
+        """The step's one-sentence summary (the developer-docs title)."""
+        ...
+
+    @property
+    def overlay_text(self) -> str:
+        """The GIVEN/WHEN/THEN block, the SAME fields as :attr:`scenario_name`."""
+        ...
+
+
+@runtime_checkable
+class TutorialProgress(Protocol):
+    """The predicate-evaluation seam: is step ``step_index`` complete RIGHT
+    NOW against the live campaign?
+
+    Fulfilled for real by :class:`~babylon.game.tutorial_runtime.
+    TutorialRuntimeProgress` (the composition root's concrete evaluator,
+    reading the live campaign's tick, the paced driver's ``awaiting_ack``,
+    and the nav shell's current subject) — never implemented in this
+    module, which only ever calls through this seam.
+    """
+
+    def is_step_complete(self, step_index: int) -> bool:
+        """Whether the step at ``step_index`` currently holds.
+
+        :param step_index: an index into the SAME step sequence the caller
+            constructed this evaluator with — the overlay and its evaluator
+            must always share one common, identically-ordered step list.
+        :returns: ``True`` iff that step's completion predicate is satisfied
+            by the live campaign's CURRENT state.
+        """
+        ...
+
+
+#: Generous static bound mirroring ``TutorialScript._MAX_SCRIPT_STEPS``
+#: (Power-of-10 rule 2): :meth:`TutorialOverlay.check_progress` never
+#: advances past this many steps in one poll, and the authored arc this
+#: unit renders sits far below it either way.
+_MAX_OVERLAY_STEPS: Final = 64
+
+
+class TutorialOverlay(Container):
+    """Renders the current tutorial step over the live campaign shell.
+
+    :param steps: the ordered step sequence to walk — MUST be the exact
+        same sequence (same length, same order) the ``progress`` evaluator
+        was itself built against, since :meth:`check_progress` indexes both
+        by the same integer position.
+    :param progress: the predicate-evaluation seam (see :data:`TutorialProgress`).
+    """
+
+    BINDINGS = [Binding("escape", "dismiss_tutorial", "Dismiss Tutorial")]
+
+    DEFAULT_CSS = """
+    TutorialOverlay {
+        dock: top;
+        height: auto;
+        max-height: 40%;
+        background: $panel;
+        border: round $accent;
+        padding: 0 1;
+        margin: 1 2;
+    }
+    """
+
+    can_focus = True
+
+    def __init__(
+        self,
+        steps: Sequence[TutorialStepView],
+        progress: TutorialProgress,
+        *,
+        id: str | None = None,
+    ) -> None:
+        super().__init__(id=id)
+        self._steps: tuple[TutorialStepView, ...] = tuple(steps)
+        if len(self._steps) > _MAX_OVERLAY_STEPS:
+            msg = (
+                f"TutorialOverlay: {len(self._steps)} steps exceeds the static bound "
+                f"{_MAX_OVERLAY_STEPS} (Power-of-10 rule 2)"
+            )
+            raise ValueError(msg)
+        self._progress = progress
+        self._current_index = 0
+        self.dismissed = False
+        """``True`` once the player has dismissed this overlay via ``escape``
+        (or it has been removed some other way) — :meth:`check_progress`
+        becomes a permanent no-op afterward."""
+
+    @property
+    def current_step_index(self) -> int:
+        """The step index currently shown (may equal ``len(steps)`` once finished)."""
+        return self._current_index
+
+    @property
+    def finished(self) -> bool:
+        """``True`` once every step's completion has been observed."""
+        return self._current_index >= len(self._steps)
+
+    def compose(self) -> ComposeResult:
+        yield Label("", id="tutorial-heading")
+        yield Label("", id="tutorial-body")
+
+    def on_mount(self) -> None:
+        self.focus()
+        self.check_progress()
+
+    def check_progress(self) -> None:
+        """Re-evaluate the current step's completion predicate; advance
+        through every consecutive TRUE step (see module docstring on why
+        more than one can advance in a single poll), then re-render.
+
+        A no-op once :attr:`dismissed` — the composition root may keep
+        calling this after the player dismisses the overlay (it has no way
+        to know without asking), and this method must stay a harmless no-op
+        rather than raise against an already-removed widget.
+        """
+        if self.dismissed:
+            return
+        for _ in range(len(self._steps)):  # loop bound: _current_index < len(steps) each time
+            if self.finished or not self._progress.is_step_complete(self._current_index):
+                break
+            self._current_index += 1
+        self._render_current_step()
+
+    def _render_current_step(self) -> None:
+        heading = self.query_one("#tutorial-heading", Label)
+        body = self.query_one("#tutorial-body", Label)
+        if self.finished:
+            heading.update("Opening arc complete.")
+            body.update("Press Escape to dismiss this tutorial.")
+            return
+        step = self._steps[self._current_index]
+        heading.update(f"Step {self._current_index + 1}/{len(self._steps)}: {step.scenario_name}")
+        body.update(step.overlay_text)
+
+    async def action_dismiss_tutorial(self) -> None:
+        """``escape``: dismiss the overlay for the rest of this session."""
+        self.dismissed = True
+        await self.remove()

--- a/tests/unit/cli/test_app.py
+++ b/tests/unit/cli/test_app.py
@@ -39,12 +39,14 @@ def test_play_subcommand_boots_the_composition_root(monkeypatch) -> None:  # typ
     anyone scripting against it directly, but no entry point calls it.
 
     T5 Unit U1: ``play`` now threads ``narrator_enabled=`` into ``run`` —
-    ON by default with no flag given."""
+    ON by default with no flag given. T6 Unit U4: ``play`` ALSO threads
+    ``tutorial_enabled=`` — ``None`` (unset) by default, the tri-state
+    "defer to first-session semantics" signal."""
     calls: list[dict[str, object]] = []
     monkeypatch.setattr(play_cmd, "run", lambda **kwargs: calls.append(kwargs))
     result = runner.invoke(app, ["play"])
     assert result.exit_code == 0
-    assert calls == [{"narrator_enabled": True}]
+    assert calls == [{"narrator_enabled": True, "tutorial_enabled": None}]
 
 
 def test_play_subcommand_no_narrator_flag_disables_the_narrator(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -54,7 +56,27 @@ def test_play_subcommand_no_narrator_flag_disables_the_narrator(monkeypatch) -> 
     monkeypatch.setattr(play_cmd, "run", lambda **kwargs: calls.append(kwargs))
     result = runner.invoke(app, ["play", "--no-narrator"])
     assert result.exit_code == 0
-    assert calls == [{"narrator_enabled": False}]
+    assert calls == [{"narrator_enabled": False, "tutorial_enabled": None}]
+
+
+def test_play_subcommand_tutorial_flag_forces_it_on(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """T6 Unit U4: ``--tutorial`` threads ``tutorial_enabled=True`` through
+    to ``run`` — always shows the overlay, even for a resumed campaign."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(play_cmd, "run", lambda **kwargs: calls.append(kwargs))
+    result = runner.invoke(app, ["play", "--tutorial"])
+    assert result.exit_code == 0
+    assert calls == [{"narrator_enabled": True, "tutorial_enabled": True}]
+
+
+def test_play_subcommand_no_tutorial_flag_forces_it_off(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """T6 Unit U4: ``--no-tutorial`` threads ``tutorial_enabled=False``
+    through to ``run`` — never shows the overlay, even for a fresh campaign."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(play_cmd, "run", lambda **kwargs: calls.append(kwargs))
+    result = runner.invoke(app, ["play", "--no-tutorial"])
+    assert result.exit_code == 0
+    assert calls == [{"narrator_enabled": True, "tutorial_enabled": False}]
 
 
 def test_play_demo_preserved_for_direct_scripting(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/unit/cli/test_play.py
+++ b/tests/unit/cli/test_play.py
@@ -166,3 +166,76 @@ def test_run_threads_narrator_enabled_false_into_the_loader(
 
     loader = _captured[0].kwargs["campaign_loader"]
     assert loader.keywords == {"narrator_enabled": False}
+
+
+def test_run_wires_tutorial_steps_and_a_callable_progress_factory(
+    _patched_composition_root: None,
+) -> None:
+    """T6 Unit U4: ``run()`` always threads ``tutorial_steps=``/
+    ``tutorial_progress_factory=`` into ``ArchiveApp(...)`` — the Wayne
+    opening arc's own step slice (skipping the two pre-shell beats), and a
+    callable seam factory."""
+    from babylon.game.tutorial import WAYNE_OPENING_ARC
+
+    play_cmd.run()
+
+    kwargs = _captured[0].kwargs
+    assert kwargs["tutorial_steps"] == WAYNE_OPENING_ARC.steps[2:]
+    assert callable(kwargs["tutorial_progress_factory"])
+
+
+class _FakeCampaignForFactory:
+    """A minimal ``CampaignHandle``-shaped double — just ``tick``, all this
+    factory's own gating heuristic reads."""
+
+    def __init__(self, tick: int) -> None:
+        self.tick = tick
+
+
+class TestTutorialProgressFactoryGating:
+    """Exercises :func:`babylon.cli.play._tutorial_progress_factory`'s own
+    resolution logic directly (unit-tier, no ``ArchiveApp``/Textual needed)."""
+
+    def test_explicit_true_shows_regardless_of_tick(self) -> None:
+        factory = play_cmd._tutorial_progress_factory(True, steps=(object(),))
+        result = factory(_FakeCampaignForFactory(tick=99), None, lambda: None)
+        assert result is not None
+
+    def test_explicit_false_hides_regardless_of_tick(self) -> None:
+        factory = play_cmd._tutorial_progress_factory(False, steps=(object(),))
+        result = factory(_FakeCampaignForFactory(tick=0), None, lambda: None)
+        assert result is None
+
+    def test_default_none_shows_for_a_fresh_campaign_at_tick_zero(self) -> None:
+        factory = play_cmd._tutorial_progress_factory(None, steps=(object(),))
+        result = factory(_FakeCampaignForFactory(tick=0), None, lambda: None)
+        assert result is not None
+
+    def test_default_none_hides_for_a_campaign_already_past_tick_zero(self) -> None:
+        factory = play_cmd._tutorial_progress_factory(None, steps=(object(),))
+        result = factory(_FakeCampaignForFactory(tick=1), None, lambda: None)
+        assert result is None
+
+    def test_shown_result_is_built_over_the_exact_steps_given(self) -> None:
+        from babylon.game.tutorial_runtime import TutorialRuntimeProgress
+
+        steps = tuple(range(3))  # placeholder objects, never dispatched in this test
+        factory = play_cmd._tutorial_progress_factory(True, steps=steps)
+        result = factory(_FakeCampaignForFactory(tick=0), None, lambda: None)
+        assert isinstance(result, TutorialRuntimeProgress)
+        assert result._steps == steps  # noqa: SLF001 - white-box wiring check
+
+
+def test_tutorial_steps_skips_the_two_pre_shell_beats() -> None:
+    """:func:`babylon.cli.play._tutorial_steps` slices off ``boot_into_lobby``/
+    ``begin_the_operation`` — both already necessarily true by the time the
+    campaign shell (and the overlay) exist (module docstring)."""
+    from babylon.game.tutorial import WAYNE_OPENING_ARC
+
+    steps = play_cmd._tutorial_steps()
+
+    assert steps == WAYNE_OPENING_ARC.steps[2:]
+    assert steps[0].id == "read_the_county_dossier"
+    ids = [step.id for step in steps]
+    assert "boot_into_lobby" not in ids
+    assert "begin_the_operation" not in ids

--- a/tests/unit/game/test_tutorial.py
+++ b/tests/unit/game/test_tutorial.py
@@ -26,18 +26,20 @@ import pydantic
 import pytest
 
 from babylon.engine.scenarios.wayne_county import WayneCountyScenario
+from babylon.game.pacing import PacedTickDriver
 from babylon.game.tutorial import (
     _MAX_SCRIPT_STEPS,
     WAYNE_OPENING_ARC,
     CompletionPredicateAdapter,
     EventAcked,
     OnPage,
+    PausePending,
     TickAtLeast,
     TutorialScript,
     TutorialStep,
     VerbIssued,
 )
-from babylon.tui.app import ArchiveApp, BriefingScreen
+from babylon.tui.app import ArchiveApp, BriefingScreen, PacedDriverHandle
 from babylon.tui.campaign_menu import LobbyScreen
 
 pytestmark = [pytest.mark.unit]
@@ -118,6 +120,7 @@ class TestTutorialStepModel:
         for predicate in (
             OnPage(subject="county/26163"),
             TickAtLeast(tick=1),
+            PausePending(),
             EventAcked(),
             VerbIssued(verb="advance_tick"),
         ):
@@ -155,6 +158,7 @@ class TestCompletionPredicateAdapter:
         for predicate in (
             OnPage(subject="county/26163"),
             TickAtLeast(tick=52),
+            PausePending(),
             EventAcked(),
             VerbIssued(verb="run_until_paused"),
         ):
@@ -275,6 +279,39 @@ class TestWayneOpeningArcIntegrity:
             if step.anchor.startswith(("page:", "palette:")):
                 _, subject = step.anchor.split(":", 1)
                 assert "/" in subject, f"{step.id}: {subject!r} is not a kind/id subject"
+
+    def test_run_until_autopause_verifies_the_stop_not_just_the_dispatch(self) -> None:
+        """Reviewer finding (T6 U1 fix pass): a step whose ``then`` advertises
+        the paced driver STOPPING must carry a completion predicate that
+        checks the stop, not merely that the keypress dispatched."""
+        step = next(s for s in WAYNE_OPENING_ARC.steps if s.id == "run_until_autopause")
+        assert step.completion == PausePending()
+
+    def test_pause_pending_predicate_is_grounded_in_the_live_pacing_seam(self) -> None:
+        """``PausePending`` is not fiction: the two primitives its own
+        docstring names (``awaiting_ack``/``pending_pause``) are real,
+        live attributes on both the concrete driver and the structural
+        seam ``babylon.tui`` crosses with it — never an invented surface.
+        """
+        assert hasattr(PacedTickDriver, "awaiting_ack")
+        assert hasattr(PacedTickDriver, "pending_pause")
+        assert hasattr(PacedDriverHandle, "awaiting_ack")
+
+    def test_begin_the_operation_verifies_the_outcome_not_just_the_dispatch(self) -> None:
+        """Reviewer finding (T6 U1 fix pass): the dossier-reveal OUTCOME is
+        queryable here (unlike ``boot_into_lobby``, pre-campaign), so this
+        step is made self-contained rather than relying on the next
+        step's ``OnPage`` to cover it after the fact."""
+        step = next(s for s in WAYNE_OPENING_ARC.steps if s.id == "begin_the_operation")
+        assert step.completion == OnPage(subject="county/26163")
+
+    def test_boot_into_lobby_completion_is_the_documented_honest_floor(self) -> None:
+        """No page/tick outcome predicate is queryable pre-campaign, so
+        ``VerbIssued`` (dispatch-only) is the deliberate, documented gap —
+        never silently upgraded without also removing the honest-gap
+        comment in the authored script."""
+        step = next(s for s in WAYNE_OPENING_ARC.steps if s.id == "boot_into_lobby")
+        assert step.completion == VerbIssued(verb="new_campaign")
 
     def test_arc_covers_the_advertised_core_loop_beats(self) -> None:
         """The 9 authored beats span mint -> briefing -> dossier -> tick ->

--- a/tests/unit/game/test_tutorial.py
+++ b/tests/unit/game/test_tutorial.py
@@ -1,0 +1,339 @@
+"""Unit tests for the tutorial step model (Program v1.0.0 T6, Unit U1).
+
+Three families, per the unit's own test mandate:
+
+* **Model validation** — :class:`~babylon.game.tutorial.TutorialStep`/
+  :class:`~babylon.game.tutorial.TutorialScript` are frozen, reject unknown
+  fields, enforce unique step ids, and the closed completion-predicate
+  vocabulary reds loudly (``pydantic.ValidationError``) on an unrecognized
+  ``kind`` — never a silently-ignored predicate.
+* **Script integrity** — the authored
+  :data:`~babylon.game.tutorial.WAYNE_OPENING_ARC` carries a non-empty
+  anchor on every step, every predicate round-trips through the closed-
+  vocabulary :class:`~pydantic.TypeAdapter` (the exact shape the overlay/
+  docs/Pilot-executor consumers will deserialize), and every
+  ``"binding:<ClassName>:<key>"`` anchor names a key that is REALLY on
+  that Textual class's own ``BINDINGS`` today (no fiction).
+* **Rendering contract** — :attr:`~babylon.game.tutorial.TutorialStep.
+  scenario_name`/:attr:`~babylon.game.tutorial.TutorialStep.overlay_text`
+  derive VERBATIM from ``given``/``when``/``then`` — proving there is no
+  second, separately-authored copy of this prose anywhere.
+"""
+
+from __future__ import annotations
+
+import pydantic
+import pytest
+
+from babylon.engine.scenarios.wayne_county import WayneCountyScenario
+from babylon.game.tutorial import (
+    _MAX_SCRIPT_STEPS,
+    WAYNE_OPENING_ARC,
+    CompletionPredicateAdapter,
+    EventAcked,
+    OnPage,
+    TickAtLeast,
+    TutorialScript,
+    TutorialStep,
+    VerbIssued,
+)
+from babylon.tui.app import ArchiveApp, BriefingScreen
+from babylon.tui.campaign_menu import LobbyScreen
+
+pytestmark = [pytest.mark.unit]
+
+#: The live Textual ``BINDINGS`` registries every ``"binding:<Class>:<key>"``
+#: anchor below is checked against — no fiction (the ruling's own rule).
+_LIVE_BINDING_CLASSES: dict[str, type] = {
+    "ArchiveApp": ArchiveApp,
+    "BriefingScreen": BriefingScreen,
+    "LobbyScreen": LobbyScreen,
+}
+
+
+def _minimal_step(step_id: str = "a_step", *, anchor: str = "page:x") -> TutorialStep:
+    """One structurally-valid step, varying only what a test needs to vary."""
+    return TutorialStep(
+        id=step_id,
+        given="a precondition",
+        when="an action",
+        then="a result",
+        anchor=anchor,
+        completion=OnPage(subject="x"),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Model validation.
+# --------------------------------------------------------------------------- #
+
+
+class TestTutorialStepModel:
+    """Frozen, constrained, closed-vocabulary — never a loose dict."""
+
+    def test_step_is_frozen(self) -> None:
+        step = _minimal_step()
+        with pytest.raises(pydantic.ValidationError):
+            step.given = "mutated"  # type: ignore[misc]
+
+    def test_step_rejects_unknown_field(self) -> None:
+        with pytest.raises(pydantic.ValidationError):
+            TutorialStep(
+                id="a",
+                given="g",
+                when="w",
+                then="t",
+                anchor="page:x",
+                completion=OnPage(subject="x"),
+                bogus_field="nope",  # type: ignore[call-arg]
+            )
+
+    @pytest.mark.parametrize("field", ["id", "given", "when", "then", "anchor"])
+    def test_step_rejects_empty_required_strings(self, field: str) -> None:
+        kwargs: dict[str, object] = {
+            "id": "a",
+            "given": "g",
+            "when": "w",
+            "then": "t",
+            "anchor": "page:x",
+            "completion": OnPage(subject="x"),
+        }
+        kwargs[field] = ""
+        with pytest.raises(pydantic.ValidationError):
+            TutorialStep(**kwargs)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("bad_id", ["Not_Lower", "1leading_digit", "has space", ""])
+    def test_step_id_pattern_rejects_non_slug_ids(self, bad_id: str) -> None:
+        with pytest.raises(pydantic.ValidationError):
+            TutorialStep(
+                id=bad_id,
+                given="g",
+                when="w",
+                then="t",
+                anchor="page:x",
+                completion=OnPage(subject="x"),
+            )
+
+    def test_completion_accepts_every_closed_vocabulary_kind(self) -> None:
+        for predicate in (
+            OnPage(subject="county/26163"),
+            TickAtLeast(tick=1),
+            EventAcked(),
+            VerbIssued(verb="advance_tick"),
+        ):
+            step = _minimal_step()
+            step = step.model_copy(update={"completion": predicate})
+            assert step.completion == predicate
+
+    def test_completion_rejects_unknown_kind(self) -> None:
+        with pytest.raises(pydantic.ValidationError):
+            TutorialStep(
+                id="a",
+                given="g",
+                when="w",
+                then="t",
+                anchor="page:x",
+                completion={"kind": "teleports_the_player"},
+            )
+
+    def test_completion_rejects_payload_missing_kind(self) -> None:
+        with pytest.raises(pydantic.ValidationError):
+            TutorialStep(
+                id="a",
+                given="g",
+                when="w",
+                then="t",
+                anchor="page:x",
+                completion={"subject": "x"},
+            )
+
+
+class TestCompletionPredicateAdapter:
+    """The standalone adapter the overlay/docs/Pilot-executor consumers use."""
+
+    def test_adapter_round_trips_every_kind(self) -> None:
+        for predicate in (
+            OnPage(subject="county/26163"),
+            TickAtLeast(tick=52),
+            EventAcked(),
+            VerbIssued(verb="run_until_paused"),
+        ):
+            dumped = predicate.model_dump(mode="json")
+            reloaded = CompletionPredicateAdapter.validate_python(dumped)
+            assert reloaded == predicate
+
+    def test_adapter_reds_loudly_on_unknown_kind(self) -> None:
+        with pytest.raises(pydantic.ValidationError):
+            CompletionPredicateAdapter.validate_python({"kind": "bogus_kind"})
+
+    def test_adapter_reds_loudly_on_missing_kind(self) -> None:
+        with pytest.raises(pydantic.ValidationError):
+            CompletionPredicateAdapter.validate_python({"subject": "county/26163"})
+
+
+class TestTutorialScriptModel:
+    """Ordered, uniquely-keyed, bounded — never an unbounded/duplicated script."""
+
+    def test_script_is_frozen(self) -> None:
+        script = TutorialScript(id="s", scenario="wayne_county", steps=(_minimal_step(),))
+        with pytest.raises(pydantic.ValidationError):
+            script.id = "mutated"  # type: ignore[misc]
+
+    def test_script_rejects_empty_steps(self) -> None:
+        with pytest.raises(pydantic.ValidationError):
+            TutorialScript(id="s", scenario="wayne_county", steps=())
+
+    def test_script_rejects_duplicate_step_ids(self) -> None:
+        with pytest.raises(pydantic.ValidationError, match="duplicate step id"):
+            TutorialScript(
+                id="s",
+                scenario="wayne_county",
+                steps=(
+                    _minimal_step("same_id", anchor="page:x"),
+                    _minimal_step("same_id", anchor="page:y"),
+                ),
+            )
+
+    def test_script_accepts_pairwise_distinct_ids(self) -> None:
+        script = TutorialScript(
+            id="s",
+            scenario="wayne_county",
+            steps=(_minimal_step("first"), _minimal_step("second")),
+        )
+        assert [step.id for step in script.steps] == ["first", "second"]
+
+    def test_script_enforces_a_static_step_count_ceiling(self) -> None:
+        # Power-of-10 rule 2: the ceiling itself must be a fixed, provable
+        # bound — proven here by actually exceeding it by one.
+        too_many = tuple(_minimal_step(f"step_{i}") for i in range(_MAX_SCRIPT_STEPS + 1))
+        with pytest.raises(pydantic.ValidationError):
+            TutorialScript(id="s", scenario="wayne_county", steps=too_many)
+
+
+# --------------------------------------------------------------------------- #
+# Script integrity — the AUTHORED Wayne opening arc.
+# --------------------------------------------------------------------------- #
+
+
+def _parse_binding_anchor(anchor: str) -> tuple[str, str] | None:
+    """Split a ``"binding:<ClassName>:<key>"`` anchor into ``(class, key)``.
+
+    :param anchor: the anchor string.
+    :returns: ``(class_name, key)`` if ``anchor`` is binding-shaped, else
+        ``None`` (a ``page:``/``palette:`` anchor).
+    """
+    if not anchor.startswith("binding:"):
+        return None
+    _, class_name, key = anchor.split(":", 2)
+    return class_name, key
+
+
+class TestWayneOpeningArcIntegrity:
+    """The one authored script this unit ships — checked against reality."""
+
+    def test_scenario_matches_the_real_wayne_scenario_name(self) -> None:
+        assert WAYNE_OPENING_ARC.scenario == WayneCountyScenario.name == "wayne_county"
+
+    def test_every_step_anchor_is_non_empty(self) -> None:
+        for step in WAYNE_OPENING_ARC.steps:  # loop bound: len(steps) == 9
+            assert step.anchor.strip() != ""
+
+    def test_every_step_id_is_unique(self) -> None:
+        ids = [step.id for step in WAYNE_OPENING_ARC.steps]
+        assert len(ids) == len(set(ids))
+
+    def test_every_predicate_parses_through_the_closed_vocabulary_adapter(self) -> None:
+        for step in WAYNE_OPENING_ARC.steps:  # loop bound: len(steps) == 9
+            dumped = step.completion.model_dump(mode="json")
+            reloaded = CompletionPredicateAdapter.validate_python(dumped)
+            assert reloaded == step.completion
+
+    def test_every_binding_anchor_names_a_real_live_key(self) -> None:
+        """Cross-checks every ``binding:`` anchor against the REAL
+        ``BINDINGS`` on the named Textual class — the "verify every anchor
+        exists before authoring" rule, pinned as a durable regression
+        rather than a one-time authoring-time check.
+        """
+        checked = 0
+        for step in WAYNE_OPENING_ARC.steps:  # loop bound: len(steps) == 9
+            parsed = _parse_binding_anchor(step.anchor)
+            if parsed is None:
+                continue
+            class_name, key = parsed
+            assert class_name in _LIVE_BINDING_CLASSES, (
+                f"{step.id}: anchor names unknown class {class_name!r}"
+            )
+            live_keys = {binding.key for binding in _LIVE_BINDING_CLASSES[class_name].BINDINGS}
+            assert key in live_keys, (
+                f"{step.id}: anchor key {key!r} is not a real binding on {class_name}"
+            )
+            checked += 1
+        assert checked > 0, "no binding: anchors were exercised by this test"
+
+    def test_every_page_or_palette_anchor_names_a_kind_slash_id_subject(self) -> None:
+        for step in WAYNE_OPENING_ARC.steps:  # loop bound: len(steps) == 9
+            if step.anchor.startswith(("page:", "palette:")):
+                _, subject = step.anchor.split(":", 1)
+                assert "/" in subject, f"{step.id}: {subject!r} is not a kind/id subject"
+
+    def test_arc_covers_the_advertised_core_loop_beats(self) -> None:
+        """The 9 authored beats span mint -> briefing -> dossier -> tick ->
+        run -> ack -> palette -> theorem -> jump-back, in that order."""
+        assert [step.id for step in WAYNE_OPENING_ARC.steps] == [
+            "boot_into_lobby",
+            "begin_the_operation",
+            "read_the_county_dossier",
+            "advance_a_tick",
+            "run_until_autopause",
+            "acknowledge_the_pause",
+            "palette_to_the_economy_dossier",
+            "read_the_theorem_verdict",
+            "jump_back_to_wayne",
+        ]
+
+
+# --------------------------------------------------------------------------- #
+# Rendering contract.
+# --------------------------------------------------------------------------- #
+
+
+class TestRenderingContract:
+    """``scenario_name``/``overlay_text`` derive verbatim from the fields —
+    no separately-authored prose duplicate anywhere.
+    """
+
+    def test_scenario_name_contains_every_field_verbatim(self) -> None:
+        for step in WAYNE_OPENING_ARC.steps:  # loop bound: len(steps) == 9
+            assert step.given in step.scenario_name
+            assert step.when in step.scenario_name
+            assert step.then in step.scenario_name
+
+    def test_overlay_text_contains_every_field_verbatim(self) -> None:
+        for step in WAYNE_OPENING_ARC.steps:  # loop bound: len(steps) == 9
+            assert step.given in step.overlay_text
+            assert step.when in step.overlay_text
+            assert step.then in step.overlay_text
+
+    def test_scenario_name_and_overlay_text_are_pure_functions_of_the_fields(self) -> None:
+        """Two steps differing ONLY in ``given`` render different strings
+        that each carry their OWN ``given`` verbatim — proving derivation,
+        not a shared hardcoded template ignoring the field's actual value.
+        """
+        step_one = _minimal_step("one").model_copy(update={"given": "the FIRST precondition"})
+        step_two = _minimal_step("two").model_copy(update={"given": "the SECOND precondition"})
+
+        assert "the FIRST precondition" in step_one.scenario_name
+        assert "the SECOND precondition" not in step_one.scenario_name
+        assert "the SECOND precondition" in step_two.scenario_name
+        assert "the FIRST precondition" not in step_two.scenario_name
+
+        assert "the FIRST precondition" in step_one.overlay_text
+        assert "the SECOND precondition" in step_two.overlay_text
+
+    def test_scenario_name_is_a_single_sentence(self) -> None:
+        """The ruling: "scenario names are sentences" — one, ending in a
+        period, not a multi-line block (that's what ``overlay_text`` is
+        for)."""
+        for step in WAYNE_OPENING_ARC.steps:  # loop bound: len(steps) == 9
+            assert step.scenario_name.endswith(".")
+            assert "\n" not in step.scenario_name

--- a/tests/unit/game/test_tutorial_runtime.py
+++ b/tests/unit/game/test_tutorial_runtime.py
@@ -1,0 +1,181 @@
+"""Unit tests for the T6 tutorial's live completion-predicate evaluator
+(Program v1.0.0 T6, Unit U4).
+
+Exercises :class:`~babylon.game.tutorial_runtime.TutorialRuntimeProgress`
+against fake ``_TickSource``/``_PausedDriverSource`` doubles — no real
+engine, Postgres, or Textual app required (this evaluator's own contract is
+"read three plain signals," never anything heavier).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from babylon.game.tutorial import (
+    EventAcked,
+    OnPage,
+    PausePending,
+    TickAtLeast,
+    TutorialStep,
+    VerbIssued,
+)
+from babylon.game.tutorial_runtime import TutorialRuntimeProgress
+
+pytestmark = [pytest.mark.unit]
+
+
+def _step(step_id: str, completion: object) -> TutorialStep:
+    return TutorialStep(
+        id=step_id,
+        given="g",
+        when="w",
+        then="t",
+        anchor="page:x",
+        completion=completion,  # type: ignore[arg-type]
+    )
+
+
+@dataclass
+class _FakeCampaign:
+    tick: int = 0
+
+
+@dataclass
+class _FakeDriver:
+    awaiting_ack: bool = False
+
+
+class TestOnPage:
+    def test_true_when_current_subject_matches(self) -> None:
+        steps = (_step("s0", OnPage(subject="county/26163")),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps,
+            campaign=_FakeCampaign(),
+            driver=None,
+            current_subject=lambda: "county/26163",
+        )
+        assert evaluator.is_step_complete(0) is True
+
+    def test_false_when_current_subject_differs(self) -> None:
+        steps = (_step("s0", OnPage(subject="county/26163")),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps,
+            campaign=_FakeCampaign(),
+            driver=None,
+            current_subject=lambda: "economy/USA",
+        )
+        assert evaluator.is_step_complete(0) is False
+
+    def test_false_when_current_subject_is_none(self) -> None:
+        steps = (_step("s0", OnPage(subject="county/26163")),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps, campaign=_FakeCampaign(), driver=None, current_subject=lambda: None
+        )
+        assert evaluator.is_step_complete(0) is False
+
+
+class TestTickAtLeast:
+    def test_true_once_tick_reached(self) -> None:
+        steps = (_step("s0", TickAtLeast(tick=3)),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps, campaign=_FakeCampaign(tick=3), driver=None, current_subject=lambda: None
+        )
+        assert evaluator.is_step_complete(0) is True
+
+    def test_true_past_the_target_tick(self) -> None:
+        steps = (_step("s0", TickAtLeast(tick=3)),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps, campaign=_FakeCampaign(tick=9), driver=None, current_subject=lambda: None
+        )
+        assert evaluator.is_step_complete(0) is True
+
+    def test_false_before_the_target_tick(self) -> None:
+        steps = (_step("s0", TickAtLeast(tick=3)),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps, campaign=_FakeCampaign(tick=2), driver=None, current_subject=lambda: None
+        )
+        assert evaluator.is_step_complete(0) is False
+
+
+class TestPausePending:
+    def test_true_when_driver_awaiting_ack(self) -> None:
+        steps = (_step("s0", PausePending()),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps,
+            campaign=_FakeCampaign(),
+            driver=_FakeDriver(awaiting_ack=True),
+            current_subject=lambda: None,
+        )
+        assert evaluator.is_step_complete(0) is True
+
+    def test_false_when_driver_not_awaiting_ack(self) -> None:
+        steps = (_step("s0", PausePending()),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps,
+            campaign=_FakeCampaign(),
+            driver=_FakeDriver(awaiting_ack=False),
+            current_subject=lambda: None,
+        )
+        assert evaluator.is_step_complete(0) is False
+
+    def test_false_with_no_driver_at_all(self) -> None:
+        steps = (_step("s0", PausePending()),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps, campaign=_FakeCampaign(), driver=None, current_subject=lambda: None
+        )
+        assert evaluator.is_step_complete(0) is False
+
+
+class TestEventAcked:
+    def test_true_once_driver_no_longer_awaiting_ack(self) -> None:
+        steps = (_step("s0", EventAcked()),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps,
+            campaign=_FakeCampaign(),
+            driver=_FakeDriver(awaiting_ack=False),
+            current_subject=lambda: None,
+        )
+        assert evaluator.is_step_complete(0) is True
+
+    def test_false_while_still_awaiting_ack(self) -> None:
+        steps = (_step("s0", EventAcked()),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps,
+            campaign=_FakeCampaign(),
+            driver=_FakeDriver(awaiting_ack=True),
+            current_subject=lambda: None,
+        )
+        assert evaluator.is_step_complete(0) is False
+
+    def test_false_with_no_driver_at_all(self) -> None:
+        steps = (_step("s0", EventAcked()),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps, campaign=_FakeCampaign(), driver=None, current_subject=lambda: None
+        )
+        assert evaluator.is_step_complete(0) is False
+
+
+class TestVerbIssuedIsHonestlyUnsupported:
+    def test_raises_loudly_rather_than_silently_returning_false(self) -> None:
+        """Module docstring: this evaluator is never handed a VerbIssued
+        step in production (the composition root slices those off), but if
+        it ever IS, it must fail loudly, never rot into a silent 'never
+        completes' — Constitution III.11."""
+        steps = (_step("s0", VerbIssued(verb="new_campaign")),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps, campaign=_FakeCampaign(), driver=None, current_subject=lambda: None
+        )
+        with pytest.raises(AssertionError, match="VerbIssued"):
+            evaluator.is_step_complete(0)
+
+
+class TestIndexBounds:
+    def test_out_of_range_index_is_honestly_false_not_a_crash(self) -> None:
+        steps = (_step("s0", TickAtLeast(tick=1)),)
+        evaluator = TutorialRuntimeProgress(
+            steps=steps, campaign=_FakeCampaign(tick=5), driver=None, current_subject=lambda: None
+        )
+        assert evaluator.is_step_complete(1) is False
+        assert evaluator.is_step_complete(-1) is False

--- a/tests/unit/sentinels/test_ast_helpers.py
+++ b/tests/unit/sentinels/test_ast_helpers.py
@@ -18,6 +18,7 @@ from babylon.sentinels._ast import (
     attribute_is_none_guard_lines,
     conditional_literal_returns_by_enum_member,
     coupling_edges,
+    declared_bindings,
     dict_get_call_lines,
     frozenset_str_members,
     function_return_annotation_name,
@@ -28,6 +29,7 @@ from babylon.sentinels._ast import (
     parse_module,
     referenced_names,
     returned_dict_keys,
+    tutorial_step_anchors,
     wallclock_call_lines,
 )
 from babylon.sentinels.base import SentinelCheckError
@@ -741,3 +743,99 @@ def test_wallclock_call_lines_raises_on_unparseable_source(tmp_path: Path) -> No
     target.write_text("def (:\n", encoding="utf-8")
     with pytest.raises(SentinelCheckError):
         wallclock_call_lines(target)
+
+
+def test_declared_bindings_reads_the_real_archive_app() -> None:
+    """The live ArchiveApp's own BINDINGS list is extracted with real lines."""
+    bindings = declared_bindings(_REPO_ROOT / "src/babylon/tui/app.py")
+    triples = {(cls, key, action) for cls, key, action, _line in bindings}
+    assert ("ArchiveApp", "t", "advance_tick") in triples
+    assert ("ArchiveApp", "ctrl+o", "jump_back") in triples
+    assert ("BriefingScreen", "enter", "begin") in triples
+    for _cls, _key, _action, line in bindings:
+        assert line > 0
+
+
+def test_declared_bindings_only_reads_a_class_own_body(tmp_path: Path) -> None:
+    """A BINDINGS list belonging to a DIFFERENT class is not misattributed."""
+    target = tmp_path / "m.py"
+    target.write_text(
+        "class Outer:\n"
+        "    BINDINGS = [Binding('a', 'outer_action', 'A')]\n"
+        "\n"
+        "class Inner:\n"
+        "    BINDINGS = [Binding('b', 'inner_action', 'B')]\n",
+        encoding="utf-8",
+    )
+    triples = {(cls, key, action) for cls, key, action, _line in declared_bindings(target)}
+    assert triples == {
+        ("Outer", "a", "outer_action"),
+        ("Inner", "b", "inner_action"),
+    }
+
+
+def test_declared_bindings_skips_computed_key_or_action(tmp_path: Path) -> None:
+    """A computed key/action is not a DECLARED one -- skipped, not fabricated."""
+    target = tmp_path / "m.py"
+    target.write_text(
+        "class C:\n"
+        "    BINDINGS = [\n"
+        "        Binding('x', 'real_action', 'X'),\n"
+        "        Binding(computed_key, 'other_action', 'Y'),\n"
+        "        Binding('z', computed_action, 'Z'),\n"
+        "    ]\n",
+        encoding="utf-8",
+    )
+    triples = {(cls, key, action) for cls, key, action, _line in declared_bindings(target)}
+    assert triples == {("C", "x", "real_action")}
+
+
+def test_declared_bindings_ignores_a_class_with_no_bindings_list(tmp_path: Path) -> None:
+    target = tmp_path / "m.py"
+    target.write_text("class C:\n    pass\n", encoding="utf-8")
+    assert declared_bindings(target) == ()
+
+
+def test_declared_bindings_raises_on_unparseable_source(tmp_path: Path) -> None:
+    target = tmp_path / "broken.py"
+    target.write_text("def (:\n", encoding="utf-8")
+    with pytest.raises(SentinelCheckError):
+        declared_bindings(target)
+
+
+def test_tutorial_step_anchors_reads_the_real_wayne_arc() -> None:
+    """The authored opening-arc script's own anchors are extracted."""
+    anchors = tutorial_step_anchors(_REPO_ROOT / "src/babylon/game/tutorial.py")
+    assert "binding:LobbyScreen:n" in anchors
+    assert "binding:ArchiveApp:t" in anchors
+    assert "page:county/26163" in anchors
+    assert "palette:economy/USA" in anchors
+
+
+def test_tutorial_step_anchors_preserves_duplicates(tmp_path: Path) -> None:
+    """Two steps sharing an anchor both count -- never silently deduplicated."""
+    target = tmp_path / "m.py"
+    target.write_text(
+        "S = (\n"
+        "    TutorialStep(id='a', anchor='page:x', other=1),\n"
+        "    TutorialStep(id='b', anchor='page:x', other=2),\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    assert tutorial_step_anchors(target) == ("page:x", "page:x")
+
+
+def test_tutorial_step_anchors_skips_computed_anchor(tmp_path: Path) -> None:
+    target = tmp_path / "m.py"
+    target.write_text(
+        "S = (TutorialStep(id='a', anchor=computed_anchor),)\n",
+        encoding="utf-8",
+    )
+    assert tutorial_step_anchors(target) == ()
+
+
+def test_tutorial_step_anchors_raises_on_unparseable_source(tmp_path: Path) -> None:
+    target = tmp_path / "broken.py"
+    target.write_text("def (:\n", encoding="utf-8")
+    with pytest.raises(SentinelCheckError):
+        tutorial_step_anchors(target)

--- a/tests/unit/sentinels/test_tutorial_coverage.py
+++ b/tests/unit/sentinels/test_tutorial_coverage.py
@@ -1,0 +1,147 @@
+"""Tests for the tutorial option-coverage sentinel (T6).
+
+Per ``ai/_inbox/t6-tutorial-bdd-ruling.md``: "an option with no scenario is a
+seam — red." These tests prove the gate actually catches that: a live clean
+run against the real repo, then mutation-validated proofs that an uncovered
+binding reds the gate, a cited exemption clears it, and a stale exemption
+(naming a binding that no longer exists) reds the gate the other way.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from babylon.sentinels.exemptions import SentinelExemption
+from babylon.sentinels.tutorial_coverage.checks import (
+    check_every_binding_covered_or_exempted,
+    check_every_exemption_still_names_a_real_binding,
+)
+from babylon.sentinels.tutorial_coverage.registry import TUTORIAL_COVERAGE_EXEMPTIONS
+
+pytestmark = pytest.mark.unit
+
+
+def test_the_live_repo_is_clean() -> None:
+    """Every real declared binding is covered or exempted, right now."""
+    assert check_every_binding_covered_or_exempted() == []
+
+
+def test_every_declared_exemption_is_grounded_against_the_live_repo() -> None:
+    """No exemption in the registry is stale against the real BINDINGS."""
+    assert check_every_exemption_still_names_a_real_binding() == []
+
+
+def test_registry_rows_are_well_formed() -> None:
+    """Every declared exemption's key is a well-formed ('binding', class, key) triple."""
+    assert TUTORIAL_COVERAGE_EXEMPTIONS
+    for exemption in TUTORIAL_COVERAGE_EXEMPTIONS:
+        assert exemption.key[0] == "binding"
+        assert len(exemption.key) == 3
+
+
+def test_an_uncovered_binding_with_no_exemption_is_a_finding() -> None:
+    """The efficacy proof: a real gap, injected, is caught."""
+    options = (("binding:Ghost:x", "Ghost", "x", "src/babylon/tui/ghost.py", 7),)
+    findings = check_every_binding_covered_or_exempted(
+        options=options,
+        exercised=frozenset(),
+        exemptions=(),
+    )
+    assert len(findings) == 1
+    assert "Ghost" in findings[0]
+    assert "src/babylon/tui/ghost.py:7" in findings[0]
+
+
+def test_an_exercised_anchor_clears_the_finding() -> None:
+    """A binding whose anchor a script exercises needs no exemption at all."""
+    options = (("binding:Ghost:x", "Ghost", "x", "src/babylon/tui/ghost.py", 7),)
+    findings = check_every_binding_covered_or_exempted(
+        options=options,
+        exercised=frozenset({"binding:Ghost:x"}),
+        exemptions=(),
+    )
+    assert findings == []
+
+
+def test_a_cited_exemption_clears_the_finding() -> None:
+    """An uncovered binding with a matching exemption is not a finding."""
+    options = (("binding:Ghost:x", "Ghost", "x", "src/babylon/tui/ghost.py", 7),)
+    exemption = SentinelExemption(
+        key=("binding", "Ghost", "x"),
+        reason="test fixture",
+        owner="Persephone Raskova",
+        date="2026-07-22",
+        tracking_task="N/A (test fixture)",
+    )
+    findings = check_every_binding_covered_or_exempted(
+        options=options,
+        exercised=frozenset(),
+        exemptions=(exemption,),
+    )
+    assert findings == []
+
+
+def test_an_exemption_for_a_different_class_does_not_cross_match() -> None:
+    """('binding', 'Ghost', 'x') never exempts ('binding', 'Other', 'x')."""
+    options = (("binding:Other:x", "Other", "x", "src/babylon/tui/other.py", 3),)
+    exemption = SentinelExemption(
+        key=("binding", "Ghost", "x"),
+        reason="test fixture",
+        owner="Persephone Raskova",
+        date="2026-07-22",
+        tracking_task="N/A (test fixture)",
+    )
+    findings = check_every_binding_covered_or_exempted(
+        options=options,
+        exercised=frozenset(),
+        exemptions=(exemption,),
+    )
+    assert len(findings) == 1
+    assert "Other" in findings[0]
+
+
+def test_a_stale_exemption_is_a_finding() -> None:
+    """An exemption naming a binding that no longer exists reds the gate."""
+    options = (("binding:Real:x", "Real", "x", "src/babylon/tui/real.py", 1),)
+    exemption = SentinelExemption(
+        key=("binding", "GoneClass", "gone_key"),
+        reason="test fixture",
+        owner="Persephone Raskova",
+        date="2026-07-22",
+        tracking_task="N/A (test fixture)",
+    )
+    findings = check_every_exemption_still_names_a_real_binding(
+        options=options,
+        exemptions=(exemption,),
+    )
+    assert len(findings) == 1
+    assert "GoneClass" in findings[0]
+    assert "gone_key" in findings[0]
+
+
+def test_a_grounded_exemption_is_not_a_finding() -> None:
+    options = (("binding:Real:x", "Real", "x", "src/babylon/tui/real.py", 1),)
+    exemption = SentinelExemption(
+        key=("binding", "Real", "x"),
+        reason="test fixture",
+        owner="Persephone Raskova",
+        date="2026-07-22",
+        tracking_task="N/A (test fixture)",
+    )
+    assert (
+        check_every_exemption_still_names_a_real_binding(options=options, exemptions=(exemption,))
+        == []
+    )
+
+
+def test_registry_rejects_a_malformed_row() -> None:
+    """The shared SentinelExemption validator still fires for this family."""
+    with pytest.raises(ValidationError):
+        SentinelExemption(
+            key=("binding", "X", "y"),
+            reason="",
+            owner="Persephone Raskova",
+            date="2026-07-22",
+            tracking_task="N/A",
+        )

--- a/tests/unit/tui/test_app_tutorial_wiring.py
+++ b/tests/unit/tui/test_app_tutorial_wiring.py
@@ -1,0 +1,238 @@
+"""``ArchiveApp``'s tutorial-overlay wiring seam (Program v1.0.0 T6, Unit U4).
+
+Complements ``tests/unit/tui/test_tutorial_overlay.py`` (which drives the
+BARE :class:`~babylon.tui.tutorial_overlay.TutorialOverlay` widget with no
+``ArchiveApp`` at all): this file exercises the composition-root seam itself
+— :class:`~babylon.tui.app.ArchiveApp`'s ``tutorial_steps``/
+``tutorial_progress_factory`` constructor params — with fake
+``CampaignHandle``/``PacedDriverHandle`` doubles, following the exact
+``TestSeams``/lobby-flow idiom ``tests/unit/tui/test_app_pacing_driver.py``
+already established for :class:`~babylon.tui.app.PacedDriverHandle`.
+
+Per this unit's own mandate: "demo path and resumed campaigns never show
+it" — the demo (no ``campaign_menu``) boot path never reaches a campaign at
+all, so no tutorial wiring can fire; a REAL ``babylon play`` boot's own
+new-vs-resumed gating lives in ``babylon.cli.play``'s
+``_tutorial_progress_factory`` (tested separately in
+``tests/unit/cli/test_play.py``) — here, that gating is exercised at the
+``ArchiveApp`` seam by a factory double that itself returns ``None``
+(standing in for "the composition root decided this campaign is resumed").
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from uuid import UUID
+
+import pytest
+from textual.widgets import Label, OptionList
+
+from babylon.tui.app import ArchiveApp, CampaignHandle, PacedDriverHandle
+from babylon.tui.campaign_menu import CampaignMenu, InMemoryCampaign, InMemoryCampaignCatalog
+from babylon.tui.tutorial_overlay import TutorialOverlay, TutorialProgress
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass(frozen=True)
+class _FakeStep:
+    scenario_name: str
+    overlay_text: str
+
+
+_STEPS: tuple[_FakeStep, ...] = (
+    _FakeStep(scenario_name="a lone step.", overlay_text="GIVEN/WHEN/THEN"),
+)
+
+
+class _FakeCampaign:
+    """A minimal ``CampaignHandle`` double — mirrors ``test_app_lobby_flow.
+    py``'s own fixture, with a caller-set ``tick`` (this campaign's own
+    stand-in for "freshly minted" vs. "already progressed")."""
+
+    def __init__(self, session_id: UUID, pages: dict[str, str], *, tick: int = 0) -> None:
+        self.session_id = session_id
+        self.tick = tick
+        self._pages = pages
+
+    def read_page(self, subject: str) -> str | None:
+        return self._pages.get(subject)
+
+    def known_subjects(self) -> frozenset[str]:
+        return frozenset(self._pages)
+
+    def advance_tick(self) -> object:  # pragma: no cover - unused by these tests
+        raise AssertionError("advance_tick should not be called by these wiring tests")
+
+
+class _FakeLoader:
+    def __init__(self, campaign: _FakeCampaign) -> None:
+        self._campaign = campaign
+
+    def __call__(self, campaign_id: UUID) -> _FakeCampaign:
+        return self._campaign
+
+
+def _seeded_menu() -> tuple[CampaignMenu, UUID]:
+    campaign_id = UUID(int=1)
+    catalog = InMemoryCampaignCatalog(
+        seed=(
+            InMemoryCampaign(
+                campaign_id=campaign_id,
+                slug="campaign-one",
+                engine_version="0.1.0",
+                defines_hash="d" * 16,
+            ),
+        )
+    )
+    return CampaignMenu(catalog, engine_version="0.1.0", defines_hash="d" * 16), campaign_id
+
+
+def _campaign_for(campaign_id: UUID, *, tick: int = 0) -> _FakeCampaign:
+    briefing_subject = f"briefing/{campaign_id}"
+    return _FakeCampaign(
+        campaign_id, {briefing_subject: "# OP\n", "county/26163": "# Wayne\n"}, tick=tick
+    )
+
+
+async def _boot_into_campaign_shell(pilot: object, app: ArchiveApp) -> None:
+    """Walk the lobby -> briefing -> shell flow (mirrors ``test_app_pacing_
+    driver.py``'s own repeated sequence)."""
+    await pilot.pause()  # type: ignore[attr-defined]
+    app.screen.query_one("#campaigns", OptionList).focus()
+    await pilot.press("enter")  # type: ignore[attr-defined]
+    await pilot.pause()  # type: ignore[attr-defined]
+    await pilot.press("enter")  # type: ignore[attr-defined]
+    await pilot.pause()  # type: ignore[attr-defined]
+
+
+class TestConstructorValidation:
+    def test_tutorial_progress_factory_without_tutorial_steps_raises(self) -> None:
+        with pytest.raises(ValueError, match="tutorial_steps"):
+            ArchiveApp(tutorial_progress_factory=lambda _c, _d, _s: None)
+
+    def test_tutorial_steps_alone_is_a_valid_inert_configuration(self) -> None:
+        """The reverse pairing is NOT required to raise (unlike
+        ``campaign_menu``/``campaign_loader``): steps with no factory can
+        never activate anything, which is harmless, not a misconfiguration."""
+        app = ArchiveApp(tutorial_steps=_STEPS)
+        assert app.driver is None  # constructs cleanly, nothing crashes
+
+
+class TestDemoPathNeverShowsTutorial:
+    @pytest.mark.asyncio
+    async def test_the_bare_demo_app_never_mounts_an_overlay(self) -> None:
+        """``ArchiveApp()`` — no ``campaign_menu`` at all, the pre-existing
+        sample-page demo boot — never reaches ``_on_briefing_dismissed``,
+        so no tutorial wiring can ever fire."""
+        app = ArchiveApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert len(app.query(TutorialOverlay)) == 0
+
+    @pytest.mark.asyncio
+    async def test_a_real_campaign_boot_with_no_factory_wired_never_shows_it(self) -> None:
+        """Every pre-Unit-U4 caller/test: a real lobby->briefing->shell boot
+        with NEITHER ``tutorial_steps`` nor ``tutorial_progress_factory``
+        given — unaffected by this unit."""
+        menu, campaign_id = _seeded_menu()
+        app = ArchiveApp(
+            campaign_menu=menu, campaign_loader=_FakeLoader(_campaign_for(campaign_id))
+        )
+        async with app.run_test() as pilot:
+            await _boot_into_campaign_shell(pilot, app)
+            assert len(app.query(TutorialOverlay)) == 0
+
+
+class TestCompositionRootGating:
+    """The T6 ruling's "resumed campaigns default OFF" — exercised here at
+    the ``ArchiveApp`` seam via a factory double (the real new-vs-resumed
+    DECISION is ``babylon.cli.play``'s own job, tested in
+    ``tests/unit/cli/test_play.py``)."""
+
+    @pytest.mark.asyncio
+    async def test_a_factory_returning_none_never_mounts_the_overlay(self) -> None:
+        menu, campaign_id = _seeded_menu()
+        app = ArchiveApp(
+            campaign_menu=menu,
+            campaign_loader=_FakeLoader(_campaign_for(campaign_id, tick=5)),
+            tutorial_steps=_STEPS,
+            tutorial_progress_factory=lambda _c, _d, _s: None,
+        )
+        async with app.run_test() as pilot:
+            await _boot_into_campaign_shell(pilot, app)
+            assert len(app.query(TutorialOverlay)) == 0
+            assert app._tutorial_progress is None  # noqa: SLF001 - white-box wiring check
+
+    @pytest.mark.asyncio
+    async def test_a_factory_returning_a_seam_mounts_the_overlay(self) -> None:
+        menu, campaign_id = _seeded_menu()
+
+        @dataclass
+        class _StubProgress:
+            def is_step_complete(self, step_index: int) -> bool:
+                return False
+
+        app = ArchiveApp(
+            campaign_menu=menu,
+            campaign_loader=_FakeLoader(_campaign_for(campaign_id, tick=0)),
+            tutorial_steps=_STEPS,
+            tutorial_progress_factory=lambda _c, _d, _s: _StubProgress(),
+        )
+        async with app.run_test() as pilot:
+            await _boot_into_campaign_shell(pilot, app)
+            assert len(app.query(TutorialOverlay)) == 1
+            overlay = app.query_one(TutorialOverlay)
+            heading = str(overlay.query_one("#tutorial-heading", Label).content)
+            assert _STEPS[0].scenario_name in heading
+
+    @pytest.mark.asyncio
+    async def test_the_factory_is_called_with_the_booted_campaign_and_driver(self) -> None:
+        menu, campaign_id = _seeded_menu()
+        campaign = _campaign_for(campaign_id)
+        seen: list[tuple[CampaignHandle, PacedDriverHandle | None]] = []
+
+        def _factory(
+            booted: CampaignHandle,
+            driver: PacedDriverHandle | None,
+            _current_subject: Callable[[], str | None],
+        ) -> TutorialProgress | None:
+            seen.append((booted, driver))
+            return None
+
+        app = ArchiveApp(
+            campaign_menu=menu,
+            campaign_loader=_FakeLoader(campaign),
+            tutorial_steps=_STEPS,
+            tutorial_progress_factory=_factory,
+        )
+        async with app.run_test() as pilot:
+            await _boot_into_campaign_shell(pilot, app)
+            assert seen == [(campaign, None)]
+
+
+class TestExistingSnapshotBootUnaffected:
+    """The default-constructed module-level ``app`` (``babylon.tui.app.app``,
+    which ``tests/unit/tui/test_snapshot.py``'s golden renders) never sets
+    any tutorial param — this pins that the golden's own boot path stays
+    byte-for-byte untouched by this unit (no overlay, no CSS collision)."""
+
+    def test_default_constructed_app_has_no_tutorial_wiring(self) -> None:
+        from babylon.tui.app import app as sample_app
+
+        assert sample_app._tutorial_steps is None  # noqa: SLF001
+        assert sample_app._tutorial_progress_factory is None  # noqa: SLF001
+
+    @pytest.mark.asyncio
+    async def test_default_constructed_app_mounts_no_overlay_when_run(self) -> None:
+        from babylon.tui.app import ArchiveApp
+
+        # A FRESH instance (not the shared module-level ``app``, which other
+        # test modules may already have driven) constructed exactly the same
+        # way — the demo boot path never even reaches ``_on_briefing_
+        # dismissed``, so no overlay can mount.
+        app = ArchiveApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert len(app.query(TutorialOverlay)) == 0

--- a/tests/unit/tui/test_tutorial_overlay.py
+++ b/tests/unit/tui/test_tutorial_overlay.py
@@ -1,0 +1,209 @@
+"""Unit tests for babylon.tui.tutorial_overlay: the guided opening-arc
+overlay (Program v1.0.0 T6, Unit U4).
+
+Three families: seam conformance (the real
+:class:`~babylon.game.tutorial.TutorialStep` structurally satisfies
+:data:`~babylon.tui.tutorial_overlay.TutorialStepView`), verbatim rendering
+(the reviewer-diffable "zero copy divergence" contract — the overlay's own
+rendered text equals the REAL model's own ``scenario_name``/``overlay_text``
+fields, walked across the whole authored arc, not reconstructed locally),
+and widget behavior (advance-on-predicate, dismiss) against a scripted
+:data:`~babylon.tui.tutorial_overlay.TutorialProgress` double — no
+``ArchiveApp``/campaign/engine required, mirroring
+``tests/unit/tui/test_directives.py``'s own bare-host-``App`` idiom.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Label
+
+from babylon.game.tutorial import WAYNE_OPENING_ARC
+from babylon.tui.tutorial_overlay import TutorialOverlay, TutorialProgress, TutorialStepView
+
+pytestmark = [pytest.mark.unit]
+
+
+@dataclass(frozen=True)
+class _FakeStep:
+    """A minimal :data:`TutorialStepView` double: only the two rendered fields."""
+
+    scenario_name: str
+    overlay_text: str
+
+
+@dataclass
+class _FakeProgress:
+    """A scripted :data:`TutorialProgress` double.
+
+    ``is_step_complete(i)`` reads a caller-controlled dict, defaulting to
+    ``False`` for any index never explicitly set — never a real predicate
+    evaluation (that's :mod:`babylon.game.tutorial_runtime`'s own job,
+    tested separately).
+    """
+
+    _complete: dict[int, bool] = field(default_factory=dict)
+
+    def is_step_complete(self, step_index: int) -> bool:
+        return self._complete.get(step_index, False)
+
+    def set_complete(self, step_index: int, value: bool = True) -> None:
+        self._complete[step_index] = value
+
+
+class _OverlayHost(App[None]):
+    """Bare host mounting exactly one :class:`TutorialOverlay`."""
+
+    def __init__(self, steps: Sequence[TutorialStepView], progress: TutorialProgress) -> None:
+        super().__init__()
+        self._steps = steps
+        self._progress = progress
+
+    def compose(self) -> ComposeResult:
+        yield TutorialOverlay(self._steps, self._progress, id="tutorial-overlay")
+
+
+def _overlay(app: _OverlayHost) -> TutorialOverlay:
+    return app.query_one(TutorialOverlay)
+
+
+def _heading_text(app: _OverlayHost) -> str:
+    return str(_overlay(app).query_one("#tutorial-heading", Label).content)
+
+
+def _body_text(app: _OverlayHost) -> str:
+    return str(_overlay(app).query_one("#tutorial-body", Label).content)
+
+
+class TestSeamConformance:
+    def test_fake_progress_satisfies_the_protocol(self) -> None:
+        assert isinstance(_FakeProgress(), TutorialProgress)
+
+    def test_fake_step_satisfies_the_view_protocol(self) -> None:
+        assert isinstance(_FakeStep("s.", "S"), TutorialStepView)
+
+    def test_every_real_authored_step_satisfies_the_view_protocol(self) -> None:
+        """The REAL model — not just a test double — structurally satisfies
+        what the widget consumes; this is what makes verbatim rendering
+        possible without ``babylon.tui`` ever importing
+        ``babylon.game.tutorial``."""
+        for step in WAYNE_OPENING_ARC.steps:  # loop bound: len(steps) == 9
+            assert isinstance(step, TutorialStepView)
+
+
+class TestRendersVerbatimFromTheRealModel:
+    """The T6 ruling's "zero copy divergence" contract, string-compared
+    against the REAL :data:`~babylon.game.tutorial.WAYNE_OPENING_ARC` — not
+    a local fixture that could quietly drift from the model's own fields.
+    """
+
+    @pytest.mark.asyncio
+    async def test_first_step_renders_its_own_fields_verbatim_on_mount(self) -> None:
+        steps = WAYNE_OPENING_ARC.steps
+        app = _OverlayHost(steps, _FakeProgress())
+        async with app.run_test():
+            first = steps[0]
+            assert first.scenario_name in _heading_text(app)
+            assert _body_text(app) == first.overlay_text
+
+    @pytest.mark.asyncio
+    async def test_every_step_renders_its_own_fields_verbatim_when_current(self) -> None:
+        """Walks every real authored step forward one at a time, asserting
+        the rendered heading/body match THAT step's own fields at every
+        position — proves derivation across the whole arc, not merely the
+        first beat."""
+        steps = WAYNE_OPENING_ARC.steps
+        progress = _FakeProgress()
+        app = _OverlayHost(steps, progress)
+        async with app.run_test():
+            overlay = _overlay(app)
+            for index, step in enumerate(steps):  # loop bound: len(steps) == 9
+                assert overlay.current_step_index == index
+                assert step.scenario_name in _heading_text(app)
+                assert _body_text(app) == step.overlay_text
+                progress.set_complete(index, True)
+                overlay.check_progress()
+            assert overlay.finished is True
+
+
+class TestAdvanceOnPredicate:
+    @pytest.mark.asyncio
+    async def test_stays_on_the_current_step_while_the_predicate_is_false(self) -> None:
+        steps = (
+            _FakeStep("first sentence.", "FIRST BLOCK"),
+            _FakeStep("second sentence.", "SECOND BLOCK"),
+        )
+        app = _OverlayHost(steps, _FakeProgress())
+        async with app.run_test():
+            overlay = _overlay(app)
+            overlay.check_progress()
+            assert overlay.current_step_index == 0
+            assert "first sentence." in _heading_text(app)
+
+    @pytest.mark.asyncio
+    async def test_advances_to_the_next_step_once_the_predicate_holds(self) -> None:
+        steps = (
+            _FakeStep("first sentence.", "FIRST BLOCK"),
+            _FakeStep("second sentence.", "SECOND BLOCK"),
+        )
+        progress = _FakeProgress()
+        app = _OverlayHost(steps, progress)
+        async with app.run_test():
+            overlay = _overlay(app)
+            progress.set_complete(0, True)
+            overlay.check_progress()
+            assert overlay.current_step_index == 1
+            assert "second sentence." in _heading_text(app)
+            assert _body_text(app) == "SECOND BLOCK"
+
+    @pytest.mark.asyncio
+    async def test_advances_through_every_consecutive_true_step_in_one_poll(self) -> None:
+        steps = tuple(_FakeStep(f"s{i}.", f"B{i}") for i in range(4))
+        progress = _FakeProgress({0: True, 1: True, 2: True})
+        app = _OverlayHost(steps, progress)
+        async with app.run_test():
+            overlay = _overlay(app)
+            overlay.check_progress()
+            assert overlay.current_step_index == 3
+
+    @pytest.mark.asyncio
+    async def test_finishing_every_step_renders_the_completion_message(self) -> None:
+        steps = (_FakeStep("only sentence.", "ONLY BLOCK"),)
+        progress = _FakeProgress({0: True})
+        app = _OverlayHost(steps, progress)
+        async with app.run_test():
+            overlay = _overlay(app)
+            overlay.check_progress()
+            assert overlay.finished is True
+            assert "complete" in _heading_text(app).lower()
+
+
+class TestDismissBinding:
+    @pytest.mark.asyncio
+    async def test_escape_dismisses_the_overlay_and_removes_it_from_the_dom(self) -> None:
+        steps = (_FakeStep("only sentence.", "ONLY BLOCK"),)
+        app = _OverlayHost(steps, _FakeProgress())
+        async with app.run_test() as pilot:
+            overlay = _overlay(app)
+            assert overlay.dismissed is False
+            await pilot.press("escape")
+            await pilot.pause()
+            assert overlay.dismissed is True
+            assert len(app.query(TutorialOverlay)) == 0
+
+    @pytest.mark.asyncio
+    async def test_check_progress_is_a_harmless_no_op_after_dismissal(self) -> None:
+        steps = (_FakeStep("only sentence.", "ONLY BLOCK"),)
+        progress = _FakeProgress()
+        app = _OverlayHost(steps, progress)
+        async with app.run_test() as pilot:
+            overlay = _overlay(app)
+            await pilot.press("escape")
+            await pilot.pause()
+            progress.set_complete(0, True)
+            overlay.check_progress()  # must not raise against an unmounted widget
+            assert overlay.current_step_index == 0

--- a/tests/unit/tui/test_tutorial_pilot.py
+++ b/tests/unit/tui/test_tutorial_pilot.py
@@ -11,6 +11,18 @@ status line), structural Pilot state second (``nav.current``, the paced
 driver's own ``awaiting_ack``) only where a string alone would be ambiguous,
 never a visual/pixel comparison.
 
+**Review fix pass**: ``OnPage`` alone (nav.current + non-emptiness) is a
+navigation-only check — it cannot distinguish a step whose ``then`` merely
+advertises "the dossier pane shows/returns to X" from one whose ``then``
+advertises specific rendered CONTENT ("the wage balance ... render as real
+numbers", "Wayne's own material state, not a fixture"). Two steps
+(``read_the_county_dossier``, ``read_the_theorem_verdict``) are the latter
+kind; :func:`drive_step` layers a distinctive-token check onto those two
+(:data:`_EXTRA_CONTENT_CHECK_BY_STEP_ID`) rather than widening ``OnPage``
+itself or adding a new :data:`~babylon.game.tutorial.CompletionPredicate`
+kind in U1 — a reviewer-specified, minimally-scoped fix over U2's own
+assertion path.
+
 Runs against a REAL :class:`~babylon.game.session.GameSession` — the real
 30-system engine, the real :class:`~babylon.game.pacing.PacedTickDriver` +
 :class:`~babylon.engine.observers.endgame_detector.EndgameDetector`, and a
@@ -55,6 +67,7 @@ a durable regression rather than a one-time comment.
 from __future__ import annotations
 
 import io
+import re
 from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -467,6 +480,106 @@ def _assert_completion(app: ArchiveApp, predicate: object, *, step_id: str) -> N
     raise AssertionError(f"{step_id}: unrecognized completion predicate kind {predicate!r}")
 
 
+# --------------------------------------------------------------------------- #
+# Step-specific content checks (review fix pass) — see module note above     #
+# drive_step for why these are layered ON TOP OF _assert_completion rather   #
+# than folded into it or promoted to a new CompletionPredicate kind.         #
+# --------------------------------------------------------------------------- #
+
+#: A real ``ClassComposition`` row, always present on Wayne's county
+#: statblock by the time ``read_the_county_dossier`` runs (verified against
+#: this exact composition's own emitted transcript). Distinguishes a REAL
+#: rendered county statblock from any other non-empty page shown at the
+#: same subject — unlike ``_WAYNE_FIPS`` alone, this string cannot leak in
+#: from a refusal message (``_directive_statblock``'s own "no statblock
+#: projection for {arg}"/"MALFORMED STATBLOCK BODY" refusals echo the
+#: subject id too, so the FIPS alone is not fully distinctive; a genuine
+#: class-composition row only ever comes from an actually-rendered
+#: statblock body).
+_WAYNE_CLASS_COMPOSITION_ROW: Final = "class_composition.labor_aristocracy"
+
+#: ``wage_balance``'s own statblock row, rendered by
+#: ``babylon.tui.directives._directive_statblock`` as
+#: ``"wage_balance<padding><value>"`` (the colon from the baked
+#: ``key: value`` fence body is stripped at parse time — verified against
+#: this exact composition's own emitted transcript, never assumed). The
+#: numeric value itself is NOT pinned (unlike ``test_t3_live_
+#: reachability.py``'s fixture-backed ``"0.180000"`` literal) because this
+#: suite runs the real engine through real ticks — a genuine coefficient
+#: retune could shift the float without being a regression this step's own
+#: Then cares about; what the Then actually advertises is "renders as a
+#: real number", which a numeric-shaped regex proves without over-pinning.
+_WAGE_BALANCE_ROW_PATTERN: Final = re.compile(r"wage_balance\s+-?\d+\.\d+")
+
+#: ``labor_aristocracy_verdict``'s own statblock row — same rendering
+#: contract as above, value is the literal ``str(bool)`` render
+#: (``"True"``/``"False"``), verified against the emitted transcript.
+_LABOR_ARISTOCRACY_VERDICT_ROW_PATTERN: Final = re.compile(
+    r"labor_aristocracy_verdict\s+(True|False)"
+)
+
+
+def _assert_county_dossier_is_wayne_real(app: ArchiveApp, *, step_id: str) -> None:
+    """``read_the_county_dossier``'s own extra Then-check (review fix pass).
+
+    The step's own ``then`` advertises Wayne's REAL material state, "not a
+    fixture" — ``OnPage`` alone (nav.current + non-emptiness) cannot tell
+    that apart from any other non-empty page shown under the same subject.
+    A real class-composition row is the distinctive proof.
+
+    :raises AssertionError: no real class-composition row (or the county's
+        own FIPS) appears in the rendered statblock.
+    """
+    text = _dossier_plain_text(app)
+    assert _WAYNE_CLASS_COMPOSITION_ROW in text, (
+        f"{step_id}: no real {_WAYNE_CLASS_COMPOSITION_ROW!r} row in the rendered "
+        "statblock — cannot distinguish Wayne's own state from an empty/fixture page"
+    )
+    assert _WAYNE_FIPS in text, f"{step_id}: county/{_WAYNE_FIPS}'s own FIPS never rendered"
+
+
+def _assert_theorem_verdict_is_real(app: ArchiveApp, *, step_id: str) -> None:
+    """``read_the_theorem_verdict``'s own extra Then-check (review fix pass).
+
+    The step's own ``then`` advertises the wage balance and the
+    labor-aristocracy verdict rendering "as real numbers read off the SAME
+    opposition the engine itself adjudicates" — ``OnPage`` alone cannot
+    verify that distinctive content is actually on screen, only that
+    *something* non-empty is showing at ``economy/USA``.
+
+    :raises AssertionError: either row is missing, or ``wage_balance``'s
+        value is not numeric-shaped.
+    """
+    text = _dossier_plain_text(app)
+    assert _WAGE_BALANCE_ROW_PATTERN.search(text), (
+        f"{step_id}: no 'wage_balance <number>' row in the rendered statblock"
+    )
+    assert _LABOR_ARISTOCRACY_VERDICT_ROW_PATTERN.search(text), (
+        f"{step_id}: no 'labor_aristocracy_verdict <bool>' row in the rendered statblock"
+    )
+
+
+#: Closed, named extension keyed by step id — NOT a second predicate
+#: vocabulary alongside :func:`_assert_completion` (that function alone
+#: owns closed dispatch over :data:`~babylon.game.tutorial.
+#: CompletionPredicate`). Every OTHER step id is a deliberate no-op here:
+#: the two entries below are exactly the CONTENT-advertising ``OnPage``
+#: steps the review identified (their ``then`` names specific rendered
+#: numbers/rows) as opposed to the NAVIGATION-only ``OnPage`` steps
+#: (``begin_the_operation``, ``palette_to_the_economy_dossier``,
+#: ``jump_back_to_wayne``) whose own ``then`` only advertises "the dossier
+#: pane shows/returns to/navigates to X" — already fully covered by
+#: ``_assert_completion``'s nav.current + non-emptiness check.
+_EXTRA_CONTENT_CHECK_BY_STEP_ID: Final[dict[str, Callable[[ArchiveApp], None]]] = {
+    "read_the_county_dossier": lambda app: _assert_county_dossier_is_wayne_real(
+        app, step_id="read_the_county_dossier"
+    ),
+    "read_the_theorem_verdict": lambda app: _assert_theorem_verdict_is_real(
+        app, step_id="read_the_theorem_verdict"
+    ),
+}
+
+
 async def drive_step(pilot: Pilot[None], step: TutorialStep) -> None:
     """The step interpreter's public entry point: drive ``step.when`` via
     its anchor, then hard-assert ``step.then`` via its completion predicate.
@@ -474,7 +587,11 @@ async def drive_step(pilot: Pilot[None], step: TutorialStep) -> None:
     Closed dispatch over the anchor grammar (:func:`_perform_anchor`) and
     the completion-predicate union (:func:`_assert_completion`) — an
     anchor prefix or predicate kind outside either closed vocabulary raises
-    loudly, never skips (Constitution III.11).
+    loudly, never skips (Constitution III.11). A second, narrow layer
+    (:data:`_EXTRA_CONTENT_CHECK_BY_STEP_ID`, review fix pass) asserts the
+    distinctive rendered content two CONTENT-advertising steps promise,
+    on top of (never instead of) the generic ``OnPage`` check — see that
+    dict's own docstring for why only those two step ids need it.
     """
     if isinstance(step.completion, VerbIssued):
         await _drive_verb_issued(pilot, step.anchor, step.completion.verb, step_id=step.id)
@@ -482,7 +599,11 @@ async def drive_step(pilot: Pilot[None], step: TutorialStep) -> None:
     await _perform_anchor(pilot, step.anchor)
     await pilot.app.workers.wait_for_complete()
     await pilot.pause()
-    _assert_completion(_archive_app(pilot), step.completion, step_id=step.id)
+    app = _archive_app(pilot)
+    _assert_completion(app, step.completion, step_id=step.id)
+    extra_check = _EXTRA_CONTENT_CHECK_BY_STEP_ID.get(step.id)
+    if extra_check is not None:
+        extra_check(app)
 
 
 async def _load_the_minted_campaign(pilot: Pilot[None]) -> None:

--- a/tests/unit/tui/test_tutorial_pilot.py
+++ b/tests/unit/tui/test_tutorial_pilot.py
@@ -1,0 +1,733 @@
+"""The headless Pilot executor for the tutorial-as-BDD suite (Program v1.0.0
+T6, Unit U2).
+
+Per ``ai/_inbox/t6-tutorial-bdd-ruling.md``: the same
+:data:`~babylon.game.tutorial.WAYNE_OPENING_ARC` step script the (future)
+player overlay renders is executed here headlessly — drive each step's
+``when`` through a real Textual ``Pilot``, then hard-assert its ``then``
+via its own closed-vocabulary completion predicate. Assertion tiers strictly
+ordered per the ruling: semantic TEXT first (rendered dossier content, the
+status line), structural Pilot state second (``nav.current``, the paced
+driver's own ``awaiting_ack``) only where a string alone would be ambiguous,
+never a visual/pixel comparison.
+
+Runs against a REAL :class:`~babylon.game.session.GameSession` — the real
+30-system engine, the real :class:`~babylon.game.pacing.PacedTickDriver` +
+:class:`~babylon.engine.observers.endgame_detector.EndgameDetector`, and a
+real vault bake (:class:`~babylon.projection.vault.tick_baker.
+ArchiveTickBaker` over a ``dulwich``-backed temp directory), so
+``county/26163``/``economy/USA`` are REAL rendered pages, never a fixture
+lookalike (the T3 idiom, ``test_t3_live_reachability.py``). The ONE thing
+faked is Postgres itself (:class:`_InMemoryGameStore`, structurally
+satisfying :class:`~babylon.game.session.GameRuntimeStore` — the SAME
+WO-37 trick :mod:`babylon.game.session` itself documents), which is what
+keeps this whole module at the UNIT tier per the T6 ruling's own tier
+split ("pure-Pilot steps with a fake handle can stay unit-tier") — the
+PG-reachable tier law belongs to ``tests/integration/game/
+test_session_integration.py``, which this module never needs to duplicate
+since nothing here talks to a real database.
+
+**Wayne's own material state autopauses on TICK 1** (verified empirically
+against this exact composition: ``ECOLOGICAL_OVERSHOOT``/``PERIPHERAL_
+REVOLT`` fire critical-tier every single tick under
+:func:`~babylon.game.session.default_pause_predicate` — not a rare event
+this scenario's coefficients eventually cross into, but its steady state
+from tick 0 onward). This is an HONEST GAP in the authored arc, surfaced
+by running it for real (exactly what the ruling promises BDD-as-truth
+would do — "a step that stops being true goes red ... before a player ever
+sees the lie"): ``advance_a_tick``'s own ``t`` press already leaves the
+driver ``awaiting_ack``, so ``run_until_autopause``'s ``r`` press is
+observably a NO-OP refusal ("autopause pending ... press 'a' to
+acknowledge"), never a genuine multi-tick auto-run through "uneventful"
+ticks — there are none to run through. ``PausePending()``'s own
+completion predicate still holds (the STOP-state the step's ``then``
+names), so this suite does not fail, but the "auto-advances through
+uneventful ticks" prose is not exercised by this concrete scenario; the
+real multi-tick auto-run behavior is separately proven by
+``tests/unit/tui/test_app_pacing_driver.py::TestRunUntilPaused`` (a
+scripted fake driver) and ``tests/unit/game/test_pacing.py`` (the driver's
+own unit tests). Flagged here for a future scenario-tuning/BD review, not
+silently smoothed over (Constitution III.11) — see
+``TestRunUntilAutopauseHonestGap`` below, which pins the no-op finding as
+a durable regression rather than a one-time comment.
+"""
+
+from __future__ import annotations
+
+import io
+from collections.abc import AsyncIterator, Callable, Sequence
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, Final, cast
+from unittest import mock
+from uuid import UUID
+
+import pytest
+from rich.console import Console
+from textual.content import Content
+from textual.pilot import Pilot
+from textual.widgets import Label, OptionList
+
+from babylon.engine.scenarios import WayneCountyScenario
+from babylon.game.pacing import PacedTickDriver, paced_driver_for_session
+from babylon.game.session import (
+    GameSession,
+    create_new_campaign,
+    vault_known_subjects,
+    vault_page_source,
+)
+from babylon.game.tutorial import (
+    WAYNE_OPENING_ARC,
+    EventAcked,
+    OnPage,
+    PausePending,
+    TickAtLeast,
+    TutorialStep,
+    VerbIssued,
+)
+from babylon.persistence.envelope import PerTickTransactionEnvelope
+from babylon.projection.briefing import project_briefing
+from babylon.projection.vault.materializer import VaultMaterializer
+from babylon.projection.vault.tick_baker import ArchiveTickBaker
+from babylon.topology import BabylonGraph
+from babylon.tui.app import ArchiveApp, BabylonMarkdown, CampaignHandle
+from babylon.tui.campaign_menu import CampaignMenu, InMemoryCampaignCatalog
+from babylon.tui.palette import EntityNavigated
+from babylon.tui.router import parse_babylon_uri
+
+pytestmark = pytest.mark.unit
+
+_WAYNE_FIPS: Final = "26163"
+#: Wide enough that the economy dossier's statblock rows are not truncated —
+#: a deliberate choice over Textual's own ``run_test`` default (80, 24), made
+#: for THIS module's own transcript readability (module docstring: the
+#: transcript doubles as developer documentation).
+_PILOT_SIZE: Final[tuple[int, int]] = (120, 50)
+#: The lobby mints a campaign id via a bare ``uuid4()`` call
+#: (``CampaignMenu.new_campaign`` -> ``InMemoryCampaignCatalog.
+#: create_campaign``) with no seam to inject one — unlike
+#: ``create_new_campaign``'s own ``session_id=`` parameter. Pinning this ONE
+#: genuinely-random id (via ``mock.patch`` on ``campaign_menu``'s own
+#: ``uuid4`` import, in :func:`_live_pilot` below) is what keeps the lobby
+#: row's derived codename — real, on-screen, transcript content — identical
+#: across two independent runs; it never touches the engine's own
+#: ``rng_seed`` determinism (Constitution III.7), which is already fixed by
+#: ``WayneCountyScenario``'s own default (``rng_seed=0``).
+_PINNED_CAMPAIGN_ID: Final = UUID(int=99)
+
+
+# --------------------------------------------------------------------------- #
+# The in-memory GameRuntimeStore double — keeps this module at the unit tier. #
+# --------------------------------------------------------------------------- #
+
+
+class _InMemoryGameStore:
+    """A minimal in-memory double satisfying ``GameRuntimeStore`` structurally.
+
+    Mirrors ``tests/unit/game/test_session.py``'s own ``_FakeStore`` shape
+    (not imported directly — that class is private to its own test module,
+    and this one's needs are a strict subset); the WO-37 structural-Protocol
+    trick means :mod:`babylon.game.session` cannot tell this apart from a
+    real :class:`~babylon.persistence.postgres_runtime.PostgresRuntime`.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[UUID, dict[str, Any]] = {}
+        self._graphs: dict[tuple[UUID | None, int], BabylonGraph] = {}
+        self._last_committed: dict[UUID, int] = {}
+
+    def create_session(
+        self,
+        scenario: str,
+        config_json: dict[str, Any],
+        game_defines_json: dict[str, Any],
+        rng_seed: int,
+        *,
+        trace_level: str = "NONE",
+        player_id: int | None = None,
+        session_id: UUID | None = None,
+    ) -> UUID:
+        """See ``GameRuntimeStore.create_session``."""
+        resolved = session_id if session_id is not None else UUID(int=len(self._sessions))
+        self._sessions[resolved] = {
+            "id": resolved,
+            "scenario": scenario,
+            "config_json": config_json,
+            "game_defines_json": game_defines_json,
+            "rng_seed": rng_seed,
+            "trace_level": trace_level,
+            "player_id": player_id,
+        }
+        return resolved
+
+    def get_session(self, session_id: UUID) -> dict[str, Any] | None:
+        """See ``GameRuntimeStore.get_session``."""
+        return self._sessions.get(session_id)
+
+    def get_pending_turns(self, session_id: UUID, tick: int) -> list[dict[str, Any]]:
+        """See ``GameRuntimeStore.get_pending_turns`` — this suite never
+        submits a player verb, so this is honestly always empty."""
+        return []
+
+    def mark_turns_resolved(self, session_id: UUID, tick: int) -> int:
+        """See ``GameRuntimeStore.mark_turns_resolved``."""
+        return 0
+
+    def persist_tick(
+        self,
+        tick: int,
+        graph: BabylonGraph,
+        events: list[dict[str, Any]] | None = None,
+        *,
+        session_id: UUID | None = None,
+    ) -> None:
+        """See ``GameRuntimeStore.persist_tick``."""
+        self._graphs[(session_id, tick)] = graph
+
+    def persist_tick_summary(
+        self,
+        tick: int,
+        summary: dict[str, Any],
+        *,
+        session_id: UUID,
+    ) -> None:
+        """See ``GameRuntimeStore.persist_tick_summary``."""
+
+    def hydrate_graph(
+        self, tick: int | None = None, *, session_id: UUID | None = None
+    ) -> BabylonGraph:
+        """See ``GameRuntimeStore.hydrate_graph`` — unused (this suite never
+        crash-resumes), kept only for structural completeness."""
+        if tick is None:
+            tick = max(t for sid, t in self._graphs if sid == session_id)
+        return self._graphs[(session_id, tick)]
+
+    def persist_tick_atomic(
+        self, envelope: PerTickTransactionEnvelope, *, write_commit_marker: bool = True
+    ) -> None:
+        """See ``GameRuntimeStore.persist_tick_atomic``."""
+        if write_commit_marker:
+            self._last_committed[envelope.session_id] = envelope.tick
+
+    def get_last_committed_tick(self, session_id: UUID) -> int | None:
+        """See ``GameRuntimeStore.get_last_committed_tick``."""
+        return self._last_committed.get(session_id)
+
+    def submit_turn(
+        self,
+        session_id: UUID,
+        tick: int,
+        org_id: str,
+        verb: str,
+        *,
+        action_type: str | None = None,
+        target_id: str | None = None,
+        target_community: str | None = None,
+        params_json: dict[str, Any] | None = None,
+    ) -> int:
+        """See ``TurnSink.submit_turn`` — unused (this suite never submits a
+        player verb), kept only for structural completeness."""
+        return 0
+
+
+# --------------------------------------------------------------------------- #
+# The composition-root harness — mirrors babylon.cli.play's REAL wiring.      #
+# --------------------------------------------------------------------------- #
+
+
+def _driver_factory(campaign: CampaignHandle) -> PacedTickDriver:
+    """The ``babylon.tui.app.DriverFactory`` seam.
+
+    Mirrors ``babylon.cli.play._driver_factory`` exactly (that module's own
+    docstring explains the cast): :func:`~babylon.game.pacing.
+    paced_driver_for_session` needs a full ``GameSession`` (specifically
+    ``session.services.defines``), strictly more than ``CampaignHandle``
+    structurally promises, so mypy correctly refuses the function directly.
+    The cast is sound for the same reason production's is — this harness's
+    own ``campaign_loader`` (:func:`_build_harness`) always resolves to a
+    real ``GameSession``.
+    """
+    return paced_driver_for_session(cast(GameSession, campaign))
+
+
+def _build_harness(vault_root: Path) -> ArchiveApp:
+    """Wire a fresh ``ArchiveApp`` against a REAL composed campaign.
+
+    The same ``babylon.game.session``/``babylon.game.pacing`` composition
+    idiom ``tests/integration/game/test_session_integration.py`` (and the
+    real ``babylon.cli.play`` composition root) use, minus Postgres (see
+    :class:`_InMemoryGameStore`). Real engine, real ``PacedTickDriver`` +
+    ``EndgameDetector``, real vault baking (``ArchiveTickBaker`` over a
+    ``dulwich``-backed ``vault_root``, plus the SAME explicit
+    ``bake_briefing`` call ``babylon.cli.play._load_campaign`` makes — the
+    per-tick baker never bakes the briefing itself), so ``county/26163``,
+    ``economy/USA``, and the Scenario Briefing are all REAL rendered pages,
+    never a fixture lookalike. Narrator OFF (``narrator=None``, never
+    threaded here) and Wayne's own fixed ``rng_seed=0`` default keep the
+    whole session deterministic (T6 ruling).
+
+    :param vault_root: a fresh, empty directory (a test's own ``tmp_path``)
+        for this campaign's baked vault.
+    :returns: a freshly constructed ``ArchiveApp``, not yet running.
+    """
+    store = _InMemoryGameStore()
+    # EMPTY catalog: "a fresh boot with no campaign chosen yet" — WAYNE_OPENING_ARC's
+    # own boot_into_lobby.given.
+    catalog = InMemoryCampaignCatalog()
+    menu = CampaignMenu(catalog, engine_version="t6-tutorial-pilot", defines_hash="d" * 16)
+    materializer = VaultMaterializer(vault_root)
+    baker = ArchiveTickBaker(materializer, (_WAYNE_FIPS,))
+
+    def _loader(campaign_id: UUID) -> GameSession:
+        session = create_new_campaign(
+            store,
+            scenario=WayneCountyScenario(),
+            session_id=campaign_id,
+            tick_commit_observer=baker,
+            pages=vault_page_source(vault_root),
+            known_subjects=vault_known_subjects(vault_root),
+            narrator=None,
+        )
+        view = project_briefing(
+            session.session_id, tick=session.tick, defines=session.services.defines
+        )
+        materializer.bake_briefing(view, tick=session.tick)
+        return session
+
+    return ArchiveApp(campaign_menu=menu, campaign_loader=_loader, driver_factory=_driver_factory)
+
+
+@asynccontextmanager
+async def _live_pilot(vault_root: Path) -> AsyncIterator[Pilot[None]]:
+    """Boot a fresh harness and yield its running ``Pilot`` — the one seam
+    every test in this module drives through. See :data:`_PINNED_CAMPAIGN_ID`
+    for why the lobby's own mint id is pinned for the duration.
+    """
+    app = _build_harness(vault_root)
+    with mock.patch("babylon.tui.campaign_menu.uuid4", return_value=_PINNED_CAMPAIGN_ID):
+        async with app.run_test(size=_PILOT_SIZE) as pilot:
+            yield pilot
+
+
+def _archive_app(pilot: Pilot[None]) -> ArchiveApp:
+    """``pilot.app`` narrowed back to ``ArchiveApp``.
+
+    ``Pilot[None]`` only types ``.app`` as the generic ``App[None]`` (the
+    type parameter is the app's RESULT type, not the app class itself), but
+    every app this module's :func:`_live_pilot` ever boots is a concrete
+    ``ArchiveApp`` — the same narrowing ``babylon.cli.play._driver_factory``
+    documents for its own analogous cast.
+    """
+    return cast(ArchiveApp, pilot.app)
+
+
+# --------------------------------------------------------------------------- #
+# The step interpreter — closed dispatch over the anchor grammar and the      #
+# completion-predicate union (babylon.game.tutorial's module docstring).      #
+# --------------------------------------------------------------------------- #
+
+
+def _binding_key(anchor: str) -> str:
+    """The key portion of a ``"binding:<ClassName>:<key>"`` anchor."""
+    _, _class_name, key = anchor.split(":", 2)
+    return key
+
+
+async def _perform_anchor(pilot: Pilot[None], anchor: str) -> None:
+    """Drive exactly the UI action ``anchor`` names — closed dispatch over
+    the anchor grammar (``babylon.game.tutorial``'s module docstring: the
+    ``binding:``/``page:``/``palette:`` prefixes).
+
+    :raises ValueError: ``anchor`` names no recognized prefix — never a
+        silent no-op for an anchor kind the executor does not understand.
+    """
+    if anchor.startswith("binding:"):
+        await pilot.press(_binding_key(anchor))
+        return
+    if anchor.startswith("page:"):
+        # A pure "read" step: the arc always reaches a page: anchor already
+        # navigated there by a prior step's own action — nothing to drive.
+        return
+    if anchor.startswith("palette:"):
+        _, subject = anchor.split(":", 1)
+        target = parse_babylon_uri(f"babylon://{subject}")
+        # Posts the SAME production message a real palette pick posts
+        # (mirrors tests/unit/tui/test_t3_live_reachability.py's own
+        # navigation idiom) rather than scripting Textual's built-in
+        # CommandPalette widget's own internal keystrokes — this anchor's
+        # contract is "the pick landed", not "the fuzzy-search UI works"
+        # (a Textual-library concern, not this game's own code).
+        _archive_app(pilot).screen.post_message(EntityNavigated(target))
+        return
+    raise ValueError(f"unrecognized anchor grammar: {anchor!r}")
+
+
+def _action_owner(app: ArchiveApp, verb: str, *, step_id: str) -> object:
+    """Whichever live object (the active screen, else the app) declares
+    ``action_<verb>`` — the same bubbling order Textual's own dispatcher
+    uses for a ``BINDINGS``-declared action.
+
+    :raises AssertionError: neither the screen nor the app declares it.
+    """
+    for candidate in (app.screen, app):
+        if hasattr(candidate, f"action_{verb}"):
+            return candidate
+    raise AssertionError(f"{step_id}: no live action_{verb} found on {app.screen!r} or {app!r}")
+
+
+async def _drive_verb_issued(pilot: Pilot[None], anchor: str, verb: str, *, step_id: str) -> None:
+    """Drive ``anchor`` while spying on ``action_<verb>``, then hard-assert
+    it was actually dispatched — :class:`~babylon.game.tutorial.VerbIssued`
+    proves DISPATCH only (its own docstring), never an outcome, so this is
+    a Pilot structural check (tier 2), never a text assertion standing in
+    for one.
+    """
+    app = _archive_app(pilot)
+    owner = _action_owner(app, verb, step_id=step_id)
+    original = getattr(owner, f"action_{verb}")
+    with mock.patch.object(owner, f"action_{verb}", wraps=original) as spy:
+        await _perform_anchor(pilot, anchor)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+    assert spy.called, f"{step_id}: action_{verb} was never dispatched via anchor {anchor!r}"
+
+
+def _status_text(app: ArchiveApp) -> str:
+    """The status line's current plain text."""
+    return str(app.query_one("#status", Label).content)
+
+
+def _dossier_plain_text(app: ArchiveApp) -> str:
+    """Every fence-rendered ``Label``'s plain text under ``#dossier``, joined.
+
+    Runs each label back through the real ``Content`` markup parser — the
+    same oracle ``tests/unit/tui/test_directives_hardening.py``'s
+    ``_plain_text`` and ``test_t3_live_reachability.py``'s ``_dossier_text``
+    already use — checking a substring against the raw, unparsed
+    ``label.content`` would pass even for a bug where markup silently ate
+    part of the text.
+    """
+    dossier = app.query_one("#dossier", BabylonMarkdown)
+    parts: list[str] = []
+    for label in dossier.query(Label):
+        if label._render_markup:
+            parts.append(Content.from_markup(label.content).plain)
+        else:
+            parts.append(str(label.content))
+    return "\n".join(parts)
+
+
+def _assert_completion(app: ArchiveApp, predicate: object, *, step_id: str) -> None:
+    """Hard-assert one completion predicate against the live app — closed
+    dispatch over the five-member :data:`~babylon.game.tutorial.
+    CompletionPredicate` union (``VerbIssued`` is handled separately, in
+    :func:`_drive_verb_issued`, since its verification must wrap the drive
+    itself). Semantic text first, structural state second — never a visual
+    snapshot (the T6 ruling's assertion tiers).
+
+    :raises AssertionError: the predicate does not hold, OR is a kind
+        outside the closed vocabulary — never a silent skip.
+    """
+    if isinstance(predicate, OnPage):
+        text = _dossier_plain_text(app)
+        assert "UNKNOWN DIRECTIVE" not in text, (
+            f"{step_id}: dossier shows an unknown-directive refusal"
+        )
+        assert "MALFORMED STATBLOCK BODY" not in text, (
+            f"{step_id}: dossier shows a malformed-statblock refusal"
+        )
+        assert text.strip(), f"{step_id}: dossier rendered no content at all"
+        assert app.nav.current == predicate.subject, (
+            f"{step_id}: expected nav.current == {predicate.subject!r}, got {app.nav.current!r}"
+        )
+        return
+    if isinstance(predicate, TickAtLeast):
+        assert "tick" in _status_text(app).lower(), f"{step_id}: status line never mentions a tick"
+        assert app.campaign is not None, f"{step_id}: no live campaign to read a tick from"
+        assert app.campaign.tick >= predicate.tick, (
+            f"{step_id}: expected tick >= {predicate.tick}, campaign is at {app.campaign.tick}"
+        )
+        return
+    if isinstance(predicate, PausePending):
+        assert "paus" in _status_text(app).lower(), (
+            f"{step_id}: status line never mentions a pause ('PAUSED'/'autopause')"
+        )
+        assert app.driver is not None, f"{step_id}: no paced driver to check for a pending pause"
+        assert app.driver.awaiting_ack is True, (
+            f"{step_id}: expected a pending autopause, found none"
+        )
+        return
+    if isinstance(predicate, EventAcked):
+        assert "acknowledged" in _status_text(app).lower(), (
+            f"{step_id}: status line never confirms the acknowledgement"
+        )
+        assert app.driver is not None, f"{step_id}: no paced driver to check acknowledgement on"
+        assert app.driver.awaiting_ack is False, f"{step_id}: the autopause is still pending"
+        return
+    raise AssertionError(f"{step_id}: unrecognized completion predicate kind {predicate!r}")
+
+
+async def drive_step(pilot: Pilot[None], step: TutorialStep) -> None:
+    """The step interpreter's public entry point: drive ``step.when`` via
+    its anchor, then hard-assert ``step.then`` via its completion predicate.
+
+    Closed dispatch over the anchor grammar (:func:`_perform_anchor`) and
+    the completion-predicate union (:func:`_assert_completion`) — an
+    anchor prefix or predicate kind outside either closed vocabulary raises
+    loudly, never skips (Constitution III.11).
+    """
+    if isinstance(step.completion, VerbIssued):
+        await _drive_verb_issued(pilot, step.anchor, step.completion.verb, step_id=step.id)
+        return
+    await _perform_anchor(pilot, step.anchor)
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    _assert_completion(_archive_app(pilot), step.completion, step_id=step.id)
+
+
+async def _load_the_minted_campaign(pilot: Pilot[None]) -> None:
+    """Bridging glue the authored arc itself does not script.
+
+    After minting a campaign (``boot_into_lobby``'s own ``when``), the
+    lobby's freshly-added row must be highlighted + confirmed with Enter to
+    actually load it — the same two-key tail
+    ``tests/unit/tui/test_app_pacing_driver.py``'s/``test_t3_live_
+    reachability.py``'s own ``_boot_into_campaign_shell`` helpers already
+    drive against a PRE-SEEDED row; this arc starts with an EMPTY catalog
+    (``boot_into_lobby``'s own ``given``), so minting is the one extra step
+    before that same sequence applies. Not itself a scripted Given/When/Then
+    beat: ``LobbyScreen._reload()`` already keeps the freshly minted row
+    highlighted (index 0, the only row), so this is exactly "select what is
+    already highlighted, and confirm."
+    """
+    pilot.app.screen.query_one("#campaigns", OptionList).focus()
+    await pilot.press("enter")
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+
+
+#: Repo loop-bound rule (Power-of-10 #2): the authored arc is fixed at 9
+#: steps today and statically bounded at 64 (``TutorialScript``'s own
+#: ``_MAX_SCRIPT_STEPS``) — this loop's upper bound is that same constant.
+_MAX_REPLAY_STEPS: Final = 64
+
+
+async def _replay_through(
+    pilot: Pilot[None],
+    steps: Sequence[TutorialStep],
+    *,
+    after_step: Callable[[int, TutorialStep], None] | None = None,
+) -> None:
+    """Drive + hard-assert every step in ``steps``, in order, against ONE
+    live Pilot session, bridging the one gap the authored arc does not
+    script (see :func:`_load_the_minted_campaign`).
+
+    :param after_step: if given, called with ``(1-based index, step)``
+        immediately after that step's own drive+assert (before any
+        bridging) — the transcript capturer's own hook.
+    """
+    assert len(steps) <= _MAX_REPLAY_STEPS
+    for index, step in enumerate(steps, start=1):  # loop bound: _MAX_REPLAY_STEPS
+        await drive_step(pilot, step)
+        if after_step is not None:
+            after_step(index, step)
+        if step.id == "boot_into_lobby":
+            await _load_the_minted_campaign(pilot)
+
+
+# --------------------------------------------------------------------------- #
+# One pytest test per authored step — pytest ids ARE the step sentences.      #
+# --------------------------------------------------------------------------- #
+
+
+class TestEachStepOfTheWayneOpeningArc:
+    """One test per authored step (the T6 ruling: "scenario names are
+    sentences; the suite is the game-loop's behavioral contract"). Each
+    test replays the arc from a fresh boot through this step, inclusive —
+    a step's own ``given`` is the state the PRECEDING steps' actions left
+    behind (one continuous first session, not independently fixtured
+    scenarios), so replaying is how its precondition is actually reached.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "target_index",
+        range(len(WAYNE_OPENING_ARC.steps)),
+        ids=[step.scenario_name for step in WAYNE_OPENING_ARC.steps],
+    )
+    async def test_step_resolves_its_own_then(self, tmp_path: Path, target_index: int) -> None:
+        steps = WAYNE_OPENING_ARC.steps[: target_index + 1]
+        async with _live_pilot(tmp_path / "vault") as pilot:
+            await _replay_through(pilot, steps)
+
+
+class TestWholeOpeningArcInOneSession:
+    """The whole-arc proof: every step, in order, in a single session — the
+    complete first-session flow ``WAYNE_OPENING_ARC`` advertises, verified
+    end to end (redundant with the last parametrized case above by
+    construction, kept separately named because it is itself the
+    documentation artifact a developer skimming test names would want).
+    """
+
+    @pytest.mark.asyncio
+    async def test_every_step_resolves_in_order(self, tmp_path: Path) -> None:
+        async with _live_pilot(tmp_path / "vault") as pilot:
+            await _replay_through(pilot, WAYNE_OPENING_ARC.steps)
+
+
+class TestRunUntilAutopauseHonestGap:
+    """Pins the module docstring's HONEST GAP finding as a durable
+    regression: Wayne's own material state is critical-tier from tick 1
+    onward, so ``run_until_autopause``'s ``r`` press is a no-op refusal
+    (the driver already paused from ``advance_a_tick``'s own tick), never a
+    genuine multi-tick auto-run. If a future scenario/coefficient change
+    ever gives Wayne even one genuinely quiet tick, THIS test goes red
+    first — the signal that the honest-gap comments above (and the
+    module docstring) need updating, not silently stale.
+    """
+
+    @pytest.mark.asyncio
+    async def test_r_is_a_no_op_refusal_because_advance_a_tick_already_paused(
+        self, tmp_path: Path
+    ) -> None:
+        run_until_autopause = next(
+            s for s in WAYNE_OPENING_ARC.steps if s.id == "run_until_autopause"
+        )
+        prior = WAYNE_OPENING_ARC.steps[: WAYNE_OPENING_ARC.steps.index(run_until_autopause)]
+
+        async with _live_pilot(tmp_path / "vault") as pilot:
+            await _replay_through(pilot, prior)
+            # Given: advance_a_tick already left the driver awaiting ack.
+            app = _archive_app(pilot)
+            assert app.driver is not None
+            assert app.driver.awaiting_ack is True
+
+            await drive_step(pilot, run_until_autopause)
+
+            # Then: still awaiting ack (PausePending holds, as asserted inside
+            # drive_step) — AND the status line shows the REFUSAL phrasing
+            # ("... press 'a' to acknowledge"), never the success phrasing
+            # ("ran to tick N ...") a genuine auto-run would report.
+            status = _status_text(app)
+            assert "press 'a' to acknowledge" in status
+            assert "ran to tick" not in status
+
+
+# --------------------------------------------------------------------------- #
+# The transcript artifact — every screen, at every step, as plain text.       #
+# --------------------------------------------------------------------------- #
+
+#: GENERATED, not committed: mirrors the EXISTING ``reports/sim-runs/``
+#: convention (``.gitignore``: "Ingest audit reports + per-run sim artifacts
+#: (regenerable byproducts)") rather than ``tests/baselines/**``'s
+#: ceremony-gated goldens. This transcript is a build BYPRODUCT of a run,
+#: regenerated fresh every time the suite executes — never hand-edited,
+#: never diffed against a committed reference requiring a
+#: ``Baselines: blessed(...)`` ceremony (§6.5). The determinism test below
+#: is what makes it trustworthy, not a committed golden copy.
+_ARTIFACT_PATH: Final = (
+    Path(__file__).resolve().parents[3] / "reports" / "sim-runs" / "tutorial-transcript.txt"
+)
+
+
+def _export_screen_text(app: ArchiveApp) -> str:
+    """A literal plain-text capture of the CURRENTLY rendered screen.
+
+    Mirrors ``textual.app.App.export_screenshot``'s own internals exactly
+    (the same ``Console``/``screen._compositor.render_update`` setup that
+    method uses to build its SVG), swapping Rich's ``Console.export_svg``
+    for ``Console.export_text`` — the T6 ruling's own words: "the terminal
+    grid IS a text buffer." ``styles=False`` strips every color/style code,
+    so this capture is untouched by the ``NO_COLOR`` grayscale-vs-truecolor
+    lane split that otherwise plagues the SVG snapshot goldens
+    (``tests/unit/tui/conftest.py``) — one plain, assertable text buffer
+    either way.
+
+    HONEST GAP, surfaced by this literal capture (not by this unit's own
+    behavioral assertions, which read ``#status``'s widget content directly
+    and are unaffected): ``ArchiveApp``'s ``#status`` ``Label`` and its
+    ``Footer`` are BOTH docked ``bottom`` at the same row, and the wider
+    ``Footer`` paints over ``#status`` in every capture this module took —
+    the string ``"status:"`` never appears anywhere in the transcript this
+    module writes, at ANY step, in the actual rendered screen, even though
+    the widget's own content is always correct (proven by every passing
+    ``TickAtLeast``/``PausePending``/``EventAcked`` assertion above, and by
+    grepping the ALREADY-COMMITTED ``test_archive_app_renders_the_sample_
+    dossier`` SVG golden, which shows the identical collision — this is
+    PRE-EXISTING production layout behavior, not something this unit's
+    harness introduces). Filed here as a finding for a future ``babylon.tui.
+    app`` CSS fix (give ``#status`` its own reserved row above the Footer);
+    not fixed by this unit — a UI layout change is out of this executor
+    unit's scope and would need its own review against the existing SVG
+    snapshot goldens (a controller-owned re-bake decision per this repo's
+    own golden-drift rule).
+    """
+    assert app._driver is not None, "app must be running to export its screen"
+    width, height = app.size
+    console = Console(
+        width=width,
+        height=height,
+        file=io.StringIO(),
+        force_terminal=True,
+        color_system="truecolor",
+        record=True,
+        legacy_windows=False,
+        safe_box=False,
+    )
+    screen_render = app.screen._compositor.render_update(
+        full=True, screen_stack=app._background_screens, simplify=False
+    )
+    console.print(screen_render)
+    return console.export_text(styles=False)
+
+
+async def _capture_whole_arc_transcript(vault_root: Path) -> str:
+    """Boot a fresh harness, replay the whole arc, and return the
+    transcript — every screen, at every step, as plain text, headed by
+    that step's own ``scenario_name`` sentence (the developer-education
+    document the T6 ruling promises).
+    """
+    blocks: list[str] = []
+    total = len(WAYNE_OPENING_ARC.steps)
+
+    async with _live_pilot(vault_root) as pilot:
+
+        def _record(index: int, step: TutorialStep) -> None:
+            blocks.append(f"=== step {index}/{total}: {step.id} ===")
+            blocks.append(step.scenario_name)
+            blocks.append("")
+            blocks.append(_export_screen_text(_archive_app(pilot)))
+            blocks.append("")
+
+        await _replay_through(pilot, WAYNE_OPENING_ARC.steps, after_step=_record)
+
+    return "\n".join(blocks)
+
+
+class TestTranscriptArtifact:
+    """The T6 ruling's playthrough-transcript artifact."""
+
+    @pytest.mark.asyncio
+    async def test_two_independent_runs_produce_a_byte_identical_transcript(
+        self, tmp_path: Path
+    ) -> None:
+        """Deterministic under narrator-OFF + Wayne's fixed seed: two
+        independently-booted runs of the whole arc must be byte-identical —
+        transcript drift IS behavior drift (module docstring)."""
+        transcript_a = await _capture_whole_arc_transcript(tmp_path / "vault-a")
+        transcript_b = await _capture_whole_arc_transcript(tmp_path / "vault-b")
+        assert transcript_a, "the transcript must not be empty"
+        assert transcript_a == transcript_b
+
+    @pytest.mark.asyncio
+    async def test_transcript_names_every_step_and_is_written_to_the_artifact_path(
+        self, tmp_path: Path
+    ) -> None:
+        transcript = await _capture_whole_arc_transcript(tmp_path / "vault")
+        for step in WAYNE_OPENING_ARC.steps:  # loop bound: len(steps) <= _MAX_REPLAY_STEPS
+            assert step.id in transcript
+            assert step.scenario_name in transcript
+
+        _ARTIFACT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _ARTIFACT_PATH.write_text(transcript)
+        assert _ARTIFACT_PATH.read_text() == transcript

--- a/tests/unit/tui/test_tutorial_pilot.py
+++ b/tests/unit/tui/test_tutorial_pilot.py
@@ -580,6 +580,26 @@ _EXTRA_CONTENT_CHECK_BY_STEP_ID: Final[dict[str, Callable[[ArchiveApp], None]]] 
 }
 
 
+def _raise_deferred_app_exception(pilot: Pilot[None], *, step_id: str) -> None:
+    """Surface a screen-callback exception at the step that caused it.
+
+    Textual stores an exception raised inside a ``call_next``-deferred
+    callback (e.g. a screen-dismiss result callback) on ``App._exception``
+    and only re-raises it at ``run_test()`` teardown — detaching the
+    failure from its cause and misattributing it to whichever step's
+    ``run_test`` block happens to close. Checking it right after the
+    per-step settle turns that into a loud, attributable, immediate
+    failure at the real step (Constitution III.11), instead of a
+    mysterious teardown crash under concurrent CI load.
+    """
+    deferred = getattr(pilot.app, "_exception", None)
+    if deferred is not None:
+        raise AssertionError(
+            f"tutorial step {step_id!r} left a deferred app exception "
+            f"({type(deferred).__name__}: {deferred})"
+        ) from deferred
+
+
 async def drive_step(pilot: Pilot[None], step: TutorialStep) -> None:
     """The step interpreter's public entry point: drive ``step.when`` via
     its anchor, then hard-assert ``step.then`` via its completion predicate.
@@ -599,6 +619,7 @@ async def drive_step(pilot: Pilot[None], step: TutorialStep) -> None:
     await _perform_anchor(pilot, step.anchor)
     await pilot.app.workers.wait_for_complete()
     await pilot.pause()
+    _raise_deferred_app_exception(pilot, step_id=step.id)
     app = _archive_app(pilot)
     _assert_completion(app, step.completion, step_id=step.id)
     extra_check = _EXTRA_CONTENT_CHECK_BY_STEP_ID.get(step.id)

--- a/tools/sentinel_check.py
+++ b/tools/sentinel_check.py
@@ -33,6 +33,7 @@ from babylon.sentinels.seam.checks import main as seam_main
 from babylon.sentinels.seam_algebra.checks import main as seam_algebra_main
 from babylon.sentinels.surface.checks import main as surface_main
 from babylon.sentinels.synthetic.checks import main as synthetic_main
+from babylon.sentinels.tutorial_coverage.checks import main as tutorial_coverage_main
 from babylon.sentinels.unconsumed.checks import main as unconsumed_main
 from babylon.sentinels.vocabulary.checks import main as vocabulary_main
 
@@ -135,6 +136,7 @@ _SENSORS: dict[str, Callable[[list[str] | None], int]] = {
     "liveness": liveness_main,
     "coupling": coupling_main,
     "surface": surface_main,
+    "tutorial-coverage": tutorial_coverage_main,
 }
 
 


### PR DESCRIPTION
## T6 — Tutorial-as-BDD (v1.0.0, the last pre-Gate-3 train)

Implements `ai/_inbox/t6-tutorial-bdd-ruling.md` verbatim: ONE data-driven step script consumed three ways — player overlay, headless CI executor, developer documentation — so advertisement and behavior cannot drift apart.

### Units
- **U1** `9b0c62b4` + `51a64637` — frozen `TutorialStep`/`TutorialScript` models with a closed, data-only completion-predicate vocabulary (discriminated union; no callables) + the authored 9-step Wayne opening arc. Opus review forced two honesty upgrades: a new `PausePending` predicate grounding "run until autopause" on the real driver stop (not keypress dispatch), and outcome-grounded completions on the boot/begin steps. The "read the chronicle" beat was honestly folded away — no live Chronicle screen exists in the shell today.
- **U2** `9ba3e3dd` + `0d508e72` — headless executor: runs the arc against a REAL GameSession (real 30-system engine, real PacedTickDriver + EndgameDetector, real dulwich vault bake; only Postgres faked structurally) + the deterministic playthrough-transcript artifact (two runs byte-identical, proven by test). Review forced distinctive-content checks on the two page-reading steps. Known honest gap documented in-code: `export_text` clips the bottom-docked status line from transcript captures.
- **U3** `424e1cf5` — the option-coverage sentinel, 18th family: AST-enumerates every Textual `BINDINGS` surface under `tui/`+`game/`, diffs against step anchors, gates coverage-or-cited-exemption with a reverse stale-exemption check. (My workflow's implementer died on a connection error mid-unit; a parallel session's agent completed and landed it — 799/799 sentinel tests green.)
- **U4** `5b99ce59` — the guided opening-arc overlay + `TutorialRuntimeProgress` evaluator + `ArchiveApp` wiring + tri-state `--tutorial/--no-tutorial` on `babylon play` (unset → first-session heuristic at `campaign.tick == 0`). A two-author unit after a coordinated collision resolution (overlay+tests+exemption row from one implementer; runtime+app+cli wiring from another; single-writer discipline enforced via the coordination note; combined surface verified consistent) — first-pass opus APPROVE on the committed result. All 25 Textual snapshot goldens byte-identical.

### Battery (controller-run, single-flight)
- `mise run check` — **14,100 passed**
- `check:sentinels` — all green, now **18 families** including `tutorial-coverage`
- `qa:regression` — 6/6 byte-identical + two-process determinism PASS
- `qa:vault-regression` — byte-identical to existing goldens (no bake-path change; no ceremony)

### Post-merge
This completes the NORTH_STAR §7 pre-Gate-3 road (T3 ✓ T5 ✓ T6 ✓). Next: **BD Gate 3** (full TUI campaign session, eyes-on) → PR #241 cutover. T8 DoD language ("tutorial completes" → "tutorial BDD suite green headlessly AND completable interactively" + coverage check) rides the ruling doc; the release train amends the DoD text when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)