### PR TITLE
feat(game+tui): player interface shell — ActionSpec registry, AppShell, four views, two drivers, BDD gate

### DIFF
--- a/src/babylon/game/actions/__init__.py
+++ b/src/babylon/game/actions/__init__.py
@@ -1,0 +1,10 @@
+"""Agent action registry and drivers."""
+
+from babylon.game.actions.registry import (
+    ACTION_REGISTRY,
+    ActionSpec,
+    ActionStatus,
+    actions_for,
+)
+
+__all__ = ["ACTION_REGISTRY", "ActionSpec", "ActionStatus", "actions_for"]

--- a/src/babylon/game/actions/player_driver.py
+++ b/src/babylon/game/actions/player_driver.py
@@ -1,0 +1,65 @@
+"""Player driver — the keyboard write-path, closing the dead ``submit_verb`` seam.
+
+The TUI verb plate is render-only; this module is the caller it names. It gates an action
+against the registry (agent-type + LIVE status) then delegates to the existing
+:func:`babylon.projection.verbs.submit.submit_verb` — which keeps the affordability gate and
+canonical-verb check — feeding the ``TurnSink`` → ``game_turn`` queue. Lives in ``babylon.game``
+(not ``tui``) to respect the projection-only import contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from babylon.game.actions.registry import ACTION_REGISTRY
+from babylon.projection.verbs.submit import TurnSink, submit_verb
+from babylon.topology import BabylonGraph
+
+
+class ActionNotPermitted(RuntimeError):
+    """Raised when an agent type may not issue the requested action."""
+
+
+class ActionNotLive(RuntimeError):
+    """Raised when a registered action is a STUB (no wired effect yet)."""
+
+
+def issue_action(
+    action_id: str,
+    agent_type: str,
+    org_id: str,
+    sink: TurnSink,
+    *,
+    session_id: UUID,
+    tick: int,
+    graph: BabylonGraph,
+    target_id: str | None = None,
+    target_community: str | None = None,
+    params_json: dict[str, Any] | None = None,
+) -> int:
+    """Gate ``action_id`` for ``agent_type`` then enqueue it; return the turn id.
+
+    :raises KeyError: Unknown action id (loud failure).
+    :raises ActionNotPermitted: ``agent_type`` is not in the spec's ``agent_types``.
+    :raises ActionNotLive: The spec is a STUB with no wired effect.
+    :raises ValueError: Propagated from ``submit_verb`` (non-canonical verb or
+        the affordability gate).
+    """
+    spec = ACTION_REGISTRY[action_id]  # KeyError = unknown action (loud)
+    if agent_type not in spec.agent_types:
+        raise ActionNotPermitted(f"{agent_type!r} may not issue {action_id!r}")
+    if spec.status != "LIVE":
+        raise ActionNotLive(f"{action_id!r} is a STUB; no wired effect")
+    return submit_verb(
+        sink,
+        session_id=session_id,
+        tick=tick,
+        org_id=org_id,
+        verb=spec.id,
+        graph=graph,
+        action_type=spec.effect_ref,
+        target_id=target_id,
+        target_community=target_community,
+        params_json=params_json,
+    )

--- a/src/babylon/game/actions/policy.py
+++ b/src/babylon/game/actions/policy.py
@@ -1,0 +1,60 @@
+"""Deterministic CPU ActionPolicy — the generalized npc_stub.
+
+Non-human agents (state, corporations, institutions) decide via this deterministic policy over
+the shared ActionSpec registry, seated in-tick and part of the hash (design §A: "opponents ARE
+the physics"). Ordering reuses :data:`babylon.ooda.npc_stub._NPC_PRIORITIES` — the per-OrgType
+priority table — with a stable id tiebreak for unlisted actions; no LLM, no wall-clock, no
+randomness.
+
+Follow-up (flagged in the design, out of this task): route the selected actions through the
+SAME game_turn queue player verbs use, so human and CPU actions are adjudicated identically —
+today npc_stub writes engine state directly. That unification is an engine refactor.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from babylon.game.actions.registry import ActionSpec, actions_for
+from babylon.models.enums import OrgType
+from babylon.ooda.npc_stub import _NPC_PRIORITIES
+
+#: Registry agent types → the engine OrgType whose npc_stub priority list orders them.
+_AGENT_TYPE_TO_ORG_TYPE: dict[str, str] = {
+    "organizer": OrgType.POLITICAL_FACTION.value,
+    "state": OrgType.STATE_APPARATUS.value,
+    "corporation": OrgType.BUSINESS.value,
+}
+
+
+def _priority_key(spec: ActionSpec, priorities: list[str]) -> tuple[int, str]:
+    """Sort key: position in the org-type priority table, then stable id tiebreak."""
+    try:
+        rank = priorities.index(spec.effect_ref)
+    except ValueError:
+        rank = len(priorities)
+    return (rank, spec.id)
+
+
+def select_actions(
+    agent_type: str,
+    budget: int,
+    observed: Mapping[str, float],  # noqa: ARG001 — the precondition feed, evaluated at wiring
+) -> tuple[str, ...]:
+    """Greedily select LIVE actions for ``agent_type`` until ``budget`` is spent.
+
+    Deterministic: same inputs → same output tuple. ``observed`` is the agent's
+    projected observation, reserved for the registry's named preconditions —
+    the selection itself is priority-table-driven.
+    """
+    org_type = _AGENT_TYPE_TO_ORG_TYPE.get(agent_type, "")
+    priorities = [a.value for a in _NPC_PRIORITIES.get(org_type, [])]
+    chosen: list[str] = []
+    remaining = budget
+    for spec in sorted(actions_for(agent_type), key=lambda s: _priority_key(s, priorities)):
+        if spec.status != "LIVE":
+            continue
+        if spec.cost <= remaining:
+            chosen.append(spec.id)
+            remaining -= spec.cost
+    return tuple(chosen)

--- a/src/babylon/game/actions/registry.py
+++ b/src/babylon/game/actions/registry.py
@@ -1,0 +1,103 @@
+"""The unified, agent-type-gated action registry.
+
+One action algebra: the player's nine Article V verbs and the institutional macro-actions are
+all :class:`ActionSpec` rows, gated by ``agent_types``. Intersections are actions available to
+several types. ``status`` marks whether the effect is wired (``LIVE``) or an honest placeholder
+(``STUB``). See ``project/research/24-the-archive/PLAYER_INTERFACE_SHELL_design.md`` §D.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from babylon.projection.verbs.preview import CANONICAL_VERBS, VERB_TO_ACTION_TYPE
+
+ActionStatus = Literal["LIVE", "STUB"]
+
+
+class ActionSpec(BaseModel):
+    """A single action any qualifying agent may issue.
+
+    :param id: stable action key (a verb name or macro-action slug).
+    :param label: human-facing label for the action bar / dossier.
+    :param agent_types: the agent types permitted to issue it.
+    :param cost: action-point cost.
+    :param preconditions: named precondition keys (evaluated by the driver).
+    :param effect_ref: the engine ``ActionType`` (or macro-effect slug) this maps to.
+    :param status: ``LIVE`` if the effect is wired, ``STUB`` for an honest placeholder.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: str
+    label: str
+    agent_types: frozenset[str]
+    cost: int = Field(ge=0)
+    preconditions: tuple[str, ...] = ()
+    effect_ref: str
+    status: ActionStatus
+
+
+_ORGANIZER = frozenset({"organizer"})
+_STATE_CORP = frozenset({"state", "corporation"})
+
+# The nine Article V verbs — LIVE, organizer-gated, mapped to real engine ActionTypes.
+_VERB_LABELS = {
+    "educate": "Educate",
+    "reproduce": "Reproduce",
+    "attack": "Attack",
+    "mobilize": "Mobilize",
+    "campaign": "Campaign",
+    "aid": "Aid",
+    "investigate": "Investigate",
+    "move": "Move",
+    "negotiate": "Negotiate",
+}
+
+# Institutional macro-actions — STUB for v1.0 (mechanics gated on Vol I+II and beyond).
+_STUB_MACRO = (
+    ("construct", "Invest in construction"),
+    ("fund_research", "Fund scientific research"),
+    ("guide_tech", "Guide technology research"),
+    ("procure_military", "Procure military equipment"),
+    ("police", "Direct policing"),
+    ("public_health", "Fund public health"),
+    ("courts", "Direct the courts"),
+    ("trade", "Conduct trade"),
+    ("logistics", "Direct freight & logistics"),
+)
+
+
+def _build_registry() -> dict[str, ActionSpec]:
+    registry: dict[str, ActionSpec] = {}
+    for verb in sorted(CANONICAL_VERBS):
+        registry[verb] = ActionSpec(
+            id=verb,
+            label=_VERB_LABELS[verb],
+            agent_types=_ORGANIZER,
+            cost=1,
+            effect_ref=VERB_TO_ACTION_TYPE[verb],
+            status="LIVE",
+        )
+    for slug, label in _STUB_MACRO:
+        registry[slug] = ActionSpec(
+            id=slug,
+            label=label,
+            agent_types=_STATE_CORP,
+            cost=1,
+            effect_ref=f"macro.{slug}",
+            status="STUB",
+        )
+    return registry
+
+
+ACTION_REGISTRY: dict[str, ActionSpec] = _build_registry()
+
+
+def actions_for(agent_type: str) -> tuple[ActionSpec, ...]:
+    """Return the actions a given agent type may issue, id-sorted for determinism."""
+    return tuple(
+        spec for _, spec in sorted(ACTION_REGISTRY.items()) if agent_type in spec.agent_types
+    )

--- a/src/babylon/tui/shell/__init__.py
+++ b/src/babylon/tui/shell/__init__.py
@@ -1,0 +1,1 @@
+"""The v1.0 player interface shell (design: PLAYER_INTERFACE_SHELL_design.md)."""

--- a/src/babylon/tui/shell/app_shell.py
+++ b/src/babylon/tui/shell/app_shell.py
@@ -48,3 +48,10 @@ class AppShell(App[None]):
     def action_switch_view(self, view: str) -> None:
         """Switch the main region to ``view`` (one of the four domain pane ids)."""
         self.query_one("#main", ContentSwitcher).current = view
+
+    def export_visible_text(self) -> str:
+        """Export the visible widget tree as plain text (BDD capture, design §G)."""
+        # Lazy import: bdd may grow an AppShell type reference; keep the seam one-way.
+        from babylon.tui.shell.bdd.harness import export_visible_text
+
+        return export_visible_text(self)

--- a/src/babylon/tui/shell/app_shell.py
+++ b/src/babylon/tui/shell/app_shell.py
@@ -1,0 +1,50 @@
+"""The hybrid player shell: tabbed main region + persistent rails.
+
+Layout (design §B): docked header · left chronicle rail · right watchlist rail · bottom action
+bar · a ``ContentSwitcher`` main region across the four domains, switched by number keys. Views
+are projection clients only — the shell never imports the engine (import-linter contract).
+"""
+
+from __future__ import annotations
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.widgets import ContentSwitcher, Footer, Header, Static
+
+_VIEW_ORDER = ("dashboard", "map", "wiki", "topology")
+
+
+class DomainPane(Static):
+    """Placeholder pane; replaced by real view widgets in Phase 3."""
+
+
+class AppShell(App[None]):
+    """Root player shell."""
+
+    CSS = """
+    #chronicle-rail { width: 24; dock: left; border-right: solid $panel; }
+    #watchlist-rail { width: 24; dock: right; border-left: solid $panel; }
+    #action-bar { height: 3; dock: bottom; border-top: solid $panel; }
+    #main { height: 1fr; }
+    """
+
+    BINDINGS = [
+        Binding(str(i + 1), f"switch_view({name!r})", name.capitalize())
+        for i, name in enumerate(_VIEW_ORDER)
+    ]
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static("chronicle", id="chronicle-rail")
+        yield Static("watchlist", id="watchlist-rail")
+        with Vertical():
+            with ContentSwitcher(initial="dashboard", id="main"):
+                for name in _VIEW_ORDER:
+                    yield DomainPane(name, id=name)
+            yield Static("action bar", id="action-bar")
+        yield Footer()
+
+    def action_switch_view(self, view: str) -> None:
+        """Switch the main region to ``view`` (one of the four domain pane ids)."""
+        self.query_one("#main", ContentSwitcher).current = view

--- a/src/babylon/tui/shell/backlinks.py
+++ b/src/babylon/tui/shell/backlinks.py
@@ -1,0 +1,33 @@
+"""Computed backlink index for the Wiki view (design §C3).
+
+Replaces the current backlinks-as-convention ("incidence") with a real "what links here",
+derived cheaply by inverting each page's outbound wikilinks. Link grammar is
+:data:`babylon.tui.wikilinks.WIKILINK_RE` — reused, never re-derived. Full property-query
+language is a post-1.0 BFM concern; this is the v1.0 semantic floor.
+"""
+
+from __future__ import annotations
+
+from babylon.tui.wikilinks import WIKILINK_RE
+
+
+def _outbound(markdown: str) -> set[str]:
+    return {m.group(1).strip() for m in WIKILINK_RE.finditer(markdown)}
+
+
+def build_backlink_index(pages: dict[str, str]) -> dict[str, tuple[str, ...]]:
+    """Return target-slug → sorted sources linking to it. Targets with no inbound links absent."""
+    inbound: dict[str, set[str]] = {}
+    for source, markdown in pages.items():
+        for target in _outbound(markdown):
+            inbound.setdefault(target, set()).add(source)
+    return {target: tuple(sorted(sources)) for target, sources in inbound.items()}
+
+
+def facets_by_type(pages: dict[str, str]) -> dict[str, tuple[str, ...]]:
+    """Group page slugs by their type prefix (``county/26163`` → type ``county``)."""
+    facets: dict[str, set[str]] = {}
+    for slug in pages:
+        page_type = slug.split("/", 1)[0]
+        facets.setdefault(page_type, set()).add(slug)
+    return {t: tuple(sorted(members)) for t, members in facets.items()}

--- a/src/babylon/tui/shell/bdd/__init__.py
+++ b/src/babylon/tui/shell/bdd/__init__.py
@@ -1,0 +1,1 @@
+"""The three-layer BDD e2e gate: Pilot harness + assertion layers (design §G)."""

--- a/src/babylon/tui/shell/bdd/assertions.py
+++ b/src/babylon/tui/shell/bdd/assertions.py
@@ -1,0 +1,67 @@
+"""The three BDD assertion layers (design §G): behavior · render · algebra.
+
+One transcript validates all three: every verb is exercised (coverage), the emitted text is what
+the player should see (render), and the state the verbs produced obeys the mathematical-core
+property laws (algebra). Determinism uses the v1.0 replay-identity hash; content-hash arrives
+with III.13. The algebra layer honors honest-None (III.11): an absent Φ feed is an absence,
+never a violation — only present values are law-checked.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+from babylon.projection.verbs.preview import CANONICAL_VERBS
+from babylon.projection.view_models import EconomyView
+from babylon.tui.shell.bdd.harness import TutorialStep
+
+
+class CoverageError(AssertionError):
+    """Layer 1: a canonical verb was never exercised (a dead option = ∂L red gate)."""
+
+
+class RenderError(AssertionError):
+    """Layer 2: the emitted screen text did not contain an expected fragment."""
+
+
+class InvariantError(AssertionError):
+    """Layer 3: an algebraic property law was violated."""
+
+
+def assert_coverage(steps: Sequence[TutorialStep]) -> None:
+    """Layer 1 — every canonical verb appears in the step script."""
+    exercised = {step.verb for step in steps}
+    missing = sorted(CANONICAL_VERBS - exercised)
+    if missing:
+        raise CoverageError(f"verbs never exercised (dead options): {missing}")
+
+
+def assert_render(captured: str, expect: Sequence[str]) -> None:
+    """Layer 2 — every expected fragment appears in the captured screen text."""
+    for fragment in expect:
+        if fragment not in captured:
+            raise RenderError(f"expected {fragment!r} in emitted screen text; not found")
+
+
+def assert_invariants(econ: EconomyView, replay_hashes: Sequence[str]) -> None:
+    """Layer 3 — Φ component non-negativity, tri-decomposition closure, hash stability."""
+    components = (
+        ("phi_unequal_exchange", econ.phi_unequal_exchange),
+        ("phi_reproduction", econ.phi_reproduction),
+        ("phi_domestic", econ.phi_domestic),
+    )
+    for name, value in components:
+        if value is not None and value < 0:
+            raise InvariantError(f"Φ component {name}={value} < 0")
+    if econ.phi_decomposition_total is not None:
+        present = [value for _, value in components if value is not None]
+        if len(present) == len(components):
+            expected = sum(present)
+            if not math.isclose(econ.phi_decomposition_total, expected, rel_tol=1e-9):
+                raise InvariantError(
+                    f"Φ closure broken: total={econ.phi_decomposition_total} "
+                    f"≠ φ_UE+φ_repro+φ_dom={expected}"
+                )
+    if len(set(replay_hashes)) > 1:
+        raise InvariantError(f"replay-identity hash drifted across run: {list(replay_hashes)}")

--- a/src/babylon/tui/shell/bdd/harness.py
+++ b/src/babylon/tui/shell/bdd/harness.py
@@ -1,0 +1,53 @@
+"""BDD harness — headless Pilot text-capture (design §G).
+
+Runs the shell via Textual Pilot, issues a step's verb, and captures the emitted screen text —
+the raw render of what the player sees. Determinism: narrator OFF (byte-reproducible); no
+wall-clock. Text export uses a recording Rich Console (Textual 8.2.8 has no App.export_text).
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+from rich.console import Console
+from textual.app import App
+from textual.pilot import Pilot
+from textual.widget import Widget
+
+
+class TutorialStep(BaseModel):
+    """One tutorial/BDD step: a verb to issue and the text expected on the resulting screen."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    verb: str
+    expect_text: tuple[str, ...]
+
+
+def export_visible_text(app: App[Any]) -> str:
+    """Export the currently-visible widget tree as plain text via a recording Console.
+
+    Textual 8.2.8 has no ``App.export_text``; content-bearing widgets (``Static`` and its
+    subclasses) expose their visual via ``render()`` — containers render blank and are skipped
+    by the emptiness check, keeping the capture to what the player actually reads.
+    """
+    console = Console(record=True, width=app.size.width or 120, file=io.StringIO())
+    for node in app.screen.walk_children():
+        if not isinstance(node, Widget):
+            continue
+        rendered = node.render()
+        # Only content-bearing renders carry .plain (textual Content / rich Text);
+        # container fills (Blank) stringify with memory addresses — never capture those.
+        text = getattr(rendered, "plain", None)
+        if text is not None and text.strip():
+            console.print(text)
+    return console.export_text()
+
+
+async def run_step(pilot: Pilot[Any], step: TutorialStep) -> str:
+    """Issue ``step.verb`` and return the captured screen text after it settles."""
+    await pilot.press(*step.verb)  # verb keybinding; integration maps verb→key
+    await pilot.pause()
+    return export_visible_text(pilot.app)

--- a/src/babylon/tui/shell/views/__init__.py
+++ b/src/babylon/tui/shell/views/__init__.py
@@ -1,0 +1,1 @@
+"""Domain view widgets hosted by the AppShell's ContentSwitcher."""

--- a/src/babylon/tui/shell/views/dashboard_view.py
+++ b/src/babylon/tui/shell/views/dashboard_view.py
@@ -1,0 +1,60 @@
+"""The Dashboard domain view — the economy read-model.
+
+Renders T3's :class:`~babylon.projection.view_models.EconomyView`: the Fundamental-Theorem
+verdict off the ``wage`` opposition balance, the Φ tri-decomposition, the Vol III surplus
+split, and the matter book. All values arrive as extensive ratio-of-sums from the projection
+(design §C1) — this view only formats them. Honest-None discipline (III.11): an unwired feed
+renders as a loud absence, never a fabricated zero.
+"""
+
+from __future__ import annotations
+
+from textual.widget import Widget
+
+from babylon.projection.view_models import EconomyView
+
+_ABSENT = "— absent (feed unwired)"
+
+
+def _fmt(value: float | None, *, prefix: str = "", digits: int = 4) -> str:
+    if value is None:
+        return _ABSENT
+    return f"{prefix}{value:.{digits}g}"
+
+
+def render_economy_text(view: EconomyView) -> str:
+    """Format the economy read-model as glyph-floor text."""
+    if view.wage_balance is None or view.labor_aristocracy_verdict is None:
+        theorem = f"FUNDAMENTAL THEOREM: {_ABSENT}"
+    else:
+        verdict = (
+            "revolution impossible (Wc>Vc)"
+            if view.labor_aristocracy_verdict
+            else "revolution not-impossible (Wc≤Vc)"
+        )
+        theorem = f"FUNDAMENTAL THEOREM: wage balance {view.wage_balance:+.2f} → {verdict}"
+    phi = (
+        f"IMPERIAL RENT Φ={_fmt(view.phi_decomposition_total)}"
+        f"  (φ_UE={_fmt(view.phi_unequal_exchange)}"
+        f" φ_repro={_fmt(view.phi_reproduction)}"
+        f" φ_dom={_fmt(view.phi_domestic)})"
+    )
+    surplus = (
+        f"SURPLUS s={_fmt(view.surplus_produced)}"
+        f"  (p={_fmt(view.profit_of_enterprise)} i={_fmt(view.interest_burden)}"
+        f" r={_fmt(view.ground_rent)} t={_fmt(view.taxes_on_surplus)})"
+    )
+    matter = (
+        f"MATTER O={_fmt(view.overshoot_ratio)}"
+        f"  (C={_fmt(view.total_consumption)} B={_fmt(view.total_biocapacity)}"
+        f" M̄={_fmt(view.biocapacity_ceiling)})"
+    )
+    return "\n".join((theorem, phi, surplus, matter))
+
+
+class DashboardView(Widget):
+    """Economic dashboard pane."""
+
+    def render_economy(self, view: EconomyView) -> str:
+        """Render ``view`` as the pane's glyph-floor body text."""
+        return render_economy_text(view)

--- a/src/babylon/tui/shell/views/map_view.py
+++ b/src/babylon/tui/shell/views/map_view.py
@@ -1,0 +1,28 @@
+"""The Map domain view — choropleth with selectable lenses.
+
+The lens promotes today's fog/class-vision payload gate into a player-selectable overlay, plus
+value-band and tension lenses. Rendering reuses ``render_map_room`` (glyph floor + kitty raster
+at information parity, ADR097). No engine import — the shell hands lens+cells to the renderer.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, get_args
+
+from textual.reactive import reactive
+from textual.widget import Widget
+
+MapLens = Literal["value", "tension", "fog"]
+_LENSES = frozenset(get_args(MapLens))
+
+
+class MapView(Widget):
+    """Choropleth map with a lens selector."""
+
+    lens: reactive[MapLens] = reactive("value")
+
+    def set_lens(self, lens: MapLens) -> None:
+        """Select the active lens; raises ``ValueError`` on an unknown lens (loud failure)."""
+        if lens not in _LENSES:
+            raise ValueError(f"unknown map lens {lens!r}; known: {sorted(_LENSES)}")
+        self.lens = lens

--- a/src/babylon/tui/shell/views/topology_view.py
+++ b/src/babylon/tui/shell/views/topology_view.py
@@ -1,0 +1,34 @@
+"""The Topology domain view — the graph, text-floor first.
+
+Glyph floor: the existing ASCII incidence/egotree/PAOH renderers. Raster polish (rustworkx /
+XGI → SVG/PNG via the kitty lane) hooks in later, always over a text floor. Individuals and
+coalitions are NOT production node types (KEY_FIGURE retired ADR084, PERSON fixture-only) — they
+render as declared-future absence, never as fabricated nodes (design §C4).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from textual.widget import Widget
+
+TopologyKind = Literal["incidence", "egotree", "paoh"]
+
+_ABSENT_KINDS = {
+    "individual": "Individuals are not yet a production node type (design §C4).",
+    "coalition": "Coalitions/alliances are not yet a production node type (design §C4).",
+}
+
+
+def render_absence(node_kind: str) -> str:
+    """Render a visible declared-future stub for a node kind that does not exist in production."""
+    reason = _ABSENT_KINDS.get(node_kind, f"{node_kind} is not a production node type.")
+    return f"▌ {node_kind}: {reason}"
+
+
+class TopologyView(Widget):
+    """Graph view over org/institution/sovereign/faction/class/territory nodes."""
+
+    def render_topology(self, kind: TopologyKind) -> str:
+        """Render the requested topology surface; bound to the live graph at T4-integration."""
+        raise NotImplementedError("bound to live graph at T4-integration")

--- a/src/babylon/tui/shell/views/wiki_view.py
+++ b/src/babylon/tui/shell/views/wiki_view.py
@@ -1,0 +1,25 @@
+"""The Wiki domain view — the baked-vault reader.
+
+Wraps the existing wikilink-aware markdown renderer. The current single-document ArchiveApp body
+becomes this pane; page navigation swaps the document in place (no Screen push).
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
+from textual.widget import Widget
+
+from babylon.tui.app import BabylonMarkdown
+
+
+class WikiView(Widget):
+    """Renders one vault markdown page with wikilink resolution."""
+
+    def compose(self) -> ComposeResult:
+        with VerticalScroll():
+            yield BabylonMarkdown(id="wiki-doc")
+
+    def load_page(self, markdown: str) -> None:
+        """Replace the displayed document with ``markdown``."""
+        self.query_one("#wiki-doc", BabylonMarkdown).update(markdown)

--- a/tests/unit/game/actions/test_player_driver.py
+++ b/tests/unit/game/actions/test_player_driver.py
@@ -1,0 +1,81 @@
+"""Behavioral contract for the player driver — the action-bar → submit_verb seam (Task 8)."""
+
+from uuid import uuid4
+
+import pytest
+
+from babylon.game.actions.player_driver import (
+    ActionNotLive,
+    ActionNotPermitted,
+    issue_action,
+)
+from babylon.topology import BabylonGraph
+
+
+class _RecordingSink:
+    """Journal stub satisfying the real TurnSink protocol shape."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def submit_turn(
+        self,
+        session_id,
+        tick,
+        org_id,
+        verb,
+        *,
+        action_type=None,
+        target_id=None,
+        target_community=None,
+        params_json=None,
+    ) -> int:
+        self.calls.append(
+            {
+                "session_id": session_id,
+                "tick": tick,
+                "org_id": org_id,
+                "verb": verb,
+                "action_type": action_type,
+                "target_id": target_id,
+            }
+        )
+        return len(self.calls)
+
+
+def _issue(action_id: str, agent_type: str, sink: _RecordingSink) -> int:
+    return issue_action(
+        action_id,
+        agent_type,
+        "org/vanguard",
+        sink,
+        session_id=uuid4(),
+        tick=3,
+        graph=BabylonGraph(),
+    )
+
+
+def test_organizer_can_issue_a_live_verb_through_submit_verb():
+    sink = _RecordingSink()
+    turn_id = _issue("educate", "organizer", sink)
+    assert turn_id == 1
+    (call,) = sink.calls
+    assert call["org_id"] == "org/vanguard"
+    assert call["verb"] == "educate"
+    assert call["tick"] == 3
+    assert call["action_type"] == "educate"  # the spec's effect_ref passthrough
+
+
+def test_state_cannot_issue_an_organizer_verb():
+    with pytest.raises(ActionNotPermitted):
+        _issue("educate", "state", _RecordingSink())
+
+
+def test_stub_action_is_refused_as_not_live():
+    with pytest.raises(ActionNotLive):
+        _issue("fund_research", "state", _RecordingSink())
+
+
+def test_unknown_action_fails_loud():
+    with pytest.raises(KeyError):
+        _issue("teleport", "organizer", _RecordingSink())

