### PR TITLE
feat(rust): Ratatui M1 — read-only Archive (plan Tasks 11–20 + verify-panel remediation)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -179,8 +179,16 @@ repos:
         # kept at the Wave-1 merge: integration-tier goldens live under
         # tests/integration/**/__snapshots__/ too. Excluded, not fixed: these
         # are generated artifacts, not hand-authored text.
-        exclude: ^tests/.*/__snapshots__/.*\.raw$
+        #
+        # rust/crates/babylon-md/: the vendored tui-markdown fork (ADR150) —
+        # upstream's bytes carry trailing whitespace, including inside insta
+        # .snap goldens where trimming desyncs the byte-exact match (same
+        # failure class as the .raw goldens above). The fork's diff-vs-upstream
+        # must stay the two declared patches, not a whitespace normalization.
+        exclude: ^(tests/.*/__snapshots__/.*\.raw|rust/crates/babylon-md/)
       - id: end-of-file-fixer
+        # Same vendored-fork rationale as trailing-whitespace above.
+        exclude: ^rust/crates/babylon-md/
       - id: check-yaml
         args: [--unsafe]  # Allow custom tags in GitHub Actions
       - id: check-json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -185,7 +185,7 @@ repos:
         # .snap goldens where trimming desyncs the byte-exact match (same
         # failure class as the .raw goldens above). The fork's diff-vs-upstream
         # must stay the two declared patches, not a whitespace normalization.
-        exclude: ^(tests/.*/__snapshots__/.*\.raw|rust/crates/babylon-md/)
+        exclude: ^(tests/.*/__snapshots__/.*\.raw$|rust/crates/babylon-md/)
       - id: end-of-file-fixer
         # Same vendored-fork rationale as trailing-whitespace above.
         exclude: ^rust/crates/babylon-md/

--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -2,9 +2,41 @@
 # What exists vs what's planned - KEEP THIS UPDATED
 
 meta:
-  version: "2.55.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
+  version: "2.56.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
   updated: "2026-07-27"
   truth_status: |
+    (2026-07-27 RASTER CUTOVER M1 EXECUTED — read-only Archive) Tasks 11-20
+    on feature/ratatui-m1: babylon-md fork (tui-markdown 0.3.9, exactly two
+    marked patches: Options passthrough + link-metadata side channel;
+    MIT/Apache preserved; excluded from whitespace fixers — byte-exact insta
+    goldens), wiki_render (wikilink LinkSpans, GOLD known / CRIMSON redlink
+    per theme.rs, the §9b SSOT guarded cross-language by
+    tests/unit/render/test_rust_theme_parity.py), router (BARE_KIND
+    sentinel parity byte-identical to Python), layout registry +
+    depth-0..3 peek (serde_json preserve_order = pydantic declaration-order
+    field selection), Lobby/Wiki/Palette/Watchlist views (codename display
+    spec-116; loud UNREADABLE states distinct from honest absence), app
+    shell (view stack, palette overlay + Clear, keyboard link cursor n/p
+    feeding peek, mouse hit-registry, scripted-input headless replay = the
+    M3 BDD foundation), Host M1 read surface BOTH sides incl.
+    load_campaign — the production composition-root verb (_run_rust_client
+    threads the SAME _load_campaign/_driver_factory/catalog factories the
+    Textual path builds; a raising host PANICS across the FFI after
+    printing the traceback, III.11; RAII terminal restore incl. panic
+    path), backlink index + its consumer (the wiki 'What links here'
+    footer, ADR109 motion closed). 3-lens Opus adversarial verify panel ran
+    mid-milestone: 31 findings, every one remediated same-session (headline:
+    the read surface had NO production caller — caught before merge).
+    Real-vault smoke GREEN: campaign minted via the real menu, lobby shows
+    the codename, Enter binds via load_campaign and renders the live
+    Postgres briefing page, exact seam call order pinned. Deviation
+    recorded: tui-scrollview NOT adopted — WikiView's own span-preserving
+    word wrap keeps exact link-cell hit mapping. Gates: rust:check green
+    (132 tests, clippy -D all-features, rustdoc), 54 seam-adjacent Python
+    tests green; full test:unit green except the 16 pre-existing
+    unmounted-babylon-data-drive failures (environment, not diff). TTY
+    smoke owner-side. NEXT: M2 Playable (plan Tasks 21-26).
+    PREVIOUS (same day):
     (2026-07-27 RASTER CUTOVER M0 EXECUTED, activation BD-gated) P25 merged
     to dev same day (PR #308, U1-U13, ADR127-140, #261 closed) — the BD-6
     sequencing gate cleared — then M0 Tasks 1-4/6-7 landed on

--- a/docs/superpowers/plans/2026-07-26-ratatui-client.md
+++ b/docs/superpowers/plans/2026-07-26-ratatui-client.md
@@ -496,7 +496,7 @@ rust/crates/
 
 **Interfaces:** Produces `pub fn render_page(src: &str, width: u16, known: &BTreeSet<String>) -> (ratatui::text::Text<'static>, Vec<LinkSpan>)`. The fork carries exactly two patches (keep the diff minimal — upstream is actively maintained and we may rebase): (1) **Options passthrough** — expose `pulldown_cmark::Options` on the parser-construction call so `ENABLE_WIKILINKS` can be set (upstream hardcodes its option set); (2) **link metadata retention** — `link.rs` currently renders the destination as trailing literal text and discards `LinkType`; patch it to emit link start/end + `LinkType::WikiLink`/dest through a callback the caller uses to build `LinkSpan`s (ratatui `Span` has no metadata slot — the side-channel IS the design). Everything else (headings, lists, box-drawn tables, blockquotes, GFM alerts, syntect-highlighted fences via the bundled ansi-to-tui pipeline) is inherited working. Fenced directive blocks render as styled fences (fence-only rule; payloads pre-resolved by the vault bake).
 
-- [ ] Steps: vendor the crate + license/NOTICE → failing tests (heading style, fence block, `[[Target]]` → LinkSpan with `exists=false` when unknown, `[[Target|Label]]` pothole, empty→honest-absence) → apply the two patches → insta snapshots per fixture in `tests/fixtures/markdown/*.md` → `mise run rust:check` → commit `feat(rust): babylon-md fork with wikilink passthrough`.
+- [x] Steps: vendor the crate + license/NOTICE → failing tests (heading style, fence block, `[[Target]]` → LinkSpan with `exists=false` when unknown, `[[Target|Label]]` pothole, empty→honest-absence) → apply the two patches → insta snapshots per fixture in `tests/fixtures/markdown/*.md` → `mise run rust:check` → commit `feat(rust): babylon-md fork with wikilink passthrough`.
 
 ### Task 12: Wikilink semantics parity (TDD)
 
@@ -504,7 +504,7 @@ rust/crates/
 
 **Interfaces:** Native `ENABLE_WIKILINKS` (pulldown-cmark 0.13) replaces rev 1's custom inline pass — there is NO scanning code to write. This task ports the behavior TABLE from `tests/unit/tui/test_wikilinks.py` as contract tests over `render_page`: bare `[[t]]`, aliased `[[t|Label]]`, unknown target → redlink style + `exists=false`, `babylon://` target normalization (via Task 13's router). Document the two upstream parser quirks for content authors: pipe cannot be backslash-escaped inside a wikilink; empty `[[]]` renders literal.
 
-- [ ] Steps: red (ported table) → green (wiring only, no parser code) → commit `test(rust): wikilink semantics parity table`.
+- [x] Steps: red (ported table) → green (wiring only, no parser code) → commit `test(rust): wikilink semantics parity table`.
 
 ### Task 13: Router (TDD)
 
@@ -512,7 +512,7 @@ rust/crates/
 
 **Interfaces:** Produces `pub enum BabylonTarget { Entity(String), Kind { kind: String, id: String }, Redlink(String) }` and `pub fn parse_babylon_uri(uri: &str) -> Result<BabylonTarget, RouterError>` — `babylon://<kind>/<id>`, `babylon://<id>`, `babylon://redlink/<id>`. Port the case table from `tests/unit/tui/test_router.py` verbatim.
 
-- [ ] Steps: red (ported cases) → green → commit `feat(rust): babylon:// router`.
+- [x] Steps: red (ported cases) → green → commit `feat(rust): babylon:// router`.
 
 ### Task 14: Layout registry + hover/peek foundation (TDD)
 
@@ -520,7 +520,7 @@ rust/crates/
 
 **Interfaces:** Produces `pub struct LayoutRegistry { rects: Vec<(WidgetId, Rect, Option<String>)> }` with `pub fn register(&mut self, id: WidgetId, area: Rect, entity: Option<String>)` and `pub fn hit(&self, col: u16, row: u16) -> Option<&(WidgetId, Rect, Option<String>)>`; `App::handle_mouse(MouseEvent)` → on `Moved`, `hit()` → set `peek_target: Option<String>`; `views/peek.rs::render_peek(frame, area, subject_view_json, depth)` rendering depths 0–3 (port depth semantics from `src/babylon/tui/peek.py`). Mouse, not OSC 8 (ratatui#1227 unresolved — design R1).
 
-- [ ] Steps: failing hit-test unit tests (nested rects → innermost wins; miss → None) → implement → commit `feat(rust): layout registry + hover peek foundation`.
+- [x] Steps: failing hit-test unit tests (nested rects → innermost wins; miss → None) → implement → commit `feat(rust): layout registry + hover peek foundation`.
 
 ### Task 15: WikiView (TDD)
 
@@ -528,7 +528,7 @@ rust/crates/
 
 **Interfaces:** Consumes Tasks 11–14 + host `read_page`/`known_subjects_json`. Produces `pub struct WikiView { current: Option<String>, jumplist: Vec<String>, jumplist_idx: usize }` with `pub fn open(&mut self, target: &BabylonTarget, host: &dyn Host)` — redlink target renders the honest-absence page; `Ctrl-O`/`Ctrl-I` and `[`/`]` traverse the jumplist. Rendering pipeline: `read_page` → `render_page` (babylon-md) → link spans registered into `LayoutRegistry` (hover/click navigates; hover peeks); long pages scroll via `tui-scrollview`.
 
-- [ ] Steps: failing snapshot tests (entity page with links; redlink page; jumplist back/forward across 3 pages) → implement → commit `feat(rust): wiki view with jumplist navigation`.
+- [x] Steps: failing snapshot tests (entity page with links; redlink page; jumplist back/forward across 3 pages) → implement → commit `feat(rust): wiki view with jumplist navigation`.
 
 ### Task 16: LobbyView (TDD)
 
@@ -536,7 +536,7 @@ rust/crates/
 
 **Interfaces:** Consumes `host.lobby_catalog_json()`. Produces `pub struct LobbyView { rows: Vec<LobbyRow>, selected: usize }`; `Enter` on a row → `AppEvent::LoadCampaign(Uuid)`; `n` → `AppEvent::NewCampaign`. Empty catalog → honest-absence body. Mirrors `campaign_menu.py` display fields (name, tick, engine version, defines hash).
 
-- [ ] Steps: failing snapshot tests (populated, empty, selection move) → implement → commit `feat(rust): lobby view`.
+- [x] Steps: failing snapshot tests (populated, empty, selection move) → implement → commit `feat(rust): lobby view`.
 
 ### Task 17: Host M1 surface (Python, TDD) — includes the backlink-index build
 
@@ -544,7 +544,7 @@ rust/crates/
 
 **Interfaces:** Implements `read_page(subject) -> str | None` (delegates to the vault read path — read-only, never bakes), `known_subjects_json() -> str` (sorted list from `known_subjects()`), `backlinks_json(subject) -> str` — **`GameSession` has no counterpart today (design §6 gap ledger): build the vault backlink-index read path here**, `subject_view_json(subject) -> str` (`GameSession.subject_view` → `model_dump_json`).
 
-- [ ] Steps: failing contract tests (round-trip a `CountyView` fixture through `subject_view_json` and assert the JSON decodes with the expected tag; unknown subject → `None`; backlinks over a 3-page fixture vault) → implement → `mise run check` → commit `feat(tui): host M1 read surface + backlink index`.
+- [x] Steps: failing contract tests (round-trip a `CountyView` fixture through `subject_view_json` and assert the JSON decodes with the expected tag; unknown subject → `None`; backlinks over a 3-page fixture vault) → implement → `mise run check` → commit `feat(tui): host M1 read surface + backlink index`.
 
 ### Task 18: Palette + watchlist read (TDD)
 
@@ -552,7 +552,7 @@ rust/crates/
 
 **Interfaces:** Palette: `/` opens fuzzy input over `known_subjects_json`; `Enter` → `open()`. Watchlist rail: renders `watchlist_json()` rows; click/`p` navigation. (Pin WRITES land in M2 Task 25.)
 
-- [ ] Steps: failing snapshot tests → implement → commit `feat(rust): palette + watchlist read view`.
+- [x] Steps: failing snapshot tests → implement → commit `feat(rust): palette + watchlist read view`.
 
 ### Task 19: App shell integration — view stack + key/mouse routing (TDD)
 
@@ -560,13 +560,29 @@ rust/crates/
 
 **Interfaces:** `App` gains `view_stack: Vec<View>` (Lobby root), global bindings (tab/`1`–`5` view switch scaffold, `q` back/quit, `K` peek, `/` palette), crossterm mouse capture enabled in `run_interactive`, `handle_mouse` wired to `LayoutRegistry`. Headless mode gains scripted-input replay: `config_json` accepts `"script": [{"key": "..."}, {"mouse": [c, r]}...]` so integration tests drive flows without a terminal (this is the BDD harness foundation M3 builds on).
 
-- [ ] Steps: failing scripted-input integration test (lobby → open campaign page → back → quit; assert transcript frame count + host call order) → implement → `mise run rust:check` + `mise run check` → commit `feat(rust): app shell — view stack, global keys, mouse, scripted-input headless`.
+- [x] Steps: failing scripted-input integration test (lobby → open campaign page → back → quit; assert transcript frame count + host call order) → implement → `mise run rust:check` + `mise run check` → commit `feat(rust): app shell — view stack, global keys, mouse, scripted-input headless`.
 
 ### Task 20: M1 close-out
 
-- [ ] Both gates green; manual smoke `babylon play --client rust` browses the REAL vault for a live campaign; `ai/state.yaml` updated; commit `docs(state): raster cutover M1`.
+- [x] Both gates green; manual smoke `babylon play --client rust` browses the REAL vault for a live campaign; `ai/state.yaml` updated; commit `docs(state): raster cutover M1`.
 
 ---
+
+
+**M1 CLOSED 2026-07-27** (branch `feature/ratatui-m1`). Recorded deviations:
+`tui-scrollview` was NOT adopted — WikiView wraps with its own span-preserving
+word wrap because the layout registry needs the exact display cells each
+wikilink occupies and ratatui-side wrapping discards that mapping; scrolling is
+`Paragraph::scroll` clamped to content. Additions beyond the task list, from
+the adversarial verify panel: `Host::load_campaign` (the production
+composition-root verb — plan Task 7's `bind_session` had no caller),
+loud-failure FFI (a raising host panics across the seam, III.11), keyboard
+link cursor `n`/`p`/`Enter` feeding peek, the backlinks footer as the Task 17
+seam's consumer, lobby `codename` display (spec-116), theme.rs + the
+cross-language palette guard, and loud parse-failure states in
+lobby/palette/watchlist. Real-vault smoke: campaign minted via the real menu,
+Enter → briefing rendered from the live Postgres vault, exact seam call order
+pinned. TTY smoke remains owner-side (as M0 Task 10).
 
 # M2 — Playable (task-level; expand at kickoff)
 

--- a/docs/superpowers/specs/2026-07-27-wiki-content-architecture.md
+++ b/docs/superpowers/specs/2026-07-27-wiki-content-architecture.md
@@ -1,0 +1,260 @@
+# Wiki Content Architecture — Namespaces, Templates, and the Fact→Flavor Contract
+
+**Date:** 2026-07-27 · **Status: DRAFT FOR DIRECTOR REVIEW — NOTHING HERE IS RATIFIED.**
+**The content/ideological line is the Director's alone (Amendment AD, Constitution §IX.5); this
+document proposes structure, never doctrine.** Every claim below is either (a) grounded in an
+existing file/line, marked **[EXISTS]**, or (b) a proposal with no code behind it yet, marked
+**[PROPOSAL]**. Nothing is claimed that isn't one or the other.
+
+**Scope:** Diataxis explanation quadrant — a mental model for "what kind of page is this, who
+authored it, and what may touch it," answering the Director's brief: *"some templates or something
+to work from in order to generate a wiki structure... look into semantic wiki and Wikipedia...
+Babylon Glossary that's a thing we write which no AI touches, but actual game-state files could be
+generated with creative flavor while maintaining facts — the flavor is derived from the facts."*
+
+## 1. The headline finding: two-thirds of this already exists
+
+The vault estate (`src/babylon/projection/vault/`) already implements two of the three namespaces
+the Director described, under different names. This document proposes naming the third and
+formalizing the seam between them — it is much less new work than "generate a wiki structure"
+sounds.
+
+| Director's ask | Existing Babylon construct | Status |
+|---|---|---|
+| "Babylon Glossary... no AI touches" | Concept cards (`vault/concept_cards.py`, `vault/templates/concept.md.j2`) | **[EXISTS]**, unnamed as a namespace |
+| "game state files... generated" | County/state/national/org/... dossiers (`vault/render*.py`, `vault/templates/*.md.j2`, the two tick bakers) | **[EXISTS]** |
+| "creative flavor... derived from facts" | The narrator-cache skeleton (`vault/narrator_cache.py`) + provider seam (`intelligence/providers.py`) | **[EXISTS as skeleton]** — cache/attribution/async plumbing is built; the fact-derivation *validator* is **[PROPOSAL]** |
+
+## 2. Namespace model (proposal, naming what exists + one new tier)
+
+### 2.1 `Glossary` — hand-written, AI-forbidden, static
+
+**[EXISTS], unnamed.** `vault/concept_cards.py` already ships exactly this: four pages
+(`fundamental-theorem`, `survival-calculus`, `metabolic-rift`, `nine-verbs`) as a closed
+`CONCEPT_CARDS` registry (lines 259–267), each a frozen `ConceptCard` with `statement`, `formula`,
+`terms`, `implementation` (dotted code refs), `citation`, `see_also`. Two properties make it the
+Glossary prototype:
+
+- **No `verified_tick`.** The module docstring (lines 34–43) is explicit: "a mathematical
+  definition does not go stale the way a committed-tick observation does" — it is compiled once at
+  import time, not projected from live state.
+- **No narrator fence.** `templates/concept.md.j2` carries only `{statblock}`; there is no
+  `{narrative}` block on a concept card, structurally — nothing here is ever AI-authored.
+
+**Enforcement gap — currently NONE, and this is the one piece of actual net-new engineering the
+Director's ask requires: [PROPOSAL].** Today "no AI touches the Glossary" holds only because
+nothing calls a narrator over `concept.md.j2` output — there is no sentinel that would catch a
+future PR wiring one in. A path-based guard (any bake targeting `concept/*.md` may only originate
+from `render_concept_card()`, never from `NarratorCache.narrate()`) would be the cheapest version,
+mirroring the existing `mise run check:vocabulary` sentinel-per-error-class pattern
+(`src/babylon/sentinels/vocabulary/`, cited in this repo's `CLAUDE.md` Gotchas section) rather than
+inventing a new enforcement idiom.
+
+### 2.2 `State` — engine-templated facts, deterministic, tick-hash-adjacent
+
+**[EXISTS].** The bulk of the vault: county/state/national/organization/institution/sovereign/
+industry/social_class/economy/field_state/community dossiers. Grounding:
+
+- `render.py`'s `_build_environment()` (lines 234–254) is an `ImmutableSandboxedEnvironment` with
+  `StrictUndefined`, no custom filters/globals (ADR099: "environment construction is code, never
+  data"), loading only from this package's own `templates/` via `PackageLoader` — no
+  filesystem-escape surface.
+- Every optional field is resolved through a `statblock_rows`/`absent_fields` precompute
+  (`render.py` lines 73–134) rather than the template touching an `Optional` field directly —
+  Jinja's `StrictUndefined` only fires on a genuinely *absent* name, so this is how the templates
+  stay honest about `None` vs a present zero (III.11).
+- Determinism is structural, not a convention: `ArchiveTickBaker` (`tick_baker.py`) re-bakes every
+  kind every tick (the correctness baseline); `IncrementalArchiveTickBaker`
+  (`incremental_baker.py`) re-bakes only dirty entities, but every enumeration and budget clamp
+  iterates a *sorted* sequence (module docstring lines 62–64) so the two bakers are byte-identical
+  on the same inputs.
+- One more sub-case worth naming explicitly: **`epilogues.py`** is *dev-authored conditional
+  prose* (the six terminal-outcome texts, `EPILOGUES` dict lines 73–146) that is nonetheless
+  `State`, not `Chronicle` — `templates/epilogue.md.j2` says so directly (lines 5–9): "the headline
+  and body below are deterministic, dev-authored copy, not narrator-generated prose... none of this
+  text is AI-attributed." This is a real, already-shipped instance of "hand-written flavor
+  triggered by a fact pattern" that is distinct from both a stat-scaffold page and an AI-narrated
+  one — a third texture worth keeping in mind when the Director rules on Chronicle's voice (§6.1).
+
+### 2.3 `Chronicle` (a.k.a. Flavor) — AI-narrated prose, derived from facts, outside the tick hash
+
+**[EXISTS as skeleton — the cache/attribution/async plumbing]. [PROPOSAL — the fact-derivation
+validator itself, which does not exist yet].**
+
+`vault/narrator_cache.py` is the closest thing in this repo to the Director's "flavor is derived
+from the facts" sentence, already built to the following contract:
+
+- **Path-disjoint from `State`.** Narrative pages live under `narrative/<entity>/` (line 71), never
+  under `county/`, `concept/`, etc. — "the byte-identity gates never see it" (line 20). This is
+  *exactly* the namespace-as-path enforcement the Glossary needs and doesn't have yet (§2.1); the
+  pattern is proven, just not applied to `concept/`.
+- **Keyed `(entity, tick, model_pin)`** per Constitution III.6 (`CONSTITUTION.md` line 438:
+  "Every persisted AI artifact... MUST carry its model pin... Replayability across model
+  deprecation is a constitutional requirement"). A provider swap writes a *new* page; the old pin's
+  page is untouched (`narrator_cache.py` lines 9–10).
+- **Silence is honest, degradation is loud.** An empty narration writes nothing (`narrate()` line
+  313: `if result.text == "": return None`) — the deterministic dossier is fully informative with no
+  narrator (III.11/R4). A transport failure writes a *visible* `{absence}` fence naming the error
+  (lines 154–157), never a silently-dropped generation.
+- **LLM text never meets Jinja** (module docstring lines 22–27): narrative pages are assembled by
+  plain string building (`_render_narrative_page`, lines 135–161), with the fence outrun-length
+  computed from the prose itself (`_fence_for`, lines 119–132) so hostile model output containing
+  backtick runs cannot close the page's own block early. This is the concrete answer to "how does
+  untrusted generated text stay safely embedded in a trusted Markdown page."
+- **Off the tick path, single-flight.** `NarratorSideProcess` (lines 339–393) is a
+  one-worker-thread fire-and-forget scheduler — deliberately one worker so narrative commits to
+  the shared dulwich repo serialize with each other and with the tick baker's own commits
+  (`git_backend.py`, referenced but not separately cited here).
+
+What is **missing** — the actual net-new work the Director's ask requires beyond naming things:
+
+1. **No fact-derivation validator exists.** `narrate()` (`intelligence/providers.py` lines 406–429)
+   takes opaque `(system, prompt)` strings and returns opaque `text`; nothing checks that a number
+   or named entity in `text` traces back to the `CountyView`/whichever view-model that prompted it.
+   `narrator_cache.py`'s own docstring flags the adjacent gap directly (line 42): "Doctrine-
+   conditioning of prompts is DEFERRED past v1... callers supply `(system, prompt)` and this module
+   treats them as opaque." **[PROPOSAL]:** a validator function,
+   `verify_grounded(view: BaseModel, prose: str) -> GroundingReport`, run *before* `NarratorCache._write`
+   commits a healthy entry — walking the view's populated fields (the same walk `render.py`'s
+   `_statblock_rows` already does per-kind) and confirming every number/proper-noun surfaced in
+   `prose` appears (verbatim or in a declared paraphrase set — e.g. "a third" for 0.33) among the
+   view's own field values. A prose block that fails the check is **not** silently dropped —
+   consistent with III.11, it should write a *visible* `{absence}`-style flag ("narration rejected —
+   ungrounded claim: `<span>`") rather than either fabricating trust or discarding the failure.
+   This is the one piece of this whole document that has zero prior art in the codebase; it needs
+   the Director's or an ADR's sign-off before anyone builds it (§6.3).
+2. **`Persona` is built but not wired here.** `intelligence/ai/persona.py`'s `Persona`/`VoiceConfig`
+   (voice/tone/obsessions/directives/restrictions, `render_system_prompt()` lines 150–175) is a
+   complete "who is narrating and in what register" model, consumed today by
+   `intelligence/ai/prompt_builder.py`/`director.py` — but `narrator_cache.narrate()`'s `system`
+   parameter is just a `str`; nothing currently threads a `Persona` into a vault narration call.
+   Wiring this is small (a `Persona.render_system_prompt()` call at the narration call site) but is
+   a real decision point, not a mechanical one — see §6.1.
+
+## 3. Template layer
+
+**Proposal: extend the existing `.j2` vault estate, do not invent a second templating system.**
+
+The vault already has the primitives Wikipedia/SMW templates provide:
+
+- **Infobox partial [EXISTS, implicit]:** every dossier's `{statblock}` fence (e.g.
+  `templates/county.md.j2` lines 25–29) IS the infobox — a fixed-order key/value panel resolved
+  from typed fields. It is currently duplicated per template (`county.md.j2`, `concept.md.j2`, and
+  every other `templates/*.md.j2` each write their own `{statblock}` loop) rather than factored into
+  a shared Jinja macro/partial. **[PROPOSAL]:** a single `_statblock.md.j2` include, parameterized
+  on `(rows,)`, would remove that duplication without changing rendered output — pure factoring,
+  no behavior change, safe to do without Director sign-off.
+- **Lead-paragraph convention [PROPOSAL, no prior art]:** Wikipedia's lead-section rule ("a summary
+  of the article's most important contents... before the first heading," WP:LEAD) has no analog
+  today — every dossier template goes straight from the H1 to the `{statblock}` fence
+  (`county.md.j2` lines 23–25). Adding one deterministic summary line (e.g. "County {fips}:
+  population N, sovereign {sovereign_id or 'unclaimed'}, bifurcation {axis}") ahead of the
+  statblock is a `State`-namespace, non-AI change — cheap, and arguably improves the page even
+  without any Chronicle content. Flagging as a proposal because it changes every baked page's bytes
+  (a baseline-ceremony-triggering change per this repo's `CLAUDE.md` §6.5), not because it's
+  risky in kind.
+- **Categories/footer partial [PROPOSAL]:** nothing today renders a "category" or "see also beyond
+  `concept.md.j2`'s own `see_also` loop" footer on non-concept pages. `facets_by_type()`
+  (`tui/shell/backlinks.py` lines 27–33) already computes exactly this grouping (page slugs grouped
+  by their `type/` prefix) for the Wiki view's use, but it is not rendered *into* the baked page
+  itself — it is a client-side facet, not a page-embedded category list. Whether categories belong
+  baked into pages (Wikipedia-style, in the git history) or computed live by the client (current
+  approach) is an open question (§6.2), not a foregone one.
+- **What-links-here [EXISTS]:** `build_backlink_index()` (`tui/shell/backlinks.py` lines 18–24)
+  inverts every page's outbound `[[wikilinks]]` (matched via
+  `tui/wikilinks.py::WIKILINK_RE`, line 51) into a target→sources map. The ratatui design doc
+  explicitly homes this as a real M1 work item on the Rust side too: "`backlinks_json`:
+  `GameSession` has no counterpart today — the M1 host task **builds** the vault backlink-index
+  read path" (`docs/superpowers/specs/2026-07-26-ratatui-client-design.md` lines 225–226).
+
+## 4. The semantic layer — Semantic MediaWiki and Wikipedia mapped onto what exists
+
+External research grounding (WebSearch, this session): SMW's typed-property model
+(`Has type` annotations on a property; semantic-mediawiki.org/wiki/Help:Properties_and_types),
+`#ask` query syntax (properties prefixed `?`, semantic-mediawiki.org/wiki/Help:Inline_queries), and
+`Special:Browse` ("displays all semantic properties of a page as well as all semantic links that
+point to that page," semantic-mediawiki.org/wiki/Help:Browsing_interfaces). Wikipedia grounding:
+lead-section convention (`Wikipedia:Manual_of_Style/Lead_section`), infobox as a
+"panel that summarizes key facts... top-right... next to the lead" (`Wikipedia:Manual_of_Style/
+Infoboxes`), categories as a reader/editor navigation aid
+(`Wikipedia:Manual_of_Style/Category_pages`), the namespace system ("30 current namespaces: 14
+subject, 14 talk, 2 virtual"; Template namespace = transclusion; Portal = reader/editor bridge;
+`Help:Namespaces`), `What links here` (`Template:What_links_here`), protection tiers (full /
+semi- / template-protection, `Wikipedia:Protection_policy`), and WP:V ("material must be
+attributable to a reliable published source... whether or not it is cited,"
+`Wikipedia:Verifiability`).
+
+| SMW / Wikipedia concept | Babylon mapping | Grounding |
+|---|---|---|
+| Typed property (`Has type: Number`) | A `ProjectionRecord` field (e.g. `CountyView.imperial_rent_phi: SignedLaborHours \| None`) | `view_models.py` lines 141–201; the whole point of the module docstring (lines 1–19): "records... composes fields drawn from multiple subsystems... every field a fog/veil gate can withhold is `Optional` with honest `None` semantics" |
+| `#ask` query / `Special:Ask` | **[PROPOSAL, no prior art]** — nothing today lets a page or client ask "every county with `bifurcation_score < -0.5`" | `DeclaredView.fts_columns` (`registry.py` lines 62–64, 80) is the closest existing surface — a declared *subset* of columns exposed to full-text search — but it is lexical search over SQL views, not a typed-property query language |
+| `Special:Browse` (all properties + all inbound links for one page) | `peek(view, depth=3)` (full transclusion, every field) + `build_backlink_index()` | `tui/peek.py` docstring lines 17–36 (depth table) + `backlinks.py` lines 18–24 — the two together ARE Special:Browse, just not unified behind one page/command yet |
+| Lead section (summary-first) | Not yet present | §3, `[PROPOSAL]` |
+| Infobox | `{statblock}` fence + `peek()` at any depth | `render.py` `_statblock_rows`/`sovereign_statblock_rows`; `peek.py` `_FIELD_CAP_BY_DEPTH` (line 96) is literally Wikipedia's "infobox vs. hover-preview vs. full-page" idea made explicit as a size table |
+| Categories | `facets_by_type()` (client-side only) | `backlinks.py` lines 27–33; see §3's open question on baked-in vs. computed |
+| Template namespace (transclusion) | The `.j2` templates themselves, plus `peek(depth=3)` as literal transclusion of a whole dossier inline | `peek.py` line 35: "page transclusion (embeds the *whole* dossier inline)" |
+| Portal namespace | No analog; **[PROPOSAL, not yet scoped]** — a possible home for a hand-curated "start here" page distinct from both Glossary (definitions) and a dossier (one entity) | none |
+| Protected pages | The Glossary's *intended* AI-forbidden status | §2.1 — currently a convention, not an enforced protection tier; **[PROPOSAL]** to make it one |
+| What-links-here | `build_backlink_index()` | as above |
+| WP:V ("traceable to a source, whether or not cited") | Constitution III.8, the Aleksandrov Test: "every formal construct... MUST trace a chain of abstractions back to a material relation" (`CONSTITUTION.md` line 442) + III.11 Loud Failure (line 456) | Babylon's version is *stricter* than WP:V — WP:V permits an uncited-but-verifiable claim; Babylon's honest-`None` discipline (§2.2) means an untraceable field renders as an explicit `{absence}` block, never an omitted-but-true claim |
+
+## 5. Determinism boundaries
+
+The load-bearing rule, stated once so every section above can rely on it rather than re-derive it:
+**`Glossary` and `State` pages are pure functions of committed engine state and are part of the
+byte-identity gate surface (`qa:vault-regression-ci`, cited in this repo's `CLAUDE.md` under
+"Definition of done"); `Chronicle` pages are not, by construction, and must never be made to be.**
+
+This is the same shape as the project's existing fog/epistemic ruling (project memory:
+"Fog = EPISTEMIC, engine = MATERIAL — player knowledge never in tick hash; ask who WRITES the
+store"): the question to ask of any new wiki page kind is not "does this look like game content"
+but "who writes this store, and does a second identical run at the same tick produce the same
+bytes." `narrator_cache.py` already answers this correctly in its own docstring (lines 28–32): "the
+byte-identity gates run narrator-OFF and never see this subtree." The Glossary needs the same
+answer made *structural* rather than incidental (§2.1's enforcement gap) — today it is
+byte-identical only because nothing writes to `concept/*.md` except `render_concept_card()`, not
+because anything would stop a future caller from doing otherwise.
+
+## 6. Open questions for the Director
+
+### 6.1 Chronicle's voice — is `Persona` the right instrument, and whose call is the register?
+
+`Persona`/`VoiceConfig` (`intelligence/ai/persona.py`) already models tone/obsessions/directives/
+restrictions as data, not code — matching this repo's Paradox Pattern
+(`/home/user/projects/game/CLAUDE.md` §5: "game logic... defined in TOML/data, not hardcoded"). But
+*which* persona narrates the Chronicle, and what its `directives`/`restrictions` say about
+ideological framing, is squarely "touches the ideological line" (Constitution §IX.5) — this
+document does not propose a persona, only that the wiring point (`narrator_cache.narrate()`'s
+opaque `system` string, §2.3 item 2) exists and is small once a persona is chosen.
+
+### 6.2 Do categories/see-also get baked into `State` pages, or stay a client-side facet?
+
+`facets_by_type()` already computes the grouping (§3). Baking it into every page's footer makes the
+git-history vault itself browsable outside any client (closer to Wikipedia, where categories are
+page content); leaving it client-side keeps `State` pages minimal and avoids a whole-vault
+re-bake whenever the faceting logic changes. Both are legitimate; this is a taste/cost call, not a
+correctness one.
+
+### 6.3 Is a fact-grounding validator (§2.3 item 1) worth building pre-1.0, and what's its failure mode?
+
+This is the one genuinely new engineering surface in this whole document. Three sub-questions the
+Director's ruling should settle before anyone writes code: (a) does an ungrounded Chronicle block
+get rejected outright (never committed) or committed-but-flagged (III.11-style visible `{absence}`
+annotation alongside the prose); (b) is the check exact-string-match against view-model field
+values, or does it need a declared paraphrase vocabulary (so "roughly a third" passes against
+`0.33`) — the former is buildable today, the latter needs its own small spec; (c) does this gate
+every Chronicle write or only the ones a player will actually see (narration is currently
+fire-and-forget and off the tick path — gating it synchronously would reintroduce latency the
+`NarratorSideProcess` design (§2.3) exists specifically to avoid).
+
+### 6.4 Does the Glossary ever need a *second* hand-written tier — a Portal-style "start here"?
+
+Flagged in §4's mapping table as unscoped. Not urgent; noted so it isn't lost.
+
+---
+
+**Everything in §§1–5 not explicitly marked `[PROPOSAL]` is a description of code that exists
+today, cited to file and line, at the time this document was written (2026-07-27, worktree
+`political-superstructure`).** Nothing here authorizes building the `[PROPOSAL]` items; they are
+scoped for discussion, not for autonomous implementation, per Amendment AD's escalation rule for
+anything touching the ideological line or adding a primitive.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +33,19 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "ansi-to-tui"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42366bb9d958f042bf58f0a85e1b2d091997c1257ca49bddd7e4827aadc65fd"
+dependencies = [
+ "nom 8.0.0",
+ "ratatui-core",
+ "simdutf8",
+ "smallvec",
+ "thiserror 2.0.19",
+]
 
 [[package]]
 name = "anyhow"
@@ -68,11 +87,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "babylon-md"
+version = "0.3.9"
+dependencies = [
+ "ansi-to-tui",
+ "document-features",
+ "indoc",
+ "insta",
+ "itertools 0.15.0",
+ "pretty_assertions",
+ "pulldown-cmark",
+ "ratatui",
+ "ratatui-core",
+ "rstest",
+ "syntect",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "babylon-tui"
 version = "0.1.0"
 dependencies = [
+ "babylon-md",
  "hypergraph-rs",
  "insta",
+ "pulldown-cmark",
  "ratatui",
  "serde",
  "serde_json",
@@ -95,6 +135,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -157,6 +206,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -232,6 +291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -381,6 +449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +544,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +566,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float_eq"
@@ -518,10 +608,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -530,6 +637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -543,6 +651,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -568,6 +685,12 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h3o"
@@ -606,7 +729,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "rayon",
 ]
 
 [[package]]
@@ -618,6 +740,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "rayon",
 ]
 
 [[package]]
@@ -719,6 +842,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +910,12 @@ checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.13.1",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -863,6 +1001,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +1059,24 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -992,6 +1158,28 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "ordered-float"
@@ -1171,6 +1359,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plist"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1399,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "priority-queue"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1420,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1436,25 @@ checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.13.1",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pyo3"
@@ -1266,6 +1511,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1366,7 +1620,7 @@ dependencies = [
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
@@ -1431,7 +1685,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -1464,7 +1718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -1517,6 +1771,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.119",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,7 +1841,7 @@ checksum = "4b213df2cbfa5f580ed2c0ac3619eda06692a4ff0211f0aebbb4008eaa9724a6"
 dependencies = [
  "fixedbitset 0.5.7",
  "foldhash 0.1.5",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "ndarray",
  "num-traits",
@@ -1570,6 +1859,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1638,6 +1936,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +1980,18 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -1783,6 +2108,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.19",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,7 +2167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -1918,6 +2264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,6 +2285,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1937,6 +2293,103 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
 
 [[package]]
 name = "typenum"
@@ -1949,6 +2402,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -1968,7 +2427,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1998,6 +2457,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2484,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2170,6 +2645,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,10 +2675,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zmij"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1917,6 +1917,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/babylon-tui", "crates/babylon-tui-python"]
+members = ["crates/babylon-md", "crates/babylon-tui", "crates/babylon-tui-python"]
 resolver = "2"
 
 [workspace.package]

--- a/rust/crates/babylon-md/CHANGELOG.md
+++ b/rust/crates/babylon-md/CHANGELOG.md
@@ -1,0 +1,173 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [unreleased]
+
+## [0.3.9](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.3.8...tui-markdown-v0.3.9) - 2026-07-23
+
+- Render GFM tables and alerts, raw HTML, math, footnotes, and definition lists ([#153], [#154]).
+- Render configurable image text fallbacks using alt text or URLs ([#155], [#156]).
+- Choose from bundled syntax-highlighting themes or load a custom TextMate theme ([#158], [#159]).
+- Customize or hide heading markers and code-block fences, with style sheets that only override
+  the choices they need ([#167], [#168]).
+- Style visible link labels consistently with their URLs.
+- Keep styled list content beside its marker ([#166]).
+
+[#153]: https://github.com/joshka/tui-markdown/pull/153
+[#154]: https://github.com/joshka/tui-markdown/pull/154
+[#155]: https://github.com/joshka/tui-markdown/pull/155
+[#156]: https://github.com/joshka/tui-markdown/pull/156
+[#158]: https://github.com/joshka/tui-markdown/pull/158
+[#159]: https://github.com/joshka/tui-markdown/pull/159
+[#167]: https://github.com/joshka/tui-markdown/pull/167
+[#168]: https://github.com/joshka/tui-markdown/pull/168
+[#166]: https://github.com/joshka/tui-markdown/pull/166
+
+## [0.3.8](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.3.7...tui-markdown-v0.3.8) - 2026-06-27
+
+- Maintenance and dependency updates ([#116], [#120], [#132], [#133]).
+
+[#116]: https://github.com/joshka/tui-markdown/pull/116
+[#120]: https://github.com/joshka/tui-markdown/pull/120
+[#132]: https://github.com/joshka/tui-markdown/pull/132
+[#133]: https://github.com/joshka/tui-markdown/pull/133
+
+## [0.3.7](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.3.6...tui-markdown-v0.3.7) - 2025-12-27
+
+- Add custom style sheets and render metadata blocks, subscript, superscript, soft line breaks, and
+  horizontal rules ([#80], [#107], [#108], [#109], [#110], [#111]).
+- Preserve heading metadata and update compatibility to Ratatui 0.30 ([#105], [#106]).
+
+[#80]: https://github.com/joshka/tui-markdown/pull/80
+[#107]: https://github.com/joshka/tui-markdown/pull/107
+[#108]: https://github.com/joshka/tui-markdown/pull/108
+[#109]: https://github.com/joshka/tui-markdown/pull/109
+[#110]: https://github.com/joshka/tui-markdown/pull/110
+[#111]: https://github.com/joshka/tui-markdown/pull/111
+[#105]: https://github.com/joshka/tui-markdown/pull/105
+[#106]: https://github.com/joshka/tui-markdown/pull/106
+
+## [0.3.6](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.3.5...tui-markdown-v0.3.6) - 2025-11-03
+
+- Render task lists ([#99]).
+
+[#99]: https://github.com/joshka/tui-markdown/pull/99
+
+## [0.3.5](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.3.4...tui-markdown-v0.3.5) - 2025-05-07
+
+- Maintenance and dependency updates ([#79]).
+
+[#79]: https://github.com/joshka/tui-markdown/pull/79
+
+## [0.3.4](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.3.3...tui-markdown-v0.3.4) - 2025-05-07
+
+- Maintenance release ([#81], [#82]).
+
+[#81]: https://github.com/joshka/tui-markdown/pull/81
+[#82]: https://github.com/joshka/tui-markdown/pull/82
+
+## [0.3.3](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.3.2...tui-markdown-v0.3.3) - 2025-03-11
+
+- Maintenance and dependency updates ([#71]).
+
+[#71]: https://github.com/joshka/tui-markdown/pull/71
+
+## [0.3.2](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.3.1...tui-markdown-v0.3.2) - 2025-03-09
+
+- Maintenance and dependency updates ([#64], [#66], [#70]).
+
+[#64]: https://github.com/joshka/tui-markdown/pull/64
+[#66]: https://github.com/joshka/tui-markdown/pull/66
+[#70]: https://github.com/joshka/tui-markdown/pull/70
+
+## [0.3.1](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.3.0...tui-markdown-v0.3.1) - 2024-12-17
+
+- Render links as their visible label followed by the destination URL ([#62]).
+
+[#62]: https://github.com/joshka/tui-markdown/pull/62
+
+## [0.3.0](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.2.12...tui-markdown-v0.3.0) - 2024-11-20
+
+- Update compatibility to Ratatui 0.29 ([#58]).
+
+[#58]: https://github.com/joshka/tui-markdown/pull/58
+
+## [0.2.12](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.2.11...tui-markdown-v0.2.12) - 2024-10-22
+
+- Maintenance and dependency updates ([#54]).
+
+[#54]: https://github.com/joshka/tui-markdown/pull/54
+
+## [0.2.11](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.2.10...tui-markdown-v0.2.11) - 2024-10-13
+
+- Syntax-highlight fenced code blocks ([#51]).
+
+[#51]: https://github.com/joshka/tui-markdown/pull/51
+
+## [0.2.10](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.2.9...tui-markdown-v0.2.10) - 2024-09-20
+
+- Render headings, blockquotes, ordered and nested lists, strong, emphasized, and struck-through
+  text, and Markdown line breaks ([#45]).
+- Ignore unsupported Markdown constructs instead of panicking ([#45]).
+
+[#45]: https://github.com/joshka/tui-markdown/pull/45
+
+## [0.2.9](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.2.8...tui-markdown-v0.2.9) - 2024-09-20
+
+- Render unordered lists ([#44]).
+
+[#44]: https://github.com/joshka/tui-markdown/pull/44
+
+## [0.2.8](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.2.7...tui-markdown-v0.2.8) - 2024-09-02
+
+- Maintenance and dependency updates ([#38], [#41]).
+
+[#38]: https://github.com/joshka/tui-markdown/pull/38
+[#41]: https://github.com/joshka/tui-markdown/pull/41
+
+## [0.2.7](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.2.6...tui-markdown-v0.2.7) - 2024-08-06
+
+- Maintenance release.
+
+## [0.2.6](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.2.5...tui-markdown-v0.2.6) - 2024-06-24
+
+- Update Ratatui compatibility ([#29]).
+
+[#29]: https://github.com/joshka/tui-markdown/pull/29
+
+## [0.2.5](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.2.4...tui-markdown-v0.2.5) - 2024-06-08
+
+- Correct links to the crate documentation.
+
+## [0.2.4](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.2.3...tui-markdown-v0.2.4) - 2024-05-22
+
+- Maintenance and dependency updates ([#24]).
+
+[#24]: https://github.com/joshka/tui-markdown/pull/24
+
+## [0.2.3](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.2.2...tui-markdown-v0.2.3) - 2024-04-24
+
+- Update Markdown parser and Ratatui compatibility ([#19], [#20], [#23]).
+
+[#19]: https://github.com/joshka/tui-markdown/pull/19
+[#20]: https://github.com/joshka/tui-markdown/pull/20
+[#23]: https://github.com/joshka/tui-markdown/pull/23
+
+## [0.2.2](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.2.1...tui-markdown-v0.2.2) - 2024-02-29
+
+- Clarify licensing and the project's experimental status.
+
+## [0.2.1](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.2.0...tui-markdown-v0.2.1) - 2024-02-27
+
+- Correct documentation links and package metadata.
+
+## [0.2.0](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.1.1...tui-markdown-v0.2.0) - 2024-02-27
+
+- Render fenced code blocks and preserve Markdown line breaks.
+
+## [0.1.1](https://github.com/joshka/tui-markdown/compare/tui-markdown-v0.1.0...tui-markdown-v0.1.1) - 2024-02-27
+
+- Introduce the Markdown-to-Ratatui renderer.
+
+<!-- generated by git-cliff -->

--- a/rust/crates/babylon-md/Cargo.toml
+++ b/rust/crates/babylon-md/Cargo.toml
@@ -36,5 +36,5 @@ tracing = "0.1.37"
 [dev-dependencies]
 indoc = "2"
 insta = "1"
-ratatui = "0.30"
+ratatui = { version = "0.30", default-features = false }
 tracing-subscriber = "0.3"

--- a/rust/crates/babylon-md/Cargo.toml
+++ b/rust/crates/babylon-md/Cargo.toml
@@ -1,0 +1,40 @@
+# babylon-md — Babylon's fork of tui-markdown v0.3.9 (ADR150 ecosystem ruling).
+# Upstream: https://github.com/joshka/tui-markdown (Josh McKinney, MIT OR Apache-2.0;
+# LICENSE-MIT / LICENSE-APACHE preserved in this directory). The fork carries exactly
+# two surgical patches — pulldown-cmark Options passthrough and link-metadata
+# retention — to keep rebasing onto upstream cheap. License fields are NOT
+# workspace-inherited: this crate stays under upstream's dual license.
+
+[package]
+name = "babylon-md"
+description = "Babylon fork of tui-markdown: markdown to Ratatui Text with wikilink passthrough"
+version = "0.3.9"
+edition = "2021"
+rust-version = "1.88.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/joshka/tui-markdown"
+authors = ["Joshka", "Babylon contributors"]
+publish = false
+
+[features]
+default = ["highlight-code"]
+
+## Enable syntax highlighting using syntect and ansi-to-tui
+highlight-code = ["dep:syntect", "dep:ansi-to-tui"]
+
+[dependencies]
+ansi-to-tui = { version = "8", optional = true }
+document-features = { version = "0.2.11", optional = true }
+itertools = "0.15"
+pretty_assertions = "1"
+pulldown-cmark = "0.13"
+ratatui-core = { version = "0.1", default-features = false }
+rstest = "0.26"
+syntect = { version = "5", optional = true }
+tracing = "0.1.37"
+
+[dev-dependencies]
+indoc = "2"
+insta = "1"
+ratatui = "0.30"
+tracing-subscriber = "0.3"

--- a/rust/crates/babylon-md/LICENSE-APACHE
+++ b/rust/crates/babylon-md/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rust/crates/babylon-md/LICENSE-MIT
+++ b/rust/crates/babylon-md/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Josh McKinney
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rust/crates/babylon-md/README.md
+++ b/rust/crates/babylon-md/README.md
@@ -1,0 +1,328 @@
+# babylon-md — Babylon's fork of tui-markdown
+
+**FORK NOTICE:** this crate is Babylon's in-tree fork of
+[tui-markdown v0.3.9](https://github.com/joshka/tui-markdown) by Josh McKinney
+(MIT OR Apache-2.0 — `LICENSE-MIT` / `LICENSE-APACHE` in this directory).
+It carries exactly two surgical patches (ADR150 ecosystem ruling, plan Task 11):
+a `pulldown_cmark::Options` passthrough so `ENABLE_WIKILINKS` can be set, and
+link-metadata retention through a side-channel sink so the caller can build
+`LinkSpan`s. Everything below this notice is upstream's README, kept for
+attribution and reference.
+
+---
+
+# Tui-markdown
+
+An experimental Proof of Concept library for converting markdown content to a [Ratatui] `Text`
+value. See [Markdown-reader] for an example application that uses this library.
+
+[![Crate badge]][tui-markdown]
+[![Docs.rs Badge]][API Docs]
+[![Deps.rs Badge]][Dependency Status]
+[![License Badge]](../LICENSE-MIT)
+[![Codecov.io Badge]][Code Coverage]
+[![Discord Badge]][Ratatui Discord]
+
+[GitHub Repository] · [API Docs] · [Examples] · [Changelog] · [Contributing]
+
+## Installation
+
+```shell
+cargo add tui-markdown
+```
+
+## Usage
+
+```rust
+let input = "# Heading\n\n**bold**"; // this can come from wherever
+let text = tui_markdown::from_str(input);
+text.render(area, &mut buf);
+```
+
+### Syntax highlighting themes
+
+With the default `highlight-code` feature enabled, fenced code blocks whose language is recognized
+use the built-in `Base16OceanDark` syntax-highlighting theme. Pass a [`BuiltinCodeTheme`] to select
+a different bundled theme:
+
+```rust
+use tui_markdown::{from_str_with_options, BuiltinCodeTheme, Options};
+
+let options = Options::default().code_theme(BuiltinCodeTheme::InspiredGitHub);
+let markdown = r#"```rust
+fn main() {}
+```"#;
+let text = from_str_with_options(markdown, &options);
+```
+
+[`CodeTheme::from_file`] reads and parses a TextMate `.tmTheme` file immediately. The returned theme
+owns the parsed data, so rendering does not access the file again:
+
+```rust
+use tui_markdown::{CodeTheme, CodeThemeLoadError, Options};
+
+fn options() -> Result<Options, CodeThemeLoadError> {
+    let theme = CodeTheme::from_file("themes/solarized.tmTheme")?;
+    Ok(Options::default().code_theme(theme))
+}
+```
+
+Use [`CodeTheme::from_textmate`] with [`include_str!`] to compile a theme into the application
+instead of reading it at runtime. The returned theme owns the parsed data and does not borrow the
+source string:
+
+```rust
+use tui_markdown::{CodeTheme, CodeThemeLoadError, Options};
+
+fn options() -> Result<Options, CodeThemeLoadError> {
+    let source = include_str!("../themes/my-theme.tmTheme");
+    let theme = CodeTheme::from_textmate(source)?;
+    Ok(Options::default().code_theme(theme))
+}
+```
+
+[`CodeTheme::from_file`]: https://docs.rs/tui-markdown/latest/tui_markdown/struct.CodeTheme.html#method.from_file
+[`CodeTheme::from_textmate`]: https://docs.rs/tui-markdown/latest/tui_markdown/struct.CodeTheme.html#method.from_textmate
+[`include_str!`]: https://doc.rust-lang.org/std/macro.include_str.html
+[`BuiltinCodeTheme`]: https://docs.rs/tui-markdown/latest/tui_markdown/enum.BuiltinCodeTheme.html
+
+### Markdown presentation symbols
+
+The renderer normally retains heading markers and frames block code with triple backticks. A custom
+style sheet can replace either symbol with [`StyleSheet::heading_marker()`] and
+[`StyleSheet::code_block_fence()`], or return an empty string to hide it:
+
+```rust
+use ratatui::style::Style;
+use tui_markdown::{from_str_with_options, DefaultStyleSheet, Options, StyleSheet};
+
+#[derive(Clone, Copy)]
+struct MinimalStyleSheet;
+
+impl StyleSheet for MinimalStyleSheet {
+    fn heading(&self, level: u8) -> Style {
+        DefaultStyleSheet.heading(level)
+    }
+
+    fn code(&self) -> Style {
+        DefaultStyleSheet.code()
+    }
+
+    fn link(&self) -> Style {
+        DefaultStyleSheet.link()
+    }
+
+    fn blockquote(&self) -> Style {
+        DefaultStyleSheet.blockquote()
+    }
+
+    fn heading_meta(&self) -> Style {
+        DefaultStyleSheet.heading_meta()
+    }
+
+    fn metadata_block(&self) -> Style {
+        DefaultStyleSheet.metadata_block()
+    }
+
+    fn heading_marker(&self, _level: u8) -> &str {
+        ""
+    }
+
+    fn code_block_fence(&self) -> &str {
+        ""
+    }
+}
+
+let options = Options::new(MinimalStyleSheet);
+let markdown = "# Heading\n\n```text\ncode\n```";
+let text = from_str_with_options(markdown, &options);
+
+assert_eq!(text.to_string(), "Heading\n\ncode");
+```
+
+The code-block fence choice is independent of syntax highlighting and applies to fenced and
+indented code blocks alike. Other presentation symbols, such as list markers, blockquote prefixes,
+image indicators, and table borders, retain their standard output.
+
+## Status
+
+This is working code, but not every markdown feature is supported. PRs welcome!
+
+- [x] Headings
+- [x] Heading attributes / classes / anchors
+- [x] Normal paragraphs
+- [x] Block quotes
+- [x] Nested block quotes
+- [x] GFM alerts
+- [x] Bold (strong)
+- [x] Italic (emphasis)
+- [x] Strikethrough
+- [x] Ordered lists
+- [x] Unordered lists
+- [x] Code blocks
+- [x] HTML
+- [x] Math
+- [x] Footnotes
+- [x] Definition lists
+- [x] Linebreak handling
+- [x] Rule
+- [x] Tables
+- [x] Tasklists
+- [x] Links
+- [x] Images
+- [x] Metadata blocks
+- [x] Superscript
+- [x] Subscript
+
+Linebreaks are rendered with Markdown defaults: soft breaks become spaces, hard breaks insert a
+new line.
+
+Images render as text fallbacks rather than terminal graphics. The default output uses `[img]`
+followed by the image description, or the destination when the description is empty. For example,
+`Before ![diagram](diagram.png) after` renders as `Before [img] diagram after`.
+
+Use [`ImageFallback`] to show the destination instead, or to include it after the description:
+
+```rust
+use tui_markdown::{from_str_with_options, ImageFallback, Options};
+
+let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
+let text = from_str_with_options("![diagram](diagram.png)", &options);
+assert_eq!(text.to_string(), "[img] diagram (diagram.png)");
+```
+
+GFM tables render with Unicode box-drawing borders and honor left, center, and right column
+alignment:
+
+```markdown
+| Name | Status |
+|:-----|-------:|
+| API  | Ready  |
+```
+
+```text
+┌──────┬────────┐
+│ Name │ Status │
+├──────┼────────┤
+│ API  │  Ready │
+└──────┴────────┘
+```
+
+Column widths use terminal display width, so wide CJK and emoji characters remain aligned. Use
+[`StyleSheet::table_header()`] for header cells, [`StyleSheet::table_cell()`] for body cells, and
+[`StyleSheet::table_border()`] for the box-drawing borders. Cell styles cover content and padding
+while preserving inline formatting unless they set the same style property.
+
+Links are rendered as `label (URL)`. The link style applies to both the visible label and URL while
+preserving nested inline formatting such as bold text.
+
+GFM alerts render a bold icon and canonical English label above their quoted body. Customize each
+kind's color with [`StyleSheet::alert()`], its terminal-friendly icon with
+[`StyleSheet::alert_icon()`], and its label with [`StyleSheet::alert_label()`]. Returning an empty
+icon or label displays only the other component.
+
+Raw inline HTML tags and HTML blocks are displayed literally rather than interpreted as terminal
+markup. They are dimmed by default and can be customized with [`StyleSheet::html()`].
+
+Inline and display math keep their `$...$` and `$$...$$` delimiters visible. Inline math is
+magenta and italic by default, while display math is magenta and preserves multiline formulas as
+separate terminal lines. Customize these styles with [`StyleSheet::math_inline()`] and
+[`StyleSheet::math_display()`].
+
+Footnote references such as `[^source]` are displayed as `[source]`, and definitions are displayed
+as `[source]: ...`. References are dim and italic by default, while definitions are dim. Customize
+these styles with [`StyleSheet::footnote_ref()`] and [`StyleSheet::footnote_def()`].
+
+Definition-list terms are bold by default, with each description rendered on its own line after a
+colon-and-space prefix. Customize them with [`StyleSheet::definition_term()`] and
+[`StyleSheet::definition_description()`].
+
+Metadata blocks are rendered using the metadata block style so front matter is visible, including
+the delimiter lines (for example `---` in YAML-style blocks).
+
+```rust
+use ratatui::text::Text;
+use tui_markdown::from_str;
+
+let markdown = r#"---
+title: Demo
+tags:
+  - one
+  - two
+---
+
+Body
+"#;
+
+let text = from_str(markdown);
+assert_eq!(
+    text,
+    Text::from_iter([
+        "---".into(),
+        "title: Demo".into(),
+        "tags:".into(),
+        "  - one".into(),
+        "  - two".into(),
+        "---".into(),
+        "".into(),
+        "Body".into(),
+    ])
+);
+```
+
+## License
+
+Copyright (c) 2024 Josh McKinney
+
+This project is licensed under either of
+
+- Apache License, Version 2.0
+   ([LICENSE-APACHE](../LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license
+   ([LICENSE-MIT](../LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+[tui-markdown]: https://crates.io/crates/tui-markdown
+[markdown-reader]: https://crates.io/crates/markdown-reader
+[Ratatui]: https://crates.io/crates/ratatui
+[`StyleSheet::html()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.html
+[`StyleSheet::math_display()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.math_display
+[`StyleSheet::math_inline()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.math_inline
+[`StyleSheet::footnote_def()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.footnote_def
+[`StyleSheet::footnote_ref()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.footnote_ref
+[`StyleSheet::definition_description()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.definition_description
+[`StyleSheet::definition_term()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.definition_term
+[`StyleSheet::alert()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.alert
+[`StyleSheet::alert_icon()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.alert_icon
+[`StyleSheet::alert_label()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.alert_label
+[`StyleSheet::table_border()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.table_border
+[`StyleSheet::table_cell()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.table_cell
+[`StyleSheet::table_header()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.table_header
+[`StyleSheet::heading_marker()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.heading_marker
+[`StyleSheet::code_block_fence()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.code_block_fence
+[`ImageFallback`]: https://docs.rs/tui-markdown/latest/tui_markdown/enum.ImageFallback.html
+
+[Crate badge]: https://img.shields.io/crates/v/tui-markdown?logo=rust&style=for-the-badge
+[Docs.rs Badge]: https://img.shields.io/docsrs/tui-markdown?logo=rust&style=for-the-badge
+[Deps.rs Badge]: https://deps.rs/repo/github/joshka/tui-markdown/status.svg?path=tui-markdown&style=for-the-badge
+[License Badge]: https://img.shields.io/crates/l/tui-markdown?style=for-the-badge
+[Codecov.io Badge]: https://img.shields.io/codecov/c/github/joshka/tui-markdown?logo=codecov&style=for-the-badge&token=BAQ8SOKEST
+[Discord Badge]: https://img.shields.io/discord/1070692720437383208?label=ratatui+discord&logo=discord&style=for-the-badge
+
+[API Docs]: https://docs.rs/crate/tui-markdown/
+[Dependency Status]: https://deps.rs/crate/tui-markdown
+[Code Coverage]: https://app.codecov.io/gh/joshka/tui-markdown
+[Ratatui Discord]: https://discord.gg/pMCEU9hNEj
+
+[GitHub Repository]: https://github.com/joshka/tui-markdown
+[Changelog]: https://github.com/joshka/tui-markdown/blob/main/tui-markdown/CHANGELOG.md
+[Contributing]: https://github.com/joshka/tui-markdown/blob/main/CONTRIBUTING.md

--- a/rust/crates/babylon-md/src/code_theme.rs
+++ b/rust/crates/babylon-md/src/code_theme.rs
@@ -1,0 +1,311 @@
+//! Syntax-highlighting themes for fenced code blocks.
+//!
+//! [`CodeTheme`] represents bundled themes converted from [`BuiltinCodeTheme`] and TextMate themes
+//! parsed with [`CodeTheme::from_textmate`] or loaded with [`CodeTheme::from_file`]. Select any of
+//! them with [`Options::code_theme`](crate::Options::code_theme). The renderer consults the theme
+//! when a fenced code block names a recognized language.
+//!
+//! A configured [`CodeTheme`] owns its theme data. [`Options`](crate::Options) stores no theme by
+//! default; the renderer instead borrows a shared [`CodeTheme`] for
+//! [`BuiltinCodeTheme::Base16OceanDark`] when it first encounters a recognized fenced language.
+
+use std::error::Error;
+use std::fmt;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use syntect::highlighting::{Theme, ThemeSet};
+
+/// An owned syntax-highlighting theme for fenced code blocks.
+///
+/// Convert a [`BuiltinCodeTheme`] into this type, parse TextMate source with
+/// [`CodeTheme::from_textmate`], or load a TextMate file with [`CodeTheme::from_file`]. Then pass
+/// the theme to [`Options::code_theme`](crate::Options::code_theme).
+///
+/// The renderer consults the theme only for fenced code blocks whose language is recognized.
+///
+/// This type hides the syntax-highlighting implementation so applications do not need to depend on
+/// its types or version.
+#[derive(Clone, Debug)]
+pub struct CodeTheme {
+    theme: Theme,
+}
+
+impl CodeTheme {
+    /// Parses a TextMate syntax-highlighting theme.
+    ///
+    /// This constructor parses `source` immediately and does not access the filesystem. The
+    /// returned theme owns the parsed data and does not borrow `source`. Applications can combine
+    /// this method with [`include_str!`] to compile a theme into their binary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CodeThemeLoadError`] when `source` is not a valid TextMate theme.
+    pub fn from_textmate(source: &str) -> Result<Self, CodeThemeLoadError> {
+        let mut reader = Cursor::new(source);
+        let theme = ThemeSet::load_from_reader(&mut reader)
+            .map_err(|source| CodeThemeLoadError { path: None, source })?;
+        Ok(Self { theme })
+    }
+
+    /// Loads a TextMate syntax-highlighting theme from disk.
+    ///
+    /// This function reads and parses the file synchronously. The resulting `CodeTheme` owns the
+    /// parsed theme, so rendering does not access the file again. Use [`CodeTheme::from_textmate`]
+    /// with [`include_str!`] when the theme should be compiled into the application instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CodeThemeLoadError`] when the file cannot be read or its contents are not a valid
+    /// TextMate theme. The error message includes the requested path.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use babylon_md::{CodeTheme, Options};
+    ///
+    /// let theme = CodeTheme::from_file("themes/solarized.tmTheme")?;
+    /// let options = Options::default().code_theme(theme);
+    /// # Ok::<(), babylon_md::CodeThemeLoadError>(())
+    /// ```
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, CodeThemeLoadError> {
+        let path = path.as_ref();
+        let theme = ThemeSet::get_theme(path).map_err(|source| CodeThemeLoadError {
+            path: Some(path.to_owned()),
+            source,
+        })?;
+        Ok(Self { theme })
+    }
+}
+
+/// A syntax-highlighting theme bundled with tui-markdown.
+///
+/// Pass a variant directly to [`Options::code_theme`](crate::Options::code_theme), or convert it
+/// into an owned [`CodeTheme`].
+#[non_exhaustive]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BuiltinCodeTheme {
+    /// The dark Base16 Eighties theme.
+    Base16EightiesDark,
+    /// The dark Base16 Mocha theme.
+    Base16MochaDark,
+    /// The default dark Base16 Ocean theme.
+    #[default]
+    Base16OceanDark,
+    /// The light Base16 Ocean theme.
+    Base16OceanLight,
+    /// The light Inspired GitHub theme.
+    InspiredGitHub,
+    /// The dark Solarized theme.
+    SolarizedDark,
+    /// The light Solarized theme.
+    SolarizedLight,
+}
+
+impl BuiltinCodeTheme {
+    fn syntect_name(self) -> &'static str {
+        match self {
+            Self::Base16EightiesDark => "base16-eighties.dark",
+            Self::Base16MochaDark => "base16-mocha.dark",
+            Self::Base16OceanDark => "base16-ocean.dark",
+            Self::Base16OceanLight => "base16-ocean.light",
+            Self::InspiredGitHub => "InspiredGitHub",
+            Self::SolarizedDark => "Solarized (dark)",
+            Self::SolarizedLight => "Solarized (light)",
+        }
+    }
+}
+
+impl From<BuiltinCodeTheme> for CodeTheme {
+    fn from(theme: BuiltinCodeTheme) -> Self {
+        let theme = builtin_theme(theme).clone();
+        Self { theme }
+    }
+}
+
+/// An error returned when a syntax-highlighting theme cannot be parsed or loaded.
+///
+/// Errors from [`CodeTheme::from_file`] include the requested path. Errors from
+/// [`CodeTheme::from_textmate`] identify invalid TextMate source. [`Error::source`] provides the
+/// underlying parsing error without making the parser part of tui-markdown's public API.
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct CodeThemeLoadError {
+    path: Option<PathBuf>,
+    source: syntect::LoadingError,
+}
+
+impl fmt::Display for CodeThemeLoadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(path) = &self.path {
+            write!(
+                formatter,
+                "failed to load code theme from `{}`: {}",
+                path.display(),
+                self.source
+            )
+        } else {
+            write!(
+                formatter,
+                "failed to parse TextMate code theme: {}",
+                self.source
+            )
+        }
+    }
+}
+
+impl Error for CodeThemeLoadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+/// Returns the syntax-highlighting data for a code theme.
+pub fn theme(code_theme: &CodeTheme) -> &Theme {
+    &code_theme.theme
+}
+
+/// Returns the lazily initialized default code theme.
+///
+/// The renderer calls this only after recognizing a fenced language, so ordinary Markdown and
+/// unrecognized code fences do not initialize the bundled theme set.
+pub fn default() -> &'static CodeTheme {
+    &DEFAULT_THEME
+}
+
+fn builtin_theme(code_theme: BuiltinCodeTheme) -> &'static Theme {
+    THEMES
+        .themes
+        .get(code_theme.syntect_name())
+        .expect("every BuiltinCodeTheme variant must map to a bundled theme")
+}
+
+static DEFAULT_THEME: LazyLock<CodeTheme> = LazyLock::new(|| BuiltinCodeTheme::default().into());
+static THEMES: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use indoc::indoc;
+    use ratatui_core::style::Color;
+
+    use crate::{from_str_with_options, Options};
+
+    use super::*;
+
+    fn fixture(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/code_theme/fixtures")
+            .join(name)
+    }
+
+    #[test]
+    fn every_builtin_theme_can_be_selected() {
+        let themes = [
+            BuiltinCodeTheme::Base16EightiesDark,
+            BuiltinCodeTheme::Base16MochaDark,
+            BuiltinCodeTheme::Base16OceanDark,
+            BuiltinCodeTheme::Base16OceanLight,
+            BuiltinCodeTheme::InspiredGitHub,
+            BuiltinCodeTheme::SolarizedDark,
+            BuiltinCodeTheme::SolarizedLight,
+        ];
+
+        for built_in in themes {
+            let code_theme = CodeTheme::from(built_in);
+            let _ = theme(&code_theme);
+        }
+    }
+
+    #[test]
+    fn configured_theme_is_borrowed_directly() {
+        let code_theme = CodeTheme::from(BuiltinCodeTheme::SolarizedDark);
+
+        assert!(std::ptr::eq(theme(&code_theme), &code_theme.theme));
+    }
+
+    #[test]
+    fn default_theme_is_shared() {
+        assert!(std::ptr::eq(default(), default()));
+    }
+
+    #[test]
+    fn loaded_theme_applies_its_foreground_color() {
+        let theme = CodeTheme::from_file(fixture("custom.tmTheme")).unwrap();
+
+        assert_eq!(
+            rendered_keyword_foreground(theme),
+            Some(Color::Rgb(255, 255, 255))
+        );
+    }
+
+    #[test]
+    fn embedded_theme_applies_its_foreground_color() {
+        let source = include_str!("code_theme/fixtures/custom.tmTheme");
+        let theme = CodeTheme::from_textmate(source).unwrap();
+
+        assert_eq!(
+            rendered_keyword_foreground(theme),
+            Some(Color::Rgb(255, 255, 255))
+        );
+    }
+
+    fn rendered_keyword_foreground(theme: CodeTheme) -> Option<Color> {
+        let input = indoc! {"
+            ```rust
+            fn main() {}
+            ```
+        "};
+        let options = Options::default().code_theme(theme);
+        let rendered = from_str_with_options(input, &options);
+        rendered
+            .lines
+            .iter()
+            .flat_map(|line| &line.spans)
+            .find(|span| span.content == "fn")
+            .expect("Rust highlighting should emit the `fn` keyword")
+            .style
+            .fg
+    }
+
+    #[test]
+    fn missing_theme_reports_its_path_and_read_error() {
+        let path = fixture("missing.tmTheme");
+        let error = CodeTheme::from_file(&path).unwrap_err();
+
+        let prefix = format!("failed to load code theme from `{}`:", path.display());
+        assert!(error.to_string().starts_with(&prefix));
+        assert!(matches!(&error.source, syntect::LoadingError::Io(_)));
+        assert!(error.source().is_some());
+    }
+
+    #[test]
+    fn malformed_theme_reports_its_path_and_parse_error() {
+        let path = fixture("invalid.tmTheme");
+        let error = CodeTheme::from_file(&path).unwrap_err();
+
+        let prefix = format!("failed to load code theme from `{}`:", path.display());
+        assert!(error.to_string().starts_with(&prefix));
+        assert!(matches!(
+            &error.source,
+            syntect::LoadingError::ReadSettings(_)
+        ));
+        assert!(error.source().is_some());
+    }
+
+    #[test]
+    fn malformed_embedded_theme_reports_a_parse_error() {
+        let error = CodeTheme::from_textmate("this is not a TextMate theme").unwrap_err();
+
+        assert!(error
+            .to_string()
+            .starts_with("failed to parse TextMate code theme:"));
+        assert!(matches!(
+            &error.source,
+            syntect::LoadingError::ReadSettings(_)
+        ));
+        assert!(error.source().is_some());
+    }
+}

--- a/rust/crates/babylon-md/src/code_theme/fixtures/custom.tmTheme
+++ b/rust/crates/babylon-md/src/code_theme/fixtures/custom.tmTheme
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>tui-markdown test theme</string>
+  <key>settings</key>
+  <array>
+    <dict>
+      <key>settings</key>
+      <dict>
+        <key>background</key>
+        <string>#000000</string>
+        <key>foreground</key>
+        <string>#FFFFFF</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Keywords</string>
+      <key>scope</key>
+      <string>keyword</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#FF0000</string>
+      </dict>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/rust/crates/babylon-md/src/code_theme/fixtures/invalid.tmTheme
+++ b/rust/crates/babylon-md/src/code_theme/fixtures/invalid.tmTheme
@@ -1,0 +1,1 @@
+this is not a TextMate theme

--- a/rust/crates/babylon-md/src/lib.rs
+++ b/rust/crates/babylon-md/src/lib.rs
@@ -1,0 +1,63 @@
+//! Convert Markdown into Ratatui [`Text`](ratatui_core::text::Text).
+//!
+//! [`from_str`] renders with the default styles and options. [`from_str_with_options`] accepts an
+//! [`Options`] value for custom [`StyleSheet`] styles and symbols, image fallback mode, and, when
+//! the `highlight-code` feature is enabled, syntax-highlighting theme.
+//!
+//! The returned text may borrow from the Markdown input. It contains terminal text and styles only;
+//! image syntax produces a configurable text fallback and does not read or render image resources.
+//!
+//! # Markdown output
+//!
+//! Tables use Unicode box-drawing borders, terminal display widths, and the alignment declared by
+//! the Markdown delimiter row. Raw HTML stays visible as literal text. Math retains its delimiters,
+//! and images render as `[img]` followed by their description or destination.
+//!
+//! # Syntax highlighting
+//!
+//! The default `highlight-code` feature highlights fenced code blocks whose language is recognized.
+//! It uses `Base16OceanDark` unless [`Options`] selects another [`CodeTheme`]. Themes can come from
+//! the built-in set, TextMate source bundled with the application, or a TextMate file read before
+//! rendering. Unrecognized code fences use [`StyleSheet::code`] instead.
+#![cfg_attr(feature = "document-features", doc = "\n# Features")]
+#![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
+//!
+//! # Example
+//!
+//! ~~~
+//! use ratatui::text::Text;
+//! use babylon_md::from_str;
+//!
+//! # fn draw(frame: &mut ratatui::Frame) {
+//! let markdown = r#"
+//! This is a simple markdown renderer for Ratatui.
+//!
+//! - List item 1
+//! - List item 2
+//!
+//! ```rust
+//! fn main() {
+//!     println!("Hello, world!");
+//! }
+//! ```
+//! "#;
+//!
+//! let text = from_str(markdown);
+//! frame.render_widget(text, frame.area());
+//! # }
+//! ~~~
+
+#[cfg(feature = "highlight-code")]
+mod code_theme;
+mod options;
+mod renderer;
+mod style_sheet;
+
+#[doc(inline)]
+#[cfg(feature = "highlight-code")]
+pub use crate::code_theme::{BuiltinCodeTheme, CodeTheme, CodeThemeLoadError};
+pub use crate::options::{ImageFallback, Options};
+pub use crate::renderer::{
+    from_str, from_str_with_options, from_str_with_options_and_links, LinkInfo, LinkLocation,
+};
+pub use crate::style_sheet::{AlertKind, DefaultStyleSheet, StyleSheet};

--- a/rust/crates/babylon-md/src/lib.rs
+++ b/rust/crates/babylon-md/src/lib.rs
@@ -57,6 +57,7 @@ mod style_sheet;
 #[cfg(feature = "highlight-code")]
 pub use crate::code_theme::{BuiltinCodeTheme, CodeTheme, CodeThemeLoadError};
 pub use crate::options::{ImageFallback, Options};
+// BABYLON PATCH 2 (fork): the links-aware entry point + side-channel types.
 pub use crate::renderer::{
     from_str, from_str_with_options, from_str_with_options_and_links, LinkInfo, LinkLocation,
 };

--- a/rust/crates/babylon-md/src/options.rs
+++ b/rust/crates/babylon-md/src/options.rs
@@ -1,0 +1,244 @@
+//! Rendering configuration for tui-markdown.
+//!
+//! Options control the renderer's style sheet, image fallback content, and syntax-highlighting
+//! theme. [`Options`] is non-exhaustive, allowing new rendering choices to be added without
+//! breaking existing code.
+
+#[cfg(feature = "highlight-code")]
+use crate::CodeTheme;
+use crate::{DefaultStyleSheet, StyleSheet};
+
+/// Text used to represent Markdown images in rendered terminal output.
+///
+/// This option does not load or render image resources. It controls whether the text fallback
+/// contains the image description, destination, or both. [`AltText`](Self::AltText) is the
+/// default.
+///
+/// # Example
+///
+/// ```
+/// use babylon_md::{from_str_with_options, ImageFallback, Options};
+///
+/// let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
+/// let text = from_str_with_options("![Architecture diagram](diagram.png)", &options);
+///
+/// assert_eq!(
+///     text.to_string(),
+///     "[img] Architecture diagram (diagram.png)"
+/// );
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ImageFallback {
+    /// Show `[img]` followed by the description, or the destination when the description is empty.
+    #[default]
+    AltText,
+    /// Show `[img]` followed by the destination, ignoring the description.
+    Url,
+    /// Show `[img] {description} ({destination})`, omitting either value when it is empty.
+    AltTextAndUrl,
+}
+
+/// Rendering options for [`crate::from_str_with_options`].
+///
+/// `S` is the style sheet consulted while Markdown events are rendered. [`Options::default`] uses
+/// [`DefaultStyleSheet`]. Use [`Options::new`] to supply another [`StyleSheet`].
+/// [`StyleSheet::heading_marker`] and [`StyleSheet::code_block_fence`] customize or hide the
+/// corresponding presentation symbols.
+///
+/// # Example
+///
+/// ```
+/// use babylon_md::Options;
+///
+/// let options = Options::default();
+///
+/// // or with a custom style sheet
+///
+/// use ratatui_core::style::{Style, Stylize};
+/// use babylon_md::StyleSheet;
+///
+/// #[derive(Debug, Clone)]
+/// struct MyStyleSheet;
+///
+/// impl StyleSheet for MyStyleSheet {
+///     fn heading(&self, _level: u8) -> Style {
+///         Style::new().bold()
+///     }
+/// }
+///
+/// let options = Options::new(MyStyleSheet);
+/// ```
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct Options<S: StyleSheet = DefaultStyleSheet> {
+    /// The [`StyleSheet`] implementation that will be consulted every time the renderer needs a
+    /// style or symbol choice.
+    pub(crate) styles: S,
+    /// The content to render in place of images.
+    pub(crate) image_fallback: ImageFallback,
+    /// Explicit syntax-highlighting theme for fenced code blocks.
+    ///
+    /// When absent, the renderer uses the shared built-in default.
+    #[cfg(feature = "highlight-code")]
+    code_theme: Option<CodeTheme>,
+    /// BABYLON PATCH 1 (fork): extra [`pulldown_cmark::Options`] unioned into
+    /// the renderer's baseline parser option set (upstream hardcodes it, which
+    /// makes `ENABLE_WIKILINKS` unreachable).
+    pub(crate) extra_parse_options: pulldown_cmark::Options,
+}
+
+impl<S: StyleSheet> Options<S> {
+    /// Creates rendering options that use `styles`.
+    ///
+    /// Image fallback and syntax-highlighting settings retain their defaults.
+    pub fn new(styles: S) -> Self {
+        Self {
+            styles,
+            image_fallback: ImageFallback::default(),
+            #[cfg(feature = "highlight-code")]
+            code_theme: None,
+            extra_parse_options: pulldown_cmark::Options::empty(),
+        }
+    }
+
+    /// BABYLON PATCH 1 (fork): unions `extra` into the parser option set used
+    /// by [`crate::from_str_with_options`].
+    ///
+    /// The baseline set (GFM, tables, footnotes, …) always stays enabled;
+    /// this only ADDS options — pass
+    /// [`pulldown_cmark::Options::ENABLE_WIKILINKS`] to parse
+    /// `[[Target]]` / `[[Target|Label]]` wikilinks.
+    #[must_use]
+    pub fn parse_options(mut self, extra: pulldown_cmark::Options) -> Self {
+        self.extra_parse_options.insert(extra);
+        self
+    }
+
+    /// Selects the text used to represent Markdown images.
+    ///
+    /// See [`ImageFallback`] for the exact output of each mode.
+    #[must_use]
+    pub fn image_fallback(mut self, image_fallback: ImageFallback) -> Self {
+        self.image_fallback = image_fallback;
+        self
+    }
+
+    /// Selects the syntax-highlighting theme for fenced code blocks.
+    ///
+    /// By default, no explicit theme is stored and the renderer borrows its shared
+    /// [`Base16OceanDark`](crate::BuiltinCodeTheme::Base16OceanDark) theme.
+    /// Pass a [`BuiltinCodeTheme`](crate::BuiltinCodeTheme) directly, or pass an owned
+    /// [`CodeTheme`]. Construct custom themes from TextMate source with
+    /// [`CodeTheme::from_textmate`](crate::CodeTheme::from_textmate), or load a TextMate file with
+    /// [`CodeTheme::from_file`](crate::CodeTheme::from_file). The selected theme applies when a
+    /// fenced code block names a recognized language.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use babylon_md::{BuiltinCodeTheme, Options};
+    ///
+    /// let options = Options::default().code_theme(BuiltinCodeTheme::SolarizedDark);
+    /// ```
+    #[cfg(feature = "highlight-code")]
+    #[must_use]
+    pub fn code_theme(mut self, code_theme: impl Into<CodeTheme>) -> Self {
+        self.code_theme = Some(code_theme.into());
+        self
+    }
+
+    /// Returns the explicitly configured syntax-highlighting theme.
+    ///
+    /// Returns `None` when the renderer will use the shared
+    /// [`Base16OceanDark`](crate::BuiltinCodeTheme::Base16OceanDark) default.
+    #[cfg(feature = "highlight-code")]
+    #[must_use]
+    pub fn selected_code_theme(&self) -> Option<&CodeTheme> {
+        self.code_theme.as_ref()
+    }
+}
+
+impl Default for Options<DefaultStyleSheet> {
+    fn default() -> Self {
+        Self::new(DefaultStyleSheet)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui_core::style::Style;
+
+    use super::*;
+
+    #[test]
+    fn default() {
+        let options: Options = Default::default();
+        assert_eq!(
+            options.styles.heading(1),
+            Style::new().on_cyan().bold().underlined()
+        );
+    }
+
+    #[test]
+    fn custom_style_sheet() {
+        #[derive(Debug, Clone)]
+        struct CustomStyleSheet;
+
+        impl StyleSheet for CustomStyleSheet {
+            fn heading(&self, level: u8) -> Style {
+                match level {
+                    1 => Style::new().red().bold(),
+                    _ => Style::new().green(),
+                }
+            }
+        }
+
+        let options = Options {
+            styles: CustomStyleSheet,
+            image_fallback: ImageFallback::default(),
+            #[cfg(feature = "highlight-code")]
+            code_theme: None,
+            extra_parse_options: pulldown_cmark::Options::empty(),
+        };
+
+        assert_eq!(options.styles.heading(1), Style::new().red().bold());
+        assert_eq!(options.styles.heading(2), Style::new().green());
+        assert_eq!(options.styles.code(), Style::new().white().on_black());
+        assert_eq!(options.styles.link(), Style::new().blue().underlined());
+        assert_eq!(options.styles.blockquote(), Style::new().green());
+        assert_eq!(options.styles.heading_meta(), Style::new().dim());
+        assert_eq!(options.styles.metadata_block(), Style::new().light_yellow());
+        assert_eq!(options.styles.image_alt(), Style::new().dim().italic());
+    }
+
+    #[test]
+    fn image_fallback_defaults_to_alt_text() {
+        let options = Options::default();
+
+        assert_eq!(options.image_fallback, ImageFallback::AltText);
+    }
+
+    #[test]
+    fn image_fallback_setter_updates_mode() {
+        let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
+
+        assert_eq!(options.image_fallback, ImageFallback::AltTextAndUrl);
+    }
+
+    #[test]
+    #[cfg(feature = "highlight-code")]
+    fn default_has_no_explicit_code_theme() {
+        let options: Options = Options::default();
+
+        assert!(options.selected_code_theme().is_none());
+    }
+
+    #[test]
+    #[cfg(feature = "highlight-code")]
+    fn code_theme_selects_theme() {
+        let options = Options::default().code_theme(crate::BuiltinCodeTheme::SolarizedDark);
+
+        assert!(options.selected_code_theme().is_some());
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/blockquote.rs
+++ b/rust/crates/babylon-md/src/renderer/blockquote.rs
@@ -1,0 +1,459 @@
+//! Markdown blockquote and GFM alert rendering.
+//!
+//! Plain blockquotes use the configured blockquote style and `>` prefix. A recognized GFM alert
+//! adds a styled icon and label, then renders its body with the alert style.
+
+use pulldown_cmark::{BlockQuoteKind, Event};
+use ratatui_core::style::Style;
+use ratatui_core::text::{Line, Span};
+
+use super::TextWriter;
+use crate::{AlertKind, StyleSheet};
+
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
+where
+    I: Iterator<Item = Event<'a>>,
+    S: StyleSheet,
+{
+    pub fn start_blockquote(&mut self, kind: Option<BlockQuoteKind>) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+            self.needs_newline = false;
+        }
+
+        match kind {
+            Some(kind) => self.start_alert(alert_kind(kind)),
+            None => self.start_plain_blockquote(),
+        }
+    }
+
+    pub fn end_blockquote(&mut self) {
+        self.line_prefixes.pop();
+        self.line_styles.pop();
+        self.needs_newline = true;
+    }
+
+    fn start_alert(&mut self, kind: AlertKind) {
+        let style = self.styles.alert(kind);
+        self.push_blockquote_style(style);
+        self.push_line(Line::default());
+        self.push_span(Span::styled(self.alert_heading(kind), style.bold()));
+        self.needs_newline = false;
+    }
+
+    fn start_plain_blockquote(&mut self) {
+        self.push_blockquote_style(self.styles.blockquote());
+    }
+
+    fn push_blockquote_style(&mut self, style: Style) {
+        self.line_prefixes.push(Span::from(">"));
+        self.line_styles.push(style);
+    }
+
+    fn alert_heading(&self, kind: AlertKind) -> String {
+        let icon = self.styles.alert_icon(kind);
+        let label = self.styles.alert_label(kind);
+        // Either component may be intentionally suppressed; add a separator only when both exist.
+        match (icon.is_empty(), label.is_empty()) {
+            (false, false) => format!("{icon} {label}"),
+            (false, true) => icon.to_owned(),
+            (true, false) => label.to_owned(),
+            (true, true) => String::new(),
+        }
+    }
+}
+
+fn alert_kind(kind: BlockQuoteKind) -> AlertKind {
+    match kind {
+        BlockQuoteKind::Note => AlertKind::Note,
+        BlockQuoteKind::Tip => AlertKind::Tip,
+        BlockQuoteKind::Important => AlertKind::Important,
+        BlockQuoteKind::Warning => AlertKind::Warning,
+        BlockQuoteKind::Caution => AlertKind::Caution,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::{formatdoc, indoc};
+    use rstest::rstest;
+
+    use super::*;
+    use crate::renderer::test_support::{with_tracing, DefaultGuard};
+    use crate::renderer::*;
+    use crate::*;
+
+    mod gfm_alerts {
+        use pretty_assertions::assert_eq;
+
+        use super::*;
+
+        #[derive(Clone)]
+        struct CustomAlertStyleSheet;
+
+        impl StyleSheet for CustomAlertStyleSheet {
+            fn alert(&self, kind: AlertKind) -> Style {
+                match kind {
+                    AlertKind::Note => Style::new().on_red(),
+                    _ => Style::default(),
+                }
+            }
+        }
+
+        #[derive(Clone)]
+        struct CustomAlertHeadingStyleSheet;
+
+        impl StyleSheet for CustomAlertHeadingStyleSheet {
+            fn alert_icon(&self, kind: AlertKind) -> &str {
+                match kind {
+                    AlertKind::Note => "!!",
+                    AlertKind::Caution => "",
+                    _ => DefaultStyleSheet.alert_icon(kind),
+                }
+            }
+
+            fn alert_label(&self, kind: AlertKind) -> &str {
+                match kind {
+                    AlertKind::Tip => "Hint",
+                    AlertKind::Important => "",
+                    _ => kind.label(),
+                }
+            }
+        }
+
+        #[rstest]
+        #[case("NOTE", "\u{2139}\u{FE0F} Note", Style::new().blue())]
+        #[case("TIP", "\u{1F4A1} Tip", Style::new().green())]
+        #[case("IMPORTANT", "\u{2757} Important", Style::new().magenta())]
+        #[case("WARNING", "\u{26A0}\u{FE0F} Warning", Style::new().yellow())]
+        #[case("CAUTION", "\u{1F534} Caution", Style::new().red())]
+        fn alert_kind_renders_exact_output(
+            _with_tracing: DefaultGuard,
+            #[case] marker: &str,
+            #[case] heading: &str,
+            #[case] style: Style,
+        ) {
+            let markdown = formatdoc! {"
+                > [!{marker}]
+                > Body
+            "};
+
+            assert_eq!(
+                from_str(&markdown),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled(heading.to_owned(), style.bold()),
+                    ])
+                    .style(style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Body")])
+                        .style(style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn custom_alert_style_applies_to_header_and_body(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > [!NOTE]
+                > Body
+            "};
+            let options = Options::new(CustomAlertStyleSheet);
+            let style = Style::new().on_red();
+
+            assert_eq!(
+                from_str_with_options(markdown, &options),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled("\u{2139}\u{FE0F} Note", style.bold()),
+                    ])
+                    .style(style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Body")])
+                        .style(style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn custom_alert_icon_replaces_default(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > [!NOTE]
+                > Body
+            "};
+            let options = Options::new(CustomAlertHeadingStyleSheet);
+            let style = DefaultStyleSheet.alert(AlertKind::Note);
+
+            assert_eq!(
+                from_str_with_options(markdown, &options),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled("!! Note", style.bold()),
+                    ])
+                    .style(style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Body")])
+                        .style(style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn empty_alert_icon_suppresses_icon_and_separator(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > [!CAUTION]
+                > Body
+            "};
+            let options = Options::new(CustomAlertHeadingStyleSheet);
+            let style = DefaultStyleSheet.alert(AlertKind::Caution);
+
+            assert_eq!(
+                from_str_with_options(markdown, &options),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled("Caution", style.bold()),
+                    ])
+                    .style(style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Body")])
+                        .style(style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn custom_alert_label_replaces_default(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > [!TIP]
+                > Body
+            "};
+            let options = Options::new(CustomAlertHeadingStyleSheet);
+            let style = DefaultStyleSheet.alert(AlertKind::Tip);
+
+            assert_eq!(
+                from_str_with_options(markdown, &options),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled("💡 Hint", style.bold()),
+                    ])
+                    .style(style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Body")])
+                        .style(style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn empty_alert_label_suppresses_label_and_separator(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > [!IMPORTANT]
+                > Body
+            "};
+            let options = Options::new(CustomAlertHeadingStyleSheet);
+            let style = DefaultStyleSheet.alert(AlertKind::Important);
+
+            assert_eq!(
+                from_str_with_options(markdown, &options),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled("❗", style.bold()),
+                    ])
+                    .style(style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Body")])
+                        .style(style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn ordinary_blockquote_keeps_standard_prefix(_with_tracing: DefaultGuard) {
+            let style = DefaultStyleSheet.blockquote();
+            assert_eq!(
+                from_str("> Ordinary"),
+                Text::from(Line::from_iter([">", " ", "Ordinary"]).style(style))
+            );
+        }
+
+        #[rstest]
+        fn nested_blockquote_keeps_each_standard_prefix(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > Parent
+                >> Child
+            "};
+            let style = DefaultStyleSheet.blockquote();
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from_iter([">", " ", "Parent"]).style(style),
+                    Line::from_iter([">", " "]).style(style),
+                    Line::from_iter([">", ">", " ", "Child"]).style(style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn alert_preserves_nested_blockquote(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > [!NOTE]
+                > Parent
+                >> Child
+            "};
+            let alert_style = Style::new().blue();
+            let blockquote_style = DefaultStyleSheet.blockquote();
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled("\u{2139}\u{FE0F} Note", alert_style.bold()),
+                    ])
+                    .style(alert_style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Parent")])
+                        .style(alert_style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" ")]).style(alert_style),
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::raw("Child"),
+                    ])
+                    .style(blockquote_style),
+                ])
+            );
+        }
+    }
+
+    mod blockquote {
+        use pretty_assertions::assert_eq;
+        use ratatui::style::Color;
+
+        use super::*;
+
+        const STYLE: Style = Style::new().fg(Color::Green);
+
+        /// I was having difficulty getting the right number of newlines between paragraphs, so this
+        /// test is to help debug and ensure that.
+        #[rstest]
+        fn after_paragraph(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Hello, world!
+
+                > Blockquote
+            "};
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from("Hello, world!"),
+                    Line::default(),
+                    Line::from_iter([">", " ", "Blockquote"]).style(STYLE),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn style_does_not_leak_into_following_paragraph(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > Blockquote
+
+                After
+            "};
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from_iter([">", " ", "Blockquote"]).style(STYLE),
+                    Line::default(),
+                    Line::from("After"),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn single(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("> Blockquote"),
+                Text::from(Line::from_iter([">", " ", "Blockquote"]).style(STYLE))
+            );
+        }
+
+        #[rstest]
+        fn soft_break(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > Blockquote 1
+                > Blockquote 2
+            "};
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from(
+                    Line::from_iter([">", " ", "Blockquote 1", " ", "Blockquote 2"]).style(STYLE)
+                )
+            );
+        }
+
+        #[rstest]
+        fn multiple(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > Blockquote 1
+                >
+                > Blockquote 2
+            "};
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from_iter([">", " ", "Blockquote 1"]).style(STYLE),
+                    Line::from_iter([">", " "]).style(STYLE),
+                    Line::from_iter([">", " ", "Blockquote 2"]).style(STYLE),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn multiple_with_break(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > Blockquote 1
+
+                > Blockquote 2
+            "};
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from_iter([">", " ", "Blockquote 1"]).style(STYLE),
+                    Line::default(),
+                    Line::from_iter([">", " ", "Blockquote 2"]).style(STYLE),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn nested(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > Blockquote 1
+                >> Nested Blockquote
+            "};
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from_iter([">", " ", "Blockquote 1"]).style(STYLE),
+                    Line::from_iter([">", " "]).style(STYLE),
+                    Line::from_iter([">", ">", " ", "Nested Blockquote"]).style(STYLE),
+                ])
+            );
+        }
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/code.rs
+++ b/rust/crates/babylon-md/src/renderer/code.rs
@@ -1,0 +1,330 @@
+//! Markdown inline and fenced code rendering.
+//!
+//! Inline code and unrecognized fences use the style sheet's code style. With `highlight-code`
+//! enabled, a recognized fenced language uses the selected syntax-highlighting theme.
+
+#[cfg(feature = "highlight-code")]
+use std::sync::LazyLock;
+
+#[cfg(feature = "highlight-code")]
+use ansi_to_tui::IntoText;
+use pulldown_cmark::{CodeBlockKind, CowStr, Event};
+#[cfg(feature = "highlight-code")]
+use ratatui_core::text::Text;
+use ratatui_core::text::{Line, Span};
+#[cfg(feature = "highlight-code")]
+use syntect::{
+    easy::HighlightLines,
+    parsing::SyntaxSet,
+    util::{as_24_bit_terminal_escaped, LinesWithEndings},
+};
+#[cfg(feature = "highlight-code")]
+use tracing::{debug, instrument, warn};
+
+use super::TextWriter;
+#[cfg(feature = "highlight-code")]
+use crate::code_theme::{self, CodeTheme};
+use crate::StyleSheet;
+
+#[cfg(feature = "highlight-code")]
+static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
+
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
+where
+    I: Iterator<Item = Event<'a>>,
+    S: StyleSheet,
+{
+    pub fn code(&mut self, code: CowStr<'a>) {
+        let style = if self.images.is_empty() {
+            self.styles.code()
+        } else {
+            let inline_style = self.inline_styles.last().copied().unwrap_or_default();
+            inline_style.patch(self.styles.code())
+        };
+
+        self.push_span(Span::styled(code, style));
+    }
+
+    pub fn start_codeblock(&mut self, kind: CodeBlockKind<'_>) {
+        if !self.text.lines.is_empty() {
+            self.push_line(Line::default());
+        }
+        let lang = match kind {
+            CodeBlockKind::Fenced(ref lang) => lang.as_ref(),
+            CodeBlockKind::Indented => "",
+        };
+
+        #[cfg(not(feature = "highlight-code"))]
+        self.line_styles.push(self.styles.code());
+
+        #[cfg(feature = "highlight-code")]
+        self.set_code_highlighter(lang);
+
+        let fence = self.styles.code_block_fence();
+        if !fence.is_empty() {
+            let span = Span::from(format!("{fence}{lang}"));
+            self.push_line(span.into());
+        }
+        self.needs_newline = true;
+    }
+
+    pub fn end_codeblock(&mut self) {
+        let fence = self.styles.code_block_fence();
+        if !fence.is_empty() {
+            let span = Span::from(fence.to_owned());
+            self.push_line(span.into());
+        }
+        self.needs_newline = true;
+
+        #[cfg(not(feature = "highlight-code"))]
+        self.line_styles.pop();
+
+        #[cfg(feature = "highlight-code")]
+        self.clear_code_highlighter();
+    }
+
+    #[cfg(feature = "highlight-code")]
+    pub fn with_code_theme(mut self, theme: Option<&'theme CodeTheme>) -> Self {
+        self.code_theme = theme;
+        self
+    }
+
+    #[cfg(feature = "highlight-code")]
+    pub fn push_highlighted_text(&mut self, text: &str) -> bool {
+        let Some(highlighter) = &mut self.code_highlighter else {
+            return false;
+        };
+        let text: Text = LinesWithEndings::from(text)
+            .filter_map(|line| highlighter.highlight_line(line, &SYNTAX_SET).ok())
+            .filter_map(|part| as_24_bit_terminal_escaped(&part, false).into_text().ok())
+            .flatten()
+            .collect();
+
+        for line in text.lines {
+            self.text.push_line(line);
+        }
+        self.needs_newline = false;
+        true
+    }
+
+    #[cfg(not(feature = "highlight-code"))]
+    pub fn push_highlighted_text(&mut self, _text: &str) -> bool {
+        false
+    }
+
+    #[cfg(feature = "highlight-code")]
+    #[instrument(level = "trace", skip(self))]
+    fn set_code_highlighter(&mut self, lang: &str) {
+        if let Some(syntax) = SYNTAX_SET.find_syntax_by_token(lang) {
+            debug!("Starting code block with syntax: {:?}", lang);
+            let code_theme = match self.code_theme {
+                Some(code_theme) => code_theme,
+                None => code_theme::default(),
+            };
+            let theme = code_theme::theme(code_theme);
+            let highlighter = HighlightLines::new(syntax, theme);
+            self.code_highlighter = Some(highlighter);
+        } else {
+            warn!("Could not find syntax for code block: {:?}", lang);
+        }
+    }
+
+    #[cfg(feature = "highlight-code")]
+    #[instrument(level = "trace", skip(self))]
+    fn clear_code_highlighter(&mut self) {
+        self.code_highlighter = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::renderer::test_support::{with_tracing, DefaultGuard};
+    use crate::renderer::*;
+
+    #[derive(Clone, Copy)]
+    struct CustomCodeBlockFence(&'static str);
+
+    impl StyleSheet for CustomCodeBlockFence {
+        fn code_block_fence(&self) -> &str {
+            self.0
+        }
+    }
+
+    #[cfg_attr(not(feature = "highlight-code"), ignore)]
+    #[rstest]
+    fn highlighted_code(_with_tracing: DefaultGuard) {
+        // Assert no extra newlines are added
+        let highlighted_code = from_str(indoc! {"
+            ```rust
+            fn main() {
+                println!(\"Hello, highlighted code!\");
+            }
+            ```"});
+
+        insta::assert_snapshot!(highlighted_code);
+        insta::assert_debug_snapshot!(highlighted_code);
+    }
+
+    #[cfg_attr(not(feature = "highlight-code"), ignore)]
+    #[rstest]
+    fn highlighted_code_with_indentation(_with_tracing: DefaultGuard) {
+        // Assert no extra newlines are added
+        let highlighted_code_indented = from_str(indoc! {"
+            ```rust
+            fn main() {
+                // This is a comment
+                HelloWorldBuilder::new()
+                    .with_text(\"Hello, highlighted code!\")
+                    .build()
+                    .show();
+                            
+            }
+            ```"});
+
+        insta::assert_snapshot!(highlighted_code_indented);
+        insta::assert_debug_snapshot!(highlighted_code_indented);
+    }
+
+    #[cfg_attr(feature = "highlight-code", ignore)]
+    #[rstest]
+    fn unhighlighted_code(_with_tracing: DefaultGuard) {
+        // Assert no extra newlines are added
+        let unhiglighted_code = from_str(indoc! {"
+            ```rust
+            fn main() {
+                println!(\"Hello, unhighlighted code!\");
+            }
+            ```"});
+
+        insta::assert_snapshot!(unhiglighted_code);
+
+        // Code highlighting is complex, assert on on the debug snapshot
+        insta::assert_debug_snapshot!(unhiglighted_code);
+    }
+
+    #[rstest]
+    fn inline_code(_with_tracing: DefaultGuard) {
+        let text = from_str("Example of `Inline code`");
+        insta::assert_snapshot!(text);
+
+        assert_eq!(
+            text,
+            Line::from_iter([
+                Span::from("Example of "),
+                Span::styled("Inline code", Style::new().white().on_black())
+            ])
+            .into()
+        );
+    }
+
+    #[rstest]
+    fn fenced_code_style_does_not_leak_into_following_paragraph(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            ```rust
+            fn main() {}
+            ```
+
+            After
+        "};
+        let text = from_str(markdown);
+
+        assert_eq!(text.lines.last(), Some(&Line::from("After")));
+    }
+
+    #[rstest]
+    fn custom_code_block_fence(_with_tracing: DefaultGuard) {
+        let options = Options::new(CustomCodeBlockFence("~~~"));
+        let markdown = "```not-a-language\ncode\n```";
+
+        assert_eq!(
+            from_str_with_options(markdown, &options).to_string(),
+            "~~~not-a-language\ncode\n~~~"
+        );
+    }
+
+    #[rstest]
+    fn empty_code_block_fence_preserves_spacing(_with_tracing: DefaultGuard) {
+        let options = Options::new(CustomCodeBlockFence(""));
+        let markdown = "Before\n\n```not-a-language\ncode\n```\n\nAfter";
+
+        assert_eq!(
+            from_str_with_options(markdown, &options).to_string(),
+            "Before\n\ncode\n\nAfter"
+        );
+    }
+
+    #[rstest]
+    fn empty_code_block_fence_applies_to_indented_code(_with_tracing: DefaultGuard) {
+        let options = Options::new(CustomCodeBlockFence(""));
+
+        assert_eq!(
+            from_str_with_options("    indented code", &options).to_string(),
+            "indented code"
+        );
+    }
+
+    #[cfg(feature = "highlight-code")]
+    #[rstest]
+    fn empty_code_block_fence_applies_to_highlighted_code(_with_tracing: DefaultGuard) {
+        let options = Options::new(CustomCodeBlockFence(""));
+        let markdown = "```rust\nfn main() {}\n```";
+        let text = from_str_with_options(markdown, &options);
+
+        assert_eq!(text.to_string(), "fn main() {}");
+    }
+
+    #[cfg(feature = "highlight-code")]
+    mod code_theme {
+        use pretty_assertions::assert_eq;
+
+        use super::*;
+        use crate::{BuiltinCodeTheme, Options};
+
+        #[rstest]
+        fn different_theme_produces_different_output(_with_tracing: DefaultGuard) {
+            let input = indoc! {"
+                ```rust
+                fn main() {}
+                ```
+            "};
+            let default_out = from_str(input);
+            let options = Options::default().code_theme(BuiltinCodeTheme::InspiredGitHub);
+            let custom_out = from_str_with_options(input, &options);
+
+            assert_ne!(default_out, custom_out);
+        }
+
+        #[rstest]
+        fn explicit_default_theme_matches_implicit_default(_with_tracing: DefaultGuard) {
+            let input = indoc! {"
+                ```rust
+                fn main() {}
+                ```
+            "};
+            let implicit = from_str(input);
+            let options = Options::default().code_theme(BuiltinCodeTheme::default());
+            let explicit = from_str_with_options(input, &options);
+
+            assert_eq!(explicit, implicit);
+        }
+
+        #[rstest]
+        fn selected_theme_does_not_change_unrecognized_code(_with_tracing: DefaultGuard) {
+            let input = indoc! {"
+                ```not-a-language
+                some code
+                ```
+            "};
+            let default_out = from_str(input);
+            let options = Options::default().code_theme(BuiltinCodeTheme::InspiredGitHub);
+            let selected_out = from_str_with_options(input, &options);
+
+            assert_eq!(selected_out, default_out);
+        }
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/definition_list.rs
+++ b/rust/crates/babylon-md/src/renderer/definition_list.rs
@@ -1,0 +1,232 @@
+//! Markdown definition-list rendering.
+//!
+//! Terms and descriptions have separate styles. Each description starts with `: `, and paragraph
+//! handling preserves blank lines inside multi-paragraph descriptions.
+
+use pulldown_cmark::Event;
+use ratatui_core::text::{Line, Span};
+
+use super::TextWriter;
+use crate::StyleSheet;
+
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
+where
+    I: Iterator<Item = Event<'a>>,
+    S: StyleSheet,
+{
+    pub fn start_definition_list(&mut self) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+        }
+        self.needs_newline = false;
+    }
+
+    pub fn end_definition_list(&mut self) {
+        self.needs_newline = true;
+    }
+
+    pub fn start_definition_title(&mut self) {
+        // Definition-list terms contain inline events without an ordinary paragraph start, so the
+        // term handler owns the output line and applies the term style before consuming them.
+        self.push_line(Line::default());
+        self.push_inline_style(self.styles.definition_term());
+        self.needs_newline = false;
+    }
+
+    pub fn end_definition_title(&mut self) {
+        self.pop_inline_style();
+        self.needs_newline = false;
+    }
+
+    pub fn start_definition_description(&mut self) {
+        // A tight description contains inline events without an ordinary paragraph start. Create
+        // its line here and write the visible Markdown `: ` marker before consuming the content so
+        // the marker and content share the description style.
+        self.push_line(Line::default());
+        self.push_span(Span::styled(": ", self.styles.definition_description()));
+        self.push_inline_style(self.styles.definition_description());
+        self.in_definition_description = true;
+        self.needs_newline = false;
+    }
+
+    pub fn end_definition_description(&mut self) {
+        self.pop_inline_style();
+        self.in_definition_description = false;
+        self.needs_newline = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::renderer::test_support::{with_tracing, DefaultGuard};
+    use crate::renderer::*;
+
+    mod definition_list {
+        use pretty_assertions::assert_eq;
+
+        use super::*;
+
+        #[derive(Clone)]
+        struct CustomDefinitionStyleSheet;
+
+        impl StyleSheet for CustomDefinitionStyleSheet {
+            fn definition_term(&self) -> Style {
+                Style::new().red().underlined()
+            }
+
+            fn definition_description(&self) -> Style {
+                Style::new().blue().italic()
+            }
+        }
+
+        #[rstest]
+        fn exact_output_and_default_styles(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Term
+                : Definition
+            "};
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from(Span::styled("Term", Style::new().bold())),
+                    Line::from_iter([Span::raw(": "), Span::raw("Definition")]),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn custom_styles_apply_to_terms_and_definitions(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Term
+                : Definition
+            "};
+            let options = Options::new(CustomDefinitionStyleSheet);
+            let title_style = Style::new().red().underlined();
+            let description_style = Style::new().blue().italic();
+
+            assert_eq!(
+                from_str_with_options(markdown, &options),
+                Text::from_iter([
+                    Line::from(Span::styled("Term", title_style)),
+                    Line::from_iter([
+                        Span::styled(": ", description_style),
+                        Span::styled("Definition", description_style),
+                    ]),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn inline_formatting_combines_with_definition_styles(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                *Term*
+                : **Description**
+            "};
+            let options = Options::new(CustomDefinitionStyleSheet);
+            let term_style = Style::new().red().underlined().italic();
+            let description_style = Style::new().blue().italic();
+
+            assert_eq!(
+                from_str_with_options(markdown, &options),
+                Text::from_iter([
+                    Line::from(Span::styled("Term", term_style)),
+                    Line::from_iter([
+                        Span::styled(": ", description_style),
+                        Span::styled("Description", description_style.bold()),
+                    ]),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn multiline_definition(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Term
+                : First line
+                  second line
+            "};
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from(Span::styled("Term", Style::new().bold())),
+                    Line::from_iter([
+                        Span::raw(": "),
+                        Span::raw("First line"),
+                        Span::raw(" "),
+                        Span::raw("second line"),
+                    ]),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn multiple_descriptions(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Term
+                : First description
+                : Second description
+            "};
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from(Span::styled("Term", Style::new().bold())),
+                    Line::from_iter([Span::raw(": "), Span::raw("First description")]),
+                    Line::from_iter([Span::raw(": "), Span::raw("Second description")]),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn multiple_description_paragraphs_keep_prefix_and_blank_line(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Term
+                : First paragraph.
+
+                  Second paragraph.
+            "};
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from(Span::styled("Term", Style::new().bold())),
+                    Line::from_iter([Span::raw(": "), Span::raw("First paragraph.")]),
+                    Line::default(),
+                    Line::from("Second paragraph."),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn repeated_items_do_not_leak_into_following_paragraph(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Term one
+                : First description.
+
+                Term two
+                : Second description.
+
+                After.
+            "};
+            let term_style = Style::new().bold();
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from(Span::styled("Term one", term_style)),
+                    Line::from_iter([Span::raw(": "), Span::raw("First description.")]),
+                    Line::from(Span::styled("Term two", term_style)),
+                    Line::from_iter([Span::raw(": "), Span::raw("Second description.")]),
+                    Line::default(),
+                    Line::from("After."),
+                ])
+            );
+        }
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/footnote.rs
+++ b/rust/crates/babylon-md/src/renderer/footnote.rs
@@ -1,0 +1,252 @@
+//! Markdown footnote rendering.
+//!
+//! References render inline as `[label]`. Definitions start with `[label]: ` and retain paragraph
+//! boundaries without leaking their line style into following content.
+
+use pulldown_cmark::{CowStr, Event};
+use ratatui_core::text::{Line, Span};
+
+use super::TextWriter;
+use crate::StyleSheet;
+
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
+where
+    I: Iterator<Item = Event<'a>>,
+    S: StyleSheet,
+{
+    pub fn footnote_reference(&mut self, label: CowStr<'a>) {
+        // A reference can appear inside other inline formatting, as in `**Text[^label]**`.
+        // Styling it with only `footnote_ref()` would make `[label]` dim and italic but drop the
+        // surrounding bold style. Start with the active inline style and patch the footnote style
+        // over it so the reference adds its own appearance without losing enclosing formatting.
+        let inline_style = self.inline_styles.last().copied().unwrap_or_default();
+        let style = inline_style.patch(self.styles.footnote_ref());
+        self.push_span(Span::styled(format!("[{label}]"), style));
+    }
+
+    pub fn start_footnote_definition(&mut self, label: CowStr<'a>) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+        }
+        let style = self.styles.footnote_def();
+        self.line_styles.push(style);
+        self.push_line(Line::default());
+        self.push_span(Span::styled(format!("[{label}]: "), style));
+        self.in_footnote_definition = true;
+        self.needs_newline = false;
+    }
+
+    pub fn end_footnote_definition(&mut self) {
+        self.line_styles.pop();
+        self.in_footnote_definition = false;
+        self.needs_newline = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::renderer::test_support::{with_tracing, DefaultGuard};
+    use crate::renderer::*;
+
+    mod footnotes {
+        use pretty_assertions::assert_eq;
+
+        use super::*;
+
+        #[rstest]
+        fn multiline_definition_has_exact_layout(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Text[^one]
+
+                [^one]: First line
+                    continued line.
+            "};
+            let reference_style = Style::new().dim().italic();
+            let definition_style = Style::new().dim();
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from_iter([Span::raw("Text"), Span::styled("[one]", reference_style),]),
+                    Line::default(),
+                    Line::from_iter([
+                        Span::styled("[one]: ", definition_style),
+                        Span::raw("First line"),
+                        Span::raw(" "),
+                        Span::raw("continued line."),
+                    ])
+                    .style(definition_style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn multiple_definitions_have_exact_layout(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                First[^a] second[^b].
+
+                [^a]: Alpha.
+
+                [^b]: Beta.
+            "};
+            let reference_style = Style::new().dim().italic();
+            let definition_style = Style::new().dim();
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw("First"),
+                        Span::styled("[a]", reference_style),
+                        Span::raw(" second"),
+                        Span::styled("[b]", reference_style),
+                        Span::raw("."),
+                    ]),
+                    Line::default(),
+                    Line::from_iter(
+                        [Span::styled("[a]: ", definition_style), Span::raw("Alpha."),]
+                    )
+                    .style(definition_style),
+                    Line::default(),
+                    Line::from_iter([Span::styled("[b]: ", definition_style), Span::raw("Beta."),])
+                        .style(definition_style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn reference_combines_with_enclosing_style(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                **Text[^one]**
+
+                [^one]: Note.
+            "};
+            let reference_style = Style::new().bold().dim().italic();
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::styled("Text", Style::new().bold()),
+                        Span::styled("[one]", reference_style),
+                    ]),
+                    Line::default(),
+                    Line::from_iter([
+                        Span::styled("[one]: ", Style::new().dim()),
+                        Span::raw("Note."),
+                    ])
+                    .style(Style::new().dim()),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn multiple_definition_paragraphs_keep_blank_line(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Text[^one]
+
+                [^one]: First paragraph.
+
+                    Second paragraph.
+            "};
+            let definition_style = Style::new().dim();
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw("Text"),
+                        Span::styled("[one]", definition_style.italic()),
+                    ]),
+                    Line::default(),
+                    Line::from_iter([
+                        Span::styled("[one]: ", definition_style),
+                        Span::raw("First paragraph."),
+                    ])
+                    .style(definition_style),
+                    Line::default().style(definition_style),
+                    Line::from("Second paragraph.").style(definition_style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn definition_style_does_not_leak_into_following_paragraph(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Text[^one]
+
+                [^one]: First paragraph.
+
+                    Second paragraph.
+
+                After.
+            "};
+            let definition_style = Style::new().dim();
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw("Text"),
+                        Span::styled("[one]", definition_style.italic()),
+                    ]),
+                    Line::default(),
+                    Line::from_iter([
+                        Span::styled("[one]: ", definition_style),
+                        Span::raw("First paragraph."),
+                    ])
+                    .style(definition_style),
+                    Line::default().style(definition_style),
+                    Line::from("Second paragraph.").style(definition_style),
+                    Line::default(),
+                    Line::from("After."),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn custom_styles_compose_with_enclosing_formatting(_with_tracing: DefaultGuard) {
+            #[derive(Clone, Copy)]
+            struct CustomFootnoteStyle;
+
+            impl StyleSheet for CustomFootnoteStyle {
+                fn footnote_ref(&self) -> Style {
+                    Style::new().red().underlined()
+                }
+
+                fn footnote_def(&self) -> Style {
+                    Style::new().blue().underlined()
+                }
+            }
+
+            let markdown = indoc! {"
+                **Text[^one]**
+
+                [^one]: Note.
+            "};
+            let options = Options::new(CustomFootnoteStyle);
+            let reference_style = Style::new().red().bold().underlined();
+            let definition_style = Style::new().blue().underlined();
+
+            assert_eq!(
+                from_str_with_options(markdown, &options),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::styled("Text", Style::new().bold()),
+                        Span::styled("[one]", reference_style),
+                    ]),
+                    Line::default(),
+                    Line::from_iter([
+                        Span::styled("[one]: ", definition_style),
+                        Span::raw("Note."),
+                    ])
+                    .style(definition_style),
+                ])
+            );
+        }
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/formatting.rs
+++ b/rust/crates/babylon-md/src/renderer/formatting.rs
@@ -1,0 +1,113 @@
+//! Markdown inline formatting.
+//!
+//! The inline style stack patches nested formatting over its enclosing style. Closing a formatting
+//! tag restores the previous style.
+
+use pulldown_cmark::Event;
+use ratatui_core::style::Style;
+use tracing::{debug, instrument};
+
+use super::TextWriter;
+use crate::StyleSheet;
+
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
+where
+    I: Iterator<Item = Event<'a>>,
+    S: StyleSheet,
+{
+    #[instrument(level = "trace", skip(self))]
+    pub fn push_inline_style(&mut self, style: Style) {
+        let current_style = self.inline_styles.last().copied().unwrap_or_default();
+        let style = current_style.patch(style);
+        self.inline_styles.push(style);
+        debug!("Pushed inline style: {:?}", style);
+        debug!("Current inline styles: {:?}", self.inline_styles);
+    }
+
+    #[instrument(level = "trace", skip(self))]
+    pub fn pop_inline_style(&mut self) {
+        self.inline_styles.pop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use ratatui_core::style::Stylize;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::renderer::test_support::{with_tracing, DefaultGuard};
+    use crate::renderer::*;
+
+    #[rstest]
+    fn superscript(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str("H ^2^ O"),
+            Text::from(Line::from_iter([
+                Span::from("H "),
+                Span::styled("2", Style::new().dim().italic()),
+                Span::from(" O"),
+            ]))
+        );
+    }
+
+    #[rstest]
+    fn subscript(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str("H ~2~ O"),
+            Text::from(Line::from_iter([
+                Span::from("H "),
+                Span::styled("2", Style::new().dim().italic()),
+                Span::from(" O"),
+            ]))
+        );
+    }
+
+    #[rstest]
+    fn strong(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str("**Strong**"),
+            Text::from(Line::from("Strong".bold()))
+        );
+    }
+
+    #[rstest]
+    fn emphasis(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str("*Emphasis*"),
+            Text::from(Line::from("Emphasis".italic()))
+        );
+    }
+
+    #[rstest]
+    fn strikethrough(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str("~~Strikethrough~~"),
+            Text::from(Line::from("Strikethrough".crossed_out()))
+        );
+    }
+
+    #[rstest]
+    fn strong_emphasis(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str("**Strong *emphasis***"),
+            Text::from(Line::from_iter([
+                "Strong ".bold(),
+                "emphasis".bold().italic()
+            ]))
+        );
+    }
+
+    #[rstest]
+    fn formatting_does_not_leak_into_following_text(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str("Before **strong** after"),
+            Text::from(Line::from_iter([
+                Span::raw("Before "),
+                Span::raw("strong").bold(),
+                Span::raw(" after"),
+            ]))
+        );
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/heading.rs
+++ b/rust/crates/babylon-md/src/renderer/heading.rs
@@ -1,0 +1,226 @@
+//! Markdown heading rendering.
+//!
+//! Headings retain their Markdown `#` prefix. IDs, classes, and key-value attributes render as a
+//! styled attribute-block suffix after the heading text.
+
+use pulldown_cmark::{CowStr, Event, HeadingLevel};
+use ratatui_core::text::{Line, Span};
+
+use super::TextWriter;
+use crate::StyleSheet;
+
+/// Heading attributes collected from pulldown-cmark to render after the heading text.
+pub struct HeadingMeta<'a> {
+    pub id: Option<CowStr<'a>>,
+    pub classes: Vec<CowStr<'a>>,
+    pub attrs: Vec<(CowStr<'a>, Option<CowStr<'a>>)>,
+}
+
+impl<'a> HeadingMeta<'a> {
+    fn into_option(self) -> Option<Self> {
+        let has_id = self.id.is_some();
+        let has_classes = !self.classes.is_empty();
+        let has_attrs = !self.attrs.is_empty();
+        if has_id || has_classes || has_attrs {
+            Some(self)
+        } else {
+            None
+        }
+    }
+
+    /// Formats the attributes as a Markdown attribute block suffix.
+    fn to_suffix(&self) -> Option<String> {
+        let mut parts = Vec::new();
+
+        if let Some(id) = &self.id {
+            parts.push(format!("#{id}"));
+        }
+        for class in &self.classes {
+            parts.push(format!(".{class}"));
+        }
+        for (key, value) in &self.attrs {
+            match value {
+                Some(value) => parts.push(format!("{key}={value}")),
+                None => parts.push(key.to_string()),
+            }
+        }
+
+        if parts.is_empty() {
+            None
+        } else {
+            Some(format!(" {{{}}}", parts.join(" ")))
+        }
+    }
+}
+
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
+where
+    I: Iterator<Item = Event<'a>>,
+    S: StyleSheet,
+{
+    pub fn start_heading(&mut self, level: HeadingLevel, heading_meta: HeadingMeta<'a>) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+        }
+        let heading_level = match level {
+            HeadingLevel::H1 => 1,
+            HeadingLevel::H2 => 2,
+            HeadingLevel::H3 => 3,
+            HeadingLevel::H4 => 4,
+            HeadingLevel::H5 => 5,
+            HeadingLevel::H6 => 6,
+        };
+        let style = self.styles.heading(heading_level);
+        let marker = self.styles.heading_marker(heading_level);
+        let content = if marker.is_empty() {
+            String::new()
+        } else {
+            format!("{marker} ")
+        };
+        self.push_line(Line::styled(content, style));
+        self.heading_meta = heading_meta.into_option();
+        self.needs_newline = false;
+    }
+
+    pub fn end_heading(&mut self) {
+        if let Some(meta) = self.heading_meta.take() {
+            if let Some(suffix) = meta.to_suffix() {
+                self.push_span(Span::styled(suffix, self.styles.heading_meta()));
+            }
+        }
+        self.needs_newline = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+    use ratatui_core::style::Style;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::renderer::test_support::{with_tracing, DefaultGuard};
+    use crate::renderer::*;
+
+    #[derive(Clone, Copy)]
+    struct CustomHeadingMarker;
+
+    impl StyleSheet for CustomHeadingMarker {
+        fn heading_marker(&self, level: u8) -> &str {
+            match level {
+                1 => "",
+                _ => "§",
+            }
+        }
+    }
+
+    #[rstest]
+    fn headings(_with_tracing: DefaultGuard) {
+        let h1 = Style::new().on_cyan().bold().underlined();
+        let h2 = Style::new().cyan().bold();
+        let h3 = Style::new().cyan().bold().italic();
+        let h4 = Style::new().light_cyan().italic();
+        let h5 = Style::new().light_cyan().italic();
+        let h6 = Style::new().light_cyan().italic();
+
+        assert_eq!(
+            from_str(indoc! {"
+                # Heading 1
+                ## Heading 2
+                ### Heading 3
+                #### Heading 4
+                ##### Heading 5
+                ###### Heading 6
+            "}),
+            Text::from_iter([
+                Line::from_iter(["# ", "Heading 1"]).style(h1),
+                Line::default(),
+                Line::from_iter(["## ", "Heading 2"]).style(h2),
+                Line::default(),
+                Line::from_iter(["### ", "Heading 3"]).style(h3),
+                Line::default(),
+                Line::from_iter(["#### ", "Heading 4"]).style(h4),
+                Line::default(),
+                Line::from_iter(["##### ", "Heading 5"]).style(h5),
+                Line::default(),
+                Line::from_iter(["###### ", "Heading 6"]).style(h6),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn heading_attributes(_with_tracing: DefaultGuard) {
+        let h1 = Style::new().on_cyan().bold().underlined();
+        let meta = Style::new().dim();
+
+        assert_eq!(
+            from_str("# Heading {#title .primary data-kind=doc}"),
+            Text::from(
+                Line::from_iter([
+                    Span::from("# "),
+                    Span::from("Heading"),
+                    Span::styled(" {#title .primary data-kind=doc}", meta),
+                ])
+                .style(h1)
+            )
+        );
+    }
+
+    #[rstest]
+    fn heading_attributes_do_not_carry_to_next_heading(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            # First {#first}
+            # Second
+        "};
+        let h1 = Style::new().on_cyan().bold().underlined();
+        let meta = Style::new().dim();
+
+        assert_eq!(
+            from_str(markdown),
+            Text::from_iter([
+                Line::from_iter([
+                    Span::raw("# "),
+                    Span::raw("First"),
+                    Span::styled(" {#first}", meta),
+                ])
+                .style(h1),
+                Line::default(),
+                Line::from_iter([Span::raw("# "), Span::raw("Second")]).style(h1),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn custom_and_empty_heading_markers(_with_tracing: DefaultGuard) {
+        let options = Options::new(CustomHeadingMarker);
+        let h1 = Style::new().on_cyan().bold().underlined();
+        let h2 = Style::new().cyan().bold();
+
+        assert_eq!(
+            from_str_with_options("# Hidden\n\n## Custom", &options),
+            Text::from_iter([
+                Line::from("Hidden").style(h1),
+                Line::default(),
+                Line::from_iter(["§ ", "Custom"]).style(h2),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn empty_heading_marker_preserves_attributes(_with_tracing: DefaultGuard) {
+        let options = Options::new(CustomHeadingMarker);
+        let h1 = Style::new().on_cyan().bold().underlined();
+
+        assert_eq!(
+            from_str_with_options("# Heading {#title}", &options),
+            Text::from(
+                Line::from_iter([
+                    Span::raw("Heading"),
+                    Span::styled(" {#title}", Style::new().dim()),
+                ])
+                .style(h1)
+            )
+        );
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/html.rs
+++ b/rust/crates/babylon-md/src/renderer/html.rs
@@ -1,0 +1,120 @@
+//! Raw Markdown HTML rendering.
+//!
+//! HTML remains visible as literal text. Inline tags compose with enclosing formatting, while HTML
+//! blocks preserve their physical lines and surrounding block spacing.
+
+use pulldown_cmark::{CowStr, Event};
+use ratatui_core::text::{Line, Span};
+
+use super::TextWriter;
+use crate::StyleSheet;
+
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
+where
+    I: Iterator<Item = Event<'a>>,
+    S: StyleSheet,
+{
+    pub fn start_html_block(&mut self) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+        }
+        self.push_line(Line::default());
+        self.line_styles.push(self.styles.html());
+        self.needs_newline = false;
+    }
+
+    pub fn end_html_block(&mut self) {
+        self.line_styles.pop();
+        self.needs_newline = true;
+    }
+
+    pub fn html_block(&mut self, html: CowStr<'a>) {
+        let style = self.styles.html();
+        for line in html.lines() {
+            if self.needs_newline {
+                self.push_line(Line::default());
+                self.needs_newline = false;
+            }
+            self.push_span(Span::styled(line.to_owned(), style));
+            self.needs_newline = true;
+        }
+    }
+
+    pub fn inline_html(&mut self, html: CowStr<'a>) {
+        let inline_style = self.inline_styles.last().copied().unwrap_or_default();
+        let style = inline_style.patch(self.styles.html());
+        self.push_span(Span::styled(html, style));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::renderer::test_support::{with_tracing, DefaultGuard};
+    use crate::renderer::*;
+
+    mod html {
+        use pretty_assertions::assert_eq;
+
+        use super::*;
+
+        #[rstest]
+        fn inline_html_tag(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("Hello <em>world</em>"),
+                Text::from(Line::from_iter([
+                    Span::from("Hello "),
+                    Span::styled("<em>", Style::new().dim()),
+                    Span::from("world"),
+                    Span::styled("</em>", Style::new().dim()),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn inline_html_combines_with_emphasis(_with_tracing: DefaultGuard) {
+            let italic = Style::new().italic();
+            let html = italic.dim();
+            assert_eq!(
+                from_str("*Hello <em>world</em>*"),
+                Text::from(Line::from_iter([
+                    Span::styled("Hello ", italic),
+                    Span::styled("<em>", html),
+                    Span::styled("world", italic),
+                    Span::styled("</em>", html),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn html_block_preserves_paragraph_spacing(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Before
+
+                <div>
+                Custom HTML
+                </div>
+
+                After
+            "};
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from("Before"),
+                    Line::default(),
+                    Line::from(Span::styled("<div>", Style::new().dim())),
+                    Line::from(Span::styled("Custom HTML", Style::new().dim()))
+                        .style(Style::new().dim()),
+                    Line::from(Span::styled("</div>", Style::new().dim()))
+                        .style(Style::new().dim()),
+                    Line::default(),
+                    Line::from("After"),
+                ])
+            );
+        }
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/image.rs
+++ b/rust/crates/babylon-md/src/renderer/image.rs
@@ -1,0 +1,449 @@
+//! Markdown image fallback rendering.
+
+use pulldown_cmark::{CowStr, Event};
+use ratatui_core::style::Style;
+use ratatui_core::text::Span;
+use tracing::instrument;
+
+use super::TextWriter;
+use crate::{ImageFallback, StyleSheet};
+
+const IMAGE_INDICATOR: &str = "[img]";
+
+/// An image whose description is still being emitted by pulldown-cmark.
+///
+/// Image descriptions arrive as the same inline event stream used for ordinary text: formatting,
+/// code, HTML, math, and even nested images are separate events between the image's start and end.
+/// Buffer the rendered spans until the end event so the fallback marker stays at the correct image
+/// boundary and the destination is used only when the description produced no content. A stack is
+/// required because pulldown-cmark can emit nested image events inside a description.
+#[derive(Debug)]
+pub struct PendingImage<'a> {
+    destination: CowStr<'a>,
+    style: Style,
+    description: Vec<Span<'a>>,
+}
+
+impl<'a> PendingImage<'a> {
+    fn new(destination: CowStr<'a>, style: Style) -> Self {
+        Self {
+            destination,
+            style,
+            description: Vec::new(),
+        }
+    }
+
+    pub fn push_span(&mut self, span: Span<'a>) {
+        self.description.push(span);
+    }
+
+    fn into_fallback(self, fallback: ImageFallback) -> Vec<Span<'a>> {
+        let Self {
+            destination,
+            style,
+            description,
+        } = self;
+        let mut content = match fallback {
+            ImageFallback::AltText if description.is_empty() => {
+                Self::destination_span(destination, style)
+            }
+            ImageFallback::AltText => description,
+            ImageFallback::Url => Self::destination_span(destination, style),
+            ImageFallback::AltTextAndUrl if description.is_empty() => {
+                Self::destination_span(destination, style)
+            }
+            ImageFallback::AltTextAndUrl if destination.is_empty() => description,
+            ImageFallback::AltTextAndUrl => {
+                let mut description = description;
+                let destination = format!(" ({destination})");
+                description.push(Span::styled(destination, style));
+                description
+            }
+        };
+
+        let indicator = if content.is_empty() {
+            IMAGE_INDICATOR.to_owned()
+        } else {
+            format!("{IMAGE_INDICATOR} ")
+        };
+        content.insert(0, Span::styled(indicator, style));
+        content
+    }
+
+    fn destination_span(destination: CowStr<'a>, style: Style) -> Vec<Span<'a>> {
+        if destination.is_empty() {
+            Vec::new()
+        } else {
+            vec![Span::styled(destination, style)]
+        }
+    }
+}
+
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
+where
+    I: Iterator<Item = Event<'a>>,
+    S: StyleSheet,
+{
+    /// Begins collecting the rendered image description.
+    #[instrument(level = "trace", skip(self))]
+    pub fn start_image(&mut self, dest_url: CowStr<'a>) {
+        self.push_inline_style(self.styles.image_alt());
+        let style = self.inline_styles.last().copied().unwrap_or_default();
+        self.images.push(PendingImage::new(dest_url, style));
+    }
+
+    /// Finishes the current image and emits its text fallback to the enclosing output.
+    ///
+    /// Pop the image before emitting so a nested image becomes part of its parent's description,
+    /// while an outer image continues through the usual table or document span sink.
+    #[instrument(level = "trace", skip(self))]
+    pub fn end_image(&mut self) {
+        self.pop_inline_style();
+        if let Some(image) = self.images.pop() {
+            for span in image.into_fallback(self.image_fallback) {
+                self.push_span(span);
+            }
+        }
+    }
+
+    pub fn image_description_break(&mut self) {
+        // Image descriptions are inline content. Keep a break readable without allowing it to
+        // split the surrounding document, and retain the image style in case it has a background.
+        let style = self.inline_styles.last().copied().unwrap_or_default();
+        self.push_span(Span::styled(" ", style));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::renderer::test_support::{with_tracing, DefaultGuard};
+    use crate::renderer::*;
+    use crate::*;
+
+    mod image {
+        use pretty_assertions::assert_eq;
+
+        use super::*;
+
+        const IMAGE_STYLE: Style = Style::new().dim().italic();
+
+        #[derive(Clone)]
+        struct UnstyledImageStyleSheet;
+
+        impl StyleSheet for UnstyledImageStyleSheet {
+            fn heading(&self, _level: u8) -> Style {
+                Style::default()
+            }
+
+            fn code(&self) -> Style {
+                Style::default()
+            }
+
+            fn link(&self) -> Style {
+                Style::default()
+            }
+
+            fn blockquote(&self) -> Style {
+                Style::default()
+            }
+
+            fn heading_meta(&self) -> Style {
+                Style::default()
+            }
+
+            fn metadata_block(&self) -> Style {
+                Style::default()
+            }
+
+            fn image_alt(&self) -> Style {
+                Style::default()
+            }
+        }
+
+        #[rstest]
+        fn image_with_alt(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![Alt text](https://example.com/image.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("Alt text", IMAGE_STYLE),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn image_without_alt(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![](https://example.com/image.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("https://example.com/image.png", IMAGE_STYLE),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn image_with_title(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![Alt](https://example.com/img.png \"My Title\")"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("Alt", IMAGE_STYLE),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn image_in_paragraph(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("Before ![photo](url.png) after"),
+                Text::from(Line::from_iter([
+                    Span::from("Before "),
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("photo", IMAGE_STYLE),
+                    Span::from(" after"),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn multiple_images_in_paragraph(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![first](first.png) and ![second](second.png)").to_string(),
+                "[img] first and [img] second"
+            );
+        }
+
+        #[rstest]
+        fn formatted_alt_text_keeps_prefix_before_content(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![**bold**](image.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("bold", IMAGE_STYLE.bold()),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn inline_code_counts_as_alt_text(_with_tracing: DefaultGuard) {
+            let code_style = IMAGE_STYLE.patch(DefaultStyleSheet.code());
+            assert_eq!(
+                from_str("![`code`](image.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("code", code_style),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn marker_and_alt_compose_with_enclosing_style(_with_tracing: DefaultGuard) {
+            let style = IMAGE_STYLE.bold();
+            assert_eq!(
+                from_str("**![diagram](diagram.png)**"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", style),
+                    Span::styled("diagram", style),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn marker_and_url_compose_with_enclosing_style(_with_tracing: DefaultGuard) {
+            let style = IMAGE_STYLE.bold();
+            assert_eq!(
+                from_str("**![](diagram.png)**"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", style),
+                    Span::styled("diagram.png", style),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn inline_math_counts_as_alt_text(_with_tracing: DefaultGuard) {
+            let math_style = IMAGE_STYLE.magenta();
+            assert_eq!(
+                from_str("![$x$](equation.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("$x$", math_style),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn inline_html_counts_as_alt_text(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![<br>](break.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("<br>", IMAGE_STYLE),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn nested_image_description_preserves_order_and_style(_with_tracing: DefaultGuard) {
+            let code_style = IMAGE_STYLE.patch(DefaultStyleSheet.code());
+            assert_eq!(
+                from_str("![outer ![inner](inner.png) `code`](outer.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("outer ", IMAGE_STYLE),
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("inner", IMAGE_STYLE),
+                    Span::styled(" ", IMAGE_STYLE),
+                    Span::styled("code", code_style),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn empty_description_and_destination_omit_trailing_space(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("Before ![]() after"),
+                Text::from(Line::from_iter([
+                    Span::raw("Before "),
+                    Span::styled("[img]", IMAGE_STYLE),
+                    Span::raw(" after"),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn multiline_description_renders_as_styled_inline_text(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                ![first line
+                second line](image.png)
+            "};
+            assert_eq!(
+                from_str(markdown),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("first line", IMAGE_STYLE),
+                    Span::styled(" ", IMAGE_STYLE),
+                    Span::styled("second line", IMAGE_STYLE),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn hard_break_in_description_stays_inline(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                ![first line  
+                second line](image.png)
+            "};
+            assert_eq!(
+                from_str(markdown),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("first line", IMAGE_STYLE),
+                    Span::styled(" ", IMAGE_STYLE),
+                    Span::styled("second line", IMAGE_STYLE),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn image_fallback_stays_inside_table_cell(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                | Image |
+                |-------|
+                | ![photo](photo.png) |
+            "};
+            let rendered = from_str(markdown)
+                .lines
+                .iter()
+                .map(ToString::to_string)
+                .collect_vec();
+            assert_eq!(
+                rendered,
+                [
+                    "┌─────────────┐",
+                    "│ Image       │",
+                    "├─────────────┤",
+                    "│ [img] photo │",
+                    "└─────────────┘",
+                ]
+            );
+        }
+
+        #[rstest]
+        fn url_fallback_uses_destination(_with_tracing: DefaultGuard) {
+            let options = Options::default().image_fallback(ImageFallback::Url);
+            assert_eq!(
+                from_str_with_options("![diagram](diagram.png)", &options),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("diagram.png", IMAGE_STYLE),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn url_fallback_discards_complete_formatted_description(_with_tracing: DefaultGuard) {
+            let options = Options::default().image_fallback(ImageFallback::Url);
+            assert_eq!(
+                from_str_with_options("![**bold** $x$ <br> `code`](diagram.png)", &options)
+                    .to_string(),
+                "[img] diagram.png"
+            );
+        }
+
+        #[rstest]
+        fn alt_text_and_url_fallback_preserves_formatted_description(_with_tracing: DefaultGuard) {
+            let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
+            assert_eq!(
+                from_str_with_options("![**diagram**](diagram.png)", &options),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("diagram", IMAGE_STYLE.bold()),
+                    Span::styled(" (diagram.png)", IMAGE_STYLE),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn alt_text_and_url_fallback_uses_destination_for_empty_description(
+            _with_tracing: DefaultGuard,
+        ) {
+            let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
+            assert_eq!(
+                from_str_with_options("![](diagram.png)", &options).to_string(),
+                "[img] diagram.png"
+            );
+        }
+
+        #[rstest]
+        fn configured_fallback_omits_space_when_destination_is_empty(
+            #[values(ImageFallback::Url, ImageFallback::AltTextAndUrl)] fallback: ImageFallback,
+            _with_tracing: DefaultGuard,
+        ) {
+            let options = Options::default().image_fallback(fallback);
+            assert_eq!(
+                from_str_with_options("![]()", &options),
+                Text::from(Line::from(Span::styled("[img]", IMAGE_STYLE)))
+            );
+        }
+
+        #[rstest]
+        fn unstyled_fallback_does_not_modify_surrounding_text(_with_tracing: DefaultGuard) {
+            let options = Options::new(UnstyledImageStyleSheet);
+            assert_eq!(
+                from_str_with_options("Before ![photo](photo.png) after", &options),
+                Text::from(Line::from_iter([
+                    Span::raw("Before "),
+                    Span::raw("[img] "),
+                    Span::raw("photo"),
+                    Span::raw(" after"),
+                ]))
+            );
+        }
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/link.rs
+++ b/rust/crates/babylon-md/src/renderer/link.rs
@@ -1,0 +1,240 @@
+//! Markdown link rendering.
+//!
+//! Links render as `label (destination)`. The link style applies to the label and destination while
+//! nested inline formatting remains on the label.
+//!
+//! BABYLON PATCH 2 (fork): link metadata is retained through a side-channel
+//! sink instead of being discarded. [`crate::from_str_with_options_and_links`]
+//! collects one [`LinkInfo`] per link — `LinkType`, destination, and the
+//! label's span coordinates in the output text — because ratatui's `Span` has
+//! no metadata slot (the side channel IS the design). Wikilinks additionally
+//! render label-only: the upstream ` (destination)` suffix is suppressed for
+//! [`pulldown_cmark::LinkType::WikiLink`], whose destination duplicates the
+//! target and is never a navigable URL.
+
+use pulldown_cmark::{CowStr, Event, LinkType};
+use ratatui_core::text::Span;
+use tracing::instrument;
+
+use super::TextWriter;
+use crate::StyleSheet;
+
+/// Metadata for one rendered link, captured through the side-channel sink
+/// (BABYLON PATCH 2).
+///
+/// `Eq` is not derived because [`LinkType`] only implements `PartialEq`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LinkInfo {
+    /// The pulldown-cmark link type (wikilink, inline, autolink, …).
+    pub link_type: LinkType,
+    /// The link destination (for wikilinks: the target page subject).
+    pub dest: String,
+    /// Where the label sits in the output text; `None` when the link was
+    /// rendered inside a buffered construct (table cell, image description)
+    /// whose final position the writer cannot know.
+    pub location: Option<LinkLocation>,
+}
+
+/// Span coordinates of a link label inside the rendered text.
+///
+/// `start_span` is inclusive within `start_line`; `end_span` is exclusive
+/// within `end_line` (the line of the label's last span). A label may cross
+/// lines when its source wraps.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkLocation {
+    /// Line index of the label's first span.
+    pub start_line: usize,
+    /// Span index of the label's first span within `start_line`.
+    pub start_span: usize,
+    /// Line index of the label's last span.
+    pub end_line: usize,
+    /// Span index just past the label's last span within `end_line`.
+    pub end_span: usize,
+}
+
+/// A link whose label is currently being rendered (BABYLON PATCH 2: carries
+/// the `LinkType` and start position upstream discarded).
+#[derive(Debug)]
+pub(super) struct PendingLink<'a> {
+    pub(super) link_type: LinkType,
+    pub(super) dest_url: CowStr<'a>,
+    /// `(line, span)` where the label starts, when the main text is the span
+    /// sink; `None` inside buffered constructs.
+    pub(super) start: Option<(usize, usize)>,
+}
+
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
+where
+    I: Iterator<Item = Event<'a>>,
+    S: StyleSheet,
+{
+    /// Stores the destination and applies the link style to the label.
+    #[instrument(level = "trace", skip(self))]
+    pub fn push_link(&mut self, link_type: LinkType, dest_url: CowStr<'a>) {
+        let start = self.main_flow_position();
+        self.link = Some(PendingLink {
+            link_type,
+            dest_url,
+            start,
+        });
+        self.push_inline_style(self.styles.link());
+    }
+
+    /// Restores the enclosing style, records the side-channel metadata, and
+    /// appends the destination (except for wikilinks, which render
+    /// label-only).
+    #[instrument(level = "trace", skip(self))]
+    pub fn pop_link(&mut self) {
+        self.pop_inline_style();
+        if let Some(pending) = self.link.take() {
+            let is_wikilink = matches!(pending.link_type, LinkType::WikiLink { .. });
+            // Record before any suffix so the location covers the label only.
+            let end = self.main_flow_position();
+            if let Some(links) = &mut self.links {
+                let location = match (pending.start, end) {
+                    (Some((start_line, start_span)), Some((end_line, end_span)))
+                        if (end_line, end_span) >= (start_line, start_span) =>
+                    {
+                        Some(LinkLocation {
+                            start_line,
+                            start_span,
+                            end_line,
+                            end_span,
+                        })
+                    }
+                    _ => None,
+                };
+                links.push(LinkInfo {
+                    link_type: pending.link_type,
+                    dest: pending.dest_url.to_string(),
+                    location,
+                });
+            }
+            if !is_wikilink {
+                self.push_span(" (".into());
+                self.push_span(Span::styled(pending.dest_url, self.styles.link()));
+                self.push_span(")".into());
+            }
+        }
+    }
+
+    /// The current `(line, span)` write position in the main output text, or
+    /// `None` while a buffered construct (image description, table cell) owns
+    /// the span sink (BABYLON PATCH 2).
+    fn main_flow_position(&self) -> Option<(usize, usize)> {
+        if !self.images.is_empty() || self.table_builder.is_some() {
+            return None;
+        }
+        match self.text.lines.last() {
+            Some(line) => Some((self.text.lines.len() - 1, line.spans.len())),
+            None => Some((0, 0)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::renderer::test_support::{with_tracing, DefaultGuard};
+    use crate::renderer::*;
+
+    #[rstest]
+    fn link_uses_default_style(_with_tracing: DefaultGuard) {
+        let link_style = Style::new().blue().underlined();
+        assert_eq!(
+            from_str("[Link](https://example.com)"),
+            Text::from(Line::from_iter([
+                Span::styled("Link", link_style),
+                Span::from(" ("),
+                Span::styled("https://example.com", link_style),
+                Span::from(")")
+            ]))
+        );
+    }
+
+    #[rstest]
+    fn link_combines_with_bold_style(_with_tracing: DefaultGuard) {
+        let link_style = Style::new().blue().underlined();
+        assert_eq!(
+            from_str("[**Bold link**](https://example.com)"),
+            Text::from(Line::from_iter([
+                Span::styled("Bold link", link_style.bold()),
+                Span::from(" ("),
+                Span::styled("https://example.com", link_style),
+                Span::from(")"),
+            ]))
+        );
+    }
+
+    #[rstest]
+    fn consecutive_links_restore_surrounding_style(_with_tracing: DefaultGuard) {
+        let link_style = Style::new().blue().underlined();
+        assert_eq!(
+            from_str("[One](one) and [Two](two) after"),
+            Text::from(Line::from_iter([
+                Span::styled("One", link_style),
+                Span::raw(" ("),
+                Span::styled("one", link_style),
+                Span::raw(")"),
+                Span::raw(" and "),
+                Span::styled("Two", link_style),
+                Span::raw(" ("),
+                Span::styled("two", link_style),
+                Span::raw(")"),
+                Span::raw(" after"),
+            ]))
+        );
+    }
+
+    // BABYLON PATCH 2 tests below.
+
+    #[rstest]
+    fn side_channel_records_regular_link(_with_tracing: DefaultGuard) {
+        let options = Options::default();
+        let (text, links) = from_str_with_options_and_links("[One](one) tail", &options);
+        assert_eq!(links.len(), 1);
+        let info = &links[0];
+        assert_eq!(info.dest, "one");
+        assert_eq!(info.link_type, LinkType::Inline);
+        let loc = info.location.as_ref().expect("main-flow link located");
+        let label: String = text.lines[loc.start_line].spans[loc.start_span..loc.end_span]
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert_eq!(label, "One");
+    }
+
+    #[rstest]
+    fn side_channel_records_wikilink_without_suffix(_with_tracing: DefaultGuard) {
+        let options = Options::default().parse_options(pulldown_cmark::Options::ENABLE_WIKILINKS);
+        let (text, links) = from_str_with_options_and_links("[[Target|Label]]", &options);
+        assert_eq!(links.len(), 1);
+        let info = &links[0];
+        assert!(matches!(info.link_type, LinkType::WikiLink { .. }));
+        assert_eq!(info.dest, "Target");
+        let flat: String = text
+            .lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert_eq!(flat, "Label", "wikilinks render label-only, no ' (dest)'");
+    }
+
+    #[rstest]
+    fn plain_entry_points_stay_upstream_shaped(_with_tracing: DefaultGuard) {
+        // Without the links-aware entry point, behavior is byte-identical to
+        // upstream: no sink allocation, dest suffix still rendered.
+        let text = from_str("[One](one)");
+        let flat: String = text
+            .lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert_eq!(flat, "One (one)");
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/list.rs
+++ b/rust/crates/babylon-md/src/renderer/list.rs
@@ -1,0 +1,312 @@
+//! Markdown list and task-item rendering.
+
+use pulldown_cmark::Event;
+use ratatui_core::style::Stylize;
+use ratatui_core::text::{Line, Span};
+
+use super::TextWriter;
+use crate::StyleSheet;
+
+/// Records how an active list item occupies the rendered output.
+///
+/// List markers are written as soon as pulldown-cmark emits an item start, but tables are buffered
+/// until the matching table end. Remembering the marker's location lets the completed table attach
+/// to that already-written marker instead of appearing as a separate, unindented block. These
+/// values form a stack because an outer item remains active while a nested item is parsed.
+#[derive(Clone, Copy, Debug)]
+pub struct ListItemLayout {
+    /// Output line containing the list marker.
+    pub marker_line: usize,
+    /// Number of spans on `marker_line` immediately after writing the marker.
+    ///
+    /// Comparing this with the eventual span count distinguishes a table that is the item's first
+    /// content from a table following text on the same line.
+    pub marker_span_count: usize,
+    /// Display width reserved by the complete marker, including nesting indentation.
+    ///
+    /// This uses terminal display width rather than bytes so continuation lines align after
+    /// unordered markers and multi-digit ordered markers alike.
+    pub continuation_width: usize,
+}
+
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
+where
+    I: Iterator<Item = Event<'a>>,
+    S: StyleSheet,
+{
+    pub fn start_list(&mut self, index: Option<u64>) {
+        if self.list_indices.is_empty() && self.needs_newline {
+            self.push_line(Line::default());
+        }
+        self.list_indices.push(index);
+    }
+
+    pub fn end_list(&mut self) {
+        self.list_indices.pop();
+        self.needs_newline = true;
+    }
+
+    pub fn start_item(&mut self) {
+        let marker_line = self.text.lines.len();
+        self.push_line(Line::default());
+        let width = self.list_indices.len() * 4 - 3;
+        if let Some(last_index) = self.list_indices.last_mut() {
+            let span = match last_index {
+                None => Span::from(" ".repeat(width - 1) + "- "),
+                Some(index) => {
+                    *index += 1;
+                    format!("{:width$}. ", *index - 1).light_blue()
+                }
+            };
+            let continuation_width = span.width();
+            self.push_span(span);
+            let marker_span_count = self.text.lines[marker_line].spans.len();
+            self.list_items.push(ListItemLayout {
+                marker_line,
+                marker_span_count,
+                continuation_width,
+            });
+        }
+        self.needs_newline = false;
+    }
+
+    pub fn end_item(&mut self) {
+        self.list_items.pop();
+    }
+
+    pub fn task_list_marker(&mut self, checked: bool) {
+        let marker = if checked { 'x' } else { ' ' };
+        let marker_span = Span::from(format!("[{marker}] "));
+        if let Some(line) = self.text.lines.last_mut() {
+            if let Some(first_span) = line.spans.first_mut() {
+                let content = first_span.content.to_mut();
+                if content.ends_with("- ") {
+                    let len = content.len();
+                    content.truncate(len - 2);
+                    content.push_str("- [");
+                    content.push(marker);
+                    content.push_str("] ");
+                    return;
+                }
+            }
+            line.spans.insert(1, marker_span);
+        } else {
+            self.push_span(marker_span);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::renderer::test_support::{with_tracing, DefaultGuard};
+    use crate::renderer::*;
+
+    #[rstest]
+    fn list_single(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str(indoc! {"
+                - List item 1
+            "}),
+            Text::from_iter([Line::from_iter(["- ", "List item 1"])])
+        );
+    }
+
+    #[rstest]
+    fn list_multiple(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str(indoc! {"
+                - List item 1
+                - List item 2
+            "}),
+            Text::from_iter([
+                Line::from_iter(["- ", "List item 1"]),
+                Line::from_iter(["- ", "List item 2"]),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn list_ordered(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str(indoc! {"
+                1. List item 1
+                2. List item 2
+            "}),
+            Text::from_iter([
+                Line::from_iter(["1. ".light_blue(), "List item 1".into()]),
+                Line::from_iter(["2. ".light_blue(), "List item 2".into()]),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn styled_list_items_keep_content_on_marker_line(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            - *Emphasis* and **strong**
+            - Before **strong *emphasis*** after
+
+            1. **Strong**
+            2. Before *emphasis* after
+        "};
+
+        assert_eq!(
+            from_str(markdown),
+            Text::from_iter([
+                Line::from_iter([
+                    Span::raw("- "),
+                    Span::raw("Emphasis").italic(),
+                    Span::raw(" and "),
+                    Span::raw("strong").bold(),
+                ]),
+                Line::from_iter([
+                    Span::raw("- "),
+                    Span::raw("Before "),
+                    Span::raw("strong ").bold(),
+                    Span::raw("emphasis").bold().italic(),
+                    Span::raw(" after"),
+                ]),
+                Line::default(),
+                Line::from_iter([Span::raw("1. ").light_blue(), Span::raw("Strong").bold()]),
+                Line::from_iter([
+                    Span::raw("2. ").light_blue(),
+                    Span::raw("Before "),
+                    Span::raw("emphasis").italic(),
+                    Span::raw(" after"),
+                ]),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn loose_styled_list_items_keep_first_paragraph_on_marker_line(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            - *Emphasized first item.*
+
+            - **Strong second item.**
+
+            1. **Strong first item.**
+
+            2. *Emphasized second item.*
+        "};
+
+        // Regression: loose lists emit paragraph boundaries after their item markers.
+        assert_eq!(
+            from_str(markdown),
+            Text::from_iter([
+                Line::from_iter([
+                    Span::raw("- "),
+                    Span::raw("Emphasized first item.").italic(),
+                ]),
+                Line::from_iter([Span::raw("- "), Span::raw("Strong second item.").bold(),]),
+                Line::default(),
+                Line::from_iter([
+                    Span::raw("1. ").light_blue(),
+                    Span::raw("Strong first item.").bold(),
+                ]),
+                Line::from_iter([
+                    Span::raw("2. ").light_blue(),
+                    Span::raw("Emphasized second item.").italic(),
+                ]),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn later_styled_paragraph_in_list_stays_separate(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            - **First paragraph.**
+
+              *Second paragraph.*
+        "};
+
+        assert_eq!(
+            from_str(markdown),
+            Text::from_iter([
+                Line::from_iter([Span::raw("- "), Span::raw("First paragraph.").bold(),]),
+                Line::default(),
+                Line::from(Span::raw("Second paragraph.").italic()),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn ordered_list_respects_start_index(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            10. Tenth
+            11. Eleventh
+        "};
+
+        assert_eq!(
+            from_str(markdown),
+            Text::from_iter([
+                Line::from_iter(["10. ".light_blue(), "Tenth".into()]),
+                Line::from_iter(["11. ".light_blue(), "Eleventh".into()]),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn list_nested(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str(indoc! {"
+                - List item 1
+                  - Nested list item 1
+            "}),
+            Text::from_iter([
+                Line::from_iter(["- ", "List item 1"]),
+                Line::from_iter(["    - ", "Nested list item 1"]),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn list_task_items(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str(indoc! {"
+                - [ ] Incomplete
+                - [x] Complete
+            "}),
+            Text::from_iter([
+                Line::from_iter(["- [ ] ", "Incomplete"]),
+                Line::from_iter(["- [x] ", "Complete"]),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn list_task_items_ordered(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str(indoc! {"
+                1. [ ] Incomplete
+                2. [x] Complete
+            "}),
+            Text::from_iter([
+                Line::from_iter(["1. ".light_blue(), "[ ] ".into(), "Incomplete".into(),]),
+                Line::from_iter(["2. ".light_blue(), "[x] ".into(), "Complete".into(),]),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn list_does_not_indent_following_paragraph(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            - Item
+
+            After
+        "};
+
+        assert_eq!(
+            from_str(markdown),
+            Text::from_iter([
+                Line::from_iter(["- ", "Item"]),
+                Line::default(),
+                Line::from("After"),
+            ])
+        );
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/math.rs
+++ b/rust/crates/babylon-md/src/renderer/math.rs
@@ -1,0 +1,135 @@
+//! Markdown inline and display math rendering.
+//!
+//! Inline math retains `$` delimiters and its position in the surrounding line. Display math keeps
+//! `$$` delimiters and writes each source line as a physical Ratatui line.
+
+use pulldown_cmark::{CowStr, Event};
+use ratatui_core::text::{Line, Span};
+
+use super::TextWriter;
+use crate::StyleSheet;
+
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
+where
+    I: Iterator<Item = Event<'a>>,
+    S: StyleSheet,
+{
+    pub fn inline_math(&mut self, math: CowStr<'a>) {
+        let inline_style = self.inline_styles.last().copied().unwrap_or_default();
+        let style = inline_style.patch(self.styles.math_inline());
+        self.push_span(Span::styled(format!("${math}$"), style));
+    }
+
+    pub fn display_math(&mut self, math: CowStr<'a>) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+        }
+        let style = self.styles.math_display();
+        let display_math = format!("$${math}$$");
+        for (index, line) in display_math.lines().enumerate() {
+            if index > 0 {
+                self.push_line(Line::default());
+            }
+            self.push_span(Span::styled(line.to_owned(), style));
+        }
+        self.needs_newline = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::renderer::test_support::{with_tracing, DefaultGuard};
+    use crate::renderer::*;
+
+    mod math {
+        use pretty_assertions::assert_eq;
+        use ratatui_core::style::Color;
+
+        use super::*;
+
+        #[rstest]
+        fn inline_math_has_exact_output_and_style(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("The formula $E=mc^2$ is famous."),
+                Text::from(Line::from_iter([
+                    Span::raw("The formula "),
+                    Span::styled("$E=mc^2$", Style::new().italic().fg(Color::Magenta)),
+                    Span::raw(" is famous."),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn inline_math_combines_with_enclosing_style(_with_tracing: DefaultGuard) {
+            let style = Style::new().bold().italic().fg(Color::Magenta);
+            assert_eq!(
+                from_str("**$x$**"),
+                Text::from(Line::from(Span::styled("$x$", style)))
+            );
+        }
+
+        #[rstest]
+        fn multiline_display_math_styles_every_line(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Before
+
+                $$
+                x = y
+                y = z
+                $$
+
+                After
+            "};
+            let style = Style::new().fg(Color::Magenta);
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from("Before"),
+                    Line::default(),
+                    Line::from(Span::styled("$$", style)),
+                    Line::from(Span::styled("x = y", style)),
+                    Line::from(Span::styled("y = z", style)),
+                    Line::from(Span::styled("$$", style)),
+                    Line::default(),
+                    Line::from("After"),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn multiline_display_math_uses_custom_style(_with_tracing: DefaultGuard) {
+            #[derive(Clone, Copy)]
+            struct CustomMathStyle;
+
+            impl StyleSheet for CustomMathStyle {
+                fn math_display(&self) -> Style {
+                    Style::new().red().bold()
+                }
+            }
+
+            let markdown = indoc! {"
+                $$
+                x = y
+                y = z
+                $$
+            "};
+            let options = Options::new(CustomMathStyle);
+            let style = Style::new().red().bold();
+
+            assert_eq!(
+                from_str_with_options(markdown, &options),
+                Text::from_iter([
+                    Line::from(Span::styled("$$", style)),
+                    Line::from(Span::styled("x = y", style)),
+                    Line::from(Span::styled("y = z", style)),
+                    Line::from(Span::styled("$$", style)),
+                ])
+            );
+        }
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/mod.rs
+++ b/rust/crates/babylon-md/src/renderer/mod.rs
@@ -1,0 +1,587 @@
+//! Markdown event rendering.
+//!
+//! [`TextWriter`] owns the event loop and shared output state. The event matches remain here as an
+//! index of supported pulldown-cmark events, while each Markdown construct keeps its state,
+//! rendering behavior, and tests in the corresponding child module.
+//!
+//! Inline handlers ultimately write spans through [`TextWriter::push_span`]. Active image
+//! descriptions receive those spans first, followed by active table cells, then the output line.
+//! This sink order preserves inline event ordering inside buffered constructs.
+
+use std::vec;
+
+use itertools::Itertools;
+use pulldown_cmark::{CowStr, Event, Options as ParseOptions, Parser, Tag, TagEnd};
+use ratatui_core::style::Style;
+use ratatui_core::text::{Line, Span, Text};
+use tracing::{debug, instrument};
+
+#[cfg(feature = "highlight-code")]
+use crate::code_theme::CodeTheme;
+use crate::options::{ImageFallback, Options};
+use crate::style_sheet::StyleSheet;
+
+mod blockquote;
+mod code;
+mod definition_list;
+mod footnote;
+mod formatting;
+mod heading;
+mod html;
+mod image;
+mod link;
+mod list;
+mod math;
+mod table;
+#[cfg(test)]
+mod test_support;
+
+// BABYLON PATCH 2 (fork): the link side-channel types are public API.
+pub use link::{LinkInfo, LinkLocation};
+
+/// Render Markdown `input` into a [`Text`] using the default [`Options`].
+///
+/// The returned text may borrow from `input`. Image syntax renders as a styled text fallback; this
+/// function does not read or render image resources.
+///
+/// # Example
+///
+/// ```
+/// use babylon_md::from_str;
+///
+/// let text = from_str("# Status\n\nReady");
+///
+/// assert_eq!(text.to_string(), "# Status\n\nReady");
+/// ```
+pub fn from_str(input: &str) -> Text<'_> {
+    from_str_with_options(input, &Options::default())
+}
+
+/// Render Markdown `input` into a [`Text`] using the supplied [`Options`].
+///
+/// The returned text may borrow from `input`. The options control styles, image fallback content,
+/// and, with the `highlight-code` feature, fenced-code syntax highlighting.
+///
+/// # Example
+///
+/// ```
+/// use babylon_md::{from_str_with_options, ImageFallback, Options};
+///
+/// let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
+/// let text = from_str_with_options("![diagram](diagram.png)", &options);
+///
+/// assert_eq!(text.to_string(), "[img] diagram (diagram.png)");
+/// ```
+pub fn from_str_with_options<'a, S>(input: &'a str, options: &Options<S>) -> Text<'a>
+where
+    S: StyleSheet,
+{
+    let parser = Parser::new_ext(input, baseline_parse_options(options));
+
+    let writer = TextWriter::new(parser, options.styles.clone(), options.image_fallback);
+    #[cfg(feature = "highlight-code")]
+    let writer = writer.with_code_theme(options.selected_code_theme());
+    writer.run()
+}
+
+/// BABYLON PATCH 2 (fork): render like [`from_str_with_options`] while
+/// collecting one [`LinkInfo`] per link through the side-channel sink.
+///
+/// ratatui's `Span` carries no metadata, so link identity (`LinkType`,
+/// destination, label coordinates) travels out of band; callers use it to
+/// build hit registries and wikilink `LinkSpan`s. Wikilinks (parsed when
+/// [`Options::parse_options`] enables
+/// [`pulldown_cmark::Options::ENABLE_WIKILINKS`]) render label-only — the
+/// upstream ` (destination)` suffix is suppressed for them.
+pub fn from_str_with_options_and_links<'a, S>(
+    input: &'a str,
+    options: &Options<S>,
+) -> (Text<'a>, Vec<LinkInfo>)
+where
+    S: StyleSheet,
+{
+    let parser = Parser::new_ext(input, baseline_parse_options(options));
+
+    let writer = TextWriter::new(parser, options.styles.clone(), options.image_fallback).with_links();
+    #[cfg(feature = "highlight-code")]
+    let writer = writer.with_code_theme(options.selected_code_theme());
+    writer.run_with_links()
+}
+
+/// The renderer's baseline parser option set, plus BABYLON PATCH 1's
+/// caller-supplied extras.
+fn baseline_parse_options<S: StyleSheet>(options: &Options<S>) -> ParseOptions {
+    let mut parse_opts = ParseOptions::empty();
+    parse_opts.insert(ParseOptions::ENABLE_STRIKETHROUGH);
+    parse_opts.insert(ParseOptions::ENABLE_TASKLISTS);
+    parse_opts.insert(ParseOptions::ENABLE_HEADING_ATTRIBUTES);
+    parse_opts.insert(ParseOptions::ENABLE_YAML_STYLE_METADATA_BLOCKS);
+    parse_opts.insert(ParseOptions::ENABLE_SUPERSCRIPT);
+    parse_opts.insert(ParseOptions::ENABLE_SUBSCRIPT);
+    parse_opts.insert(ParseOptions::ENABLE_MATH);
+    parse_opts.insert(ParseOptions::ENABLE_FOOTNOTES);
+    parse_opts.insert(ParseOptions::ENABLE_DEFINITION_LIST);
+    parse_opts.insert(ParseOptions::ENABLE_GFM);
+    parse_opts.insert(ParseOptions::ENABLE_TABLES);
+    // BABYLON PATCH 1 (fork): union in the caller's extra options.
+    parse_opts.insert(options.extra_parse_options);
+    parse_opts
+}
+
+struct TextWriter<'a, 'theme, I, S: StyleSheet> {
+    // Core output state.
+    /// Iterator supplying Markdown events.
+    iter: I,
+    /// Rendered terminal text.
+    text: Text<'a>,
+    /// Styles for nested inline constructs, with the active style at the top.
+    inline_styles: Vec<Style>,
+    /// Prefixes added to each output line, from the outermost block to the innermost.
+    line_prefixes: Vec<Span<'a>>,
+    /// Styles for nested line-oriented constructs, with the active style at the top.
+    line_styles: Vec<Style>,
+    /// The [`StyleSheet`] used to style the output.
+    styles: S,
+    /// Whether the next block needs to start on a new line.
+    needs_newline: bool,
+    /// Whether raw text is inside a metadata block.
+    in_metadata_block: bool,
+
+    // Code rendering state.
+    /// Active syntax highlighter while rendering a recognized fenced code block.
+    #[cfg(feature = "highlight-code")]
+    code_highlighter: Option<syntect::easy::HighlightLines<'theme>>,
+    /// Explicit theme used when a fenced code block starts highlighting.
+    ///
+    /// When absent, code highlighting resolves the shared built-in default.
+    #[cfg(feature = "highlight-code")]
+    code_theme: Option<&'theme CodeTheme>,
+    /// Keeps the writer's shape consistent when syntax highlighting is disabled.
+    #[cfg(not(feature = "highlight-code"))]
+    code_theme_lifetime: std::marker::PhantomData<&'theme ()>,
+
+    // Heading rendering state.
+    /// Heading attributes to append after heading content.
+    heading_meta: Option<heading::HeadingMeta<'a>>,
+
+    // Link rendering state.
+    /// A link which will be appended to the current line when the link tag is
+    /// closed (BABYLON PATCH 2: carries type + start position, not just the
+    /// destination).
+    link: Option<link::PendingLink<'a>>,
+    /// BABYLON PATCH 2: the side-channel sink; `Some` only via
+    /// [`from_str_with_options_and_links`].
+    links: Option<Vec<LinkInfo>>,
+
+    // Image rendering state.
+    /// Images whose descriptions are currently being collected.
+    images: Vec<image::PendingImage<'a>>,
+    /// Content to render in place of images.
+    image_fallback: ImageFallback,
+
+    // List rendering state.
+    /// Current list index as a stack of indices.
+    list_indices: Vec<Option<u64>>,
+    /// Layout of each active list item, from the outermost item to the innermost.
+    list_items: Vec<list::ListItemLayout>,
+
+    // Paragraph-suppression state.
+    /// Whether we are inside a footnote definition.
+    in_footnote_definition: bool,
+    /// Whether we are inside a definition-list description.
+    in_definition_description: bool,
+
+    // Table rendering state.
+    /// Active table builder that accumulates cells during table parsing.
+    table_builder: Option<table::TableBuilder<'a>>,
+}
+
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
+where
+    I: Iterator<Item = Event<'a>>,
+    S: StyleSheet,
+{
+    fn new(iter: I, styles: S, image_fallback: ImageFallback) -> Self {
+        Self {
+            iter,
+            text: Text::default(),
+            inline_styles: vec![],
+            line_styles: vec![],
+            line_prefixes: vec![],
+            styles,
+            needs_newline: false,
+            in_metadata_block: false,
+            #[cfg(feature = "highlight-code")]
+            code_highlighter: None,
+            #[cfg(feature = "highlight-code")]
+            code_theme: None,
+            #[cfg(not(feature = "highlight-code"))]
+            code_theme_lifetime: std::marker::PhantomData,
+            heading_meta: None,
+            link: None,
+            links: None,
+            images: vec![],
+            image_fallback,
+            list_indices: vec![],
+            list_items: vec![],
+            in_footnote_definition: false,
+            in_definition_description: false,
+            table_builder: None,
+        }
+    }
+
+    /// BABYLON PATCH 2: activates the link side-channel sink.
+    fn with_links(mut self) -> Self {
+        self.links = Some(Vec::new());
+        self
+    }
+
+    fn run(mut self) -> Text<'a> {
+        debug!("Running text writer");
+        while let Some(event) = self.iter.next() {
+            self.handle_event(event);
+        }
+        self.text
+    }
+
+    /// BABYLON PATCH 2: like [`Self::run`], also returning the collected
+    /// link metadata (empty when the sink was never activated).
+    fn run_with_links(mut self) -> (Text<'a>, Vec<LinkInfo>) {
+        debug!("Running text writer with link sink");
+        while let Some(event) = self.iter.next() {
+            self.handle_event(event);
+        }
+        let links = self.links.take().unwrap_or_default();
+        (self.text, links)
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    fn handle_event(&mut self, event: Event<'a>) {
+        match event {
+            Event::Start(tag) => self.start_tag(tag),
+            Event::End(tag) => self.end_tag(tag),
+            Event::Text(text) => self.text(text),
+            Event::Code(code) => self.code(code),
+            Event::Html(html) => self.html_block(html),
+            Event::InlineHtml(html) => self.inline_html(html),
+            Event::FootnoteReference(label) => self.footnote_reference(label),
+            Event::SoftBreak => self.soft_break(),
+            Event::HardBreak => self.hard_break(),
+            Event::Rule => self.rule(),
+            Event::TaskListMarker(checked) => self.task_list_marker(checked),
+            Event::InlineMath(math) => self.inline_math(math),
+            Event::DisplayMath(math) => self.display_math(math),
+        }
+    }
+
+    fn start_tag(&mut self, tag: Tag<'a>) {
+        match tag {
+            Tag::Paragraph => self.start_paragraph(),
+            Tag::Heading {
+                level,
+                id,
+                classes,
+                attrs,
+            } => self.start_heading(level, heading::HeadingMeta { id, classes, attrs }),
+            Tag::BlockQuote(kind) => self.start_blockquote(kind),
+            Tag::CodeBlock(kind) => self.start_codeblock(kind),
+            Tag::HtmlBlock => self.start_html_block(),
+            Tag::List(start_index) => self.start_list(start_index),
+            Tag::Item => self.start_item(),
+            Tag::FootnoteDefinition(label) => self.start_footnote_definition(label),
+            Tag::Table(alignments) => self.start_table(alignments),
+            Tag::TableHead => {}
+            Tag::TableRow => {}
+            Tag::TableCell => self.start_table_cell(),
+            Tag::Emphasis => self.push_inline_style(Style::new().italic()),
+            Tag::Strong => self.push_inline_style(Style::new().bold()),
+            Tag::Strikethrough => self.push_inline_style(Style::new().crossed_out()),
+            Tag::Subscript => self.push_inline_style(Style::new().dim().italic()),
+            Tag::Superscript => self.push_inline_style(Style::new().dim().italic()),
+            Tag::Link {
+                link_type,
+                dest_url,
+                ..
+            } => self.push_link(link_type, dest_url),
+            Tag::Image { dest_url, .. } => self.start_image(dest_url),
+            Tag::MetadataBlock(_) => self.start_metadata_block(),
+            Tag::DefinitionList => self.start_definition_list(),
+            Tag::DefinitionListTitle => self.start_definition_title(),
+            Tag::DefinitionListDefinition => self.start_definition_description(),
+        }
+    }
+
+    fn end_tag(&mut self, tag: TagEnd) {
+        match tag {
+            TagEnd::Paragraph => self.end_paragraph(),
+            TagEnd::Heading(_) => self.end_heading(),
+            TagEnd::BlockQuote(_) => self.end_blockquote(),
+            TagEnd::CodeBlock => self.end_codeblock(),
+            TagEnd::HtmlBlock => self.end_html_block(),
+            TagEnd::List(_is_ordered) => self.end_list(),
+            TagEnd::Item => self.end_item(),
+            TagEnd::FootnoteDefinition => self.end_footnote_definition(),
+            TagEnd::Table => self.end_table(),
+            TagEnd::TableHead => self.end_table_header(),
+            TagEnd::TableRow => self.end_table_row(),
+            TagEnd::TableCell => self.end_table_cell(),
+            TagEnd::Emphasis => self.pop_inline_style(),
+            TagEnd::Strong => self.pop_inline_style(),
+            TagEnd::Strikethrough => self.pop_inline_style(),
+            TagEnd::Subscript => self.pop_inline_style(),
+            TagEnd::Superscript => self.pop_inline_style(),
+            TagEnd::Link => self.pop_link(),
+            TagEnd::Image => self.end_image(),
+            TagEnd::MetadataBlock(_) => self.end_metadata_block(),
+            TagEnd::DefinitionList => self.end_definition_list(),
+            TagEnd::DefinitionListTitle => self.end_definition_title(),
+            TagEnd::DefinitionListDefinition => self.end_definition_description(),
+        }
+    }
+
+    fn start_paragraph(&mut self) {
+        // Loose list items emit a paragraph start after the item handler has already written the
+        // marker. Keep only that first paragraph on the marker line; later paragraphs have either
+        // added content or set `needs_newline`.
+        let list_marker_line_is_open = self.list_items.last().is_some_and(|item| {
+            !self.needs_newline
+                && self.text.lines.len() == item.marker_line + 1
+                && self.text.lines[item.marker_line].spans.len() == item.marker_span_count
+        });
+        if list_marker_line_is_open {
+            return;
+        }
+
+        // Footnote definitions and loose definition-list descriptions start with a paragraph event
+        // after their handlers have already written a visible prefix (`[label]: ` or `: `) to the
+        // current line. Skip normal paragraph handling only for that first paragraph so its content
+        // stays beside the prefix. For a later paragraph, `needs_newline` is true; allowing the
+        // normal path below to run preserves the blank line in definitions such as:
+        //
+        //     [^label]: First paragraph.
+        //
+        //         Second paragraph.
+        let prefix_line_is_open = self.in_footnote_definition || self.in_definition_description;
+        if prefix_line_is_open && !self.needs_newline {
+            return;
+        }
+        // Insert an empty line between paragraphs if there is at least one line of text already.
+        if self.needs_newline {
+            self.push_line(Line::default());
+        }
+        self.push_line(Line::default());
+        self.needs_newline = false;
+    }
+
+    fn end_paragraph(&mut self) {
+        self.needs_newline = true;
+    }
+
+    fn text(&mut self, text: CowStr<'a>) {
+        if self.table_builder.is_some() {
+            let style = self.inline_styles.last().copied().unwrap_or_default();
+            self.push_span(Span::styled(text, style));
+            return;
+        }
+
+        if self.push_highlighted_text(&text) {
+            return;
+        }
+
+        for (position, line) in text.lines().with_position() {
+            if self.needs_newline {
+                self.push_line(Line::default());
+                self.needs_newline = false;
+            }
+            if !position.is_first() {
+                self.push_line(Line::default());
+            }
+
+            let style = self.inline_styles.last().copied().unwrap_or_default();
+
+            let span = Span::styled(line.to_owned(), style);
+
+            self.push_span(span);
+        }
+        self.needs_newline = false;
+    }
+
+    fn hard_break(&mut self) {
+        if self.images.is_empty() {
+            self.push_line(Line::default());
+        } else {
+            self.image_description_break();
+        }
+    }
+
+    fn start_metadata_block(&mut self) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+        }
+        self.line_styles.push(self.styles.metadata_block());
+        self.push_line(Line::from("---"));
+        self.push_line(Line::default());
+        self.in_metadata_block = true;
+    }
+
+    fn end_metadata_block(&mut self) {
+        if self.in_metadata_block {
+            self.push_line(Line::from("---"));
+            self.line_styles.pop();
+            self.in_metadata_block = false;
+            self.needs_newline = true;
+        }
+    }
+
+    fn rule(&mut self) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+        }
+        self.push_line(Line::from("---"));
+        self.needs_newline = true;
+    }
+
+    fn soft_break(&mut self) {
+        if self.in_metadata_block {
+            self.hard_break();
+        } else if self.images.is_empty() {
+            self.push_span(Span::raw(" "));
+        } else {
+            self.image_description_break();
+        }
+    }
+
+    #[instrument(level = "trace", skip(self))]
+    fn push_line(&mut self, line: Line<'a>) {
+        let style = self.line_styles.last().copied().unwrap_or_default();
+        let mut line = line.patch_style(style);
+
+        // Add line prefixes to the start of the line.
+        let line_prefixes = self.line_prefixes.iter().cloned().collect_vec();
+        let has_prefixes = !line_prefixes.is_empty();
+        if has_prefixes {
+            line.spans.insert(0, " ".into());
+        }
+        for prefix in line_prefixes.iter().rev().cloned() {
+            line.spans.insert(0, prefix);
+        }
+        self.text.lines.push(line);
+    }
+
+    #[instrument(level = "trace", skip(self))]
+    fn push_span(&mut self, span: Span<'a>) {
+        // An active image owns every span produced by its inline event stream. Checking it before
+        // the table sink also lets a completed fallback enter a table cell as one ordered unit.
+        if let Some(image) = self.images.last_mut() {
+            image.push_span(span);
+            return;
+        }
+
+        // GFM tables are leaf blocks: their cells parse inline content, and block-level elements
+        // cannot occur inside them. Pulldown-cmark preserves that boundary by emitting only inline
+        // events inside `TableCell`. Keep the active cell as the single span sink anyway so a new
+        // inline event handler cannot accidentally write table content into the surrounding text.
+        // See <https://github.github.com/gfm/#tables-extension->.
+        if let Some(builder) = &mut self.table_builder {
+            builder.push_span(span);
+            return;
+        }
+
+        if let Some(line) = self.text.lines.last_mut() {
+            line.push_span(span);
+        } else {
+            self.push_line(Line::from(vec![span]));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    use super::test_support::{with_tracing, DefaultGuard};
+    use super::*;
+
+    #[rstest]
+    fn empty(_with_tracing: DefaultGuard) {
+        assert_eq!(from_str(""), Text::default());
+    }
+
+    #[rstest]
+    fn paragraph_single(_with_tracing: DefaultGuard) {
+        assert_eq!(from_str("Hello, world!"), Text::from("Hello, world!"));
+    }
+
+    #[rstest]
+    fn paragraph_soft_break(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str(indoc! {"
+                Hello
+                World
+            "}),
+            Text::from(Line::from_iter([
+                Span::from("Hello"),
+                Span::from(" "),
+                Span::from("World"),
+            ]))
+        );
+    }
+
+    #[rstest]
+    fn paragraph_hard_break(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {r"
+            Hello\
+            World
+        "};
+
+        assert_eq!(from_str(markdown), Text::from_iter(["Hello", "World"]));
+    }
+
+    #[rstest]
+    fn paragraph_multiple(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str(indoc! {"
+                Paragraph 1
+                
+                Paragraph 2
+            "}),
+            Text::from_iter(["Paragraph 1", "", "Paragraph 2",])
+        );
+    }
+
+    #[rstest]
+    fn rule(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str(indoc! {"
+                Paragraph 1
+
+                ---
+
+                Paragraph 2
+            "}),
+            Text::from_iter(["Paragraph 1", "", "---", "", "Paragraph 2"])
+        );
+    }
+
+    #[rstest]
+    fn metadata_block(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str(indoc! {"
+                ---
+                title: Demo
+                ---
+
+                Body
+            "}),
+            Text::from_iter([
+                Line::from("---").style(Style::new().light_yellow()),
+                Line::from("title: Demo").style(Style::new().light_yellow()),
+                Line::from("---").style(Style::new().light_yellow()),
+                Line::default(),
+                Line::from("Body"),
+            ])
+        );
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/mod.rs
+++ b/rust/crates/babylon-md/src/renderer/mod.rs
@@ -102,7 +102,8 @@ where
 {
     let parser = Parser::new_ext(input, baseline_parse_options(options));
 
-    let writer = TextWriter::new(parser, options.styles.clone(), options.image_fallback).with_links();
+    let writer =
+        TextWriter::new(parser, options.styles.clone(), options.image_fallback).with_links();
     #[cfg(feature = "highlight-code")]
     let writer = writer.with_code_theme(options.selected_code_theme());
     writer.run_with_links()

--- a/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__highlighted_code-2.snap
+++ b/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__highlighted_code-2.snap
@@ -1,0 +1,29 @@
+---
+source: tui-markdown/src/renderer/code.rs
+expression: highlighted_code
+snapshot_kind: text
+---
+Text::from_iter([
+    Line::from("```rust"),
+    Line::from_iter([
+        Span::from("fn").fg(Color::Rgb(180, 142, 173)),
+        Span::from(" ").fg(Color::Rgb(192, 197, 206)),
+        Span::from("main").fg(Color::Rgb(143, 161, 179)),
+        Span::from("(").fg(Color::Rgb(192, 197, 206)),
+        Span::from(")").fg(Color::Rgb(192, 197, 206)),
+        Span::from(" ").fg(Color::Rgb(192, 197, 206)),
+        Span::from("{").fg(Color::Rgb(192, 197, 206)),
+    ]),
+    Line::from_iter([
+        Span::from("    ").fg(Color::Rgb(192, 197, 206)),
+        Span::from("println!").fg(Color::Rgb(192, 197, 206)),
+        Span::from("(").fg(Color::Rgb(192, 197, 206)),
+        Span::from("\"").fg(Color::Rgb(192, 197, 206)),
+        Span::from("Hello, highlighted code!").fg(Color::Rgb(163, 190, 140)),
+        Span::from("\"").fg(Color::Rgb(192, 197, 206)),
+        Span::from(")").fg(Color::Rgb(192, 197, 206)),
+        Span::from(";").fg(Color::Rgb(192, 197, 206)),
+    ]),
+    Line::from(Span::from("}").fg(Color::Rgb(192, 197, 206))),
+    Line::from("```"),
+])

--- a/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__highlighted_code.snap
+++ b/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__highlighted_code.snap
@@ -1,0 +1,9 @@
+---
+source: tui-markdown/src/renderer/code.rs
+expression: highlighted_code
+---
+```rust
+fn main() {
+    println!("Hello, highlighted code!");
+}
+```

--- a/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__highlighted_code_with_indentation-2.snap
+++ b/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__highlighted_code_with_indentation-2.snap
@@ -1,0 +1,55 @@
+---
+source: tui-markdown/src/renderer/code.rs
+expression: highlighted_code_indented
+snapshot_kind: text
+---
+Text::from_iter([
+    Line::from("```rust"),
+    Line::from_iter([
+        Span::from("fn").fg(Color::Rgb(180, 142, 173)),
+        Span::from(" ").fg(Color::Rgb(192, 197, 206)),
+        Span::from("main").fg(Color::Rgb(143, 161, 179)),
+        Span::from("(").fg(Color::Rgb(192, 197, 206)),
+        Span::from(")").fg(Color::Rgb(192, 197, 206)),
+        Span::from(" ").fg(Color::Rgb(192, 197, 206)),
+        Span::from("{").fg(Color::Rgb(192, 197, 206)),
+    ]),
+    Line::from_iter([
+        Span::from("    ").fg(Color::Rgb(192, 197, 206)),
+        Span::from("//").fg(Color::Rgb(101, 115, 126)),
+        Span::from(" This is a comment").fg(Color::Rgb(101, 115, 126)),
+    ]),
+    Line::from_iter([
+        Span::from("    ").fg(Color::Rgb(192, 197, 206)),
+        Span::from("HelloWorldBuilder").fg(Color::Rgb(192, 197, 206)),
+        Span::from("::").fg(Color::Rgb(192, 197, 206)),
+        Span::from("new").fg(Color::Rgb(192, 197, 206)),
+        Span::from("(").fg(Color::Rgb(192, 197, 206)),
+        Span::from(")").fg(Color::Rgb(192, 197, 206)),
+    ]),
+    Line::from_iter([
+        Span::from("        .").fg(Color::Rgb(192, 197, 206)),
+        Span::from("with_text").fg(Color::Rgb(150, 181, 180)),
+        Span::from("(").fg(Color::Rgb(192, 197, 206)),
+        Span::from("\"").fg(Color::Rgb(192, 197, 206)),
+        Span::from("Hello, highlighted code!").fg(Color::Rgb(163, 190, 140)),
+        Span::from("\"").fg(Color::Rgb(192, 197, 206)),
+        Span::from(")").fg(Color::Rgb(192, 197, 206)),
+    ]),
+    Line::from_iter([
+        Span::from("        .").fg(Color::Rgb(192, 197, 206)),
+        Span::from("build").fg(Color::Rgb(150, 181, 180)),
+        Span::from("(").fg(Color::Rgb(192, 197, 206)),
+        Span::from(")").fg(Color::Rgb(192, 197, 206)),
+    ]),
+    Line::from_iter([
+        Span::from("        .").fg(Color::Rgb(192, 197, 206)),
+        Span::from("show").fg(Color::Rgb(150, 181, 180)),
+        Span::from("(").fg(Color::Rgb(192, 197, 206)),
+        Span::from(")").fg(Color::Rgb(192, 197, 206)),
+        Span::from(";").fg(Color::Rgb(192, 197, 206)),
+    ]),
+    Line::from(Span::from("                ").fg(Color::Rgb(192, 197, 206))),
+    Line::from(Span::from("}").fg(Color::Rgb(192, 197, 206))),
+    Line::from("```"),
+])

--- a/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__highlighted_code_with_indentation.snap
+++ b/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__highlighted_code_with_indentation.snap
@@ -1,0 +1,14 @@
+---
+source: tui-markdown/src/renderer/code.rs
+expression: highlighted_code_indented
+---
+```rust
+fn main() {
+    // This is a comment
+    HelloWorldBuilder::new()
+        .with_text("Hello, highlighted code!")
+        .build()
+        .show();
+                
+}
+```

--- a/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__inline_code.snap
+++ b/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__inline_code.snap
@@ -1,0 +1,5 @@
+---
+source: tui-markdown/src/renderer/code.rs
+expression: text
+---
+Example of Inline code

--- a/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__unhighlighted_code-2.snap
+++ b/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__unhighlighted_code-2.snap
@@ -1,0 +1,11 @@
+---
+source: tui-markdown/src/renderer/code.rs
+expression: unhiglighted_code
+---
+Text::from_iter([
+    Line::from("```rust").white().on_black(),
+    Line::from("fn main() {").white().on_black(),
+    Line::from("    println!("Hello, unhighlighted code!");").white().on_black(),
+    Line::from("}").white().on_black(),
+    Line::from("```").white().on_black(),
+])

--- a/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__unhighlighted_code.snap
+++ b/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__code__tests__unhighlighted_code.snap
@@ -1,0 +1,9 @@
+---
+source: tui-markdown/src/renderer/code.rs
+expression: unhiglighted_code
+---
+```rust
+fn main() {
+    println!("Hello, unhighlighted code!");
+}
+```

--- a/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__table__tests__table_snapshot.snap
+++ b/rust/crates/babylon-md/src/renderer/snapshots/babylon_md__renderer__table__tests__table_snapshot.snap
@@ -1,0 +1,10 @@
+---
+source: tui-markdown/src/renderer/table.rs
+expression: text
+---
+┌──────┬───────┐
+│ Name │ Value │
+├──────┼───────┤
+│ foo  │ bar   │
+│ baz  │ qux   │
+└──────┴───────┘

--- a/rust/crates/babylon-md/src/renderer/table.rs
+++ b/rust/crates/babylon-md/src/renderer/table.rs
@@ -1,0 +1,1011 @@
+//! Table rendering support for tui-markdown.
+//!
+//! A table must be buffered before rendering because every cell can increase its column's terminal
+//! display width. [`TableBuilder`] collects the header and body rows, then renders their content,
+//! alignment, padding, and Unicode box-drawing borders once pulldown-cmark closes the table.
+//!
+//! The central renderer dispatches events and owns shared inline state. This module owns the table
+//! event handlers, buffered table state, list-aware output placement, and final table layout.
+
+use pulldown_cmark::Alignment;
+use ratatui_core::style::Style;
+use ratatui_core::text::{Line, Span};
+
+use super::TextWriter;
+use crate::StyleSheet;
+
+const HORIZONTAL_BORDER: char = '─';
+const VERTICAL_BORDER: &str = "│";
+const TOP_BORDER: BorderGlyphs = BorderGlyphs::new('┌', '┬', '┐');
+const HEADER_SEPARATOR: BorderGlyphs = BorderGlyphs::new('├', '┼', '┤');
+const BOTTOM_BORDER: BorderGlyphs = BorderGlyphs::new('└', '┴', '┘');
+
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
+where
+    I: Iterator<Item = pulldown_cmark::Event<'a>>,
+    S: StyleSheet,
+{
+    pub fn start_table(&mut self, alignments: Vec<Alignment>) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+        }
+        self.table_builder = Some(TableBuilder::new(alignments));
+        self.needs_newline = false;
+    }
+
+    pub fn end_table_header(&mut self) {
+        if let Some(builder) = &mut self.table_builder {
+            builder.finish_header();
+        }
+    }
+
+    pub fn end_table_row(&mut self) {
+        if let Some(builder) = &mut self.table_builder {
+            builder.finish_row();
+        }
+    }
+
+    pub fn start_table_cell(&mut self) {
+        if let Some(builder) = &mut self.table_builder {
+            builder.start_cell();
+        }
+    }
+
+    pub fn end_table_cell(&mut self) {
+        if let Some(builder) = &mut self.table_builder {
+            builder.finish_cell();
+        }
+    }
+
+    pub fn end_table(&mut self) {
+        if let Some(builder) = self.table_builder.take() {
+            let lines = builder.render(&self.styles);
+            self.push_table_lines(lines);
+            self.needs_newline = true;
+        }
+    }
+
+    /// Adds a buffered table to the output while preserving an active list item's layout.
+    ///
+    /// A table that is the first content in an item starts on the marker line. Its remaining lines
+    /// are indented by the marker's display width. A later table cannot reuse the marker line, but
+    /// all of its lines still need the continuation indentation.
+    ///
+    /// Table rendering currently puts styles on individual spans and leaves the line style and
+    /// alignment at their defaults. This makes it safe to move the first rendered line's spans
+    /// onto the existing marker line.
+    fn push_table_lines(&mut self, lines: Vec<Line<'a>>) {
+        let Some(list_item) = self.list_items.last().copied() else {
+            for line in lines {
+                self.push_line(line);
+            }
+            return;
+        };
+
+        let mut lines = lines.into_iter();
+        // The line position alone is insufficient: inline item content may already have appended
+        // spans to the marker line before the table was buffered.
+        let marker_line_is_last = self.text.lines.len() == list_item.marker_line + 1;
+        let marker_has_no_content =
+            self.text.lines[list_item.marker_line].spans.len() == list_item.marker_span_count;
+        let table_starts_on_marker = marker_line_is_last && marker_has_no_content;
+        if table_starts_on_marker {
+            if let Some(first_line) = lines.next() {
+                self.text.lines[list_item.marker_line]
+                    .spans
+                    .extend(first_line.spans);
+            }
+        }
+
+        let continuation = " ".repeat(list_item.continuation_width);
+        for mut line in lines {
+            line.spans.insert(0, Span::raw(continuation.clone()));
+            self.push_line(line);
+        }
+    }
+}
+
+/// Accumulates a complete table before calculating its column widths and rendering it.
+///
+/// The parent renderer starts and finishes each cell as pulldown-cmark emits table events. It then
+/// finishes the header or body row and calls [`Self::render`] after the table closes.
+pub struct TableBuilder<'a> {
+    alignments: Vec<Alignment>,
+    header: TableHeader<'a>,
+    rows: Vec<TableRow<'a>>,
+    current_row: TableRow<'a>,
+    current_cell: TableCell<'a>,
+}
+
+impl<'a> TableBuilder<'a> {
+    pub fn new(alignments: Vec<Alignment>) -> Self {
+        Self {
+            alignments,
+            header: TableHeader::default(),
+            rows: Vec::new(),
+            current_row: TableRow::default(),
+            current_cell: TableCell::default(),
+        }
+    }
+
+    pub fn start_cell(&mut self) {
+        self.current_cell = TableCell::default();
+    }
+
+    pub fn push_span(&mut self, span: Span<'a>) {
+        self.current_cell.push(span);
+    }
+
+    pub fn finish_cell(&mut self) {
+        let cell = std::mem::take(&mut self.current_cell);
+        self.current_row.cells.push(cell);
+    }
+
+    pub fn finish_header(&mut self) {
+        self.header.cells = std::mem::take(&mut self.current_row.cells);
+    }
+
+    pub fn finish_row(&mut self) {
+        self.rows.push(std::mem::take(&mut self.current_row));
+    }
+
+    pub fn render<S: StyleSheet>(self, styles: &S) -> Vec<Line<'a>> {
+        let column_count = self.column_count();
+        if column_count == 0 {
+            return Vec::new();
+        }
+
+        let column_widths = self.column_widths(column_count);
+        let border_style = styles.table_border();
+
+        let top_border = TOP_BORDER.render(&column_widths, border_style);
+        let header = self.header.render(&column_widths, &self.alignments, styles);
+        let header_separator = HEADER_SEPARATOR.render(&column_widths, border_style);
+        let body = self
+            .rows
+            .iter()
+            .map(|row| row.render(&column_widths, &self.alignments, styles));
+        let bottom_border = BOTTOM_BORDER.render(&column_widths, border_style);
+
+        let mut lines = vec![top_border, header, header_separator];
+        lines.extend(body);
+        lines.push(bottom_border);
+        lines
+    }
+
+    fn column_count(&self) -> usize {
+        self.alignments.len().max(self.header.cells.len()).max(
+            self.rows
+                .iter()
+                .map(|row| row.cells.len())
+                .max()
+                .unwrap_or(0),
+        )
+    }
+
+    fn column_widths(&self, column_count: usize) -> Vec<usize> {
+        let mut widths = vec![0; column_count];
+        for (col_idx, cell) in self.header.cells.iter().enumerate() {
+            widths[col_idx] = widths[col_idx].max(cell.width());
+        }
+        for row in &self.rows {
+            for (col_idx, cell) in row.cells.iter().enumerate() {
+                widths[col_idx] = widths[col_idx].max(cell.width());
+            }
+        }
+        for width in &mut widths {
+            *width = (*width).max(1);
+        }
+        widths
+    }
+}
+
+#[derive(Default)]
+struct TableHeader<'a> {
+    cells: Vec<TableCell<'a>>,
+}
+
+impl<'a> TableHeader<'a> {
+    fn render<S: StyleSheet>(
+        &self,
+        column_widths: &[usize],
+        alignments: &[Alignment],
+        styles: &S,
+    ) -> Line<'a> {
+        render_line(
+            &self.cells,
+            column_widths,
+            alignments,
+            styles.table_header(),
+            styles.table_border(),
+        )
+    }
+}
+
+#[derive(Default)]
+struct TableRow<'a> {
+    cells: Vec<TableCell<'a>>,
+}
+
+impl<'a> TableRow<'a> {
+    fn render<S: StyleSheet>(
+        &self,
+        column_widths: &[usize],
+        alignments: &[Alignment],
+        styles: &S,
+    ) -> Line<'a> {
+        render_line(
+            &self.cells,
+            column_widths,
+            alignments,
+            styles.table_cell(),
+            styles.table_border(),
+        )
+    }
+}
+
+#[derive(Default)]
+struct TableCell<'a> {
+    spans: Vec<Span<'a>>,
+}
+
+impl<'a> TableCell<'a> {
+    fn push(&mut self, span: Span<'a>) {
+        self.spans.push(span);
+    }
+
+    fn width(&self) -> usize {
+        self.spans.iter().map(Span::width).sum()
+    }
+
+    fn render_spans(
+        &self,
+        column_width: usize,
+        alignment: Alignment,
+        style: Style,
+    ) -> Vec<Span<'a>> {
+        let (pad_left, pad_right) = padding(column_width, self.width(), alignment);
+        let mut spans = vec![Span::styled(" ".repeat(pad_left + 1), style)];
+
+        for span in &self.spans {
+            let mut span = span.clone();
+            span.style = span.style.patch(style);
+            spans.push(span);
+        }
+        spans.push(Span::styled(" ".repeat(pad_right + 1), style));
+        spans
+    }
+}
+
+#[derive(Clone, Copy)]
+struct BorderGlyphs {
+    left: char,
+    intersection: char,
+    right: char,
+}
+
+impl BorderGlyphs {
+    const fn new(left: char, intersection: char, right: char) -> Self {
+        Self {
+            left,
+            intersection,
+            right,
+        }
+    }
+
+    fn render<'a>(self, column_widths: &[usize], style: Style) -> Line<'a> {
+        let mut border = String::new();
+        border.push(self.left);
+        for (index, width) in column_widths.iter().enumerate() {
+            for _ in 0..(width + 2) {
+                border.push(HORIZONTAL_BORDER);
+            }
+            if index + 1 < column_widths.len() {
+                border.push(self.intersection);
+            }
+        }
+        border.push(self.right);
+        Line::from(Span::styled(border, style))
+    }
+}
+
+fn render_line<'a>(
+    cells: &[TableCell<'a>],
+    column_widths: &[usize],
+    alignments: &[Alignment],
+    content_style: Style,
+    border_style: Style,
+) -> Line<'a> {
+    let mut spans = vec![Span::styled(VERTICAL_BORDER, border_style)];
+    let empty_cell = TableCell::default();
+    for (column_index, &column_width) in column_widths.iter().enumerate() {
+        let cell = cells.get(column_index).unwrap_or(&empty_cell);
+        let alignment = alignments
+            .get(column_index)
+            .copied()
+            .unwrap_or(Alignment::None);
+        spans.extend(cell.render_spans(column_width, alignment, content_style));
+        spans.push(Span::styled(VERTICAL_BORDER, border_style));
+    }
+    Line::from(spans)
+}
+
+fn padding(column_width: usize, content_width: usize, alignment: Alignment) -> (usize, usize) {
+    if content_width >= column_width {
+        return (0, 0);
+    }
+    let total_pad = column_width - content_width;
+    match alignment {
+        Alignment::Left | Alignment::None => (0, total_pad),
+        Alignment::Right => (total_pad, 0),
+        Alignment::Center => {
+            let left = total_pad / 2;
+            (left, total_pad - left)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use itertools::Itertools;
+    use pretty_assertions::assert_eq;
+    use ratatui_core::style::{Style, Stylize};
+    use ratatui_core::text::{Line, Span, Text};
+
+    use super::*;
+    use crate::{from_str, from_str_with_options, DefaultStyleSheet, Options, StyleSheet};
+
+    #[test]
+    fn empty_table() {
+        let builder = TableBuilder::new(vec![]);
+        assert!(builder.render(&DefaultStyleSheet).is_empty());
+    }
+
+    #[test]
+    fn single_cell() {
+        let mut builder = TableBuilder::new(vec![Alignment::None]);
+        builder.start_cell();
+        builder.push_span(Span::raw("hi"));
+        builder.finish_cell();
+        builder.finish_header();
+        assert_eq!(builder.render(&DefaultStyleSheet).len(), 4);
+    }
+
+    #[test]
+    fn padding_for_each_alignment() {
+        assert_eq!(padding(10, 3, Alignment::Left), (0, 7));
+        assert_eq!(padding(10, 3, Alignment::Right), (7, 0));
+        assert_eq!(padding(10, 4, Alignment::Center), (3, 3));
+        assert_eq!(padding(10, 3, Alignment::Center), (3, 4));
+    }
+
+    #[test]
+    fn cell_style_covers_padding_and_empty_cells() {
+        let style = Style::new().on_green();
+        let cell = TableCell {
+            spans: vec![Span::raw("x")],
+        };
+        assert_eq!(
+            cell.render_spans(4, Alignment::Center, style),
+            [
+                Span::styled("  ", style),
+                Span::styled("x", style),
+                Span::styled("   ", style),
+            ]
+        );
+
+        let empty_cell = TableCell::default();
+        assert_eq!(
+            empty_cell.render_spans(4, Alignment::Right, style),
+            [Span::styled("     ", style), Span::styled(" ", style)]
+        );
+    }
+
+    #[test]
+    fn column_widths_have_a_minimum_of_one() {
+        let mut builder = TableBuilder::new(vec![]);
+        builder.header.cells.push(TableCell::default());
+        assert_eq!(builder.column_widths(1), vec![1]);
+    }
+
+    #[test]
+    fn styled_cell_width() {
+        let cell = TableCell {
+            spans: vec![Span::from("hello").bold(), Span::raw(" world")],
+        };
+        assert_eq!(cell.width(), 11);
+    }
+
+    #[test]
+    fn emoji_cell_width() {
+        let cell = TableCell {
+            spans: vec![Span::raw("✅"), Span::raw(" ok")],
+        };
+        assert_eq!(cell.width(), 5);
+    }
+
+    #[test]
+    fn cjk_cell_width() {
+        let cell = TableCell {
+            spans: vec![Span::raw("日本"), Span::raw(" ok")],
+        };
+        assert_eq!(cell.width(), 7);
+    }
+
+    #[test]
+    fn table_with_alignment() {
+        let text = from_str(indoc! {"
+                | Left | Center | Right |
+                |:-----|:------:|------:|
+                | a    | b      | c     |
+            "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+        assert_eq!(
+            rendered,
+            [
+                "┌──────┬────────┬───────┐",
+                "│ Left │ Center │ Right │",
+                "├──────┼────────┼───────┤",
+                "│ a    │   b    │     c │",
+                "└──────┴────────┴───────┘",
+            ]
+        );
+    }
+
+    #[test]
+    fn table_without_outer_pipes() {
+        let text = from_str(indoc! {"
+            A | B
+            ---|---
+            a | b
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+
+        assert_eq!(
+            rendered,
+            [
+                "┌───┬───┐",
+                "│ A │ B │",
+                "├───┼───┤",
+                "│ a │ b │",
+                "└───┴───┘",
+            ]
+        );
+    }
+
+    #[test]
+    fn escaped_pipe_stays_inside_its_cell() {
+        let text = from_str(indoc! {"
+            | Value |
+            |-------|
+            | a \\| b |
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+
+        assert_eq!(
+            rendered,
+            [
+                "┌───────┐",
+                "│ Value │",
+                "├───────┤",
+                "│ a | b │",
+                "└───────┘",
+            ]
+        );
+    }
+
+    #[test]
+    fn table_with_cjk_content() {
+        let text = from_str(indoc! {"
+                | Latin | CJK |
+                |-------|-----|
+                | a     | 日本 |
+            "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+        assert_eq!(
+            rendered,
+            [
+                "┌───────┬──────┐",
+                "│ Latin │ CJK  │",
+                "├───────┼──────┤",
+                "│ a     │ 日本 │",
+                "└───────┴──────┘",
+            ]
+        );
+        assert!(text.lines.iter().all(|line| line.width() == 16));
+    }
+
+    #[derive(Clone)]
+    struct CustomTableStyleSheet;
+
+    impl StyleSheet for CustomTableStyleSheet {
+        fn heading(&self, _level: u8) -> Style {
+            Style::default()
+        }
+
+        fn code(&self) -> Style {
+            Style::default()
+        }
+
+        fn link(&self) -> Style {
+            Style::new().blue().underlined()
+        }
+
+        fn blockquote(&self) -> Style {
+            Style::default()
+        }
+
+        fn heading_meta(&self) -> Style {
+            Style::default()
+        }
+
+        fn metadata_block(&self) -> Style {
+            Style::default()
+        }
+
+        fn table_header(&self) -> Style {
+            Style::new().on_blue()
+        }
+
+        fn table_cell(&self) -> Style {
+            Style::new().red().on_green()
+        }
+
+        fn table_border(&self) -> Style {
+            Style::new().red()
+        }
+    }
+
+    #[test]
+    fn custom_styles_apply_to_header_cells_body_cells_and_borders() {
+        let border_style = Style::new().red();
+        let header_style = Style::new().on_blue();
+        let cell_style = Style::new().red().on_green();
+        let options = Options::new(CustomTableStyleSheet);
+        let text = from_str_with_options(
+            indoc! {"
+                | A |
+                |---|
+                | a |
+            "},
+            &options,
+        );
+        assert_eq!(
+            text,
+            Text::from_iter([
+                Line::from(Span::styled("┌───┐", border_style)),
+                Line::from_iter([
+                    Span::styled("│", border_style),
+                    Span::styled(" ", header_style),
+                    Span::styled("A", header_style),
+                    Span::styled(" ", header_style),
+                    Span::styled("│", border_style),
+                ]),
+                Line::from(Span::styled("├───┤", border_style)),
+                Line::from_iter([
+                    Span::styled("│", border_style),
+                    Span::styled(" ", cell_style),
+                    Span::styled("a", cell_style),
+                    Span::styled(" ", cell_style),
+                    Span::styled("│", border_style),
+                ]),
+                Line::from(Span::styled("└───┘", border_style)),
+            ])
+        );
+    }
+
+    #[test]
+    fn custom_cell_style_composes_with_inline_formatting() {
+        let options = Options::new(CustomTableStyleSheet);
+        let text = from_str_with_options(
+            indoc! {"
+                | A |
+                |---|
+                | **bold** |
+            "},
+            &options,
+        );
+        let body = &text.lines[3];
+
+        assert!(body
+            .spans
+            .contains(&Span::styled("bold", Style::new().bold().red().on_green())));
+    }
+
+    #[test]
+    fn table_cell_style_overrides_conflicting_inline_properties() {
+        let options = Options::new(CustomTableStyleSheet);
+        let text = from_str_with_options(
+            indoc! {"
+                | A |
+                |---|
+                | [docs](url) |
+            "},
+            &options,
+        );
+        let link = text.lines[3]
+            .spans
+            .iter()
+            .find(|span| span.content == "docs")
+            .expect("link cell content");
+
+        assert_eq!(
+            link,
+            &Span::styled("docs", Style::new().red().underlined().on_green())
+        );
+    }
+
+    #[test]
+    fn table_preserves_surrounding_paragraph_spacing() {
+        let text = from_str(indoc! {"
+                Before
+
+                | A |
+                |---|
+                | a |
+
+                After
+            "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+        assert_eq!(
+            rendered,
+            [
+                "Before",
+                "",
+                "┌───┐",
+                "│ A │",
+                "├───┤",
+                "│ a │",
+                "└───┘",
+                "",
+                "After",
+            ]
+        );
+    }
+
+    #[test]
+    fn consecutive_tables_keep_separate_layout_state() {
+        let text = from_str(indoc! {"
+            | Long |
+            |------|
+            | value |
+
+            | A |
+            |---|
+            | b |
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+
+        assert_eq!(
+            rendered,
+            [
+                "┌───────┐",
+                "│ Long  │",
+                "├───────┤",
+                "│ value │",
+                "└───────┘",
+                "",
+                "┌───┐",
+                "│ A │",
+                "├───┤",
+                "│ b │",
+                "└───┘",
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_cells_keep_minimum_column_width() {
+        let text = from_str(indoc! {"
+            | A | B |
+            |---|---|
+            |   |   |
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+        assert_eq!(
+            rendered,
+            [
+                "┌───┬───┐",
+                "│ A │ B │",
+                "├───┼───┤",
+                "│   │   │",
+                "└───┴───┘",
+            ]
+        );
+    }
+
+    #[test]
+    fn header_only_table_has_a_complete_frame() {
+        let text = from_str(indoc! {"
+            | A |
+            |---|
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+
+        #[rustfmt::skip]
+        let expected = [
+            "┌───┐",
+            "│ A │",
+            "├───┤",
+            "└───┘",
+        ];
+        assert_eq!(rendered, expected);
+    }
+
+    #[test]
+    fn short_rows_are_padded_and_extra_cells_are_ignored() {
+        let text = from_str(indoc! {"
+            | A | B |
+            |---|---|
+            | one |
+            | x | y | ignored |
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+
+        assert_eq!(
+            rendered,
+            [
+                "┌─────┬───┐",
+                "│ A   │ B │",
+                "├─────┼───┤",
+                "│ one │   │",
+                "│ x   │ y │",
+                "└─────┴───┘",
+            ]
+        );
+    }
+
+    #[test]
+    fn table_with_inline_code() {
+        let text = from_str(indoc! {"
+            | Name | Type |
+            |------|------|
+            | foo  | `u32` |
+        "});
+        let code_style = Style::new().white().on_black();
+        let code = text.lines[3]
+            .spans
+            .iter()
+            .find(|span| span.content == "u32")
+            .expect("inline code cell content");
+        assert_eq!(code, &Span::styled("u32", code_style));
+    }
+
+    #[test]
+    fn table_with_bold_in_cells() {
+        let text = from_str(indoc! {"
+            | Col |
+            |-----|
+            | **bold** |
+        "});
+        let bold = text.lines[3]
+            .spans
+            .iter()
+            .find(|span| span.content == "bold")
+            .expect("bold cell content");
+        assert_eq!(bold, &Span::styled("bold", Style::new().bold()));
+    }
+
+    #[test]
+    fn table_keeps_link_destination_in_cell() {
+        let text = from_str(indoc! {"
+            | Link |
+            |------|
+            | [docs](u) |
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+        assert_eq!(
+            rendered,
+            [
+                "┌──────────┐",
+                "│ Link     │",
+                "├──────────┤",
+                "│ docs (u) │",
+                "└──────────┘",
+            ]
+        );
+        let link_style = DefaultStyleSheet.link();
+        assert_eq!(
+            text.lines[3],
+            Line::from_iter([
+                Span::styled("│", DefaultStyleSheet.table_border()),
+                Span::raw(" "),
+                Span::styled("docs", link_style),
+                Span::raw(" ("),
+                Span::styled("u", link_style),
+                Span::raw(")"),
+                Span::raw(" "),
+                Span::styled("│", DefaultStyleSheet.table_border()),
+            ])
+        );
+    }
+
+    #[test]
+    fn table_keeps_inline_features_in_cell() {
+        let text = from_str(indoc! {"
+            | Value |
+            |-------|
+            | <em>x</em> $y$ |
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+        assert_eq!(
+            rendered,
+            [
+                "┌────────────────┐",
+                "│ Value          │",
+                "├────────────────┤",
+                "│ <em>x</em> $y$ │",
+                "└────────────────┘",
+            ]
+        );
+
+        let row = &text.lines[3];
+        assert!(row
+            .spans
+            .contains(&Span::styled("<em>", DefaultStyleSheet.html())));
+        assert!(row
+            .spans
+            .contains(&Span::styled("$y$", DefaultStyleSheet.math_inline())));
+    }
+
+    #[test]
+    fn table_routes_inline_content_through_the_active_cell() {
+        let text = from_str(indoc! {"
+            | Value |
+            |-------|
+            | **bold** `code` [link](url) <em>x</em> $y$ [^n] |
+
+            [^n]: note
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+
+        assert_eq!(rendered[3], "│ bold code link (url) <em>x</em> $y$ [n] │");
+    }
+
+    #[test]
+    fn block_markers_inside_cells_remain_inline_text() {
+        let text = from_str(indoc! {"
+            | Value |
+            |-------|
+            | # heading |
+            | > quote |
+            | - list |
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+
+        assert_eq!(
+            rendered,
+            [
+                "┌───────────┐",
+                "│ Value     │",
+                "├───────────┤",
+                "│ # heading │",
+                "│ > quote   │",
+                "│ - list    │",
+                "└───────────┘",
+            ]
+        );
+    }
+
+    #[test]
+    fn table_in_blockquote_keeps_quote_prefix() {
+        let text = from_str(indoc! {"
+            > | A |
+            > |---|
+            > | a |
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+        #[rustfmt::skip]
+        let expected = [
+            "> ┌───┐",
+            "> │ A │",
+            "> ├───┤",
+            "> │ a │",
+            "> └───┘",
+        ];
+        assert_eq!(rendered, expected);
+    }
+
+    #[test]
+    fn table_list_item_keeps_marker_and_continuation_indent() {
+        let text = from_str(indoc! {"
+            - | A |
+              |---|
+              | a |
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+        #[rustfmt::skip]
+        let expected = [
+            "- ┌───┐",
+            "  │ A │",
+            "  ├───┤",
+            "  │ a │",
+            "  └───┘",
+        ];
+        assert_eq!(rendered, expected);
+    }
+
+    #[test]
+    fn later_table_in_list_uses_continuation_indent() {
+        let text = from_str(indoc! {"
+            - | A |
+              |---|
+              | a |
+
+              | B |
+              |---|
+              | b |
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+        assert_eq!(
+            rendered,
+            [
+                "- ┌───┐",
+                "  │ A │",
+                "  ├───┤",
+                "  │ a │",
+                "  └───┘",
+                "",
+                "  ┌───┐",
+                "  │ B │",
+                "  ├───┤",
+                "  │ b │",
+                "  └───┘",
+            ]
+        );
+    }
+
+    #[test]
+    fn ordered_table_list_item_uses_full_marker_width() {
+        let text = from_str(indoc! {"
+            10. | A |
+                |---|
+                | a |
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+        assert_eq!(
+            rendered,
+            [
+                "10. ┌───┐",
+                "    │ A │",
+                "    ├───┤",
+                "    │ a │",
+                "    └───┘",
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_table_list_item_uses_nested_marker_width() {
+        let text = from_str(indoc! {"
+            - Parent
+              - | A |
+                |---|
+                | a |
+        "});
+        let rendered = text.lines.iter().map(ToString::to_string).collect_vec();
+        assert_eq!(
+            rendered,
+            [
+                "- Parent",
+                "    - ┌───┐",
+                "      │ A │",
+                "      ├───┤",
+                "      │ a │",
+                "      └───┘",
+            ]
+        );
+    }
+
+    #[test]
+    fn table_snapshot() {
+        let text = from_str(indoc! {"
+                | Name | Value |
+                |------|-------|
+                | foo  | bar   |
+                | baz  | qux   |
+            "});
+        insta::assert_snapshot!(text);
+    }
+}

--- a/rust/crates/babylon-md/src/renderer/test_support.rs
+++ b/rust/crates/babylon-md/src/renderer/test_support.rs
@@ -1,0 +1,19 @@
+//! Shared renderer test infrastructure.
+
+use rstest::fixture;
+use tracing::level_filters::LevelFilter;
+use tracing::subscriber;
+pub use tracing::subscriber::DefaultGuard;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::fmt::time::Uptime;
+
+#[fixture]
+pub fn with_tracing() -> DefaultGuard {
+    let subscriber = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_timer(Uptime::default())
+        .with_max_level(LevelFilter::TRACE)
+        .with_span_events(FmtSpan::ENTER)
+        .finish();
+    subscriber::set_default(subscriber)
+}

--- a/rust/crates/babylon-md/src/style_sheet.rs
+++ b/rust/crates/babylon-md/src/style_sheet.rs
@@ -1,0 +1,241 @@
+//! Style sheet abstraction for tui-markdown.
+//!
+//! [`StyleSheet`] supplies the styles and alert text used while Markdown events are rendered.
+//! Every choice has a default. Implementations only need to override the styles or text they want
+//! to customize.
+//!
+//! [`DefaultStyleSheet`] is used by [`crate::Options::default`]. Applications can pass another
+//! implementation to [`crate::Options::new`].
+
+use ratatui_core::style::Style;
+
+/// The kind of a GitHub Flavored Markdown alert.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum AlertKind {
+    /// Supplementary information.
+    Note,
+    /// Helpful advice.
+    Tip,
+    /// Information essential to success.
+    Important,
+    /// Urgent information that needs attention.
+    Warning,
+    /// A risk or negative outcome.
+    Caution,
+}
+
+impl AlertKind {
+    /// The canonical English label for this alert kind.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Note => "Note",
+            Self::Tip => "Tip",
+            Self::Important => "Important",
+            Self::Warning => "Warning",
+            Self::Caution => "Caution",
+        }
+    }
+}
+
+/// Visual styles and symbols consumed by the renderer.
+///
+/// Every method has a default, which [`DefaultStyleSheet`] uses unchanged. Implementations only
+/// need to override the choices they want to customize.
+pub trait StyleSheet: Clone + Send + Sync + 'static {
+    /// Style for a Markdown heading.
+    ///
+    /// `level` is one-based (`1` for `# H1`, …).
+    fn heading(&self, level: u8) -> Style {
+        match level {
+            1 => Style::new().on_cyan().bold().underlined(),
+            2 => Style::new().cyan().bold(),
+            3 => Style::new().cyan().bold().italic(),
+            4 => Style::new().light_cyan().italic(),
+            5 => Style::new().light_cyan().italic(),
+            _ => Style::new().light_cyan().italic(),
+        }
+    }
+
+    /// Style for inline `code` spans and fenced code blocks when syntax highlighting is disabled.
+    fn code(&self) -> Style {
+        Style::new().white().on_black()
+    }
+
+    /// Style for an inline or reference link's visible label and appended destination.
+    fn link(&self) -> Style {
+        Style::new().blue().underlined()
+    }
+
+    /// Base style applied to blockquotes (`>` prefix and body text).
+    fn blockquote(&self) -> Style {
+        Style::new().green()
+    }
+
+    /// Style for heading attribute metadata appended to the heading text.
+    fn heading_meta(&self) -> Style {
+        Style::new().dim()
+    }
+
+    /// Style for metadata blocks (front matter).
+    fn metadata_block(&self) -> Style {
+        Style::new().light_yellow()
+    }
+
+    /// Marker displayed before a Markdown heading.
+    ///
+    /// `level` is one-based (`1` for an H1, …). The renderer adds one separating space after a
+    /// non-empty marker. Return an empty string to omit the marker and its separator.
+    fn heading_marker(&self, level: u8) -> &str {
+        match level {
+            1 => "#",
+            2 => "##",
+            3 => "###",
+            4 => "####",
+            5 => "#####",
+            _ => "######",
+        }
+    }
+
+    /// Delimiter displayed above and below block code.
+    ///
+    /// The renderer appends fenced-code info to the opening delimiter. Return an empty string to
+    /// omit both delimiter lines.
+    fn code_block_fence(&self) -> &str {
+        "```"
+    }
+
+    /// Style for raw HTML blocks and inline HTML tags.
+    fn html(&self) -> Style {
+        Style::new().dim()
+    }
+
+    /// Style for inline math (`$...$`).
+    fn math_inline(&self) -> Style {
+        Style::new().italic().magenta()
+    }
+
+    /// Style for display math (`$$...$$`).
+    fn math_display(&self) -> Style {
+        Style::new().magenta()
+    }
+
+    /// Style for footnote references, rendered as `[label]`.
+    fn footnote_ref(&self) -> Style {
+        Style::new().dim().italic()
+    }
+
+    /// Style for footnote definitions, including the `[label]: ` prefix.
+    fn footnote_def(&self) -> Style {
+        Style::new().dim()
+    }
+
+    /// Style for definition list terms.
+    fn definition_term(&self) -> Style {
+        Style::new().bold()
+    }
+
+    /// Style for definition list descriptions, including the `: ` prefix.
+    fn definition_description(&self) -> Style {
+        Style::default()
+    }
+    /// Style for a GFM alert heading and body.
+    ///
+    /// The generated icon and label are bold in addition to this base style.
+    fn alert(&self, kind: AlertKind) -> Style {
+        use ratatui_core::style::Color;
+
+        match kind {
+            AlertKind::Note => Style::new().fg(Color::Blue),
+            AlertKind::Tip => Style::new().fg(Color::Green),
+            AlertKind::Important => Style::new().fg(Color::Magenta),
+            AlertKind::Warning => Style::new().fg(Color::Yellow),
+            AlertKind::Caution => Style::new().fg(Color::Red),
+        }
+    }
+
+    /// Icon displayed before a GFM alert label.
+    ///
+    /// Return an empty string to render the label without an icon.
+    fn alert_icon(&self, kind: AlertKind) -> &str {
+        match kind {
+            AlertKind::Note => "\u{2139}\u{FE0F}",
+            AlertKind::Tip => "\u{1F4A1}",
+            AlertKind::Important => "\u{2757}",
+            AlertKind::Warning => "\u{26A0}\u{FE0F}",
+            AlertKind::Caution => "\u{1F534}",
+        }
+    }
+
+    /// Label displayed after a GFM alert icon.
+    ///
+    /// Return an empty string to render the icon without a label.
+    fn alert_label(&self, kind: AlertKind) -> &str {
+        kind.label()
+    }
+
+    /// Style patched onto cells in the table header row.
+    ///
+    /// Properties set by this style override the same properties in an inline style. The style
+    /// covers cell padding, while borders use [`Self::table_border`].
+    fn table_header(&self) -> Style {
+        Style::new().bold().cyan()
+    }
+
+    /// Style patched onto ordinary table cells.
+    ///
+    /// Properties set by this style override the same properties in an inline style. The style
+    /// covers cell padding, while borders use [`Self::table_border`].
+    fn table_cell(&self) -> Style {
+        Style::default()
+    }
+
+    /// Style for the Unicode box-drawing characters around table cells.
+    ///
+    /// This changes the presentation of the borders, not the box-drawing characters themselves.
+    fn table_border(&self) -> Style {
+        Style::new().dark_gray()
+    }
+
+    /// Style for the `[img]` marker and text used to represent Markdown images.
+    ///
+    /// The default is dim and italic. The renderer patches this over any enclosing inline style.
+    fn image_alt(&self) -> Style {
+        Style::new().dim().italic()
+    }
+}
+
+/// The default style set
+///
+/// This style sheet will be used by default if the user does not provide their own implementation.
+///
+/// Styles are:
+/// - H1: white on cyan, bold, underlined
+/// - H2: cyan, bold
+/// - H3: cyan, bold, italic
+/// - H4-H6: light cyan, italic
+/// - code: white on black
+/// - link: blue, underlined
+/// - blockquote: green
+/// - metadata block: light yellow
+/// - heading markers: one to six `#` characters
+/// - code block fences: three backticks
+/// - raw HTML: dim
+/// - inline math: magenta, italic
+/// - display math: magenta
+/// - footnote references: dim, italic
+/// - footnote definitions: dim
+/// - definition list terms: bold
+/// - definition list descriptions: the surrounding style
+/// - note alerts: blue
+/// - tip alerts: green
+/// - important alerts: magenta
+/// - warning alerts: yellow
+/// - caution alerts: red
+/// - table headers: bold cyan
+/// - table cells: the surrounding style
+/// - table borders: dark gray
+/// - image fallback text: dim and italic
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DefaultStyleSheet;
+
+impl StyleSheet for DefaultStyleSheet {}

--- a/rust/crates/babylon-tui-python/src/lib.rs
+++ b/rust/crates/babylon-tui-python/src/lib.rs
@@ -17,36 +17,85 @@ struct PyHost {
     obj: Py<PyAny>,
 }
 
-impl Host for PyHost {
-    fn lobby_catalog_json(&self) -> String {
+impl PyHost {
+    /// Call a zero-arg host method returning a JSON string; `absent` is the
+    /// honest-absence encoding used when the call fails.
+    fn call0(&self, name: &str, absent: &str) -> String {
         Python::attach(|py| {
             self.obj
-                .call_method0(py, "lobby_catalog_json")
+                .call_method0(py, name)
                 .and_then(|v| v.extract::<String>(py))
-                .unwrap_or_else(|_| "[]".into()) // honest absence: empty catalog
+                .unwrap_or_else(|_| absent.to_string())
+        })
+    }
+
+    /// Call a one-string-arg host method returning a JSON string.
+    fn call1(&self, name: &str, arg: &str, absent: &str) -> String {
+        Python::attach(|py| {
+            self.obj
+                .call_method1(py, name, (arg,))
+                .and_then(|v| v.extract::<String>(py))
+                .unwrap_or_else(|_| absent.to_string())
         })
     }
 }
 
-/// Run the client. Headless configs render one frame to a test backend and
-/// return a JSON transcript `{"frames": [...], "host_calls": [...]}`; the
-/// interactive path owns the terminal until `q`/`Esc`.
+impl Host for PyHost {
+    fn lobby_catalog_json(&self) -> String {
+        self.call0("lobby_catalog_json", "[]")
+    }
+
+    fn read_page_json(&self, subject: &str) -> String {
+        self.call1("read_page_json", subject, "null")
+    }
+
+    fn known_subjects_json(&self) -> String {
+        self.call0("known_subjects_json", "[]")
+    }
+
+    fn backlinks_json(&self, subject: &str) -> String {
+        self.call1("backlinks_json", subject, "[]")
+    }
+
+    fn subject_view_json(&self, subject: &str) -> String {
+        self.call1("subject_view_json", subject, "null")
+    }
+
+    fn watchlist_json(&self) -> String {
+        self.call0("watchlist_json", "[]")
+    }
+}
+
+/// Run the client. Headless configs render the initial frame, replay the
+/// config's script steps (each appending its frame), and return a JSON
+/// transcript `{"frames": [...], "host_calls": [...]}`; the interactive
+/// path owns the terminal until quit.
 #[pyfunction]
 fn run(py: Python<'_>, host: Py<PyAny>, config_json: &str) -> PyResult<String> {
     let cfg = AppConfig::from_json(config_json)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
     let py_host = PyHost { obj: host };
     let headless = cfg.headless;
-    let app = App::new(cfg, py_host);
+    let script = cfg.script.clone();
+    let mut app = App::new(cfg, py_host);
     py.detach(|| {
         if headless {
             let mut t = Terminal::new(TestBackend::new(80, 24))
                 .map_err(|e| format!("test backend init: {e:?}"))?;
+            let mut frames = Vec::new();
             app.render_frame(&mut t)
                 .map_err(|e| format!("headless render: {e:?}"))?;
-            let frame = format!("{:?}", t.backend().buffer());
+            frames.push(format!("{:?}", t.backend().buffer()));
+            for step in &script {
+                if app.apply_step(step) {
+                    break; // quit — the last recorded frame stands
+                }
+                app.render_frame(&mut t)
+                    .map_err(|e| format!("headless step render: {e:?}"))?;
+                frames.push(format!("{:?}", t.backend().buffer()));
+            }
             let calls = app.host_calls();
-            Ok(serde_json::json!({"frames": [frame], "host_calls": calls}).to_string())
+            Ok(serde_json::json!({"frames": frames, "host_calls": calls}).to_string())
         } else {
             run_interactive(app)
                 .map(|calls| serde_json::json!({"frames": [], "host_calls": calls}).to_string())

--- a/rust/crates/babylon-tui-python/src/lib.rs
+++ b/rust/crates/babylon-tui-python/src/lib.rs
@@ -18,51 +18,76 @@ struct PyHost {
 }
 
 impl PyHost {
-    /// Call a zero-arg host method returning a JSON string; `absent` is the
-    /// honest-absence encoding used when the call fails.
-    fn call0(&self, name: &str, absent: &str) -> String {
+    /// Call a zero-arg host method returning a JSON string.
+    ///
+    /// A raising host PANICS (after printing the Python traceback): an
+    /// error must never be indistinguishable from honest absence
+    /// (Constitution III.11 — a dropped Postgres connection is not an
+    /// empty world). The unwind crosses back through the FFI boundary as
+    /// a Python `PanicException` — after `TerminalSession`'s Drop has
+    /// restored the terminal — so the player sees the real failure.
+    fn call0(&self, name: &str) -> String {
         Python::attach(|py| {
-            self.obj
+            match self
+                .obj
                 .call_method0(py, name)
                 .and_then(|v| v.extract::<String>(py))
-                .unwrap_or_else(|_| absent.to_string())
+            {
+                Ok(value) => value,
+                Err(error) => {
+                    error.print(py);
+                    panic!("host method {name} raised — traceback above (III.11 loud failure)")
+                }
+            }
         })
     }
 
-    /// Call a one-string-arg host method returning a JSON string.
-    fn call1(&self, name: &str, arg: &str, absent: &str) -> String {
+    /// Call a one-string-arg host method returning a JSON string; raises
+    /// loudly exactly like [`Self::call0`].
+    fn call1(&self, name: &str, arg: &str) -> String {
         Python::attach(|py| {
-            self.obj
+            match self
+                .obj
                 .call_method1(py, name, (arg,))
                 .and_then(|v| v.extract::<String>(py))
-                .unwrap_or_else(|_| absent.to_string())
+            {
+                Ok(value) => value,
+                Err(error) => {
+                    error.print(py);
+                    panic!("host method {name} raised — traceback above (III.11 loud failure)")
+                }
+            }
         })
     }
 }
 
 impl Host for PyHost {
     fn lobby_catalog_json(&self) -> String {
-        self.call0("lobby_catalog_json", "[]")
+        self.call0("lobby_catalog_json")
+    }
+
+    fn load_campaign(&self, campaign_id: &str) -> String {
+        self.call1("load_campaign", campaign_id)
     }
 
     fn read_page_json(&self, subject: &str) -> String {
-        self.call1("read_page_json", subject, "null")
+        self.call1("read_page_json", subject)
     }
 
     fn known_subjects_json(&self) -> String {
-        self.call0("known_subjects_json", "[]")
+        self.call0("known_subjects_json")
     }
 
     fn backlinks_json(&self, subject: &str) -> String {
-        self.call1("backlinks_json", subject, "[]")
+        self.call1("backlinks_json", subject)
     }
 
     fn subject_view_json(&self, subject: &str) -> String {
-        self.call1("subject_view_json", subject, "null")
+        self.call1("subject_view_json", subject)
     }
 
     fn watchlist_json(&self) -> String {
-        self.call0("watchlist_json", "[]")
+        self.call0("watchlist_json")
     }
 }
 

--- a/rust/crates/babylon-tui/Cargo.toml
+++ b/rust/crates/babylon-tui/Cargo.toml
@@ -14,6 +14,8 @@ license.workspace = true
 raster = ["dep:hypergraph-rs"]
 
 [dependencies]
+babylon-md = { path = "../babylon-md" }
+pulldown-cmark = "0.13"
 ratatui = "0.30"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/crates/babylon-tui/Cargo.toml
+++ b/rust/crates/babylon-tui/Cargo.toml
@@ -14,14 +14,21 @@ license.workspace = true
 raster = ["dep:hypergraph-rs"]
 
 [dependencies]
-babylon-md = { path = "../babylon-md" }
+# default-features off: highlight-code pulls syntect/onig (a native C
+# build) and M1 renders fences as styled fences with pre-resolved payloads —
+# no highlighting needed; keeps the client C-toolchain-free (AA disclosure:
+# also removes the classic MSVC cross-compile failure point).
+babylon-md = { path = "../babylon-md", default-features = false }
 pulldown-cmark = "0.13"
 ratatui = "0.30"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+# preserve_order: peek plates must walk view-model fields in Python
+# declaration order (model_dump_json insertion order) — alphabetical maps
+# would TRUNCATE to a different field subset at capped depths.
+serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "2"
+unicode-width = "0.2"
 hypergraph-rs = { git = "https://github.com/percy-raskova/hypergraph-rs.git", rev = "0c95db0663737b492af27f85e70b223833a18c2e", default-features = false, features = ["cells3d"], optional = true }
 
 [dev-dependencies]
 insta = { version = "1", features = ["filters"] }
-unicode-width = "0.2"

--- a/rust/crates/babylon-tui/src/app.rs
+++ b/rust/crates/babylon-tui/src/app.rs
@@ -22,7 +22,6 @@ use ratatui::crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
 use ratatui::layout::Rect;
-use ratatui::Frame;
 use ratatui::Terminal;
 
 use crate::config::{AppConfig, ScriptStep};
@@ -62,6 +61,11 @@ impl<H: Host> Host for RecordingHost<'_, H> {
     fn lobby_catalog_json(&self) -> String {
         self.record("lobby_catalog_json");
         self.inner.lobby_catalog_json()
+    }
+
+    fn load_campaign(&self, campaign_id: &str) -> String {
+        self.record("load_campaign");
+        self.inner.load_campaign(campaign_id)
     }
 
     fn read_page_json(&self, subject: &str) -> String {
@@ -107,6 +111,10 @@ pub struct App<H: Host> {
     peek_target: Option<String>,
     /// Peek overlay depth, 0 = off (K cycles 0→1→2→3→0).
     peek_depth: u8,
+    /// Cache of the last peek fetch: `(subject, view json)` — the seam is
+    /// crossed once per subject, not once per frame (M1 views are frozen
+    /// per campaign bind; M2 tick advances invalidate by subject change).
+    peek_cache: Option<(String, String)>,
 }
 
 impl<H: Host> App<H> {
@@ -123,6 +131,7 @@ impl<H: Host> App<H> {
             known: None,
             peek_target: None,
             peek_depth: 0,
+            peek_cache: None,
         }
     }
 
@@ -167,7 +176,19 @@ impl<H: Host> App<H> {
         // the host is never called mid-draw).
         let peek_json = match (&self.peek_target, self.peek_depth) {
             (Some(subject), depth) if depth > 0 => {
-                Some(self.recording().subject_view_json(subject))
+                let cached = self
+                    .peek_cache
+                    .as_ref()
+                    .filter(|(cached_subject, _)| cached_subject == subject)
+                    .map(|(_, json)| json.clone());
+                Some(match cached {
+                    Some(json) => json,
+                    None => {
+                        let json = self.recording().subject_view_json(subject);
+                        self.peek_cache = Some((subject.clone(), json.clone()));
+                        json
+                    }
+                })
             }
             _ => None,
         };
@@ -190,7 +211,11 @@ impl<H: Host> App<H> {
                 palette.render(frame, area);
             }
             if let Some(json) = &peek_json {
-                render_peek(frame, peek_overlay_area(area), json, peek_depth);
+                let overlay = peek_overlay_area(area);
+                // Clear first: widgets only write where they have content,
+                // so the view underneath would bleed through unwritten cells.
+                frame.render_widget(ratatui::widgets::Clear, overlay);
+                render_peek(frame, overlay, json, peek_depth);
             }
             let _ = title; // chrome title is owned by each view's block (M1)
         })?;
@@ -214,8 +239,12 @@ impl<H: Host> App<H> {
         // Global bindings (Task 19): palette, peek, view-switch scaffold.
         match code {
             KeyCode::Char('/') => {
-                self.ensure_known();
+                // One seam crossing refreshes BOTH consumers: the palette
+                // and the redlink-styling cache (which would otherwise stay
+                // frozen at first campaign entry while ticks bake pages).
                 let raw = self.recording().known_subjects_json();
+                let subjects: Vec<String> = serde_json::from_str(&raw).unwrap_or_default();
+                self.known = Some(subjects.into_iter().collect());
                 self.palette = Some(PaletteView::open(&raw));
                 return false;
             }
@@ -243,6 +272,13 @@ impl<H: Host> App<H> {
             Some(View::Watchlist(watchlist)) => watchlist.handle_key(code),
             None => None,
         };
+        // Keyboard peek is first-class (S7 canon): the wiki link cursor
+        // feeds the peek target exactly like mouse hover does.
+        if let Some(View::Wiki(wiki)) = self.views.last() {
+            if let Some(target) = wiki.focused_target() {
+                self.peek_target = Some(target.to_string());
+            }
+        }
         match ev {
             Some(ev) => self.route(ev),
             None => false,
@@ -293,9 +329,36 @@ impl<H: Host> App<H> {
     fn route(&mut self, ev: AppEvent) -> bool {
         match ev {
             AppEvent::LoadCampaign(campaign_id) => {
+                // Bind the session Python-side FIRST (the composition-root
+                // verb the M1 verify panel found missing), THEN read pages.
+                let ack = self.recording().load_campaign(&campaign_id);
+                let ok = serde_json::from_str::<serde_json::Value>(&ack)
+                    .ok()
+                    .and_then(|v| v.get("ok").and_then(serde_json::Value::as_bool))
+                    .unwrap_or(false);
+                self.peek_target = None;
+                if !ok {
+                    // Loud failure page — an error is never an empty world
+                    // (Constitution III.11); the ack carries the real error.
+                    let error = serde_json::from_str::<serde_json::Value>(&ack)
+                        .ok()
+                        .and_then(|v| {
+                            v.get("error")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::to_string)
+                        })
+                        .unwrap_or_else(|| ack.clone());
+                    let markdown =
+                        format!("# Campaign load failed\n\nCampaign `{campaign_id}`:\n\n{error}");
+                    self.push_failure_page("load-failure", &markdown);
+                    return false;
+                }
+                // Known subjects only exist once a session is bound —
+                // (re)fetch AFTER the bind, never before.
+                self.known = None;
+                self.ensure_known();
                 // Textual parity: the first page after campaign selection is
                 // the briefing subject (honest absence when unbaked).
-                self.ensure_known();
                 let subject = format!("briefing/{campaign_id}");
                 self.open_in_wiki(&BabylonTarget::Entity(subject));
                 false
@@ -304,6 +367,7 @@ impl<H: Host> App<H> {
             // (plan Task 25 wires writes); until then the intent is a no-op.
             AppEvent::NewCampaign => false,
             AppEvent::OpenSubject(subject) => {
+                self.peek_target = None;
                 self.ensure_known();
                 let target = if subject.starts_with("babylon://") {
                     parse_babylon_uri(&subject).unwrap_or(BabylonTarget::Redlink(subject))
@@ -314,6 +378,7 @@ impl<H: Host> App<H> {
                 false
             }
             AppEvent::Back => {
+                self.peek_target = None;
                 if self.views.len() > 1 {
                     self.views.pop();
                     false
@@ -325,8 +390,29 @@ impl<H: Host> App<H> {
         }
     }
 
-    /// Open `target` in the top wiki view, pushing one if none is on top.
+    /// Push (or reuse) a wiki view showing the loud campaign-load-failure
+    /// page — an error is never rendered as an empty world.
+    fn push_failure_page(&mut self, campaign_id: &str, error: &str) {
+        let markdown = format!("# Campaign load failed\n\nCampaign `{campaign_id}`:\n\n{error}");
+        if let Some(View::Wiki(wiki)) = self.views.last_mut() {
+            wiki.open_page("load-failure", markdown);
+            return;
+        }
+        let mut wiki = WikiView::new();
+        wiki.open_page("load-failure", markdown);
+        self.views.push(View::Wiki(wiki));
+    }
+
+    /// Open `target` in the topmost wiki view, unwinding any views stacked
+    /// above it first (Enter-from-watchlist must reuse the wiki and its
+    /// jumplist, never grow the stack without bound); pushes a fresh wiki
+    /// only when none exists on the stack at all.
     fn open_in_wiki(&mut self, target: &BabylonTarget) {
+        if self.views.iter().any(|v| matches!(v, View::Wiki(_))) {
+            while !matches!(self.views.last(), Some(View::Wiki(_))) {
+                self.views.pop();
+            }
+        }
         let recording = RecordingHost {
             inner: &self.host,
             calls: &self.calls,
@@ -410,43 +496,53 @@ pub fn key_event_from_name(name: &str) -> Option<(KeyCode, KeyModifiers)> {
     Some((code, KeyModifiers::NONE))
 }
 
+/// RAII terminal session: raw mode + alternate screen + mouse capture on
+/// construction, restored on Drop — INCLUDING the unwind path (a panicking
+/// host callback must never leave the user's terminal raw; the restore
+/// runs before the panic re-crosses the FFI as a Python exception).
+struct TerminalSession;
+
+impl TerminalSession {
+    fn enter() -> std::io::Result<Self> {
+        enable_raw_mode()?;
+        execute!(std::io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalSession {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(std::io::stdout(), LeaveAlternateScreen, DisableMouseCapture);
+    }
+}
+
 /// Run the interactive client: crossterm init (alternate screen + mouse
-/// capture) → render/input loop → restore. Returns the recorded host-call
-/// names.
+/// capture) → render/input loop → restore (via the RAII session guard's Drop,
+/// on success, error, AND panic paths alike). Returns the recorded
+/// host-call names.
 ///
 /// Always uses the `ratatui::crossterm` re-export, never a direct crossterm
 /// dependency (version-skew constraint from the plan).
 pub fn run_interactive<H: Host>(mut app: App<H>) -> std::io::Result<Vec<String>> {
-    enable_raw_mode()?;
-    let mut stdout = std::io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend: CrosstermBackend<Stdout> = CrosstermBackend::new(stdout);
+    let _session = TerminalSession::enter()?;
+    let backend: CrosstermBackend<Stdout> = CrosstermBackend::new(std::io::stdout());
     let mut terminal = Terminal::new(backend)?;
-    let mut run = || -> std::io::Result<()> {
-        loop {
-            app.render_frame(&mut terminal)?;
-            match event::read()? {
-                Event::Key(key) => {
-                    if app.handle_key(key.code, key.modifiers) {
-                        return Ok(());
-                    }
+    loop {
+        app.render_frame(&mut terminal)?;
+        match event::read()? {
+            Event::Key(key) => {
+                if app.handle_key(key.code, key.modifiers) {
+                    break;
                 }
-                Event::Mouse(mouse) => {
-                    if app.handle_mouse(mouse) {
-                        return Ok(());
-                    }
-                }
-                _ => {} // resize redraws on the next loop pass
             }
+            Event::Mouse(mouse) => {
+                if app.handle_mouse(mouse) {
+                    break;
+                }
+            }
+            _ => {} // resize redraws on the next loop pass
         }
-    };
-    let result = run();
-    disable_raw_mode()?;
-    execute!(std::io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
-    result.map(|()| app.host_calls())
+    }
+    Ok(app.host_calls())
 }
-
-/// Reserved: keeps `Frame` in the module's public-signature vocabulary for
-/// view-render plumbing docs.
-#[allow(dead_code)]
-fn _frame_vocabulary(_frame: &mut Frame<'_>) {}

--- a/rust/crates/babylon-tui/src/app.rs
+++ b/rust/crates/babylon-tui/src/app.rs
@@ -1,46 +1,128 @@
-//! The client application shell: M0 renders the lobby hello-frame.
+//! The client application shell (plan Task 19): view stack over the lobby
+//! root, global key/mouse routing, palette + peek overlays, and headless
+//! scripted-input replay.
+//!
+//! Views never mutate app state: their handlers return `AppEvent`s and
+//! this shell routes them.
+//! Every host read crosses the seam through the recording wrapper, so
+//! headless transcripts can assert the exact call order (the FFI contract's
+//! `host_calls`).
 
 use std::cell::RefCell;
+use std::collections::BTreeSet;
 use std::io::Stdout;
 
 use ratatui::backend::{Backend, CrosstermBackend};
-use ratatui::crossterm::event::{self, Event, KeyCode};
+use ratatui::crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyModifiers, MouseButton,
+    MouseEvent, MouseEventKind,
+};
 use ratatui::crossterm::execute;
 use ratatui::crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
-use ratatui::widgets::{Block, List, Paragraph};
+use ratatui::layout::Rect;
+use ratatui::Frame;
 use ratatui::Terminal;
-use serde::Deserialize;
 
-use crate::config::AppConfig;
+use crate::config::{AppConfig, ScriptStep};
 use crate::host::Host;
+use crate::layout_registry::LayoutRegistry;
+use crate::router::{parse_babylon_uri, BabylonTarget};
+use crate::views::lobby::LobbyView;
+use crate::views::msg::AppEvent;
+use crate::views::palette::PaletteView;
+use crate::views::peek::render_peek;
+use crate::views::watchlist::WatchlistView;
+use crate::views::wiki::WikiView;
 
-/// One lobby catalog row as served by `Host::lobby_catalog_json` (design §4).
-#[derive(Debug, Deserialize)]
-struct LobbyRow {
-    campaign_id: String,
-    name: String,
-    tick: u64,
+/// One member of the view stack (the lobby is always the root).
+enum View {
+    /// The campaign catalog (root).
+    Lobby(LobbyView),
+    /// The read-only Archive dossier.
+    Wiki(WikiView),
+    /// The watchlist rail as a full view (M1 read-only).
+    Watchlist(WatchlistView),
 }
 
-/// The client application: config + host seam, renders frames.
-///
-/// Every host read is recorded by method name so headless transcripts can
-/// assert the seam was exercised (the FFI contract's `host_calls`).
+/// A [`Host`] wrapper recording every call by method name.
+struct RecordingHost<'a, H: Host> {
+    inner: &'a H,
+    calls: &'a RefCell<Vec<String>>,
+}
+
+impl<H: Host> RecordingHost<'_, H> {
+    fn record(&self, name: &str) {
+        self.calls.borrow_mut().push(name.to_string());
+    }
+}
+
+impl<H: Host> Host for RecordingHost<'_, H> {
+    fn lobby_catalog_json(&self) -> String {
+        self.record("lobby_catalog_json");
+        self.inner.lobby_catalog_json()
+    }
+
+    fn read_page_json(&self, subject: &str) -> String {
+        self.record("read_page_json");
+        self.inner.read_page_json(subject)
+    }
+
+    fn known_subjects_json(&self) -> String {
+        self.record("known_subjects_json");
+        self.inner.known_subjects_json()
+    }
+
+    fn backlinks_json(&self, subject: &str) -> String {
+        self.record("backlinks_json");
+        self.inner.backlinks_json(subject)
+    }
+
+    fn subject_view_json(&self, subject: &str) -> String {
+        self.record("subject_view_json");
+        self.inner.subject_view_json(subject)
+    }
+
+    fn watchlist_json(&self) -> String {
+        self.record("watchlist_json");
+        self.inner.watchlist_json()
+    }
+}
+
+/// The client application: config + host seam + the M1 view stack.
 pub struct App<H: Host> {
     cfg: AppConfig,
     host: H,
     calls: RefCell<Vec<String>>,
+    views: Vec<View>,
+    /// The command palette overlay; `Some` while open (keys route to it
+    /// first, mirroring the Textual client's modal palette).
+    palette: Option<PaletteView>,
+    /// Per-frame widget→rect→entity map for mouse hit-testing.
+    registry: LayoutRegistry,
+    /// Known page subjects, fetched once on first Archive entry.
+    known: Option<BTreeSet<String>>,
+    /// The entity under the mouse cursor (hover), if any.
+    peek_target: Option<String>,
+    /// Peek overlay depth, 0 = off (K cycles 0→1→2→3→0).
+    peek_depth: u8,
 }
 
 impl<H: Host> App<H> {
-    /// Build the app over a parsed config and a host implementation.
+    /// Build the app over a parsed config and a host implementation; the
+    /// lobby view is the root of the stack from the first frame.
     pub fn new(cfg: AppConfig, host: H) -> Self {
         Self {
             cfg,
             host,
             calls: RefCell::new(Vec::new()),
+            views: Vec::new(),
+            palette: None,
+            registry: LayoutRegistry::new(),
+            known: None,
+            peek_target: None,
+            peek_depth: 0,
         }
     }
 
@@ -49,59 +131,322 @@ impl<H: Host> App<H> {
         self.calls.borrow().clone()
     }
 
-    /// Render one frame into `terminal` (M0: the lobby hello-frame).
+    fn recording(&self) -> RecordingHost<'_, H> {
+        RecordingHost {
+            inner: &self.host,
+            calls: &self.calls,
+        }
+    }
+
+    /// Lazily fetch + cache the known-subjects set (first Archive entry).
+    fn ensure_known(&mut self) {
+        if self.known.is_none() {
+            let raw = self.recording().known_subjects_json();
+            let subjects: Vec<String> = serde_json::from_str(&raw).unwrap_or_default();
+            self.known = Some(subjects.into_iter().collect());
+        }
+    }
+
+    /// Lazily build the root lobby view on first render.
+    fn ensure_root(&mut self) {
+        if self.views.is_empty() {
+            let raw = self.recording().lobby_catalog_json();
+            self.views
+                .push(View::Lobby(LobbyView::from_catalog_json(&raw)));
+        }
+    }
+
+    /// Render one frame into `terminal`.
     ///
     /// ratatui 0.30 gives `Backend` an associated `Error` type, so this
     /// returns `Result<(), B::Error>` (the plan's `io::Result` was the
     /// 0.29-era shape of the same contract).
-    pub fn render_frame<B: Backend>(&self, terminal: &mut Terminal<B>) -> Result<(), B::Error> {
-        self.calls.borrow_mut().push("lobby_catalog_json".into());
-        let raw = self.host.lobby_catalog_json();
-        let rows: Vec<LobbyRow> = serde_json::from_str(&raw).unwrap_or_default();
-        let title = format!("The Archive — {}", self.cfg.campaign_name);
-        terminal.draw(|frame| {
-            let block = Block::bordered().title(title.as_str());
-            if rows.is_empty() {
-                // Honest absence (III.11): an empty catalog is a loud state,
-                // never a fabricated placeholder row.
-                let empty = Paragraph::new("No campaigns in the catalog.").block(block);
-                frame.render_widget(empty, frame.area());
-            } else {
-                let items: Vec<String> = rows
-                    .iter()
-                    .map(|r| format!("{}  [{}] tick {}", r.name, r.campaign_id, r.tick))
-                    .collect();
-                let list = List::new(items).block(block);
-                frame.render_widget(list, frame.area());
+    pub fn render_frame<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> Result<(), B::Error> {
+        self.ensure_root();
+        // Pre-fetch overlay data outside the draw closure (single writer:
+        // the host is never called mid-draw).
+        let peek_json = match (&self.peek_target, self.peek_depth) {
+            (Some(subject), depth) if depth > 0 => {
+                Some(self.recording().subject_view_json(subject))
             }
+            _ => None,
+        };
+        let title = format!("The Archive — {}", self.cfg.campaign_name);
+        let known = self.known.clone().unwrap_or_default();
+        let views = &mut self.views;
+        let registry = &mut self.registry;
+        let palette = &self.palette;
+        let peek_depth = self.peek_depth;
+        terminal.draw(|frame| {
+            registry.clear();
+            let area = frame.area();
+            match views.last_mut() {
+                Some(View::Lobby(lobby)) => lobby.render(frame, area),
+                Some(View::Wiki(wiki)) => wiki.render(frame, area, registry, &known),
+                Some(View::Watchlist(watchlist)) => watchlist.render(frame, area),
+                None => unreachable!("ensure_root always seeds the lobby"),
+            }
+            if let Some(palette) = palette {
+                palette.render(frame, area);
+            }
+            if let Some(json) = &peek_json {
+                render_peek(frame, peek_overlay_area(area), json, peek_depth);
+            }
+            let _ = title; // chrome title is owned by each view's block (M1)
         })?;
         Ok(())
     }
+
+    /// Handle one key event. Returns `true` when the app should quit.
+    pub fn handle_key(&mut self, code: KeyCode, modifiers: KeyModifiers) -> bool {
+        // Palette is modal: it sees every key while open.
+        if let Some(palette) = &mut self.palette {
+            if let Some(ev) = palette.handle_key(code) {
+                if matches!(ev, AppEvent::Back) {
+                    self.palette = None;
+                    return false;
+                }
+                self.palette = None;
+                return self.route(ev);
+            }
+            return false;
+        }
+        // Global bindings (Task 19): palette, peek, view-switch scaffold.
+        match code {
+            KeyCode::Char('/') => {
+                self.ensure_known();
+                let raw = self.recording().known_subjects_json();
+                self.palette = Some(PaletteView::open(&raw));
+                return false;
+            }
+            KeyCode::Char('K') => {
+                self.peek_depth = (self.peek_depth + 1) % 4;
+                return false;
+            }
+            KeyCode::Tab => {
+                self.toggle_watchlist();
+                return false;
+            }
+            // '1'–'5' view switch scaffold: only the wiki ('3', mirroring
+            // the Textual shell's dashboard/map/wiki/topology order) is
+            // routable in M1; the rest are reserved no-ops until their
+            // views exist (M4+).
+            KeyCode::Char('3') if self.in_campaign() => {
+                self.focus_wiki();
+                return false;
+            }
+            _ => {}
+        }
+        let ev = match self.views.last_mut() {
+            Some(View::Lobby(lobby)) => lobby.handle_key(code),
+            Some(View::Wiki(wiki)) => wiki.handle_key(code, modifiers),
+            Some(View::Watchlist(watchlist)) => watchlist.handle_key(code),
+            None => None,
+        };
+        match ev {
+            Some(ev) => self.route(ev),
+            None => false,
+        }
+    }
+
+    /// Handle one mouse event: hover feeds the peek target, left-click
+    /// navigates the hit entity. Never quits.
+    pub fn handle_mouse(&mut self, ev: MouseEvent) -> bool {
+        match ev.kind {
+            MouseEventKind::Moved => {
+                self.peek_target = self
+                    .registry
+                    .hit(ev.column, ev.row)
+                    .and_then(|(_, _, entity)| entity.clone());
+            }
+            MouseEventKind::Down(MouseButton::Left) => {
+                let target = self
+                    .registry
+                    .hit(ev.column, ev.row)
+                    .and_then(|(_, _, entity)| entity.clone());
+                if let Some(subject) = target {
+                    return self.route(AppEvent::OpenSubject(subject));
+                }
+            }
+            _ => {}
+        }
+        false
+    }
+
+    /// Apply one headless script step. Returns `true` on quit.
+    pub fn apply_step(&mut self, step: &ScriptStep) -> bool {
+        match step {
+            ScriptStep::Key { key } => match key_event_from_name(key) {
+                Some((code, modifiers)) => self.handle_key(code, modifiers),
+                None => false, // unknown key names are transcript-visible no-ops
+            },
+            ScriptStep::Mouse { mouse: (col, row) } => self.handle_mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: *col,
+                row: *row,
+                modifiers: KeyModifiers::NONE,
+            }),
+        }
+    }
+
+    /// Route a view-emitted [`AppEvent`]. Returns `true` on quit.
+    fn route(&mut self, ev: AppEvent) -> bool {
+        match ev {
+            AppEvent::LoadCampaign(campaign_id) => {
+                // Textual parity: the first page after campaign selection is
+                // the briefing subject (honest absence when unbaked).
+                self.ensure_known();
+                let subject = format!("briefing/{campaign_id}");
+                self.open_in_wiki(&BabylonTarget::Entity(subject));
+                false
+            }
+            // M1 is read-only: the new-campaign write path lands in M2
+            // (plan Task 25 wires writes); until then the intent is a no-op.
+            AppEvent::NewCampaign => false,
+            AppEvent::OpenSubject(subject) => {
+                self.ensure_known();
+                let target = if subject.starts_with("babylon://") {
+                    parse_babylon_uri(&subject).unwrap_or(BabylonTarget::Redlink(subject))
+                } else {
+                    BabylonTarget::Entity(subject)
+                };
+                self.open_in_wiki(&target);
+                false
+            }
+            AppEvent::Back => {
+                if self.views.len() > 1 {
+                    self.views.pop();
+                    false
+                } else {
+                    true // q at the lobby root quits, like M0
+                }
+            }
+            AppEvent::Quit => true,
+        }
+    }
+
+    /// Open `target` in the top wiki view, pushing one if none is on top.
+    fn open_in_wiki(&mut self, target: &BabylonTarget) {
+        let recording = RecordingHost {
+            inner: &self.host,
+            calls: &self.calls,
+        };
+        if let Some(View::Wiki(wiki)) = self.views.last_mut() {
+            wiki.open(target, &recording);
+            return;
+        }
+        let mut wiki = WikiView::new();
+        wiki.open(target, &recording);
+        self.views.push(View::Wiki(wiki));
+    }
+
+    /// Whether a campaign view (wiki/watchlist) is anywhere on the stack.
+    fn in_campaign(&self) -> bool {
+        self.views
+            .iter()
+            .any(|v| matches!(v, View::Wiki(_) | View::Watchlist(_)))
+    }
+
+    /// Tab: toggle between the wiki and the watchlist view (campaign only).
+    fn toggle_watchlist(&mut self) {
+        match self.views.last() {
+            Some(View::Wiki(_)) => {
+                let raw = self.recording().watchlist_json();
+                self.views.push(View::Watchlist(WatchlistView::open(&raw)));
+            }
+            Some(View::Watchlist(_)) => {
+                self.views.pop();
+            }
+            _ => {}
+        }
+    }
+
+    /// Pop back to the topmost wiki view if one exists below the top.
+    fn focus_wiki(&mut self) {
+        while matches!(self.views.last(), Some(View::Watchlist(_))) {
+            self.views.pop();
+        }
+    }
 }
 
-/// Run the interactive M0 client: crossterm init → hello-frame → quit on
-/// `q`/`Esc` → restore. Returns the recorded host-call names.
+/// The centered rect the peek overlay renders into (bottom-right quadrant,
+/// mirroring the Textual peek panel's placement).
+fn peek_overlay_area(area: Rect) -> Rect {
+    let w = area.width / 2;
+    let h = area.height / 2;
+    Rect::new(area.x + area.width - w, area.y + area.height - h, w, h)
+}
+
+/// Map a script key name to a crossterm key event (plan Task 19 headless
+/// replay). `None` for unknown names — a loud transcript no-op, never a
+/// guessed key.
+pub fn key_event_from_name(name: &str) -> Option<(KeyCode, KeyModifiers)> {
+    if let Some(rest) = name.strip_prefix("ctrl-") {
+        let mut chars = rest.chars();
+        let (Some(c), None) = (chars.next(), chars.next()) else {
+            return None;
+        };
+        return Some((KeyCode::Char(c), KeyModifiers::CONTROL));
+    }
+    let code = match name {
+        "enter" => KeyCode::Enter,
+        "esc" => KeyCode::Esc,
+        "up" => KeyCode::Up,
+        "down" => KeyCode::Down,
+        "left" => KeyCode::Left,
+        "right" => KeyCode::Right,
+        "tab" => KeyCode::Tab,
+        "backspace" => KeyCode::Backspace,
+        "pageup" => KeyCode::PageUp,
+        "pagedown" => KeyCode::PageDown,
+        _ => {
+            let mut chars = name.chars();
+            let (Some(c), None) = (chars.next(), chars.next()) else {
+                return None;
+            };
+            KeyCode::Char(c)
+        }
+    };
+    Some((code, KeyModifiers::NONE))
+}
+
+/// Run the interactive client: crossterm init (alternate screen + mouse
+/// capture) → render/input loop → restore. Returns the recorded host-call
+/// names.
 ///
 /// Always uses the `ratatui::crossterm` re-export, never a direct crossterm
 /// dependency (version-skew constraint from the plan).
-pub fn run_interactive<H: Host>(app: App<H>) -> std::io::Result<Vec<String>> {
+pub fn run_interactive<H: Host>(mut app: App<H>) -> std::io::Result<Vec<String>> {
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
     let backend: CrosstermBackend<Stdout> = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
     let mut run = || -> std::io::Result<()> {
-        app.render_frame(&mut terminal)?;
         loop {
-            if let Event::Key(key) = event::read()? {
-                if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) {
-                    return Ok(());
+            app.render_frame(&mut terminal)?;
+            match event::read()? {
+                Event::Key(key) => {
+                    if app.handle_key(key.code, key.modifiers) {
+                        return Ok(());
+                    }
                 }
+                Event::Mouse(mouse) => {
+                    if app.handle_mouse(mouse) {
+                        return Ok(());
+                    }
+                }
+                _ => {} // resize redraws on the next loop pass
             }
         }
     };
     let result = run();
     disable_raw_mode()?;
-    execute!(std::io::stdout(), LeaveAlternateScreen)?;
+    execute!(std::io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
     result.map(|()| app.host_calls())
 }
+
+/// Reserved: keeps `Frame` in the module's public-signature vocabulary for
+/// view-render plumbing docs.
+#[allow(dead_code)]
+fn _frame_vocabulary(_frame: &mut Frame<'_>) {}

--- a/rust/crates/babylon-tui/src/config.rs
+++ b/rust/crates/babylon-tui/src/config.rs
@@ -17,6 +17,26 @@ pub enum RenderTier {
 #[error("invalid client config: {0}")]
 pub struct ConfigError(#[from] serde_json::Error);
 
+/// One scripted input step for headless replay (plan Task 19) — the BDD
+/// harness foundation: integration tests drive full flows without a
+/// terminal.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum ScriptStep {
+    /// A key press by name: single characters (`"q"`, `"/"`, `"["`) or the
+    /// named keys `enter`, `esc`, `up`, `down`, `left`, `right`, `tab`,
+    /// `backspace`, `pageup`, `pagedown`, plus `ctrl-<char>` chords.
+    Key {
+        /// The key name.
+        key: String,
+    },
+    /// A left-click at `[column, row]` cell coordinates.
+    Mouse {
+        /// `[column, row]` of the click.
+        mouse: (u16, u16),
+    },
+}
+
 /// Frozen per-run client configuration, parsed once at startup.
 #[derive(Debug, Clone, Deserialize)]
 pub struct AppConfig {
@@ -30,9 +50,14 @@ pub struct AppConfig {
     pub tutorial_enabled: bool,
     /// Whether narrator beats render.
     pub narrator_enabled: bool,
-    /// Headless mode: render one frame to a test backend and return (CI path).
+    /// Headless mode: render to a test backend and return a transcript
+    /// (CI path); interactive terminals never see it.
     #[serde(default)]
     pub headless: bool,
+    /// Headless-only scripted inputs, applied in order after the initial
+    /// frame; each step appends the resulting frame to the transcript.
+    #[serde(default)]
+    pub script: Vec<ScriptStep>,
 }
 
 impl AppConfig {
@@ -56,6 +81,22 @@ mod tests {
         assert_eq!(cfg.campaign_name, "Wayne");
         assert_eq!(cfg.render_tier, RenderTier::Glyph);
         assert!(!cfg.headless); // default false
+    }
+
+    #[test]
+    fn parses_script_steps() {
+        let cfg = AppConfig::from_json(
+            r#"{"campaign_id":"c1","campaign_name":"W","render_tier":"glyph",
+                "tutorial_enabled":false,"narrator_enabled":false,"headless":true,
+                "script":[{"key":"down"},{"key":"enter"},{"mouse":[4,2]},{"key":"q"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.script.len(), 4);
+        assert!(matches!(&cfg.script[0], ScriptStep::Key { key } if key == "down"));
+        assert!(matches!(
+            &cfg.script[2],
+            ScriptStep::Mouse { mouse: (4, 2) }
+        ));
     }
 
     #[test]

--- a/rust/crates/babylon-tui/src/host.rs
+++ b/rust/crates/babylon-tui/src/host.rs
@@ -11,6 +11,15 @@ pub trait Host {
     /// The lobby campaign catalog as a JSON array string.
     fn lobby_catalog_json(&self) -> String;
 
+    /// Bind the chosen campaign's session on the Python side (the M1
+    /// composition root's load verb — plan Task 7's `bind_session`).
+    /// Returns `{"ok": true, "campaign_id": "..."}` on success; the
+    /// default is a LOUD not-implemented failure so a host that forgot to
+    /// wire loading can never masquerade as an empty world.
+    fn load_campaign(&self, _campaign_id: &str) -> String {
+        r#"{"ok": false, "error": "load_campaign not implemented by this host"}"#.to_string()
+    }
+
     /// The rendered Archive page for `subject` as JSON: a Markdown string,
     /// or `null` when the vault has no page for it (plan Task 17).
     fn read_page_json(&self, _subject: &str) -> String {

--- a/rust/crates/babylon-tui/src/host.rs
+++ b/rust/crates/babylon-tui/src/host.rs
@@ -1,7 +1,40 @@
 //! The Python↔Rust seam: every read crosses as a JSON string (design §4).
 
-/// Host surface the Python side implements (M0: lobby only; grows per milestone).
+/// Host surface the Python side implements (M1: lobby + read-only Archive).
+///
+/// Every method returns a JSON string; absence is JSON `null` or `[]`, never
+/// a fabricated value (Constitution III.11 — honest absence). The M1 methods
+/// carry default implementations returning the honest-absence encoding so
+/// milestone-earlier fakes keep compiling; the production Python host
+/// overrides every method.
 pub trait Host {
     /// The lobby campaign catalog as a JSON array string.
     fn lobby_catalog_json(&self) -> String;
+
+    /// The rendered Archive page for `subject` as JSON: a Markdown string,
+    /// or `null` when the vault has no page for it (plan Task 17).
+    fn read_page_json(&self, _subject: &str) -> String {
+        "null".to_string()
+    }
+
+    /// Every known page subject, sorted, as a JSON array of strings.
+    fn known_subjects_json(&self) -> String {
+        "[]".to_string()
+    }
+
+    /// Subjects whose pages link to `subject`, as a JSON array of strings.
+    fn backlinks_json(&self, _subject: &str) -> String {
+        "[]".to_string()
+    }
+
+    /// The frozen view-model for `subject` as a JSON object, or `null`
+    /// (feeds the peek overlay's depth rendering).
+    fn subject_view_json(&self, _subject: &str) -> String {
+        "null".to_string()
+    }
+
+    /// Watchlist rows as a JSON array (M1 reads; pin writes land in M2).
+    fn watchlist_json(&self) -> String {
+        "[]".to_string()
+    }
 }

--- a/rust/crates/babylon-tui/src/layout_registry.rs
+++ b/rust/crates/babylon-tui/src/layout_registry.rs
@@ -1,0 +1,110 @@
+//! Per-frame widget-id → screen-area → entity registry (the hover/peek
+//! foundation, plan Task 14).
+//!
+//! Every view render pass registers the screen [`Rect`] of anything a mouse
+//! move or click should resolve against (a wikilink span, a stat-plate row,
+//! a map hex). [`LayoutRegistry::hit`] then answers "what's under this
+//! point" for `App::handle_mouse` to route into a hover-peek or a click
+//! navigation. The registry is rebuilt every frame — [`LayoutRegistry::clear`]
+//! is called once at the top of each render pass, then every widget that
+//! wants to be hit-testable calls [`LayoutRegistry::register`] as it draws.
+//! Mouse is a convenience path only (design R1: ratatui#1227 leaves OSC 8
+//! hyperlinks unavailable, so hover/click both go through this registry
+//! rather than terminal-native links); keyboard navigation never depends on
+//! it.
+//!
+//! **Innermost-wins hit testing.** Widgets nest (a wikilink span sits inside
+//! a wiki-page paragraph, which sits inside the page viewport); a hit test
+//! must resolve to the smallest registered area containing the point, not
+//! whichever was registered first or drawn outermost. Ties (two rects of
+//! identical area both containing the point — e.g. two links stacked at
+//! the same coordinates across a jumplist transition) resolve to whichever
+//! was **registered last**, so a widget re-registering itself after an
+//! earlier stale entry always wins.
+
+use ratatui::layout::Rect;
+
+/// Opaque identifier for a registered widget/span.
+///
+/// Callers mint their own ids (a wikilink index, a stat-row index, a hex
+/// coordinate encoded as an integer); the registry never interprets it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WidgetId(pub u32);
+
+/// One frame's worth of hit-testable screen areas.
+///
+/// Cleared and rebuilt every render pass (see the module docs);
+/// [`LayoutRegistry::hit`] never mutates it, so a hover/click frame can
+/// query it as many times as it needs without side effects.
+#[derive(Debug, Default)]
+pub struct LayoutRegistry {
+    rects: Vec<(WidgetId, Rect, Option<String>)>,
+}
+
+/// Returns `true` when `(col, row)` falls inside `area`.
+///
+/// A zero-width or zero-height `area` contains no point (Rect's own
+/// invariant: `x + width` and `y + height` are exclusive upper bounds).
+fn contains(area: Rect, col: u16, row: u16) -> bool {
+    let within_columns = col >= area.x && col < area.x.saturating_add(area.width);
+    let within_rows = row >= area.y && row < area.y.saturating_add(area.height);
+    within_columns && within_rows
+}
+
+/// `area`'s cell count as `u32` (max `u16::MAX * u16::MAX` fits `u32`
+/// without overflow), used only to compare "smaller area" for the
+/// innermost-wins rule — never printed or serialized.
+fn cell_count(area: Rect) -> u32 {
+    u32::from(area.width) * u32::from(area.height)
+}
+
+impl LayoutRegistry {
+    /// A fresh, empty registry.
+    pub fn new() -> Self {
+        Self { rects: Vec::new() }
+    }
+
+    /// Drop every registered rect — call once at the top of each frame's
+    /// render pass, before any widget registers itself for this frame.
+    pub fn clear(&mut self) {
+        self.rects.clear();
+    }
+
+    /// Register `area` as hit-testable, tagged with `id` and an optional
+    /// navigation target (`entity`, e.g. a `babylon://` subject id).
+    ///
+    /// Registration order matters only for tie-breaking (see the module
+    /// docs' "ties resolve to last registered" rule) — otherwise later
+    /// calls neither shadow nor depend on earlier ones.
+    pub fn register(&mut self, id: WidgetId, area: Rect, entity: Option<String>) {
+        self.rects.push((id, area, entity));
+    }
+
+    /// Resolve the point `(col, row)` to the innermost registered rect that
+    /// contains it, or `None` if nothing was registered there.
+    ///
+    /// "Innermost" means smallest cell count; a tie between two equally
+    /// small containing rects goes to whichever was registered later (a
+    /// single linear scan with a `<=` comparison against the current best
+    /// gives exactly that — no separate tie-break pass is needed).
+    pub fn hit(&self, col: u16, row: u16) -> Option<&(WidgetId, Rect, Option<String>)> {
+        let mut best: Option<(usize, u32)> = None;
+        for (index, (_, area, _)) in self.rects.iter().enumerate() {
+            if !contains(*area, col, row) {
+                continue;
+            }
+            let size = cell_count(*area);
+            let is_better = match best {
+                None => true,
+                Some((_, best_size)) => size <= best_size,
+            };
+            if is_better {
+                best = Some((index, size));
+            }
+        }
+        best.map(|(index, _)| &self.rects[index])
+    }
+}
+
+// Contract tests (nested/tie/miss/clear) live in `tests/layout_registry.rs`
+// as an integration suite over this module's public API only.

--- a/rust/crates/babylon-tui/src/lib.rs
+++ b/rust/crates/babylon-tui/src/lib.rs
@@ -6,5 +6,9 @@
 pub mod app;
 pub mod config;
 pub mod host;
+pub mod layout_registry;
 #[cfg(feature = "raster")]
 pub mod raster_bridge;
+pub mod router;
+pub mod views;
+pub mod wiki_render;

--- a/rust/crates/babylon-tui/src/lib.rs
+++ b/rust/crates/babylon-tui/src/lib.rs
@@ -10,5 +10,6 @@ pub mod layout_registry;
 #[cfg(feature = "raster")]
 pub mod raster_bridge;
 pub mod router;
+pub mod theme;
 pub mod views;
 pub mod wiki_render;

--- a/rust/crates/babylon-tui/src/router.rs
+++ b/rust/crates/babylon-tui/src/router.rs
@@ -1,0 +1,173 @@
+//! Parser for `babylon://` navigation URIs.
+//!
+//! Ports `babylon.tui.router` (Python) semantics exactly. The wikilink render
+//! rule emits two href shapes:
+//!
+//! * `babylon://<target>` — a known entity, addressed bare (no kind segment).
+//! * `babylon://redlink/<target>` — an unresolved target.
+//!
+//! Other Archive UI (statblocks, the command palette, future explicit-kind
+//! links) may address entities with an explicit kind segment:
+//! `babylon://<kind>/<id>`. This module parses all three shapes into one
+//! [`BabylonTarget`]; anything else is a [`RouterError`] (Constitution
+//! III.11 — no silent best-effort parsing of a malformed URI).
+
+use thiserror::Error;
+
+/// The `babylon://` URI scheme.
+pub const SCHEME: &str = "babylon";
+
+/// The netloc value that marks an unresolved (redlink) target.
+pub const REDLINK_KIND: &str = "redlink";
+
+/// A parsed `babylon://` navigation target.
+///
+/// * [`BabylonTarget::Entity`] — a bare `babylon://<id>` href (no explicit
+///   kind segment; corresponds to the Python module's `kind="wikilink"`).
+/// * [`BabylonTarget::Kind`] — an explicit-kind `babylon://<kind>/<id>` href.
+/// * [`BabylonTarget::Redlink`] — an unresolved `babylon://redlink/<id>` href.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BabylonTarget {
+    /// A bare `babylon://<id>` href; the payload is the raw identifier
+    /// segment (the Python module's `entity_id` with `kind="wikilink"`).
+    Entity(String),
+    /// An explicit-kind `babylon://<kind>/<id>` href.
+    Kind {
+        /// The entity kind (e.g. `"county"`).
+        kind: String,
+        /// The raw identifier segment (may itself contain `/`).
+        id: String,
+    },
+    /// An unresolved `babylon://redlink/<id>` href; the payload is the raw
+    /// target (may itself contain `/`, e.g. `"org/uaw-9999"`).
+    Redlink(String),
+}
+
+/// Errors raised when parsing a malformed `babylon://` URI.
+///
+/// Mirrors the four failure modes of the Python module's
+/// `InvalidBabylonUri`, split into distinct variants for programmatic
+/// matching; the `Display` text preserves the Python messages' key phrases
+/// (`"not a babylon"`, `"missing host"`, `"malformed"`) so callers porting
+/// Python's `pytest.raises(..., match=...)` assertions have a direct analog.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum RouterError {
+    /// The URI scheme was not `babylon://` (includes the empty string, which
+    /// has no scheme at all).
+    #[error("not a babylon:// uri: {0:?}")]
+    NotBabylonScheme(String),
+    /// The URI had no host/kind segment (e.g. `babylon:///26163`).
+    #[error("missing host/kind segment: {0:?}")]
+    MissingHost(String),
+    /// The host/kind segment failed the kind character class.
+    #[error("malformed kind/id segment: {0:?}")]
+    MalformedKind(String),
+    /// The path segment failed the entity-id character class.
+    #[error("malformed entity id: {0:?}")]
+    MalformedEntityId(String),
+}
+
+/// A kind segment, or a bare (no-path) target: a single path token, no `/`.
+///
+/// Ports the Python module's `_KIND_RE = r"^[A-Za-z0-9][A-Za-z0-9._-]*$"`.
+fn is_valid_kind(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphanumeric() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
+}
+
+/// An entity id following an explicit kind: may itself be `/`-shaped (e.g.
+/// wikilink targets conventionally look like `county/26163`).
+///
+/// Ports the Python module's `_ENTITY_ID_RE = r"^[A-Za-z0-9][A-Za-z0-9._/-]*$"`.
+fn is_valid_entity_id(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphanumeric() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '/' || c == '-')
+}
+
+/// Splits a URI into `(scheme, netloc, path)`, mirroring the subset of
+/// Python's `urllib.parse.urlsplit` behavior this module depends on: a
+/// `scheme://netloc/path` shape, where `netloc` is everything up to the next
+/// `/`, `?`, or `#` (or end of string). Not a general URI parser — this is
+/// the same narrow slice of `urlsplit` semantics `router.py` itself relies on.
+fn split_uri(uri: &str) -> (String, String, String) {
+    if let Some(idx) = uri.find("://") {
+        let scheme = uri[..idx].to_string();
+        let rest = &uri[idx + 3..];
+        let end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+        let netloc = rest[..end].to_string();
+        let path = rest[end..].to_string();
+        (scheme, netloc, path)
+    } else if let Some(idx) = uri.find(':') {
+        let scheme = uri[..idx].to_string();
+        let path = uri[idx + 1..].to_string();
+        (scheme, String::new(), path)
+    } else {
+        (String::new(), String::new(), uri.to_string())
+    }
+}
+
+/// Parses a `babylon://` URI into a [`BabylonTarget`].
+///
+/// Accepted shapes:
+///
+/// * `babylon://<id>` — bare form; [`BabylonTarget::Entity`].
+/// * `babylon://redlink/<id>` — [`BabylonTarget::Redlink`].
+/// * `babylon://<kind>/<id>` — explicit kind; [`BabylonTarget::Kind`].
+///
+/// # Errors
+///
+/// Returns [`RouterError`] if the scheme is wrong, a required segment is
+/// missing, or a segment fails the entity-id character class.
+pub fn parse_babylon_uri(uri: &str) -> Result<BabylonTarget, RouterError> {
+    let (scheme, netloc, path_raw) = split_uri(uri);
+    if scheme != SCHEME {
+        return Err(RouterError::NotBabylonScheme(uri.to_string()));
+    }
+    let path = path_raw.trim_start_matches('/');
+
+    if netloc.is_empty() {
+        return Err(RouterError::MissingHost(uri.to_string()));
+    }
+    if !is_valid_kind(&netloc) {
+        return Err(RouterError::MalformedKind(uri.to_string()));
+    }
+
+    if path.is_empty() {
+        // Bare form: babylon://<id> — netloc IS the id, kind defaults.
+        return Ok(BabylonTarget::Entity(netloc));
+    }
+
+    if !is_valid_entity_id(path) {
+        return Err(RouterError::MalformedEntityId(uri.to_string()));
+    }
+
+    if netloc == REDLINK_KIND {
+        Ok(BabylonTarget::Redlink(path.to_string()))
+    } else {
+        Ok(BabylonTarget::Kind {
+            kind: netloc,
+            id: path.to_string(),
+        })
+    }
+}
+
+/// Renders a [`BabylonTarget`] back to its `babylon://` URI form.
+///
+/// Round-trips with [`parse_babylon_uri`]:
+/// `parse_babylon_uri(&format_babylon_uri(&t)) == Ok(t)` for any `t` produced
+/// by that function. Ports the Python module's `format_babylon_uri`.
+pub fn format_babylon_uri(target: &BabylonTarget) -> String {
+    match target {
+        BabylonTarget::Entity(id) => format!("{SCHEME}://{id}"),
+        BabylonTarget::Kind { kind, id } => format!("{SCHEME}://{kind}/{id}"),
+        BabylonTarget::Redlink(id) => format!("{SCHEME}://{REDLINK_KIND}/{id}"),
+    }
+}

--- a/rust/crates/babylon-tui/src/router.rs
+++ b/rust/crates/babylon-tui/src/router.rs
@@ -20,6 +20,13 @@ pub const SCHEME: &str = "babylon";
 /// The netloc value that marks an unresolved (redlink) target.
 pub const REDLINK_KIND: &str = "redlink";
 
+/// Kind sentinel assigned to bare `babylon://<id>` hrefs (no explicit kind
+/// segment) — ports the Python module's `BARE_KIND`. Python's
+/// `format_babylon_uri` emits the bare form THROUGH this sentinel
+/// (`babylon://wikilink/<id>`), so both spellings parse to
+/// [`BabylonTarget::Entity`] for cross-implementation round-trips.
+pub const BARE_KIND: &str = "wikilink";
+
 /// A parsed `babylon://` navigation target.
 ///
 /// * [`BabylonTarget::Entity`] — a bare `babylon://<id>` href (no explicit
@@ -151,6 +158,10 @@ pub fn parse_babylon_uri(uri: &str) -> Result<BabylonTarget, RouterError> {
 
     if netloc == REDLINK_KIND {
         Ok(BabylonTarget::Redlink(path.to_string()))
+    } else if netloc == BARE_KIND {
+        // babylon://wikilink/<id> — the sentinel-prefixed bare form Python's
+        // format_babylon_uri emits; same target as bare babylon://<id>.
+        Ok(BabylonTarget::Entity(path.to_string()))
     } else {
         Ok(BabylonTarget::Kind {
             kind: netloc,
@@ -166,7 +177,11 @@ pub fn parse_babylon_uri(uri: &str) -> Result<BabylonTarget, RouterError> {
 /// by that function. Ports the Python module's `format_babylon_uri`.
 pub fn format_babylon_uri(target: &BabylonTarget) -> String {
     match target {
-        BabylonTarget::Entity(id) => format!("{SCHEME}://{id}"),
+        // Python parity: the bare form formats THROUGH the BARE_KIND
+        // sentinel (`prefix = target.kind` where the bare kind IS
+        // "wikilink"), never as `babylon://<id>` — a bare id could
+        // otherwise collide with a kind segment on re-parse.
+        BabylonTarget::Entity(id) => format!("{SCHEME}://{BARE_KIND}/{id}"),
         BabylonTarget::Kind { kind, id } => format!("{SCHEME}://{kind}/{id}"),
         BabylonTarget::Redlink(id) => format!("{SCHEME}://{REDLINK_KIND}/{id}"),
     }

--- a/rust/crates/babylon-tui/src/theme.rs
+++ b/rust/crates/babylon-tui/src/theme.rs
@@ -1,0 +1,19 @@
+//! KSBC role colors for the Rust client (DESIGN_BIBLE §9b).
+//!
+//! The single source of truth is Python's
+//! `babylon/render/tiers.py::TRUECOLOR_PALETTE`; these constants mirror it
+//! for the FFI side, and the cross-language parity guard
+//! `tests/unit/render/test_rust_theme_parity.py` parses THIS file's
+//! `Color::Rgb(r, g, b)` literals against the Python palette — keep each
+//! constant on one line so the guard's regex stays trivial.
+
+use ratatui::style::Color;
+
+/// Accent crimson (`#dc143c`): absence markers, redlinks, plate borders.
+pub const CRIMSON: Color = Color::Rgb(220, 20, 60);
+/// Accent gold (`#ffd700`): titles, known wikilinks.
+pub const GOLD: Color = Color::Rgb(255, 215, 0);
+/// Body text (`#e8e8e8`).
+pub const BONE: Color = Color::Rgb(232, 232, 232);
+/// Secondary/dim labels (`#404040`).
+pub const DIM: Color = Color::Rgb(64, 64, 64);

--- a/rust/crates/babylon-tui/src/views/lobby.rs
+++ b/rust/crates/babylon-tui/src/views/lobby.rs
@@ -1,0 +1,129 @@
+//! The lobby view: the campaign load/new menu (M1 Task 16).
+//!
+//! Mirrors `babylon.tui.campaign_menu`'s `LobbyScreen` framing and display
+//! fields over the wire shape `Host::lobby_catalog_json` actually serves
+//! (`src/babylon/tui/host.py::RustClientHost.lobby_catalog_json`):
+//! `campaign_id`, `name`, `tick`, `status`, `defines_hash`, `engine_version`.
+//! An empty catalog renders the honest-absence body used by the M0
+//! hello-frame (Constitution III.11), never a fabricated row.
+
+use ratatui::crossterm::event::KeyCode;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Block, List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
+use serde::Deserialize;
+
+use crate::views::msg::AppEvent;
+
+/// The lobby's idle title, mirroring `LobbyScreen.compose`'s
+/// `Label("THE ARCHIVE — CAMPAIGNS")`.
+const LOBBY_TITLE: &str = "THE ARCHIVE — CAMPAIGNS";
+
+/// The honest-absence body for an empty catalog (mirrors the M0 hello-frame).
+const EMPTY_BODY: &str = "No campaigns in the catalog.";
+
+/// One lobby catalog row as served by `Host::lobby_catalog_json`.
+///
+/// Field shape pins to `RustClientHost.lobby_catalog_json`'s emitted keys —
+/// see `src/babylon/tui/host.py`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct LobbyRow {
+    /// The campaign's UUID, as a string (never parsed to a UUID type here —
+    /// it round-trips opaquely into `AppEvent::LoadCampaign`).
+    pub campaign_id: String,
+    /// The campaign's slug (`InMemoryCampaign.slug` / the store's `name`).
+    pub name: String,
+    /// Highest tick reached.
+    pub tick: u64,
+    /// Lifecycle status (`"ACTIVE"` / `"ABANDONED"`).
+    pub status: String,
+    /// Provenance stamp: the `GameDefines` hash active when the row was
+    /// written.
+    pub defines_hash: String,
+    /// Provenance stamp: the engine version active when the row was written.
+    pub engine_version: String,
+}
+
+/// The lobby's rows and current selection.
+///
+/// Views never mutate app state directly: [`Self::handle_key`] returns an
+/// [`AppEvent`] for the app shell to route.
+pub struct LobbyView {
+    /// The catalog rows, in the order the host served them.
+    pub rows: Vec<LobbyRow>,
+    /// The highlighted row index (saturates at `0` and `rows.len() - 1`).
+    pub selected: usize,
+}
+
+impl LobbyView {
+    /// Build a lobby view from `Host::lobby_catalog_json`'s raw JSON.
+    ///
+    /// Malformed or empty JSON never panics: it decodes to an empty catalog
+    /// (honest absence, III.11), matching `serde_json::from_str(..).unwrap_or_default()`
+    /// as used by the M0 hello-frame in `app.rs`.
+    #[must_use]
+    pub fn from_catalog_json(raw: &str) -> Self {
+        let rows: Vec<LobbyRow> = serde_json::from_str(raw).unwrap_or_default();
+        Self { rows, selected: 0 }
+    }
+
+    /// Handle one key press, returning the routed event (if any).
+    ///
+    /// `Up`/`k` and `Down`/`j` move the selection, saturating at both ends
+    /// (never wrapping, never panicking on an empty catalog). `Enter` loads
+    /// the highlighted row's campaign (`None` when the catalog is empty).
+    /// `n` mints a new campaign. `q`/`Esc` quits.
+    pub fn handle_key(&mut self, code: KeyCode) -> Option<AppEvent> {
+        match code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.selected = self.selected.saturating_sub(1);
+                None
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.rows.is_empty() && self.selected + 1 < self.rows.len() {
+                    self.selected += 1;
+                }
+                None
+            }
+            KeyCode::Enter => self
+                .rows
+                .get(self.selected)
+                .map(|row| AppEvent::LoadCampaign(row.campaign_id.clone())),
+            KeyCode::Char('n') => Some(AppEvent::NewCampaign),
+            KeyCode::Char('q') | KeyCode::Esc => Some(AppEvent::Quit),
+            _ => None,
+        }
+    }
+
+    /// Render the lobby into `area` of `frame`.
+    ///
+    /// Populated: a bordered, titled list — one line per row showing name,
+    /// tick, status, engine version and defines hash (mirrors
+    /// `campaign_menu.py`'s display fields), with the selected row
+    /// highlighted. Empty: the honest-absence paragraph.
+    pub fn render(&self, frame: &mut Frame<'_>, area: Rect) {
+        let block = Block::bordered().title(LOBBY_TITLE);
+        if self.rows.is_empty() {
+            frame.render_widget(Paragraph::new(EMPTY_BODY).block(block), area);
+            return;
+        }
+        let items: Vec<ListItem<'_>> = self
+            .rows
+            .iter()
+            .map(|row| {
+                ListItem::new(format!(
+                    "{}  ·  Tick {}  ·  {}  ·  engine {}  ·  defines {}",
+                    row.name, row.tick, row.status, row.engine_version, row.defines_hash
+                ))
+            })
+            .collect();
+        let list = List::new(items)
+            .block(block)
+            .highlight_symbol("> ")
+            .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+        let mut state = ListState::default();
+        state.select(Some(self.selected));
+        frame.render_stateful_widget(list, area, &mut state);
+    }
+}

--- a/rust/crates/babylon-tui/src/views/lobby.rs
+++ b/rust/crates/babylon-tui/src/views/lobby.rs
@@ -32,8 +32,12 @@ pub struct LobbyRow {
     /// The campaign's UUID, as a string (never parsed to a UUID type here —
     /// it round-trips opaquely into `AppEvent::LoadCampaign`).
     pub campaign_id: String,
-    /// The campaign's slug (`InMemoryCampaign.slug` / the store's `name`).
+    /// The campaign's slug (`InMemoryCampaign.slug` / the store's `name`) —
+    /// a MACHINE key, never displayed (spec-116 FR-116-3).
     pub name: String,
+    /// The derived human-facing operation codename
+    /// (`campaign_menu.operation_codename`) — what the lobby DISPLAYS.
+    pub codename: String,
     /// Highest tick reached.
     pub tick: u64,
     /// Lifecycle status (`"ACTIVE"` / `"ABANDONED"`).
@@ -54,18 +58,32 @@ pub struct LobbyView {
     pub rows: Vec<LobbyRow>,
     /// The highlighted row index (saturates at `0` and `rows.len() - 1`).
     pub selected: usize,
+    /// `true` when the catalog payload failed to parse — rendered as a
+    /// LOUD distinct state, never conflated with a genuinely empty catalog
+    /// (a serialization break must not read as a wiped database).
+    pub parse_failed: bool,
 }
 
 impl LobbyView {
     /// Build a lobby view from `Host::lobby_catalog_json`'s raw JSON.
     ///
-    /// Malformed or empty JSON never panics: it decodes to an empty catalog
-    /// (honest absence, III.11), matching `serde_json::from_str(..).unwrap_or_default()`
-    /// as used by the M0 hello-frame in `app.rs`.
+    /// Never panics: malformed JSON opens in the loud `parse_failed` state
+    /// (III.11 — an unreadable catalog is an ERROR, not an empty world),
+    /// while a well-formed empty array is the honest-absence state.
     #[must_use]
     pub fn from_catalog_json(raw: &str) -> Self {
-        let rows: Vec<LobbyRow> = serde_json::from_str(raw).unwrap_or_default();
-        Self { rows, selected: 0 }
+        match serde_json::from_str::<Vec<LobbyRow>>(raw) {
+            Ok(rows) => Self {
+                rows,
+                selected: 0,
+                parse_failed: false,
+            },
+            Err(_) => Self {
+                rows: Vec::new(),
+                selected: 0,
+                parse_failed: true,
+            },
+        }
     }
 
     /// Handle one key press, returning the routed event (if any).
@@ -104,6 +122,13 @@ impl LobbyView {
     /// highlighted. Empty: the honest-absence paragraph.
     pub fn render(&self, frame: &mut Frame<'_>, area: Rect) {
         let block = Block::bordered().title(LOBBY_TITLE);
+        if self.parse_failed {
+            let loud = Paragraph::new("Campaign catalog UNREADABLE — malformed host data.")
+                .style(ratatui::style::Style::new().fg(crate::theme::CRIMSON))
+                .block(block);
+            frame.render_widget(loud, area);
+            return;
+        }
         if self.rows.is_empty() {
             frame.render_widget(Paragraph::new(EMPTY_BODY).block(block), area);
             return;
@@ -114,7 +139,7 @@ impl LobbyView {
             .map(|row| {
                 ListItem::new(format!(
                     "{}  ·  Tick {}  ·  {}  ·  engine {}  ·  defines {}",
-                    row.name, row.tick, row.status, row.engine_version, row.defines_hash
+                    row.codename, row.tick, row.status, row.engine_version, row.defines_hash
                 ))
             })
             .collect();

--- a/rust/crates/babylon-tui/src/views/mod.rs
+++ b/rust/crates/babylon-tui/src/views/mod.rs
@@ -1,0 +1,8 @@
+//! Client views (M1): lobby, wiki, palette, watchlist, peek.
+
+pub mod lobby;
+pub mod msg;
+pub mod palette;
+pub mod peek;
+pub mod watchlist;
+pub mod wiki;

--- a/rust/crates/babylon-tui/src/views/msg.rs
+++ b/rust/crates/babylon-tui/src/views/msg.rs
@@ -1,0 +1,20 @@
+//! Events views emit for the app shell to route (plan Task 19).
+
+/// A view-level intent for the app shell.
+///
+/// Views never mutate app state directly: key/mouse handlers return an
+/// `AppEvent` and the shell routes it (push/pop the view stack, call the
+/// host, or quit).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AppEvent {
+    /// Load the selected campaign into the Archive (M1: read-only browse).
+    LoadCampaign(String),
+    /// Begin the new-campaign flow (M2 wires the write path).
+    NewCampaign,
+    /// Navigate to a wiki subject (an entity id or redlink target).
+    OpenSubject(String),
+    /// Pop the current view from the stack.
+    Back,
+    /// Quit the client.
+    Quit,
+}

--- a/rust/crates/babylon-tui/src/views/palette.rs
+++ b/rust/crates/babylon-tui/src/views/palette.rs
@@ -63,6 +63,9 @@ pub struct PaletteView {
     pub matches: Vec<String>,
     /// Index into [`PaletteView::matches`] of the highlighted row.
     pub selected: usize,
+    /// `true` when the known-subjects payload failed to parse — rendered
+    /// loudly, never conflated with "no matching subjects".
+    pub parse_failed: bool,
 }
 
 impl PaletteView {
@@ -73,12 +76,17 @@ impl PaletteView {
     /// III.11), mirroring `_known_entities`'s own absent-attribute fallback
     /// to `frozenset()`.
     pub fn open(known_subjects_json: &str) -> Self {
-        let subjects: Vec<String> = serde_json::from_str(known_subjects_json).unwrap_or_default();
+        let (subjects, parse_failed) =
+            match serde_json::from_str::<Vec<String>>(known_subjects_json) {
+                Ok(subjects) => (subjects, false),
+                Err(_) => (Vec::new(), true),
+            };
         let mut view = Self {
             subjects,
             query: String::new(),
             matches: Vec::new(),
             selected: 0,
+            parse_failed,
         };
         view.refilter();
         view
@@ -170,6 +178,9 @@ impl PaletteView {
     /// row reversed-video), or an honest-absence line when nothing matches.
     pub fn render(&self, frame: &mut Frame, area: Rect) {
         let overlay = centered_rect(60, 60, area);
+        // Clear first: widgets only write where they have content, so the
+        // view underneath would bleed through every unwritten overlay cell.
+        frame.render_widget(ratatui::widgets::Clear, overlay);
         let block = Block::default().borders(Borders::ALL).title("Open subject");
         let inner = block.inner(overlay);
         frame.render_widget(block, overlay);
@@ -186,8 +197,17 @@ impl PaletteView {
         frame.render_widget(query_line, chunks[0]);
 
         if self.matches.is_empty() {
-            // Honest absence (Constitution III.11): never a blank list.
-            let absence = Paragraph::new("no matching subjects").alignment(Alignment::Left);
+            // Honest absence (Constitution III.11): never a blank list —
+            // and an unreadable catalog is an ERROR, not an empty result.
+            let text = if self.parse_failed {
+                "subject catalog UNREADABLE — malformed host data"
+            } else {
+                "no matching subjects"
+            };
+            let mut absence = Paragraph::new(text).alignment(Alignment::Left);
+            if self.parse_failed {
+                absence = absence.style(ratatui::style::Style::new().fg(crate::theme::CRIMSON));
+            }
             frame.render_widget(absence, chunks[1]);
             return;
         }

--- a/rust/crates/babylon-tui/src/views/palette.rs
+++ b/rust/crates/babylon-tui/src/views/palette.rs
@@ -1,0 +1,468 @@
+//! The command palette: fuzzy navigation over the known-subject set.
+//!
+//! Ports `babylon.tui.palette.EntityNavigatorProvider.search`'s ranking
+//! semantics. That Python provider does not implement its own fuzzy
+//! matching — it delegates to `Provider.matcher(query)`, which builds a
+//! `textual.fuzzy.Matcher(query, case_sensitive=False)`, itself a thin
+//! wrapper over `textual.fuzzy.FuzzySearch`. `fuzzy_score` below is a
+//! faithful, from-source port of `FuzzySearch._match`/`FuzzySearch.score`
+//! (`textual/fuzzy.py`, read from the vendored `.venv` at port time):
+//!
+//! * If (lowercased) `query` is a substring of (lowercased) `candidate`, the
+//!   match is the contiguous run at its first occurrence, scored and then
+//!   boosted ×2.0 (exact equality) or ×1.5 (proper substring) — Python's
+//!   "quick exit when the query exists as a substring" path.
+//! * Otherwise every query character must appear, in order, as a
+//!   (possibly non-contiguous) subsequence of `candidate`; all valid
+//!   subsequence position-combinations are scored and the best kept.
+//! * The base score rewards more matched characters, extra credit for
+//!   landing on a "word start" (the position just after a run of
+//!   non-word characters — Python's `\w+` regex groups), and a
+//!   `(1 + cohesion²)` multiplier that favors fewer, longer contiguous
+//!   runs over many scattered single-character hits.
+//!
+//! One deliberate divergence: the Python `FuzzySearch.score` crashes
+//! (`ValueError: not enough values to unpack`) when handed an empty-string
+//! query — reachable in principle through `Provider.search("")`, but never
+//! hit in practice because Textual's own command palette routes empty
+//! input to `Provider.discover()` instead (`palette.py`'s own docstring:
+//! "`discover()` is optional... empty-input suggestions"). [`PaletteView`]
+//! mirrors that real dispatch rather than the underlying crash: an empty
+//! query short-circuits to "every known subject, sorted" without ever
+//! calling `fuzzy_score`.
+//!
+//! No verb commands here (design canon R4, `palette.py`'s own docstring):
+//! the palette carries exactly one command shape, "open a known subject's
+//! page" — [`AppEvent::OpenSubject`].
+
+use std::collections::BTreeSet;
+
+use ratatui::crossterm::event::KeyCode;
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::Frame;
+
+use crate::views::msg::AppEvent;
+
+/// The command palette view: fuzzy-filters the known-subject catalog as the
+/// player types, and opens the highlighted match.
+pub struct PaletteView {
+    /// The full known-subject catalog, fixed at [`PaletteView::open`] time
+    /// (the fuzzy filter always re-scores from this list, never from a
+    /// previously-filtered subset — matching `EntityNavigatorProvider`,
+    /// which re-scans `_known_entities(self.app)` on every keystroke).
+    subjects: Vec<String>,
+    /// The current query text, edited by [`PaletteView::handle_key`].
+    pub query: String,
+    /// Subjects passing the current query filter, ranked best match first
+    /// (ties broken by subject id, ascending — deterministic; matches the
+    /// Python provider's own iteration order, `sorted(_known_entities(...))`,
+    /// which stable-sorts equal-score hits into id order).
+    pub matches: Vec<String>,
+    /// Index into [`PaletteView::matches`] of the highlighted row.
+    pub selected: usize,
+}
+
+impl PaletteView {
+    /// Opens the palette over a `known_subjects_json` payload
+    /// ([`crate::host::Host::known_subjects_json`]'s shape: a JSON array of
+    /// subject-id strings). A malformed or absent payload opens with an
+    /// honestly empty catalog rather than a fabricated one (Constitution
+    /// III.11), mirroring `_known_entities`'s own absent-attribute fallback
+    /// to `frozenset()`.
+    pub fn open(known_subjects_json: &str) -> Self {
+        let subjects: Vec<String> = serde_json::from_str(known_subjects_json).unwrap_or_default();
+        let mut view = Self {
+            subjects,
+            query: String::new(),
+            matches: Vec::new(),
+            selected: 0,
+        };
+        view.refilter();
+        view
+    }
+
+    /// Re-scores every known subject against the current query and rebuilds
+    /// [`PaletteView::matches`], resetting the selection to the top hit.
+    ///
+    /// An empty query never calls `fuzzy_score` (see module docs): it
+    /// lists every subject, sorted — the same shape as
+    /// `EntityNavigatorProvider.discover()`.
+    fn refilter(&mut self) {
+        self.matches = if self.query.is_empty() {
+            let mut all = self.subjects.clone();
+            all.sort();
+            all
+        } else {
+            let mut scored: Vec<(f64, &str)> = self
+                .subjects
+                .iter()
+                .filter_map(|subject| {
+                    let score = fuzzy_score(&self.query, subject);
+                    (score > 0.0).then_some((score, subject.as_str()))
+                })
+                .collect();
+            // Score descending; ties broken by subject id ascending — a
+            // total order, so this sort's outcome never depends on the
+            // input's original ordering (determinism, Constitution III.13).
+            scored.sort_by(|a, b| {
+                // `fuzzy_score` only ever combines finite arithmetic on
+                // non-negative integers, so `partial_cmp` never returns
+                // `None` in practice; the fallback keeps this comparator
+                // total (and panic-free) even so.
+                b.0.partial_cmp(&a.0)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.1.cmp(b.1))
+            });
+            scored
+                .into_iter()
+                .map(|(_, subject)| subject.to_string())
+                .collect()
+        };
+        self.selected = 0;
+    }
+
+    /// Routes one key press.
+    ///
+    /// * A printable character or Backspace edits [`PaletteView::query`]
+    ///   and re-filters.
+    /// * Up/Down move [`PaletteView::selected`] within the current matches
+    ///   (clamped, never wrapping).
+    /// * Enter opens the highlighted match (`None` if there is nothing to
+    ///   open — an honestly-empty match list).
+    /// * Esc backs out of the palette.
+    pub fn handle_key(&mut self, code: KeyCode) -> Option<AppEvent> {
+        match code {
+            KeyCode::Char(c) => {
+                self.query.push(c);
+                self.refilter();
+                None
+            }
+            KeyCode::Backspace => {
+                self.query.pop();
+                self.refilter();
+                None
+            }
+            KeyCode::Up => {
+                self.selected = self.selected.saturating_sub(1);
+                None
+            }
+            KeyCode::Down => {
+                if self.selected + 1 < self.matches.len() {
+                    self.selected += 1;
+                }
+                None
+            }
+            KeyCode::Enter => self
+                .matches
+                .get(self.selected)
+                .cloned()
+                .map(AppEvent::OpenSubject),
+            KeyCode::Esc => Some(AppEvent::Back),
+            _ => None,
+        }
+    }
+
+    /// Renders the palette as a centered overlay box atop whatever `area`
+    /// covers: a query line, then the ranked match list (the highlighted
+    /// row reversed-video), or an honest-absence line when nothing matches.
+    pub fn render(&self, frame: &mut Frame, area: Rect) {
+        let overlay = centered_rect(60, 60, area);
+        let block = Block::default().borders(Borders::ALL).title("Open subject");
+        let inner = block.inner(overlay);
+        frame.render_widget(block, overlay);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Min(1)])
+            .split(inner);
+
+        let query_line = Paragraph::new(Line::from(vec![
+            Span::raw("> "),
+            Span::raw(self.query.as_str()),
+        ]));
+        frame.render_widget(query_line, chunks[0]);
+
+        if self.matches.is_empty() {
+            // Honest absence (Constitution III.11): never a blank list.
+            let absence = Paragraph::new("no matching subjects").alignment(Alignment::Left);
+            frame.render_widget(absence, chunks[1]);
+            return;
+        }
+
+        let lines: Vec<Line> = self
+            .matches
+            .iter()
+            .enumerate()
+            .map(|(index, subject)| {
+                let style = if index == self.selected {
+                    Style::default().add_modifier(Modifier::REVERSED)
+                } else {
+                    Style::default()
+                };
+                Line::from(Span::styled(subject.as_str(), style))
+            })
+            .collect();
+        let list = Paragraph::new(Text::from(lines));
+        frame.render_widget(list, chunks[1]);
+    }
+}
+
+/// Carves a `percent_x`% × `percent_y`% box out of the center of `area`.
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+/// Word-start positions in `chars`: the index just after any run boundary
+/// into a run of "word" characters (alphanumeric or `_`).
+///
+/// Ports `FuzzySearch.get_first_letters`'s `re.finditer(r"\w+", candidate)`
+/// start-offset set (over already-lowercased, already-char-indexed input;
+/// Python string indices are code-point indices, matched here by indexing
+/// `chars: &[char]` rather than raw byte offsets).
+fn word_start_positions(chars: &[char]) -> BTreeSet<usize> {
+    let mut starts = BTreeSet::new();
+    let mut prev_is_word = false;
+    for (index, ch) in chars.iter().enumerate() {
+        let is_word = ch.is_alphanumeric() || *ch == '_';
+        if is_word && !prev_is_word {
+            starts.insert(index);
+        }
+        prev_is_word = is_word;
+    }
+    starts
+}
+
+/// Ports `FuzzySearch.score`: rewards more matched characters (plus a
+/// bonus per position landing on a word start) and a cohesion multiplier
+/// that favors fewer, longer contiguous runs of `positions`.
+///
+/// `positions` must be non-empty and strictly increasing (the only shape
+/// `fuzzy_score` ever builds); an empty slice returns `0.0` defensively
+/// (the Python original panics on this input instead — never reachable
+/// from any call site here, since every caller below only invokes this
+/// with at least one position).
+fn score_positions(positions: &[usize], word_starts: &BTreeSet<usize>) -> f64 {
+    let Some(&first) = positions.first() else {
+        return 0.0;
+    };
+    let offset_count = positions.len();
+    let word_start_hits = positions.iter().filter(|p| word_starts.contains(p)).count();
+    let mut score = (offset_count + word_start_hits) as f64;
+
+    let mut groups = 1usize;
+    let mut last_offset = first;
+    for &offset in &positions[1..] {
+        if offset != last_offset + 1 {
+            groups += 1;
+        }
+        last_offset = offset;
+    }
+    let normalized_groups = (offset_count as f64 - (groups as f64 - 1.0)) / offset_count as f64;
+    score *= 1.0 + normalized_groups * normalized_groups;
+    score
+}
+
+/// Finds the first index `>= start` in `chars` equal to `target`.
+fn find_char_from(chars: &[char], target: char, start: usize) -> Option<usize> {
+    chars[start.min(chars.len())..]
+        .iter()
+        .position(|&c| c == target)
+        .map(|offset| offset + start)
+}
+
+/// Finds the first (leftmost) index where `needle` occurs as a contiguous
+/// run within `haystack`, or `None`.
+fn find_subsequence_run(haystack: &[char], needle: &[char]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    if needle.len() > haystack.len() {
+        return None;
+    }
+    (0..=(haystack.len() - needle.len()))
+        .find(|&start| haystack[start..start + needle.len()] == *needle)
+}
+
+/// Recursively enumerates every strictly-increasing offset combination
+/// drawing one position per query character from `letter_positions` (in
+/// order), scoring each complete combination and keeping the best.
+///
+/// Ports `FuzzySearch._match`'s nested `get_offsets` closure. Recursion
+/// depth is bounded by `query_length` (the number of query characters,
+/// fixed and small for palette queries) — a statically bounded descent,
+/// never unbounded.
+fn best_combination_score(
+    letter_positions: &[Vec<usize>],
+    positions_index: usize,
+    current: &mut Vec<usize>,
+    query_length: usize,
+    word_starts: &BTreeSet<usize>,
+    best: &mut f64,
+) {
+    for &offset in &letter_positions[positions_index] {
+        if current.last().is_some_and(|&last| offset <= last) {
+            continue;
+        }
+        current.push(offset);
+        if current.len() == query_length {
+            let candidate_score = score_positions(current, word_starts);
+            if candidate_score > *best {
+                *best = candidate_score;
+            }
+        } else {
+            best_combination_score(
+                letter_positions,
+                positions_index + 1,
+                current,
+                query_length,
+                word_starts,
+                best,
+            );
+        }
+        current.pop();
+    }
+}
+
+/// Scores `candidate` against `query`, case-insensitively — a from-source
+/// port of `textual.fuzzy.FuzzySearch.match(query, candidate)[0]` (the
+/// score half of its `(score, offsets)` pair; see module docs for the
+/// algorithm and its one deliberate divergence).
+///
+/// Returns `0.0` for no match (including the never-hit-in-practice empty
+/// query, guarded here rather than replicating the Python crash — see
+/// module docs) and a positive score otherwise; higher is a tighter match.
+pub(crate) fn fuzzy_score(query: &str, candidate: &str) -> f64 {
+    if query.is_empty() {
+        return 0.0;
+    }
+    let query_chars: Vec<char> = query.to_lowercase().chars().collect();
+    let candidate_chars: Vec<char> = candidate.to_lowercase().chars().collect();
+
+    if let Some(start) = find_subsequence_run(&candidate_chars, &query_chars) {
+        let offsets: Vec<usize> = (start..start + query_chars.len()).collect();
+        let word_starts = word_start_positions(&candidate_chars);
+        let base = score_positions(&offsets, &word_starts);
+        return base
+            * if candidate_chars == query_chars {
+                2.0
+            } else {
+                1.5
+            };
+    }
+
+    let candidate_len = candidate_chars.len();
+    let mut letter_positions: Vec<Vec<usize>> = Vec::with_capacity(query_chars.len());
+    let mut window_start = 0usize;
+    for (query_offset, &letter) in query_chars.iter().enumerate() {
+        // Signed: Python's `len(candidate) - offset` may go negative when
+        // the query outruns the candidate, which only tightens (never
+        // panics) the `index >= last_index` break check below.
+        let last_index = candidate_len as i64 - query_offset as i64;
+        let mut positions = Vec::new();
+        let mut index = window_start;
+        while let Some(location) = find_char_from(&candidate_chars, letter, index) {
+            positions.push(location);
+            index = location + 1;
+            if index as i64 >= last_index {
+                break;
+            }
+        }
+        if positions.is_empty() {
+            return 0.0;
+        }
+        window_start = positions[0] + 1;
+        letter_positions.push(positions);
+    }
+
+    let word_starts = word_start_positions(&candidate_chars);
+    let mut best = 0.0f64;
+    let mut current = Vec::with_capacity(query_chars.len());
+    best_combination_score(
+        &letter_positions,
+        0,
+        &mut current,
+        query_chars.len(),
+        &word_starts,
+        &mut best,
+    );
+    best
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Exact float values captured from the vendored Textual runtime itself:
+    //
+    //     .venv/bin/python3 -c "
+    //     from textual.fuzzy import FuzzySearch
+    //     fs = FuzzySearch()
+    //     print(fs.match('county/26163', 'county/26163'))
+    //     print(fs.match('county', 'county/26163'))
+    //     print(fs.match('c26163', 'county/26163'))
+    //     print(fs.match('tenants', 'org/tenants-un'))
+    //     print(fs.match('tenants', 'org/uaw-9999'))
+    //     "
+    //
+    // pinning `fuzzy_score` to the real algorithm's own numbers, not just
+    // its ranking order.
+
+    #[test]
+    fn exact_match_scores_56() {
+        assert_eq!(fuzzy_score("county/26163", "county/26163"), 56.0);
+    }
+
+    #[test]
+    fn tight_prefix_substring_scores_21() {
+        assert_eq!(fuzzy_score("county", "county/26163"), 21.0);
+    }
+
+    #[test]
+    fn scattered_subsequence_scores_13_5556() {
+        let score = fuzzy_score("c26163", "county/26163");
+        assert!((score - 13.555_555_555_555_557).abs() < 1e-9, "got {score}");
+    }
+
+    #[test]
+    fn substring_mid_word_scores_24() {
+        assert_eq!(fuzzy_score("tenants", "org/tenants-un"), 24.0);
+    }
+
+    #[test]
+    fn no_common_subsequence_scores_zero() {
+        assert_eq!(fuzzy_score("tenants", "org/uaw-9999"), 0.0);
+    }
+
+    #[test]
+    fn case_insensitive_matches_the_lowercase_score() {
+        assert_eq!(fuzzy_score("COUNTY", "county/26163"), 21.0);
+    }
+
+    #[test]
+    fn empty_query_never_panics_and_scores_zero() {
+        assert_eq!(fuzzy_score("", "county/26163"), 0.0);
+    }
+
+    #[test]
+    fn query_longer_than_candidate_scores_zero() {
+        assert_eq!(fuzzy_score("countycountycounty", "county"), 0.0);
+    }
+}

--- a/rust/crates/babylon-tui/src/views/peek.rs
+++ b/rust/crates/babylon-tui/src/views/peek.rs
@@ -34,19 +34,17 @@
 //! renders that as a loud, explicit "no view available" plate rather than
 //! an empty one.
 //!
-//! **Field walk order is alphabetical, not declaration order** — another
-//! deliberate deviation from `peek.py`, which walks `model_fields`
-//! insertion order. `serde_json::Value::Object` is backed by a `BTreeMap`
-//! (this crate's `serde_json` has no `preserve_order` feature — house style
-//! prefers `BTreeMap`/`BTreeSet` wherever iteration order reaches output,
-//! `CLAUDE.md`'s Power-of-10 gloss), so key order is alphabetical and fully
-//! deterministic; it will differ from the Python original's field order for
-//! any view with more than one field. This is a determinism-preserving
-//! trade, not a data-fidelity gap — every present field still renders,
-//! just in a different (still deterministic) order.
+//! **Field walk order is JSON insertion order** — the crate enables
+//! `serde_json`'s `preserve_order` feature, so `Value::Object` iterates in
+//! the order `model_dump_json` emitted, which is pydantic DECLARATION
+//! order: exactly `peek.py`'s `model_fields` walk. This is load-bearing,
+//! not cosmetic — depths 0–2 TRUNCATE the row list, and truncating a
+//! differently-ordered list selects a different field SUBSET, so an
+//! alphabetical walk would show a different headline stat than the Python
+//! client for the same view (the M1 verify panel caught precisely that).
 
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Paragraph};
 use ratatui::Frame;
@@ -73,10 +71,7 @@ const UNIVERSAL_FIELDS: [&str; 2] = ["kind", "verified_tick"];
 /// absence — no `kind` is available to build a real header from).
 const NO_VIEW_HEADER: &str = "(no view available)";
 
-const CRIMSON: Color = Color::Rgb(220, 20, 60);
-const GOLD: Color = Color::Rgb(255, 215, 0);
-const BONE: Color = Color::Rgb(232, 232, 232);
-const DIM: Color = Color::Rgb(64, 64, 64);
+use crate::theme::{BONE, CRIMSON, DIM, GOLD};
 
 /// Find `view`'s own identity field name by the `{kind}_fips`/`{kind}_id`
 /// convention, or `None` if `view` has no string `kind` or no field
@@ -251,8 +246,12 @@ mod tests {
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
 
+    // Real CountyView field names in DECLARATION order — and deliberately
+    // NOT alphabetical (population before median_wage): depth-0 showing
+    // population proves the walk preserves insertion order, since an
+    // alphabetical walk would pick median_wage first.
     const FIXTURE: &str = r#"{"kind":"county","county_fips":"26163","verified_tick":42,
-        "wealth":1234.5,"population":98765}"#;
+        "population":98765,"median_wage":1234.5}"#;
 
     const FIXTURE_ABSENT: &str = r#"{"kind":"county","county_fips":"26163","verified_tick":1}"#;
 
@@ -298,7 +297,7 @@ mod tests {
         assert!(text.contains("county/26163 @ T0042"));
         assert!(text.contains("population"));
         assert!(text.contains("98765"));
-        assert!(text.contains("wealth"));
+        assert!(text.contains("median_wage"));
         assert!(text.contains("1234.500000"));
     }
 
@@ -307,7 +306,7 @@ mod tests {
         let buffer = draw(FIXTURE, 2);
         let text = buffer_text(&buffer);
         assert!(text.contains("county/26163 @ T0042"));
-        assert!(text.contains("wealth"));
+        assert!(text.contains("median_wage"));
         assert!(text.contains("population"));
     }
 
@@ -316,7 +315,7 @@ mod tests {
         let buffer = draw(FIXTURE, 3);
         let text = buffer_text(&buffer);
         assert!(text.contains("county/26163 @ T0042"));
-        assert!(text.contains("wealth"));
+        assert!(text.contains("median_wage"));
         assert!(text.contains("population"));
     }
 
@@ -348,6 +347,6 @@ mod tests {
         let buffer = draw(FIXTURE, 200);
         let text = buffer_text(&buffer);
         assert!(text.contains("county/26163 @ T0042"));
-        assert!(text.contains("wealth"));
+        assert!(text.contains("median_wage"));
     }
 }

--- a/rust/crates/babylon-tui/src/views/peek.rs
+++ b/rust/crates/babylon-tui/src/views/peek.rs
@@ -1,0 +1,353 @@
+//! `render_peek` — the Rust port of `peek.py`'s single `peek(entity, depth)`
+//! stat-plate renderer (S7 design canon, plan Task 14).
+//!
+//! S7: *"A single `peek(entity, depth)` renderer producing a compact stat
+//! plate implements, at different sizes: Vic3 nested tooltips, Obsidian
+//! hover preview, page transclusion, and watchlist rows."* [`render_peek`]
+//! is that one renderer, painting directly into a ratatui [`Frame`] rather
+//! than returning a `rich` renderable (the Python original's own return
+//! type) — this crate has no `rich` dependency, and painting into the frame
+//! is this client's native idiom.
+//!
+//! **Depth is a size selector**, matching the Python original's four fixed
+//! verbosity tiers one-to-one:
+//!
+//! | `depth` | Context                             | Stat rows shown |
+//! |---------|--------------------------------------|------------------|
+//! | `0`     | watchlist row                         | at most 1        |
+//! | `1`     | Obsidian-style hover preview           | at most 3        |
+//! | `2`     | Vic3-style nested tooltip               | at most 6        |
+//! | `3`     | page transclusion                       | every present field |
+//!
+//! **Depth clamps rather than errors** — a deliberate deviation from
+//! `peek.py`, which raises `ValueError` outside `[0, MAX_DEPTH]`. This
+//! function has no `Result` in its signature (it paints a frame; there is
+//! no caller-visible failure channel to report through) and production
+//! rendering code never panics, so an out-of-range `depth` clamps to
+//! [`MAX_DEPTH`] instead of raising — the honest-absence discipline
+//! (Constitution III.11) applied to a caller bug rather than to missing
+//! data.
+//!
+//! **JSON `null` → honest absence**, never a fabricated placeholder: the
+//! host returns the literal string `"null"` from `subject_view_json` when
+//! it cannot resolve a subject (`host.rs`'s own doc comment); this module
+//! renders that as a loud, explicit "no view available" plate rather than
+//! an empty one.
+//!
+//! **Field walk order is alphabetical, not declaration order** — another
+//! deliberate deviation from `peek.py`, which walks `model_fields`
+//! insertion order. `serde_json::Value::Object` is backed by a `BTreeMap`
+//! (this crate's `serde_json` has no `preserve_order` feature — house style
+//! prefers `BTreeMap`/`BTreeSet` wherever iteration order reaches output,
+//! `CLAUDE.md`'s Power-of-10 gloss), so key order is alphabetical and fully
+//! deterministic; it will differ from the Python original's field order for
+//! any view with more than one field. This is a determinism-preserving
+//! trade, not a data-fidelity gap — every present field still renders,
+//! just in a different (still deterministic) order.
+
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Paragraph};
+use ratatui::Frame;
+use serde_json::Value;
+
+/// The hard upper bound on `depth` (mirrors `peek.py::MAX_DEPTH`).
+pub const MAX_DEPTH: u8 = 3;
+
+/// Stat-row cap per depth `0..=MAX_DEPTH`; `None` means uncapped — indexed
+/// directly by depth (mirrors `peek.py::_FIELD_CAP_BY_DEPTH`).
+const FIELD_CAP_BY_DEPTH: [Option<usize>; (MAX_DEPTH as usize) + 1] =
+    [Some(1), Some(3), Some(6), None];
+
+/// Identity-field suffixes tried against a view's own `kind`, in order
+/// (mirrors `peek.py::_IDENTITY_SUFFIXES` — `CountyView.county_fips` is
+/// `"county" + "_fips"`).
+const IDENTITY_SUFFIXES: [&str; 2] = ["_fips", "_id"];
+
+/// Fields every view carries by the keel convention, folded into the header
+/// rather than walked as stat rows (mirrors `peek.py::_UNIVERSAL_FIELDS`).
+const UNIVERSAL_FIELDS: [&str; 2] = ["kind", "verified_tick"];
+
+/// Header used when `subject_view_json` is JSON `null` (host-level honest
+/// absence — no `kind` is available to build a real header from).
+const NO_VIEW_HEADER: &str = "(no view available)";
+
+const CRIMSON: Color = Color::Rgb(220, 20, 60);
+const GOLD: Color = Color::Rgb(255, 215, 0);
+const BONE: Color = Color::Rgb(232, 232, 232);
+const DIM: Color = Color::Rgb(64, 64, 64);
+
+/// Find `view`'s own identity field name by the `{kind}_fips`/`{kind}_id`
+/// convention, or `None` if `view` has no string `kind` or no field
+/// matches either suffix (mirrors `peek.py::_identity_field_name`).
+fn identity_field_name(view: &Value) -> Option<String> {
+    let kind = view.get("kind")?.as_str()?;
+    let object = view.as_object()?;
+    IDENTITY_SUFFIXES
+        .iter()
+        .map(|suffix| format!("{kind}{suffix}"))
+        .find(|candidate| object.contains_key(candidate))
+}
+
+/// One JSON leaf value rendered for display: a JSON float formats to six
+/// decimals (mirroring `peek.py::_format_scalar`'s float branch); a JSON
+/// integer, string, or bool formats as its own natural text. Booleans
+/// render lowercase (`"true"`/`"false"`) rather than the Python original's
+/// `str(True)` == `"True"` — a JSON-vs-Python-native deviation, documented
+/// here since no known `ProjectionRecord` field is boolean today.
+fn format_scalar(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => {
+            if n.is_i64() || n.is_u64() {
+                n.to_string()
+            } else {
+                format!("{:.6}", n.as_f64().unwrap_or(0.0))
+            }
+        }
+        // Arrays/objects never appear as ProjectionRecord leaf fields in
+        // the Python original; falling back to compact JSON keeps this
+        // renderer total rather than panicking on an unexpected shape.
+        other => other.to_string(),
+    }
+}
+
+/// Resolve one field into zero, one, or several `(label, value)` rows.
+///
+/// `null` contributes nothing; a nested JSON object flattens into one
+/// dotted row per present sub-field (mirrors a `pydantic.BaseModel` nested
+/// field in the Python original); anything else is one scalar row.
+fn format_field(name: &str, value: &Value) -> Vec<(String, String)> {
+    if value.is_null() {
+        return Vec::new();
+    }
+    if let Some(object) = value.as_object() {
+        return object
+            .iter()
+            .filter(|(_, sub_value)| !sub_value.is_null())
+            .map(|(sub_name, sub_value)| (format!("{name}.{sub_name}"), format_scalar(sub_value)))
+            .collect();
+    }
+    vec![(name.to_string(), format_scalar(value))]
+}
+
+/// Build the plate header: `"{kind}/{identity} @ T{tick:04}"`, degrading
+/// field-by-field when a piece is missing (mirrors `peek.py::_header`).
+fn header_of(view: &Value) -> String {
+    let mut label = view
+        .get("kind")
+        .and_then(Value::as_str)
+        .unwrap_or("entity")
+        .to_string();
+
+    if let Some(identity_name) = identity_field_name(view) {
+        if let Some(identity_value) = view.get(&identity_name).filter(|v| !v.is_null()) {
+            label = format!("{label}/{}", format_scalar(identity_value));
+        }
+    }
+
+    match view.get("verified_tick").and_then(Value::as_u64) {
+        Some(tick) => format!("{label} @ T{tick:04}"),
+        None => label,
+    }
+}
+
+/// Walk every non-identity, non-universal field of `view` into ordered stat
+/// rows (mirrors `peek.py::_stat_rows`; see the module docs for the
+/// alphabetical-vs-declaration-order deviation).
+fn stat_rows(view: &Value) -> Vec<(String, String)> {
+    let Some(object) = view.as_object() else {
+        return Vec::new();
+    };
+    let identity_name = identity_field_name(view);
+    let mut rows = Vec::new();
+    for (name, value) in object {
+        if UNIVERSAL_FIELDS.contains(&name.as_str()) {
+            continue;
+        }
+        if identity_name.as_deref() == Some(name.as_str()) {
+            continue;
+        }
+        rows.extend(format_field(name, value));
+    }
+    rows
+}
+
+/// The honest-absence marker line shown when a plate has no populated
+/// field, or no view at all (mirrors `peek.py::_absence_text`).
+fn absence_line(header: &str) -> Line<'static> {
+    Line::from(Span::styled(
+        format!("▌ {header} — no attributed data"),
+        Style::new().fg(CRIMSON).add_modifier(Modifier::BOLD),
+    ))
+}
+
+/// The depth-0 plate: one unadorned line, no border (mirrors
+/// `peek.py::_watchlist_row`).
+fn watchlist_line(header: &str, rows: &[(String, String)]) -> Line<'static> {
+    match rows.first() {
+        None => absence_line(header),
+        Some((label, value)) => Line::from(Span::styled(
+            format!("{header}  {label}={value}"),
+            Style::new().fg(BONE),
+        )),
+    }
+}
+
+/// Render a compact stat plate for the view-model in `subject_view_json`
+/// into `area`, at the given size tier.
+///
+/// `subject_view_json` is the JSON the host's `subject_view_json` method
+/// returns: an object, or the literal `null` when the host has no view for
+/// the subject. `depth` selects the size tier (`0` most compact, up to
+/// [`MAX_DEPTH`] most detailed) and clamps rather than errors outside that
+/// range — see the module docs.
+pub fn render_peek(frame: &mut Frame, area: Rect, subject_view_json: &str, depth: u8) {
+    let depth = depth.min(MAX_DEPTH);
+    let parsed: Value = serde_json::from_str(subject_view_json).unwrap_or(Value::Null);
+
+    let (header, mut rows) = match parsed.as_object() {
+        Some(_) => (header_of(&parsed), stat_rows(&parsed)),
+        None => (NO_VIEW_HEADER.to_string(), Vec::new()),
+    };
+    if let Some(cap) = FIELD_CAP_BY_DEPTH[usize::from(depth)] {
+        rows.truncate(cap);
+    }
+
+    if depth == 0 {
+        frame.render_widget(Paragraph::new(watchlist_line(&header, &rows)), area);
+        return;
+    }
+
+    let block = Block::bordered()
+        .title(Line::styled(
+            header.clone(),
+            Style::new().fg(GOLD).add_modifier(Modifier::BOLD),
+        ))
+        .border_style(Style::new().fg(CRIMSON));
+
+    let paragraph = if rows.is_empty() {
+        Paragraph::new(absence_line(&header)).block(block)
+    } else {
+        let lines: Vec<Line> = rows
+            .iter()
+            .map(|(label, value)| {
+                Line::from(vec![
+                    Span::styled(format!("{label:<24}"), Style::new().fg(DIM)),
+                    Span::styled(value.clone(), Style::new().fg(BONE)),
+                ])
+            })
+            .collect();
+        Paragraph::new(lines).block(block)
+    };
+    frame.render_widget(paragraph, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    const FIXTURE: &str = r#"{"kind":"county","county_fips":"26163","verified_tick":42,
+        "wealth":1234.5,"population":98765}"#;
+
+    const FIXTURE_ABSENT: &str = r#"{"kind":"county","county_fips":"26163","verified_tick":1}"#;
+
+    fn draw(json: &str, depth: u8) -> ratatui::buffer::Buffer {
+        // Wide enough that the longest absence line ("▌ county/26163 @
+        // T0001 — no attributed data", 43 cells) fits inside a border.
+        let backend = TestBackend::new(60, 8);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                render_peek(frame, area, json, depth);
+            })
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn buffer_text(buffer: &ratatui::buffer::Buffer) -> String {
+        let area = buffer.area;
+        (0..area.height)
+            .map(|row| {
+                (0..area.width)
+                    .map(|col| buffer[(col, row)].symbol())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn depth_0_renders_bare_line_with_first_row_only() {
+        let buffer = draw(FIXTURE, 0);
+        let text = buffer_text(&buffer);
+        assert!(text.starts_with("county/26163 @ T0042  population=98765"));
+    }
+
+    #[test]
+    fn depth_1_renders_bordered_plate_capped_at_three_rows() {
+        let buffer = draw(FIXTURE, 1);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("county/26163 @ T0042"));
+        assert!(text.contains("population"));
+        assert!(text.contains("98765"));
+        assert!(text.contains("wealth"));
+        assert!(text.contains("1234.500000"));
+    }
+
+    #[test]
+    fn depth_2_renders_bordered_plate_capped_at_six_rows() {
+        let buffer = draw(FIXTURE, 2);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("county/26163 @ T0042"));
+        assert!(text.contains("wealth"));
+        assert!(text.contains("population"));
+    }
+
+    #[test]
+    fn depth_3_renders_bordered_plate_uncapped() {
+        let buffer = draw(FIXTURE, 3);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("county/26163 @ T0042"));
+        assert!(text.contains("wealth"));
+        assert!(text.contains("population"));
+    }
+
+    #[test]
+    fn absent_fields_render_the_honest_absence_marker_in_the_panel() {
+        let buffer = draw(FIXTURE_ABSENT, 2);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("county/26163 @ T0001 — no attributed data"));
+    }
+
+    #[test]
+    fn depth_0_absence_renders_bare_marker_line_no_border() {
+        let buffer = draw(FIXTURE_ABSENT, 0);
+        let text = buffer_text(&buffer);
+        assert!(text.starts_with("▌ county/26163 @ T0001 — no attributed data"));
+        // No border box-drawing character on the bare watchlist line.
+        assert!(!text.contains('┌'));
+    }
+
+    #[test]
+    fn null_view_renders_honest_absence_not_a_fabricated_plate() {
+        let buffer = draw("null", 2);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("(no view available) — no attributed data"));
+    }
+
+    #[test]
+    fn out_of_range_depth_clamps_to_max_depth_rather_than_panicking() {
+        let buffer = draw(FIXTURE, 200);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("county/26163 @ T0042"));
+        assert!(text.contains("wealth"));
+    }
+}

--- a/rust/crates/babylon-tui/src/views/watchlist.rs
+++ b/rust/crates/babylon-tui/src/views/watchlist.rs
@@ -1,0 +1,182 @@
+//! The watchlist rail: a read-only, row-addressable view over pinned subjects.
+//!
+//! Ports the *display* shape of `babylon.tui.watchlist` — specifically
+//! `watchlist_rows`'s contract (one selectable row per pinned id, keyed by
+//! its subject id, plus a single named absence row when nothing is pinned)
+//! — over the wire shape [`crate::host::Host::watchlist_json`] actually
+//! serves: a JSON array of row objects, each carrying at least a `"subject"`
+//! string key (the id [`WatchlistView::handle_key`]'s `Enter` opens).
+//!
+//! **Schema note (Python-owned, not yet pinned):** the exact set of display
+//! fields a watchlist row carries beyond `"subject"` is Program 24 P3
+//! WO-46/Task 17 territory (`babylon.tui.watchlist._row_text` computes a
+//! `peek(view, depth=0)` line, which is Python-side `ProjectionRecord`
+//! rendering logic with no Rust port target in this milestone). Rather than
+//! guess at field names that may not match what Task 17 ships, each row
+//! stays a `serde_json::Value` object and [`WatchlistView::render`] renders
+//! it generically: the `"subject"` value first, then every other key sorted
+//! (`serde_json::Map`'s default backing is a `BTreeMap` — deterministic
+//! iteration with no `preserve_order` feature enabled here) as `key: value`.
+//! This is forward-compatible with whatever concrete fields Task 17 lands
+//! without a follow-up Rust change, at the cost of not reproducing
+//! `_row_text`'s exact prose today.
+//!
+//! Absence follows the [`crate::host::Host`] trait's own documented
+//! contract (`"or \`null\`/\`[]\`, never a fabricated value"`) rather than
+//! `watchlist_rows`'s Python-internal convention of a single
+//! `(None, absence_text)` placeholder row for `OptionList` — an empty JSON
+//! array here means "nothing pinned", and [`WatchlistView`] renders its own
+//! honest-absence line for it, reusing `_absence_text`'s exact wording.
+
+use ratatui::crossterm::event::KeyCode;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::Frame;
+use serde_json::Value;
+
+use crate::views::msg::AppEvent;
+
+/// The exact wording of `babylon.tui.watchlist._absence_text` (ported
+/// verbatim so the honest-absence line reads identically to the Textual
+/// client).
+const ABSENCE_TEXT: &str = "▌ watchlist — nothing pinned yet";
+
+/// The watchlist rail: pinned-subject rows, read-only in M1 (pin/unpin
+/// writes land in M2 — see `babylon.tui.watchlist`'s own module docs on the
+/// `WatchlistPersistence` seam).
+pub struct WatchlistView {
+    /// One JSON object per pinned subject, as served by
+    /// [`crate::host::Host::watchlist_json`]. Each row is expected to carry
+    /// at least a `"subject"` string key; rows failing that are still shown
+    /// (their fields render generically) but never open on `Enter`.
+    pub rows: Vec<Value>,
+    /// Index into [`WatchlistView::rows`] of the highlighted row.
+    pub selected: usize,
+}
+
+impl WatchlistView {
+    /// Opens the watchlist over a `watchlist_json` payload. A malformed or
+    /// absent payload opens with an honestly empty row list rather than a
+    /// fabricated one (Constitution III.11).
+    pub fn open(watchlist_json: &str) -> Self {
+        let rows: Vec<Value> = serde_json::from_str(watchlist_json).unwrap_or_default();
+        Self { rows, selected: 0 }
+    }
+
+    /// Routes one key press: Up/Down move the selection (clamped, never
+    /// wrapping); Enter opens the highlighted row's `"subject"` (`None` if
+    /// the row list is empty, or the highlighted row has no string
+    /// `"subject"` field); Esc backs out of the rail.
+    pub fn handle_key(&mut self, code: KeyCode) -> Option<AppEvent> {
+        match code {
+            KeyCode::Up => {
+                self.selected = self.selected.saturating_sub(1);
+                None
+            }
+            KeyCode::Down => {
+                if self.selected + 1 < self.rows.len() {
+                    self.selected += 1;
+                }
+                None
+            }
+            KeyCode::Enter => self
+                .rows
+                .get(self.selected)
+                .and_then(|row| row.get("subject"))
+                .and_then(Value::as_str)
+                .map(|subject| AppEvent::OpenSubject(subject.to_string())),
+            KeyCode::Esc => Some(AppEvent::Back),
+            _ => None,
+        }
+    }
+
+    /// Renders the watchlist rail: a bordered panel titled with the pin
+    /// count, one line per pinned row, or the honest-absence line when
+    /// nothing is pinned.
+    pub fn render(&self, frame: &mut Frame, area: Rect) {
+        let title = format!("Watchlist ({} pinned)", self.rows.len());
+        let block = Block::default().borders(Borders::ALL).title(title);
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        if self.rows.is_empty() {
+            let absence = Paragraph::new(ABSENCE_TEXT);
+            frame.render_widget(absence, inner);
+            return;
+        }
+
+        let lines: Vec<Line> = self
+            .rows
+            .iter()
+            .enumerate()
+            .map(|(index, row)| {
+                let style = if index == self.selected {
+                    Style::default().add_modifier(Modifier::REVERSED)
+                } else {
+                    Style::default()
+                };
+                Line::from(Span::styled(row_text(row), style))
+            })
+            .collect();
+        let list = Paragraph::new(Text::from(lines));
+        frame.render_widget(list, inner);
+    }
+}
+
+/// Renders one row object generically: `"subject"`'s value first, then
+/// every other key (sorted, `serde_json::Map`'s deterministic default
+/// order) as `key: value`. A row with no `"subject"` string still renders
+/// its other fields — never silently dropped (Constitution III.11) — just
+/// unopenable (see [`WatchlistView::handle_key`]).
+fn row_text(row: &Value) -> String {
+    let Some(object) = row.as_object() else {
+        return format_value(row);
+    };
+    let subject = object
+        .get("subject")
+        .and_then(Value::as_str)
+        .unwrap_or("(no subject)");
+    let mut parts = vec![subject.to_string()];
+    for (key, value) in object {
+        if key == "subject" {
+            continue;
+        }
+        parts.push(format!("{key}: {}", format_value(value)));
+    }
+    parts.join("  ")
+}
+
+/// Formats a JSON scalar for display: strings unquoted, null as an explicit
+/// em-dash placeholder, everything else via its compact JSON form.
+fn format_value(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Null => "—".to_string(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn row_text_puts_subject_first_then_sorted_fields() {
+        let row: Value = serde_json::from_str(
+            r#"{"subject":"county/26163","population":1749343,"note":"Wayne"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            row_text(&row),
+            "county/26163  note: Wayne  population: 1749343"
+        );
+    }
+
+    #[test]
+    fn row_text_handles_a_missing_subject_without_panicking() {
+        let row: Value = serde_json::from_str(r#"{"population":1749343}"#).unwrap();
+        assert_eq!(row_text(&row), "(no subject)  population: 1749343");
+    }
+}

--- a/rust/crates/babylon-tui/src/views/watchlist.rs
+++ b/rust/crates/babylon-tui/src/views/watchlist.rs
@@ -15,8 +15,8 @@
 //! guess at field names that may not match what Task 17 ships, each row
 //! stays a `serde_json::Value` object and [`WatchlistView::render`] renders
 //! it generically: the `"subject"` value first, then every other key sorted
-//! (`serde_json::Map`'s default backing is a `BTreeMap` — deterministic
-//! iteration with no `preserve_order` feature enabled here) as `key: value`.
+//! explicitly (the crate DOES enable `preserve_order` for the peek plates,
+//! so sorted display never leans on map iteration order) as `key: value`.
 //! This is forward-compatible with whatever concrete fields Task 17 lands
 //! without a follow-up Rust change, at the cost of not reproducing
 //! `_row_text`'s exact prose today.
@@ -54,6 +54,9 @@ pub struct WatchlistView {
     pub rows: Vec<Value>,
     /// Index into [`WatchlistView::rows`] of the highlighted row.
     pub selected: usize,
+    /// `true` when the watchlist payload failed to parse — rendered
+    /// loudly, never conflated with "nothing pinned".
+    pub parse_failed: bool,
 }
 
 impl WatchlistView {
@@ -61,8 +64,18 @@ impl WatchlistView {
     /// absent payload opens with an honestly empty row list rather than a
     /// fabricated one (Constitution III.11).
     pub fn open(watchlist_json: &str) -> Self {
-        let rows: Vec<Value> = serde_json::from_str(watchlist_json).unwrap_or_default();
-        Self { rows, selected: 0 }
+        match serde_json::from_str::<Vec<Value>>(watchlist_json) {
+            Ok(rows) => Self {
+                rows,
+                selected: 0,
+                parse_failed: false,
+            },
+            Err(_) => Self {
+                rows: Vec::new(),
+                selected: 0,
+                parse_failed: true,
+            },
+        }
     }
 
     /// Routes one key press: Up/Down move the selection (clamped, never
@@ -101,6 +114,13 @@ impl WatchlistView {
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
+        if self.parse_failed {
+            // An unreadable payload is an ERROR, never "nothing pinned".
+            let loud = Paragraph::new("▌ watchlist UNREADABLE — malformed host data")
+                .style(Style::new().fg(crate::theme::CRIMSON));
+            frame.render_widget(loud, inner);
+            return;
+        }
         if self.rows.is_empty() {
             let absence = Paragraph::new(ABSENCE_TEXT);
             frame.render_widget(absence, inner);
@@ -126,8 +146,10 @@ impl WatchlistView {
 }
 
 /// Renders one row object generically: `"subject"`'s value first, then
-/// every other key (sorted, `serde_json::Map`'s deterministic default
-/// order) as `key: value`. A row with no `"subject"` string still renders
+/// every other key (sorted EXPLICITLY — the crate enables `serde_json`'s
+/// `preserve_order` feature for the peek plates, so map iteration is
+/// insertion order and this view's sorted display must not lean on it)
+/// as `key: value`. A row with no `"subject"` string still renders
 /// its other fields — never silently dropped (Constitution III.11) — just
 /// unopenable (see [`WatchlistView::handle_key`]).
 fn row_text(row: &Value) -> String {
@@ -139,11 +161,12 @@ fn row_text(row: &Value) -> String {
         .and_then(Value::as_str)
         .unwrap_or("(no subject)");
     let mut parts = vec![subject.to_string()];
-    for (key, value) in object {
-        if key == "subject" {
-            continue;
+    let mut keys: Vec<&String> = object.keys().filter(|k| *k != "subject").collect();
+    keys.sort();
+    for key in keys {
+        if let Some(value) = object.get(key) {
+            parts.push(format!("{key}: {}", format_value(value)));
         }
-        parts.push(format!("{key}: {}", format_value(value)));
     }
     parts.join("  ")
 }

--- a/rust/crates/babylon-tui/src/views/wiki.rs
+++ b/rust/crates/babylon-tui/src/views/wiki.rs
@@ -1,29 +1,65 @@
 //! The Archive reading view: renders one wiki page and its link spans, with
-//! vim-style jumplist navigation (`Ctrl-O`/`Ctrl-I`, `[`/`]`; plan Task 15).
+//! vim-style jumplist navigation (`Ctrl-O`/`Ctrl-I`, `[`/`]`; plan Task 15),
+//! a keyboard link cursor (`n`/`p` — keyboard peek is first-class, mouse
+//! hover is never load-bearing, per the S7 canon `peek.rs` quotes), and a
+//! "What links here" backlinks footer (the Task 17 read path's consumer —
+//! ADR109: a seam without a caller is an unclosed motion).
 //!
 //! Mirrors the jumplist semantics of `babylon.tui.nav.JumplistState` (visit
 //! truncates forward history; `back`/`forward` are idempotent at the edges)
 //! but is not a line-for-line port: [`WikiView`] stores plain subject
 //! strings with no Pydantic model and no persistence seam — M1 is
 //! read-only, and `NavPersistence` stays a Python-side concern for M2.
+//!
+//! **Wrapping**: pages wrap to the pane width with a span-preserving greedy
+//! word wrap done HERE, not by `Paragraph::wrap` — the layout registry and
+//! the link cursor need to know exactly which display cells each wikilink
+//! occupies, and ratatui's own wrapping discards that mapping. babylon-md
+//! folds Markdown soft breaks into long logical lines, so without this every
+//! real vault paragraph would clip at the pane edge unreachably (the M1
+//! verify panel's finding). Continuation rows do not repeat block prefixes
+//! (a wrapped blockquote row loses its `▌ ` gutter) — accepted for M1.
 
 use std::collections::BTreeSet;
 
 use ratatui::crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::layout::Rect;
-use ratatui::text::Line;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Paragraph};
 use ratatui::Frame;
+use unicode_width::UnicodeWidthStr;
 
 use crate::host::Host;
 use crate::layout_registry::{LayoutRegistry, WidgetId};
 use crate::router::BabylonTarget;
+use crate::theme::{DIM, GOLD};
 use crate::views::msg::AppEvent;
-use crate::wiki_render::{render_page, LinkPosition};
+use crate::wiki_render::render_page;
 
 /// Lines scrolled per `PageUp`/`PageDown` — a display constant for this
 /// view, not a `GameDefines` coefficient (no gameplay tuning involved).
 const PAGE_SCROLL: u16 = 10;
+
+/// One navigable link in the laid-out page: a target plus the display-cell
+/// segments its label occupies (row, col start, col end — cols relative to
+/// the pane's inner area, rows relative to the unscrolled layout).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LinkHit {
+    target: String,
+    segments: Vec<(usize, u16, u16)>,
+}
+
+/// The wrapped, hit-mapped layout of the current page at one pane width.
+#[derive(Debug, Default)]
+struct PageLayout {
+    /// Width the layout was computed for (`0` = layout absent/stale).
+    width: u16,
+    /// Display rows (already wrapped; index = unscrolled row).
+    rows: Vec<Line<'static>>,
+    /// Navigable links in document order (content links, then backlinks).
+    hits: Vec<LinkHit>,
+}
 
 /// The Archive reading view over one open wiki page.
 ///
@@ -46,11 +82,20 @@ pub struct WikiView {
     /// Index of `current` within `jumplist`; meaningless while `jumplist`
     /// is empty.
     pub jumplist_idx: usize,
-    /// Vertical scroll offset (rows), saturating at both ends.
+    /// Vertical scroll offset (rows), clamped to the content in `render`.
     scroll: u16,
     /// The raw Markdown for `current`, cached on `open` so `render` never
     /// touches the host (design §4 — the seam is crossed once, on demand).
     page_markdown: String,
+    /// Subjects linking TO `current` (the Task 17 backlink read path),
+    /// fetched on `open`, rendered as the "What links here" footer.
+    backlinks: Vec<String>,
+    /// The wrapped layout, rebuilt lazily when the pane width changes.
+    layout: PageLayout,
+    /// Keyboard link cursor: index into `layout.hits` (`None` = no focus).
+    cursor: Option<usize>,
+    /// Inner pane height seen at the last render (scroll clamp input).
+    last_height: u16,
 }
 
 impl WikiView {
@@ -82,8 +127,8 @@ impl WikiView {
     }
 
     /// Navigate to `target`: resolve its subject, load the page (or render
-    /// the honest-absence page when the host has none), and record the
-    /// visit in the jumplist.
+    /// the honest-absence page when the host has none), fetch its
+    /// backlinks, and record the visit in the jumplist.
     ///
     /// Truncates any forward history when opening from mid-jumplist (the
     /// browser-navigation convention, `JumplistState.visit`) and is
@@ -98,9 +143,25 @@ impl WikiView {
             Ok(Some(markdown)) => markdown,
             Ok(None) | Err(_) => Self::honest_absence_page(&subject),
         };
+        let raw_backlinks = host.backlinks_json(&subject);
+        self.backlinks = serde_json::from_str(&raw_backlinks).unwrap_or_default();
         self.push_jump(&subject);
         self.page_markdown = page;
         self.scroll = 0;
+        self.cursor = None;
+        self.layout = PageLayout::default();
+    }
+
+    /// Show a synthetic page (the shell's loud-failure channel) without
+    /// touching the host — used for campaign-load failures, which must
+    /// never render as an empty world (Constitution III.11).
+    pub fn open_page(&mut self, subject: &str, markdown: String) {
+        self.backlinks = Vec::new();
+        self.push_jump(subject);
+        self.page_markdown = markdown;
+        self.scroll = 0;
+        self.cursor = None;
+        self.layout = PageLayout::default();
     }
 
     /// Record a visit in the jumplist (the `JumplistState.visit` port).
@@ -148,18 +209,60 @@ impl WikiView {
         Some(subject)
     }
 
+    /// The link target the keyboard cursor currently focuses, if any —
+    /// the app shell feeds this to the peek overlay (keyboard peek is
+    /// first-class; mouse hover is never load-bearing).
+    #[must_use]
+    pub fn focused_target(&self) -> Option<&str> {
+        self.cursor
+            .and_then(|idx| self.layout.hits.get(idx))
+            .map(|hit| hit.target.as_str())
+    }
+
+    /// Move the link cursor by `delta` (wrapping), scrolling the focused
+    /// link into view.
+    fn move_cursor(&mut self, delta: isize) {
+        let count = self.layout.hits.len();
+        if count == 0 {
+            return;
+        }
+        let next = match self.cursor {
+            None if delta >= 0 => 0,
+            None => count - 1,
+            Some(idx) => (idx as isize + delta).rem_euclid(count as isize) as usize,
+        };
+        self.cursor = Some(next);
+        if let Some(first_row) = self.layout.hits[next].segments.first().map(|s| s.0) {
+            let row = first_row as u16;
+            let height = self.last_height.max(1);
+            if row < self.scroll {
+                self.scroll = row;
+            } else if row >= self.scroll + height {
+                self.scroll = row + 1 - height;
+            }
+        }
+    }
+
+    /// The largest useful scroll offset for the current layout (the last
+    /// content row rests on the bottom pane row; 0 while content fits).
+    fn max_scroll(&self) -> u16 {
+        let rows = self.layout.rows.len() as u16;
+        rows.saturating_sub(self.last_height.max(1))
+    }
+
     /// Handle one key event, returning the app event (if any) to route.
     ///
-    /// `[` and `Ctrl-O` walk back; `]` and `Ctrl-I` walk forward — both
-    /// emit `AppEvent::OpenSubject` for the shell to re-open. `Up`/`Down`
-    /// adjust scroll by one row, `PageUp`/`PageDown` by `PAGE_SCROLL`
-    /// rows, both saturating. `q`/`Esc` emit `AppEvent::Back`.
+    /// `[`/`Ctrl-O` walk back; `]`/`Ctrl-I` walk forward — both emit
+    /// `AppEvent::OpenSubject` for the shell to re-open. `n`/`p` move the
+    /// keyboard link cursor (next/previous, wrapping) and `Enter` opens the
+    /// focused link. `Up`/`Down` scroll by one row, `PageUp`/`PageDown` by
+    /// `PAGE_SCROLL`, clamped to the content. `q`/`Esc` emit
+    /// `AppEvent::Back`.
     ///
     /// Takes `modifiers` in addition to `code` — a deliberate deviation
     /// from the crate's other views (`LobbyView::handle_key` takes only
     /// `code`): `Ctrl-O`/`Ctrl-I` are not representable in `KeyCode` alone,
-    /// only via `KeyModifiers::CONTROL`. See the task report for the full
-    /// rationale.
+    /// only via `KeyModifiers::CONTROL`.
     pub fn handle_key(&mut self, code: KeyCode, modifiers: KeyModifiers) -> Option<AppEvent> {
         let ctrl = modifiers.contains(KeyModifiers::CONTROL);
         match code {
@@ -167,12 +270,23 @@ impl WikiView {
             KeyCode::Char(']') => self.forward().map(AppEvent::OpenSubject),
             KeyCode::Char('o' | 'O') if ctrl => self.back().map(AppEvent::OpenSubject),
             KeyCode::Char('i' | 'I') if ctrl => self.forward().map(AppEvent::OpenSubject),
+            KeyCode::Char('n') => {
+                self.move_cursor(1);
+                None
+            }
+            KeyCode::Char('p') => {
+                self.move_cursor(-1);
+                None
+            }
+            KeyCode::Enter => self
+                .focused_target()
+                .map(|target| AppEvent::OpenSubject(target.to_string())),
             KeyCode::Up => {
                 self.scroll = self.scroll.saturating_sub(1);
                 None
             }
             KeyCode::Down => {
-                self.scroll = self.scroll.saturating_add(1);
+                self.scroll = self.scroll.saturating_add(1).min(self.max_scroll());
                 None
             }
             KeyCode::PageUp => {
@@ -180,7 +294,10 @@ impl WikiView {
                 None
             }
             KeyCode::PageDown => {
-                self.scroll = self.scroll.saturating_add(PAGE_SCROLL);
+                self.scroll = self
+                    .scroll
+                    .saturating_add(PAGE_SCROLL)
+                    .min(self.max_scroll());
                 None
             }
             KeyCode::Char('q') | KeyCode::Esc => Some(AppEvent::Back),
@@ -188,46 +305,58 @@ impl WikiView {
         }
     }
 
+    /// Rebuild the wrapped layout when the pane width changed.
+    fn ensure_layout(&mut self, width: u16, known: &BTreeSet<String>) {
+        if self.layout.width == width && width != 0 {
+            return;
+        }
+        self.layout = build_layout(&self.page_markdown, &self.backlinks, width, known);
+        self.cursor = self.cursor.filter(|idx| *idx < self.layout.hits.len());
+    }
+
     /// Render the cached page into `area` of `frame`.
     ///
-    /// Pipeline: `page_markdown` → [`render_page`] → a scrolled, bordered
-    /// `Paragraph`, then every returned `LinkSpan`'s on-screen rect is
-    /// registered into `registry` (entity = the link target), accounting
-    /// for the current scroll offset and the block's border inset. A link
-    /// scrolled entirely out of the visible area is not registered.
+    /// Pipeline: `page_markdown` → [`render_page`] → span-preserving word
+    /// wrap (+ the backlinks footer) → a scrolled, bordered `Paragraph`;
+    /// every visible link segment registers into `registry` (entity = the
+    /// link target) and the keyboard-focused link renders reversed.
     pub fn render(
-        &self,
+        &mut self,
         frame: &mut Frame<'_>,
         area: Rect,
         registry: &mut LayoutRegistry,
         known: &BTreeSet<String>,
     ) {
-        let title = self.current.as_deref().unwrap_or("Wiki");
+        let title = self.current.as_deref().unwrap_or("Wiki").to_string();
         let block = Block::bordered().title(title);
         let inner = block.inner(area);
-        let (text, links) = render_page(&self.page_markdown, inner.width, known);
-        let paragraph = Paragraph::new(text.clone())
-            .block(block)
-            .scroll((self.scroll, 0));
+        self.last_height = inner.height;
+        self.ensure_layout(inner.width, known);
+        self.scroll = self.scroll.min(self.max_scroll());
+
+        let focused: Vec<(usize, u16, u16)> = self
+            .cursor
+            .and_then(|idx| self.layout.hits.get(idx))
+            .map(|hit| hit.segments.clone())
+            .unwrap_or_default();
+        let mut rows = self.layout.rows.clone();
+        for (row, col_start, col_end) in &focused {
+            if let Some(line) = rows.get_mut(*row) {
+                *line = highlight_segment(line, *col_start, *col_end);
+            }
+        }
+
+        let paragraph = Paragraph::new(rows).block(block).scroll((self.scroll, 0));
         frame.render_widget(paragraph, area);
 
-        for (idx, link) in links.iter().enumerate() {
-            let Some(pos) = &link.position else {
-                continue;
-            };
-            for line_idx in pos.start_line..=pos.end_line {
-                let Some(line) = text.lines.get(line_idx) else {
-                    continue;
-                };
-                let Some((col_start, col_end)) = column_range(line, pos, line_idx) else {
-                    continue;
-                };
-                let screen_row = line_idx as i64 - i64::from(self.scroll);
+        for (idx, hit) in self.layout.hits.iter().enumerate() {
+            for (row, col_start, col_end) in &hit.segments {
+                let screen_row = *row as i64 - i64::from(self.scroll);
                 if screen_row < 0 || screen_row as u16 >= inner.height {
                     continue; // scrolled out of view
                 }
-                let col_start = col_start.min(inner.width as usize) as u16;
-                let col_end = col_end.min(inner.width as usize) as u16;
+                let col_start = (*col_start).min(inner.width);
+                let col_end = (*col_end).min(inner.width);
                 if col_end <= col_start {
                     continue;
                 }
@@ -237,39 +366,285 @@ impl WikiView {
                     width: col_end - col_start,
                     height: 1,
                 };
-                registry.register(WidgetId(idx as u32), rect, Some(link.target.clone()));
+                registry.register(WidgetId(idx as u32), rect, Some(hit.target.clone()));
             }
         }
     }
 }
 
-/// The `[start, end)` column range `pos` covers on `line_idx` of `line`
-/// (display-cell widths, not byte offsets — wide glyphs count correctly).
-///
-/// `start_span` is inclusive, `end_span` exclusive (the `LinkPosition`
-/// contract); a line strictly between `start_line` and `end_line` is
-/// covered in full — the case of a link label wrapped across more than
-/// two display lines.
-fn column_range(line: &Line<'_>, pos: &LinkPosition, line_idx: usize) -> Option<(usize, usize)> {
-    let spans = &line.spans;
-    let width_before = |upto: usize| -> usize {
-        spans
-            .iter()
-            .take(upto)
-            .map(ratatui::text::Span::width)
-            .sum()
-    };
-    let line_width: usize = spans.iter().map(ratatui::text::Span::width).sum();
+/// One wrap-unit: a word or run of spaces from one source span, with its
+/// provenance (source line + span index) for link-range mapping.
+#[derive(Debug, Clone)]
+struct Chunk {
+    text: String,
+    style: Style,
+    orig_line: usize,
+    orig_span: usize,
+}
 
-    let start = if line_idx == pos.start_line {
-        width_before(pos.start_span)
-    } else {
-        0
-    };
-    let end = if line_idx == pos.end_line {
-        width_before(pos.end_span)
-    } else {
-        line_width
-    };
-    Some((start, end))
+impl Chunk {
+    fn width(&self) -> u16 {
+        self.text.as_str().width() as u16
+    }
+}
+
+/// Re-style `[col_start, col_end)` of `line` with `REVERSED` (the keyboard
+/// link-cursor highlight), splitting spans at the boundaries.
+fn highlight_segment(line: &Line<'static>, col_start: u16, col_end: u16) -> Line<'static> {
+    let mut out: Vec<Span<'static>> = Vec::new();
+    let mut col: u16 = 0;
+    for span in &line.spans {
+        let w = span.content.as_ref().width() as u16;
+        let (start, end) = (col, col + w);
+        if end <= col_start || start >= col_end {
+            out.push(span.clone());
+        } else {
+            // Split by display cells; labels are narrow so a char walk is fine.
+            let mut acc_plain = String::new();
+            let mut acc_hot = String::new();
+            let mut acc_tail = String::new();
+            let mut c = start;
+            for ch in span.content.chars() {
+                let cw = ch.to_string().as_str().width() as u16;
+                if c + cw <= col_start {
+                    acc_plain.push(ch);
+                } else if c < col_end {
+                    acc_hot.push(ch);
+                } else {
+                    acc_tail.push(ch);
+                }
+                c += cw;
+            }
+            if !acc_plain.is_empty() {
+                out.push(Span::styled(acc_plain, span.style));
+            }
+            if !acc_hot.is_empty() {
+                out.push(Span::styled(
+                    acc_hot,
+                    span.style.add_modifier(Modifier::REVERSED),
+                ));
+            }
+            if !acc_tail.is_empty() {
+                out.push(Span::styled(acc_tail, span.style));
+            }
+        }
+        col += w;
+    }
+    let mut new_line = Line::from(out);
+    new_line.style = line.style;
+    new_line.alignment = line.alignment;
+    new_line
+}
+
+/// Build the wrapped, hit-mapped layout: render the page, word-wrap it to
+/// `width` preserving span provenance, map each wikilink's span range to
+/// display segments, then append the "What links here" footer (each
+/// backlink itself a navigable hit).
+fn build_layout(
+    markdown: &str,
+    backlinks: &[String],
+    width: u16,
+    known: &BTreeSet<String>,
+) -> PageLayout {
+    let width = width.max(1);
+    let (text, links) = render_page(markdown, width, known);
+
+    let mut rows: Vec<Line<'static>> = Vec::new();
+    // Per placed row: the chunks with provenance, for link mapping.
+    let mut placed: Vec<Vec<(Chunk, u16, u16)>> = Vec::new();
+
+    for (orig_line, line) in text.lines.iter().enumerate() {
+        let chunks = chop_line(line, orig_line);
+        let wrapped = wrap_chunks(&chunks, width);
+        if wrapped.is_empty() {
+            rows.push(Line::default().style(line.style));
+            placed.push(Vec::new());
+            continue;
+        }
+        for row_chunks in wrapped {
+            let mut spans: Vec<Span<'static>> = Vec::new();
+            let mut with_cols: Vec<(Chunk, u16, u16)> = Vec::new();
+            let mut col: u16 = 0;
+            for chunk in row_chunks {
+                let w = chunk.width();
+                spans.push(Span::styled(chunk.text.clone(), chunk.style));
+                with_cols.push((chunk, col, col + w));
+                col += w;
+            }
+            let mut new_line = Line::from(spans);
+            new_line.style = line.style;
+            rows.push(new_line);
+            placed.push(with_cols);
+        }
+    }
+
+    // Map each wikilink's (line, span) range onto placed display segments.
+    let mut hits: Vec<LinkHit> = Vec::new();
+    for link in &links {
+        let Some(pos) = &link.position else { continue };
+        let in_range = |chunk: &Chunk| {
+            let at = (chunk.orig_line, chunk.orig_span);
+            at >= (pos.start_line, pos.start_span)
+                && (chunk.orig_line < pos.end_line
+                    || (chunk.orig_line == pos.end_line && chunk.orig_span < pos.end_span))
+        };
+        let mut segments: Vec<(usize, u16, u16)> = Vec::new();
+        for (row, row_chunks) in placed.iter().enumerate() {
+            let mut run: Option<(u16, u16)> = None;
+            for (chunk, start, end) in row_chunks {
+                if in_range(chunk) && !chunk.text.trim().is_empty() {
+                    run = Some(match run {
+                        None => (*start, *end),
+                        Some((s, _)) => (s, *end),
+                    });
+                } else if let Some(done) = run.take() {
+                    segments.push((row, done.0, done.1));
+                }
+            }
+            if let Some(done) = run.take() {
+                segments.push((row, done.0, done.1));
+            }
+        }
+        if !segments.is_empty() {
+            hits.push(LinkHit {
+                target: link.target.clone(),
+                segments,
+            });
+        }
+    }
+
+    // The backlinks footer (ADR109: the Task 17 seam's consumer).
+    if !backlinks.is_empty() {
+        rows.push(Line::default());
+        rows.push(Line::from(Span::styled(
+            "── What links here ──",
+            Style::new().fg(DIM),
+        )));
+        for backlink in backlinks {
+            let row = rows.len();
+            let marker = "· ";
+            let col_start = marker.width() as u16;
+            let col_end = col_start + backlink.as_str().width() as u16;
+            rows.push(Line::from(vec![
+                Span::styled(marker, Style::new().fg(DIM)),
+                Span::styled(backlink.clone(), Style::new().fg(GOLD)),
+            ]));
+            hits.push(LinkHit {
+                target: backlink.clone(),
+                segments: vec![(row, col_start.min(width), col_end.min(width))],
+            });
+        }
+    }
+
+    PageLayout { width, rows, hits }
+}
+
+/// Split one source line's spans into word/space chunks with provenance.
+fn chop_line(line: &Line<'_>, orig_line: usize) -> Vec<Chunk> {
+    let mut chunks = Vec::new();
+    for (orig_span, span) in line.spans.iter().enumerate() {
+        let content = span.content.as_ref();
+        let mut current = String::new();
+        let mut current_is_space: Option<bool> = None;
+        for ch in content.chars() {
+            let is_space = ch == ' ';
+            if current_is_space != Some(is_space) && !current.is_empty() {
+                chunks.push(Chunk {
+                    text: std::mem::take(&mut current),
+                    style: span.style,
+                    orig_line,
+                    orig_span,
+                });
+            }
+            current_is_space = Some(is_space);
+            current.push(ch);
+        }
+        if !current.is_empty() {
+            chunks.push(Chunk {
+                text: current,
+                style: span.style,
+                orig_line,
+                orig_span,
+            });
+        }
+    }
+    chunks
+}
+
+/// Greedy word wrap of a chunk list to `width` display cells. A chunk wider
+/// than the whole pane splits at cell boundaries; leading spaces on a
+/// continuation row are dropped (standard greedy-wrap convention).
+fn wrap_chunks(chunks: &[Chunk], width: u16) -> Vec<Vec<Chunk>> {
+    let mut out: Vec<Vec<Chunk>> = Vec::new();
+    let mut row: Vec<Chunk> = Vec::new();
+    let mut col: u16 = 0;
+    for chunk in chunks {
+        let mut chunk = chunk.clone();
+        loop {
+            let w = chunk.width();
+            if col + w <= width {
+                col += w;
+                row.push(chunk);
+                break;
+            }
+            let is_space = chunk.text.starts_with(' ');
+            if !is_space && w <= width {
+                // Word fits on a fresh row: wrap first.
+                out.push(std::mem::take(&mut row));
+                col = 0;
+                continue;
+            }
+            if is_space {
+                // Spaces never carry onto a continuation row.
+                let keep = (width - col) as usize;
+                let kept: String = chunk.text.chars().take(keep).collect();
+                if !kept.is_empty() {
+                    row.push(Chunk {
+                        text: kept,
+                        ..chunk.clone()
+                    });
+                }
+                out.push(std::mem::take(&mut row));
+                col = 0;
+                break;
+            }
+            // A single word wider than the pane: hard-split at the edge.
+            let available = (width - col) as usize;
+            let mut head = String::new();
+            let mut used = 0usize;
+            let mut rest = String::new();
+            for ch in chunk.text.chars() {
+                let cw = ch.to_string().as_str().width();
+                if rest.is_empty() && used + cw <= available && cw > 0 {
+                    head.push(ch);
+                    used += cw;
+                } else {
+                    rest.push(ch);
+                }
+            }
+            if head.is_empty() {
+                // No room on this row at all: wrap and retry.
+                out.push(std::mem::take(&mut row));
+                col = 0;
+                continue;
+            }
+            row.push(Chunk {
+                text: head,
+                ..chunk.clone()
+            });
+            out.push(std::mem::take(&mut row));
+            col = 0;
+            chunk = Chunk {
+                text: rest,
+                ..chunk
+            };
+            if chunk.text.is_empty() {
+                break;
+            }
+        }
+    }
+    if !row.is_empty() {
+        out.push(row);
+    }
+    out
 }

--- a/rust/crates/babylon-tui/src/views/wiki.rs
+++ b/rust/crates/babylon-tui/src/views/wiki.rs
@@ -1,0 +1,275 @@
+//! The Archive reading view: renders one wiki page and its link spans, with
+//! vim-style jumplist navigation (`Ctrl-O`/`Ctrl-I`, `[`/`]`; plan Task 15).
+//!
+//! Mirrors the jumplist semantics of `babylon.tui.nav.JumplistState` (visit
+//! truncates forward history; `back`/`forward` are idempotent at the edges)
+//! but is not a line-for-line port: [`WikiView`] stores plain subject
+//! strings with no Pydantic model and no persistence seam — M1 is
+//! read-only, and `NavPersistence` stays a Python-side concern for M2.
+
+use std::collections::BTreeSet;
+
+use ratatui::crossterm::event::{KeyCode, KeyModifiers};
+use ratatui::layout::Rect;
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Paragraph};
+use ratatui::Frame;
+
+use crate::host::Host;
+use crate::layout_registry::{LayoutRegistry, WidgetId};
+use crate::router::BabylonTarget;
+use crate::views::msg::AppEvent;
+use crate::wiki_render::{render_page, LinkPosition};
+
+/// Lines scrolled per `PageUp`/`PageDown` — a display constant for this
+/// view, not a `GameDefines` coefficient (no gameplay tuning involved).
+const PAGE_SCROLL: u16 = 10;
+
+/// The Archive reading view over one open wiki page.
+///
+/// `jumplist`/`jumplist_idx` form a vim-style back-stack: `jumplist_idx`
+/// indexes into `jumplist` and is only meaningful while `jumplist` is
+/// non-empty (an empty jumplist means no page has ever been opened).
+#[derive(Debug, Default)]
+pub struct WikiView {
+    /// The subject the view is positioned at.
+    ///
+    /// Stays in sync with `jumplist[jumplist_idx]` through `open`, `back`
+    /// and `forward` alike — but note `back`/`forward` move the cursor
+    /// WITHOUT re-fetching `page_markdown` (see their docs): `current` can
+    /// therefore briefly name a subject the rendered page doesn't match
+    /// until the app shell re-opens it.
+    pub current: Option<String>,
+    /// Visited subjects, oldest first — the full back-stack, not merely a
+    /// display trail.
+    pub jumplist: Vec<String>,
+    /// Index of `current` within `jumplist`; meaningless while `jumplist`
+    /// is empty.
+    pub jumplist_idx: usize,
+    /// Vertical scroll offset (rows), saturating at both ends.
+    scroll: u16,
+    /// The raw Markdown for `current`, cached on `open` so `render` never
+    /// touches the host (design §4 — the seam is crossed once, on demand).
+    page_markdown: String,
+}
+
+impl WikiView {
+    /// A fresh view with no page open.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resolve `target` to the subject id the host indexes pages under.
+    ///
+    /// `Entity(id)` and `Redlink(id)` both resolve to the bare id;
+    /// `Kind{kind, id}` resolves to `"<kind>/<id>"` (mirrors
+    /// `nav.subject_for`'s explicit-kind branch). Unlike
+    /// `nav.subject_for`, a redlink resolves here rather than raising —
+    /// rendering the honest-absence page for exactly that case is this
+    /// view's job, not an error path.
+    fn resolve_subject(target: &BabylonTarget) -> String {
+        match target {
+            BabylonTarget::Entity(id) | BabylonTarget::Redlink(id) => id.clone(),
+            BabylonTarget::Kind { kind, id } => format!("{kind}/{id}"),
+        }
+    }
+
+    /// The deterministic honest-absence page for a subject with no
+    /// recorded page (Constitution III.11 — never fabricate content).
+    fn honest_absence_page(subject: &str) -> String {
+        format!("# {subject}\n\nNo page recorded for this subject.")
+    }
+
+    /// Navigate to `target`: resolve its subject, load the page (or render
+    /// the honest-absence page when the host has none), and record the
+    /// visit in the jumplist.
+    ///
+    /// Truncates any forward history when opening from mid-jumplist (the
+    /// browser-navigation convention, `JumplistState.visit`) and is
+    /// idempotent for the subject already current: re-opening the current
+    /// page leaves the jumplist untouched but still refreshes
+    /// `page_markdown` (the mechanism `back`/`forward` rely on the shell
+    /// to invoke via `AppEvent::OpenSubject`).
+    pub fn open(&mut self, target: &BabylonTarget, host: &dyn Host) {
+        let subject = Self::resolve_subject(target);
+        let raw = host.read_page_json(&subject);
+        let page = match serde_json::from_str::<Option<String>>(&raw) {
+            Ok(Some(markdown)) => markdown,
+            Ok(None) | Err(_) => Self::honest_absence_page(&subject),
+        };
+        self.push_jump(&subject);
+        self.page_markdown = page;
+        self.scroll = 0;
+    }
+
+    /// Record a visit in the jumplist (the `JumplistState.visit` port).
+    fn push_jump(&mut self, subject: &str) {
+        if self.current.as_deref() == Some(subject) {
+            return;
+        }
+        let kept_len = if self.jumplist.is_empty() {
+            0
+        } else {
+            self.jumplist_idx + 1
+        };
+        self.jumplist.truncate(kept_len);
+        self.jumplist.push(subject.to_string());
+        self.jumplist_idx = self.jumplist.len() - 1;
+        self.current = Some(subject.to_string());
+    }
+
+    /// Walk one step back (`Ctrl-O`/`[`); idempotent at the oldest entry.
+    ///
+    /// Returns the subject now positioned at (for the caller to re-open),
+    /// or `None` when already at the oldest entry (or the jumplist is
+    /// empty). Does not itself reload `page_markdown` — see the struct
+    /// docs on `current`.
+    pub fn back(&mut self) -> Option<String> {
+        if self.jumplist.is_empty() || self.jumplist_idx == 0 {
+            return None;
+        }
+        self.jumplist_idx -= 1;
+        let subject = self.jumplist[self.jumplist_idx].clone();
+        self.current = Some(subject.clone());
+        Some(subject)
+    }
+
+    /// Walk one step forward (`Ctrl-I`/`]`); idempotent at the newest entry.
+    ///
+    /// See [`Self::back`] for the re-open contract and the return shape.
+    pub fn forward(&mut self) -> Option<String> {
+        if self.jumplist.is_empty() || self.jumplist_idx + 1 >= self.jumplist.len() {
+            return None;
+        }
+        self.jumplist_idx += 1;
+        let subject = self.jumplist[self.jumplist_idx].clone();
+        self.current = Some(subject.clone());
+        Some(subject)
+    }
+
+    /// Handle one key event, returning the app event (if any) to route.
+    ///
+    /// `[` and `Ctrl-O` walk back; `]` and `Ctrl-I` walk forward — both
+    /// emit `AppEvent::OpenSubject` for the shell to re-open. `Up`/`Down`
+    /// adjust scroll by one row, `PageUp`/`PageDown` by `PAGE_SCROLL`
+    /// rows, both saturating. `q`/`Esc` emit `AppEvent::Back`.
+    ///
+    /// Takes `modifiers` in addition to `code` — a deliberate deviation
+    /// from the crate's other views (`LobbyView::handle_key` takes only
+    /// `code`): `Ctrl-O`/`Ctrl-I` are not representable in `KeyCode` alone,
+    /// only via `KeyModifiers::CONTROL`. See the task report for the full
+    /// rationale.
+    pub fn handle_key(&mut self, code: KeyCode, modifiers: KeyModifiers) -> Option<AppEvent> {
+        let ctrl = modifiers.contains(KeyModifiers::CONTROL);
+        match code {
+            KeyCode::Char('[') => self.back().map(AppEvent::OpenSubject),
+            KeyCode::Char(']') => self.forward().map(AppEvent::OpenSubject),
+            KeyCode::Char('o' | 'O') if ctrl => self.back().map(AppEvent::OpenSubject),
+            KeyCode::Char('i' | 'I') if ctrl => self.forward().map(AppEvent::OpenSubject),
+            KeyCode::Up => {
+                self.scroll = self.scroll.saturating_sub(1);
+                None
+            }
+            KeyCode::Down => {
+                self.scroll = self.scroll.saturating_add(1);
+                None
+            }
+            KeyCode::PageUp => {
+                self.scroll = self.scroll.saturating_sub(PAGE_SCROLL);
+                None
+            }
+            KeyCode::PageDown => {
+                self.scroll = self.scroll.saturating_add(PAGE_SCROLL);
+                None
+            }
+            KeyCode::Char('q') | KeyCode::Esc => Some(AppEvent::Back),
+            _ => None,
+        }
+    }
+
+    /// Render the cached page into `area` of `frame`.
+    ///
+    /// Pipeline: `page_markdown` → [`render_page`] → a scrolled, bordered
+    /// `Paragraph`, then every returned `LinkSpan`'s on-screen rect is
+    /// registered into `registry` (entity = the link target), accounting
+    /// for the current scroll offset and the block's border inset. A link
+    /// scrolled entirely out of the visible area is not registered.
+    pub fn render(
+        &self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        registry: &mut LayoutRegistry,
+        known: &BTreeSet<String>,
+    ) {
+        let title = self.current.as_deref().unwrap_or("Wiki");
+        let block = Block::bordered().title(title);
+        let inner = block.inner(area);
+        let (text, links) = render_page(&self.page_markdown, inner.width, known);
+        let paragraph = Paragraph::new(text.clone())
+            .block(block)
+            .scroll((self.scroll, 0));
+        frame.render_widget(paragraph, area);
+
+        for (idx, link) in links.iter().enumerate() {
+            let Some(pos) = &link.position else {
+                continue;
+            };
+            for line_idx in pos.start_line..=pos.end_line {
+                let Some(line) = text.lines.get(line_idx) else {
+                    continue;
+                };
+                let Some((col_start, col_end)) = column_range(line, pos, line_idx) else {
+                    continue;
+                };
+                let screen_row = line_idx as i64 - i64::from(self.scroll);
+                if screen_row < 0 || screen_row as u16 >= inner.height {
+                    continue; // scrolled out of view
+                }
+                let col_start = col_start.min(inner.width as usize) as u16;
+                let col_end = col_end.min(inner.width as usize) as u16;
+                if col_end <= col_start {
+                    continue;
+                }
+                let rect = Rect {
+                    x: inner.x + col_start,
+                    y: inner.y + screen_row as u16,
+                    width: col_end - col_start,
+                    height: 1,
+                };
+                registry.register(WidgetId(idx as u32), rect, Some(link.target.clone()));
+            }
+        }
+    }
+}
+
+/// The `[start, end)` column range `pos` covers on `line_idx` of `line`
+/// (display-cell widths, not byte offsets — wide glyphs count correctly).
+///
+/// `start_span` is inclusive, `end_span` exclusive (the `LinkPosition`
+/// contract); a line strictly between `start_line` and `end_line` is
+/// covered in full — the case of a link label wrapped across more than
+/// two display lines.
+fn column_range(line: &Line<'_>, pos: &LinkPosition, line_idx: usize) -> Option<(usize, usize)> {
+    let spans = &line.spans;
+    let width_before = |upto: usize| -> usize {
+        spans
+            .iter()
+            .take(upto)
+            .map(ratatui::text::Span::width)
+            .sum()
+    };
+    let line_width: usize = spans.iter().map(ratatui::text::Span::width).sum();
+
+    let start = if line_idx == pos.start_line {
+        width_before(pos.start_span)
+    } else {
+        0
+    };
+    let end = if line_idx == pos.end_line {
+        width_before(pos.end_span)
+    } else {
+        line_width
+    };
+    Some((start, end))
+}

--- a/rust/crates/babylon-tui/src/wiki_render.rs
+++ b/rust/crates/babylon-tui/src/wiki_render.rs
@@ -1,0 +1,157 @@
+//! Wiki page rendering: babylon-md plus the wikilink → [`LinkSpan`] side
+//! channel (plan Task 11).
+//!
+//! ratatui's `Span` has no metadata slot, so link identity travels OUT OF
+//! BAND: [`render_page`] returns the rendered [`Text`] together with a vec of
+//! [`LinkSpan`]s whose positions index into that text. The hit registry and
+//! hover/peek layers consume the side channel; the text stays plain ratatui.
+
+use std::collections::BTreeSet;
+
+use ratatui::text::Text;
+
+/// One wikilink discovered while rendering a page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkSpan {
+    /// The link target (the page subject the wikilink names).
+    pub target: String,
+    /// The visible label ([[t]] → `t`; [[t|Label]] → `Label`).
+    pub label: String,
+    /// Whether the target is a known page subject (false = redlink).
+    pub exists: bool,
+    /// Where the label sits in the returned text; `None` when the link was
+    /// rendered inside a buffered construct (table cell, image alt) whose
+    /// final position babylon-md cannot know.
+    pub position: Option<LinkPosition>,
+}
+
+/// Span coordinates of a link label inside the rendered [`Text`].
+///
+/// `start_span` is inclusive, `end_span` is exclusive, both within their
+/// respective lines; a label may cross lines when the source wraps.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkPosition {
+    /// Line index of the label's first span.
+    pub start_line: usize,
+    /// Span index of the label's first span within `start_line`.
+    pub start_span: usize,
+    /// Line index of the label's last span.
+    pub end_line: usize,
+    /// Span index just past the label's last span within `end_line`.
+    pub end_span: usize,
+}
+
+/// Render a page's Markdown into ratatui text plus the wikilink side channel.
+///
+/// `known` is the set of page subjects that exist in the vault: wikilinks
+/// whose target is absent from it are redlinks (`exists = false`, styled
+/// red). Empty source renders the honest-absence line (Constitution III.11),
+/// never a fabricated page. `_width` is reserved for wrap-aware hit mapping
+/// (M1 renders unwrapped; the scroll view handles overflow).
+pub fn render_page(
+    src: &str,
+    _width: u16,
+    known: &BTreeSet<String>,
+) -> (Text<'static>, Vec<LinkSpan>) {
+    if src.trim().is_empty() {
+        return (Text::from("No content recorded."), Vec::new());
+    }
+    let options = babylon_md::Options::default()
+        .parse_options(pulldown_cmark::Options::ENABLE_WIKILINKS);
+    let (text, infos) = babylon_md::from_str_with_options_and_links(src, &options);
+    let mut text = own_text(text);
+    let mut links = Vec::new();
+    for info in infos {
+        if !matches!(
+            info.link_type,
+            pulldown_cmark::LinkType::WikiLink { .. }
+        ) {
+            continue;
+        }
+        let target = info.dest;
+        let exists = known.contains(&target);
+        let position = info.location.map(|loc| LinkPosition {
+            start_line: loc.start_line,
+            start_span: loc.start_span,
+            end_line: loc.end_line,
+            end_span: loc.end_span,
+        });
+        let label = match &position {
+            Some(pos) => label_at(&text, pos),
+            // Buffered constructs lose position AND label; the target is the
+            // only honest stand-in (bare wikilinks label as their target).
+            None => target.clone(),
+        };
+        if !exists {
+            if let Some(pos) = &position {
+                restyle_redlink(&mut text, pos);
+            }
+        }
+        links.push(LinkSpan {
+            target,
+            label,
+            exists,
+            position,
+        });
+    }
+    (text, links)
+}
+
+/// Concatenate the span contents a [`LinkPosition`] covers.
+fn label_at(text: &Text<'_>, pos: &LinkPosition) -> String {
+    let mut out = String::new();
+    for (line_idx, line) in text.lines.iter().enumerate() {
+        if line_idx < pos.start_line || line_idx > pos.end_line {
+            continue;
+        }
+        for (span_idx, span) in line.spans.iter().enumerate() {
+            let before_start = line_idx == pos.start_line && span_idx < pos.start_span;
+            let past_end = line_idx == pos.end_line && span_idx >= pos.end_span;
+            if !(before_start || past_end) {
+                out.push_str(span.content.as_ref());
+            }
+        }
+    }
+    out
+}
+
+/// Restyle the spans a redlink label covers: red foreground over the link
+/// style, so a missing page is visually loud (Constitution III.11).
+fn restyle_redlink(text: &mut Text<'static>, pos: &LinkPosition) {
+    for (line_idx, line) in text.lines.iter_mut().enumerate() {
+        if line_idx < pos.start_line || line_idx > pos.end_line {
+            continue;
+        }
+        for (span_idx, span) in line.spans.iter_mut().enumerate() {
+            let before_start = line_idx == pos.start_line && span_idx < pos.start_span;
+            let past_end = line_idx == pos.end_line && span_idx >= pos.end_span;
+            if !(before_start || past_end) {
+                span.style = span.style.fg(ratatui::style::Color::Red);
+            }
+        }
+    }
+}
+
+/// Deep-copy a borrowed [`Text`] into an owned `Text<'static>`.
+fn own_text(text: Text<'_>) -> Text<'static> {
+    Text {
+        lines: text
+            .lines
+            .into_iter()
+            .map(|line| ratatui::text::Line {
+                spans: line
+                    .spans
+                    .into_iter()
+                    .map(|span| ratatui::text::Span {
+                        content: span.content.into_owned().into(),
+                        style: span.style,
+                    })
+                    .collect(),
+                style: line.style,
+                alignment: line.alignment,
+            })
+            .collect(),
+        style: text.style,
+        alignment: text.alignment,
+    }
+}

--- a/rust/crates/babylon-tui/src/wiki_render.rs
+++ b/rust/crates/babylon-tui/src/wiki_render.rs
@@ -79,10 +79,13 @@ pub fn render_page(
             // only honest stand-in (bare wikilinks label as their target).
             None => target.clone(),
         };
-        if !exists {
-            if let Some(pos) = &position {
-                restyle_redlink(&mut text, pos);
-            }
+        if let Some(pos) = &position {
+            let color = if exists {
+                crate::theme::GOLD
+            } else {
+                crate::theme::CRIMSON
+            };
+            restyle_link(&mut text, pos, color);
         }
         links.push(LinkSpan {
             target,
@@ -112,9 +115,10 @@ fn label_at(text: &Text<'_>, pos: &LinkPosition) -> String {
     out
 }
 
-/// Restyle the spans a redlink label covers: red foreground over the link
-/// style, so a missing page is visually loud (Constitution III.11).
-fn restyle_redlink(text: &mut Text<'static>, pos: &LinkPosition) {
+/// Restyle the spans a link label covers (ADR099: wikilinks carry their own
+/// visual register — gold for known targets, crimson for redlinks — instead
+/// of piggy-backing on the ordinary-link style).
+fn restyle_link(text: &mut Text<'static>, pos: &LinkPosition, color: ratatui::style::Color) {
     for (line_idx, line) in text.lines.iter_mut().enumerate() {
         if line_idx < pos.start_line || line_idx > pos.end_line {
             continue;
@@ -123,7 +127,7 @@ fn restyle_redlink(text: &mut Text<'static>, pos: &LinkPosition) {
             let before_start = line_idx == pos.start_line && span_idx < pos.start_span;
             let past_end = line_idx == pos.end_line && span_idx >= pos.end_span;
             if !(before_start || past_end) {
-                span.style = span.style.fg(ratatui::style::Color::Red);
+                span.style = span.style.fg(color);
             }
         }
     }

--- a/rust/crates/babylon-tui/src/wiki_render.rs
+++ b/rust/crates/babylon-tui/src/wiki_render.rs
@@ -15,7 +15,7 @@ use ratatui::text::Text;
 pub struct LinkSpan {
     /// The link target (the page subject the wikilink names).
     pub target: String,
-    /// The visible label ([[t]] → `t`; [[t|Label]] → `Label`).
+    /// The visible label (`[[t]]` → `t`; `[[t|Label]]` → `Label`).
     pub label: String,
     /// Whether the target is a known page subject (false = redlink).
     pub exists: bool,
@@ -56,16 +56,13 @@ pub fn render_page(
     if src.trim().is_empty() {
         return (Text::from("No content recorded."), Vec::new());
     }
-    let options = babylon_md::Options::default()
-        .parse_options(pulldown_cmark::Options::ENABLE_WIKILINKS);
+    let options =
+        babylon_md::Options::default().parse_options(pulldown_cmark::Options::ENABLE_WIKILINKS);
     let (text, infos) = babylon_md::from_str_with_options_and_links(src, &options);
     let mut text = own_text(text);
     let mut links = Vec::new();
     for info in infos {
-        if !matches!(
-            info.link_type,
-            pulldown_cmark::LinkType::WikiLink { .. }
-        ) {
+        if !matches!(info.link_type, pulldown_cmark::LinkType::WikiLink { .. }) {
             continue;
         }
         let target = info.dest;

--- a/rust/crates/babylon-tui/tests/app_shell.rs
+++ b/rust/crates/babylon-tui/tests/app_shell.rs
@@ -1,0 +1,175 @@
+//! Scripted-flow integration tests for the M1 app shell (plan Task 19):
+//! lobby → campaign briefing → link navigation → back → quit, driven
+//! entirely through the same key/mouse handlers the interactive loop and
+//! the headless script replay use.
+
+use babylon_tui::app::{key_event_from_name, App};
+use babylon_tui::config::AppConfig;
+use babylon_tui::host::Host;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::Terminal;
+
+struct FakeHost;
+
+impl Host for FakeHost {
+    fn lobby_catalog_json(&self) -> String {
+        r#"[{"campaign_id":"c1","name":"Wayne County","tick":3,
+            "status":"ACTIVE","defines_hash":"dh1","engine_version":"ev1"}]"#
+            .to_string()
+    }
+
+    fn read_page_json(&self, subject: &str) -> String {
+        let page = match subject {
+            "briefing/c1" => "# Briefing\n\nSee [[Detroit]].",
+            "Detroit" => "# Detroit\n\nThe motor city dossier.",
+            _ => return "null".to_string(),
+        };
+        serde_json::to_string(page).expect("fixture page encodes")
+    }
+
+    fn known_subjects_json(&self) -> String {
+        r#"["Detroit"]"#.to_string()
+    }
+}
+
+fn test_app() -> App<FakeHost> {
+    let cfg = AppConfig::from_json(
+        r#"{"campaign_id":"c1","campaign_name":"Wayne County","render_tier":"glyph",
+            "tutorial_enabled":false,"narrator_enabled":false,"headless":true}"#,
+    )
+    .expect("fixture config parses");
+    App::new(cfg, FakeHost)
+}
+
+fn render(app: &mut App<FakeHost>, terminal: &mut Terminal<TestBackend>) -> Buffer {
+    app.render_frame(terminal).expect("frame renders");
+    terminal.backend().buffer().clone()
+}
+
+fn buffer_text(buffer: &Buffer) -> String {
+    let area = buffer.area;
+    (0..area.height)
+        .map(|row| {
+            (0..area.width)
+                .map(|col| buffer[(col, row)].symbol())
+                .collect::<String>()
+                .trim_end()
+                .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn press(app: &mut App<FakeHost>, name: &str) -> bool {
+    let (code, modifiers) = key_event_from_name(name).expect("known key name");
+    app.handle_key(code, modifiers)
+}
+
+#[test]
+fn lobby_to_briefing_to_back_to_quit() {
+    let mut app = test_app();
+    let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("backend");
+
+    // Frame 1: the lobby root.
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(
+        frame.contains("Wayne County"),
+        "lobby row missing:\n{frame}"
+    );
+
+    // Enter loads the selected campaign → the briefing page (Textual
+    // parity: briefing/<campaign_id> is the first page after selection).
+    assert!(!press(&mut app, "enter"), "enter must not quit");
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(
+        frame.contains("Briefing"),
+        "briefing page missing:\n{frame}"
+    );
+    assert!(
+        frame.contains("Detroit"),
+        "briefing wikilink missing:\n{frame}"
+    );
+
+    // q pops back to the lobby (stack depth 2 → 1), not quit.
+    assert!(!press(&mut app, "q"), "q above the root pops, not quits");
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(frame.contains("CAMPAIGNS"), "lobby not restored:\n{frame}");
+
+    // q at the root quits.
+    assert!(press(&mut app, "q"), "q at the lobby root quits");
+
+    // Host-call order is the seam contract: catalog once (root build),
+    // known-subjects once (campaign entry), briefing page read once.
+    assert_eq!(
+        app.host_calls(),
+        vec![
+            "lobby_catalog_json".to_string(),
+            "known_subjects_json".to_string(),
+            "read_page_json".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn clicking_a_wikilink_navigates_to_its_page() {
+    let mut app = test_app();
+    let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("backend");
+
+    render(&mut app, &mut terminal);
+    press(&mut app, "enter");
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+
+    // Find "Detroit" on the rendered briefing page and click it. Hunting
+    // the coordinates from the frame keeps the test honest about where the
+    // registry actually placed the hit rect.
+    let (row, col) = frame
+        .lines()
+        .enumerate()
+        .find_map(|(row, line)| line.find("Detroit").map(|col| (row as u16, col as u16)))
+        .expect("briefing page shows the Detroit link");
+    let quit = app.handle_mouse(MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column: col,
+        row,
+        modifiers: KeyModifiers::NONE,
+    });
+    assert!(!quit);
+
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(
+        frame.contains("motor city dossier"),
+        "click did not open the Detroit page:\n{frame}"
+    );
+
+    // Two page reads crossed the seam: briefing, then Detroit.
+    let reads = app
+        .host_calls()
+        .iter()
+        .filter(|c| c.as_str() == "read_page_json")
+        .count();
+    assert_eq!(reads, 2);
+}
+
+#[test]
+fn palette_opens_filters_and_navigates() {
+    let mut app = test_app();
+    let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("backend");
+
+    render(&mut app, &mut terminal);
+    press(&mut app, "enter"); // into the campaign
+    press(&mut app, "/"); // palette over the wiki
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(
+        frame.contains("Detroit"),
+        "palette lists subjects:\n{frame}"
+    );
+
+    press(&mut app, "enter"); // accept the selected match
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(
+        frame.contains("motor city dossier"),
+        "palette enter did not navigate:\n{frame}"
+    );
+}

--- a/rust/crates/babylon-tui/tests/app_shell.rs
+++ b/rust/crates/babylon-tui/tests/app_shell.rs
@@ -15,7 +15,7 @@ struct FakeHost;
 
 impl Host for FakeHost {
     fn lobby_catalog_json(&self) -> String {
-        r#"[{"campaign_id":"c1","name":"Wayne County","tick":3,
+        r#"[{"campaign_id":"c1","name":"campaign-a3f9b2c1d0e5","codename":"Wayne County","tick":3,
             "status":"ACTIVE","defines_hash":"dh1","engine_version":"ev1"}]"#
             .to_string()
     }
@@ -31,6 +31,10 @@ impl Host for FakeHost {
 
     fn known_subjects_json(&self) -> String {
         r#"["Detroit"]"#.to_string()
+    }
+
+    fn load_campaign(&self, campaign_id: &str) -> String {
+        format!(r#"{{"ok": true, "campaign_id": "{campaign_id}"}}"#)
     }
 }
 
@@ -101,13 +105,16 @@ fn lobby_to_briefing_to_back_to_quit() {
     assert!(press(&mut app, "q"), "q at the lobby root quits");
 
     // Host-call order is the seam contract: catalog once (root build),
-    // known-subjects once (campaign entry), briefing page read once.
+    // the campaign BIND (the composition-root verb), known-subjects after
+    // the bind, then the briefing page read + its backlinks.
     assert_eq!(
         app.host_calls(),
         vec![
             "lobby_catalog_json".to_string(),
+            "load_campaign".to_string(),
             "known_subjects_json".to_string(),
             "read_page_json".to_string(),
+            "backlinks_json".to_string(),
         ]
     );
 }

--- a/rust/crates/babylon-tui/tests/fixtures/markdown/heading_fence.md
+++ b/rust/crates/babylon-tui/tests/fixtures/markdown/heading_fence.md
@@ -1,0 +1,7 @@
+# The Contradiction
+
+The principal contradiction sharpens.
+
+```rust
+fn main() {}
+```

--- a/rust/crates/babylon-tui/tests/fixtures/markdown/wikilinks.md
+++ b/rust/crates/babylon-tui/tests/fixtures/markdown/wikilinks.md
@@ -1,0 +1,3 @@
+# Detroit
+
+Class struggle in [[Detroit]] deepens; see [[Wayne County|the county]] and [[Atlantis]].

--- a/rust/crates/babylon-tui/tests/hello_frame.rs
+++ b/rust/crates/babylon-tui/tests/hello_frame.rs
@@ -7,7 +7,7 @@ impl Host for FakeHost {
         // The FULL row shape RustClientHost emits (host.py) — LobbyRow is
         // deliberately strict, so a fake omitting fields renders an empty
         // catalog (the M0 three-field fake did exactly that, silently).
-        r#"[{"campaign_id":"c1","name":"Wayne County","tick":0,
+        r#"[{"campaign_id":"c1","name":"campaign-a3f9b2c1d0e5","codename":"Wayne County","tick":0,
             "status":"ACTIVE","defines_hash":"dh1","engine_version":"ev1"}]"#
             .to_string()
     }

--- a/rust/crates/babylon-tui/tests/hello_frame.rs
+++ b/rust/crates/babylon-tui/tests/hello_frame.rs
@@ -4,7 +4,12 @@ use ratatui::{backend::TestBackend, Terminal};
 struct FakeHost;
 impl Host for FakeHost {
     fn lobby_catalog_json(&self) -> String {
-        r#"[{"campaign_id":"c1","name":"Wayne County","tick":0}]"#.to_string()
+        // The FULL row shape RustClientHost emits (host.py) — LobbyRow is
+        // deliberately strict, so a fake omitting fields renders an empty
+        // catalog (the M0 three-field fake did exactly that, silently).
+        r#"[{"campaign_id":"c1","name":"Wayne County","tick":0,
+            "status":"ACTIVE","defines_hash":"dh1","engine_version":"ev1"}]"#
+            .to_string()
     }
 }
 
@@ -15,7 +20,7 @@ fn hello_frame_shows_campaign() {
             "tutorial_enabled":false,"narrator_enabled":false,"headless":true}"#,
     )
     .unwrap();
-    let app = App::new(cfg, FakeHost);
+    let mut app = App::new(cfg, FakeHost);
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).unwrap();
     app.render_frame(&mut terminal).unwrap();

--- a/rust/crates/babylon-tui/tests/layout_registry.rs
+++ b/rust/crates/babylon-tui/tests/layout_registry.rs
@@ -1,0 +1,170 @@
+//! Contract tests for `LayoutRegistry::{register,hit,clear}` (plan Task 14).
+//!
+//! Pins the hit-test contract the hover/peek foundation depends on:
+//! innermost containing rect wins; a tie between equally-sized containing
+//! rects goes to whichever was registered last; a point outside every
+//! registered rect (or a registry with nothing registered yet, or one just
+//! `clear()`-ed) misses with `None`.
+
+use babylon_tui::layout_registry::{LayoutRegistry, WidgetId};
+use ratatui::layout::Rect;
+
+#[test]
+fn miss_on_an_empty_registry() {
+    let registry = LayoutRegistry::new();
+    assert_eq!(registry.hit(0, 0), None);
+}
+
+#[test]
+fn miss_on_a_point_outside_every_registered_rect() {
+    let mut registry = LayoutRegistry::new();
+    registry.register(
+        WidgetId(1),
+        Rect::new(0, 0, 10, 10),
+        Some("outer".to_string()),
+    );
+    assert_eq!(registry.hit(50, 50), None);
+}
+
+#[test]
+fn nested_rects_innermost_wins() {
+    let mut registry = LayoutRegistry::new();
+    registry.register(
+        WidgetId(1),
+        Rect::new(0, 0, 20, 20),
+        Some("outer".to_string()),
+    );
+    registry.register(
+        WidgetId(2),
+        Rect::new(5, 5, 5, 5),
+        Some("inner".to_string()),
+    );
+
+    let (id, area, entity) = registry
+        .hit(6, 6)
+        .expect("point (6,6) is inside both rects");
+    assert_eq!(*id, WidgetId(2));
+    assert_eq!(*area, Rect::new(5, 5, 5, 5));
+    assert_eq!(entity.as_deref(), Some("inner"));
+}
+
+#[test]
+fn nested_rects_innermost_wins_regardless_of_registration_order() {
+    let mut registry = LayoutRegistry::new();
+    // Inner registered first this time — the rule is area-based, not
+    // registration-order-based, so the outcome must not change.
+    registry.register(
+        WidgetId(2),
+        Rect::new(5, 5, 5, 5),
+        Some("inner".to_string()),
+    );
+    registry.register(
+        WidgetId(1),
+        Rect::new(0, 0, 20, 20),
+        Some("outer".to_string()),
+    );
+
+    let (id, _, entity) = registry
+        .hit(6, 6)
+        .expect("point (6,6) is inside both rects");
+    assert_eq!(*id, WidgetId(2));
+    assert_eq!(entity.as_deref(), Some("inner"));
+}
+
+#[test]
+fn overlapping_same_size_rects_last_registered_wins() {
+    let mut registry = LayoutRegistry::new();
+    registry.register(
+        WidgetId(1),
+        Rect::new(0, 0, 10, 10),
+        Some("first".to_string()),
+    );
+    registry.register(
+        WidgetId(2),
+        Rect::new(0, 0, 10, 10),
+        Some("second".to_string()),
+    );
+
+    let (id, _, entity) = registry
+        .hit(3, 3)
+        .expect("point (3,3) is inside both rects");
+    assert_eq!(*id, WidgetId(2));
+    assert_eq!(entity.as_deref(), Some("second"));
+}
+
+#[test]
+fn three_way_tie_last_registered_still_wins() {
+    let mut registry = LayoutRegistry::new();
+    registry.register(WidgetId(1), Rect::new(0, 0, 4, 4), Some("a".to_string()));
+    registry.register(WidgetId(2), Rect::new(0, 0, 4, 4), Some("b".to_string()));
+    registry.register(WidgetId(3), Rect::new(0, 0, 4, 4), Some("c".to_string()));
+
+    let (id, _, entity) = registry
+        .hit(1, 1)
+        .expect("point (1,1) is inside all three rects");
+    assert_eq!(*id, WidgetId(3));
+    assert_eq!(entity.as_deref(), Some("c"));
+}
+
+#[test]
+fn cleared_registry_misses_everything() {
+    let mut registry = LayoutRegistry::new();
+    registry.register(
+        WidgetId(1),
+        Rect::new(0, 0, 10, 10),
+        Some("outer".to_string()),
+    );
+    assert!(registry.hit(1, 1).is_some());
+
+    registry.clear();
+
+    assert_eq!(registry.hit(1, 1), None);
+}
+
+#[test]
+fn clear_then_register_starts_a_fresh_frame() {
+    let mut registry = LayoutRegistry::new();
+    registry.register(
+        WidgetId(1),
+        Rect::new(0, 0, 10, 10),
+        Some("stale".to_string()),
+    );
+    registry.clear();
+    registry.register(
+        WidgetId(2),
+        Rect::new(0, 0, 5, 5),
+        Some("fresh".to_string()),
+    );
+
+    let (id, _, entity) = registry
+        .hit(1, 1)
+        .expect("point (1,1) is inside the fresh rect");
+    assert_eq!(*id, WidgetId(2));
+    assert_eq!(entity.as_deref(), Some("fresh"));
+    // The stale rect's wider bounds are gone — a point that was only ever
+    // inside it now misses.
+    assert_eq!(registry.hit(7, 7), None);
+}
+
+#[test]
+fn hit_test_bounds_are_exclusive_on_the_right_and_bottom() {
+    let mut registry = LayoutRegistry::new();
+    registry.register(
+        WidgetId(1),
+        Rect::new(0, 0, 10, 10),
+        Some("box".to_string()),
+    );
+
+    assert!(registry.hit(9, 9).is_some());
+    assert_eq!(registry.hit(10, 10), None);
+}
+
+#[test]
+fn registered_entity_may_be_none() {
+    let mut registry = LayoutRegistry::new();
+    registry.register(WidgetId(1), Rect::new(0, 0, 10, 10), None);
+
+    let (id, _, entity) = registry.hit(1, 1).expect("point (1,1) is inside the rect");
+    assert_eq!(*id, WidgetId(1));
+    assert_eq!(*entity, None);
+}

--- a/rust/crates/babylon-tui/tests/lobby_view.rs
+++ b/rust/crates/babylon-tui/tests/lobby_view.rs
@@ -13,8 +13,8 @@ use ratatui::Terminal;
 /// Two rows, mirroring `Host::lobby_catalog_json`'s emitted shape
 /// (`src/babylon/tui/host.py`).
 const TWO_ROWS: &str = r#"[
-    {"campaign_id":"11111111-1111-1111-1111-111111111111","name":"Wayne County","tick":3,"status":"ACTIVE","defines_hash":"abc123","engine_version":"0.9.0"},
-    {"campaign_id":"22222222-2222-2222-2222-222222222222","name":"Cuyahoga Front","tick":0,"status":"ABANDONED","defines_hash":"def456","engine_version":"0.9.0"}
+    {"campaign_id":"11111111-1111-1111-1111-111111111111","name":"campaign-1111","codename":"Wayne County","tick":3,"status":"ACTIVE","defines_hash":"abc123","engine_version":"0.9.0"},
+    {"campaign_id":"22222222-2222-2222-2222-222222222222","name":"campaign-2222","codename":"Cuyahoga Front","tick":0,"status":"ABANDONED","defines_hash":"def456","engine_version":"0.9.0"}
 ]"#;
 
 /// Render `view` into a fresh `TestBackend` buffer of `width`x`height`.

--- a/rust/crates/babylon-tui/tests/lobby_view.rs
+++ b/rust/crates/babylon-tui/tests/lobby_view.rs
@@ -1,0 +1,206 @@
+//! `LobbyView` contract tests (plan Task 16).
+//!
+//! Explicit expected-content asserts over a `TestBackend` buffer — no insta
+//! snapshots (blessing needs a `cargo run` the parent session owns).
+
+use babylon_tui::views::lobby::LobbyView;
+use babylon_tui::views::msg::AppEvent;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::crossterm::event::KeyCode;
+use ratatui::Terminal;
+
+/// Two rows, mirroring `Host::lobby_catalog_json`'s emitted shape
+/// (`src/babylon/tui/host.py`).
+const TWO_ROWS: &str = r#"[
+    {"campaign_id":"11111111-1111-1111-1111-111111111111","name":"Wayne County","tick":3,"status":"ACTIVE","defines_hash":"abc123","engine_version":"0.9.0"},
+    {"campaign_id":"22222222-2222-2222-2222-222222222222","name":"Cuyahoga Front","tick":0,"status":"ABANDONED","defines_hash":"def456","engine_version":"0.9.0"}
+]"#;
+
+/// Render `view` into a fresh `TestBackend` buffer of `width`x`height`.
+fn render(view: &LobbyView, width: u16, height: u16) -> Buffer {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| view.render(frame, frame.area()))
+        .unwrap();
+    terminal.backend().buffer().clone()
+}
+
+/// Join the buffer's rows into one string for substring assertions
+/// (whitespace-preserving, so `contains` on a joined phrase still works
+/// within one row).
+fn buffer_lines(buf: &Buffer) -> Vec<String> {
+    let area = buf.area;
+    (0..area.height)
+        .map(|y| {
+            (0..area.width)
+                .map(|x| {
+                    buf.cell((area.x + x, area.y + y))
+                        .map(|c| c.symbol())
+                        .unwrap_or(" ")
+                })
+                .collect::<String>()
+        })
+        .collect()
+}
+
+fn buffer_text(buf: &Buffer) -> String {
+    buffer_lines(buf).join("\n")
+}
+
+#[test]
+fn populated_catalog_renders_all_rows_and_fields() {
+    let view = LobbyView::from_catalog_json(TWO_ROWS);
+    assert_eq!(view.rows.len(), 2);
+    let buf = render(&view, 80, 10);
+    let text = buffer_text(&buf);
+
+    assert!(text.contains("THE ARCHIVE"));
+    assert!(text.contains("CAMPAIGNS"));
+
+    assert!(text.contains("Wayne County"));
+    assert!(text.contains("Tick 3"));
+    assert!(text.contains("ACTIVE"));
+    assert!(text.contains("engine 0.9.0"));
+    assert!(text.contains("defines abc123"));
+
+    assert!(text.contains("Cuyahoga Front"));
+    assert!(text.contains("Tick 0"));
+    assert!(text.contains("ABANDONED"));
+    assert!(text.contains("defines def456"));
+}
+
+#[test]
+fn empty_catalog_renders_honest_absence() {
+    let view = LobbyView::from_catalog_json("[]");
+    assert!(view.rows.is_empty());
+    let buf = render(&view, 80, 10);
+    let text = buffer_text(&buf);
+    assert!(text.contains("No campaigns in the catalog."));
+    assert!(!text.contains("Wayne County"));
+}
+
+#[test]
+fn malformed_json_never_panics_and_yields_empty_catalog() {
+    let view = LobbyView::from_catalog_json("not json at all");
+    assert!(view.rows.is_empty());
+    assert_eq!(view.selected, 0);
+
+    let view_null = LobbyView::from_catalog_json("null");
+    assert!(view_null.rows.is_empty());
+
+    let view_blank = LobbyView::from_catalog_json("");
+    assert!(view_blank.rows.is_empty());
+}
+
+#[test]
+fn down_then_up_moves_selection_and_highlight_follows() {
+    let mut view = LobbyView::from_catalog_json(TWO_ROWS);
+    assert_eq!(view.selected, 0);
+
+    let event = view.handle_key(KeyCode::Down);
+    assert_eq!(event, None);
+    assert_eq!(view.selected, 1);
+    let buf = render(&view, 80, 10);
+    let lines = buffer_lines(&buf);
+    let cuyahoga_line = lines
+        .iter()
+        .find(|l| l.contains("Cuyahoga Front"))
+        .expect("Cuyahoga Front row present");
+    assert!(
+        cuyahoga_line.contains('>'),
+        "selected row should carry the highlight symbol"
+    );
+    let wayne_line = lines
+        .iter()
+        .find(|l| l.contains("Wayne County"))
+        .expect("Wayne County row present");
+    assert!(
+        !wayne_line.trim_start().starts_with('>'),
+        "unselected row should not be highlighted"
+    );
+
+    let event = view.handle_key(KeyCode::Up);
+    assert_eq!(event, None);
+    assert_eq!(view.selected, 0);
+}
+
+#[test]
+fn vim_keys_move_selection_same_as_arrows() {
+    let mut view = LobbyView::from_catalog_json(TWO_ROWS);
+    assert_eq!(view.handle_key(KeyCode::Char('j')), None);
+    assert_eq!(view.selected, 1);
+    assert_eq!(view.handle_key(KeyCode::Char('k')), None);
+    assert_eq!(view.selected, 0);
+}
+
+#[test]
+fn selection_saturates_at_both_ends() {
+    let mut view = LobbyView::from_catalog_json(TWO_ROWS);
+
+    // Up at index 0 stays at 0.
+    assert_eq!(view.handle_key(KeyCode::Up), None);
+    assert_eq!(view.selected, 0);
+
+    // Down past the last row stays at the last row.
+    assert_eq!(view.handle_key(KeyCode::Down), None);
+    assert_eq!(view.selected, 1);
+    assert_eq!(view.handle_key(KeyCode::Down), None);
+    assert_eq!(view.selected, 1);
+    assert_eq!(view.handle_key(KeyCode::Down), None);
+    assert_eq!(view.selected, 1);
+}
+
+#[test]
+fn enter_emits_load_campaign_for_the_selected_row() {
+    let mut view = LobbyView::from_catalog_json(TWO_ROWS);
+    view.selected = 1;
+    let event = view.handle_key(KeyCode::Enter);
+    assert_eq!(
+        event,
+        Some(AppEvent::LoadCampaign(
+            "22222222-2222-2222-2222-222222222222".to_string()
+        ))
+    );
+}
+
+#[test]
+fn enter_on_first_row_emits_its_own_campaign_id() {
+    let mut view = LobbyView::from_catalog_json(TWO_ROWS);
+    let event = view.handle_key(KeyCode::Enter);
+    assert_eq!(
+        event,
+        Some(AppEvent::LoadCampaign(
+            "11111111-1111-1111-1111-111111111111".to_string()
+        ))
+    );
+}
+
+#[test]
+fn enter_on_empty_catalog_emits_nothing() {
+    let mut view = LobbyView::from_catalog_json("[]");
+    assert_eq!(view.handle_key(KeyCode::Enter), None);
+}
+
+#[test]
+fn n_emits_new_campaign() {
+    let mut view = LobbyView::from_catalog_json(TWO_ROWS);
+    assert_eq!(
+        view.handle_key(KeyCode::Char('n')),
+        Some(AppEvent::NewCampaign)
+    );
+}
+
+#[test]
+fn q_and_esc_emit_quit() {
+    let mut view = LobbyView::from_catalog_json(TWO_ROWS);
+    assert_eq!(view.handle_key(KeyCode::Char('q')), Some(AppEvent::Quit));
+    assert_eq!(view.handle_key(KeyCode::Esc), Some(AppEvent::Quit));
+}
+
+#[test]
+fn unmapped_key_emits_nothing() {
+    let mut view = LobbyView::from_catalog_json(TWO_ROWS);
+    assert_eq!(view.handle_key(KeyCode::Char('z')), None);
+}

--- a/rust/crates/babylon-tui/tests/palette_view.rs
+++ b/rust/crates/babylon-tui/tests/palette_view.rs
@@ -1,0 +1,221 @@
+//! Behavior tests for `babylon_tui::views::palette::PaletteView`.
+//!
+//! The filtering case table below is read straight off the vendored
+//! Textual runtime — not invented — via:
+//!
+//!     .venv/bin/python3 -c "
+//!     import asyncio
+//!     from babylon.tui.palette import EntityNavigatorProvider
+//!     from textual.app import App, ComposeResult
+//!     from textual.widgets import Label
+//!
+//!     KNOWN = frozenset({'county/26163', 'county/48999', 'org/tenants-un', 'org/uaw-9999'})
+//!
+//!     class Host(App):
+//!         def __init__(self):
+//!             super().__init__()
+//!             self.known_entities = KNOWN
+//!         def compose(self):
+//!             yield Label('host')
+//!
+//!     async def main():
+//!         app = Host()
+//!         async with app.run_test():
+//!             provider = EntityNavigatorProvider(app.screen)
+//!             for q in ['county', 'tenants', 'org', 'un', '999', 'c26163',
+//!                       'county/26163', 'uaw', 'zzz']:
+//!                 hits = [hit async for hit in provider.search(q)]
+//!                 ranked = sorted(hits, key=lambda h: -h.score)
+//!                 print(repr(q), [h.text for h in ranked])
+//!
+//!     asyncio.run(main())
+//!
+//! (`''` is omitted from this table: `Provider.search("")` crashes inside
+//! Textual's own `FuzzySearch.score` — `palette.rs`'s module docs cover why
+//! `PaletteView` deliberately does not reproduce that call shape.)
+
+use babylon_tui::views::msg::AppEvent;
+use babylon_tui::views::palette::PaletteView;
+use ratatui::backend::TestBackend;
+use ratatui::crossterm::event::KeyCode;
+use ratatui::Terminal;
+
+const KNOWN_JSON: &str = r#"["county/26163", "county/48999", "org/tenants-un", "org/uaw-9999"]"#;
+
+/// Types `query` character-by-character, as the real key-event stream would.
+fn type_query(view: &mut PaletteView, query: &str) {
+    for c in query.chars() {
+        assert!(view.handle_key(KeyCode::Char(c)).is_none());
+    }
+}
+
+/// Dumps a `TestBackend` buffer's visible text, one line per row, for
+/// substring assertions.
+fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+    let buffer = terminal.backend().buffer();
+    let area = buffer.area;
+    let mut out = String::new();
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            out.push_str(buffer[(x, y)].symbol());
+        }
+        out.push('\n');
+    }
+    out
+}
+
+#[test]
+fn opens_with_every_known_subject_sorted_and_no_query() {
+    let view = PaletteView::open(KNOWN_JSON);
+    assert_eq!(view.query, "");
+    assert_eq!(
+        view.matches,
+        vec![
+            "county/26163",
+            "county/48999",
+            "org/tenants-un",
+            "org/uaw-9999"
+        ]
+    );
+    assert_eq!(view.selected, 0);
+}
+
+#[test]
+fn filters_a_tied_prefix_query_in_alphabetical_order() {
+    // Python: fs.match('county', ..) == 21.0 for both counties (an exact tie).
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "county");
+    assert_eq!(view.matches, vec!["county/26163", "county/48999"]);
+}
+
+#[test]
+fn filters_to_a_single_mid_word_substring_match() {
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "tenants");
+    assert_eq!(view.matches, vec!["org/tenants-un"]);
+}
+
+#[test]
+fn filters_a_tied_org_query_in_alphabetical_order() {
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "org");
+    assert_eq!(view.matches, vec!["org/tenants-un", "org/uaw-9999"]);
+}
+
+#[test]
+fn ranks_a_tighter_contiguous_match_above_a_looser_scattered_one() {
+    // Python: fs.match('999', 'org/uaw-9999') == 12.0 (contiguous digit run,
+    // a word start) > fs.match('999', 'county/48999') == 9.0 (scattered).
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "999");
+    assert_eq!(view.matches, vec!["org/uaw-9999", "county/48999"]);
+}
+
+#[test]
+fn filters_an_exact_full_id_query_to_only_that_id() {
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "county/26163");
+    assert_eq!(view.matches, vec!["county/26163"]);
+}
+
+#[test]
+fn filters_a_single_word_query() {
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "uaw");
+    assert_eq!(view.matches, vec!["org/uaw-9999"]);
+}
+
+#[test]
+fn a_query_matching_nothing_yields_an_empty_honest_list() {
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "zzz");
+    assert_eq!(view.matches, Vec::<String>::new());
+}
+
+#[test]
+fn backspace_removes_the_last_query_character_and_refilters() {
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "tenantz");
+    assert_eq!(view.matches, Vec::<String>::new());
+    assert!(view.handle_key(KeyCode::Backspace).is_none());
+    assert_eq!(view.query, "tenant");
+    assert_eq!(view.matches, vec!["org/tenants-un"]);
+}
+
+#[test]
+fn down_then_enter_opens_the_second_ranked_match() {
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "county");
+    assert_eq!(view.selected, 0);
+    assert!(view.handle_key(KeyCode::Down).is_none());
+    assert_eq!(view.selected, 1);
+    let event = view.handle_key(KeyCode::Enter);
+    assert_eq!(
+        event,
+        Some(AppEvent::OpenSubject("county/48999".to_string()))
+    );
+}
+
+#[test]
+fn up_at_the_top_row_stays_clamped_at_zero() {
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "county");
+    assert!(view.handle_key(KeyCode::Up).is_none());
+    assert_eq!(view.selected, 0);
+}
+
+#[test]
+fn down_at_the_last_row_stays_clamped() {
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "county");
+    assert!(view.handle_key(KeyCode::Down).is_none());
+    assert!(view.handle_key(KeyCode::Down).is_none());
+    assert_eq!(view.selected, 1); // only 2 matches: index can't exceed 1
+}
+
+#[test]
+fn enter_on_an_empty_match_list_emits_nothing() {
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "zzz");
+    assert_eq!(view.handle_key(KeyCode::Enter), None);
+}
+
+#[test]
+fn esc_emits_back() {
+    let mut view = PaletteView::open(KNOWN_JSON);
+    assert_eq!(view.handle_key(KeyCode::Esc), Some(AppEvent::Back));
+}
+
+#[test]
+fn a_malformed_catalog_opens_honestly_empty() {
+    let view = PaletteView::open("not json");
+    assert_eq!(view.matches, Vec::<String>::new());
+}
+
+#[test]
+fn render_shows_the_query_line_and_ranked_matches() {
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "county");
+    let backend = TestBackend::new(40, 12);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| view.render(frame, frame.area()))
+        .unwrap();
+    let text = buffer_text(&terminal);
+    assert!(text.contains("> county"), "{text}");
+    assert!(text.contains("county/26163"), "{text}");
+    assert!(text.contains("county/48999"), "{text}");
+}
+
+#[test]
+fn render_shows_the_honest_absence_line_when_nothing_matches() {
+    let mut view = PaletteView::open(KNOWN_JSON);
+    type_query(&mut view, "zzz");
+    let backend = TestBackend::new(40, 12);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| view.render(frame, frame.area()))
+        .unwrap();
+    let text = buffer_text(&terminal);
+    assert!(text.contains("no matching subjects"), "{text}");
+}

--- a/rust/crates/babylon-tui/tests/router.rs
+++ b/rust/crates/babylon-tui/tests/router.rs
@@ -95,6 +95,23 @@ fn it_round_trips_a_bare_wikilink_target() {
     assert_eq!(round_tripped, target);
 }
 
+#[test]
+fn it_formats_the_bare_form_through_the_wikilink_sentinel_like_python() {
+    // Python's format_babylon_uri emits `prefix = target.kind` and the bare
+    // kind IS "wikilink" — cross-implementation strings must round-trip.
+    let target = parse_babylon_uri("babylon://uaw-600").unwrap();
+    assert_eq!(format_babylon_uri(&target), "babylon://wikilink/uaw-600");
+}
+
+#[test]
+fn it_parses_the_python_emitted_sentinel_form_as_a_bare_entity() {
+    assert_eq!(
+        parse_babylon_uri("babylon://wikilink/uaw-600").unwrap(),
+        BabylonTarget::Entity("uaw-600".to_string()),
+        "the sentinel-prefixed bare form is the SAME target as babylon://uaw-600"
+    );
+}
+
 // --- TestBabylonTarget ---------------------------------------------------
 //
 // The Python suite's `test_it_is_frozen`, `test_it_rejects_an_empty_kind`,

--- a/rust/crates/babylon-tui/tests/router.rs
+++ b/rust/crates/babylon-tui/tests/router.rs
@@ -1,0 +1,107 @@
+//! Ports `tests/unit/tui/test_router.py` (babylon.tui.router) verbatim: every
+//! input/expected pair from the Python case table, against the Rust
+//! `BabylonTarget` enum contract (`Entity`/`Kind`/`Redlink`, not the Python
+//! module's `kind`/`entity_id`/`redlink` struct fields — see router.rs docs
+//! for the mapping).
+
+use babylon_tui::router::{format_babylon_uri, parse_babylon_uri, BabylonTarget, RouterError};
+
+// --- TestParseBabylonUri -----------------------------------------------
+
+#[test]
+fn it_parses_an_explicit_kind_href() {
+    let target = parse_babylon_uri("babylon://county/26163").unwrap();
+    assert_eq!(
+        target,
+        BabylonTarget::Kind {
+            kind: "county".to_string(),
+            id: "26163".to_string(),
+        }
+    );
+}
+
+#[test]
+fn it_parses_a_fully_bare_href_with_no_slash() {
+    let target = parse_babylon_uri("babylon://uaw-600").unwrap();
+    assert_eq!(target, BabylonTarget::Entity("uaw-600".to_string()));
+}
+
+#[test]
+fn it_parses_a_redlink_href() {
+    let target = parse_babylon_uri("babylon://redlink/org/uaw-9999").unwrap();
+    assert_eq!(target, BabylonTarget::Redlink("org/uaw-9999".to_string()));
+}
+
+#[test]
+fn it_parses_a_redlink_href_with_a_single_token_target() {
+    let target = parse_babylon_uri("babylon://redlink/uaw-9999").unwrap();
+    assert_eq!(target, BabylonTarget::Redlink("uaw-9999".to_string()));
+}
+
+#[test]
+fn it_rejects_a_non_babylon_scheme() {
+    let err = parse_babylon_uri("http://county/26163").unwrap_err();
+    assert!(matches!(err, RouterError::NotBabylonScheme(_)));
+    assert!(err.to_string().contains("not a babylon"));
+}
+
+#[test]
+fn it_rejects_a_uri_with_no_host_segment() {
+    let err = parse_babylon_uri("babylon:///26163").unwrap_err();
+    assert!(matches!(err, RouterError::MissingHost(_)));
+    assert!(err.to_string().contains("missing host"));
+}
+
+#[test]
+fn it_rejects_a_malformed_id_segment() {
+    let err = parse_babylon_uri("babylon://county/26 163").unwrap_err();
+    assert!(matches!(err, RouterError::MalformedEntityId(_)));
+    assert!(err.to_string().contains("malformed"));
+}
+
+#[test]
+fn it_rejects_a_malformed_kind_segment() {
+    let err = parse_babylon_uri("babylon://coun ty/26163").unwrap_err();
+    assert!(matches!(err, RouterError::MalformedKind(_)));
+    assert!(err.to_string().contains("malformed"));
+}
+
+#[test]
+fn it_rejects_an_empty_string() {
+    let err = parse_babylon_uri("").unwrap_err();
+    assert!(matches!(err, RouterError::NotBabylonScheme(_)));
+}
+
+// --- TestFormatBabylonUri -----------------------------------------------
+
+#[test]
+fn it_round_trips_an_explicit_kind_target() {
+    let target = parse_babylon_uri("babylon://county/26163").unwrap();
+    let round_tripped = parse_babylon_uri(&format_babylon_uri(&target)).unwrap();
+    assert_eq!(round_tripped, target);
+}
+
+#[test]
+fn it_round_trips_a_redlink_target() {
+    let target = parse_babylon_uri("babylon://redlink/org/uaw-9999").unwrap();
+    let round_tripped = parse_babylon_uri(&format_babylon_uri(&target)).unwrap();
+    assert_eq!(round_tripped, target);
+}
+
+#[test]
+fn it_round_trips_a_bare_wikilink_target() {
+    let target = parse_babylon_uri("babylon://uaw-600").unwrap();
+    let round_tripped = parse_babylon_uri(&format_babylon_uri(&target)).unwrap();
+    assert_eq!(round_tripped, target);
+}
+
+// --- TestBabylonTarget ---------------------------------------------------
+//
+// The Python suite's `test_it_is_frozen`, `test_it_rejects_an_empty_kind`,
+// and `test_it_rejects_an_empty_entity_id` exercise direct construction of
+// the pydantic `BabylonTarget` model (frozen + field validators). The Rust
+// `BabylonTarget` is a plain enum with no direct-construction validation —
+// those invariants aren't reachable through the pinned contract's surface,
+// only through `parse_babylon_uri`, whose character-class regexes already
+// require at least one character in every segment they accept. See this
+// test file's module doc and the final report for the deviation note.

--- a/rust/crates/babylon-tui/tests/snapshots/hello_frame__hello_frame_shows_campaign.snap
+++ b/rust/crates/babylon-tui/tests/snapshots/hello_frame__hello_frame_shows_campaign.snap
@@ -5,8 +5,8 @@ expression: "format!(\"{:?}\", buffer)"
 Buffer {
     area: Rect { x: 0, y: 0, width: 80, height: 24 },
     content: [
-        "┌The Archive — Wayne County────────────────────────────────────────────────────┐",
-        "│Wayne County  [c1] tick 0                                                     │",
+        "┌THE ARCHIVE — CAMPAIGNS───────────────────────────────────────────────────────┐",
+        "│> Wayne County  ·  Tick 0  ·  ACTIVE  ·  engine ev1  ·  defines dh1           │",
         "│                                                                              │",
         "│                                                                              │",
         "│                                                                              │",
@@ -32,5 +32,7 @@ Buffer {
     ],
     styles: [
         x: 0, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 1, y: 1, fg: Reset, bg: Reset, underline: Reset, modifier: REVERSED,
+        x: 79, y: 1, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
     ]
 }

--- a/rust/crates/babylon-tui/tests/watchlist_view.rs
+++ b/rust/crates/babylon-tui/tests/watchlist_view.rs
@@ -1,0 +1,139 @@
+//! Behavior tests for `babylon_tui::views::watchlist::WatchlistView`.
+//!
+//! The row shape here is deliberately generic (`serde_json::Value` objects,
+//! per the pinned `WatchlistView` contract) rather than a literal port of
+//! `babylon.tui.watchlist`'s `ProjectionRecord`-typed rows — see
+//! `watchlist.rs`'s module docs for why: the exact non-`"subject"` field
+//! set is Task 17's Python-owned schema, not yet on disk. What IS ported
+//! verbatim from `babylon.tui.watchlist`: the `"▌ watchlist — nothing
+//! pinned yet"` absence wording (`_absence_text`) and the read-only
+//! Up/Down/Enter/Esc row-navigation shape `watchlist_rows` exists to feed
+//! an `OptionList` with.
+
+use babylon_tui::views::msg::AppEvent;
+use babylon_tui::views::watchlist::WatchlistView;
+use ratatui::backend::TestBackend;
+use ratatui::crossterm::event::KeyCode;
+use ratatui::Terminal;
+
+const TWO_PINS_JSON: &str = r#"[
+    {"subject": "county/26163", "population": 1749343},
+    {"subject": "county/26125", "population": 1270432}
+]"#;
+
+/// Dumps a `TestBackend` buffer's visible text, one line per row, for
+/// substring assertions.
+fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+    let buffer = terminal.backend().buffer();
+    let area = buffer.area;
+    let mut out = String::new();
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            out.push_str(buffer[(x, y)].symbol());
+        }
+        out.push('\n');
+    }
+    out
+}
+
+#[test]
+fn opens_with_every_row_from_the_json_payload() {
+    let view = WatchlistView::open(TWO_PINS_JSON);
+    assert_eq!(view.rows.len(), 2);
+    assert_eq!(view.selected, 0);
+}
+
+#[test]
+fn a_malformed_payload_opens_honestly_empty() {
+    let view = WatchlistView::open("not json");
+    assert_eq!(view.rows.len(), 0);
+}
+
+#[test]
+fn an_absent_payload_opens_honestly_empty() {
+    let view = WatchlistView::open("[]");
+    assert_eq!(view.rows.len(), 0);
+}
+
+#[test]
+fn down_then_enter_opens_the_second_rows_subject() {
+    let mut view = WatchlistView::open(TWO_PINS_JSON);
+    assert!(view.handle_key(KeyCode::Down).is_none());
+    assert_eq!(view.selected, 1);
+    let event = view.handle_key(KeyCode::Enter);
+    assert_eq!(
+        event,
+        Some(AppEvent::OpenSubject("county/26125".to_string()))
+    );
+}
+
+#[test]
+fn enter_on_the_first_row_opens_its_subject() {
+    let mut view = WatchlistView::open(TWO_PINS_JSON);
+    let event = view.handle_key(KeyCode::Enter);
+    assert_eq!(
+        event,
+        Some(AppEvent::OpenSubject("county/26163".to_string()))
+    );
+}
+
+#[test]
+fn up_at_the_top_row_stays_clamped_at_zero() {
+    let mut view = WatchlistView::open(TWO_PINS_JSON);
+    assert!(view.handle_key(KeyCode::Up).is_none());
+    assert_eq!(view.selected, 0);
+}
+
+#[test]
+fn down_at_the_last_row_stays_clamped() {
+    let mut view = WatchlistView::open(TWO_PINS_JSON);
+    view.handle_key(KeyCode::Down);
+    view.handle_key(KeyCode::Down);
+    assert_eq!(view.selected, 1);
+}
+
+#[test]
+fn enter_on_an_empty_watchlist_emits_nothing() {
+    let mut view = WatchlistView::open("[]");
+    assert_eq!(view.handle_key(KeyCode::Enter), None);
+}
+
+#[test]
+fn enter_on_a_row_with_no_subject_field_emits_nothing() {
+    let mut view = WatchlistView::open(r#"[{"population": 42}]"#);
+    assert_eq!(view.handle_key(KeyCode::Enter), None);
+}
+
+#[test]
+fn esc_emits_back() {
+    let mut view = WatchlistView::open(TWO_PINS_JSON);
+    assert_eq!(view.handle_key(KeyCode::Esc), Some(AppEvent::Back));
+}
+
+#[test]
+fn render_shows_the_pin_count_title_and_row_fields() {
+    let view = WatchlistView::open(TWO_PINS_JSON);
+    let backend = TestBackend::new(50, 12);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| view.render(frame, frame.area()))
+        .unwrap();
+    let text = buffer_text(&terminal);
+    assert!(text.contains("Watchlist (2 pinned)"), "{text}");
+    assert!(text.contains("county/26163"), "{text}");
+    assert!(text.contains("population: 1749343"), "{text}");
+    assert!(text.contains("county/26125"), "{text}");
+}
+
+#[test]
+fn render_shows_the_honest_absence_line_and_zero_pin_count() {
+    let view = WatchlistView::open("[]");
+    let backend = TestBackend::new(50, 12);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| view.render(frame, frame.area()))
+        .unwrap();
+    let text = buffer_text(&terminal);
+    assert!(text.contains("Watchlist (0 pinned)"), "{text}");
+    assert!(text.contains("watchlist — nothing pinned yet"), "{text}");
+}

--- a/rust/crates/babylon-tui/tests/wiki_render.rs
+++ b/rust/crates/babylon-tui/tests/wiki_render.rs
@@ -6,8 +6,9 @@
 
 use std::collections::BTreeSet;
 
+use babylon_tui::theme::{CRIMSON, GOLD};
 use babylon_tui::wiki_render::{render_page, LinkPosition, LinkSpan};
-use ratatui::style::{Color, Modifier};
+use ratatui::style::Modifier;
 use ratatui::text::Text;
 
 const WIKILINKS: &str = include_str!("fixtures/markdown/wikilinks.md");
@@ -90,10 +91,19 @@ fn fence_block_renders_content() {
 
 #[test]
 fn known_wikilink_resolves() {
-    let (_, links) = render_page(WIKILINKS, 80, &known(&["Detroit", "Wayne County"]));
+    let (text, links) = render_page(WIKILINKS, 80, &known(&["Detroit", "Wayne County"]));
     let detroit = find_link(&links, "Detroit");
     assert!(detroit.exists, "Detroit is a known subject");
     assert_eq!(detroit.label, "Detroit", "bare [[t]] labels as the target");
+    let pos = detroit.position.as_ref().expect("main-flow link located");
+    let span = &text.lines[pos.start_line].spans[pos.start_span];
+    assert_eq!(
+        span.style.fg,
+        Some(GOLD),
+        "known wikilinks carry the ksbc gold (ADR099: their own visual \
+         register, distinct from ordinary links), got {:?}",
+        span.style
+    );
 }
 
 #[test]
@@ -117,8 +127,8 @@ fn unknown_wikilink_is_redlink() {
     let span = &line.spans[pos.start_span];
     assert_eq!(
         span.style.fg,
-        Some(Color::Red),
-        "redlink spans are styled red, got {:?}",
+        Some(CRIMSON),
+        "redlink spans carry the ksbc crimson (ADR099 visual register), got {:?}",
         span.style
     );
 }

--- a/rust/crates/babylon-tui/tests/wiki_render.rs
+++ b/rust/crates/babylon-tui/tests/wiki_render.rs
@@ -1,0 +1,162 @@
+//! Contract tests for `wiki_render::render_page` (plan Task 11).
+//!
+//! These encode the required behavior of the babylon-md fork's two patches:
+//! `ENABLE_WIKILINKS` passthrough (patch 1) and link-metadata retention
+//! (patch 2). They are written RED against the unpatched vendored crate.
+
+use std::collections::BTreeSet;
+
+use babylon_tui::wiki_render::{render_page, LinkPosition, LinkSpan};
+use ratatui::style::{Color, Modifier};
+use ratatui::text::Text;
+
+const WIKILINKS: &str = include_str!("fixtures/markdown/wikilinks.md");
+const HEADING_FENCE: &str = include_str!("fixtures/markdown/heading_fence.md");
+const EMPTY: &str = include_str!("fixtures/markdown/empty.md");
+
+fn known(subjects: &[&str]) -> BTreeSet<String> {
+    subjects.iter().map(|s| (*s).to_string()).collect()
+}
+
+fn rendered_string(text: &Text) -> String {
+    text.lines
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Concatenate the span contents a [`LinkPosition`] covers.
+fn label_at(text: &Text, pos: &LinkPosition) -> String {
+    let mut out = String::new();
+    for (line_idx, line) in text.lines.iter().enumerate() {
+        if line_idx < pos.start_line || line_idx > pos.end_line {
+            continue;
+        }
+        for (span_idx, span) in line.spans.iter().enumerate() {
+            let before_start = line_idx == pos.start_line && span_idx < pos.start_span;
+            let past_end = line_idx == pos.end_line && span_idx >= pos.end_span;
+            if before_start || past_end {
+                continue;
+            }
+            out.push_str(span.content.as_ref());
+        }
+    }
+    out
+}
+
+fn find_link<'a>(links: &'a [LinkSpan], target: &str) -> &'a LinkSpan {
+    links
+        .iter()
+        .find(|l| l.target == target)
+        .unwrap_or_else(|| panic!("no LinkSpan for target {target:?} in {links:?}"))
+}
+
+#[test]
+fn heading_renders_with_heading_style() {
+    let (text, _) = render_page(HEADING_FENCE, 80, &known(&[]));
+    let flat = rendered_string(&text);
+    assert!(
+        flat.contains("The Contradiction"),
+        "heading text missing from:\n{flat}"
+    );
+    let heading_line = text
+        .lines
+        .iter()
+        .find(|l| {
+            l.spans
+                .iter()
+                .any(|s| s.content.contains("The Contradiction"))
+        })
+        .expect("heading line present");
+    assert!(
+        heading_line.style.add_modifier.contains(Modifier::BOLD),
+        "heading line should carry the bold heading style, got {:?}",
+        heading_line.style
+    );
+}
+
+#[test]
+fn fence_block_renders_content() {
+    let (text, _) = render_page(HEADING_FENCE, 80, &known(&[]));
+    let flat = rendered_string(&text);
+    assert!(flat.contains("fn main()"), "fence content missing:\n{flat}");
+}
+
+#[test]
+fn known_wikilink_resolves() {
+    let (_, links) = render_page(WIKILINKS, 80, &known(&["Detroit", "Wayne County"]));
+    let detroit = find_link(&links, "Detroit");
+    assert!(detroit.exists, "Detroit is a known subject");
+    assert_eq!(detroit.label, "Detroit", "bare [[t]] labels as the target");
+}
+
+#[test]
+fn aliased_wikilink_keeps_pothole_label() {
+    let (_, links) = render_page(WIKILINKS, 80, &known(&["Detroit", "Wayne County"]));
+    let county = find_link(&links, "Wayne County");
+    assert!(county.exists);
+    assert_eq!(county.label, "the county", "[[t|Label]] labels as Label");
+}
+
+#[test]
+fn unknown_wikilink_is_redlink() {
+    let (text, links) = render_page(WIKILINKS, 80, &known(&["Detroit", "Wayne County"]));
+    let atlantis = find_link(&links, "Atlantis");
+    assert!(!atlantis.exists, "Atlantis is not a known subject");
+    let pos = atlantis
+        .position
+        .as_ref()
+        .expect("main-flow link has a position");
+    let line = &text.lines[pos.start_line];
+    let span = &line.spans[pos.start_span];
+    assert_eq!(
+        span.style.fg,
+        Some(Color::Red),
+        "redlink spans are styled red, got {:?}",
+        span.style
+    );
+}
+
+#[test]
+fn positions_point_at_labels() {
+    let (text, links) = render_page(WIKILINKS, 80, &known(&["Detroit", "Wayne County"]));
+    assert_eq!(links.len(), 3, "three wikilinks in the fixture: {links:?}");
+    for link in &links {
+        let pos = link
+            .position
+            .as_ref()
+            .unwrap_or_else(|| panic!("main-flow link {link:?} has a position"));
+        assert_eq!(
+            label_at(&text, pos),
+            link.label,
+            "position spans reconstruct the label for {link:?}"
+        );
+    }
+}
+
+#[test]
+fn wikilinks_render_without_trailing_destination() {
+    let (text, _) = render_page(WIKILINKS, 80, &known(&["Detroit", "Wayne County"]));
+    let flat = rendered_string(&text);
+    assert!(
+        !flat.contains("(Detroit)"),
+        "wikilinks must not render the upstream ' (dest)' suffix:\n{flat}"
+    );
+    assert!(
+        !flat.contains("(Wayne County)"),
+        "aliased wikilinks must not render the target as a suffix:\n{flat}"
+    );
+}
+
+#[test]
+fn empty_page_renders_honest_absence() {
+    let (text, links) = render_page(EMPTY, 80, &known(&["Detroit"]));
+    assert_eq!(rendered_string(&text), "No content recorded.");
+    assert!(links.is_empty());
+}

--- a/rust/crates/babylon-tui/tests/wiki_view.rs
+++ b/rust/crates/babylon-tui/tests/wiki_view.rs
@@ -1,0 +1,241 @@
+//! `WikiView` contract tests (plan Task 15).
+//!
+//! Explicit expected-content asserts over a `TestBackend` buffer — no insta
+//! snapshots (blessing needs a `cargo run` the parent session owns).
+
+use std::collections::BTreeSet;
+
+use babylon_tui::host::Host;
+use babylon_tui::layout_registry::LayoutRegistry;
+use babylon_tui::router::BabylonTarget;
+use babylon_tui::views::msg::AppEvent;
+use babylon_tui::views::wiki::WikiView;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::crossterm::event::{KeyCode, KeyModifiers};
+use ratatui::Terminal;
+
+/// A fake host serving three fixture pages (`alpha`, `beta`, `gamma`);
+/// every other subject is an honest absence (JSON `null`).
+struct FakeHost;
+
+impl Host for FakeHost {
+    fn lobby_catalog_json(&self) -> String {
+        "[]".to_string()
+    }
+
+    fn read_page_json(&self, subject: &str) -> String {
+        let page = match subject {
+            "alpha" => "# Alpha\n\nThe first fixture page.",
+            "beta" => "# Beta\n\nThe second fixture page.",
+            "gamma" => "# Gamma\n\nThe third fixture page.",
+            _ => return "null".to_string(),
+        };
+        serde_json::to_string(page).expect("fixture page encodes")
+    }
+}
+
+/// Join the buffer's rows into one string for substring assertions
+/// (mirrors `tests/lobby_view.rs`'s helper).
+fn buffer_lines(buf: &Buffer) -> Vec<String> {
+    let area = buf.area;
+    (0..area.height)
+        .map(|y| {
+            (0..area.width)
+                .map(|x| {
+                    buf.cell((area.x + x, area.y + y))
+                        .map(|c| c.symbol())
+                        .unwrap_or(" ")
+                })
+                .collect::<String>()
+        })
+        .collect()
+}
+
+fn buffer_text(buf: &Buffer) -> String {
+    buffer_lines(buf).join("\n")
+}
+
+/// Render `view` into a fresh `TestBackend` buffer.
+fn render(view: &WikiView) -> Buffer {
+    let backend = TestBackend::new(60, 15);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let known: BTreeSet<String> = BTreeSet::new();
+    let mut registry = LayoutRegistry::new();
+    terminal
+        .draw(|frame| {
+            let area = frame.area();
+            view.render(frame, area, &mut registry, &known);
+        })
+        .unwrap();
+    terminal.backend().buffer().clone()
+}
+
+#[test]
+fn open_entity_with_page_renders_its_heading() {
+    let mut view = WikiView::new();
+    view.open(&BabylonTarget::Entity("alpha".to_string()), &FakeHost);
+    assert_eq!(view.current.as_deref(), Some("alpha"));
+
+    let text = buffer_text(&render(&view));
+    assert!(text.contains("Alpha"), "expected heading in:\n{text}");
+    assert!(
+        text.contains("first fixture page"),
+        "expected body in:\n{text}"
+    );
+}
+
+#[test]
+fn open_subject_with_no_page_renders_the_honest_absence_page() {
+    let mut view = WikiView::new();
+    view.open(
+        &BabylonTarget::Redlink("missing_thing".to_string()),
+        &FakeHost,
+    );
+    assert_eq!(view.current.as_deref(), Some("missing_thing"));
+
+    let text = buffer_text(&render(&view));
+    assert!(
+        text.contains("missing_thing"),
+        "expected subject name in:\n{text}"
+    );
+    assert!(
+        text.contains("No page recorded for this subject."),
+        "expected honest-absence body in:\n{text}"
+    );
+}
+
+#[test]
+fn kind_target_resolves_subject_as_kind_slash_id() {
+    // A `Kind` target's subject is "<kind>/<id>" — this fixture host has no
+    // page under that composite subject, so it renders honest absence
+    // naming the composite id (proving the resolution, not just the
+    // absence path).
+    let mut view = WikiView::new();
+    view.open(
+        &BabylonTarget::Kind {
+            kind: "county".to_string(),
+            id: "wayne".to_string(),
+        },
+        &FakeHost,
+    );
+    assert_eq!(view.current.as_deref(), Some("county/wayne"));
+}
+
+#[test]
+fn jumplist_back_back_forward_and_branch_truncation() {
+    let mut view = WikiView::new();
+    view.open(&BabylonTarget::Entity("alpha".to_string()), &FakeHost);
+    view.open(&BabylonTarget::Entity("beta".to_string()), &FakeHost);
+    view.open(&BabylonTarget::Entity("gamma".to_string()), &FakeHost);
+    assert_eq!(view.jumplist, vec!["alpha", "beta", "gamma"]);
+    assert_eq!(view.jumplist_idx, 2);
+
+    assert_eq!(view.back(), Some("beta".to_string()));
+    assert_eq!(view.jumplist_idx, 1);
+    assert_eq!(view.back(), Some("alpha".to_string()));
+    assert_eq!(view.jumplist_idx, 0);
+    assert_eq!(view.back(), None, "idempotent at the oldest entry");
+    assert_eq!(view.jumplist_idx, 0);
+
+    assert_eq!(view.forward(), Some("beta".to_string()));
+    assert_eq!(view.jumplist_idx, 1);
+
+    // Opening a new page from mid-jumplist (currently positioned at "beta")
+    // truncates the discarded forward entry ("gamma"), browser-style.
+    view.open(&BabylonTarget::Entity("delta".to_string()), &FakeHost);
+    assert_eq!(view.jumplist, vec!["alpha", "beta", "delta"]);
+    assert_eq!(view.jumplist_idx, 2);
+    assert_eq!(view.forward(), None, "delta is now the newest entry");
+}
+
+#[test]
+fn reopening_the_current_subject_does_not_grow_the_jumplist() {
+    let mut view = WikiView::new();
+    view.open(&BabylonTarget::Entity("alpha".to_string()), &FakeHost);
+    view.open(&BabylonTarget::Entity("alpha".to_string()), &FakeHost);
+    assert_eq!(view.jumplist, vec!["alpha"]);
+    assert_eq!(view.jumplist_idx, 0);
+}
+
+#[test]
+fn back_and_forward_are_none_on_a_view_with_no_history() {
+    let mut view = WikiView::new();
+    assert_eq!(view.back(), None);
+    assert_eq!(view.forward(), None);
+}
+
+#[test]
+fn handle_key_bracket_and_ctrl_bindings_emit_open_subject() {
+    let mut view = WikiView::new();
+    view.open(&BabylonTarget::Entity("alpha".to_string()), &FakeHost);
+    view.open(&BabylonTarget::Entity("beta".to_string()), &FakeHost);
+
+    assert_eq!(
+        view.handle_key(KeyCode::Char('['), KeyModifiers::NONE),
+        Some(AppEvent::OpenSubject("alpha".to_string())),
+        "[ walks back"
+    );
+    assert_eq!(
+        view.handle_key(KeyCode::Char(']'), KeyModifiers::NONE),
+        Some(AppEvent::OpenSubject("beta".to_string())),
+        "] walks forward"
+    );
+    assert_eq!(
+        view.handle_key(KeyCode::Char('o'), KeyModifiers::CONTROL),
+        Some(AppEvent::OpenSubject("alpha".to_string())),
+        "Ctrl-O walks back"
+    );
+    assert_eq!(
+        view.handle_key(KeyCode::Char('i'), KeyModifiers::CONTROL),
+        Some(AppEvent::OpenSubject("beta".to_string())),
+        "Ctrl-I walks forward"
+    );
+
+    // A bare 'o'/'i' (no Ctrl) is not a jumplist binding.
+    assert_eq!(
+        view.handle_key(KeyCode::Char('o'), KeyModifiers::NONE),
+        None
+    );
+    assert_eq!(
+        view.handle_key(KeyCode::Char('i'), KeyModifiers::NONE),
+        None
+    );
+}
+
+#[test]
+fn q_and_esc_emit_back() {
+    let mut view = WikiView::new();
+    assert_eq!(
+        view.handle_key(KeyCode::Char('q'), KeyModifiers::NONE),
+        Some(AppEvent::Back)
+    );
+    assert_eq!(
+        view.handle_key(KeyCode::Esc, KeyModifiers::NONE),
+        Some(AppEvent::Back)
+    );
+}
+
+#[test]
+fn scroll_keys_adjust_scroll_and_saturate() {
+    let mut view = WikiView::new();
+    view.open(&BabylonTarget::Entity("alpha".to_string()), &FakeHost);
+
+    // Up at the top saturates at 0 (no underflow panic).
+    assert_eq!(view.handle_key(KeyCode::Up, KeyModifiers::NONE), None);
+    assert_eq!(view.handle_key(KeyCode::PageUp, KeyModifiers::NONE), None);
+
+    assert_eq!(view.handle_key(KeyCode::Down, KeyModifiers::NONE), None);
+    assert_eq!(view.handle_key(KeyCode::PageDown, KeyModifiers::NONE), None);
+    // Rendering after scrolling should not panic even with no visible link.
+    let _ = render(&view);
+}
+
+#[test]
+fn unmapped_key_emits_nothing() {
+    let mut view = WikiView::new();
+    assert_eq!(
+        view.handle_key(KeyCode::Char('z'), KeyModifiers::NONE),
+        None
+    );
+}

--- a/rust/crates/babylon-tui/tests/wiki_view.rs
+++ b/rust/crates/babylon-tui/tests/wiki_view.rs
@@ -57,7 +57,7 @@ fn buffer_text(buf: &Buffer) -> String {
 }
 
 /// Render `view` into a fresh `TestBackend` buffer.
-fn render(view: &WikiView) -> Buffer {
+fn render(view: &mut WikiView) -> Buffer {
     let backend = TestBackend::new(60, 15);
     let mut terminal = Terminal::new(backend).unwrap();
     let known: BTreeSet<String> = BTreeSet::new();
@@ -77,7 +77,7 @@ fn open_entity_with_page_renders_its_heading() {
     view.open(&BabylonTarget::Entity("alpha".to_string()), &FakeHost);
     assert_eq!(view.current.as_deref(), Some("alpha"));
 
-    let text = buffer_text(&render(&view));
+    let text = buffer_text(&render(&mut view));
     assert!(text.contains("Alpha"), "expected heading in:\n{text}");
     assert!(
         text.contains("first fixture page"),
@@ -94,7 +94,7 @@ fn open_subject_with_no_page_renders_the_honest_absence_page() {
     );
     assert_eq!(view.current.as_deref(), Some("missing_thing"));
 
-    let text = buffer_text(&render(&view));
+    let text = buffer_text(&render(&mut view));
     assert!(
         text.contains("missing_thing"),
         "expected subject name in:\n{text}"
@@ -228,7 +228,7 @@ fn scroll_keys_adjust_scroll_and_saturate() {
     assert_eq!(view.handle_key(KeyCode::Down, KeyModifiers::NONE), None);
     assert_eq!(view.handle_key(KeyCode::PageDown, KeyModifiers::NONE), None);
     // Rendering after scrolling should not panic even with no visible link.
-    let _ = render(&view);
+    let _ = render(&mut view);
 }
 
 #[test]

--- a/rust/crates/babylon-tui/tests/wikilinks.rs
+++ b/rust/crates/babylon-tui/tests/wikilinks.rs
@@ -1,0 +1,291 @@
+//! Wikilink semantics parity table (plan Task 12).
+//!
+//! Ports the behavior TABLE from `tests/unit/tui/test_wikilinks.py`
+//! (`babylon.tui.wikilinks`, the markdown-it-py inline rule + Textual
+//! content-span mixin) as contract tests over `render_page`
+//! (`babylon_tui::wiki_render`). Rev 2 of the plan retires the custom
+//! `[[target]]` scanning rule entirely: pulldown-cmark 0.13's **native**
+//! `ENABLE_WIKILINKS` extension does the parsing, so there is no scanning
+//! code to write here — these tests exist to pin what `render_page` must DO
+//! with the events that extension emits, exactly as the Python suite pinned
+//! `wikilink_plugin`/`WikilinkContentMixin`.
+//!
+//! Field mapping from the Python token pair to the Rust `LinkSpan`:
+//!
+//! | Python                                             | Rust                        |
+//! |-----------------------------------------------------|-----------------------------|
+//! | `text_token.content` (the alias, or target if none) | `LinkSpan::label`           |
+//! | the wikilink's raw target (pre-`href` string)        | `LinkSpan::target`          |
+//! | `kind == "wikilink"` (`resolver(target)` truthy)     | `LinkSpan::exists == true`  |
+//! | `kind == "redlink"` (`resolver(target)` falsy)       | `LinkSpan::exists == false` |
+//!
+//! Python builds a `babylon://<target>` / `babylon://redlink/<target>` `href`
+//! string directly in the inline rule. The Rust split moves that
+//! construction to `router::format_babylon_uri` (Task 13): `render_page`
+//! itself only ever hands back the BARE target text — never a `babylon://`
+//! scheme, never a `redlink/` path segment baked into `target` — leaving
+//! `exists` as the sole discriminant. Every test below that checks a target
+//! also asserts that invariant, since a stray prefix baked into `target`
+//! would silently break `router::parse_babylon_uri` round-tripping.
+//!
+//! Python's `_ContentBuilder` span-based styling (`WIKILINK_COLOR` /
+//! `REDLINK_COLOR`, the `@click` meta) has no Rust analogue to assert against
+//! here: per the task brief, style is asserted ONLY via `exists` (the
+//! redlink case), never a specific color — `render_page`'s caller decides
+//! how `exists` maps to a color.
+//!
+//! ## Two upstream pulldown-cmark parser quirks (for content authors)
+//!
+//! Both are documented at
+//! <https://github.com/pulldown-cmark/pulldown-cmark/blob/main/pulldown-cmark/specs/wikilinks.txt>
+//! and have no Python-side equivalent (the old `WIKILINK_RE` regex had
+//! different — simpler, and in one case stricter — rules; native
+//! `ENABLE_WIKILINKS` is now the sole authority):
+//!
+//! 1. **A pipe cannot be backslash-escaped inside a wikilink.** Unlike table
+//!    cells or emphasis, `\|` inside `[[...]]` does NOT produce a literal
+//!    `|` in the target. The pipe still delimits target/label, and the
+//!    backslash is retained literally as part of the target text — e.g.
+//!    `[[first\|second]]` parses as target `` first\ `` (trailing literal
+//!    backslash) / label `second`, matching pulldown-cmark's chosen
+//!    (commonmark-hs-style) behavior. Content authors who want a literal `|`
+//!    in a page id have no escape hatch; don't use `|` in entity ids.
+//! 2. **Empty or malformed `[[...]]` renders as literal text**, not a link:
+//!    `[[]]`, `[[|]]`, `[[|Symbol]]`, an unmatched `[[` or `]]` — none of
+//!    these produce a `LinkSpan`; the brackets and any inner text pass
+//!    through into the rendered page verbatim.
+
+use std::collections::BTreeSet;
+
+use babylon_tui::wiki_render::render_page;
+
+/// Build a `known`-subjects set from string literals (test convenience only;
+/// production code fills this from `Host::known_subjects_json`).
+fn known(subjects: &[&str]) -> BTreeSet<String> {
+    subjects.iter().map(|s| s.to_string()).collect()
+}
+
+/// A `known` set wide enough for tests that don't care about existence.
+fn no_subjects() -> BTreeSet<String> {
+    BTreeSet::new()
+}
+
+/// Every target/label/redlink assertion below also checks this: `target`
+/// must never carry a `babylon://` scheme or a `redlink/` segment — URI
+/// construction is `router::format_babylon_uri`'s job, not `render_page`'s.
+fn assert_bare_target(target: &str) {
+    assert!(
+        !target.contains("babylon://"),
+        "LinkSpan::target must be bare, got {target:?}"
+    );
+    assert!(
+        !target.contains("redlink/"),
+        "LinkSpan::target must not bake in the redlink path segment, got {target:?}"
+    );
+}
+
+// --- Bare wikilink, known target ---------------------------------------
+// Ports test_it_emits_wikilink_tokens_for_a_known_target.
+
+#[test]
+fn bare_wikilink_to_a_known_target_is_a_wikilink_span() {
+    let (text, spans) = render_page("[[county/26163]]", 80, &known(&["county/26163"]));
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.target, "county/26163");
+    assert_eq!(span.label, "county/26163");
+    assert!(span.exists);
+    assert_bare_target(&span.target);
+
+    assert_eq!(text.to_string(), "county/26163");
+    assert!(
+        span.position.is_some(),
+        "an inline link must carry a position"
+    );
+    assert_eq!(span.position.as_ref().unwrap().start_line, 0);
+}
+
+// --- Bare wikilink, unknown target (redlink) ---------------------------
+// Ports test_it_emits_redlink_tokens_for_an_unknown_target.
+
+#[test]
+fn bare_wikilink_to_an_unknown_target_is_a_redlink_span() {
+    let (text, spans) = render_page("[[org/uaw-9999]]", 80, &no_subjects());
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.target, "org/uaw-9999");
+    assert_eq!(span.label, "org/uaw-9999");
+    assert!(
+        !span.exists,
+        "unknown target must be a redlink: exists == false"
+    );
+    assert_bare_target(&span.target);
+
+    assert_eq!(text.to_string(), "org/uaw-9999");
+}
+
+// --- Aliased wikilink ---------------------------------------------------
+// Ports test_it_uses_the_alias_as_display_text.
+
+#[test]
+fn aliased_wikilink_uses_the_alias_as_the_label_but_keeps_the_real_target() {
+    let (text, spans) = render_page(
+        "[[county/26163|Wayne County]]",
+        80,
+        &known(&["county/26163"]),
+    );
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.target, "county/26163");
+    assert_eq!(span.label, "Wayne County");
+    assert!(span.exists);
+
+    assert_eq!(text.to_string(), "Wayne County");
+}
+
+// --- Aliased redlink -----------------------------------------------------
+// Combines the alias case with the redlink case (both independently
+// pinned above by the Python table; this checks they compose).
+
+#[test]
+fn aliased_wikilink_to_an_unknown_target_is_still_a_redlink() {
+    let (_text, spans) = render_page(
+        "[[org/uaw-9999|The UAW Local]]",
+        80,
+        &known(&["county/26163"]),
+    );
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.target, "org/uaw-9999");
+    assert_eq!(span.label, "The UAW Local");
+    assert!(!span.exists);
+}
+
+// --- `known` is the sole existence authority ---------------------------
+// Ports the parametrization implied by known_target_resolver: the SAME
+// source's existence flips purely with the `known` argument.
+
+#[test]
+fn existence_is_determined_solely_by_the_known_parameter() {
+    let source = "[[org/uaw-9999]]";
+
+    let (_t, absent) = render_page(source, 80, &no_subjects());
+    assert!(!absent[0].exists);
+
+    let (_t, present) = render_page(source, 80, &known(&["org/uaw-9999"]));
+    assert!(present[0].exists);
+}
+
+#[test]
+fn known_matching_is_exact_not_case_insensitive() {
+    // Not in the Python table (the old resolver was also exact-match via
+    // frozenset membership) but worth pinning explicitly: `known` is an
+    // *exact* BTreeSet<String> membership test, not a case-folded one.
+    let (_text, spans) = render_page("[[county/26163]]", 80, &known(&["COUNTY/26163"]));
+    assert!(!spans[0].exists);
+}
+
+// --- Ordinary markdown links are left untouched -------------------------
+// Ports test_it_leaves_ordinary_links_untouched: an `[text](url)` inline
+// link is NOT a wikilink and must not produce a LinkSpan (hit-registry
+// wiring is a wikilink-only side channel; see the `LinkSpan` doc comment).
+
+#[test]
+fn ordinary_markdown_links_produce_no_link_span() {
+    let (text, spans) = render_page("[a link](http://example.com)", 80, &no_subjects());
+
+    assert!(
+        spans.is_empty(),
+        "an ordinary (non-wikilink) link must not appear in the wikilink side channel"
+    );
+    assert!(text.to_string().contains("a link"));
+}
+
+// --- Emphasis still renders as upstream babylon-md/tui-markdown does ----
+// Ports test_it_still_handles_emphasis_as_upstream_does: a sanity check
+// that plain markdown formatting is untouched and, in particular, does not
+// spuriously produce a LinkSpan.
+
+#[test]
+fn emphasis_renders_plain_text_with_no_link_span() {
+    let (text, spans) = render_page("*urgent*", 80, &no_subjects());
+
+    assert!(spans.is_empty());
+    assert!(text.to_string().contains("urgent"));
+}
+
+// --- Multiple wikilinks in one page: order and independence -------------
+// Not a single Python test, but the direct consequence of applying the
+// per-link rule above to more than one link in the same page: order must
+// match source order (the hit registry depends on this) and each link's
+// existence is independent.
+
+#[test]
+fn multiple_wikilinks_are_reported_in_source_order_independently() {
+    let (_text, spans) = render_page(
+        "[[county/26163]] and [[org/uaw-9999]]",
+        80,
+        &known(&["county/26163"]),
+    );
+
+    assert_eq!(spans.len(), 2);
+    assert_eq!(spans[0].target, "county/26163");
+    assert!(spans[0].exists);
+    assert_eq!(spans[1].target, "org/uaw-9999");
+    assert!(!spans[1].exists);
+}
+
+// --- Quirk 1: a pipe cannot be backslash-escaped inside a wikilink -------
+// New in the Rust port (native ENABLE_WIKILINKS behavior; the old WIKILINK_RE
+// had no escaping concept at all since `|` was simply excluded from the
+// target character class). Per the upstream spec, `[[first\|second]]`
+// still splits on the pipe; the backslash survives literally as part of
+// the target rather than escaping it away.
+
+#[test]
+fn a_pipe_cannot_be_backslash_escaped_inside_a_wikilink() {
+    let (text, spans) = render_page(r"[[first\|second]]", 80, &known(&[r"first\"]));
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(
+        span.target, r"first\",
+        "the backslash is retained literally, not consumed as an escape"
+    );
+    assert_eq!(span.label, "second");
+    assert!(
+        span.exists,
+        "existence check must match against the raw (unencoded) target, backslash included"
+    );
+    assert_bare_target(&span.target);
+
+    assert_eq!(text.to_string(), "second");
+}
+
+// --- Quirk 2: empty / malformed wikilinks render as literal text --------
+
+#[test]
+fn an_empty_wikilink_renders_as_literal_text_not_a_link() {
+    let (text, spans) = render_page("[[]]", 80, &no_subjects());
+
+    assert!(spans.is_empty(), "[[]] must not produce a LinkSpan");
+    assert_eq!(text.to_string(), "[[]]");
+}
+
+#[test]
+fn malformed_wikilink_variants_all_render_literally() {
+    // Verbatim fixture from the upstream pulldown-cmark spec
+    // (specs/wikilinks.txt, "Empty or Invalid Wikilinks"): every one of
+    // these is malformed (empty target, empty-target-with-pipe, pipe with
+    // no target before it, an unmatched opening `[[`) and none of them
+    // produce a link.
+    let source = "]] [[]] [[|]] [[|Symbol]] [[";
+    let (text, spans) = render_page(source, 80, &no_subjects());
+
+    assert!(spans.is_empty());
+    assert_eq!(text.to_string(), source);
+}

--- a/src/babylon/cli/play.py
+++ b/src/babylon/cli/play.py
@@ -390,7 +390,7 @@ def _tutorial_progress_factory(
 
 
 def _run_rust_client(*, narrator_enabled: bool, tutorial_enabled: bool | None) -> None:
-    """Boot the Rust/Ratatui client lane (M0: the lobby hello-frame).
+    """Boot the Rust/Ratatui client lane (M0 lobby hello-frame + M1 read wiring).
 
     Fails LOUDLY and actionably — before touching Postgres — when the
     opt-in extension is absent; with it, composes the real catalog into a
@@ -398,7 +398,19 @@ def _run_rust_client(*, narrator_enabled: bool, tutorial_enabled: bool | None) -
     ``babylon_tui.run`` (the seam ``ArchiveApp(...).run()`` occupies on the
     textual path).
 
-    :param narrator_enabled: threaded into the client config verbatim.
+    M1 wiring (review fix): threads the SAME ``campaign_loader``/
+    ``driver_factory``/``watchlist_persistence`` seams :func:`run` builds
+    for ``ArchiveApp`` on the textual path — :func:`_load_campaign` (partial
+    over this ``runtime``/``catalog``), :func:`_driver_factory`, and
+    ``catalog`` itself — into ``RustClientHost``, so
+    :meth:`~babylon.tui.host.RustClientHost.load_campaign` has a real
+    campaign to resolve once the Rust lobby picks one. Before this fix,
+    ``RustClientHost`` had no way to bind a session at all: every M1 read
+    method served absence against a session that could never exist.
+
+    :param narrator_enabled: threaded into the client config verbatim, AND
+        into :func:`_load_campaign`'s partial (the same flag
+        :func:`_load_campaign` already threads on the textual path).
     :param tutorial_enabled: the tri-state flag; the M0 config carries a
         plain bool (tutorial rendering is M3), so unset coerces to False.
     """
@@ -411,6 +423,8 @@ def _run_rust_client(*, narrator_enabled: bool, tutorial_enabled: bool | None) -
             "develop` in rust/). The textual client remains the default."
         )
         raise RuntimeError(msg) from exc
+
+    from functools import partial
 
     import babylon
     from babylon.config.defines import GameDefines
@@ -426,6 +440,11 @@ def _run_rust_client(*, narrator_enabled: bool, tutorial_enabled: bool | None) -
         catalog,
         defines_hash=_defines_hash(GameDefines.load_default()),
         engine_version=babylon.__version__,
+        campaign_loader=partial(
+            _load_campaign, runtime, catalog, narrator_enabled=narrator_enabled
+        ),
+        driver_factory=_driver_factory,
+        watchlist_persistence=catalog,
     )
     config_json = json.dumps(
         {

--- a/src/babylon/tui/campaign_menu.py
+++ b/src/babylon/tui/campaign_menu.py
@@ -43,6 +43,7 @@ __all__ = [
     "InMemoryCampaignCatalog",
     "LobbyRow",
     "LobbyScreen",
+    "operation_codename",
 ]
 
 

--- a/src/babylon/tui/host.py
+++ b/src/babylon/tui/host.py
@@ -17,24 +17,33 @@ exactly the same ``CampaignHandle`` Protocol surface
 which would defeat the whole point of the Protocol seam. The backlink index
 (:meth:`RustClientHost.backlinks_json`) reuses
 :func:`babylon.tui.shell.backlinks.build_backlink_index` verbatim rather
-than re-deriving the wikilink inversion a second time (that module already
-inverts each page's outbound ``babylon.tui.wikilinks.WIKILINK_RE`` matches
-for the Textual Wiki view's own "what links here" panel).
+than re-deriving the wikilink inversion a second time — a shared
+``babylon.tui.shell`` helper, not something the Textual client itself
+consumes (no Textual "what links here" panel exists today); the Rust
+client's wiki footer is :meth:`RustClientHost.backlinks_json`'s only
+consumer so far.
+
+:meth:`load_campaign` (M1 wiring) is the seam the Rust lobby actually
+calls once a player picks a campaign row: it resolves ``campaign_id``
+through the ``campaign_loader`` the constructor now accepts, builds the
+paced driver through the optional ``driver_factory``, and binds both via
+:meth:`bind_session` — closing the gap where ``bind_session`` shipped
+with zero production caller.
 """
 
 from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING
+from uuid import UUID
 
+from babylon.tui.campaign_menu import operation_codename
 from babylon.tui.shell.backlinks import build_backlink_index
 from babylon.tui.watchlist import load_watchlist
 
 if TYPE_CHECKING:
-    from uuid import UUID
-
     from babylon.projection.view_models import ProjectionRecord
-    from babylon.tui.app import CampaignHandle, PacedDriverHandle
+    from babylon.tui.app import CampaignHandle, CampaignLoader, DriverFactory, PacedDriverHandle
     from babylon.tui.campaign_menu import CampaignCatalog
     from babylon.tui.watchlist import WatchlistPersistence
 
@@ -49,13 +58,25 @@ class RustClientHost:
     :param defines_hash: Provenance hash of the loaded :class:`GameDefines`,
         stamped on every lobby row.
     :param engine_version: The running engine version, stamped alongside.
+    :param campaign_loader: The lobby's boot-or-resume seam (see
+        :data:`~babylon.tui.app.CampaignLoader`) — the SAME seam
+        ``ArchiveApp(campaign_loader=...)`` accepts on the Textual path.
+        ``None`` (the default) is an honest "no loader wired" —
+        :meth:`load_campaign` then raises :class:`RuntimeError` rather than
+        silently serving absence (Constitution III.11); the real
+        ``_run_rust_client`` composition root always wires one.
+    :param driver_factory: The booted campaign's pacing-driver seam (see
+        :data:`~babylon.tui.app.DriverFactory`) — the SAME seam
+        ``ArchiveApp(driver_factory=...)`` accepts. ``None`` (the default)
+        is a legal M1 answer too: the read-only M1 surface never calls
+        :meth:`~babylon.tui.app.PacedDriverHandle.advance_once` through
+        :attr:`driver`, so :meth:`load_campaign` binds a driver-less
+        session rather than manufacturing one nothing here needs yet.
     :param watchlist_persistence: The watchlist's cross-session store (see
         :mod:`babylon.tui.watchlist`) — the SAME seam
         ``ArchiveApp(watchlist_persistence=...)`` accepts on the Textual
         path. ``None`` (the default) is an honest "no watchlist store wired"
-        — :meth:`watchlist_json` then always serves ``"[]"``, matching M0's
-        ``_run_rust_client`` composition root, which does not thread one in
-        yet (pin *writes* land in M2; M1 is read-only).
+        — :meth:`watchlist_json` then always serves ``"[]"``.
     """
 
     def __init__(
@@ -64,11 +85,15 @@ class RustClientHost:
         *,
         defines_hash: str,
         engine_version: str,
+        campaign_loader: CampaignLoader | None = None,
+        driver_factory: DriverFactory | None = None,
         watchlist_persistence: WatchlistPersistence | None = None,
     ) -> None:
         self._catalog = catalog
         self._defines_hash = defines_hash
         self._engine_version = engine_version
+        self._campaign_loader = campaign_loader
+        self._driver_factory = driver_factory
         self._watchlist_persistence = watchlist_persistence
         #: The bound campaign session (``None`` until :meth:`bind_session`).
         self.session: CampaignHandle | None = None
@@ -85,14 +110,20 @@ class RustClientHost:
         """The lobby catalog as a JSON array string.
 
         Each row carries the keys the Rust ``LobbyRow`` deserializer
-        requires (``campaign_id``/``name``/``tick``) plus ``status`` and the
-        provenance stamps. An empty catalog is ``[]`` — honest absence
+        requires (``campaign_id``/``name``/``tick``) plus ``status``, the
+        provenance stamps, and ``codename`` — the SAME
+        :func:`~babylon.projection.briefing.operation_codename` derivation
+        the Textual lobby's own ``LobbyRow.codename`` renders (spec-116
+        FR-116-3): ``name`` is the machine slug, ``codename`` is the
+        player-facing display name, and the Rust lobby must render the
+        latter, not the former. An empty catalog is ``[]`` — honest absence
         (III.11), never a fabricated row.
         """
         rows = [
             {
                 "campaign_id": str(campaign.campaign_id),
                 "name": campaign.slug,
+                "codename": operation_codename(campaign.campaign_id),
                 "tick": campaign.last_tick,
                 "status": campaign.status,
                 "defines_hash": self._defines_hash,
@@ -102,11 +133,56 @@ class RustClientHost:
         ]
         return json.dumps(rows)
 
-    def bind_session(self, session: CampaignHandle, driver: PacedDriverHandle) -> None:
+    def load_campaign(self, campaign_id: str) -> str:
+        """Resolve and bind the campaign the Rust lobby just chose (M1 wiring).
+
+        The Rust shell calls this once the player picks a lobby row.
+        Mirrors :meth:`~babylon.tui.app.ArchiveApp._on_campaign_chosen`'s own
+        composition: resolves ``campaign_id`` through :attr:`_campaign_loader`
+        (:data:`~babylon.tui.app.CampaignLoader`), builds the paced driver
+        through :attr:`_driver_factory` when one was wired (``None``
+        otherwise — legal for M1's read-only surface), and binds both
+        through :meth:`bind_session` — closing the gap where
+        ``bind_session`` shipped with zero production caller and every M1
+        read method served absence against a never-bound session.
+
+        :param campaign_id: the campaign UUID, as the string the Rust side
+            holds.
+        :raises RuntimeError: no ``campaign_loader`` was wired at
+            construction — unreachable through the real ``babylon play
+            --client rust`` composition root (which always wires one);
+            never silently served as absence (Constitution III.11).
+        :raises ValueError: ``campaign_id`` is not a valid UUID string.
+        :raises Exception: whatever the wired ``campaign_loader`` itself
+            raises (e.g. a session that fails to boot/resume) — propagated
+            verbatim, never caught and re-encoded as a fabricated failure
+            payload: the Rust seam propagates Python exceptions loudly by
+            design (M1).
+        :returns: ``json.dumps({"ok": True, "campaign_id": campaign_id})``
+            on success.
+        """
+        if self._campaign_loader is None:
+            msg = (
+                "RustClientHost.load_campaign: no campaign_loader was wired "
+                "at construction — the Rust lobby has no way to boot this "
+                "campaign"
+            )
+            raise RuntimeError(msg)
+        campaign = self._campaign_loader(UUID(campaign_id))
+        driver = self._driver_factory(campaign) if self._driver_factory is not None else None
+        self.bind_session(campaign, driver)
+        return json.dumps({"ok": True, "campaign_id": campaign_id})
+
+    def bind_session(self, session: CampaignHandle, driver: PacedDriverHandle | None) -> None:
         """Bind the booted campaign session and its paced driver.
 
-        Called by the composition root's campaign loader once the session
-        exists; M1+ read methods serve from these handles.
+        Called by :meth:`load_campaign` once the wired ``campaign_loader``
+        resolves a session; M1+ read methods serve from these handles.
+
+        :param session: the just-resolved campaign handle.
+        :param driver: the campaign's paced tick driver, or ``None`` when no
+            ``driver_factory`` was wired (a legal M1 answer — the read-only
+            M1 surface never advances a tick through :attr:`driver`).
         """
         self.session = session
         self.driver = driver
@@ -152,10 +228,12 @@ class RustClientHost:
         """The bound campaign's ``target -> sorted [linking subjects]`` index.
 
         Delegates the actual inversion to
-        :func:`~babylon.tui.shell.backlinks.build_backlink_index` — the SAME
-        function the Textual Wiki view's own "what links here" panel already
-        uses — over every page the bound session's vault has baked so far
-        (:meth:`~babylon.tui.app.CampaignHandle.known_subjects`, itself
+        :func:`~babylon.tui.shell.backlinks.build_backlink_index` — a shared
+        ``babylon.tui.shell`` helper, not something any Textual view
+        consumes today (no Textual "what links here" panel exists; this
+        host method and the Rust client's wiki footer are its only
+        consumer) — over every page the bound session's vault has baked so
+        far (:meth:`~babylon.tui.app.CampaignHandle.known_subjects`, itself
         bounded by :func:`~babylon.game.session.vault_known_subjects`'s own
         ``_MAX_VAULT_PAGES`` static scan ceiling, so this walk is never
         unbounded even though its trip count is runtime-determined).
@@ -166,6 +244,16 @@ class RustClientHost:
         commits — recomputing it on every :meth:`backlinks_json` call within
         the same tick would re-walk and re-parse every known page for no
         benefit.
+
+        KNOWN M1 LIMITATION (accepted, not fixed by this cache's semantics):
+        :meth:`~babylon.projection.vault.incremental_baker.
+        IncrementalArchiveTickBaker.bake_page_on_visit` can bake a page
+        MID-tick (the lazy on-demand path for ``community`` dossiers, which
+        have no backing graph node to dirty-track), so a page baked that way
+        can go unreflected in this index until the NEXT tick commits and
+        changes ``self.session.tick`` (and therefore this cache's key) —
+        within the same tick, this cache has no signal that a mid-tick bake
+        happened at all.
 
         :returns: ``{target: sorted_subjects}``, or ``{}`` when no session
             is bound.

--- a/src/babylon/tui/host.py
+++ b/src/babylon/tui/host.py
@@ -1,4 +1,4 @@
-"""The Rust client's host seam (M0 lobby surface — the raster cutover, ADR150).
+"""The Rust client's host seam (M0 lobby surface + M1 read surface — ADR150).
 
 :class:`RustClientHost` is THE seam between the Python composition root and
 the Rust/Ratatui client: Python remains the single writer, and every read
@@ -8,7 +8,18 @@ crosses the FFI as a JSON string of primitives (``model_dump_json()`` /
 Layering: like the rest of ``babylon.tui``, this module never imports
 ``babylon.engine``, ``babylon.persistence``, or the game session directly
 (the import-linter contract) — the session and driver arrive pre-composed
-through :meth:`RustClientHost.bind_session` as structural protocols.
+through :meth:`RustClientHost.bind_session` as structural protocols. The M1
+read methods (:meth:`RustClientHost.read_page_json` and friends) reuse
+exactly the same ``CampaignHandle`` Protocol surface
+(:mod:`babylon.tui.app`) the Textual client already reads through —
+``read_page``/``known_subjects``/``subject_view`` — never a private
+``babylon.game.session.GameSession`` attribute (e.g. a raw vault root),
+which would defeat the whole point of the Protocol seam. The backlink index
+(:meth:`RustClientHost.backlinks_json`) reuses
+:func:`babylon.tui.shell.backlinks.build_backlink_index` verbatim rather
+than re-deriving the wikilink inversion a second time (that module already
+inverts each page's outbound ``babylon.tui.wikilinks.WIKILINK_RE`` matches
+for the Textual Wiki view's own "what links here" panel).
 """
 
 from __future__ import annotations
@@ -16,9 +27,16 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+from babylon.tui.shell.backlinks import build_backlink_index
+from babylon.tui.watchlist import load_watchlist
+
 if TYPE_CHECKING:
+    from uuid import UUID
+
+    from babylon.projection.view_models import ProjectionRecord
     from babylon.tui.app import CampaignHandle, PacedDriverHandle
     from babylon.tui.campaign_menu import CampaignCatalog
+    from babylon.tui.watchlist import WatchlistPersistence
 
 __all__ = ["RustClientHost"]
 
@@ -31,6 +49,13 @@ class RustClientHost:
     :param defines_hash: Provenance hash of the loaded :class:`GameDefines`,
         stamped on every lobby row.
     :param engine_version: The running engine version, stamped alongside.
+    :param watchlist_persistence: The watchlist's cross-session store (see
+        :mod:`babylon.tui.watchlist`) — the SAME seam
+        ``ArchiveApp(watchlist_persistence=...)`` accepts on the Textual
+        path. ``None`` (the default) is an honest "no watchlist store wired"
+        — :meth:`watchlist_json` then always serves ``"[]"``, matching M0's
+        ``_run_rust_client`` composition root, which does not thread one in
+        yet (pin *writes* land in M2; M1 is read-only).
     """
 
     def __init__(
@@ -39,14 +64,22 @@ class RustClientHost:
         *,
         defines_hash: str,
         engine_version: str,
+        watchlist_persistence: WatchlistPersistence | None = None,
     ) -> None:
         self._catalog = catalog
         self._defines_hash = defines_hash
         self._engine_version = engine_version
+        self._watchlist_persistence = watchlist_persistence
         #: The bound campaign session (``None`` until :meth:`bind_session`).
         self.session: CampaignHandle | None = None
         #: The bound paced tick driver (``None`` until :meth:`bind_session`).
         self.driver: PacedDriverHandle | None = None
+        #: The backlink index's cache key (``(session_id, tick)``), or
+        #: ``None`` before the first :meth:`backlinks_json` call — see
+        #: :meth:`_backlink_index`.
+        self._backlink_cache_key: tuple[UUID, int] | None = None
+        #: The cached backlink index for :attr:`_backlink_cache_key`.
+        self._backlink_index_cache: dict[str, list[str]] = {}
 
     def lobby_catalog_json(self) -> str:
         """The lobby catalog as a JSON array string.
@@ -77,3 +110,139 @@ class RustClientHost:
         """
         self.session = session
         self.driver = driver
+
+    def read_page(self, subject: str) -> str | None:
+        """Read one baked vault page for the bound campaign — read-only.
+
+        Thin passthrough to :meth:`~babylon.tui.app.CampaignHandle.read_page`
+        (:meth:`~babylon.game.session.GameSession.read_page` in production):
+        never bakes or writes anything, just reads whatever the vault has
+        already materialized.
+
+        :param subject: the vault-relative subject id (e.g.
+            ``"county/26163"``).
+        :returns: the page's rendered markdown, or ``None`` when no session
+            is bound yet, or the vault hasn't baked ``subject`` — never
+            fabricated content (Constitution III.11).
+        """
+        if self.session is None:
+            return None
+        return self.session.read_page(subject)
+
+    def read_page_json(self, subject: str) -> str:
+        """:meth:`read_page`, JSON-encoded — the Rust seam's actual entry point.
+
+        :param subject: the vault-relative subject id.
+        :returns: ``json.dumps`` of :meth:`read_page`'s result — a quoted
+            JSON string, or the literal ``"null"`` for honest absence.
+        """
+        return json.dumps(self.read_page(subject))
+
+    def known_subjects_json(self) -> str:
+        """Every subject id the bound campaign's vault has baked, sorted.
+
+        :returns: a sorted JSON array of subject ids, or ``"[]"`` when no
+            session is bound — never fabricated (Constitution III.11).
+        """
+        if self.session is None:
+            return json.dumps([])
+        return json.dumps(sorted(self.session.known_subjects()))
+
+    def _backlink_index(self) -> dict[str, list[str]]:
+        """The bound campaign's ``target -> sorted [linking subjects]`` index.
+
+        Delegates the actual inversion to
+        :func:`~babylon.tui.shell.backlinks.build_backlink_index` — the SAME
+        function the Textual Wiki view's own "what links here" panel already
+        uses — over every page the bound session's vault has baked so far
+        (:meth:`~babylon.tui.app.CampaignHandle.known_subjects`, itself
+        bounded by :func:`~babylon.game.session.vault_known_subjects`'s own
+        ``_MAX_VAULT_PAGES`` static scan ceiling, so this walk is never
+        unbounded even though its trip count is runtime-determined).
+
+        Cached per ``(session_id, tick)``: a live campaign's vault only
+        grows between ticks (never mutates an already-baked page in place),
+        so the index built for a given tick stays valid until the next one
+        commits — recomputing it on every :meth:`backlinks_json` call within
+        the same tick would re-walk and re-parse every known page for no
+        benefit.
+
+        :returns: ``{target: sorted_subjects}``, or ``{}`` when no session
+            is bound.
+        """
+        if self.session is None:
+            return {}
+        cache_key = (self.session.session_id, self.session.tick)
+        if cache_key != self._backlink_cache_key:
+            pages = {
+                subject: page
+                for subject in self.session.known_subjects()
+                if (page := self.session.read_page(subject)) is not None
+            }
+            self._backlink_index_cache = {
+                target: list(sources) for target, sources in build_backlink_index(pages).items()
+            }
+            self._backlink_cache_key = cache_key
+        return self._backlink_index_cache
+
+    def backlinks_json(self, subject: str) -> str:
+        """Subjects whose pages link to ``subject``, sorted.
+
+        :param subject: the target subject id to look up inbound links for.
+        :returns: a sorted JSON array of subject ids, or ``"[]"`` when no
+            session is bound, or nothing links to ``subject`` — never
+            fabricated (Constitution III.11).
+        """
+        return json.dumps(sorted(self._backlink_index().get(subject, [])))
+
+    def subject_view_json(self, subject: str) -> str:
+        """The bound campaign's live per-subject dossier view-model, as JSON.
+
+        Thin passthrough to
+        :meth:`~babylon.tui.app.CampaignHandle.subject_view`
+        (:meth:`~babylon.game.session.GameSession.subject_view` in
+        production), computed fresh off the live graph every call — never
+        cached, unlike :meth:`backlinks_json`'s vault-page index (a
+        subject's projected view can change every tick even when its baked
+        vault page has not been re-rendered).
+
+        :param subject: the vault-relative subject id.
+        :returns: :meth:`~pydantic.BaseModel.model_dump_json` of the
+            resolved :data:`~babylon.projection.view_models.ProjectionRecord`,
+            or the literal ``"null"`` when no session is bound, or the
+            subject resolves to no live view — never a fabricated plate
+            (Constitution III.11).
+        """
+        if self.session is None:
+            return "null"
+        view: ProjectionRecord | None = self.session.subject_view(subject)
+        if view is None:
+            return "null"
+        return view.model_dump_json()
+
+    def watchlist_json(self) -> str:
+        """The bound campaign's persisted watchlist rows, read-only.
+
+        Hydrates via :func:`~babylon.tui.watchlist.load_watchlist` over
+        :attr:`_watchlist_persistence` — the SAME seam/function
+        ``ArchiveApp._on_campaign_chosen`` already uses to restore a
+        resumed campaign's pin order — keyed by the bound session's own
+        ``session_id``. Each row is ``{"subject": pinned_id}``, in pin
+        order (FIFO — see :class:`~babylon.tui.watchlist.WatchlistState`'s
+        own ordering contract, never re-sorted here): the Rust
+        ``WatchlistView`` renders generically over whatever keys a row
+        carries, requiring only a ``"subject"`` string (``host.rs``'s own
+        schema note) — pin/unpin *writes* land in M2, so this module does
+        not attempt to reproduce ``watchlist.py``'s own
+        ``peek(view, depth=0)`` row prose.
+
+        :returns: a JSON array of ``{"subject": ...}`` rows in pin order, or
+            ``"[]"`` when no session is bound, no
+            :class:`~babylon.tui.watchlist.WatchlistPersistence` was wired,
+            or the watchlist is honestly empty — never fabricated
+            (Constitution III.11).
+        """
+        if self.session is None or self._watchlist_persistence is None:
+            return json.dumps([])
+        state = load_watchlist(self._watchlist_persistence, str(self.session.session_id))
+        return json.dumps([{"subject": subject} for subject in state.pinned_ids])

--- a/tests/unit/cli/test_play.py
+++ b/tests/unit/cli/test_play.py
@@ -311,8 +311,77 @@ class TestClientRustLane:
         assert cfg["render_tier"] == "glyph"
         assert cfg["headless"] is False
         assert cfg["narrator_enabled"] is False
+        # DEFECT 1: the host handed to the Rust client must expose a real
+        # campaign-loading seam — the M1 wiring closing the gap where
+        # RustClientHost.bind_session had zero production caller.
+        assert callable(host.load_campaign)
         # The textual app must never boot on the rust lane.
         assert _captured == []
+
+    def test_rust_host_load_campaign_binds_a_real_session(
+        self, monkeypatch: pytest.MonkeyPatch, _patched_composition_root: None
+    ) -> None:
+        """DEFECT 1 (no production caller for ``bind_session``): the host
+        ``run(client=rust)`` composes must carry a REAL ``campaign_loader`` —
+        built exactly the way the textual path builds ``ArchiveApp``'s own
+        ``campaign_loader=`` (a partial over :func:`play_cmd._load_campaign`).
+        Fakes :func:`play_cmd._load_campaign` itself (the same seam the
+        textual-path tests above pin by identity) to avoid touching
+        Postgres/the engine, then drives the captured host's own
+        ``load_campaign`` exactly as the Rust lobby would and confirms
+        ``bind_session`` actually took effect — reads no longer serve
+        absence."""
+        import json
+        import sys
+        from uuid import UUID
+
+        from babylon.config.defines import GameDefines
+        from babylon.tui.host import RustClientHost
+
+        handoffs: list[tuple[object, str]] = []
+        fake = SimpleNamespace(run=lambda host, config_json: handoffs.append((host, config_json)))
+        monkeypatch.setitem(sys.modules, "babylon_tui", fake)
+
+        class _FakeSession:
+            """A minimal session-shaped double: enough for ``_load_campaign``'s
+            fake to return and for ``_driver_factory`` to wrap (it reads
+            ``services.defines`` — see ``_driver_factory``'s own docstring)."""
+
+            def __init__(self, campaign_id: UUID) -> None:
+                self.session_id = campaign_id
+                self.tick = 0
+                self.services = SimpleNamespace(defines=GameDefines())
+                self._pages = {"county/26163": "# Wayne County"}
+
+            def read_page(self, subject: str) -> str | None:
+                return self._pages.get(subject)
+
+            def known_subjects(self) -> frozenset[str]:
+                return frozenset(self._pages)
+
+            def subject_view(self, _subject_id: str) -> None:
+                return None
+
+        def _fake_load_campaign(
+            _runtime: object, _catalog: object, campaign_id: UUID, *, narrator_enabled: bool = True
+        ) -> _FakeSession:
+            return _FakeSession(campaign_id)
+
+        monkeypatch.setattr(play_cmd, "_load_campaign", _fake_load_campaign)
+
+        play_cmd.run(client=play_cmd.ClientKind.RUST)
+
+        assert len(handoffs) == 1
+        host, _config_json = handoffs[0]
+        assert isinstance(host, RustClientHost)
+
+        campaign_id = UUID("00000000-0000-0000-0000-000000000009")
+        result = json.loads(host.load_campaign(str(campaign_id)))
+        assert result == {"ok": True, "campaign_id": str(campaign_id)}
+        # bind_session actually took effect: reads no longer serve absence.
+        assert json.loads(host.read_page_json("county/26163")) == "# Wayne County"
+        assert host.session is not None
+        assert host.session.session_id == campaign_id
 
     def test_textual_default_still_boots_archive_app(self, _patched_composition_root: None) -> None:
         """The default lane is byte-identical to before: ArchiveApp boots."""

--- a/tests/unit/render/test_rust_theme_parity.py
+++ b/tests/unit/render/test_rust_theme_parity.py
@@ -1,0 +1,73 @@
+"""Cross-language ksbc palette parity: the Rust client's theme constants
+must track :data:`babylon.render.tiers.TRUECOLOR_PALETTE` (the §9b SSOT).
+
+The Rust client re-states four role colors as ``Color::Rgb(r, g, b)``
+literals in ``rust/crates/babylon-tui/src/theme.rs`` — an FFI boundary no
+import can cross, so this guard PARSES the Rust source instead (the same
+drift class the Program 24 P7 palette-SSOT pass eliminated Python-side via
+``test_design_bible_parity.py``: theme-local literals silently diverging
+from §9b). A §9b revision that moves a token now turns this red instead of
+leaving the Rust plates painting the stale color forever.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from babylon.render.tiers import TRUECOLOR_PALETTE, RoleToken
+
+_THEME_RS = (
+    Path(__file__).resolve().parents[3] / "rust" / "crates" / "babylon-tui" / "src" / "theme.rs"
+)
+
+_CONST_RE = re.compile(
+    r"pub const (?P<name>[A-Z_]+): Color = Color::Rgb\("
+    r"(?P<r>\d+), (?P<g>\d+), (?P<b>\d+)\);"
+)
+
+#: Rust constant name -> the §9b role token it mirrors.
+_ROLE_BY_CONSTANT: dict[str, RoleToken] = {
+    "CRIMSON": RoleToken.ACCENT_CRIMSON,
+    "GOLD": RoleToken.ACCENT_GOLD,
+    "BONE": RoleToken.TEXT,
+    "DIM": RoleToken.MUTED_DIM,
+}
+
+
+def _rust_constants() -> dict[str, tuple[int, int, int]]:
+    """Parse ``theme.rs``'s one-line ``Color::Rgb`` constants."""
+    source = _THEME_RS.read_text(encoding="utf-8")
+    found = {m["name"]: (int(m["r"]), int(m["g"]), int(m["b"])) for m in _CONST_RE.finditer(source)}
+    assert found, f"no Color::Rgb constants parsed from {_THEME_RS}"
+    return found
+
+
+def _hex_to_rgb(value: str) -> tuple[int, int, int]:
+    value = value.lstrip("#")
+    return (int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16))
+
+
+@pytest.mark.parametrize(("constant", "token"), sorted(_ROLE_BY_CONSTANT.items()))
+def test_rust_constant_matches_truecolor_palette(constant: str, token: RoleToken) -> None:
+    """Each Rust theme constant equals its §9b token's truecolor value."""
+    rust = _rust_constants()
+    assert constant in rust, (
+        f"{constant} missing from theme.rs — keep each constant on one line "
+        f"(the guard's regex contract, stated in theme.rs's module docs)"
+    )
+    expected = _hex_to_rgb(TRUECOLOR_PALETTE[token])
+    assert rust[constant] == expected, (
+        f"theme.rs {constant} = {rust[constant]} but §9b {token} = "
+        f"{expected} — update the Rust side (tiers.py is the SSOT)"
+    )
+
+
+def test_every_rust_constant_is_mapped() -> None:
+    """A new theme.rs constant must be added to the mapping here — an
+    unmapped constant is an unguarded literal, the exact drift class this
+    file exists to prevent."""
+    unmapped = set(_rust_constants()) - set(_ROLE_BY_CONSTANT)
+    assert not unmapped, f"unmapped theme.rs constants: {sorted(unmapped)}"

--- a/tests/unit/tui/test_host_contract.py
+++ b/tests/unit/tui/test_host_contract.py
@@ -1,25 +1,45 @@
-"""Contract for the RustClientHost seam (M0 lobby surface, ADR150).
+"""Contract for the RustClientHost seam (M0 lobby surface + M1 read surface, ADR150).
 
 The host is THE seam between the Python composition root and the Rust
 client: every read crosses as a JSON string of primitives, and the Rust
 side's ``LobbyRow`` deserializer requires ``campaign_id``/``name``/``tick``
 keys on each row (extra keys are tolerated by serde and carry provenance).
+
+The M1 classes below (``TestReadPage``/``TestKnownSubjects``/
+``TestBacklinks``/``TestSubjectView``/``TestWatchlist``) extend the contract
+to the M1 read surface: :meth:`~babylon.tui.host.RustClientHost.read_page_json`,
+:meth:`~babylon.tui.host.RustClientHost.known_subjects_json`,
+:meth:`~babylon.tui.host.RustClientHost.backlinks_json`,
+:meth:`~babylon.tui.host.RustClientHost.subject_view_json`, and
+:meth:`~babylon.tui.host.RustClientHost.watchlist_json`. ``_FakeCampaign``
+mirrors ``test_app_watchlist_live.py``'s own minimal ``CampaignHandle``
+double — only the members the M1 host methods actually call
+(``session_id``/``tick``/``read_page``/``known_subjects``/``subject_view``)
+rather than the full Protocol surface (``dashboard_view``/``issue_verb``/
+etc., which no M1 host method touches); :meth:`RustClientHost.bind_session`
+accepts it via the same ``# type: ignore[arg-type]`` the pre-existing
+``TestBindSession`` class already uses for its own trivial ``object()``
+double.
 """
 
 from __future__ import annotations
 
 import json
+from typing import Final
 from uuid import UUID
 
 import pytest
 
+from babylon.projection.view_models import CountyView, ProjectionRecord
 from babylon.tui.campaign_menu import InMemoryCampaign, InMemoryCampaignCatalog
 from babylon.tui.host import RustClientHost
+from babylon.tui.watchlist import InMemoryWatchlistPersistence
 
 pytestmark = pytest.mark.unit
 
 _DEFINES_HASH = "deadbeef" * 8
 _ENGINE_VERSION = "1.2.3"
+_SESSION_ID = UUID("00000000-0000-0000-0000-0000000000f1")
 
 
 def _catalog() -> InMemoryCampaignCatalog:
@@ -86,3 +106,167 @@ class TestBindSession:
         host = _host()
         assert host.session is None
         assert host.driver is None
+
+
+class _FakeCampaign:
+    """A minimal ``CampaignHandle`` double covering only what the M1 host
+    read methods call — see this module's own docstring for why the full
+    Protocol surface is unneeded here."""
+
+    def __init__(
+        self,
+        pages: dict[str, str],
+        *,
+        session_id: UUID = _SESSION_ID,
+        tick: int = 0,
+        views: dict[str, ProjectionRecord] | None = None,
+    ) -> None:
+        self.session_id = session_id
+        self.tick = tick
+        self._pages = pages
+        self._views: dict[str, ProjectionRecord] = views if views is not None else {}
+
+    def read_page(self, subject: str) -> str | None:
+        return self._pages.get(subject)
+
+    def known_subjects(self) -> frozenset[str]:
+        return frozenset(self._pages)
+
+    def subject_view(self, subject_id: str) -> ProjectionRecord | None:
+        return self._views.get(subject_id)
+
+
+def _bound_host(
+    pages: dict[str, str],
+    *,
+    tick: int = 0,
+    views: dict[str, ProjectionRecord] | None = None,
+    watchlist_persistence: InMemoryWatchlistPersistence | None = None,
+) -> tuple[RustClientHost, _FakeCampaign]:
+    host = RustClientHost(
+        _catalog(),
+        defines_hash=_DEFINES_HASH,
+        engine_version=_ENGINE_VERSION,
+        watchlist_persistence=watchlist_persistence,
+    )
+    session = _FakeCampaign(pages, tick=tick, views=views)
+    host.bind_session(session, object())  # type: ignore[arg-type]
+    return host, session
+
+
+class TestReadPage:
+    def test_unbound_host_reads_null(self) -> None:
+        assert _host().read_page_json("county/26163") == "null"
+
+    def test_unknown_subject_reads_null(self) -> None:
+        host, _ = _bound_host({"county/26163": "# Wayne"})
+        assert host.read_page_json("org/nowhere") == "null"
+
+    def test_known_subject_round_trips_its_markdown(self) -> None:
+        host, _ = _bound_host({"county/26163": "# Wayne County"})
+        assert json.loads(host.read_page_json("county/26163")) == "# Wayne County"
+
+    def test_read_page_never_bakes_a_missing_subject(self) -> None:
+        # read_page is a pure passthrough — reading twice never conjures a
+        # page that wasn't there the first time (Constitution III.11).
+        host, _ = _bound_host({})
+        assert host.read_page("county/26163") is None
+        assert host.read_page("county/26163") is None
+
+
+class TestKnownSubjectsJson:
+    def test_unbound_host_is_empty(self) -> None:
+        assert json.loads(_host().known_subjects_json()) == []
+
+    def test_known_subjects_are_sorted(self) -> None:
+        host, _ = _bound_host(
+            {"county/26163": "# W", "org/uaw-9999": "# U", "county/06037": "# LA"}
+        )
+        assert json.loads(host.known_subjects_json()) == [
+            "county/06037",
+            "county/26163",
+            "org/uaw-9999",
+        ]
+
+
+class TestBacklinksJson:
+    """Exercises a tiny 3-page fixture vault: A links to B and C; B links to
+    C; C links to nothing. Reuses ``babylon.tui.wikilinks``' own
+    ``[[target]]`` grammar — the SAME grammar
+    ``babylon.tui.shell.backlinks.build_backlink_index`` inverts."""
+
+    _PAGES: dict[str, str] = {
+        "page/a": "# A\n\nSee [[page/b]] and [[page/c|See C]].",
+        "page/b": "# B\n\nAlso see [[page/c]].",
+        "page/c": "# C\n\nNo outbound links here.",
+    }
+
+    def test_unbound_host_has_no_backlinks(self) -> None:
+        assert json.loads(_host().backlinks_json("page/c")) == []
+
+    def test_target_with_two_inbound_links_is_sorted(self) -> None:
+        host, _ = _bound_host(self._PAGES)
+        assert json.loads(host.backlinks_json("page/c")) == ["page/a", "page/b"]
+
+    def test_target_with_one_inbound_link(self) -> None:
+        host, _ = _bound_host(self._PAGES)
+        assert json.loads(host.backlinks_json("page/b")) == ["page/a"]
+
+    def test_page_with_no_inbound_links_is_empty(self) -> None:
+        host, _ = _bound_host(self._PAGES)
+        assert json.loads(host.backlinks_json("page/a")) == []
+
+    def test_redlink_target_with_no_baked_page_still_gets_a_backlink(self) -> None:
+        # A page can link to a subject the vault never baked (a redlink) —
+        # the backlink index records links MADE, not resolvable targets.
+        host, _ = _bound_host({"page/a": "# A\n\nSee [[org/never-baked]]."})
+        assert json.loads(host.backlinks_json("org/never-baked")) == ["page/a"]
+
+    def test_cache_recomputes_across_a_tick_boundary(self) -> None:
+        # Same session_id, tick 0 -> tick 1: a newly-baked page's outbound
+        # link must be reflected, proving the cache key includes tick.
+        host, session = _bound_host(dict(self._PAGES), tick=0)
+        assert json.loads(host.backlinks_json("page/c")) == ["page/a", "page/b"]
+        session._pages["page/c"] = "# C\n\nNow links to [[page/a]]."
+        session.tick = 1
+        assert json.loads(host.backlinks_json("page/a")) == ["page/c"]
+
+
+class TestSubjectViewJson:
+    _VIEW: Final = CountyView(county_fips="26163", verified_tick=7, population=1_749_343)
+
+    def test_unbound_host_is_null(self) -> None:
+        assert _host().subject_view_json("county/26163") == "null"
+
+    def test_unresolvable_subject_is_null(self) -> None:
+        host, _ = _bound_host({}, views={"county/26163": self._VIEW})
+        assert host.subject_view_json("org/nowhere") == "null"
+
+    def test_known_subject_round_trips_a_discriminating_field(self) -> None:
+        host, _ = _bound_host({}, views={"county/26163": self._VIEW})
+        payload = json.loads(host.subject_view_json("county/26163"))
+        assert payload["kind"] == "county"
+        assert payload["county_fips"] == "26163"
+        assert payload["population"] == 1_749_343
+
+
+class TestWatchlistJson:
+    def test_unbound_host_is_empty(self) -> None:
+        assert json.loads(_host().watchlist_json()) == []
+
+    def test_bound_session_with_no_persistence_wired_is_empty(self) -> None:
+        host, _ = _bound_host({})  # watchlist_persistence defaults to None
+        assert json.loads(host.watchlist_json()) == []
+
+    def test_bound_session_with_empty_watchlist_is_empty(self) -> None:
+        host, _ = _bound_host({}, watchlist_persistence=InMemoryWatchlistPersistence())
+        assert json.loads(host.watchlist_json()) == []
+
+    def test_pinned_subjects_round_trip_in_pin_order(self) -> None:
+        persistence = InMemoryWatchlistPersistence()
+        persistence.save(str(_SESSION_ID), ("org/uaw-9999", "county/26163"))
+        host, _ = _bound_host({}, watchlist_persistence=persistence)
+        assert json.loads(host.watchlist_json()) == [
+            {"subject": "org/uaw-9999"},
+            {"subject": "county/26163"},
+        ]

--- a/tests/unit/tui/test_host_contract.py
+++ b/tests/unit/tui/test_host_contract.py
@@ -30,6 +30,7 @@ from uuid import UUID
 
 import pytest
 
+from babylon.projection.briefing import operation_codename
 from babylon.projection.view_models import CountyView, ProjectionRecord
 from babylon.tui.campaign_menu import InMemoryCampaign, InMemoryCampaignCatalog
 from babylon.tui.host import RustClientHost
@@ -92,6 +93,18 @@ class TestLobbyCatalogJson:
         # Honest absence (III.11): no campaigns is [], never a fabricated row.
         assert json.loads(_host(InMemoryCampaignCatalog()).lobby_catalog_json()) == []
 
+    def test_rows_carry_the_display_codename_not_the_machine_slug(self) -> None:
+        # DEFECT 2: the Textual lobby renders operation_codename(campaign_id),
+        # never the machine slug (spec-116 FR-116-3) — the Rust row must
+        # carry the same derived display name, additively (name/slug stays).
+        rows = json.loads(_host().lobby_catalog_json())
+        assert [r["codename"] for r in rows] == [
+            operation_codename(UUID("00000000-0000-0000-0000-000000000001")),
+            operation_codename(UUID("00000000-0000-0000-0000-000000000002")),
+        ]
+        # name (the machine slug) is unchanged by this fix.
+        assert [r["name"] for r in rows] == ["wayne-county", "rust-belt"]
+
 
 class TestBindSession:
     def test_bind_session_stores_the_handles(self) -> None:
@@ -152,6 +165,82 @@ def _bound_host(
     session = _FakeCampaign(pages, tick=tick, views=views)
     host.bind_session(session, object())  # type: ignore[arg-type]
     return host, session
+
+
+class TestLoadCampaign:
+    """DEFECT 1 (no production caller for ``bind_session``): ``load_campaign``
+    closes the gap by resolving a campaign through the wired
+    ``campaign_loader`` seam and binding it — mirroring
+    ``ArchiveApp._on_campaign_chosen``'s own composition."""
+
+    def test_no_campaign_loader_wired_raises(self) -> None:
+        # Unreachable through the real composition root (which always wires
+        # one) — but never silently served as absence (Constitution III.11).
+        host = _host()
+        with pytest.raises(RuntimeError, match="campaign_loader"):
+            host.load_campaign(str(_SESSION_ID))
+
+    def test_success_binds_the_session_and_returns_ok_json(self) -> None:
+        campaign = _FakeCampaign({"county/26163": "# Wayne"}, session_id=_SESSION_ID)
+        host = RustClientHost(
+            _catalog(),
+            defines_hash=_DEFINES_HASH,
+            engine_version=_ENGINE_VERSION,
+            campaign_loader=lambda _campaign_id: campaign,  # type: ignore[arg-type, return-value]
+        )
+        result = json.loads(host.load_campaign(str(_SESSION_ID)))
+        assert result == {"ok": True, "campaign_id": str(_SESSION_ID)}
+        assert host.session is campaign  # type: ignore[comparison-overlap]
+        assert host.driver is None  # no driver_factory wired: a legal M1 answer.
+        # bind_session actually took effect: reads no longer serve absence.
+        assert json.loads(host.read_page_json("county/26163")) == "# Wayne"
+
+    def test_loader_that_raises_propagates(self) -> None:
+        def _boom(_campaign_id: UUID) -> _FakeCampaign:
+            raise RuntimeError("boot failed")
+
+        host = RustClientHost(
+            _catalog(),
+            defines_hash=_DEFINES_HASH,
+            engine_version=_ENGINE_VERSION,
+            campaign_loader=_boom,  # type: ignore[arg-type]
+        )
+        with pytest.raises(RuntimeError, match="boot failed"):
+            host.load_campaign(str(_SESSION_ID))
+        # A failed load never fakes a bind (Constitution III.11).
+        assert host.session is None
+
+    def test_driver_factory_is_called_when_wired(self) -> None:
+        campaign = _FakeCampaign({}, session_id=_SESSION_ID)
+        built_driver = object()
+        host = RustClientHost(
+            _catalog(),
+            defines_hash=_DEFINES_HASH,
+            engine_version=_ENGINE_VERSION,
+            campaign_loader=lambda _campaign_id: campaign,  # type: ignore[arg-type, return-value]
+            driver_factory=lambda _bound_campaign: built_driver,  # type: ignore[arg-type, return-value]
+        )
+        host.load_campaign(str(_SESSION_ID))
+        assert host.driver is built_driver
+
+    def test_watchlist_json_serves_real_pins_after_load_campaign(self) -> None:
+        persistence = InMemoryWatchlistPersistence()
+        persistence.save(str(_SESSION_ID), ("org/uaw-9999", "county/26163"))
+        campaign = _FakeCampaign({}, session_id=_SESSION_ID)
+        host = RustClientHost(
+            _catalog(),
+            defines_hash=_DEFINES_HASH,
+            engine_version=_ENGINE_VERSION,
+            campaign_loader=lambda _campaign_id: campaign,  # type: ignore[arg-type, return-value]
+            watchlist_persistence=persistence,
+        )
+        # Honest absence before any campaign is bound.
+        assert json.loads(host.watchlist_json()) == []
+        host.load_campaign(str(_SESSION_ID))
+        assert json.loads(host.watchlist_json()) == [
+            {"subject": "org/uaw-9999"},
+            {"subject": "county/26163"},
+        ]
 
 
 class TestReadPage:

--- a/tests/unit/tui/test_rust_client_ffi.py
+++ b/tests/unit/tui/test_rust_client_ffi.py
@@ -13,25 +13,83 @@ babylon_tui = pytest.importorskip(
 
 
 class _FakeHost:
+    """The M1 host surface, minimally faked (full row shape — LobbyRow is
+    strict, so a three-field M0-era row would render an empty catalog)."""
+
     def lobby_catalog_json(self) -> str:
-        return json.dumps([{"campaign_id": "c1", "name": "Wayne County", "tick": 0}])
+        return json.dumps(
+            [
+                {
+                    "campaign_id": "c1",
+                    "name": "campaign-a3f9b2c1d0e5",
+                    "codename": "Wayne County",
+                    "tick": 0,
+                    "status": "ACTIVE",
+                    "defines_hash": "dh1",
+                    "engine_version": "ev1",
+                }
+            ]
+        )
+
+    def load_campaign(self, campaign_id: str) -> str:
+        return json.dumps({"ok": True, "campaign_id": campaign_id})
+
+    def read_page_json(self, subject: str) -> str:
+        if subject == "briefing/c1":
+            return json.dumps("# Briefing\n\nOperation begins.")
+        return "null"
+
+    def known_subjects_json(self) -> str:
+        return json.dumps(["Detroit"])
+
+    def backlinks_json(self, subject: str) -> str:
+        return "[]"
+
+    def subject_view_json(self, subject: str) -> str:
+        return "null"
+
+    def watchlist_json(self) -> str:
+        return "[]"
+
+
+def _config(**overrides: object) -> str:
+    cfg: dict[str, object] = {
+        "campaign_id": "c1",
+        "campaign_name": "Wayne County",
+        "render_tier": "glyph",
+        "tutorial_enabled": False,
+        "narrator_enabled": False,
+        "headless": True,
+    }
+    cfg.update(overrides)
+    return json.dumps(cfg)
 
 
 def test_run_headless_renders_and_records_calls() -> None:
+    transcript = json.loads(babylon_tui.run(_FakeHost(), _config()))
+    assert "lobby_catalog_json" in transcript["host_calls"]
+    assert "Wayne County" in transcript["frames"][0]
+
+
+def test_run_headless_scripted_flow_lobby_to_briefing_to_quit() -> None:
+    """Task 19's BDD-harness foundation: script steps replay through the
+    real FFI, each appending a frame; host-call order pins the seam."""
     transcript = json.loads(
         babylon_tui.run(
             _FakeHost(),
-            json.dumps(
-                {
-                    "campaign_id": "c1",
-                    "campaign_name": "Wayne County",
-                    "render_tier": "glyph",
-                    "tutorial_enabled": False,
-                    "narrator_enabled": False,
-                    "headless": True,
-                }
-            ),
+            _config(script=[{"key": "enter"}, {"key": "q"}, {"key": "q"}]),
         )
     )
-    assert "lobby_catalog_json" in transcript["host_calls"]
+    # Frames: initial lobby, briefing after enter, lobby after first q;
+    # the final q quits (no frame after quit).
+    assert len(transcript["frames"]) == 3
     assert "Wayne County" in transcript["frames"][0]
+    assert "Briefing" in transcript["frames"][1]
+    assert "CAMPAIGNS" in transcript["frames"][2]
+    assert transcript["host_calls"] == [
+        "lobby_catalog_json",
+        "load_campaign",
+        "known_subjects_json",
+        "read_page_json",
+        "backlinks_json",
+    ]


### PR DESCRIPTION
## Raster cutover M1 — read-only Archive (ADR150, plan Tasks 11–20)

Second milestone of the Ratatui cutover: the Rust client goes from a lobby hello-frame to a browsable read-only Archive against the real vault.

### What's in
- **babylon-md** — in-tree fork of tui-markdown v0.3.9 (MIT/Apache preserved; exactly two marked patches: `pulldown_cmark::Options` passthrough for `ENABLE_WIKILINKS`, and link-metadata retention via a side-channel sink). All 153 upstream tests still pass. Vendored bytes excluded from whitespace fixers (byte-exact insta goldens).
- **wiki_render** — wikilink `LinkSpan` side channel; GOLD known links / CRIMSON redlinks (ADR099 register, `theme.rs` = the §9b mirror; guarded cross-language by `test_rust_theme_parity.py` parsing the Rust source against `TRUECOLOR_PALETTE`).
- **Views** — Lobby (operation-codename display, spec-116 — the machine slug never shows), Wiki (span-preserving word wrap with exact link-cell hit mapping, jumplist, keyboard link cursor `n`/`p`/`Enter`, 'What links here' backlinks footer), Palette + Watchlist (read-only), depth-0..3 peek plates (declaration-order field selection via `preserve_order` — depth caps truncate, so order selects the SUBSET). Loud UNREADABLE states for malformed host payloads, distinct from honest absence.
- **App shell** — view stack over the lobby root, palette overlay (with `Clear`), mouse hit-registry + keyboard peek, `1–5`/Tab scaffold, headless scripted-input replay (`script: [{key},{mouse:[c,r]}]`) — the M3 BDD harness foundation.
- **Host M1 surface, both sides** — `read_page/known_subjects/backlinks/subject_view/watchlist` + **`load_campaign`**: the production composition-root verb. `_run_rust_client` threads the SAME `_load_campaign`/`_driver_factory`/catalog factories the Textual path builds. The backlink index reuses `shell/backlinks.py` (no re-derivation) with a (session, tick) cache.
- **FFI loudness (III.11)** — a raising host prints its traceback and panics across the seam as `PanicException`; RAII terminal restore covers the panic path. Errors are never encoded as absence.

### Adversarial verification
A 3-lens Opus verify panel (parity / correctness+FFI / fork-hygiene) ran mid-milestone: **31 findings, all remediated in this PR**. Headline: the entire read surface had no production caller (`bind_session` was test-only) — every gate was green over a client that could never reach real data. Caught and closed before merge.

### Evidence
- `mise run rust:check` green — fmt, clippy `-D warnings` (workspace, all-features), 132 tests, rustdoc.
- 54 seam-adjacent Python tests green (host contract 30, play 17, FFI 2+scripted, theme parity 5).
- **Real-vault smoke**: campaign minted through the real menu → lobby shows `QUIET ORCHard`-style codename → Enter binds via `load_campaign` → the live Postgres briefing page renders → back → quit; seam call order `[lobby_catalog_json, load_campaign, known_subjects_json, read_page_json, backlinks_json]` exact.
- Full `test:unit`: 14,696 pass; the 16 failures are the pre-existing unmounted-babylon-data-drive class (environment, not this diff — CI provisions the DB artifact).

### Deviations (recorded in the plan's M1 close-out note)
- `tui-scrollview` not adopted: the layout registry needs the exact display cells per wikilink; ratatui-side wrapping discards that mapping, so WikiView wraps itself and clamps `Paragraph::scroll` to content.
- `babylon-md` consumed with `default-features = false`: syntect/onig (native C build) stay out of the client graph (AA disclosure: removes the MSVC cross-compile failure point).

Owner residue: the TTY smoke (`babylon play --client rust` on a real terminal), same as M0 Task 10. Next: M2 Playable (plan Tasks 21–26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)