### PR TITLE
docs(specs): Mirror/typed-core preparatory spec (post-v1.0, tabled)

### DIFF
--- a/docs/superpowers/research/2026-07-22-lawvere-archive-readings.md
+++ b/docs/superpowers/research/2026-07-22-lawvere-archive-readings.md
@@ -1,0 +1,218 @@
+# Lawvere Archive Readings — evidence base for the Mirror/typed-core spec
+
+*Five parallel full-text readings of 25 papers from the collected-works archive at
+`/media/user/data/babylon-data/lawvere-master/pdfs/` (Earnshaw collection, 92 PDFs),
+2026-07-22, commissioned for `2026-07-22-mirror-typed-core-spec.md`. Each section is
+the reader's verbatim deliverable: per-paper core definitions with page-referenced
+quotes, adversarial mappings onto Babylon's constructs, and unused constructions
+with Haskell shapes. Read the spec first; come here for the receipts.*
+
+---
+
+## Reading 1 — Dialectics / UIAO / Aufhebung
+
+Papers: Taking Categories Seriously (1986); Some Thoughts on the Future of Category
+Theory (1991); Unity and Identity of Opposites in Calculus and Physics (1996);
+Grassmann's Dialectics and Category Theory (1996); Display of Graphics … the
+Hegelian Taco (1989).
+
+Key findings (full detail in the reader deliverable, summarized here verbatim
+where load-bearing):
+
+- **Level (1991, p.6):** "By a level in a category of Being, I mean a ('downward')
+  functor from it to a smaller category which has both left and right adjoints
+  which are full inclusions." A UIO is such a triple; objects lie on "threads";
+  skeleton/coskeleton are the idempotents L·down and R·down.
+- **Aufhebung (1991, p.8, exact):** "…the longer left adjoint inclusion factors
+  across the shorter right adjoint inclusion; equivalently, the higher coskeleton
+  functor fixes both the skeleta and the coskeleta in the sense of the lower
+  level." And: "every level has a smallest aufgehobenen level over it, which could
+  reasonably be called 'the' Aufhebung of it" — a closure operator on the poset of
+  levels, NOT a linear scan for a predicate.
+- **Babylon's current phrasing ("aufhebung = least strictly-higher level where a
+  resolution predicate holds") is a weak order-theoretic gloss** that drops the
+  factoring condition; existence-of-smallest is a theorem (complete lattice of
+  UIOs — Hegelian Taco Prop 16: UIOs of a presheaf category ≅ idempotent
+  two-sided ideals; for a graphic monoid, ≅ left ideals), not a definition.
+- **Operational Aufhebung (Taco, p.68):** "T resolves the opposites of S … iff
+  every S-skeletal application is a T-sheaf, i.e. R_T L_S = L_S. The Aufhebung S'
+  of S = the smallest T resolving the opposites of S." Dimension = length of the
+  fixed-point iteration T_{n+1} = T'_n. Prop 17: 0' = 1.
+- **The Hegelian Taco itself (Prop 19, p.70):** an 8-element, dimension-3 graphic
+  monoid with known ideal chain ∅ ⊂ {0,1} ⊂ [ℓ,q,r] ⊂ [L,R] ⊂ [1] — a ready-made
+  golden test fixture for any level-lattice + Aufhebung implementation.
+- **Graphic identity:** a graphic category has endomorphism monoids satisfying
+  xyx = xy (Schützenberger–Kimura). This identity is the finite-computability
+  backbone (every left ideal two-sided, ideals idempotent, principal ideals
+  faithfully represented, Mab = Ma ∩ Mb). Whether Babylon's transition monoid is
+  graphic is an UNCHECKED, falsifiable design constraint.
+- **UIAO (1996 Unity/Identity, p.168):** AO = parallel f,g with a single h,
+  g ⊣ h ⊣ f; UIAO = AO where both are full+faithful and h is a common retraction
+  ("essential localization"). "discrete/codiscrete are AO" — Babylon's L ⊣ U ⊣ R
+  is a legitimate instance PROVIDED U is a genuine two-sided retraction; otherwise
+  it is only an adjoint triple and the label is unearned.
+- **σ (sublation) candidates with laws for free:** the image-factorization of the
+  canonical 2-map between the opposite inclusions of a UIAO (1996, p.170 — the
+  van der Waals "third section" model); or Isbell double-conjugation F ↦ F*#
+  (1986 §7: idempotent, extensive, monotone closure; "the conjugacies are the
+  first step toward expressing the duality between space and quantity").
+- **w (tension) law:** w(𝔇) = 0 ⟺ the canonical map L(X) → R(X) is iso.
+- **T (motion) candidate model:** Grassmann's boundary operator ∂ on a graded
+  algebra — linear, graded Leibniz, degree −1, ∂² = 0 (1996 Grassmann, p.260);
+  "the precise mathematical form of their relationship is not that of inverse,
+  but rather adjointness" (p.257).
+
+## Reading 2 — Space & Quantity / Cohesion
+
+Papers: Categories of Space and Quantity (1992); Axiomatic Cohesion (2007);
+Cohesive Toposes and Cantor's lauter Einsen (1994); Cohesive Toposes:
+combinatorial and infinitesimal cases (2008); Volterra's Functionals (1997).
+
+- **Extensive quantity-type (1992, p.19):** "a covariant coproduct-preserving
+  functor from a distributive category to a linear category." Intensive: "a
+  contravariant functor, taking coproducts to products … whose values have a
+  multiplicative structure as well" (p.20). Their pairing satisfies the
+  projection formula / Frobenius reciprocity / CCR (pp.21-22).
+- **VERDICT — Babylon's `allocate ⊣ aggregate`:** as implemented (proportional
+  split section of a split epi with aggregate ∘ allocate = id) it is NOT an
+  adjunction; a genuine one needs the extremal universal property or the
+  direct-image/inverse-image framing over the level-lattice-as-site. The
+  conservation law is NOT a "sheaf law" (that is a limit/gluing condition over
+  overlapping covers); it is precisely the **extensive-quantity coproduct law**
+  over a partition. Rename; reserve "sheaf" for a real overlapping-cover gluing
+  law if one is ever added.
+- **Cohesion axioms (2007, Def. 2):** the four-functor string p_! ⊣ p* ⊣ p_* ⊣ p^!
+  with (a) p_! preserves finite products, p^! full+faithful; (b) continuity;
+  (c) Nullstellensatz "the canonical map p_* → p_! is epimorphic". Babylon's
+  3-string L ⊣ U ⊣ R matches the 1994 adjoint cylinder ("Such adjoint cylinders I
+  propose as the mathematical models for many instances of the Unity and Identity
+  of Opposites", 1994 p.11) but LACKS the pieces functor p_! — the single largest
+  structural gap; with finite hom-sets, continuity then comes free, and the
+  Nullstellensatz is plausibly trivial for inhabited finite graphs.
+- **Prop 5/6 (2007):** the topos of reversible reflexive graphs is sufficiently
+  cohesive and infinitesimally generated — Lawvere already proved the strong
+  properties for the graph-topos shape Babylon would use.
+- **Atomization:** Lawvere's own invariant is the canonical map
+  X → codiscrete(points(X)) being iso-or-not, classified by the five-element
+  Ω of the reflexive-graph topos (1994 pp.12-13: totally in A / entering /
+  leaving / excursion / outside); the scalar quantification is Babylon's own
+  addition and must be justified (e.g. via [0,∞]-enrichment), not inherited.
+- **Substance machinery (2007 Thm 2, 2008):** rarefied s_*X vs condensed s_!X
+  with the cooling map — two dual intensive-quality constructions Babylon could
+  use for faction self-interaction vs cross-tie structure.
+
+## Reading 3 — Dynamics / State Categories / Chaos
+
+Papers: Categorical Dynamics (1978); State Categories, Closed Categories and
+Entropy (1984); State Categories and Response Functors (1986); Functorial Remarks
+on the General Concept of Chaos (1984); Toposes of Laws of Motion (1997).
+
+- **Babylon's tick IS Lawvere's primary discrete example** (1978, p.7: a single
+  S-endomorphism τ, "a 'discrete time dynamical system'"); but distinguish the
+  cyclic monoid ⟨T⟩ ≅ ℕ from the finitely-generated systems monoid on {S1..S30}
+  — Lawvere's structural theorems bind differently to each. The 1986 cancellation
+  theorem (no nontrivial cyclic/idempotent processes) needs a cancellative,
+  divisible duration monoid — it does NOT apply to ⟨T⟩ ≅ ℕ.
+- **Determinism has a name (1986, pp.17-18):** the discrete-op-fibration /
+  unique-lifting condition; fibers are discrete; discrete-op-fibrations over C ≅
+  S^C. Babylon's `advance` purity should be stated as this law with `Left
+  Violation` = failed unique lift.
+- **`observe` vs response functors (1986, pp.18-20):** Babylon's end-of-tick
+  snapshot is the weak "output" case; a genuine response functor is compositional
+  (Δ(P̄·P) = Δ(P̄)+Δ(P)) and path-dependent responses are Volterra integrals
+  Q = ∫θ ds accumulated over sub-steps — the Chronicle should be built as the
+  per-system mconcat with a stated law, not a snapshot.
+- **"Chaos" (1984, p.4):** an observable is T-chaotic iff X → Y^T is epi —
+  symbol-sequence surjectivity, NOT sensitivity/Lyapunov anything; Lawvere
+  himself: several instances are "normal, reasonable behavior." DO NOT use it to
+  back I.12 fold catastrophes; the entropy paper's upper-semicontinuous
+  regularization m(x1,x2) = inf sup sup Δ(P) is the closer toolkit for
+  threshold/discontinuity reasoning, and entropy functions ≡ V-functors on the
+  Lawvere-metric state category (smallest = representable M(x0,−); "Cayley-
+  Dedekind-Grothendieck-Yoneda").
+- **Freeze vs identity (1986, pp.10-11):** a freeze is a possibly-costly process
+  with every factorization endo — "statics as fixed points of T" must say which
+  of trivial-fixed-point / frozen-fixed-point it means.
+- **Universal state (1986, pp.28-30):** F_C(Y)(A) = Cat(A/C, Y) — the co-Yoneda
+  continuation ceiling; "is World expressive enough" = injectivity into it.
+- **Abstract/Concrete General (1997):** "a given model of Time … serves as an
+  Abstract General which is accompanied by the Concrete General which is the
+  category of all dynamical systems."
+
+## Reading 4 — Logic / Hyperdoctrines / Enriched Tension
+
+Papers: Adjointness in Foundations (1969); Equality in Hyperdoctrines (1970);
+Quantifiers and Sheaves (1970); Metric Spaces, Generalized Logic, and Closed
+Categories (1973); Left and Right Adjoint Operations on Spaces and Data Types
+(2004).
+
+- **The verb-grammar GADT is the generating 𝒱-graph of the base category, NOT a
+  hyperdoctrine** (which needs per-type attribute CCCs, substitution, Σf ⊣ f· ⊣ Πf
+  with Frobenius + Beck). Name it honestly.
+- **Edges are better modeled as bimodules/profunctors** (1973 §3): heterogeneous
+  sorts compose by Bellman–Fenchel convolution (ψ∘φ)(z,x) = inf_y[ψ(z,y)+φ(y,x)]
+  — derived indirect relations for free, min-plus/tropical algebra, Floyd–
+  Warshall as the concrete algorithm.
+- **Tension gets a triangle inequality only by construction:** build Tension as
+  the free [0,∞]-category on the weighted verb-graph (shortest-path closure,
+  1973 pp.164-165) and "the triangle inequality IS the composition law" (table
+  p.138, def p.146); if tension is computed any other way the inequality must be
+  separately verified — the key adversarial fork.
+- **"Unit defect as tension" is HALF a Galois connection** (1969 §4, p.14): track
+  the counit defect too, or scope the claim as unit-only; better, globalize the
+  poset connection into a functor-level adjunction ("basic examples of Galois
+  connections are really just fragments of more global adjoints").
+- **requireMembership/witnesses ≅ the Comprehension Schema** (1970, pp.12-13):
+  {B:ψ} with structural map p_ψ — exact match; caveat: Frobenius fails once types
+  carry internal automorphisms (groupoid counterexample, p.10-11; fix = hom
+  profunctor).
+- **V₀ ⊂ V adjoint triple** (1973 commentary p.3): truth-values into [0,∞] with
+  both adjoints — the principled home for continuous-control/discrete-state
+  (reachable :: Tension -> Bool as the π₀/right-adjoint collapse pair).
+- **Import-layer poset:** a real but nearly-vacuous categorical object (a
+  2-enriched category); to be non-trivial it needs enriched hom-objects or a
+  comprehension adjoint — flag honestly, do not oversell.
+- **Cauchy completeness** (1973, pp.163-164) as "solidarity-network saturation";
+  **trace** Tr(f_*) = inf_a A(a, fa) vanishing ⟺ fixed point — ties to the
+  Survival Calculus equilibrium question.
+
+## Reading 5 — Boundaries / Graphic Toposes / Kinship
+
+Papers: Intrinsic Co-Heyting Boundaries and the Leibniz Rule (1991); Categories
+of Spaces May Not Be Generalized Spaces (1986); Qualitative Distinctions Between
+Some Toposes of Generalized Graphs (1989); More on Graphic Toposes (1991);
+Kinship and Mathematical Categories (1999).
+
+- **∂ is real and unconditional on subobject lattices:** "In any presheaf topos …
+  the lattice of all subobjects of any given object is another example of a
+  co-Heyting algebra"; boundary ∂A = A ∧ non A; for directed graphs, "the
+  boundary of a subgraph A consists of all its nodes which are either sources or
+  targets of arrows (in the ambient graph) which are not in the subgraph A" —
+  EXACTLY the intended seam reading of ∂L.
+- **The Leibniz rule ∂(A×B) = (∂A×B) ∨ (A×∂B) is NOT free:** needs split-mono∘
+  split-epi factorization in the schema (checkable via the nodal-category
+  criterion, 1989 pp.296-297) or nonempty hom-sets + binary (co)products —
+  Babylon's multi-sorted, largely-disconnected schema generically FAILS the
+  corollary's hypothesis; assert Leibniz only as a property test against the
+  enumerated finite schema.
+- **∂L conflates two constructions:** (a) subobject boundary (above) vs (b)
+  boundary/Aufhebung on the lattice of essential subtoposes — (b) is the better
+  match for "audit that declared subsystems are wired" and is finite/computable
+  exactly when the schema is GRAPHIC (aba = ab ⟹ subtoposes ≅ two-sided ideals;
+  "In any graphic topos, Ω is a cogenerator" — 1991 Prop 2). Lawvere's own
+  stated applications: "hierarchical structures such as 'hypercard', library
+  catalogues" — structurally the Mirror.
+- **Reflexive vs irreflexive is a foundational decision** (1986): reflexive
+  graphs S^(Δ1^op) satisfy the topos-of-spaces axioms (gros; Ω has 2 points, 5
+  edges — the fifth element IS the boundary class); irreflexive graphs S^⇉ are
+  an étendue ("locally localic"), fail axioms 0/1, Ω has 3 elements with an
+  involutory negation. Every downstream Ω/boundary formula depends on the choice.
+- **Substitution is only laxly stable** (non(Af) ⊆ (non A)f; equality iff
+  groupoid): the boundary does NOT commute with refactoring maps — any "∂L is
+  stable under renaming" claim is generically false.
+- **Kinship (1999) is the method template:** primitive generators as structural
+  self-maps (m, f) → presheaves on the free monoid → graded co-Heyting Ω
+  ("Precisely how Irish is y?") → coarsening as epimorphic monoid quotients with
+  p_! ⊣ p* ⊣ p_* as objective ∃/∀ — port for solidarity/class relations; plus
+  the "X mod A" pushout ("rationally neglecting the remote past") for collapsing
+  extinct-faction history.

--- a/docs/superpowers/specs/2026-07-22-babylon-core-typed-haskell-draft0.md
+++ b/docs/superpowers/specs/2026-07-22-babylon-core-typed-haskell-draft0.md
@@ -1,0 +1,286 @@
+<!-- Provenance: BD-authored draft, delivered in-session 2026-07-22 and committed
+     verbatim (Immutability of History — this text is design material, not a
+     ratified spec). The companion module BabylonCoreDraft.hs referenced below is
+     held by the BD and should be committed beside this file when dropped.
+     The preparatory spec that frames this draft for ratification is
+     2026-07-22-mirror-typed-core-spec.md. -->
+
+# Babylon Core, Typed — a Haskell Algebra in the Lawverian Tradition
+
+Draft 0 · 2026-07-22 · companion module `BabylonCoreDraft.hs` **typechecks under GHC 9.4.7** (`-Wall`, deps: base + containers only; remaining warnings are unexported-constructor residue, which is the boundary working as intended).
+
+Scope per the prior feasibility discussion: this drafts the **functional core** — kernel, models, formulas, topology, dialectics — as one Haskell algebra, with the tick as the sole arrow. Persistence, the Django bridge, hydration/loaders, and intelligence stay in the Python shell. Nothing here is a spec; it is the type-level shape a spec would ratify. Every construct obeys the earn-its-keep rule (ADR051): it ships a law, a prediction, or a computation — never vocabulary.
+
+```mermaid
+flowchart LR
+    subgraph shell [Python shell]
+        H[hydration / Ledger] -->|"Material (NodeData k)"| C
+        C -->|"TickReport, deltas"| P[persistence / bridge]
+        C -->|"observe :: World -> Chronicle"| I[intelligence — read only]
+    end
+    subgraph core [Haskell core]
+        C["advance :: Defines -> Registry -> World -> Either Violation (World, TickReport)"]
+    end
+```
+
+The organizing claim: **most of the Constitution's Part I–III clauses are typing judgments that happen to be written in English.** The port's real payoff is not speed (though deleting the per-tick Pydantic round-trip will likely deliver some); it is that a class of constitutional violations stops being reviewable and becomes unrepresentable.
+
+---
+
+## 1. The two planes (I.7, I.12)
+
+Constitution I.7: floats for quantities, enums for qualities, thresholds explicit, no continuous quality gradients. I.12: continuous control parameters, discrete state variables at fold crossings. That is a two-sorted ontology, and the type system enforces the sort discipline: the continuous plane is kernel newtypes with smart constructors, the discrete plane is closed sums, and the **only** morphisms from the first to the second are values of one type:
+
+```haskell
+data Fold q s = Fold
+  { fThreshold :: q   -- explicit, Defines-sourced (I.7)
+  , fBelow     :: s
+  , fAbove     :: s }
+
+crossFold :: Ord q => Fold q s -> q -> s
+```
+
+A `Fold` is I.12's fold catastrophe as a value. Its threshold is data constructed from `Defines` and nowhere else, so a numeric literal in a formula body has no type to hide behind — the magic-constants audit's Tier taxonomy becomes a construction rule rather than a sweep.
+
+Kernel scalars are the existing constrained types, verbatim: `Probability`, `Intensity`, `Ideology` [-1,1], `Coefficient`, `Ratio` (0,∞), `Balance` [-1,1], and `Currency`. Smart constructors return `Either KernelViolation a` — refusal, not clamping; the only saturating arrow is `raiseIntensity`, and it is named, because consciousness saturating at 1 is a semantic, not an accident.
+
+`Currency` is the deliberate departure: `newtype Micro = Micro Int64` fixed-point micro-units. Moving the value plane (the Φ circuit, wages, tribute) to fixed point makes cross-implementation byte-identity *trivial* exactly where Amendment Q's gap (2) bites hardest, at the cost of a one-time re-baseline that III.12(b) already anticipates. Ruling needed (§12).
+
+## 2. Extensive and intensive quantity
+
+This is Lawvere directly ("Categories of Space and Quantity," 1992), and ADR051 Phase D already shipped it operationally as `aggregate_extensive` vs `aggregate_intensive`: extensive quantities sum under aggregation (population, value, biocapacity); intensive quantities take share-weighted means (rates, tensions, consciousness — a gap is a ratio).
+
+```haskell
+newtype Extensive a = Extensive a
+newtype Intensive a = Intensive a   -- NO Num instance, no sum arrow
+
+sumExtensive      :: Num a => [Extensive a] -> Extensive a
+meanIntensive     :: [(Share, Intensive Double)] -> Intensive Double
+allocateExtensive :: [Share] -> Extensive Micro -> [Extensive Micro]
+```
+
+The type-level payoff is blunt: `Intensive` has no `Num` instance, so the classic bug class — summing tension ratios across counties — does not compile. `allocateExtensive` is the left adjoint of the scale adjunction (allocate ⊣ aggregate), integer-deterministic (floor per share, remainder to the first region *in insertion order*, so "first" has a III.7-defined meaning), and carries the sheaf law as an executable property: gluing = conservation.
+
+```haskell
+law_allocateConserves :: [Share] -> Extensive Micro -> Bool
+```
+
+## 3. The Lawverian layer, typed
+
+Everything in this section already runs in Python under `src/babylon/dialectics/` (ADR051 A–E). Haskell adds two things: the laws become first-class `Bool`-valued functions lifted into the Amendment Q property layer, and adjunction defect becomes the **only constructor of tension** — tension cannot be invented, only measured, because `unitDefect` is the sole arrow producing it.
+
+```haskell
+data GaloisConnection p q = GaloisConnection
+  { leftAdjoint :: p -> q, rightAdjoint :: q -> p }
+
+law_adjunction :: (Ord p, Ord q) => GaloisConnection p q -> p -> q -> Bool
+-- f x <= y  <=>  x <= g y
+
+unitDefect :: (p -> p -> Intensity) -> GaloisConnection p q -> p -> Intensity
+-- the gap: how far x <= g(f x) fails to close (Laclau; ADR051 "measured adjunction defect")
+```
+
+The adjoint cylinder is Lawvere's unity-and-identity-of-adjoint-opposites, L ⊣ U ⊣ R, with the shipped Phase B instance as its motivating inhabitant: over the SOLIDARITY subgraph, L = discrete (total atomization), R = codiscrete (total solidarity), U = underlying node set. The world's actual solidarity topology sits between two adjoint opposites, and atomization is its measured distance from R's image:
+
+```haskell
+data AdjointCylinder c d = AdjointCylinder
+  { unity :: c -> d, leftOpposite :: d -> c, rightOpposite :: d -> c }
+```
+
+E1's two level lattices are chains with `aufhebung` as the least strictly-higher level where the resolution predicate (within-region variance zero) holds — `l < aufhebung resolved l` holds by construction rather than by test. E2's regime classifier transcribes verbatim as a total function, and RUPTURE stays what ADR051 made it: the crisis regime's boiling point, a `Fold` on the principal gap, not a separate mechanism.
+
+```haskell
+classifyRegime :: Epsilon -> Opposition -> Maybe Level -> Regime
+-- Reproduction | Crisis | SublationTo Level
+
+principal :: Defines -> [Opposition] -> Maybe Opposition
+-- I.13: one leads per tick; rank = gap * (1 + rate_weight * |rate|)
+```
+
+The constitutional primitive lands with its fields named for the Compact, and "motion is primitive, statics are derived" becomes literal: a static is a fixed point of the Picard operator, and `staticOf` computes it.
+
+```haskell
+data Dialectic a = Dialectic
+  { dThesis    :: Pole              -- A
+  , dNegation  :: Pole              -- A-bar (determinate negation, not complement)
+  , dWeight    :: Intensity         -- w — via unitDefect only
+  , dMotion    :: Picard a          -- T
+  , dSublation :: a -> Maybe Level  -- sigma
+  }
+```
+
+VIII.9's n-ary protection is an absence: `Pole` includes `CommunityPole CommunityId`, and no exported arrow has type `CommunityId -> (Pole, Pole)`. Dyadic reduction isn't forbidden by review; it's unwritable.
+
+## 4. The grammar: typing judgments
+
+"Verb grammar" reads literally here. A well-formed edge is a well-typed sentence; the typing judgments — which subject and object kinds each verb admits — are GADT constructor signatures. I.14's "edges MUST be directed" is inherent: constructors have ordered signatures.
+
+```haskell
+data EdgeVerb v s t where
+  Exploitation :: EdgeVerb 'ExploitationV 'SocialClassK 'SocialClassK
+  Wages        :: EdgeVerb 'WagesV        'SocialClassK 'SocialClassK
+  Tenancy      :: EdgeVerb 'TenancyV      'SocialClassK 'TerritoryK
+  Adjacency    :: EdgeVerb 'AdjacencyV    'TerritoryK   'TerritoryK
+  Membership   :: EdgeVerb 'MembershipV   'OrganizationK 'SocialClassK
+  Attention    :: EdgeVerb 'AttentionV    'InstitutionK  'OrganizationK
+  -- … full table in the module
+```
+
+| verb | subject ⊢ object | payload | source |
+|---|---|---|---|
+| EXPLOITATION | class ⊢ class | `FlowData` (Φ conduit, tension) | database-spec |
+| SOLIDARITY | class ⊢ class | `BondData` (tension, resilience) | database-spec |
+| WAGES | class ⊢ class | `FlowData` (super-wages from Φ) | database-spec |
+| TRIBUTE | class ⊢ class **[confirm]** | `FlowData` | database-spec |
+| TENANCY | class ⊢ territory | `TenancyData` | Sprint 3.5.1 |
+| ADJACENCY | territory ⊢ territory | `()` — substrate carries no dynamics | Sprint 3.5.1 |
+| MEMBERSHIP | org ⊢ class | `MembershipData` (tier: Sympathizer/Member/Cadre) | game-loop spec |
+| PRESENCE | org ⊢ territory | `PresenceData` | game-loop spec |
+| ORG_RELATION | org ⊢ org | `OrgRelationData` (mode, resilience, agreement, intel) | game-loop spec |
+| ATTENTION_THREAD | institution ⊢ org | `AttentionData` (intensity, intel, phase, stickiness) | game-loop spec |
+
+An ill-formed edge — ADJACENCY between classes, WAGES into a hex — is not invalid data caught by a Pydantic validator downstream; it fails to compile at the call site that tried to build it. Payloads are per-verb via a closed type family, so `edge.value_flow` on a SOLIDARITY edge is likewise unwritable. REPRESSION, COMPETITION, CLIENT_STATE from the database enum are omitted pending endpoint confirmation (§12) rather than guessed.
+
+Node payloads follow the same pattern (`NodeData :: NodeKind -> Type`), with every value-plane field kernel-typed — a raw `Double` in a payload record is a review artifact.
+
+## 5. Insertion order as structure (III.7)
+
+ADR052 preserved NetworkX's iteration contract by wrapping rustworkx in insertion-ordered Python mirrors. Here the mirror *is* the structure — an insertion-ordered pure map, with per-source adjacency nesting so `edgesInOrder` reproduces source-insertion-then-adjacency byte-for-byte:
+
+```haskell
+data Topology = Topology
+  { tNodes :: InsOrd AnyId SomeNode
+  , tAdj   :: InsOrd AnyId (InsOrd AnyId SomeEdge) }
+
+nodesInOrder :: Topology -> [SomeNode]
+edgesInOrder :: Topology -> [SomeEdge]
+law_insertionOrder :: [(Int, Char)] -> Bool   -- ports the nx differential oracle
+```
+
+Insert-on-existing-key updates payload and keeps position; delete drops the key (nx semantics, ADR052's pinned behaviors). The Hypothesis model test in `test_graph_iteration_order.py` ports directly as this structure's conformance property — the oracle survives the language.
+
+This section is also where the migration's one real idiom shift lives, so it should be said plainly: ADR052's payload dicts are shared by reference and mutated in place by ~28 systems; these payloads are values and every system is `World -> World`. Reference semantics out, state threading in. That rewrite is the cost center of the whole program.
+
+`addEdge` returns `Either Violation Topology`: well-*kinded* by construction (the GADT), well-*referenced* by check (dangling endpoints fail loud, ADR033). Two of ADR033's runtime invariants — dangling edges, negative currency — move into types entirely; `checkInvariants` keeps only the residue.
+
+## 6. The mode category (I.15, ADR051 E3)
+
+The modes form a presented category: objects are the five modes, generating morphisms are the ratified transition table, and `Path` is the free category on the presentation. Two constitutional facts become compiler facts.
+
+```haskell
+data Step a b where
+  Degrade   :: Step 'Solidaristic 'Transactional
+  Organize  :: Step 'Transactional 'Solidaristic   -- THE core player mechanic
+  Marketize :: Step 'Transactional 'Extractive
+  Formalize :: Step 'Extractive    'Transactional
+  Rebel     :: Step 'Extractive    'Antagonistic
+  ResolveS  :: Step 'Antagonistic  'Solidaristic
+  -- … 17 generators total, transcribed 1:1 at ratification
+
+organizingRoute :: Path 'Extractive 'Solidaristic
+organizingRoute = Then Formalize (Then Organize Here)
+```
+
+First, I.15's prohibition — EXTRACTIVE → SOLIDARISTIC requires a TRANSACTIONAL intermediate — is an **absence**: no such generator exists, so no such one-step path can be written, ever, by anyone. Second, E3's corrected law ("no direct jump AND a transactional route exists") is an **inhabitant**: `organizingRoute` is the proof term, and deleting the intermediate makes the module stop compiling. E3 currently tests this; here the compiler audits it on every build. I.15's gates ("conditions reference contradiction internals") stay value-level guards on attempted steps — the type admits the step, the gate admits the occasion.
+
+## 7. Formulas
+
+All coefficients arrive through `Defines` (the GameDefines/defines.yaml image), which deliberately has no `Default` instance. The mathematical core transcribes with its theorems as return types:
+
+```haskell
+data Rent = RentFlows Currency | RentExhausted
+
+imperialRent :: Currency -> Currency -> Rent
+-- the Fundamental Theorem is the SHAPE of the type: while W_c > V_c the rent
+-- flows and the core cannot rupture — not a comment on a float
+
+sigmoidP13   :: Double -> Probability          -- portable, no libm (see below)
+pSurvivalAcq :: Defines -> Currency -> Probability
+pSurvivalReb :: Probability -> Probability -> Either KernelViolation Probability
+rupture      :: Probability -> Probability -> Bool   -- P(S|R) > P(S|A)
+
+routeAgitation :: Maybe SolidarityWitness -> BifurcationPole   -- Revolution | Fascism
+deltaB     :: Defines -> Extensive Double -> Extensive Double -> Double  -- R − E·η
+overshootO :: Extensive Double -> Extensive Double -> Either KernelViolation Ratio
+```
+
+`sigmoidP13` is the Amendment Q gap (2) closure point: a pure-arithmetic sigmoid (no libm), byte-stable across implementations. The body in the draft is a placeholder from the fast-sigmoid family; the ratified polynomial and its error bound belong to Program 13's float-honesty document, and the migration gate compares Python-vs-core under III.12(b) tolerances until cutover, then re-baselines.
+
+`pSurvivalReb` refuses zero repression (`Left ZeroRepression`) rather than fabricating an infinity, and its saturation at 1 is named — Loud Failure applied to arithmetic.
+
+The bifurcation shows the witness pattern that generalizes in §9: `SolidarityWitness` has an unexported constructor and `requireSolidarity` is its only mint, so the routing function cannot be called with a fabricated edge.
+
+## 8. The tick: causality as types
+
+Materialist-causality order is today a list in the engine plus review discipline. Here systems are phase-indexed, the registry has one slot per phase, and `advance` composes the phases in the only order that exists — registering a Consequences system into the MaterialBase slot is a type error. Base-determines-superstructure, compiler-checked.
+
+```haskell
+newtype System (p :: Phase) = System (Defines -> World -> (World, [Event]))
+
+data Registry = Registry
+  { materialBase :: [System 'MaterialBase]
+  , oodaAction   :: [System 'OodaAction]
+  , consequences :: [System 'Consequences] }
+
+advance :: Defines -> Registry -> World -> Either Violation (World, TickReport)
+```
+
+`advance` is a function with no `IO` in its signature. Same `Defines`, same `World`: same result. III.7 stops being a discipline the regression gates check and becomes a property of the arrow's type — the gates remain as *redundant* verification, which is what Amendment Q says verification should be. The RNG is splittable pure state inside `World` with pinned seeds (ADR033); the tick hash consumes exactly the III.7 iteration surface (`nodesInOrder ++ edgesInOrder`), with the byte recipe owned by Program 13 (gap (1)). An invariant violation aborts the tick — `Left`, no partial states, no fabrication (III.11).
+
+Within a phase, the list is the strict registry order — the 28 systems keep their sequence as data. Phase membership of all 28 needs transcription (§12).
+
+## 9. Verbs as capabilities
+
+Organizations are the agents (I.16); verbs operate through them (I.21). Each verb's Requires-clause from the game-loop spec becomes an argument whose type is an unforgeable witness — `requireMembership` is the only mint for `MembershipW`, so EDUCATE without a MEMBERSHIP edge is not a rejected action, it is an uncallable function. The spec's validation table becomes the module's arguments page:
+
+```haskell
+requireMembership :: NodeId 'OrganizationK -> NodeId 'SocialClassK -> Topology -> Maybe MembershipW
+requirePresence   :: NodeId 'OrganizationK -> NodeId 'TerritoryK  -> Topology -> Maybe PresenceW
+
+educate :: Defines -> MembershipW -> Double -> World -> (World, [Event])
+```
+
+The nine verbs — EDUCATE, AID, ATTACK, MOBILIZE, CAMPAIGN, MOVE, INVESTIGATE, REPRODUCE, NEGOTIATE — form a closed sum; `educate` is given a real body in the draft because it exhibits the state-threading idiom the whole port turns on (pure payload update and re-insert, replacing shared-dict mutation). MOBILIZE's consciousness threshold arrives as a `Fold` from `Defines`; OODA capacity (I.17) makes an unpayable verb unexecutable via `Maybe`, not exception. REPRODUCE is a `Tier` transition on the MEMBERSHIP payload — quantitative organizing work, qualitative membership change, I.7 again.
+
+## 10. Boundaries as physics
+
+Three module-boundary decisions carry constitutional clauses:
+
+**Observation.** `World` exports no constructors; `observe :: World -> Chronicle` is the entire read surface for intelligence. "AI observes and narrates; the engine adjudicates" stops being a review rule and becomes linkage fact — the narrator cannot reach the math because there is no symbol to link against.
+
+**Provenance (Aleksandrov).** State enters the world only as `Material (NodeData k)`, and `Material`'s constructor is exported only to the hydration module — the Ledger boundary. A formal construct with no material source has no way into the topology.
+
+**Substrate immutability.** `HexState` and ADJACENCY payloads have no exported update arrows. The spatial substrate's immutability is an absence of functions, which is the strongest form a prohibition can take.
+
+## 11. Law → verification mapping (Amendment Q)
+
+| law (in the module) | pins | verification layer |
+|---|---|---|
+| `law_adjunction` | Galois connections are real adjunctions | QuickCheck property |
+| `law_cylinderLeft/Right` | L ⊣ U ⊣ R | QuickCheck property |
+| `law_insertionOrder` | III.7 iteration contract | property + nx differential oracle (ported) |
+| `law_allocateConserves` | gluing = conservation (Phase D sheaf) | property + `conservation_check` column |
+| `organizingRoute` | I.15 prohibition + E3 route existence | **the compiler** |
+| absence of `CommunityId -> (Pole, Pole)` | VIII.9 n-ary protection | **the compiler** |
+| `advance` purity | III.7 determinism | **the compiler** + goldens as redundancy |
+| dense goldens, tick-hash chain | cross-implementation behavior | Program 13 artifacts, III.12(b) tolerances |
+
+The pattern throughout: what the compiler can enforce, it enforces; the existing gates stay as the redundant layer Amendment Q requires rather than the only layer.
+
+## 12. Open rulings
+
+1. **Currency representation** — fixed-point `Micro` (drafted) vs Double-with-softfloat. Fixed point buys byte-identity on the value plane; costs a re-baseline. My recommendation: fixed point, and III.12(b) already licenses the re-baseline.
+2. **Endpoint typing confirmations** — TRIBUTE (comprador→core as class⊢class?), and the omitted REPRESSION / COMPETITION / CLIENT_STATE verbs (institution⊢class? sovereign⊢sovereign?). Transcribe from `src/babylon/models`, don't ratify my `[confirm]` marks.
+3. **The 17 generators** — the mode category's presentation must transcribe 1:1 from the repo's transition source; the draft carries the documented subset plus two marked speculative (`CoOpt`, `Break`).
+4. **Sigmoid polynomial** — Program 13 owns the ratified coefficients and error bound; the draft body is a shape, not a spec.
+5. **Phase membership** — assign each of the 28 systems to MaterialBase/OodaAction/Consequences; the draft pins only the composition order.
+6. **Edge payload merge** — ADR052 pins nx attribute-merge on re-add; typed payloads want per-verb field-level merge functions or replace semantics. Draft uses replace.
+7. **Where `EdgeMode` lives** — `OrgRelationData.orMode` (drafted, per the game-loop spec) vs mode as a property of more edge families.
+
+## 13. What this buys, what it costs
+
+Bought: determinism as a type rather than a discipline; the verb grammar and mode transitions as compile-time law; tension constructible only by measurement; intensive/extensive confusion unrepresentable; the intelligence boundary as linkage fact; and a formulas layer whose theorems are return types. The Lawverian layer turns out to be the *easiest* part of the port — ADR051's constructs are nearly literal Haskell already, which is evidence the 2026-04-26 discipline was load-bearing rather than aesthetic.
+
+Cost, unchanged from the feasibility discussion: rewriting ~28 systems from shared-dict mutation to state threading (§5 is the idiom), a permanent two-toolchain estate for a solo dev, and the float cutover. Sequencing recommendation stands: Program 13 first (this draft depends on its artifacts at three named points), then a spec ratifying §12's rulings, then the port validated shadow-mode against dense goldens under III.12(b) tolerances.
+
+Nix note from the prior discussion, for completeness: the toolchain (GHC 9.4+, cabal, HLS) lands in babylon-infra's existing flake devshell (ADR071 scoped Article X.1 to the production host); `packages.babylon-core` builds the core; the flake pin doubles as float-determinism infrastructure for CI. If the core binary ever deploys to the production host, ship the ELF, not a closure.

--- a/docs/superpowers/specs/2026-07-22-babylon-core-typed-haskell-draft0.md
+++ b/docs/superpowers/specs/2026-07-22-babylon-core-typed-haskell-draft0.md
@@ -1,7 +1,7 @@
 <!-- Provenance: BD-authored draft, delivered in-session 2026-07-22 and committed
      verbatim (Immutability of History — this text is design material, not a
-     ratified spec). The companion module BabylonCoreDraft.hs referenced below is
-     held by the BD and should be committed beside this file when dropped.
+     ratified spec). The companion module BabylonCoreDraft.hs is committed beside
+     this file (BD-dropped 2026-07-22, verbatim).
      The preparatory spec that frames this draft for ratification is
      2026-07-22-mirror-typed-core-spec.md. -->
 

--- a/docs/superpowers/specs/2026-07-22-mirror-typed-core-spec.md
+++ b/docs/superpowers/specs/2026-07-22-mirror-typed-core-spec.md
@@ -1,0 +1,179 @@
+# The Mirror & the Typed Core — preparatory spec (POST-v1.0, TABLED)
+
+*Status: **preparation, not ratification.** BD-directed 2026-07-22: "table this,
+but make a spec to prepare it." Everything here is post-v1.0 work, deliberately
+off the Gate-3 critical path, consistent with the 2026-07-21 ruling that the
+formalism surface is **closed for v1.0** — this spec prepares the constitutional
+amendment that would reopen it, and does nothing else. The two §4 sentinel
+motions are the only items that may be scheduled pre-1.0, at owner discretion,
+because they add gates, not formalism.*
+
+*Companions: the BD's Haskell algebra
+[`2026-07-22-babylon-core-typed-haskell-draft0.md`](2026-07-22-babylon-core-typed-haskell-draft0.md)
+(committed verbatim; its module `BabylonCoreDraft.hs` lands beside it when the
+BD drops the copy) and the Lawvere-archive evidence base
+[`../research/2026-07-22-lawvere-archive-readings.md`](../research/2026-07-22-lawvere-archive-readings.md)
+(25 papers read in full from `/media/user/data/babylon-data/lawvere-master`;
+every claim below marked **[L]** is page-cited there).*
+
+---
+
+## 1. What this prepares, in one paragraph
+
+Two programs share one foundation. **The Typed Core** ports the functional core
+(kernel, models, formulas, topology, dialectics — the tick as the sole arrow)
+to a Haskell algebra where a class of constitutional violations becomes
+unrepresentable rather than reviewable. **The Mirror** (NORTH_STAR §7, Round 2)
+turns Stratum 2's implicit self-model into explicit data: the construct graph
+as a first-class, queryable object, audited with the same boundary mathematics
+the game applies to its world. The shared foundation is Lawvere's: the archive
+reading confirms most of Babylon's constructs are *real* instances of his
+mathematics — and identifies, precisely, the five places where our current
+phrasing borrows rigor it has not earned. This spec's job is to make the
+eventual ratification honest: every construct below is tagged **EARNED**
+(matches Lawvere as stated), **CONDITIONAL** (matches if a named check passes),
+or **UNEARNED AS PHRASED** (rename or strengthen at ratification).
+
+## 2. Ground truth: what the codebase already proves (2026-07-22 audit)
+
+The kernel/system/engine audit (verified against dev) found the ontology more
+formal than feared:
+
+- **Kernel** = the initial segment of the import poset — machine-enforced
+  (import-linter "kernel is layer 0"). It is the *signature* Σ in which the
+  layers above are typed.
+- **System** = a registered, position-ordered, partition-classified,
+  deterministic endomorphism on the world graph. Membership (`_SYSTEM_CLASSES`,
+  30 entries), total order (duplicate positions = import-time `RuntimeError`),
+  and partition coverage (MATERIAL_BASE / ACTION / CONSEQUENCE, ADR081) are all
+  **proven at import time** in `simulation_engine.py`.
+- **Engine** = the terminal object: evaluator of the one canonical word
+  `T = S₃₀ ∘ … ∘ S₁` plus the hash seal; five import-linter contracts make
+  engine-ness terminal.
+
+Four audited gaps, which §4 turns into motions: (1) system **footprints**
+(reads/writes) are prose, not data — the materialist-causality rationale is
+unauditable; (2) **registration is unguarded** — an unregistered `SystemBase`
+subclass is silent dead superstructure; (3) determinism is proven only in
+aggregate (tick hash), never attributed per-system; (4) doc rot:
+`system_protocol.py` still says "Mutable NetworkX graph" (Amendment L removed
+NetworkX).
+
+## 3. The constructs, adjudicated against the archive
+
+Draft0's architecture is endorsed: two planes, kernel newtypes, GADT verb
+grammar, phase-indexed registry, witness capabilities, `observe` as the sole
+read surface. The table below is what ratification must additionally fix.
+(Draft0 sections in parentheses; **[L]** = evidence base.)
+
+| Construct (draft0) | Verdict | Ratification requirement |
+|---|---|---|
+| Adjoint cylinder L ⊣ U ⊣ R (§3) | **CONDITIONAL** | Legitimate UIAO **iff** L, R are full+faithful and U is a genuine two-sided retraction (U∘L = id = U∘R) — otherwise it is a mere adjoint triple and the "unity of opposites" label is unearned. Ship the retraction and both adjunction laws as QuickCheck properties. **[L1, L2]** |
+| Tension w as "adjunction defect" (§3) | **UNEARNED AS PHRASED** | Two fixes: (a) the current defect measures only the **unit** side — a half Galois connection; track the counit defect or scope the claim as unit-only. (b) w has no compositional law today. Either build Tension as the free [0,∞]-category on the weighted verb-graph (min-plus shortest-path closure — then the triangle inequality *is* the composition law, and derived relations compose by Bellman–Fenchel convolution), or declare in the spec that tension is non-compositional. Law to ship either way: `w(𝔇) = 0 ⟺ the canonical map L(X) → R(X) is iso`. **[L4]** |
+| σ sublation (§3) | **UNEARNED AS PHRASED** → derivable | Replace the ad hoc map with a derived construction carrying laws for free: the image-factorization of the canonical 2-map between the opposite inclusions of the UIAO (Lawvere's "third section", van der Waals model), or Isbell double-conjugation F ↦ F\*# (idempotent, extensive, monotone). **[L1]** |
+| Level lattices + aufhebung (§3) | **UNEARNED AS PHRASED** — the weakest link | "Least strictly-higher level where a resolution predicate holds" drops the mathematics. Lawvere: a *level* is a downward functor with both adjoints full inclusions; T is the Aufhebung of S iff **R_T L_S = L_S** (the higher coskeleton fixes the lower skeleton — the factoring condition); "smallest such T exists" is a **theorem** (the lattice of levels ≅ idempotent two-sided ideals; left ideals, for a graphic monoid). Implement Aufhebung as this closure operator over the finite ideal lattice, with laws (extensive, idempotent, monotone) and **the Hegelian Taco as the golden fixture**: the 8-element graphic monoid with known dimension 3 and known ideal chain ∅ ⊂ {0,1} ⊂ [ℓ,q,r] ⊂ [L,R] ⊂ [1]. A rewrite in any language must reproduce the taco — that is the behavioral contract. **[L1]** |
+| Extensive/Intensive (§2) | **EARNED**, one rename, one fork | The Num-less `Intensive` is exactly right. But: (a) the conservation property is **not a "sheaf law"** (sheaves glue over *overlapping* covers — a limit condition); it is the **extensive-quantity coproduct law** over a partition (Lawvere 1992's defining clause). Rename it; reserve "sheaf" for a genuine overlap-gluing law if border-sharing regions ever demand one. (b) `allocate ⊣ aggregate`: as drafted (proportional section with aggregate∘allocate = id) it is a **section of a split epi, not an adjunction**. Either state and test the extremal universal property, or frame the level lattice as a genuine site with aggregate as direct image (then p_! ⊣ p\* is real), or rename honestly. **[L2]** |
+| Cohesion over the solidarity graph | **CONDITIONAL** — one functor short | Babylon has the 3-string; Lawvere's category of cohesion needs the 4-string **p_! ⊣ p\* ⊣ p_\* ⊣ p^!** — the missing piece is `pieces` (connected components), which must preserve finite products (axiom a). With finite hom-sets, continuity (b) then comes free, and the Nullstellensatz (c) — "every nonempty piece contains a point" — is trivially checkable. Bonus: Lawvere already proved the reflexive-graph topos sufficiently cohesive and infinitesimally generated (2007 Props 5-6) — adopt his result rather than re-derive. Ground "atomization" in the canonical map X → codiscrete(points X) classified by the 5-element Ω (in A / entering / leaving / excursion / outside) — the scalar quantification is our own addition and must cite the enrichment fork above for its justification. **[L2]** |
+| ∂L boundary / seam space | **CONDITIONAL** — currently conflates two operators | (a) The **subobject boundary** ∂A = A ∧ non A is unconditionally lawful in any presheaf topos, and for directed graphs is *literally* the seam: nodes touched by arrows crossing out of A. (b) The **subtopos boundary/Aufhebung** on the lattice of essential subtoposes is the better match for "audit that declared subsystems are wired" (Lawvere's own use case: hypercard, library catalogues — structurally the Mirror) but is finite/computable **iff the schema is graphic** (endomorphism identity `aba = ab` — then subtoposes ≅ ideals and Ω is a cogenerator). Ratification must: pick (a) or (b) per use; **check the graphic identity** on the actual schema (falsifiable, currently unchecked); decide **reflexive vs irreflexive** edges (recommend reflexive/Δ₁ — the gros topos with the 5-element Ω; irreflexive is an étendue with different Ω and negation, and every boundary formula changes); assert the Leibniz rule ∂(A×B) = (∂A×B) ∨ (A×∂B) **only as a property test** against the enumerated finite schema (its hypotheses — nodal factorization or nonempty homs + products — generically fail for our multi-sorted schema); and never claim ∂ commutes with refactoring maps (substitution stability is lax: non(Af) ⊆ (non A)f, equality iff groupoid). **[L5]** |
+| The tick (§8) | **EARNED**, three sharpenings | It *is* Lawvere's discrete dynamical system (the 1978 example verbatim). Sharpen: (a) distinguish the cyclic monoid ⟨T⟩ ≅ ℕ from the generated systems monoid on {S₁..S₃₀} — his structural theorems bind differently to each (the no-cycles cancellation theorem does NOT apply to ⟨T⟩); (b) name determinism as the **discrete-op-fibration unique-lifting law** (fibers discrete; `Left Violation` = failed unique lift) and property-test it; (c) "statics are fixed points of T" must say whether it means the trivial fixed point (T = id, empty report) or Lawvere's **freeze** (state fixed, cost/report nonzero) — his own marginal note flags exactly this ambiguity. **[L3]** |
+| observe :: World → Chronicle (§10) | **CONDITIONAL** | As a snapshot it is Lawvere's weak "output" case. Upgrade to a **response functor**: per-system fragments with a monoid instance and the law `observe(tick) = mconcat [observeStep i wᵢ wᵢ₊₁]` — the Volterra ∫θ ds accumulation. This is also what makes per-system determinism attribution (gap 3 of §2) checkable. **[L3]** |
+| "Chaos" | **DO NOT USE** | Lawvere's chaos = symbol-sequence surjectivity of X → Y^T — unrelated to I.12's fold catastrophes ("normal, reasonable behavior" qualifies, his words). For thresholds/discontinuities, the usable toolkit is the entropy paper's Lawvere-metric state category with upper-semicontinuous regularization. **[L3]** |
+| Verb grammar GADT (§4) | **EARNED**, one naming fix | It is the **generating 𝒱-graph of the base category of types** — not a hyperdoctrine (which needs per-type attribute CCCs, substitution, Σf ⊣ f· ⊣ Πf with Frobenius + Beck). Name it honestly; heterogeneous verbs (class ⊢ territory) are naturally **bimodules/profunctors**, which buys derived indirect relations by convolution. **[L4]** |
+| Capability witnesses (§9) | **EARNED** | `requireMembership` as sole mint of `MembershipW` is precisely the **Comprehension Schema** ({B:ψ} with structural map). Recorded caveat: if node kinds ever gain internal morphisms, Frobenius fails and equality must become the hom profunctor. **[L4]** |
+| Mode category (§6), two planes (§1), formulas (§7), boundaries as physics (§10) | **EARNED** | As drafted. The V₀ ⊂ [0,∞] adjoint triple gives the two-planes discipline its formal home (`reachable :: Tension → Bool` as the collapse pair) if the enrichment fork is taken. **[L4]** |
+
+New constructions the archive offers that draft0 does not yet use (candidates,
+not commitments): the kinship method (generators → free-monoid topos → graded
+Ω "how Irish is y?" → coarsening as epimorphic quotients with p_! ⊣ p\* ⊣ p_\*
+as objective ∃/∀) as the template for class/solidarity queries; the `X mod A`
+pushout for collapsing extinct-faction history; Cauchy completeness as
+"solidarity-network saturation"; the trace Tr(f_\*) = inf_a A(a, fa) fixed-point
+criterion tied to the Survival Calculus equilibrium question; the universal
+state F_C(Y)(A) = Cat(A/C, Y) as the "is World expressive enough" ceiling test.
+
+## 4. Near-term motions (the only pre-1.0 items; owner-schedulable)
+
+Both are Stratum-2 gates inside existing machinery — no new formalism, so the
+closed-surface ruling is respected:
+
+1. **Footprint ClassVars** on `SystemBase` — `reads`/`writes` frozensets of
+   graph-attribute names, audited by the `check:vocabulary` family (which
+   already audits stamped attributes). Prize: position order becomes a proven
+   **linear extension of the writer-before-reader DAG** — the 60-line ordering
+   comment becomes a theorem the build re-proves. This is also the data
+   substrate the Mirror's construct graph will read.
+2. **Registration sentinel** — every `SystemBase` subclass under `src/` is in
+   `_SYSTEM_CLASSES` or a cited exemption. Closes the silent-dead-institution
+   hole at the system level.
+
+(Plus the one-line `system_protocol.py` NetworkX docstring fix, folded into
+whichever commit lands first.)
+
+## 5. Toolchain: GHC in Nix (post-1.0, specified here, not implemented)
+
+Draft0's toolchain note predates ADR102 and is **superseded on location**: the
+infra submodule is unmounted and babylon's own vendored `flake.nix` is the
+canonical toolchain — the Haskell lane lands **in babylon's flake**, not
+babylon-infra's. Shape at adoption time:
+
+- A third devshell `haskell` (beside `default` and `dataBuild`): pinned GHC
+  9.4+ line, `cabal-install`, HLS — all from the same rev-pinned nixpkgs so
+  the GHC pin doubles as float-determinism infrastructure (the III.12(b)
+  cross-implementation story needs a byte-stable compiler at least as much as
+  Python needs the sqlite pin).
+- `packages.babylon-core` builds the core library + a `babylon-core-check`
+  executable running the property/law suite; `checks.core-laws` wires it into
+  `nix flake check`.
+- The Python⟷Haskell seam ships as data (draft0 §Mermaid): hydration hands
+  `Material (NodeData k)` in, `TickReport` + deltas come out; shadow-mode
+  validation runs both engines against the dense goldens under III.12(b)
+  tolerances until cutover.
+- If the core binary ever deploys to the production host: ship the ELF, not a
+  closure (babylon-infra Article X.1 stays untouched).
+- Machine safety: GHC builds are heavy; they join cargo in the single-flight
+  discipline, never fanned out.
+
+## 6. Sequencing (unchanged from draft0 §13, made explicit)
+
+1. **Program 13 first** (float honesty: hash byte-recipe, sigmoid polynomial +
+   error bound, tolerance policy) — draft0 depends on its artifacts at three
+   named points.
+2. **Ratification spec** resolving draft0 §12's seven rulings **plus** this
+   spec's adjudications (§3 table) and new open rulings (§7). That spec is the
+   constitutional amendment reopening the formalism surface.
+3. **Typed core in shadow mode** against dense goldens; cutover only on
+   byte-agreement under the declared tolerances; fixed-point Currency triggers
+   the III.12(b) re-baseline ceremony.
+4. **The Mirror** opens only after the current trains merge (NORTH_STAR §7):
+   its opening brief is §3's ∂L adjudication — construct graph as data,
+   graphic-topos target, footprints (§4.1) as its first real dataset.
+
+## 7. Open rulings for the ratification spec (beyond draft0 §12)
+
+1. **Reflexive or irreflexive** world/construct graphs (changes Ω, negation,
+   and every boundary formula; recommendation: reflexive/Δ₁).
+2. **Graphic identity check**: does the schema's endomorphism monoid satisfy
+   `aba = ab`? (Determines whether the finite ideal-lattice ∂L machinery is
+   available or the general co-Heyting fallback applies.)
+3. **Tension enrichment fork**: free-[0,∞]-category (compositional, triangle
+   inequality by construction) vs declared non-compositional scalar.
+4. **allocate/aggregate**: universal-property adjunction, site-theoretic
+   framing, or honest rename.
+5. **pieces functor**: add p_! and claim full cohesion, or stay at the
+   adjoint-cylinder level and say so.
+6. **observe**: upgrade to response functor now or record the snapshot
+   limitation.
+7. **Which golden fixtures are constitutional**: the Hegelian Taco (Aufhebung),
+   the nx differential oracle port (III.7), the conservation/coproduct law,
+   the response-functor mconcat law — each is a rewrite-test artifact in the
+   Tests-as-Behavioral-Contracts sense.
+
+## 8. What this buys (unchanged) and what it must not cost
+
+Draft0 §13 stands: determinism as a type; grammar and mode transitions as
+compile-time law; tension only by measurement; the intelligence boundary as
+linkage fact. The archive reading *adds*: our dialectical vocabulary stops
+being decoration — where it survives adjudication it is Lawvere's mathematics
+with page numbers, and where it does not, we rename before we ratify. What it
+must not cost: the game. Nothing in this document schedules work before
+v1.0.0 ships except §4, and §4 only if the owner says so.

--- a/docs/superpowers/specs/BabylonCoreDraft.hs
+++ b/docs/superpowers/specs/BabylonCoreDraft.hs
@@ -1,0 +1,945 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- =============================================================================
+-- Babylon.Core.Draft — a Haskell algebra for the Babylon functional core,
+-- in the Lawverian tradition.  DRAFT 0 (2026-07-22).
+--
+-- Typechecks under GHC 9.4.7, deps: base + containers only.
+--
+-- Reading protocol: every construct cites the clause or ADR it enforces.
+-- Constructs obey the earn-its-keep rule (ADR051 / Percy 2026-04-26): a
+-- categorical construct ships only if it yields a LAW, a PREDICTION, or a
+-- COMPUTATION.  Nothing here is vocabulary.
+--
+-- The export list IS the constitutional boundary (III.11, "intelligence
+-- observes only"): World is abstract, witnesses are unforgeable, the only
+-- arrows into World are hydration and the tick.
+-- =============================================================================
+
+module Babylon.Core.Draft
+  ( -- * The world, abstractly (no constructors: the Loud-Failure boundary)
+    World
+  , advance
+  , observe
+  , Chronicle (..)
+    -- * Kernel quantities (continuous plane, I.7)
+  , Probability, probability
+  , Intensity, intensity
+  , Ideology, ideology
+  , Coefficient, coefficient
+  , Ratio, ratio
+  , Currency (..), Micro (..)
+  , Balance, KernelViolation (..)
+    -- * Extensive / intensive quantities (Lawvere; ADR051 Phase D)
+  , Extensive (..), Intensive (..), Share (..)
+  , sumExtensive, meanIntensive, allocateExtensive
+    -- * Folds: the only quantitative->qualitative morphisms (I.7 + I.12)
+  , Fold (..), crossFold
+    -- * The Lawverian layer (ADR051)
+  , GaloisConnection (..), law_adjunction, unitDefect
+  , AdjointCylinder (..), law_cylinderLeft, law_cylinderRight
+  , SpatialLevel (..), SocialLevel (..), Level (..), aufhebung
+  , Picard (..), staticOf
+  , Pole (..), Opposition (..), Regime (..), Epsilon (..), classifyRegime
+  , principal
+  , Dialectic (..)
+    -- * The grammar (nodes, verbs, payloads)
+  , NodeKind (..), NodeId (..), SNodeKind (..)
+  , VerbTag (..), EdgeVerb (..)
+  , SomeNode (..), SomeEdge (..)
+  , Topology, emptyTopology, addNode, addEdge, nodesInOrder, edgesInOrder
+  , Violation (..)
+    -- * Edge modes as a presented category (I.15; ADR051 E3)
+  , Mode (..), Step (..), Path (..), organizingRoute
+    -- * Formulas (pure, Defines-fed)
+  , Defines (..), Rent (..), imperialRent
+  , sigmoidP13, pSurvivalAcq, pSurvivalReb, rupture
+  , BifurcationPole (..), routeAgitation, SolidarityWitness, requireSolidarity
+  , deltaB, overshootO
+    -- * The tick
+  , Phase (..), System (..), Registry (..)
+  , Event (..), TickReport (..), TickHash (..)
+  , PureGen, genStep
+    -- * Laws (lifted into the Amendment Q property layer)
+  , law_insertionOrder, law_allocateConserves
+    -- * Verbs as capabilities (I.16, I.21; the nine)
+  , PlayerVerb (..), MembershipW, PresenceW, requireMembership, requirePresence
+  , educate
+  , Tier (..), OodaProfile (..)
+    -- * Provenance (Aleksandrov Test)
+  , Material  -- abstract: only the hydration boundary mints Material values
+  ) where
+
+import Data.Bits (xor)
+import Data.Foldable (toList)
+import Data.Int (Int64)
+import Data.Word (Word64)
+import Data.Kind (Type)
+import Data.List (foldl')
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (mapMaybe)
+import Data.Sequence (Seq, (|>))
+import qualified Data.Sequence as Seq
+
+-- =============================================================================
+-- §1  KERNEL: the two planes.
+--
+-- Constitution I.7: "Enums for qualities, floats for quantities.  Thresholds
+-- explicit.  No continuous quality gradients."  I.12: control parameters
+-- continuous, state variables discrete at fold crossings.
+--
+-- Here that is a type-level separation: the continuous plane is newtypes over
+-- Double / fixed-point Int64; the discrete plane is closed sums.  The ONLY
+-- morphisms from the first to the second are values of `Fold` (§3), whose
+-- thresholds are constructed from Defines and nowhere else.
+-- =============================================================================
+
+data KernelViolation
+  = OutOfRange  String Double     -- ^ smart constructor refused (Loud Failure)
+  | NonPositive String Double
+  | ZeroRepression                -- ^ P(S|R) denominator; refuse, don't fabricate
+  deriving stock (Eq, Show)
+
+-- | [0,1].  P(S|A), P(S|R), organization, repression-normalized quantities.
+newtype Probability = Probability Double deriving newtype (Eq, Ord, Show)
+
+-- | [0,1].  Contradiction intensity: 0 = dormant, 1 = rupture.  Fresh per tick
+-- (ADR051: a gap is MEASURED, never accumulated).
+newtype Intensity = Intensity Double deriving newtype (Eq, Ord, Show)
+
+-- | [-1,1].  Revolutionary (-1) to reactionary (+1).
+newtype Ideology = Ideology Double deriving newtype (Eq, Ord, Show)
+
+-- | [0,1].  Formula parameters (alpha, lambda, k).  Lives in Defines ONLY.
+newtype Coefficient = Coefficient Double deriving newtype (Eq, Ord, Show)
+
+-- | (0,inf).  Wage ratios, exchange ratios, eta.
+newtype Ratio = Ratio Double deriving newtype (Eq, Ord, Show)
+
+-- | [-1,1].  Opposition balance (ADR051): 0 = equilibrium.
+newtype Balance = Balance Double deriving newtype (Eq, Ord, Show)
+
+-- | Fixed-point 1e-6 currency units.  RULING NEEDED (§11 of the design doc):
+-- moving the value plane to fixed point makes cross-implementation
+-- byte-identity trivial where it matters most (the Phi circuit), at the cost
+-- of a one-time re-baseline.  Amendment Q III.12(b) anticipates exactly this.
+newtype Micro = Micro Int64 deriving newtype (Eq, Ord, Show)
+
+-- | [0,inf) by smart construction.  Wealth, wages, rent, GDP.
+newtype Currency = Currency Micro deriving newtype (Eq, Ord, Show)
+
+probability :: Double -> Either KernelViolation Probability
+probability x | x >= 0 && x <= 1 = Right (Probability x)
+              | otherwise        = Left (OutOfRange "Probability" x)
+
+intensity :: Double -> Either KernelViolation Intensity
+intensity x | x >= 0 && x <= 1 = Right (Intensity x)
+            | otherwise        = Left (OutOfRange "Intensity" x)
+
+ideology :: Double -> Either KernelViolation Ideology
+ideology x | x >= -1 && x <= 1 = Right (Ideology x)
+           | otherwise         = Left (OutOfRange "Ideology" x)
+
+coefficient :: Double -> Either KernelViolation Coefficient
+coefficient x | x >= 0 && x <= 1 = Right (Coefficient x)
+              | otherwise        = Left (OutOfRange "Coefficient" x)
+
+ratio :: Double -> Either KernelViolation Ratio
+ratio x | x > 0     = Right (Ratio x)
+        | otherwise = Left (NonPositive "Ratio" x)
+
+-- | Saturating raise on the intensity plane.  Saturation is a DOCUMENTED
+-- semantic (consciousness cannot exceed 1), not a silent clamp: the only
+-- clamping arrows in the kernel are this and its dual, both named.
+raiseIntensity :: Intensity -> Double -> Intensity
+raiseIntensity (Intensity x) d = Intensity (min 1 (max 0 (x + d)))
+
+-- =============================================================================
+-- §2  EXTENSIVE vs INTENSIVE QUANTITY.
+--
+-- Lawvere, "Categories of Space and Quantity" (1992): extensive quantities
+-- vary covariantly (they SUM under aggregation: population, value, biocapacity);
+-- intensive quantities vary contravariantly (they take weighted MEANS: rates,
+-- tensions, consciousness).  ADR051 Phase D shipped exactly this distinction
+-- as aggregate_extensive vs aggregate_intensive, with the sheaf reading:
+-- gluing = conservation.
+--
+-- The type-level payoff: Intensive has NO Num instance and no sum arrow.
+-- The classic bug class — summing ratios across counties — is unrepresentable.
+-- =============================================================================
+
+newtype Extensive a = Extensive a deriving newtype (Eq, Ord, Show)
+newtype Intensive a = Intensive a deriving newtype (Eq, Ord, Show)
+
+-- | [0,1], and Σ shares = 1 over a partition (a LAW, checked in properties).
+newtype Share = Share Double deriving newtype (Eq, Ord, Show)
+
+sumExtensive :: Num a => [Extensive a] -> Extensive a
+sumExtensive = Extensive . foldl' (+) 0 . map (\(Extensive x) -> x)
+
+-- | aggregate_intensive: share-weighted mean.  A gap is a RATIO (ADR051 E1),
+-- so level closure uses THIS, never sumExtensive.
+meanIntensive :: [(Share, Intensive Double)] -> Intensive Double
+meanIntensive xs = Intensive (sum [ s * v | (Share s, Intensive v) <- xs ])
+
+-- | The left adjoint of the scale adjunction (allocate ⊣ aggregate, ADR051
+-- Phase D).  Deterministic integer allocation: floor per share, remainder to
+-- the FIRST region in insertion order (III.7 gives "first" a defined meaning).
+-- Law: sumExtensive (allocateExtensive shs t) == t   (gluing = conservation).
+allocateExtensive :: [Share] -> Extensive Micro -> [Extensive Micro]
+allocateExtensive shs (Extensive (Micro total)) =
+  case floors of
+    []             -> []
+    (Micro f0 : r) -> Extensive (Micro (f0 + remainder)) : map Extensive r
+  where
+    floors    = [ Micro (floor (fromIntegral total * s :: Double)) | Share s <- shs ]
+    remainder = total - sum [ f | Micro f <- floors ]
+
+-- =============================================================================
+-- §3  FOLDS: the only quantitative->qualitative morphisms.
+--
+-- I.7 "Quantitative -> Qualitative": quantities accumulate, qualities transform
+-- discretely, thresholds explicit.  I.12: the catastrophe surface — continuous
+-- control parameters, discrete state variables at fold crossings.
+--
+-- A Fold is that clause as a value.  Its threshold is data, constructed from
+-- Defines (the single moddable source of truth) and from nowhere else; a
+-- numeric literal in a formula body is now a code-review artifact with no
+-- type to inhabit.
+-- =============================================================================
+
+data Fold q s = Fold
+  { fThreshold :: q   -- ^ explicit, Defines-sourced (I.7)
+  , fBelow     :: s
+  , fAbove     :: s
+  }
+
+crossFold :: Ord q => Fold q s -> q -> s
+crossFold f x = if x < fThreshold f then fBelow f else fAbove f
+
+-- =============================================================================
+-- §4  THE LAWVERIAN LAYER (ADR051, typed).
+--
+-- Everything in this section already runs in Python under
+-- src/babylon/dialectics/.  The Haskell versions add: laws as first-class
+-- Bool-valued functions (lifted into the Amendment Q property layer), and
+-- adjunction defect as the ONLY constructor of tension.
+-- =============================================================================
+
+-- | A poset adjunction f ⊣ g.  The Galois connection is the Lawverian
+-- primitive from which contradiction is MEASURED, not asserted.
+data GaloisConnection p q = GaloisConnection
+  { leftAdjoint  :: p -> q
+  , rightAdjoint :: q -> p
+  }
+
+-- | f x <= y  <=>  x <= g y.  QuickCheck-lifted in the property layer.
+law_adjunction :: (Ord p, Ord q) => GaloisConnection p q -> p -> q -> Bool
+law_adjunction gc x y =
+  (leftAdjoint gc x <= y) == (x <= rightAdjoint gc y)
+
+-- | The contradiction measure: how far the unit x <= g(f x) fails to close
+-- (Laclau's failed identity; ADR051 "gap = measured adjunction defect").
+-- Given a metric d on p, the defect IS the tension.  There is no other
+-- constructor of edge tension in the core: tension cannot be invented,
+-- only measured.
+unitDefect :: (p -> p -> Intensity) -> GaloisConnection p q -> p -> Intensity
+unitDefect d gc x = d x (rightAdjoint gc (leftAdjoint gc x))
+
+-- | Lawvere's Unity-and-Identity-of-Adjoint-Opposites: L ⊣ U ⊣ R.
+-- The shipped instance (ADR051 Phase B): over the SOLIDARITY subgraph,
+-- L = discrete (total atomization), R = codiscrete (total solidarity),
+-- U = underlying node set.  The world's actual solidarity topology sits
+-- BETWEEN two adjoint opposites; atomization is its measured distance
+-- from R's image.
+data AdjointCylinder c d = AdjointCylinder
+  { unity         :: c -> d   -- ^ U
+  , leftOpposite  :: d -> c   -- ^ L ⊣ U  (discrete / atomized pole)
+  , rightOpposite :: d -> c   -- ^ U ⊣ R  (codiscrete / total-solidarity pole)
+  }
+
+law_cylinderLeft :: (Ord c, Ord d) => AdjointCylinder c d -> c -> d -> Bool
+law_cylinderLeft cyl x y =
+  (leftOpposite cyl y <= x) == (y <= unity cyl x)
+
+law_cylinderRight :: (Ord c, Ord d) => AdjointCylinder c d -> c -> d -> Bool
+law_cylinderRight cyl x y =
+  (unity cyl x <= y) == (x <= rightOpposite cyl y)
+
+-- | E1's two level lattices.  Chains today; the class of lattices they
+-- inhabit is Ord + Enum + Bounded.
+data SpatialLevel = HexL | CountyL | StateL | NationL
+  deriving stock (Eq, Ord, Enum, Bounded, Show)
+
+data SocialLevel = IndividualL | CommunityL | ClassL | BlocL
+  deriving stock (Eq, Ord, Enum, Bounded, Show)
+
+data Level = Spatial SpatialLevel | Social SocialLevel
+  deriving stock (Eq, Show)
+
+-- | Aufhebung: the LEAST strictly-higher level at which the opposition
+-- resolves.  Resolution predicate per E1: within-(l+1)-region variance of the
+-- l-aggregates is zero.  Law (by construction): l < aufhebung resolved l.
+aufhebung :: (Ord l, Enum l, Bounded l) => (l -> Bool) -> l -> Maybe l
+aufhebung resolved l =
+  case [ l' | l' <- [minBound .. maxBound], l' > l, resolved l' ] of
+    []       -> Nothing
+    (l' : _) -> Just l'
+
+-- | Motion is primitive; statics are derived (Compact).  A static is a fixed
+-- point of the Picard operator W_{n+1} = T(W_n) — reproduction is not a
+-- separate mechanism but the |rate| <= eps neighborhood of this fixed point.
+newtype Picard a = Picard (a -> a)
+
+staticOf :: Eq a => Int -> Picard a -> a -> Maybe a
+staticOf fuel (Picard t) = go fuel
+  where
+    go 0 _ = Nothing
+    go n w = let w' = t w in if w' == w then Just w else go (n - 1) w'
+
+-- | VIII.9: a pole may reference a COMMUNITY; dyadic reduction of an n-ary
+-- formation is forbidden.  The prohibition is an ABSENCE: no exported arrow
+-- has type CommunityId -> (Pole, Pole).
+data Pole
+  = ClassPole     (NodeId 'SocialClassK)
+  | CommunityPole CommunityId
+  | InstPole      (NodeId 'InstitutionK)
+  deriving stock (Eq, Show)
+
+data Opposition = Opposition
+  { oName    :: String
+  , oPoles   :: (Pole, Pole)
+  , oGap     :: Intensity   -- ^ adjunction defect, fresh this tick (never +=)
+  , oBalance :: Balance
+  , oRate    :: Double      -- ^ d(gap)/dtick
+  , oHome    :: Level       -- ^ OppositionSpec.level_name
+  } deriving stock (Eq, Show)
+
+newtype Epsilon = Epsilon Double deriving newtype (Eq, Ord, Show)
+
+data Regime = Reproduction | Crisis | SublationTo Level
+  deriving stock (Eq, Show)
+
+-- | ADR051 E2, verbatim as a total function: reproduction when |rate| <= eps;
+-- else sublation if a resolving level exists; else crisis.  RUPTURE is the
+-- crisis regime's boiling point — a Fold on the principal gap, gated in
+-- Defines, NOT a separate mechanism.
+classifyRegime :: Epsilon -> Opposition -> Maybe Level -> Regime
+classifyRegime (Epsilon eps) o resolvesAt
+  | abs (oRate o) <= eps = Reproduction
+  | Just l <- resolvesAt = SublationTo l
+  | otherwise            = Crisis
+
+-- | I.13 / ADR051: one contradiction leads per tick; selection is
+-- gap * (1 + rate_weight * |rate|).  rate_weight comes from Defines.
+principal :: Defines -> [Opposition] -> Maybe Opposition
+principal d = \case
+  [] -> Nothing
+  os -> Just (foldl1 (\a b -> if rank b > rank a then b else a) os)
+  where
+    Coefficient rw = dRateWeight d
+    rank o = let Intensity g = oGap o in g * (1 + rw * abs (oRate o))
+
+-- | The constitutional primitive D = (A, A-bar, w, T, sigma).  Partitions are
+-- DERIVED from it (Pi_0 of the induced relation), never primitive.  The field
+-- names align 1:1 with the Compact; sigma is the Aufhebung route if one exists.
+data Dialectic a = Dialectic
+  { dThesis    :: Pole              -- ^ A
+  , dNegation  :: Pole              -- ^ A-bar (determinate negation, not set complement)
+  , dWeight    :: Intensity         -- ^ w — measured, §4 unitDefect only
+  , dMotion    :: Picard a          -- ^ T — motion primitive
+  , dSublation :: a -> Maybe Level  -- ^ sigma — the resolving level, if any
+  }
+
+-- =============================================================================
+-- §5  THE GRAMMAR: nodes, verbs, payloads.
+--
+-- "Verb grammar" is literal: well-formed edges are well-typed sentences.
+-- The typing judgments (which subject kinds an edge verb admits, which object
+-- kinds) are GADT constructor signatures.  An ill-formed edge — ADJACENCY
+-- between two classes, WAGES into a hex — is not invalid data caught by a
+-- validator; it fails to typecheck.  I.14's "edges MUST be directed" is
+-- inherent: a GADT constructor has an ordered signature.
+-- =============================================================================
+
+data NodeKind
+  = SocialClassK | TerritoryK | OrganizationK | InstitutionK
+  | SovereignK   | HexK       | IndustryK     | KeyFigureK
+
+newtype NodeId (k :: NodeKind) = NodeId String
+  deriving newtype (Eq, Ord, Show)
+
+newtype CommunityId = CommunityId String deriving newtype (Eq, Ord, Show)
+
+-- | Singletons: the runtime witness of a node's kind, so heterogeneous
+-- storage can recover the payload type.
+type SNodeKind :: NodeKind -> Type
+data SNodeKind k where
+  SSocialClass  :: SNodeKind 'SocialClassK
+  STerritory    :: SNodeKind 'TerritoryK
+  SOrganization :: SNodeKind 'OrganizationK
+  SInstitution  :: SNodeKind 'InstitutionK
+  SSovereign    :: SNodeKind 'SovereignK
+  SHex          :: SNodeKind 'HexK
+  SIndustry     :: SNodeKind 'IndustryK
+  SKeyFigure    :: SNodeKind 'KeyFigureK
+
+-- Node payloads.  Representative fields only — the full records transcribe
+-- from src/babylon/models at porting time.  All value-plane fields are
+-- kernel-typed; a raw Double in a payload is a review artifact.
+data ClassState = ClassState
+  { csPopulation    :: Extensive Int64
+  , csWealth        :: Currency
+  , csConstantC     :: Currency
+  , csVariableV     :: Currency
+  , csSurplusS      :: Currency
+  , csConsciousness :: Intensity
+  , csIdeology      :: Ideology
+  , csPAcquiesce    :: Probability
+  , csPRebel        :: Probability
+  } deriving stock (Eq, Show)
+
+data TerritoryState = TerritoryState
+  { tsBiocapacity :: Extensive Double   -- ^ B; extraction permanently reduces max (I.8/I.9)
+  , tsConsumption :: Extensive Double   -- ^ C
+  } deriving stock (Eq, Show)
+
+data OrgState = OrgState
+  { osCadre     :: Extensive Int64
+  , osResources :: Currency
+  , osOoda      :: OodaProfile          -- ^ I.17: OODA as organizational metabolism
+  } deriving stock (Eq, Show)
+
+-- | The spatial substrate is IMMUTABLE (Compact): note the absence — no
+-- exported arrow has HexState in its codomain except hydration.
+data HexState        = HexState        deriving stock (Eq, Show)
+data InstitutionState = InstitutionState deriving stock (Eq, Show)
+data SovereignState  = SovereignState  deriving stock (Eq, Show)
+data IndustryState   = IndustryState   deriving stock (Eq, Show)
+data KeyFigureState  = KeyFigureState  deriving stock (Eq, Show)
+
+type NodeData :: NodeKind -> Type
+type family NodeData k where
+  NodeData 'SocialClassK  = ClassState
+  NodeData 'TerritoryK    = TerritoryState
+  NodeData 'OrganizationK = OrgState
+  NodeData 'InstitutionK  = InstitutionState
+  NodeData 'SovereignK    = SovereignState
+  NodeData 'HexK          = HexState
+  NodeData 'IndustryK     = IndustryState
+  NodeData 'KeyFigureK    = KeyFigureState
+
+-- | The verb tags, promoted.  Economic + spatial substrate (managed by the
+-- engine systems) and the political overlay (managed by org verbs).
+data VerbTag
+  = ExploitationV | SolidarityV | WagesV | TributeV | TenancyV | AdjacencyV
+  | MembershipV | PresenceV | OrgRelationV | AttentionV
+
+-- | THE TYPING JUDGMENTS.  Endpoint kinds marked [confirm] must be checked
+-- against src/babylon/models before ratification — they are read off the
+-- database spec and may have drifted.
+type EdgeVerb :: VerbTag -> NodeKind -> NodeKind -> Type
+data EdgeVerb v s t where
+  Exploitation :: EdgeVerb 'ExploitationV 'SocialClassK 'SocialClassK
+  Solidarity   :: EdgeVerb 'SolidarityV   'SocialClassK 'SocialClassK
+  Wages        :: EdgeVerb 'WagesV        'SocialClassK 'SocialClassK   -- core bourgeoisie -> core workers
+  Tribute      :: EdgeVerb 'TributeV      'SocialClassK 'SocialClassK   -- comprador -> core [confirm]
+  Tenancy      :: EdgeVerb 'TenancyV      'SocialClassK 'TerritoryK     -- occupant -> territory
+  Adjacency    :: EdgeVerb 'AdjacencyV    'TerritoryK   'TerritoryK     -- immutable substrate
+  Membership   :: EdgeVerb 'MembershipV   'OrganizationK 'SocialClassK
+  Presence     :: EdgeVerb 'PresenceV     'OrganizationK 'TerritoryK
+  OrgRelation  :: EdgeVerb 'OrgRelationV  'OrganizationK 'OrganizationK
+  Attention    :: EdgeVerb 'AttentionV    'InstitutionK  'OrganizationK -- state apparatus -> org
+
+-- Edge payloads, per verb.
+data FlowData = FlowData
+  { fdFlow    :: Currency    -- ^ Phi conduit on EXPLOITATION; super-wages on WAGES
+  , fdTension :: Intensity   -- ^ fresh per tick (§4: unitDefect only)
+  } deriving stock (Eq, Show)
+
+data BondData = BondData
+  { bdTension    :: Intensity
+  , bdResilience :: Coefficient
+  } deriving stock (Eq, Show)
+
+newtype TenancyData = TenancyData { tdRent :: Currency } deriving stock (Eq, Show)
+
+data Tier = Sympathizer | Member | Cadre deriving stock (Eq, Ord, Show)
+
+newtype MembershipData = MembershipData { mdTier :: Tier } deriving stock (Eq, Show)
+
+newtype PresenceData = PresenceData { pdDepth :: Coefficient } deriving stock (Eq, Show)
+
+data Agreement = Alliance | Ceasefire | UnitedFront | NoAgreement
+  deriving stock (Eq, Show)
+
+data OrgRelationData = OrgRelationData
+  { orMode       :: Mode
+  , orResilience :: Coefficient
+  , orAgreement  :: Agreement
+  , orIntel      :: Coefficient
+  } deriving stock (Eq, Show)
+
+data AttentionPhase = Dormant | Monitoring | Active | Disruption
+  deriving stock (Eq, Show)
+
+data AttentionData = AttentionData
+  { adIntensity :: Intensity
+  , adIntel     :: Coefficient
+  , adPhase     :: AttentionPhase
+  , adStick     :: Coefficient   -- ^ institutional inertia
+  } deriving stock (Eq, Show)
+
+type EdgePayload :: VerbTag -> Type
+type family EdgePayload v where
+  EdgePayload 'ExploitationV = FlowData
+  EdgePayload 'WagesV        = FlowData
+  EdgePayload 'TributeV      = FlowData
+  EdgePayload 'SolidarityV   = BondData
+  EdgePayload 'TenancyV      = TenancyData
+  EdgePayload 'AdjacencyV    = ()           -- the substrate carries no dynamics
+  EdgePayload 'MembershipV   = MembershipData
+  EdgePayload 'PresenceV     = PresenceData
+  EdgePayload 'OrgRelationV  = OrgRelationData
+  EdgePayload 'AttentionV    = AttentionData
+
+-- Heterogeneous storage: the existential seam.  Pattern-matching the verb
+-- constructor RECOVERS the payload type — no isinstance, no dict.get.
+data SomeNode where
+  SomeNode :: SNodeKind k -> NodeId k -> NodeData k -> SomeNode
+
+data SomeEdge where
+  SomeEdge :: EdgeVerb v s t -> NodeId s -> NodeId t -> EdgePayload v -> SomeEdge
+
+-- =============================================================================
+-- §6  THE TOPOLOGY: insertion order as constitutional contract (III.7).
+--
+-- ADR052 preserved NetworkX's iteration contract with insertion-ordered
+-- mirrors around a rustworkx core.  Here the mirror IS the structure: an
+-- insertion-ordered map, pure.  nodesInOrder / edgesInOrder are the III.7
+-- surface; the differential oracle in test_graph_iteration_order.py ports as
+-- the conformance property for THIS structure.
+--
+-- The idiom shift of the whole port lives here: ADR052's payload dicts are
+-- shared by reference and mutated in place; these payloads are values, and
+-- every system is World -> World.  Reference semantics out, state threading in.
+-- =============================================================================
+
+newtype AnyId = AnyId String deriving newtype (Eq, Ord, Show)
+
+eraseId :: NodeId k -> AnyId
+eraseId (NodeId s) = AnyId s
+
+-- | Insertion-ordered map.  Insert of an EXISTING key updates the payload and
+-- keeps the original position (nx merge semantics, ADR052); delete drops the
+-- key from the order.  toListIO is THE iteration contract.
+data InsOrd k v = InsOrd
+  { ioByKey :: Map k v
+  , ioOrder :: Seq k
+  }
+
+emptyIO :: InsOrd k v
+emptyIO = InsOrd Map.empty Seq.empty
+
+insertIO :: Ord k => (v -> v -> v) -> k -> v -> InsOrd k v -> InsOrd k v
+insertIO merge k v (InsOrd m o)
+  | Map.member k m = InsOrd (Map.insertWith merge k v m) o
+  | otherwise      = InsOrd (Map.insert k v m) (o |> k)
+
+lookupIO :: Ord k => k -> InsOrd k v -> Maybe v
+lookupIO k = Map.lookup k . ioByKey
+
+toListIO :: Ord k => InsOrd k v -> [(k, v)]
+toListIO (InsOrd m o) = mapMaybe (\k -> (,) k <$> Map.lookup k m) (toList o)
+
+-- | Directed world topology.  tAdj is per-source insertion-ordered adjacency:
+-- edgesInOrder = source-insertion-then-adjacency, byte-for-byte the ADR052
+-- contract.
+data Topology = Topology
+  { tNodes :: InsOrd AnyId SomeNode
+  , tAdj   :: InsOrd AnyId (InsOrd AnyId SomeEdge)
+  }
+
+emptyTopology :: Topology
+emptyTopology = Topology emptyIO emptyIO
+
+data Violation
+  = DanglingEdge      AnyId AnyId   -- ^ ADR033: edge references nonexistent node
+  | NegativeQuantity  AnyId String
+  | KindMismatch      AnyId
+  | KernelV           KernelViolation
+  deriving stock (Eq, Show)
+
+-- | Nodes enter ONLY with Material provenance (§10, Aleksandrov Test).
+addNode :: SNodeKind k -> NodeId k -> Material (NodeData k) -> Topology -> Topology
+addNode sk nid (Material nd) t =
+  t { tNodes = insertIO (\new _ -> new) (eraseId nid) (SomeNode sk nid nd) (tNodes t) }
+
+-- | Well-kinded by construction (the GADT); well-referenced by check (fail
+-- loud, ADR033).  Payload update on an existing (u,v) replaces; typed
+-- field-level merge is an open ruling (§11).
+addEdge :: EdgeVerb v s t -> NodeId s -> NodeId t -> EdgePayload v
+        -> Topology -> Either Violation Topology
+addEdge ev u v p t
+  | Nothing <- lookupIO (eraseId u) (tNodes t) = Left (DanglingEdge (eraseId u) (eraseId v))
+  | Nothing <- lookupIO (eraseId v) (tNodes t) = Left (DanglingEdge (eraseId u) (eraseId v))
+  | otherwise =
+      let row  = maybe emptyIO id (lookupIO (eraseId u) (tAdj t))
+          row' = insertIO (\new _ -> new) (eraseId v) (SomeEdge ev u v p) row
+      in Right t { tAdj = insertIO (\new _ -> new) (eraseId u) row' (tAdj t) }
+
+nodesInOrder :: Topology -> [SomeNode]
+nodesInOrder = map snd . toListIO . tNodes
+
+edgesInOrder :: Topology -> [SomeEdge]
+edgesInOrder t =
+  [ e | (_, row) <- toListIO (tAdj t), (_, e) <- toListIO row ]
+
+-- =============================================================================
+-- §7  EDGE MODES AS A PRESENTED CATEGORY (I.15; ADR051 E3).
+--
+-- Objects: the modes.  Generating morphisms: the ratified transition table.
+-- The free category on the presentation is Path.  Two constitutional facts
+-- become compiler facts:
+--
+--   1. I.15's prohibition (EXTRACTIVE -> SOLIDARISTIC requires a
+--      TRANSACTIONAL intermediate) is an ABSENCE: there is no such generator,
+--      so no such one-step Path can be written.
+--   2. E3's corrected law ("no direct jump AND a TRANSACTIONAL route exists")
+--      is an INHABITANT: organizingRoute below.  Its existence is checked at
+--      compile time, forever.
+--
+-- Generators below are the DOCUMENTED subset; the full table (17 generators,
+-- ADR051 E3) transcribes 1:1 from the repo source at ratification.  Each
+-- generator carries a gate on contradiction internals (I.15) at the value
+-- level — the type admits the step, the gate admits the occasion.
+-- =============================================================================
+
+data Mode = Extractive | Transactional | Solidaristic | Antagonistic | CoOptive
+  deriving stock (Eq, Show)
+
+type Step :: Mode -> Mode -> Type
+data Step a b where
+  Degrade    :: Step 'Solidaristic 'Transactional   -- under pressure
+  Organize   :: Step 'Transactional 'Solidaristic   -- THE core player mechanic
+  Marketize  :: Step 'Transactional 'Extractive
+  Formalize  :: Step 'Extractive    'Transactional
+  Rebel      :: Step 'Extractive    'Antagonistic   -- consciousness + org gated
+  ResolveS   :: Step 'Antagonistic  'Solidaristic   -- outcome-dependent
+  ResolveT   :: Step 'Antagonistic  'Transactional
+  ResolveE   :: Step 'Antagonistic  'Extractive
+  CoOpt      :: Step 'Antagonistic  'CoOptive       -- [confirm: united-front routes, E3]
+  Break      :: Step 'CoOptive      'Antagonistic   -- [confirm]
+
+data Path a b where
+  Here :: Path a a
+  Then :: Step a b -> Path b c -> Path a c
+
+-- | E3's true law, as a term.  Delete the TRANSACTIONAL intermediate and this
+-- stops compiling — the law cannot silently rot.
+organizingRoute :: Path 'Extractive 'Solidaristic
+organizingRoute = Then Formalize (Then Organize Here)
+
+-- =============================================================================
+-- §8  FORMULAS: pure, Defines-fed, kernel-typed.
+--
+-- Every tunable lives in Defines (GameDefines / defines.yaml — the single
+-- moddable source of truth).  No formula takes a bare Double coefficient;
+-- Defines has no Default instance; a literal has no type to hide behind.
+-- =============================================================================
+
+data Defines = Defines
+  { dSigmoidScale :: Ratio        -- ^ survival sigmoid steepness
+  , dRegimeEps    :: Epsilon      -- ^ tension.regime_rate_epsilon
+  , dRateWeight   :: Coefficient  -- ^ principal-contradiction ranking weight
+  , dSubsistence  :: Currency     -- ^ base_subsistence > 0 (I.8: existence costs calories)
+  , dEta          :: Ratio        -- ^ metabolic eta > 1.0 (I.9)
+  , dRuptureGate  :: Fold Intensity Bool  -- ^ crisis boiling point (E2)
+  , dMobilizeGate :: Fold Intensity Bool  -- ^ MOBILIZE consciousness threshold
+  }
+
+-- | The Fundamental Theorem, as a sum: while W_c > V_c the rent flows and the
+-- core cannot rupture; the theorem is not a comment on a float, it is the
+-- shape of the return type.
+data Rent = RentFlows Currency | RentExhausted
+  deriving stock (Eq, Show)
+
+imperialRent :: Currency -> Currency -> Rent
+imperialRent (Currency (Micro wc)) (Currency (Micro vc))
+  | wc > vc   = RentFlows (Currency (Micro (wc - vc)))
+  | otherwise = RentExhausted
+
+-- | Program-13 portable sigmoid: pure arithmetic, no libm, byte-stable across
+-- implementations.  THIS BODY IS A PLACEHOLDER SHAPE (fast-sigmoid family);
+-- the ratified polynomial and its error bound belong to the Program 13
+-- float-honesty document.  Amendment Q gap (2) closes HERE.
+sigmoidP13 :: Double -> Probability
+sigmoidP13 x = Probability (0.5 * (1 + t / (1 + abs t)))
+  where t = x
+
+-- | P(S|A) = sigmoid(Wealth - Subsistence), scaled from Defines.
+pSurvivalAcq :: Defines -> Currency -> Probability
+pSurvivalAcq d (Currency (Micro w)) =
+  sigmoidP13 (k * (fromIntegral w - fromIntegral s) / 1e6)
+  where
+    Ratio k = dSigmoidScale d
+    Currency (Micro s) = dSubsistence d
+
+-- | P(S|R) = Organization / Repression.  Zero repression is a refusal, not an
+-- infinity; a ratio above 1 saturates, and the saturation is named.
+pSurvivalReb :: Probability -> Probability -> Either KernelViolation Probability
+pSurvivalReb (Probability org) (Probability rep)
+  | rep <= 0  = Left ZeroRepression
+  | otherwise = Right (Probability (min 1 (org / rep)))
+
+-- | Rupture condition: P(S|R) > P(S|A).
+rupture :: Probability -> Probability -> Bool
+rupture pRebel pAcq = pRebel > pAcq
+
+-- | The bifurcation: falling wages route agitation by SOLIDARITY edge
+-- presence.  The witness is obtainable only by querying the topology — the
+-- routing function cannot be called with a fabricated edge.
+data BifurcationPole = Revolution | Fascism   -- -1 / +1
+  deriving stock (Eq, Show)
+
+newtype SolidarityWitness = SolidarityWitness (AnyId, AnyId)  -- constructor NOT exported
+
+requireSolidarity :: NodeId 'SocialClassK -> Topology -> Maybe SolidarityWitness
+requireSolidarity nid t = do
+  row <- lookupIO (eraseId nid) (tAdj t)
+  case [ k | (k, SomeEdge Solidarity _ _ _) <- toListIO row ] of
+    (k : _) -> Just (SolidarityWitness (eraseId nid, k))
+    []      -> Nothing
+
+routeAgitation :: Maybe SolidarityWitness -> BifurcationPole
+routeAgitation (Just _) = Revolution
+routeAgitation Nothing  = Fascism
+
+-- | Metabolic rift: dB = R - E*eta, eta > 1 from Defines; overshoot O = C/B.
+deltaB :: Defines -> Extensive Double -> Extensive Double -> Double
+deltaB d (Extensive r) (Extensive e) = r - e * eta
+  where Ratio eta = dEta d
+
+overshootO :: Extensive Double -> Extensive Double -> Either KernelViolation Ratio
+overshootO (Extensive c) (Extensive b)
+  | b <= 0    = Left (NonPositive "Biocapacity" b)
+  | otherwise = ratio (c / b)
+
+-- =============================================================================
+-- §9  THE TICK: phase-indexed systems, causality as types.
+--
+-- The materialist-causality order (Material Base -> OODA Action ->
+-- Consequences) is today a list in the engine and a discipline in review.
+-- Here a System is indexed by its Phase, the Registry has one slot per phase,
+-- and advance composes the phases in the only order that exists.  Registering
+-- a consequences system into the base slot is a type error.  Within a phase,
+-- the list is the strict registry order (the 28 systems).
+--
+-- advance is a FUNCTION.  Same Defines, same World: same result — III.7 is no
+-- longer a discipline the gates check but a property of the arrow's type
+-- (no IO in its signature).  The RNG is splittable pure state INSIDE World,
+-- seeds pinned per ADR033.
+-- =============================================================================
+
+data Phase = MaterialBase | OodaAction | Consequences
+
+type System :: Phase -> Type
+newtype System p = System { runSystem :: Defines -> World -> (World, [Event]) }
+
+data Registry = Registry
+  { materialBase :: [System 'MaterialBase]
+  , oodaAction   :: [System 'OodaAction]
+  , consequences :: [System 'Consequences]
+  }
+
+data Event
+  = RuptureFired    String            -- opposition name
+  | LevelTransition Level             -- the production Aufhebung signal (ADR051 E2)
+  | RegimeShift     Regime
+  | PrincipalShift  String
+  | VerbExecuted    PlayerVerb
+  deriving stock (Eq, Show)
+
+-- | Placeholder hash carrier.  The REAL recipe is Program 13's canonical
+-- byte-level spec (Amendment Q gap (1)); the fold below exists to pin the
+-- III.7 iteration surface it must consume: nodesInOrder ++ edgesInOrder.
+newtype TickHash = TickHash Word64 deriving newtype (Eq, Show)
+
+-- | Splittable pure generator, seeds pinned (ADR033).  SplitMix at port time;
+-- an LCG stands in so the draft carries no dependency.
+newtype PureGen = PureGen Int64 deriving newtype (Eq, Show)
+
+genStep :: PureGen -> (Int64, PureGen)
+genStep (PureGen s) =
+  let s' = s * 6364136223846793005 + 1442695040888963407
+  in (s', PureGen s')
+
+data World = World
+  { wTopology    :: Topology
+  , wOppositions :: [Opposition]   -- ^ the OppositionRegistry, snapshot
+  , wRng         :: PureGen
+  , wTick        :: Int
+  }
+
+data TickReport = TickReport
+  { trEvents :: [Event]
+  , trHash   :: TickHash
+  }
+
+runPhase :: Defines -> [System p] -> (World, [Event]) -> (World, [Event])
+runPhase d systems (w0, es0) =
+  foldl' (\(w, es) s -> let (w', es') = runSystem s d w in (w', es <> es')) (w0, es0) systems
+
+checkInvariants :: World -> [Violation]
+checkInvariants w =
+  [ NegativeQuantity (eraseId nid) "population"
+  | SomeNode SSocialClass nid st <- nodesInOrder (wTopology w)
+  , let Extensive p = csPopulation st
+  , p < 0
+  ]
+  -- dangling edges are unconstructible (addEdge checks), negative currency is
+  -- unconstructible (smart constructors): those ADR033 invariants moved from
+  -- runtime checks to types.  What remains here is the residue.
+
+tickHash :: World -> TickHash
+tickHash w = TickHash (foldl' fnv 14695981039346656037 (canonical w))
+  where
+    fnv :: Word64 -> Char -> Word64
+    fnv h c = (h `xor` fromIntegral (fromEnum c)) * 1099511628211
+    -- FNV-1a stand-in over the III.7 iteration surface; Program 13 owns the
+    -- ratified byte recipe (field layout, endianness, float encoding).
+    canonical world =
+      concat [ s | SomeNode _ (NodeId s) _ <- nodesInOrder (wTopology world) ]
+
+-- | THE ARROW.  Loud Failure: an invariant violation aborts the tick — there
+-- are no partial ticks and no fabricated states (III.11).
+advance :: Defines -> Registry -> World -> Either Violation (World, TickReport)
+advance d reg w0 =
+  let (w1, es) = runPhase d (consequences reg)
+                   (runPhase d (oodaAction reg)
+                     (runPhase d (materialBase reg) (w0 { wTick = wTick w0 + 1 }, [])))
+  in case checkInvariants w1 of
+       (v : _) -> Left v
+       []      -> Right (w1, TickReport es (tickHash w1))
+
+-- =============================================================================
+-- §10  VERBS AS CAPABILITIES (I.16, I.21, the nine).
+--
+-- Organizations ARE the agents; verbs operate through them.  Each verb's
+-- Requires-clause becomes an argument whose type is an unforgeable witness:
+-- requireMembership is the only mint for MembershipW, so EDUCATE without a
+-- MEMBERSHIP edge is not a rejected action — it is an uncallable function.
+-- The spec's validation table becomes the arguments page of this module.
+-- =============================================================================
+
+data PlayerVerb
+  = Educate | Aid | Attack | Mobilize | Campaign
+  | Move | Investigate | Reproduce | Negotiate
+  deriving stock (Eq, Show)
+
+newtype MembershipW = MembershipW (NodeId 'OrganizationK, NodeId 'SocialClassK)
+newtype PresenceW   = PresenceW   (NodeId 'OrganizationK, NodeId 'TerritoryK)
+
+requireMembership :: NodeId 'OrganizationK -> NodeId 'SocialClassK -> Topology
+                  -> Maybe MembershipW
+requireMembership org cls t = do
+  row <- lookupIO (eraseId org) (tAdj t)
+  case lookupIO (eraseId cls) row of
+    Just (SomeEdge Membership _ _ _) -> Just (MembershipW (org, cls))
+    _                                -> Nothing
+
+requirePresence :: NodeId 'OrganizationK -> NodeId 'TerritoryK -> Topology
+                -> Maybe PresenceW
+requirePresence org terr t = do
+  row <- lookupIO (eraseId org) (tAdj t)
+  case lookupIO (eraseId terr) row of
+    Just (SomeEdge Presence _ _ _) -> Just (PresenceW (org, terr))
+    _                              -> Nothing
+
+-- | I.17: the OODA profile is the organization's metabolism; verbs cost
+-- capacity, and an unpayable verb is unexecutable (Maybe, not exception).
+data OodaProfile = OodaProfile
+  { opObserve :: Coefficient
+  , opOrient  :: Coefficient
+  , opDecide  :: Coefficient
+  , opAct     :: Coefficient
+  } deriving stock (Eq, Show)
+
+-- | EDUCATE, end to end: the one verb given a real body, because it exhibits
+-- the idiom the whole port turns on.  ADR013's systems mutate a shared dict;
+-- here the update is a pure re-insert.  Consciousness rises by a
+-- Defines-scaled delta and SATURATES (named semantic, §1); the edge
+-- resilience upgrade is left to the transcription pass.
+educate :: Defines -> MembershipW -> Double -> World -> (World, [Event])
+educate _d (MembershipW (_org, cls)) delta w =
+  case lookupIO (eraseId cls) (tNodes (wTopology w)) of
+    Just (SomeNode SSocialClass nid st) ->
+      let st' = st { csConsciousness = raiseIntensity (csConsciousness st) delta }
+          n'  = insertIO (\new _ -> new) (eraseId cls)
+                  (SomeNode SSocialClass nid st') (tNodes (wTopology w))
+      in ( w { wTopology = (wTopology w) { tNodes = n' } }
+         , [VerbExecuted Educate] )
+    _ -> (w, [])   -- witness guaranteed the edge; node-kind residue fails soft here,
+                   -- loud in the ported invariant layer
+
+-- =============================================================================
+-- §11  OBSERVATION AND PROVENANCE BOUNDARIES.
+-- =============================================================================
+
+-- | Aleksandrov Test as a type: state enters the world only wrapped in
+-- Material, and Material's constructor is exported ONLY to the hydration
+-- module (the Ledger boundary).  A formal construct with no material source
+-- has no way into the topology.
+newtype Material a = Material a
+
+-- | What the intelligence layer gets: a projection.  World's constructors are
+-- not exported; Chronicle is the entire read surface.  "AI observes and
+-- narrates; the engine adjudicates" stops being a review rule and becomes
+-- linkage fact.
+data Chronicle = Chronicle
+  { chEvents    :: [Event]
+  , chTick      :: Int
+  , chPrincipal :: Maybe String
+  } deriving stock (Eq, Show)
+
+observe :: World -> Chronicle
+observe w = Chronicle
+  { chEvents    = []          -- events stream out of advance, not storage
+  , chTick      = wTick w
+  , chPrincipal = Nothing     -- filled from the opposition registry projection
+  }
+
+-- =============================================================================
+-- §12  LAWS AS VALUES (Amendment Q property layer, sketched).
+--
+-- law_adjunction, law_cylinderLeft/Right above; two more that pin the port:
+-- =============================================================================
+
+-- | III.7 order contract: inserting ks in sequence iterates ks in sequence.
+-- The differential oracle against nx (test_graph_iteration_order.py) ports
+-- against toListIO.
+law_insertionOrder :: [(Int, Char)] -> Bool
+law_insertionOrder kvs =
+  map fst (toListIO built) == dedupFirst (map fst kvs)
+  where
+    built = foldl' (\io (k, v) -> insertIO (\new _ -> new) k v io) emptyIO kvs
+    dedupFirst = go []
+      where go seen (x:xs) | x `elem` seen = go seen xs
+                           | otherwise     = x : go (x:seen) xs
+            go _ [] = []
+
+-- | Sheaf gluing = conservation (ADR051 Phase D): allocation then aggregation
+-- is the identity on totals.
+law_allocateConserves :: [Share] -> Extensive Micro -> Bool
+law_allocateConserves shs total =
+  null shs || sumExtensiveM (allocateExtensive shs total) == total
+  where
+    sumExtensiveM = Extensive . Micro . foldl' (\acc (Extensive (Micro x)) -> acc + x) 0


### PR DESCRIPTION
Owner-directed (2026-07-22): prepare — do not schedule — the typed-core/Mirror program.

- **Preparatory spec**: kernel/system/engine ground truth; every construct of the BD's Haskell draft0 adjudicated against the Lawvere archive (EARNED / CONDITIONAL / UNEARNED-AS-PHRASED) with concrete ratification requirements; the two pre-1.0-eligible Stratum-2 motions (footprint ClassVars, registration sentinel); GHC-in-Nix shape for babylon's own flake; sequencing behind Program 13; open rulings.
- **BD Haskell algebra draft0** committed verbatim as design material.
- **Lawvere evidence base**: 25 papers from `/media/user/data/babylon-data/lawvere-master` read in full by five parallel readers; page-cited digest.

Highlights the adjudication surfaced: Aufhebung must be the `R_T L_S = L_S` closure operator (Hegelian Taco = golden fixture, dimension 3); the "sheaf law" is really the extensive-quantity coproduct law; `allocate ⊣ aggregate` is currently a section of a split epi, not an adjunction; the solidarity cylinder is one functor (`pieces`) short of Lawvere cohesion; ∂L conflates subobject- and subtopos-boundaries and its Leibniz rule must be property-tested, not assumed; Lawverian "chaos" must not be used for I.12 fold catastrophes.

Everything is post-v1.0 and formalism-surface-closed compliant: this prepares the amendment, it is not one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)