--- a/tests/unit/game/actions/test_policy.py
+++ b/tests/unit/game/actions/test_policy.py
@@ -1,0 +1,29 @@
+"""Behavioral contract for the deterministic CPU ActionPolicy (Task 9)."""
+
+from babylon.game.actions.policy import select_actions
+
+
+def test_selection_is_deterministic_and_budget_bounded():
+    observed = {"repression": 0.4, "solidarity": 0.7}
+    a = select_actions("organizer", budget=2, observed=observed)
+    b = select_actions("organizer", budget=2, observed=observed)
+    assert a == b  # deterministic
+    assert len(a) <= 2  # budget-bounded
+    assert all(isinstance(x, str) for x in a)
+
+
+def test_zero_budget_selects_nothing():
+    assert select_actions("organizer", budget=0, observed={}) == ()
+
+
+def test_priority_table_orders_selection():
+    # npc_stub's POLITICAL_FACTION priorities open with EDUCATE — the organizer's
+    # first pick must follow the table, not alphabetical order ("aid" would win that).
+    selected = select_actions("organizer", budget=1, observed={})
+    assert selected == ("educate",)
+
+
+def test_only_live_actions_are_selected():
+    # state/corporation actions are all STUBs today — an honest empty selection,
+    # never a fabricated macro-action.
+    assert select_actions("corporation", budget=5, observed={}) == ()

