### PR TITLE
docs(state): catch up five trains + record the 2026-07-23 v1.0 critical-path plan and BD rulings

### DIFF
--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -2,9 +2,70 @@
 # What exists vs what's planned - KEEP THIS UPDATED
 
 meta:
-  version: "2.52.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
-  updated: "2026-07-22"
+  version: "2.53.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
+  updated: "2026-07-23"
   truth_status: |
+    (2026-07-23 v1.0 CRITICAL-PATH PLAN + BD RULINGS) Remote plan session
+    ratified the road to v1.0.0: finish P25 (U12->ADR139 / U13->ADR140 —
+    mainline took ADR138 for the pg-domain ledger DOMAIN contracts, PR #295)
+    -> tutorial completion (combined #265 all-nine-verbs + #286 live
+    REPRESS-witness beat; the verb-plate barrier documented in
+    game/tutorial.py's W4 note was removed by P5 + shell-interconnect) ->
+    #266 520-tick activation-drift bake (pre-cutover, "cheap but
+    load-bearing") -> BD GATE 3 (#262) -> #241 cutover -> T7-beta embedded
+    Postgres (#291 agent half + #292 owner ceremonies; spec pre-staged) ->
+    DoD sweep (corpus ingestion + narrator on/off parity, save/load
+    round-trip verification, bounded nationwide smoke) -> T8 (#293).
+    RULINGS: (1) P25 U12/U13 GATE Gate 3 (adversary-train doctrine); (2)
+    DoD "full nationwide campaign session" AMENDED to Wayne full session +
+    bounded nationwide smoke (boot + bounded ticks + incremental-baker
+    proof); (3) ADR109 enforcement train = post-1.0 first-in-queue
+    (train:v1.0 label removed from #264); (4) T7-beta SPECS now, BUILDS
+    strictly post-cutover. BOARD: #258/#272/#273/#281 closed + Done (P25
+    U11 / Vol I / Vol II / watchlist-refresh — the last confirmed by
+    5119bb96); #259/#260 retitled to the renumbered ADRs. BRANCH ESTATE
+    pruned to {pg-domain (PR #295), political-superstructure (+worktree),
+    archive-cutover (staged #241), lane/t7-installer (reserved)} +
+    archives; all merged branches deleted local+remote; 101-trade-activation
+    KEPT as the deferred trade program's resume point (#274, OUT of v1.0).
+    POST-1.0 queue (board order): ADR109 -> Material Triad -> RED_OGV ->
+    DT Unit 6 -> Fog/Investigate -> Org estate -> Divergence Channel ->
+    hypergraph-rs family -> UI expansions -> H3 BIGINT (or rides T7-beta)
+    -> trade. OWNER QUEUE: rotate CLOUDFLARE_API_KEY + BLS_API_KEY (pending
+    since 07-22); Gate 3 session; T7 owner ceremonies (#292: keygen->
+    CACHE_KEY, R2 cache+worker, GGUF upload, signing secret).
+    (2026-07-22/23 CATCH-UP — five trains state.yaml missed) (1) ADVERSARY
+    TRAIN PR #253 (W1-W5, all opus-clean): STATE_REPRESSION/STATE_SURVEILLANCE
+    real single-site bus events; RuleBasedStateAI CPU live in the campaign;
+    Sparrow topological targeting (raid->centrality / infiltrate->cutset /
+    surveil->isolation, I.21); Wayne arc 9->13 steps; REPRESS->SOLIDARITY
+    class-base cascade closes the P(S|R)/agitation loop live. (2) PROGRAM
+    24 P1-P8 (PRs #254/#277): four-pane hybrid shell booted inside
+    ArchiveApp; live chronicle rail w/ severity tier; HUD strip; EconomyView
+    dashboard seam; live verb plate + submit_verb; pinned watchlist rail;
+    KSBC palette SSOT; tutorial teaches the shell. (3) SHELL-INTERCONNECT
+    PR #294 (11 commits): jumplist bracket rebind; selection-unwrap rails;
+    navigate<->wiki-pane coupling; post-tick fanout incl. watchlist
+    repaint; cross-pane focus model; row-addressable watchlist; live
+    subject_view projector retires the fixture; honest verb targeting via
+    nav.current + candidate sets; PeekOverlay; chronicle row-nav to event
+    subject + dedupe/volume-floor/autopause salience. (4) P25 U1-U11 on
+    feature/political-superstructure (ADR127-137): politics defines
+    namespace (A6 tiers at birth); 13 new EventTypes; political_form
+    opposition (shadow->canonical promotion at U10, qa 6/6 byte-identical);
+    OrganizationComponent port; party seeding + MEMBERSHIP/donor funding;
+    ELECTORAL faction seeding; formulas/politics.py kernel; AllegianceSystem
+    @17.42 (the Agitation->Organization valve, TRAP-1 ruling (b));
+    PolicySystem @17.47 (LEGISLATE resolver + reform ceiling, first
+    Institution node + ADMINISTERS edge); ElectoralSystem @17.45 (clocked
+    ambient machine — 33 systems total); doctrine fork five stances
+    (PracticeVariable disjoint from DoctrineTag, @coeff trap DSL,
+    liquidationism absorbing state, officeholder capture, LINE_STRUGGLE_SPLIT
+    first publisher, DoctrineCapability verb gating). (5) PG-DOMAIN ADR138
+    (PR #295): seven CREATE DOMAINs (4 numeric codegen'd from types.py +
+    3 format from the domain_sync registry) + the 19th sentinel family
+    (mutation-validated); enforce-never-compute; check 14,452 green;
+    qa 6/6 byte-identical + determinism leg.
     (2026-07-22 T3 U7 governance close-out, ADR125) T3 GAP PROJECTIONS
     PROGRAM COMPLETE (feature/t3-gap-projections, post-cascade spine-C):
     U1-U6 all APPROVED (U2 APPROVED_AFTER_FIX; the PhiDecomposition


### PR DESCRIPTION
state.yaml was five trains stale (newest entry predated the adversary train). Adds: (1) the ratified 2026-07-23 critical-path plan + four BD rulings (P25 gates Gate 3; nationwide DoD amended to bounded smoke; ADR109 post-1.0; T7-beta spec-now/build-post-cutover); (2) catch-up entries for adversary #253, Program 24 P1-P8, shell-interconnect #294, P25 U1-U11, pg-domain ADR138; (3) branch-estate + board hygiene record. Docs-only.