### PR TITLE
docs(governance): Amendment AD — the Agentic Engineering model (IX.5, v2.18.0) + ADR151 + docs sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,14 +21,18 @@ proposing structure; the Constitution stays the law, architecture.yaml stays the
 
 ## Constitutional Compact
 
-Irreducible constraints. Full text: `CONSTITUTION.md` (v2.17.0, 10 Articles +
-Amendments A–AC — T ratified 2026-07-22 (Divergence Channel, observes-only, code
+Irreducible constraints. Full text: `CONSTITUTION.md` (v2.18.0, 10 Articles +
+Amendments A–AD — T ratified 2026-07-22 (Divergence Channel, observes-only, code
 queued; ADR072/ADR126); the canonical governance doc — read it before
 proposing architecture. AA: Windows = binding post-1.0 requirement, pre-1.0 dev
 SHIELDED from all Windows obligations except a one-line ADR disclosure duty.
 AC (2026-07-27, ADR150): the Rust/Ratatui client IS v1.0's terminal client,
 in-tree at `rust/`, 3D lane v1.0-blocking via hypergraph-rs raster git-dep,
-M7 Textual deletion inside the release; P25 lands first).
+M7 Textual deletion inside the release; P25 lands first.
+AD (2026-07-27, ADR151): the **Agentic Engineering model** — IX.5; a human
+Director steers direction + holds the reserved ideological line, agents are the
+gate-licensed engineering workforce; Benevolent-Dictator subsumed as the
+Director role).
 
 **MUST**
 
@@ -149,7 +153,13 @@ regenerate the YAML (`uv run python tools/generate_defines_config.py`).
 
 ## Git & commits
 
-Benevolent-Dictator model (Persephone Raskova is BD). Branch from `dev`
+**Agentic Engineering model** (Constitution §IX.5, Amendment AD; ADR151): Persephone Raskova is the
+**Director** — she steers direction, holds sole authority over the ideological/theoretical line (the
+MLM-TW commitments, doctrine trees, political framing, the five canonical outcomes), and holds final
+merge authority to `main` (the Benevolent-Dictator role, subsumed). You are the engineering
+workforce: autonomy is **licensed by the gates** (green self-merges, red STOPs); a task that would
+add a primitive, relax a prohibition, or **touch the ideological line** escalates — to an amendment
+or to the Director — never improvise it. Full model: `CONTRIBUTORS.md`. Branch from `dev`
 (`feature/|fix/|docs/|refactor/|test/`), never commit directly to `main` or `dev`. Conventional
 commits (`type(scope): desc`). **Commit after each unit of work** — pre-commit hooks test only staged
 files, so intertwined units force ugly giant commits. Use `mise run commit -- "type(scope): msg"`

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -2,6 +2,23 @@
 ================================================================================
 SYNC IMPACT REPORT
 ================================================================================
+Version Change: 2.17.0 → 2.18.0 (2026-07-27)
+Bump Rationale: MINOR — Amendment AD (The Agentic Engineering Model)
+  registered, owner-ratified 2026-07-27 (BD directive, in-session). Names the
+  project's development model: a human DIRECTOR who steers direction and holds
+  SOLE authority over the ideological/theoretical line the simulation encodes,
+  with autonomous AI agents as the engineering workforce whose autonomy is
+  LICENSED BY THE GATES (determinism III.7 / the sentinel family / behavioral
+  contracts III.12 / TDD red phase / Loud Failure III.11 / baseline ceremonies
+  §6.5). Adds IX.5 (Development Model — Agentic Engineering); SUBSUMES the
+  Benevolent-Dictator model as the Director role (final merge authority to main
+  PLUS reserved ideological authority — not a replacement, a renaming for the
+  function it serves in an agent-executed project). No primitive, tick, or
+  architecture principle changes — a development-model designation — MINOR.
+  Docs swept: CONTRIBUTORS.md, README.md, docs/agents/governance.md, CLAUDE.md.
+  Recording ADR151.
+
+--- prior report (v2.16.0 → 2.17.0) ---
 Version Change: 2.16.0 → 2.17.0 (2026-07-27)
 Bump Rationale: MINOR — Amendment AC (The Raster Cutover) registered,
   owner-ratified 2026-07-27 via the in-session interview rulings BD-1…BD-10
@@ -577,6 +594,8 @@ No separate state Negotiate verb — negotiation is a mode of Withdraw (terms of
 
 **Amendment AC — The Raster Cutover (Rust/Ratatui Client, v1.0)** (ratified v2.17.0): The **Rust/Ratatui client is the designated v1.0 terminal Archive client** — a BD superseding ruling (2026-07-27) over the 2026-07-23 critical-path plan; the v1.0 DoD and T7 renumber around it. Operative clauses: **(i) home** — the client lives **in-tree** at `rust/` (cargo workspace: `babylon-tui` core, `babylon-tui-python` cdylib, `babylon-md` fork; maturin/PyO3 extension consumed as a uv path-source), superseding the 2026-07-22 extraction ruling **for client crates only** — generic Rust libraries remain sibling repos; **(ii) contract unchanged** — II.8/Amendment V holds in full: the client is a presentation-only viewport over `observe()`-projection JSON shapes, clients remain disposable; this amendment designates an implementation, not a primitive; **(iii) the gate** — the tutorial-BDD suite passing against the Rust client (the `test_tutorial_pilot.py` arc, ported) is the constitutional correctness/parity condition, and **BD Gate 3 runs on the Rust client at M3** as a combined content+client gate; **(iv) the cutover** — the Textual implementation retires ONLY via the declared M7 ceremony, blocked on (iii), and **v1.0.0 ships WITH the completed deletion** (the one-way door is inside the release — reaffirmed knowingly); consequence: the maturin wheel joins the default install and the T7 uv2nix player closure at M7 (the client may not remain an opt-in dependency group at release); **(v) the 3D lane** — chartered and **v1.0-blocking**, four targets: topology hypergraph and contradiction-field surface **block the release**; choropleth extrusion and trend ridgelines are best-effort (slipping to v1.1 only before they would delay v1.0); Ratatui has no built-in 3D — the lane is CPU rasterization to cell grids, with the glyph-tier text output as the ADR099 floor and the III.12 text-assertion medium, plus an optional kitty true-pixel tier; **(vi) the rasterizer** — the shared deterministic 3D rasterizer is **hypergraph-rs's `raster`/`cells3d` feature** (this ruling un-pauses that lane for feature work), consumed as a **rev-pinned cargo git-dependency** from a new git remote with read-only deploy-key CI access; ratatui never enters hypergraph-rs's dependency graph. Windows-impact note (AA duty): crossterm + cargo/maturin do not foreclose native Windows; kitty/TGP raster is absent from Windows Terminal — the glyph floor, not the raster lane, is what ports. Source: BD interview rulings BD-1…BD-10 (2026-07-27, in-session); design/plan rev 2 (`docs/superpowers/specs/2026-07-26-ratatui-client-design.md` §3); recording ADR150. Owner-ratified 2026-07-27.
 
+**Amendment AD — The Agentic Engineering Model** (ratified v2.18.0): Names and ratifies the project's development model as **Agentic Engineering** and adds **IX.5**. The **Benevolent-Dictator model is subsumed, not replaced**: the human authority is recast as the **Director** — final merge authority to `main` (unchanged) PLUS **sole, reserved authority over the ideological/theoretical line** the simulation encodes (the Article-I MLM-TW commitments, the doctrine trees, political framing, the five canonical outcomes). Autonomous AI agents are the engineering workforce, executing across parallel isolated worktree lanes under the interleaving rule (one engine train on the tick pipeline at a time); their autonomy is **licensed by the gates** — determinism (III.7), the sentinel family, behavioral contracts (III.12), the TDD red phase, Loud Failure (III.11), and the baseline ceremonies (§6.5) — a green gate self-merges, a red gate STOPs, and a question touching the ideological line escalates to the **Director** rather than resolving under IX.3. This designates a **development model, not a primitive**: no tick output, no dialectic, no architecture principle changes — MINOR. Branch/PR mechanics are unchanged and remain documented in `CONTRIBUTORS.md`. Source: BD directive 2026-07-27 (in-session); recording ADR151; docs sweep (CONTRIBUTORS.md, README.md, docs/agents/governance.md, CLAUDE.md). Owner-ratified 2026-07-27.
+
 Additional amendments will be registered as they are identified during downstream translation.
 
 **3. AI Decision Procedure** — When an AI agent encounters ambiguity, it MUST follow this escalation ladder:
@@ -595,6 +614,14 @@ Additional amendments will be registered as they are identified during downstrea
 - P1 principles are domain-mandatory. An agent editing `engine/systems/territory.py` MUST retain II.13 and III.4; an agent editing `engine/systems/solidarity.py` MUST retain I.6 and I.21.
 - P2 principles MAY be dropped when context-constrained, but the agent MUST report which P2 principles were dropped in its session summary.
 - If an agent cannot fit P0 + relevant P1 into context, it MUST escalate — it MUST NOT drop P0 or P1 silently.
+
+**5. Development Model — Agentic Engineering** `[RATIFIED — Amendment AD, 2026-07-27]` — Babylon is built by **Agentic Engineering**: a human **Director** sets direction and holds the ideological line; autonomous AI agents perform the bulk of the engineering under a discipline regime that makes their autonomy trustworthy without line-by-line human review.
+
+- **The Director.** Persephone Raskova ([@percy-raskova](https://github.com/percy-raskova)) is the Director. She sets project direction and holds **sole authority over the ideological and theoretical line the simulation encodes** — the MLM-TW theoretical commitments (Article I), the doctrine trees, political framing, and the canonical outcomes (the five terminal endgames). This is a **reserved power**: agents engineer *within* that line — they implement, refactor, test, and propose — but they do **not** author or alter political content without a Director ruling. The Director also holds **final merge authority to `main`** — the Benevolent-Dictator role (`CONTRIBUTORS.md`), subsumed here and renamed for the function it serves in an agent-executed project. A question about the political line is not an ambiguity to resolve under IX.3; it is an **escalation to the Director**.
+
+- **Agents as the engineering workforce.** Autonomous agents execute across **parallel isolated lanes** — each lane a git worktree on its own branch (`CONTRIBUTORS.md`) — under the **interleaving rule**: at most one engine train touches the tick pipeline at a time, so determinism baselines never race. Lane ownership is declared (a lane marker) so concurrent sessions do not collide on the same files.
+
+- **The discipline is what licenses the autonomy.** Agent output is trusted because the **gates**, not a reviewer, certify it: determinism (III.7 — every tick a hash; non-determinism is a bug), the **sentinel family** (built-but-dead / wrong-shape / dead-write detectors), **behavioral contracts** (III.12 — the rewrite test: golden baselines, property laws, byte-identity ceremonies), the **TDD red phase**, and **Loud Failure** (III.11). **A green gate is a self-merge license; a red gate is a STOP.** Ceremony discipline (baseline blessings, §6.5) is deferred to merge, never taxed on the inner loop. Autonomy is bounded by the same escalation ladder every agent already follows (IX.3): a task that would add a new primitive, relax a prohibition, or touch the ideological line MUST stop and escalate — to a constitutional amendment, or to the Director. Source: BD directive 2026-07-27 (in-session); recording ADR151. Owner-ratified 2026-07-27.
 
 ## X. Deployment Infrastructure
 
@@ -616,4 +643,4 @@ Additional amendments will be registered as they are identified during downstrea
 
 ______________________________________________________________________
 
-**Version**: 2.13.0 | **Ratified**: 2026-01-30 | **Last Amended**: 2026-07-20
+**Version**: 2.18.0 | **Ratified**: 2026-01-30 | **Last Amended**: 2026-07-27

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,27 +3,75 @@
 Thanks for your interest in Babylon. This file covers **governance and the git
 workflow**. For getting set up and your first contribution, see
 [SETUP_GUIDE.md](SETUP_GUIDE.md); for coding standards and architecture, see
-[CLAUDE.md](CLAUDE.md).
+[CLAUDE.md](CLAUDE.md). The model here is ratified in the Constitution
+([CONSTITUTION.md](CONSTITUTION.md) §IX.5, Amendment AD; ADR151).
 
-## Governance: Benevolent Dictator
+## Governance: Agentic Engineering
 
-This project uses the
-[Benevolent Dictator](https://producingoss.com/en/benevolent-dictator.html)
-model. Persephone Raskova ([@percy-raskova](https://github.com/percy-raskova))
-has final authority on all merges to `main`.
+Babylon is built by **Agentic Engineering** — a human **Director** sets
+direction and holds the ideological line; autonomous AI agents perform the bulk
+of the engineering under a discipline regime that makes their autonomy
+trustworthy without line-by-line human review.
+
+### The Director
+
+Persephone Raskova ([@percy-raskova](https://github.com/percy-raskova)) is the
+Director. She holds two powers:
+
+1. **Final merge authority** — nothing reaches `main` without her. (This is the
+   [Benevolent Dictator](https://producingoss.com/en/benevolent-dictator.html)
+   role, **subsumed** here and renamed for the function it serves in an
+   agent-executed project — not replaced.)
+2. **Ideological authority** — she holds **sole authority over the ideological
+   and theoretical line the simulation encodes**: the MLM-TW theoretical
+   commitments (Constitution Article I), the doctrine trees, political framing,
+   and the canonical outcomes (the five terminal endgames).
+
+This second power is a **reserved power**. Agents engineer *within* the line —
+they implement, refactor, test, and propose — but they do **not** author or
+alter political content without a Director ruling. A question about the
+political line is not an ambiguity to resolve; it is an **escalation to the
+Director**.
+
+### Agents are the engineering workforce
+
+Autonomous agents execute across **parallel isolated lanes** — each lane a git
+worktree on its own branch — under the **interleaving rule**: at most one engine
+train touches the tick pipeline at a time, so determinism baselines never race.
+Lane ownership is declared (a lane marker) so concurrent sessions do not collide
+on the same files.
+
+### The discipline is what licenses the autonomy
+
+Agent output is trusted because the **gates**, not a reviewer, certify it:
+
+- **Determinism** — every tick produces a hash; non-determinism is a bug
+  (Constitution III.7).
+- **The sentinel family** — built-but-dead, wrong-shape, and dead-write
+  detectors that fail a green-looking test sitting over dead code.
+- **Behavioral contracts** — the rewrite test (III.12): golden baselines,
+  property laws, and byte-identity ceremonies that pin what the system *does*.
+- **The TDD red phase** and **Loud Failure** (III.11) — a missing input fails
+  loudly, never silently no-ops.
+
+**A green gate is a self-merge license; a red gate is a STOP.** Ceremony
+discipline (baseline blessings, §6.5) is deferred to merge — never taxed on the
+inner loop. When a task would add a new primitive, relax a prohibition, or touch
+the ideological line, it **stops and escalates** — to a constitutional amendment
+or to the Director (the escalation ladder is Constitution §IX.3).
 
 ## Branch model
 
 ```
-main ────► stable releases        (BD merges only)
+main ────► stable releases        (Director merges only)
   ▲
 dev ─────► integration             (open your PRs here)
   ▲
-feature/*, fix/*, docs/*, refactor/*, test/*
+feature/*, fix/*, docs/*, refactor/*, test/*   (one per lane)
 ```
 
-- **Contributors** branch from `dev` and open PRs **to `dev`**.
-- **Only the BD** merges `dev` → `main` for releases.
+- Branch from `dev` and open PRs **to `dev`** — one branch per lane / worktree.
+- **Only the Director** merges `dev` → `main` for releases.
 - **Never** commit directly to `main` or `dev`.
 
 | Prefix | Purpose |
@@ -46,6 +94,12 @@ see [CLAUDE.md](CLAUDE.md) for the rationale.
 ```bash
 mise run check   # lint + format + typecheck + unit tests (the fast gate)
 ```
+
+For any engine / economics / defines change, the byte-identity gate must be
+green too (`mise run qa:regression`), and any `tests/baselines/**` movement is a
+declared ceremony — see [CLAUDE.md](CLAUDE.md) §"Definition of done". These
+gates are what let a PR self-merge on green; a red gate is a STOP, not a
+negotiation.
 
 The step-by-step fork → branch → PR walkthrough lives in
 [SETUP_GUIDE.md](SETUP_GUIDE.md#part-2--your-first-contribution).

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ determinism gate.
 
 ## Contributing
 
-This project uses the [Benevolent Dictator](https://producingoss.com/en/benevolent-dictator.html) governance model. Persephone Raskova (@percy-raskova) has final authority on merges to `main`.
+This project is built by **Agentic Engineering** (Constitution §IX.5, Amendment AD): a human **Director** — Persephone Raskova ([@percy-raskova](https://github.com/percy-raskova)) — steers direction and holds sole authority over the ideological/theoretical line, while autonomous AI agents do the bulk of the engineering across parallel worktree lanes, self-merging on green under the determinism, sentinel, and behavioral-contract gates. The Director holds final merge authority to `main` (the Benevolent-Dictator role, subsumed). Full model + git workflow: [CONTRIBUTORS.md](CONTRIBUTORS.md).
 
 | Resource                           | Description                             |
 | ---------------------------------- | --------------------------------------- |

--- a/ai/ci-workflow.yaml
+++ b/ai/ci-workflow.yaml
@@ -4,7 +4,7 @@
 meta:
   version: "1.0.0"
   updated: "2025-12-12"
-  purpose: "Document CI workflow for Benevolent Dictator governance model"
+  purpose: "Document CI workflow for the Agentic Engineering governance model (Constitution IX.5 / Amendment AD; ADR151) — a Director + gate-licensed autonomous agents. Subsumes the prior Benevolent-Dictator framing; full model in CONTRIBUTORS.md."
   related_files:
     - ".github/workflows/ci.yml"
     - ".github/workflows/docs.yml"
@@ -22,22 +22,25 @@ meta:
 # =============================================================================
 
 governance:
-  model: "Benevolent Dictator (BD)"
-  dictator: "Persephone Raskova (@percy-raskova)"
+  model: "Agentic Engineering (Constitution IX.5 / Amendment AD; ADR151) — subsumes Benevolent Dictator"
+  director: "Persephone Raskova (@percy-raskova)"
 
   description: |
-    Single maintainer has final authority on all merges to main.
-    Contributors submit PRs to dev. BD curates and releases.
+    Agentic Engineering: a human Director steers direction and holds sole
+    authority over the ideological/theoretical line, plus final merge authority
+    to main. Autonomous AI agents are the engineering workforce across parallel
+    worktree lanes; their autonomy is licensed by the gates (green self-merges,
+    red STOPs). Full model: CONTRIBUTORS.md.
 
   trust_model:
-    contributors: "Can branch from dev, PR to dev"
-    bd: "Can merge to dev, exclusively merges to main"
-    ci: "Applies equally to all code (BD included)"
+    agents: "Branch from dev, PR to dev; self-merge on green under the gates"
+    director: "Steers direction + owns the ideological line; exclusively merges to main"
+    ci: "Applies equally to all code (the Director included) — the gate, not a reviewer, certifies"
 
   rationale: |
-    - Small project with clear vision
-    - BD catches BD mistakes via CI (self-discipline)
-    - Contributors aren't blocked waiting for reviews on dev
+    - Small project with a clear vision, owned by the Director
+    - The gates catch agent mistakes (determinism/sentinels/contracts), so autonomy needs no per-line review
+    - Agents aren't blocked waiting for reviews on dev — green is the license
     - main remains pristine release branch
 
 # =============================================================================
@@ -46,7 +49,7 @@ governance:
 
 branches:
   structure: |
-    main ────► stable releases (BD merges only)
+    main ────► stable releases (Director merges only)
       │              ▲
       ▼              │
     dev ─────► integration (PRs welcome here)
@@ -56,23 +59,23 @@ branches:
 
   main:
     purpose: "Stable releases only"
-    who_merges: "BD only"
+    who_merges: "Director only"
     protection:
       require_pr: true
       require_ci_pass: ["ci", "docs"]
       require_up_to_date: true
-      require_review: true  # BD self-review as deliberate pause
+      require_review: true  # Director self-review as deliberate pause
       allow_force_push: false
       allow_deletions: false
 
   dev:
     purpose: "Integration branch for PRs"
-    who_merges: "BD (from feature branches)"
+    who_merges: "Director (from feature branches)"
     protection:
       require_pr: true
       require_ci_pass: ["ci"]
       require_up_to_date: false  # Avoid rebase churn
-      require_review: false  # BD can self-merge
+      require_review: false  # Director can self-merge
       allow_force_push: false
       allow_deletions: false
 
@@ -210,7 +213,7 @@ check_policy:
       - ci: "All correctness checks"
       - docs: "Documentation is part of the release"
     advisory:
-      - style: "BD can fix formatting in merge"
+      - style: "Director can fix formatting in merge"
     rationale: "Release quality - everything must work"
 
   enforcement: |
@@ -278,13 +281,13 @@ beginner_friendly:
       Or just ignore this - the maintainer can clean it up when merging.
 
   maintainer_safety_net: |
-    For a hobby project with beginners, the BD often fixes small issues
+    For a hobby project with beginners, the Director often fixes small issues
     rather than sending PRs back. This keeps momentum while teaching by example.
 
     Acceptable workflow:
     1. Contributor submits PR with minor style issues
     2. CI shows yellow warning (advisory)
-    3. BD merges and fixes style in the merge commit
+    3. Director merges and fixes style in the merge commit
     4. Contributor learns from the diff
 
   what_not_to_require:
@@ -375,9 +378,9 @@ hotfix_workflow:
       │
       └─► fix/critical-bug (branch from main)
             │
-            └─► PR to main (BD only)
+            └─► PR to main (Director only)
                   │
-                  ├─► CI runs, BD merges
+                  ├─► CI runs, Director merges
                   │
                   └─► Create backport PR to dev
 
@@ -387,14 +390,14 @@ hotfix_workflow:
     - Re-introduce the bug
     - Create merge conflicts
 
-  automation: "Manual - BD creates backport PR"
+  automation: "Manual - Director creates backport PR"
 
 # =============================================================================
 # RELEASE WORKFLOW
 # =============================================================================
 
 release_workflow:
-  trigger: "BD merges dev → main"
+  trigger: "Director merges dev → main"
 
   automated_steps:
     - "Full CI suite passes"
@@ -404,10 +407,10 @@ release_workflow:
     - "Create GitHub Release with notes and artifacts"
 
   manual_steps:
-    - "BD reviews dev branch stability"
-    - "BD creates PR from dev to main"
-    - "BD self-approves (deliberate pause)"
-    - "BD merges"
+    - "Director reviews dev branch stability"
+    - "Director creates PR from dev to main"
+    - "Director self-approves (deliberate pause)"
+    - "Director merges"
 
 # =============================================================================
 # CONFIGURATION CHECKLIST
@@ -433,7 +436,7 @@ configuration_checklist:
   codeowners_file:
     location: ".github/CODEOWNERS"
     content: "* @percy-raskova"
-    purpose: "Makes BD required reviewer for main PRs"
+    purpose: "Makes Director required reviewer for main PRs"
 
   workflow_permissions:
     docs_yml:

--- a/ai/decisions/ADR151_agentic_engineering_model.yaml
+++ b/ai/decisions/ADR151_agentic_engineering_model.yaml
@@ -1,0 +1,77 @@
+id: ADR151
+title: >-
+  The Agentic Engineering model: name and ratify the project's development
+  model — a human Director who steers direction and holds SOLE authority over
+  the ideological/theoretical line, with autonomous AI agents as the
+  engineering workforce whose autonomy is licensed by the gates. Amendment AD
+  records the constitutional half (adds IX.5); the Benevolent-Dictator model is
+  subsumed as the Director role, not replaced.
+status: accepted
+date: '2026-07-27'
+context: >-
+  The project had, in practice, moved to a working model the governance docs
+  did not describe: many concurrent autonomous AI agent sessions engineering in
+  parallel git-worktree lanes (feature/political-superstructure,
+  feature/raster-cutover, fix/dsn-boot-doctor-mismatch, lane/t7-installer, …
+  live simultaneously), self-merging on green under the determinism / sentinel /
+  behavioral-contract gates, while the human (Persephone Raskova) steered
+  direction and owned the political/theoretical content. The encoded model was
+  still the plain "Benevolent Dictator" (final merge authority to main),
+  documented in CONTRIBUTORS.md, README.md §Contributing, and
+  docs/agents/governance.md, and referenced from CLAUDE.md's Git-&-commits
+  section. That framing captured the AUTHORITY relation but said nothing about
+  the EXECUTION model (agents as the workforce) or — crucially for a Marxist-
+  Leninist-Maoist-Third-Worldist simulation engine, where "ideological
+  direction" is literal, not a metaphor — about the reserved human authority
+  over the political line. The Director directed formalizing the new model
+  ("our model is now Agentic Engineering"), retaining personal control of
+  ideological direction while delegating the bulk of the engineering. Four
+  directional forks were put to the Director and ruled: (name) "Agentic
+  Engineering"; (BD relationship) subsume & reframe; (formality) docs sweep PLUS
+  a Constitution amendment; (the human-role statement) "Director & Ideological
+  Authority" — the ideological line reserved explicitly, agents never author it.
+decision: >-
+  (1) NAME: the development model is "Agentic Engineering" across every doc.
+  (2) THE DIRECTOR: the human authority is recast from "Benevolent Dictator" to
+  "Director" — SUBSUMED, not replaced. The Director holds two powers: final
+  merge authority to main (the BD power, unchanged) AND sole, RESERVED authority
+  over the ideological/theoretical line the simulation encodes (the Article-I
+  MLM-TW commitments, the doctrine trees, political framing, the five canonical
+  terminal outcomes). Agents engineer WITHIN that line — implement, refactor,
+  test, propose — but do not author or alter political content without a
+  Director ruling; a political-line question is an escalation to the Director,
+  not an IX.3 ambiguity. (3) AGENTS AS THE WORKFORCE: autonomous AI agents
+  execute across parallel isolated worktree lanes under the interleaving rule
+  (at most one engine train on the tick pipeline at a time, so determinism
+  baselines never race) with declared lane ownership to prevent collisions.
+  (4) AUTONOMY IS LICENSED BY THE GATES, NOT BY TRUST: determinism (III.7), the
+  sentinel family (built-but-dead / wrong-shape / dead-write detectors),
+  behavioral contracts (III.12 — golden baselines, property laws, byte-identity
+  ceremonies), the TDD red phase, and Loud Failure (III.11). A green gate is a
+  self-merge license; a red gate is a STOP; ceremony discipline (§6.5) is
+  deferred to merge, never taxed on the inner loop. (5) CONSTITUTIONAL HALF:
+  Amendment AD adds IX.5 "Development Model — Agentic Engineering", v2.17.0 ->
+  v2.18.0 (MINOR — a development-model designation; no primitive, tick, or
+  architecture principle changes; branch/PR mechanics unchanged, still in
+  CONTRIBUTORS.md). (6) DOCS SWEEP: CONTRIBUTORS.md rewritten around the model;
+  README.md §Contributing, docs/agents/governance.md, and CLAUDE.md's
+  Git-&-commits section reframed Benevolent-Dictator -> Director / Agentic
+  Engineering.
+consequences: >-
+  POSITIVE: the governance docs now describe the model actually in use, so a new
+  agent session reads its real operating context (parallel lanes, gate-licensed
+  self-merge, the reserved ideological line) instead of a BD-only story that
+  omits it. The ideological-authority reservation is now explicit and
+  constitutional — an agent that would author or alter the political line has a
+  named STOP, and the Aleksandrov/every-construct-traces-to-a-material-relation
+  discipline gains a governance backstop. Continuity is preserved: the BD/ADR/
+  amendment trail is intact because the Director IS the benevolent dictator,
+  renamed for function, not a new office. NEUTRAL/COST: "Agentic Engineering" is
+  now load-bearing vocabulary that must stay consistent across docs; the term
+  will need pruning discipline like any other. NON-GOALS: this changes no branch
+  mechanics (still branch-from-dev, PR-to-dev, BD/Director merges to main), no
+  gate, and no tick behavior — it is a naming-and-authority ratification, and
+  qa:regression/byte-identity are untouched by design (docs-only change).
+  FOLLOW-UP: none required; future refinements to the autonomy envelope (e.g.
+  codifying the self-merge-on-green grant more tightly) would amend IX.5.
+file: ADR151_agentic_engineering_model.yaml

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -1,5 +1,5 @@
 meta:
-  version: 1.55.0
+  version: 1.56.0
   updated: '2026-07-27'
   description: Architecture Decision Records Index
   format: See individual ADR files in this directory
@@ -15,6 +15,11 @@ meta:
   # allocated blocks — 139/140 are claimed by issues #259/#260 inside the
   # T1.2/T4 blocks).
 decisions:
+  ADR151_agentic_engineering_model:
+    title: 'The Agentic Engineering model (BD directive 2026-07-27, in-session): names + ratifies the project development model — a human DIRECTOR who steers direction and holds SOLE, reserved authority over the ideological/theoretical line (Article-I MLM-TW commitments, doctrine trees, political framing, the five canonical outcomes), with autonomous AI agents as the engineering workforce across parallel isolated worktree lanes (interleaving rule: one engine train on the tick pipeline at a time). Autonomy LICENSED BY THE GATES not by trust: determinism III.7 / sentinel family / behavioral contracts III.12 / TDD red phase / Loud Failure III.11 / baseline ceremonies §6.5 — green self-merges, red STOPs, an ideological-line question escalates to the Director not IX.3. Benevolent-Dictator model SUBSUMED (not replaced) as the Director role: final merge authority to main + reserved ideological authority. Amendment AD adds IX.5, v2.17.0->v2.18.0 (MINOR — a development-model designation, no primitive/tick/architecture change). Docs swept: CONTRIBUTORS.md, README.md, docs/agents/governance.md, CLAUDE.md.'
+    status: accepted
+    date: '2026-07-27'
+    file: ADR151_agentic_engineering_model.yaml
   ADR150_raster_cutover:
     title: 'The Raster Cutover charter (BD interview rulings BD-1..BD-10, 2026-07-27): Rust/Ratatui client IS v1.0''s terminal Archive client, in-tree at rust/ (supersedes the extraction ruling for client crates only); 3D lane chartered v1.0-BLOCKING (topology hypergraph + contradiction-field surface block release; extrusion + ridgelines best-effort) rendered via hypergraph-rs raster/cells3d as a rev-pinned cargo git-dep (un-pauses that lane; deploy-key CI); tutorial-BDD parity + BD Gate 3 at M3; M7 Textual deletion INSIDE v1.0 with the maturin wheel entering the default install/T7 closure; P25 lands first; ecosystem adoptions (babylon-md fork of tui-markdown, native pulldown-cmark wikilinks, ratatui-image, tui-widgets, insta) + confirmed build-custom gaps (choropleth raster, n-ary hypergraph layout, ridgelines); Amendment AC = the constitutional half (v2.17.0); rev-1 doc errors corrected (7,866 LOC / 221 Pilot sites / real parity harness / ADR-number collisions / packaging contradiction)'
     status: accepted

--- a/ai/tooling.yaml
+++ b/ai/tooling.yaml
@@ -12,7 +12,7 @@ meta:
 
 cicd:
   philosophy: "Block on correctness, not style"
-  governance: "Benevolent Dictator model - see ci-workflow.yaml for full details"
+  governance: "Agentic Engineering model (Constitution IX.5 / Amendment AD; ADR151) - Director + gate-licensed agents; see CONTRIBUTORS.md and ci-workflow.yaml"
 
   github_actions:
     ci_yml:
@@ -316,7 +316,7 @@ code_complexity:
     push_to_main:
       complexity_check: "xenon gate"
       blocks_merge: true
-      rationale: "Redundant safety for direct pushes (BD only)"
+      rationale: "Redundant safety for direct pushes (Director only)"
 
   ci_integration:
     all_branches:
@@ -470,7 +470,7 @@ mutation_testing:
 
   why_only_main:
     - "Mutation testing is slow (full test run per mutation)"
-    - "PRs to main are rare (BD merges only)"
+    - "PRs to main are rare (Director merges only)"
     - "Main is stable release branch - quality gate justified"
     - "Dev branches move fast - don't want to block velocity"
 

--- a/docs/agents/governance.md
+++ b/docs/agents/governance.md
@@ -1,13 +1,21 @@
 # Governance & Workflow
 
-## Git Workflow
+## Model: Agentic Engineering
 
-**Benevolent Dictator** model. Persephone Raskova ([@percy-raskova](https://github.com/percy-raskova)) has final merge authority.
+Babylon is built by **Agentic Engineering** (Constitution §IX.5, Amendment AD; ADR151). A human **Director** — Persephone Raskova ([@percy-raskova](https://github.com/percy-raskova)) — steers direction and holds **sole authority over the ideological/theoretical line** (the MLM-TW commitments, the doctrine trees, political framing, the five canonical outcomes) plus **final merge authority** to `main` (the Benevolent-Dictator role, subsumed and renamed). Autonomous AI agents are the engineering workforce: they execute across **parallel isolated worktree lanes** under the interleaving rule (one engine train on the tick pipeline at a time), and their autonomy is **licensed by the gates**, not by trust —
+
+- **green gate = self-merge license; red gate = STOP;**
+- determinism (III.7), the sentinel family, behavioral contracts (III.12), the TDD red phase, Loud Failure (III.11), baseline ceremonies (§6.5);
+- a task that would add a primitive, relax a prohibition, or **touch the ideological line** stops and escalates — to an amendment or **to the Director** (the escalation ladder is Constitution §IX.3), never resolved by improvisation.
+
+Full model + git workflow: [CONTRIBUTORS.md](../../CONTRIBUTORS.md).
+
+## Git Workflow
 
 **Branch Structure**:
 
 ```
-main ────► stable releases (BD merges only)
+main ────► stable releases (Director merges only)
   │              ▲
   ▼              │
 dev ─────► integration (PRs welcome here)
@@ -16,9 +24,9 @@ dev ─────► integration (PRs welcome here)
 feature/*, fix/*, docs/*, refactor/*
 ```
 
-- Contributors branch from `dev`, PR to `dev`
-- BD only merges `dev` → `main` for releases
-- Hotfixes go `fix/*` → `main` (BD only), then backport to `dev`
+- Contributors branch from `dev`, PR to `dev` (one branch per lane / worktree)
+- The Director only merges `dev` → `main` for releases
+- Hotfixes go `fix/*` → `main` (Director only), then backport to `dev`
 - **Never** commit directly to `main` or `dev`
 
 **Branch Naming**:


### PR DESCRIPTION
## Summary

Ratifies **Amendment AD — The Agentic Engineering Model** (Constitution v2.17.0 → v2.18.0, new principle **IX.5**, **ADR151**) and sweeps the living documentation surface to match. Directed by the four Director rulings taken 2026-07-27:

1. Canonical name: **Agentic Engineering**.
2. The Benevolent-Dictator model is **subsumed and reframed** — continuity preserved; the BD becomes the **Director**.
3. Formality: full docs sweep **+ Constitution amendment** (this PR).
4. Role framing: **Director & Ideological Authority** — Persephone Raskova sets project direction and holds *sole* authority over the ideological/theoretical line the simulation encodes (MLM-TW theory, doctrine trees, political framing, the canonical outcomes). Agents engineer within that line; they do not author or alter political content without the Director's ruling.

## Commits

- `073d0833` — CONSTITUTION.md IX.5 + Amendment AD ledger entry + version 2.18.0 (also reconciles the stale 2.13.0 footer); `ai/decisions/ADR151_agentic_engineering_model.yaml`; index.yaml → 1.56.0.
- `fd661389` — docs sweep: CONTRIBUTORS.md (rewritten around the model), README.md §Contributing, docs/agents/governance.md, CLAUDE.md (AGENTS.md symlinks), ai/ci-workflow.yaml + ai/tooling.yaml (governance blocks; standalone "BD" → "Director").

History files (ADRs, reports, handoffs, brainstorm filenames) deliberately untouched per the immutability-of-history principle.

Docs-only: no tick behavior, no gate mechanics, no branch mechanics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)