--- a/tests/unit/game/actions/test_registry.py
+++ b/tests/unit/game/actions/test_registry.py
@@ -1,0 +1,35 @@
+"""Behavioral contract for the unified agent-type-gated action registry (Task 1)."""
+
+import pytest
+from pydantic import ValidationError
+
+from babylon.game.actions.registry import ACTION_REGISTRY, ActionSpec, actions_for
+from babylon.projection.verbs.preview import CANONICAL_VERBS
+
+
+def test_all_nine_verbs_present_as_live_organizer_actions():
+    for verb in CANONICAL_VERBS:
+        spec = ACTION_REGISTRY[verb]
+        assert isinstance(spec, ActionSpec)
+        assert spec.status == "LIVE"
+        assert "organizer" in spec.agent_types
+
+
+def test_institutional_stub_is_gated_and_marked():
+    spec = ACTION_REGISTRY["fund_research"]
+    assert spec.status == "STUB"
+    assert spec.agent_types == frozenset({"state", "corporation"})
+    assert "organizer" not in spec.agent_types
+
+
+def test_actions_for_filters_by_agent_type():
+    organizer = {s.id for s in actions_for("organizer")}
+    assert organizer >= CANONICAL_VERBS
+    assert "fund_research" not in organizer
+    assert "fund_research" in {s.id for s in actions_for("state")}
+
+
+def test_actionspec_is_frozen():
+    spec = ACTION_REGISTRY["educate"]
+    with pytest.raises(ValidationError):
+        spec.label = "mutated"  # frozen

--- a/tests/unit/tui/shell/bdd/test_assertions.py
+++ b/tests/unit/tui/shell/bdd/test_assertions.py
@@ -1,0 +1,68 @@
+"""Behavioral contract for the three BDD assertion layers (Task 11)."""
+
+import pytest
+
+from babylon.projection.view_models import EconomyView
+from babylon.tui.shell.bdd.assertions import (
+    CoverageError,
+    InvariantError,
+    RenderError,
+    assert_coverage,
+    assert_invariants,
+    assert_render,
+)
+from babylon.tui.shell.bdd.harness import TutorialStep
+
+
+def _econ(**overrides) -> EconomyView:
+    base = {"economy_id": "USA", "verified_tick": 1}
+    base.update(overrides)
+    return EconomyView(**base)
+
+
+def test_coverage_reds_when_a_verb_is_never_exercised():
+    steps = [TutorialStep(verb="educate", expect_text=())]
+    with pytest.raises(CoverageError) as e:
+        assert_coverage(steps)
+    assert "attack" in str(e.value)  # names a missing verb
+
+
+def test_render_layer_matches_expected_text():
+    assert_render("FUNDAMENTAL THEOREM: wage balance +0.25", ("wage balance +0.25",))
+    with pytest.raises(RenderError):
+        assert_render("nothing here", ("wage balance +0.25",))
+
+
+def test_invariants_catch_negative_phi_component():
+    good = _econ(
+        phi_unequal_exchange=10.0,
+        phi_reproduction=5.0,
+        phi_domestic=3.0,
+        phi_decomposition_total=18.0,
+    )
+    assert_invariants(good, replay_hashes=["abc", "abc", "abc"])
+    with pytest.raises(InvariantError):
+        assert_invariants(_econ(phi_unequal_exchange=-1.0), replay_hashes=["abc", "abc"])
+
+
+def test_invariants_catch_broken_phi_closure():
+    with pytest.raises(InvariantError):
+        assert_invariants(
+            _econ(
+                phi_unequal_exchange=10.0,
+                phi_reproduction=5.0,
+                phi_domestic=3.0,
+                phi_decomposition_total=99.0,  # violates total = UE + repro + dom
+            ),
+            replay_hashes=["abc"],
+        )
+
+
+def test_invariants_catch_replay_hash_drift():
+    with pytest.raises(InvariantError):
+        assert_invariants(_econ(), replay_hashes=["abc", "def"])
+
+
+def test_invariants_accept_honest_absence():
+    # All-None Φ feeds are an absence, not a violation.
+    assert_invariants(_econ(), replay_hashes=["abc", "abc"])

--- a/tests/unit/tui/shell/bdd/test_harness.py
+++ b/tests/unit/tui/shell/bdd/test_harness.py
@@ -1,0 +1,23 @@
+"""Behavioral contract for the BDD Pilot text-capture harness (Task 10)."""
+
+import pytest
+from pydantic import ValidationError
+
+from babylon.tui.shell.app_shell import AppShell
+from babylon.tui.shell.bdd.harness import TutorialStep, export_visible_text
+
+
+def test_tutorial_step_is_frozen():
+    step = TutorialStep(verb="educate", expect_text=("Educate",))
+    with pytest.raises(ValidationError):
+        step.verb = "attack"
+
+
+@pytest.mark.asyncio
+async def test_export_visible_text_is_deterministic():
+    app = AppShell()
+    async with app.run_test():
+        first = export_visible_text(app)
+        second = export_visible_text(app)
+        assert first == second  # no wall-clock, reproducible
+        assert "action bar" in first

--- a/tests/unit/tui/shell/conftest.py
+++ b/tests/unit/tui/shell/conftest.py
@@ -1,0 +1,43 @@
+"""Shared fixtures for shell view tests.
+
+``make_shell_harness`` mounts a single widget in a minimal harness app and yields the Pilot —
+the pattern Tasks 3-6 use to exercise a view in isolation. The harness app exposes
+``export_visible_text()`` (Task 10's helper) so view tests can assert on emitted screen text.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widget import Widget
+
+from babylon.tui.shell.bdd.harness import export_visible_text
+
+
+class _HarnessApp(App[None]):
+    """Minimal single-widget host used by view unit tests."""
+
+    def __init__(self, widget: Widget) -> None:
+        super().__init__()
+        self._widget = widget
+
+    def compose(self) -> ComposeResult:
+        yield self._widget
+
+    def export_visible_text(self) -> str:
+        return export_visible_text(self)
+
+
+@pytest.fixture
+def make_shell_harness():
+    """Factory: ``async with make_shell_harness(view) as pilot`` mounts ``view`` alone."""
+
+    @asynccontextmanager
+    async def _harness(widget: Widget):
+        app = _HarnessApp(widget)
+        async with app.run_test() as pilot:
+            yield pilot
+
+    return _harness

--- a/tests/unit/tui/shell/test_app_shell.py
+++ b/tests/unit/tui/shell/test_app_shell.py
@@ -1,0 +1,28 @@
+"""Behavioral contract for the AppShell hybrid layout (Task 2)."""
+
+import pytest
+from textual.widgets import ContentSwitcher
+
+from babylon.tui.shell.app_shell import AppShell
+
+
+@pytest.mark.asyncio
+async def test_shell_boots_with_four_domain_panes():
+    app = AppShell()
+    async with app.run_test():
+        switcher = app.query_one("#main", ContentSwitcher)
+        ids = {child.id for child in switcher.children}
+        assert ids == {"dashboard", "map", "wiki", "topology"}
+        assert app.query_one("#chronicle-rail") is not None
+        assert app.query_one("#watchlist-rail") is not None
+        assert app.query_one("#action-bar") is not None
+
+
+@pytest.mark.asyncio
+async def test_number_keys_switch_the_main_view():
+    app = AppShell()
+    async with app.run_test() as pilot:
+        await pilot.press("2")
+        assert app.query_one("#main", ContentSwitcher).current == "map"
+        await pilot.press("3")
+        assert app.query_one("#main", ContentSwitcher).current == "wiki"

--- a/tests/unit/tui/shell/test_backlinks.py
+++ b/tests/unit/tui/shell/test_backlinks.py
@@ -1,0 +1,25 @@
+"""Behavioral contract for the computed backlink index + facets (Task 7)."""
+
+from babylon.tui.shell.backlinks import build_backlink_index, facets_by_type
+
+
+def test_backlinks_invert_outbound_wikilinks():
+    pages = {
+        "county/26163": "Links to [[state/26|Michigan]].",
+        "org/uaw": "Based in [[county/26163|Wayne]] and [[state/26|Michigan]].",
+    }
+    idx = build_backlink_index(pages)
+    assert idx["state/26"] == ("county/26163", "org/uaw")
+    assert idx["county/26163"] == ("org/uaw",)
+
+
+def test_pages_with_no_inbound_links_are_absent_not_empty():
+    idx = build_backlink_index({"a": "no links here"})
+    assert "a" not in idx
+
+
+def test_facets_group_slugs_by_type_prefix():
+    pages = {"county/26163": "", "county/26099": "", "org/uaw": ""}
+    facets = facets_by_type(pages)
+    assert facets["county"] == ("county/26099", "county/26163")
+    assert facets["org"] == ("org/uaw",)

--- a/tests/unit/tui/shell/test_dashboard_view.py
+++ b/tests/unit/tui/shell/test_dashboard_view.py
@@ -1,0 +1,45 @@
+"""Behavioral contract for the DashboardView economy read-model renderer (Task 6).
+
+Binds to T3's REAL ``babylon.projection.view_models.EconomyView`` (landed with the
+overnight cascade) — not the plan's pre-merge ``EconomyViewLike`` placeholder contract.
+"""
+
+from babylon.projection.view_models import EconomyView
+from babylon.tui.shell.views.dashboard_view import render_economy_text
+
+
+def _view(**overrides) -> EconomyView:
+    base = {"economy_id": "USA", "verified_tick": 12}
+    base.update(overrides)
+    return EconomyView(**base)
+
+
+def test_theorem_verdict_reads_off_wage_balance():
+    view = _view(wage_balance=0.25, labor_aristocracy_verdict=True)
+    out = render_economy_text(view)
+    # Positive balance = wage exceeds value produced = the imperial bribe holds.
+    assert "+0.25" in out
+    assert "revolution impossible" in out.lower()
+
+
+def test_phi_tri_decomposition_total_is_shown():
+    view = _view(
+        phi_unequal_exchange=10.0,
+        phi_reproduction=5.0,
+        phi_domestic=3.0,
+        phi_decomposition_total=18.0,
+    )
+    out = render_economy_text(view)
+    assert "Φ=18" in out
+
+
+def test_absent_values_render_as_loud_absence_not_zero():
+    out = render_economy_text(_view())
+    # Honest-None discipline: an unwired feed is an absence block, never a fabricated 0.
+    assert "0.0" not in out
+    assert "absent" in out.lower() or "unwired" in out.lower()
+
+
+def test_overshoot_ratio_renders_when_present():
+    out = render_economy_text(_view(overshoot_ratio=1.4))
+    assert "O=1.4" in out

--- a/tests/unit/tui/shell/test_map_view.py
+++ b/tests/unit/tui/shell/test_map_view.py
@@ -1,0 +1,20 @@
+"""Behavioral contract for the MapView lens selector (Task 4)."""
+
+import pytest
+
+from babylon.tui.shell.views.map_view import MapView
+
+
+@pytest.mark.asyncio
+async def test_lens_toggle_updates_selected_field(make_shell_harness):
+    view = MapView(id="map")
+    async with make_shell_harness(view):
+        assert view.lens == "value"
+        view.set_lens("tension")
+        assert view.lens == "tension"
+
+
+def test_lens_is_restricted_to_known_values():
+    view = MapView(id="map")
+    with pytest.raises(ValueError):
+        view.set_lens("bogus")  # type: ignore[arg-type]

--- a/tests/unit/tui/shell/test_topology_view.py
+++ b/tests/unit/tui/shell/test_topology_view.py
@@ -1,0 +1,11 @@
+"""Behavioral contract for TopologyView declared-future absence (Task 5)."""
+
+from babylon.tui.shell.views.topology_view import render_absence
+
+
+def test_absent_node_kinds_render_as_declared_future_stub():
+    out = render_absence("coalition")
+    assert "coalition" in out
+    assert "not yet" in out.lower() or "declared-future" in out.lower()
+    # never fabricates a node id
+    assert "node_" not in out

--- a/tests/unit/tui/shell/test_wiki_view.py
+++ b/tests/unit/tui/shell/test_wiki_view.py
@@ -1,0 +1,15 @@
+"""Behavioral contract for the WikiView vault-page reader (Task 3)."""
+
+import pytest
+
+from babylon.tui.shell.views.wiki_view import WikiView
+
+
+@pytest.mark.asyncio
+async def test_wiki_view_renders_a_vault_page(make_shell_harness):
+    view = WikiView(id="wiki")
+    async with make_shell_harness(view) as pilot:
+        view.load_page("# Wayne County\n\nSee [[county/26163|Wayne]].")
+        await pilot.pause()
+        text = pilot.app.export_visible_text()
+        assert "Wayne County" in text


### PR DESCRIPTION
## What

Executes the BD-approved **Player Interface Shell plan** (`project/research/24-the-archive/PLAYER_INTERFACE_SHELL_plan.md`, 11 tasks; execution authorized in ADR126 ruling 4). This is the action-surface foundation: the seam that turns the nine already-real Article V verb resolvers into issuable gameplay.

### The 11 tasks (one commit each, TDD red→green throughout)

- **ActionSpec registry** (`babylon.game.actions.registry`) — one agent-type-gated action algebra: 9 LIVE organizer verbs mapped to real engine `ActionType`s + 9 honest-STUB institutional macro-actions.
- **AppShell** — hybrid layout (chronicle/watchlist rails, action bar, four-domain `ContentSwitcher`, number-key switching).
- **Four views** — `WikiView` (wraps the wikilink-aware vault renderer), `MapView` (value/tension/fog lens), `TopologyView` (ASCII floor + declared-future absence for non-production node kinds), `DashboardView` (renders **T3's real `EconomyView`** — theorem verdict, Φ tri-decomposition, s=p+i+r+t, matter book, honest-None absence blocks).
- **Two drivers** — `issue_action` (player write-path: registry gate → the REAL `submit_verb`, canonical-verb + affordability gates preserved) and `select_actions` (deterministic CPU policy ordered by `npc_stub._NPC_PRIORITIES`).
- **BDD gate** — `TutorialStep` + Pilot text-capture harness + the three assertion layers (coverage / render / algebra).

### Plan deviations (each recorded in its commit)

1. Task 6 binds to **T3's real `EconomyView`** (landed with the overnight cascade) instead of the plan's pre-merge `EconomyViewLike` placeholder — per the plan's own Interfaces rule.
2. Task 8 delegates to the real `submit_verb` (the plan's sketch bypassed its affordability gate; its own integration note forbids that).
3. Task 7 reuses `wikilinks.WIKILINK_RE` instead of duplicating the regex.
4. Added the `make_shell_harness` conftest fixture the plan consumed but never defined.

### ADR109 wiring-doctrine citation (blocking dependency)

The player write-path is a **W-P projection motion** (verb plate → `submit_verb` → `game_turn`). Its sentinel row cannot be entered: `src/babylon/sentinels/wiring/` does not exist until the **ADR109 enforcement train** (FIRST in the standing post-cascade queue) builds the registry. This citation discharges the PR-completeness duty per CLAUDE.md's wiring doctrine; the row lands when the registry exists. Integration items (boot `AppShell` from `cli/play.py`, live view data, chronicle rail, the T6 full-verb script — incl. the one deliberate `ooda.py` `_FIRST_CLASS_ACTION_EVENTS` hunk) fold into the owning trains per the plan.

## Verification

- `mise run check` — **14,132 passed**, 306 skipped, 1 xfail (pre-existing); lint/format/typecheck/imports green (9/9 contracts kept)
- `mise run qa:regression` — **byte-identical 6/6** + two-process determinism leg (the lane is engine-inert, as required)
- `mise run check:vocabulary` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)