### PR TITLE
feat(rust): Ratatui M2 — Playable (plan Tasks 21-26 + 43-finding verify-panel remediation)

### DIFF
--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -2,9 +2,43 @@
 # What exists vs what's planned - KEEP THIS UPDATED
 
 meta:
-  version: "2.56.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
+  version: "2.57.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
   updated: "2026-07-27"
   truth_status: |
+    (2026-07-27 RASTER CUTOVER M2 EXECUTED — Playable) Tasks 21-26 on
+    feature/ratatui-m2, contracts pinned FIRST from a 6-scout sweep
+    (docs/superpowers/specs/2026-07-27-m2-seam-contracts.md; every M2
+    method fits call0/call1 via single-JSON-arg — zero new FFI helpers).
+    Host trait +11 methods both sides (pacing_state/advance_tick/
+    run_until_paused/acknowledge_pause with ok-envelopes; host-owned
+    chronicle accumulator -> chronicle_rail_json, salience shipped as
+    render-ready DATA; verb_plate_view_json = VerbPlateView.model_dump_json
+    passthrough; issue_verb catches ONLY RuntimeError/ValueError/KeyError;
+    endgame_status_json passthrough; pin_watchlist ValueError=refusal
+    envelope; nav_state_json/save_nav_state over nav_persistence=catalog).
+    Play screen: HUD strip (T+tick/horizon, five 8-cell axis gauges — five
+    fit 80 cols, triggered=progress>=1.0 CRIMSON, PACING states), watchlist
+    rail LEFT, wiki center, chronicle rail RIGHT, verb plate BOTTOM (click
+    + F1-F9 dispatch, preview AP·P% + CRIMSON warnings), status line;
+    Tab focus cycle with visible ● marker + focus-gated highlights; Esc =
+    rail defocus; t/r/a through the Textual pre-check ladder (verbatim
+    refusal strings); 6-step post-tick fanout in Textual's exact order;
+    honest-target verb dispatch (_honest_target_id port); P/rail-p pin
+    writes; nav restore post-bind + dedupe/cap-20/ack-checked save on
+    leaving. Recorded deviations: NO remaining-actions test (dormant
+    feature), NO quiet row kind (chronicle_stream never emits empty
+    bulletins), envelopes not ->None, nav not via config_json. 43-finding
+    Opus panel remediated in full (headline classes: Esc tore down the
+    campaign; parse failures masqueraded as "campaign ended"; the 5th HUD
+    gauge clipped into a lying bar; unbounded persisted-jumplist growth).
+    Real-vault smoke GREEN through the production composition root: 5 real
+    engine ticks (autopause/ack ladder exercised by REAL critical events),
+    a real verb queued, pin persistence proven ACROSS SESSIONS, nav saved.
+    Gates: rust:check green (336 tests), 93 seam-adjacent Python green,
+    load_campaign ack now carries the session tick (resumed-campaign HUD
+    honesty). TTY smoke owner-side. NEXT: M3 Tutorial gate (Tasks 27-31 +
+    Gate 3 + Patches the monkey content directive).
+    PREVIOUS (same day):
     (2026-07-27 RASTER CUTOVER M1 EXECUTED — read-only Archive) Tasks 11-20
     on feature/ratatui-m1: babylon-md fork (tui-markdown 0.3.9, exactly two
     marked patches: Options passthrough + link-metadata side channel;

--- a/docs/superpowers/plans/2026-07-26-ratatui-client.md
+++ b/docs/superpowers/plans/2026-07-26-ratatui-client.md
@@ -586,12 +586,34 @@ pinned. TTY smoke remains owner-side (as M0 Task 10).
 
 # M2 — Playable (task-level; expand at kickoff)
 
-- [ ] **Task 21 — Tick controls.** Rust: `t`/`r`/`a` bindings → `host.advance_tick()` (step), run-until-paused loop flag, acknowledge. Python: `advance_tick()` delegates to the paced driver → `TickOutcome` JSON (`tick`, `paused`, `chronicle: [...]`). Tests: Rust scripted-input tick test with a fake host; Python contract test over `tests/unit/game/test_pacing.py` fixture shapes. Commit `feat(tui): tick controls`.
-- [ ] **Task 22 — Chronicle rail.** Renders `TickOutcome.chronicle` (salience/dedupe/volume-floor/autopause rules from `tui/chronicle_salience.py` ship as DATA the host pre-computes — Rust renders, never ranks; design §6 gap ledger). Snapshot goldens. Commit `feat(rust): chronicle rail`.
-- [ ] **Task 23 — Verb plate + issue_verb.** Renders `verb_plate_view_json()` (9 Article-V verbs, OODA-gated disabled states); F1–F9 + click dispatch → `host.issue_verb(action_id, target_id, target_community)` → re-render. Tests: round-trip contract test (verb decrements remaining actions, mirrors `tests/integration/archive/test_verb_resolution.py` shapes at unit level); scripted-input verb dispatch test. Commit `feat(tui): verb plate + dispatch`.
-- [ ] **Task 24 — Endgame HUD.** 5 terminal-outcome axis bars from `endgame_status_json()` (`Gauge`/`BarChart`); honest absence pre-game. Commit `feat(rust): endgame HUD`.
-- [ ] **Task 25 — Watchlist writes + nav persistence.** `p` pin/unpin → `pin_watchlist(subject, pinned)` → `BabylonMetaStore` persistence; rail re-renders. `save_nav_state(nav_json)` on exit + restore via `config_json` at launch (design §6 gap ledger — the NavPersistence home). Contract test round-trips both. Commit `feat(tui): watchlist pin writes + nav persistence`.
-- [ ] **Task 26 — M2 close-out.** Gates green; manual smoke plays 5 real ticks with one real verb; `ai/state.yaml`. Commit `docs(state): raster cutover M2`.
+- [x] **Task 21 — Tick controls.** Rust: `t`/`r`/`a` bindings → `host.advance_tick()` (step), run-until-paused loop flag, acknowledge. Python: `advance_tick()` delegates to the paced driver → `TickOutcome` JSON (`tick`, `paused`, `chronicle: [...]`). Tests: Rust scripted-input tick test with a fake host; Python contract test over `tests/unit/game/test_pacing.py` fixture shapes. Commit `feat(tui): tick controls`.
+- [x] **Task 22 — Chronicle rail.** Renders `TickOutcome.chronicle` (salience/dedupe/volume-floor/autopause rules from `tui/chronicle_salience.py` ship as DATA the host pre-computes — Rust renders, never ranks; design §6 gap ledger). Snapshot goldens. Commit `feat(rust): chronicle rail`.
+- [x] **Task 23 — Verb plate + issue_verb.** Renders `verb_plate_view_json()` (9 Article-V verbs, OODA-gated disabled states); F1–F9 + click dispatch → `host.issue_verb(action_id, target_id, target_community)` → re-render. Tests: round-trip contract test (verb decrements remaining actions, mirrors `tests/integration/archive/test_verb_resolution.py` shapes at unit level); scripted-input verb dispatch test. Commit `feat(tui): verb plate + dispatch`.
+- [x] **Task 24 — Endgame HUD.** 5 terminal-outcome axis bars from `endgame_status_json()` (`Gauge`/`BarChart`); honest absence pre-game. Commit `feat(rust): endgame HUD`.
+- [x] **Task 25 — Watchlist writes + nav persistence.** `p` pin/unpin → `pin_watchlist(subject, pinned)` → `BabylonMetaStore` persistence; rail re-renders. `save_nav_state(nav_json)` on exit + restore via `config_json` at launch (design §6 gap ledger — the NavPersistence home). Contract test round-trips both. Commit `feat(tui): watchlist pin writes + nav persistence`.
+- [x] **Task 26 — M2 close-out.** Gates green; manual smoke plays 5 real ticks with one real verb; `ai/state.yaml`. Commit `docs(state): raster cutover M2`.
+
+**M2 CLOSED 2026-07-27** (branch `feature/ratatui-m2`; contracts:
+`docs/superpowers/specs/2026-07-27-m2-seam-contracts.md`). Recorded
+deviations, all scout/panel-driven: the Task-23 test asserts the two REAL
+`test_verb_resolution.py` behaviors, never "decrements remaining actions"
+(the action-point budget is dormant — no production caller);
+`pin_watchlist`/tick verbs return ok-envelopes (the sketch's `-> None`
+would crash on the player-reachable capacity ValueError); nav restore
+rides a post-bind `nav_state_json()` pull (config_json predates
+selection) and Back-to-lobby is the sole save point; salience rides a
+host-owned accumulator (`chronicle_rail_json` — rules span ticks); NO
+"quiet" row kind (chronicle_stream never emits an empty bulletin); `P`
+pins (lowercase `p` = wiki link cursor; rail-`p` toggles the highlighted
+row). Additions from the 43-finding Opus verify panel: visible focus
+(`Tab` cycle, ● marker, focus-gated highlights), Esc = rail defocus
+(never campaign teardown), honest-unreadable pacing/outcome states
+(never "campaign ended" from a parse failure), HUD 8-cell gauges (five
+fit 80 cols), verb-plate preview+warnings render + CLICK dispatch,
+highlight preservation across refreshes, nav dedupe/cap/ack-check.
+Real-vault smoke: 5 real engine ticks + a real verb + pin/unpin
+persistence across sessions, through the production composition root.
+TTY smoke remains owner-side.
 
 # M3 — Tutorial gate (task-level; expand at kickoff) — **PARITY GATE + BD GATE 3 (BD-8)**
 

--- a/docs/superpowers/specs/2026-07-27-m2-seam-contracts.md
+++ b/docs/superpowers/specs/2026-07-27-m2-seam-contracts.md
@@ -84,8 +84,9 @@ no streaming; deviating would need a Director ruling). The loop lives in
 ### `acknowledge_pause()` → (call0)
 
 `{"ok": true}` / `{"ok": false, "error": "..."}`. Rust pre-checks
-`awaiting_ack` first; success status line: "autopause acknowledged — ready
-to advance" (`app.py:2311-2324`).
+`awaiting_ack` first; success status line: "status: autopause acknowledged
+— ready to advance" (`app.py:2311-2324`), and the ack ALSO refreshes the
+HUD's PACING feed so the strip never contradicts the status line.
 
 ### ChronicleEvent (elements of `outcome.chronicle`)
 
@@ -116,9 +117,7 @@ and exposes the render-ready rail:
    {"subject": null, "kind": "header", "tick": 847, "severity": null,
     "actor": null, "text": "T0847"},
    {"subject": "organization/org-x", "kind": "event", "tick": 847,
-    "severity": "critical", "actor": "The Vanguard", "text": "..."},
-   {"subject": null, "kind": "quiet", "tick": 846, "severity": null,
-    "actor": null, "text": "the wire is quiet"}
+    "severity": "critical", "actor": "The Vanguard", "text": "..."}
  ]}
 ```
 
@@ -129,9 +128,13 @@ and exposes the render-ready rail:
   `dedupe_consecutive(apply_volume_floors(history))` then
   `compute_autopause_state` then `chronicle_stream(salient, limit=200)`
   then `chronicle_rows` (`app.py:1655-1661`).
-- `kind`: `"header"` (tick header, non-navigable), `"event"`, `"quiet"`
-  (honest-absence line). `severity` only on events. `actor` is the
-  bold-GOLD prefix (only ~6 EventTypes ever have one); `text` EXCLUDES it.
+- `kind`: `"header"` (tick header, non-navigable) or `"event"`. There is
+  deliberately NO `"quiet"` kind (verify-panel correction): `chronicle_stream`
+  never emits an empty bulletin, so a per-tick quiet row would be a dead
+  variant — an EMPTY rail is the honest-absence state, rendered client-side.
+  `severity` only on events. `actor` is the bold-GOLD prefix (only ~6
+  EventTypes ever have one); `text` EXCLUDES it and Rust joins them with
+  the Textual `"{actor}: "` separator.
 - Honest absence (no session): `{"autopause_line": null, "rows": []}`.
 - Colors Rust-side: critical = bold CRIMSON, warning = AMBER, informational
   = BONE, header = bold GOLD, quiet = bold CRIMSON, autopause = bold AMBER.
@@ -140,8 +143,11 @@ and exposes the render-ready rail:
   `test_rust_theme_parity.py` fails on unmapped constants there). Declare
   it as a documented module const in the chronicle view, citing
   `tui/theme.py:71-74`.
-- `TickOutcome.chronicle` (raw events) still crosses in Task 21's envelope —
-  status/count uses it; the RAIL renders only from `chronicle_rail_json()`.
+- `TickOutcome.chronicle` (raw events) crosses in Task 21's envelope per
+  the plan's pinned wire shape; the RAIL renders exclusively from
+  `chronicle_rail_json()` and the Rust shell reads only `tick`/`paused`
+  today (verify-panel correction — the earlier "status/count uses it"
+  claim was false).
 
 ## 3. Verb plate + dispatch (Task 23)
 
@@ -264,16 +270,25 @@ row key stays literally `"subject"` (`watchlist.rs:100,159` hardcodes it).
 ENTRIES persist; cursor/capacity are reconstructed on restore —
 `nav.py:18-21,85-93`). Jumplist/breadcrumb tables allow duplicates
 (only watchlist has UNIQUE) — the round-trip test must NOT assert dedup.
+The CLIENT dedupes exactly one seam point: a restored trail's trailing
+entry equal to the fresh briefing visit is dropped before seeding, or
+every resume would grow the persisted jumplist without bound; the client
+also caps the saved trail to the newest 20 entries (the Python nav
+capacity).
 
 RECORDED DEVIATION from the design sketch ("restored through config_json
 at launch"): `config_json` is built BEFORE a campaign is chosen
 (`play.py:449-458`, `campaign_id: ""`) and nav state is campaign-scoped —
 restore instead rides a post-bind pull (`nav_state_json()` after
-`load_campaign`), exactly the watchlist precedent. Save cadence: on
-leaving the campaign (Back to lobby) AND on quit. (Textual never wired nav
-persistence in production at all — `app.py:1185-1187` uses a throwaway
-uuid4 + InMemory store — so this is fresh wiring on both sides, not a
-port.)
+`load_campaign`), exactly the watchlist precedent. Save cadence
+(verify-panel correction): Back-to-lobby is the SOLE save point — the
+chrome is always gone before the lobby can quit, so a quit-path save
+could never fire; quitting from inside a campaign passes through the
+leave. An empty trail still saves (a cleared trail must be able to clear
+the store), and a refused save ack reports on stderr — never silently.
+(Textual never wired nav persistence in production at all —
+`app.py:1185-1187` uses a throwaway uuid4 + InMemory store — so this is
+fresh wiring on both sides, not a port.)
 
 ## 6. Play-screen chrome + keys (integration)
 
@@ -283,8 +298,13 @@ verb plate BOTTOM, HUD strip TOP, wiki/dossier center. Keys added in M2:
 (canonical zip), `P` (capital) pin/unpin the current wiki subject —
 lowercase `p` stays the M1 link-cursor-previous inside WikiView (recorded
 divergence from Textual's `p`=pin; collision found by the scout sweep) —
-and `p` toggles the highlighted row's pin inside the Watchlist view, where
-no link cursor exists.
+and `p` toggles the highlighted row's pin while the watchlist rail holds
+focus (nothing highlighted = a refusal, never a fallback to the
+current-dossier pin). Verb rows also dispatch on left-click (their rects
+register as `verb:{slot}` pseudo-entities). `Esc` defocuses a rail back to
+the center — it never falls through and tears down the campaign. The
+focused pane is the ONLY one rendering its selection highlight, and its
+rail title carries a `●` marker.
 
 Post-tick refresh fanout (both `t` and `r`), Textual's exact order
 (`app.py:2102-2150`): (1) known subjects, (2) HUD/endgame, (3) verb plate,

--- a/docs/superpowers/specs/2026-07-27-m2-seam-contracts.md
+++ b/docs/superpowers/specs/2026-07-27-m2-seam-contracts.md
@@ -1,0 +1,292 @@
+# M2 "Playable" — FFI seam contracts (pinned 2026-07-27)
+
+Companion to `2026-07-26-ratatui-client-design.md` §6 and plan Tasks 21–26.
+Pinned from a six-scout sweep of the real Python estates (pacing, chronicle
+salience, verbs, endgame, watchlist/nav, Textual UX ground truth) — every
+shape below cites the source whose field order it inherits. **JSON strings
+only cross the FFI; field order is load-bearing** (serde_json
+`preserve_order`; see `views/peek.rs` module docs for the M1 precedent).
+
+Every new host method fits the existing PyO3 helpers: zero-arg (`call0`) or
+one-JSON-string-arg (`call1`). Multi-parameter verbs take a **single JSON
+object argument** — no new call helpers are needed (this supersedes the
+design-sketch signatures `pin_watchlist(subject, pinned)` /
+`issue_verb(action_id, target_id, target_community)`, which would have
+required new 2-arg/void FFI plumbing).
+
+## Envelope convention
+
+Write verbs and tick verbs return an **envelope**, mirroring
+`load_campaign` (host.py): `{"ok": true, ...}` on success,
+`{"ok": false, "error": "<message>"}` on a *player-reachable* refusal.
+Player-reachable refusals (watchlist capacity, verb ineligibility raced, a
+`t` press while locked) must NEVER panic the client; system-level failures
+(FK violation, TickOrderError, a raising driver after pre-checks) propagate
+as exceptions and panic loudly per III.11 — the two classes are handled
+differently on purpose. Python catches ONLY the specific exception types
+named per method below — never a blanket `except`.
+
+## 1. Tick controls (Task 21)
+
+### `pacing_state_json()` → (call0)
+
+```json
+{"attached": true, "locked": false, "lock_reason": null,
+ "awaiting_ack": false, "pause_summary": null, "busy": false}
+```
+
+Dict-literal order as above. Mirrors `PacedDriverHandle`
+(`tui/app.py:525-582` — primitives only; `PauseNotice` never crosses).
+`attached=false` (all else false/null) when no campaign/driver is bound.
+Rust pre-checks in Textual's exact order — locked → awaiting_ack → busy —
+and renders the same refusal strings (`app.py:2219-2242`); this is the
+established pre-check pattern, NOT exception translation. The HUD's PACING
+line renders from this same payload (`dashboard_view.py:154-163` states).
+
+### `advance_tick()` → (call0)
+
+```json
+{"ok": true, "outcome": {"tick": 43, "paused": false, "chronicle": [ChronicleEvent...]}}
+```
+
+or `{"ok": false, "error": "..."}` (no campaign bound; not implemented).
+`outcome` key order: **tick, paused, chronicle** — the plan's wire spec and
+the `TickOutcome` Protocol declaration order (`tui/app.py:298-328`).
+`TickAdvanceResult` is NOT pydantic and its `__slots__` is alphabetical —
+the host hand-builds this dict literal; never derive order by introspection
+(`session.py:516` vs `:518-527`). `world`/`events`/`autosaved`/
+`determinism_hash` are deliberately excluded (the narrower seam).
+Python side: delegates to `PacedDriverHandle.advance_once()`. Pacing
+refusals should be impossible after the Rust pre-check; if a `PacingError`
+still escapes it is a bug and panics loudly (III.11).
+
+### `run_until_paused()` → (call0)
+
+```json
+{"ok": true, "outcomes": [TickOutcome, TickOutcome, ...]}
+```
+
+An ARRAY of per-tick outcomes mirroring
+`PacedDriverHandle.run_until_paused() -> Sequence[TickOutcome]`; Rust
+flattens the chronicles client-side exactly as Textual does
+(`app.py:2299`). The FFI call BLOCKS until the batch returns — zero
+incremental feedback during a run is the Textual ground truth (no spinner,
+no streaming; deviating would need a Director ruling). The loop lives in
+`PacedTickDriver` (fixed bound `max_ticks=5200`); Rust never loops ticks.
+
+### `acknowledge_pause()` → (call0)
+
+`{"ok": true}` / `{"ok": false, "error": "..."}`. Rust pre-checks
+`awaiting_ack` first; success status line: "autopause acknowledged — ready
+to advance" (`app.py:2311-2324`).
+
+### ChronicleEvent (elements of `outcome.chronicle`)
+
+`model_dump_json()` of `tui/chronicle.py:148-153`, declaration order:
+
+```json
+{"tick": 42, "event_type": "uprising", "summary": "...",
+ "data": {...open bag, keys vary by EventType, may nest "anchor"...},
+ "class_names": null, "org_names": null}
+```
+
+Rust must not assume any fixed key set inside `data`.
+
+## 2. Chronicle rail (Task 22)
+
+**Salience ships as DATA the host pre-computes; Rust renders, never ranks**
+(design §6 gap ledger). The rules span ticks (dedupe collapses runs across
+adjacent bulletins; the autopause banner scans the full 200-row window), so
+per-tick payloads cannot carry them — the HOST owns the accumulator
+(mirror of `app.py:1663-1694`: append, cap `CHRONICLE_ROW_CEILING=200`)
+and exposes the render-ready rail:
+
+### `chronicle_rail_json()` → (call0)
+
+```json
+{"autopause_line": "⏸ AUTOPAUSE — THIS CANNOT PASS UNREAD",
+ "rows": [
+   {"subject": null, "kind": "header", "tick": 847, "severity": null,
+    "actor": null, "text": "T0847"},
+   {"subject": "organization/org-x", "kind": "event", "tick": 847,
+    "severity": "critical", "actor": "The Vanguard", "text": "..."},
+   {"subject": null, "kind": "quiet", "tick": 846, "severity": null,
+    "actor": null, "text": "the wire is quiet"}
+ ]}
+```
+
+- `autopause_line`: `null` when inactive (absence, never a dimmed row).
+- Row order: exactly what `chronicle_stream → chronicle_rows` yields
+  (newest-first). Row dict-literal order as above.
+- Host pipeline per repaint = Textual's:
+  `dedupe_consecutive(apply_volume_floors(history))` then
+  `compute_autopause_state` then `chronicle_stream(salient, limit=200)`
+  then `chronicle_rows` (`app.py:1655-1661`).
+- `kind`: `"header"` (tick header, non-navigable), `"event"`, `"quiet"`
+  (honest-absence line). `severity` only on events. `actor` is the
+  bold-GOLD prefix (only ~6 EventTypes ever have one); `text` EXCLUDES it.
+- Honest absence (no session): `{"autopause_line": null, "rows": []}`.
+- Colors Rust-side: critical = bold CRIMSON, warning = AMBER, informational
+  = BONE, header = bold GOLD, quiet = bold CRIMSON, autopause = bold AMBER.
+- **AMBER (#ff8c00 = Rgb(255,140,0)) is NOT a §9b role token** — do NOT add
+  it to `theme.rs` (the cross-language parity guard
+  `test_rust_theme_parity.py` fails on unmapped constants there). Declare
+  it as a documented module const in the chronicle view, citing
+  `tui/theme.py:71-74`.
+- `TickOutcome.chronicle` (raw events) still crosses in Task 21's envelope —
+  status/count uses it; the RAIL renders only from `chronicle_rail_json()`.
+
+## 3. Verb plate + dispatch (Task 23)
+
+### `verb_plate_view_json()` → (call0)
+
+`"null"` (no session / no player org) or
+`VerbPlateView.model_dump_json()` — the model ALREADY exists
+(`projection/verbs/view_models.py:80-95`; VerbRow `:44-78`; VerbPreview
+`:14-42`; all frozen, `extra='forbid'`):
+
+```json
+{"kind": "verb_plate", "org_id": "...", "tick": 0, "verbs": [
+  {"verb": "educate", "eligible": true, "reason": null, "remedy": null,
+   "can_afford": true, "afford_note": null,
+   "preview": {"estimated_consciousness_delta": 0.01, "estimated_heat_delta": 0.01,
+               "action_point_cost": 1.0, "success_probability": 0.7,
+               "affected_territory_ids": [], "warnings": []},
+   "candidate_target_ids": []},
+  ...9 rows...]}
+```
+
+Canonical verb order everywhere (F-key zip, render): **educate, reproduce,
+attack, mobilize, campaign, aid, investigate, move, negotiate**
+(`projection/verbs/preview.py:25-35` dict order). F1–F9 zip positionally.
+`investigate` renders as 3 sub-lines sharing ONE row's signals
+(`verb_plate.py:64-67`) — an honest documented limitation, do not invent
+per-sub-verb eligibility. Ineligible rows show `(reason — remedy)` inline,
+never hidden; `can_afford=false` never disables, only annotates.
+`reproduce` is self-targeting (`candidate_target_ids` always empty).
+
+### `issue_verb(args_json)` → (call1)
+
+Arg: `{"verb": "educate", "target_id": "sc-x"|null, "target_community": null}`.
+Returns `{"ok": true, "turn_id": 17}` or `{"ok": false, "error": "<verbatim>"}`.
+Python catches ONLY `RuntimeError`/`ValueError`/`KeyError` (the three types
+Textual surfaces verbatim as refusals, `app.py:2326-2387`) — anything else
+panics. Rust derives an honest target exactly like `_honest_target_id`
+(`app.py:707-739`): the current wiki subject's id-part ONLY if it is a real
+member of the row's `candidate_target_ids`; never invented. Dispatch only
+queues a turn — effects land at the NEXT tick; success status:
+`status: {verb} queued (turn #{id})` (+ afford note if `can_afford` false).
+
+### RECORDED DEVIATION (plan Task 23 test spec)
+
+The plan says the round-trip test asserts "verb decrements remaining
+actions". **No such counter exists in production**: `OODAProfile.action_points`
+is declared and `ooda/constraints.py::enforce_action_points` implements a
+budget, but NOTHING in the live path calls it (`engine/systems/ooda.py` has
+only a global `max_actions_total=500`). Writing that assertion would be a
+green test over a dead feature (the exact anti-pattern CLAUDE.md's
+vocabulary-sentinel section documents). The M2 contract test instead
+mirrors the two REAL behaviors `tests/integration/archive/
+test_verb_resolution.py` pins: (1) a submitted verb reaches
+`turn_resolution.action_phase_results` keyed by org/action_type after the
+next tick; (2) an unaffordable submission is refused at `submit_verb`
+(ValueError "Cannot afford") and never reaches the queue/engine.
+
+## 4. Endgame HUD (Task 24)
+
+### `endgame_status_json()` → (call0)
+
+`"null"` ONLY when no session is bound (the lobby). Otherwise
+`EndgameStatus.model_dump_json()` (`projection/endgame.py:51-57`
+declaration order):
+
+```json
+{"pattern": null, "outcome": "in_progress", "game_over": false,
+ "horizon_tick": 27040, "since_tick": null, "locked": false,
+ "axes": {"revolutionary_victory": 0.0, "ecological_collapse": 0.0,
+          "fascist_consolidation": 0.0, "red_ogv": 0.0,
+          "fragmented_collapse": 0.0}}
+```
+
+- Tick 0 of a bound campaign is NOT absence — it is a real all-zero axes
+  payload and renders as 5 empty bars, never the absence fence.
+- Rust keys the bars by a FIXED id array in `_AXIS_KEYS` order
+  (`endgame_detector.py:71-77`) with labels ported (copied, never imported)
+  from `dashboard_view.py:36-42`: REVOLUTIONARY VICTORY / ECOLOGICAL
+  COLLAPSE / FASCIST CONSOLIDATION / RED OGV / FRAGMENTED COLLAPSE. Never
+  iterate the `axes` JSON object for display order.
+- `triggered` is DERIVED: `progress >= 1.0` (the detector's own documented
+  invariant, `endgame_detector.py:359-371`). `tick_triggered` =
+  `since_tick` iff `pattern == <axis id>`, else honest `null` — a matched
+  but non-winning axis has NO tracked since-tick by construction.
+- Progress can FALL as well as rise (patterns dissolve); `pattern` can flip
+  back to null. Render whatever arrives.
+- HUD home (M2): a persistent top strip on the play screen —
+  `T+{tick}/{horizon_tick}` counter, five compact gauges, PACING state line
+  (from `pacing_state_json`). The Market view re-homes the bars at M5/M6.
+
+## 5. Watchlist writes + nav persistence (Task 25)
+
+### `pin_watchlist(args_json)` → (call1)
+
+Arg: `{"subject": "county/26163", "pinned": true}`. Returns
+`{"ok": true, "pinned": true}` or `{"ok": false, "error": "..."}`.
+
+RECORDED DEVIATION from the design sketch's `-> None`: the capacity
+`ValueError` (`WatchlistState.pin`, cap 20, loud, never LRU) is a
+player-reachable outcome Textual renders as a status line
+(`app.py:1878-1884`) — `-> None` + panic-on-raise would crash the client
+on "watchlist is full", violating III.11's *visible cause* intent and
+Textual parity. Python catches ONLY `ValueError`;
+`psycopg.errors.ForeignKeyViolation` and everything else propagate → panic
+(system-level). Pin/unpin semantics: FIFO append, idempotent both ways,
+persist via the SAME `load_watchlist`/`save_watchlist` path M1 reads
+(`BabylonMetaStore` already satisfies the Protocol — zero new store code).
+On success the rail re-renders from a fresh `watchlist_json()` pull. The
+row key stays literally `"subject"` (`watchlist.rs:100,159` hardcodes it).
+
+### `nav_state_json()` → (call0) and `save_nav_state(args_json)` → (call1)
+
+```json
+{"jumplist": ["county/26163", "faction/foo"], "breadcrumbs": ["county/26163"]}
+```
+
+`save_nav_state` takes the same shape; returns `{"ok": true}` /
+`{"ok": false, "error": "..."}`. Persist via `BabylonMetaStore`
+`save_jumplist`/`save_breadcrumbs` keyed by the bound session (only
+ENTRIES persist; cursor/capacity are reconstructed on restore —
+`nav.py:18-21,85-93`). Jumplist/breadcrumb tables allow duplicates
+(only watchlist has UNIQUE) — the round-trip test must NOT assert dedup.
+
+RECORDED DEVIATION from the design sketch ("restored through config_json
+at launch"): `config_json` is built BEFORE a campaign is chosen
+(`play.py:449-458`, `campaign_id: ""`) and nav state is campaign-scoped —
+restore instead rides a post-bind pull (`nav_state_json()` after
+`load_campaign`), exactly the watchlist precedent. Save cadence: on
+leaving the campaign (Back to lobby) AND on quit. (Textual never wired nav
+persistence in production at all — `app.py:1185-1187` uses a throwaway
+uuid4 + InMemory store — so this is fresh wiring on both sides, not a
+port.)
+
+## 6. Play-screen chrome + keys (integration)
+
+Per design §7 global chrome: chronicle rail RIGHT, watchlist rail LEFT,
+verb plate BOTTOM, HUD strip TOP, wiki/dossier center. Keys added in M2:
+`t` step, `r` run-until-paused, `a` acknowledge, `F1`–`F9` verbs
+(canonical zip), `P` (capital) pin/unpin the current wiki subject —
+lowercase `p` stays the M1 link-cursor-previous inside WikiView (recorded
+divergence from Textual's `p`=pin; collision found by the scout sweep) —
+and `p` toggles the highlighted row's pin inside the Watchlist view, where
+no link cursor exists.
+
+Post-tick refresh fanout (both `t` and `r`), Textual's exact order
+(`app.py:2102-2150`): (1) known subjects, (2) HUD/endgame, (3) verb plate,
+(4) chronicle rail, (5) watchlist, (6) re-fetch the open wiki page WITHOUT
+switching views.
+
+## 7. RecordingHost / fakes
+
+Every new Host method gets a `RecordingHost` arm (transcript
+under-recording breaks the Task-28 parity harness) and honest-absence or
+loud not-implemented defaults on the trait per the M1 convention, so
+milestone-earlier fakes keep compiling.

--- a/docs/superpowers/specs/2026-07-27-m2-seam-contracts.md
+++ b/docs/superpowers/specs/2026-07-27-m2-seam-contracts.md
@@ -26,6 +26,13 @@ as exceptions and panic loudly per III.11 — the two classes are handled
 differently on purpose. Python catches ONLY the specific exception types
 named per method below — never a blanket `except`.
 
+## 0. `load_campaign` ack (M2 addition)
+
+The bind ack gains the session's current tick —
+`{"ok": true, "campaign_id": "...", "tick": 300}` — so the HUD's
+`T+{tick}` counter is honest for a RESUMED campaign from the first frame
+(a zeroed counter over a tick-300 session would be fabricated, III.11).
+
 ## 1. Tick controls (Task 21)
 
 ### `pacing_state_json()` → (call0)
@@ -201,7 +208,7 @@ next tick; (2) an unaffordable submission is refused at `submit_verb`
 declaration order):
 
 ```json
-{"pattern": null, "outcome": "in_progress", "game_over": false,
+{"pattern": null, "outcome": "unresolved", "game_over": false,
  "horizon_tick": 27040, "since_tick": null, "locked": false,
  "axes": {"revolutionary_victory": 0.0, "ecological_collapse": 0.0,
           "fascist_consolidation": 0.0, "red_ogv": 0.0,

--- a/rust/crates/babylon-tui-python/src/lib.rs
+++ b/rust/crates/babylon-tui-python/src/lib.rs
@@ -89,6 +89,50 @@ impl Host for PyHost {
     fn watchlist_json(&self) -> String {
         self.call0("watchlist_json")
     }
+
+    fn pacing_state_json(&self) -> String {
+        self.call0("pacing_state_json")
+    }
+
+    fn advance_tick(&self) -> String {
+        self.call0("advance_tick")
+    }
+
+    fn run_until_paused(&self) -> String {
+        self.call0("run_until_paused")
+    }
+
+    fn acknowledge_pause(&self) -> String {
+        self.call0("acknowledge_pause")
+    }
+
+    fn chronicle_rail_json(&self) -> String {
+        self.call0("chronicle_rail_json")
+    }
+
+    fn verb_plate_view_json(&self) -> String {
+        self.call0("verb_plate_view_json")
+    }
+
+    fn issue_verb(&self, args_json: &str) -> String {
+        self.call1("issue_verb", args_json)
+    }
+
+    fn endgame_status_json(&self) -> String {
+        self.call0("endgame_status_json")
+    }
+
+    fn pin_watchlist(&self, args_json: &str) -> String {
+        self.call1("pin_watchlist", args_json)
+    }
+
+    fn nav_state_json(&self) -> String {
+        self.call0("nav_state_json")
+    }
+
+    fn save_nav_state(&self, nav_json: &str) -> String {
+        self.call1("save_nav_state", nav_json)
+    }
 }
 
 /// Run the client. Headless configs render the initial frame, replay the

--- a/rust/crates/babylon-tui/src/app.rs
+++ b/rust/crates/babylon-tui/src/app.rs
@@ -21,28 +21,97 @@ use ratatui::crossterm::execute;
 use ratatui::crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::Terminal;
+use serde::Deserialize;
 
 use crate::config::{AppConfig, ScriptStep};
 use crate::host::Host;
 use crate::layout_registry::LayoutRegistry;
 use crate::router::{parse_babylon_uri, BabylonTarget};
+use crate::views::chronicle::ChronicleRail;
+use crate::views::hud::HudStrip;
 use crate::views::lobby::LobbyView;
 use crate::views::msg::AppEvent;
 use crate::views::palette::PaletteView;
 use crate::views::peek::render_peek;
+use crate::views::verbs::VerbPlateView;
 use crate::views::watchlist::WatchlistView;
 use crate::views::wiki::WikiView;
 
 /// One member of the view stack (the lobby is always the root).
+///
+/// M2 dissolved the M1 full-screen watchlist view: the watchlist is now the
+/// play chrome's persistent LEFT rail (design §7), not a stack member.
 enum View {
     /// The campaign catalog (root).
     Lobby(LobbyView),
-    /// The read-only Archive dossier.
+    /// The Archive dossier (the play screen's center pane once bound).
     Wiki(WikiView),
-    /// The watchlist rail as a full view (M1 read-only).
-    Watchlist(WatchlistView),
+}
+
+/// Which play-chrome pane keyboard focus is on (`Tab` cycles).
+///
+/// The verb plate and HUD are passive chrome (F-keys and `t`/`r`/`a` are
+/// global) — only the three navigable panes take focus.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ChromeFocus {
+    /// The wiki dossier (center pane).
+    Center,
+    /// The chronicle rail (right).
+    Chronicle,
+    /// The watchlist rail (left).
+    Watchlist,
+}
+
+/// The paced-driver state pre-checked before every tick verb (contract §1;
+/// the Textual client's locked → awaiting_ack → busy refusal order).
+#[derive(Debug, Deserialize)]
+struct PacingSnapshot {
+    attached: bool,
+    locked: bool,
+    lock_reason: Option<String>,
+    awaiting_ack: bool,
+    pause_summary: Option<String>,
+    busy: bool,
+}
+
+impl PacingSnapshot {
+    /// A parse failure is a LOUD refusal, never a fabricated ready state:
+    /// pretend-locked with the parse error as the reason.
+    fn unreadable() -> Self {
+        Self {
+            attached: true,
+            locked: true,
+            lock_reason: Some("pacing state UNREADABLE — malformed host data".to_string()),
+            awaiting_ack: false,
+            pause_summary: None,
+            busy: false,
+        }
+    }
+}
+
+/// The persistent play-screen chrome, created when a campaign binds and
+/// dropped on return to the lobby (design §7: HUD top, watchlist rail LEFT,
+/// wiki center, chronicle rail RIGHT, verb plate BOTTOM, status line).
+struct PlayChrome {
+    hud: HudStrip,
+    chronicle: ChronicleRail,
+    verbs: VerbPlateView,
+    watchlist: WatchlistView,
+    focus: ChromeFocus,
+}
+
+impl PlayChrome {
+    fn new() -> Self {
+        Self {
+            hud: HudStrip::new(),
+            chronicle: ChronicleRail::default(),
+            verbs: VerbPlateView::open("null"),
+            watchlist: WatchlistView::open("[]"),
+            focus: ChromeFocus::Center,
+        }
+    }
 }
 
 /// A [`Host`] wrapper recording every call by method name.
@@ -170,6 +239,11 @@ pub struct App<H: Host> {
     /// crossed once per subject, not once per frame (M1 views are frozen
     /// per campaign bind; M2 tick advances invalidate by subject change).
     peek_cache: Option<(String, String)>,
+    /// The play-screen chrome; `Some` while a campaign is bound.
+    chrome: Option<PlayChrome>,
+    /// The one-line status readout (refusals, tick acks, verb queue acks) —
+    /// the Textual `#status` label's single shared line, verbatim strings.
+    status: Option<String>,
 }
 
 impl<H: Host> App<H> {
@@ -187,12 +261,20 @@ impl<H: Host> App<H> {
             peek_target: None,
             peek_depth: 0,
             peek_cache: None,
+            chrome: None,
+            status: None,
         }
     }
 
     /// Host-method names invoked so far, in call order.
     pub fn host_calls(&self) -> Vec<String> {
         self.calls.borrow().clone()
+    }
+
+    /// The wrapped host (integration tests inspect their stateful fakes
+    /// through this; production callers never need it).
+    pub fn host_ref(&self) -> &H {
+        &self.host
     }
 
     fn recording(&self) -> RecordingHost<'_, H> {
@@ -253,14 +335,41 @@ impl<H: Host> App<H> {
         let registry = &mut self.registry;
         let palette = &self.palette;
         let peek_depth = self.peek_depth;
+        let chrome = &mut self.chrome;
+        let status = self.status.clone();
         terminal.draw(|frame| {
             registry.clear();
             let area = frame.area();
-            match views.last_mut() {
-                Some(View::Lobby(lobby)) => lobby.render(frame, area),
-                Some(View::Wiki(wiki)) => wiki.render(frame, area, registry, &known),
-                Some(View::Watchlist(watchlist)) => watchlist.render(frame, area),
-                None => unreachable!("ensure_root always seeds the lobby"),
+            match (views.last_mut(), chrome.as_mut()) {
+                // The play screen (design §7): HUD top, watchlist rail LEFT,
+                // wiki center, chronicle rail RIGHT, verb plate BOTTOM, one
+                // status line.
+                (Some(View::Wiki(wiki)), Some(chrome)) => {
+                    let [hud_area, mid_area, plate_area, status_area] = Layout::vertical([
+                        Constraint::Length(3),
+                        Constraint::Min(5),
+                        Constraint::Length(8),
+                        Constraint::Length(1),
+                    ])
+                    .areas(area);
+                    let [watch_area, center_area, chron_area] = Layout::horizontal([
+                        Constraint::Length(24),
+                        Constraint::Min(20),
+                        Constraint::Length(24),
+                    ])
+                    .areas(mid_area);
+                    chrome.hud.render(frame, hud_area);
+                    chrome.watchlist.render(frame, watch_area);
+                    wiki.render(frame, center_area, registry, &known);
+                    chrome.chronicle.render(frame, chron_area);
+                    chrome.verbs.render(frame, plate_area);
+                    if let Some(text) = &status {
+                        frame.render_widget(ratatui::text::Line::from(text.as_str()), status_area);
+                    }
+                }
+                (Some(View::Lobby(lobby)), _) => lobby.render(frame, area),
+                (Some(View::Wiki(wiki)), None) => wiki.render(frame, area, registry, &known),
+                (None, _) => unreachable!("ensure_root always seeds the lobby"),
             }
             if let Some(palette) = palette {
                 palette.render(frame, area);
@@ -307,24 +416,117 @@ impl<H: Host> App<H> {
                 self.peek_depth = (self.peek_depth + 1) % 4;
                 return false;
             }
-            KeyCode::Tab => {
-                self.toggle_watchlist();
+            KeyCode::Tab if self.chrome.is_some() => {
+                // Focus cycles the three navigable panes; passive chrome
+                // (HUD, verb plate) never takes focus.
+                if let Some(chrome) = self.chrome.as_mut() {
+                    chrome.focus = match chrome.focus {
+                        ChromeFocus::Center => ChromeFocus::Chronicle,
+                        ChromeFocus::Chronicle => ChromeFocus::Watchlist,
+                        ChromeFocus::Watchlist => ChromeFocus::Center,
+                    };
+                }
                 return false;
             }
             // '1'–'5' view switch scaffold: only the wiki ('3', mirroring
             // the Textual shell's dashboard/map/wiki/topology order) is
-            // routable in M1; the rest are reserved no-ops until their
-            // views exist (M4+).
+            // routable; the rest are reserved no-ops until their views
+            // exist (M4+). With chrome, '3' returns focus to the center.
             KeyCode::Char('3') if self.in_campaign() => {
-                self.focus_wiki();
+                if let Some(chrome) = self.chrome.as_mut() {
+                    chrome.focus = ChromeFocus::Center;
+                }
+                return false;
+            }
+            // Tick controls (contract §1) — global while a campaign is
+            // bound, exactly like the Textual t/r/a bindings.
+            KeyCode::Char('t') if self.chrome.is_some() => {
+                self.cmd_advance_tick();
+                return false;
+            }
+            KeyCode::Char('r') if self.chrome.is_some() => {
+                self.cmd_run_until_paused();
+                return false;
+            }
+            KeyCode::Char('a') if self.chrome.is_some() => {
+                self.cmd_acknowledge_pause();
+                return false;
+            }
+            // 'P' pins the CURRENT dossier subject (contract §6: lowercase
+            // 'p' stays the wiki link-cursor — the recorded divergence from
+            // Textual's 'p'=pin).
+            KeyCode::Char('P') if self.chrome.is_some() => {
+                self.cmd_toggle_pin(None);
+                return false;
+            }
+            KeyCode::F(n @ 1..=9) if self.chrome.is_some() => {
+                self.cmd_issue_verb(usize::from(n) - 1);
                 return false;
             }
             _ => {}
         }
+        // Focused-rail routing: while a rail holds focus its cursor keys
+        // never reach the wiki view underneath. The rail borrow is dropped
+        // before any command/route call re-borrows `self`.
+        enum RailAction {
+            Fall,
+            Handled,
+            Route(AppEvent),
+            Pin(Option<String>),
+        }
+        let rail_action = match self.chrome.as_mut() {
+            Some(chrome)
+                if chrome.focus == ChromeFocus::Chronicle
+                    && matches!(code, KeyCode::Up | KeyCode::Down | KeyCode::Enter) =>
+            {
+                match chrome.chronicle.handle_key(code) {
+                    Some(ev) => {
+                        chrome.focus = ChromeFocus::Center;
+                        RailAction::Route(ev)
+                    }
+                    None => RailAction::Handled,
+                }
+            }
+            Some(chrome)
+                if chrome.focus == ChromeFocus::Watchlist
+                    && matches!(code, KeyCode::Up | KeyCode::Down | KeyCode::Enter) =>
+            {
+                match chrome.watchlist.handle_key(code) {
+                    Some(ev) => {
+                        chrome.focus = ChromeFocus::Center;
+                        RailAction::Route(ev)
+                    }
+                    None => RailAction::Handled,
+                }
+            }
+            // In the watchlist rail 'p' toggles the highlighted row's pin
+            // (no link cursor exists here — contract §6).
+            Some(chrome)
+                if chrome.focus == ChromeFocus::Watchlist && code == KeyCode::Char('p') =>
+            {
+                let subject = chrome
+                    .watchlist
+                    .rows
+                    .get(chrome.watchlist.selected)
+                    .and_then(|row| row.get("subject"))
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string);
+                RailAction::Pin(subject)
+            }
+            _ => RailAction::Fall,
+        };
+        match rail_action {
+            RailAction::Handled => return false,
+            RailAction::Route(ev) => return self.route(ev),
+            RailAction::Pin(subject) => {
+                self.cmd_toggle_pin(subject);
+                return false;
+            }
+            RailAction::Fall => {}
+        }
         let ev = match self.views.last_mut() {
             Some(View::Lobby(lobby)) => lobby.handle_key(code),
             Some(View::Wiki(wiki)) => wiki.handle_key(code, modifiers),
-            Some(View::Watchlist(watchlist)) => watchlist.handle_key(code),
             None => None,
         };
         // Keyboard peek is first-class (S7 canon): the wiki link cursor
@@ -412,10 +614,41 @@ impl<H: Host> App<H> {
                 // (re)fetch AFTER the bind, never before.
                 self.known = None;
                 self.ensure_known();
+                // Nav restore rides a post-bind pull (contract §5 — never
+                // config_json, which predates selection).
+                let nav_raw = self.recording().nav_state_json();
+                let restored: Vec<String> = serde_json::from_str::<serde_json::Value>(&nav_raw)
+                    .ok()
+                    .and_then(|v| {
+                        v.get("jumplist")
+                            .and_then(|j| serde_json::from_value(j.clone()).ok())
+                    })
+                    .unwrap_or_default();
                 // Textual parity: the first page after campaign selection is
                 // the briefing subject (honest absence when unbaked).
                 let subject = format!("briefing/{campaign_id}");
                 self.open_in_wiki(&BabylonTarget::Entity(subject));
+                if !restored.is_empty() {
+                    if let Some(View::Wiki(wiki)) = self.views.last_mut() {
+                        // Seed the restored history BELOW the briefing visit
+                        // (the briefing stays current, `[` walks into the
+                        // restored trail).
+                        let mut entries = restored;
+                        entries.append(&mut wiki.jumplist);
+                        wiki.jumplist = entries;
+                        wiki.jumplist_idx = wiki.jumplist.len().saturating_sub(1);
+                    }
+                }
+                // The bind ack carries the session's current tick (a resumed
+                // campaign is NOT at tick 0 — honesty over a zeroed counter).
+                let tick = serde_json::from_str::<serde_json::Value>(&ack)
+                    .ok()
+                    .and_then(|v| v.get("tick").and_then(serde_json::Value::as_u64))
+                    .unwrap_or(0);
+                let mut chrome = PlayChrome::new();
+                chrome.hud.set_tick(tick);
+                self.chrome = Some(chrome);
+                self.refresh_chrome();
                 false
             }
             // M1 is read-only: the new-campaign write path lands in M2
@@ -435,14 +668,62 @@ impl<H: Host> App<H> {
             AppEvent::Back => {
                 self.peek_target = None;
                 if self.views.len() > 1 {
+                    // Leaving the campaign (the pop returns to the lobby
+                    // root): persist nav BEFORE the pop drops the wiki view
+                    // whose jumplist is the payload, then drop the chrome
+                    // (contract §5 cadence).
+                    let leaving_campaign = matches!(self.views.last(), Some(View::Wiki(_)))
+                        && self
+                            .views
+                            .iter()
+                            .filter(|v| matches!(v, View::Wiki(_)))
+                            .count()
+                            == 1;
+                    if leaving_campaign {
+                        self.save_nav();
+                    }
                     self.views.pop();
+                    if leaving_campaign {
+                        self.chrome = None;
+                        self.status = None;
+                    }
                     false
                 } else {
+                    self.save_nav();
                     true // q at the lobby root quits, like M0
                 }
             }
-            AppEvent::Quit => true,
+            AppEvent::Quit => {
+                self.save_nav();
+                true
+            }
         }
+    }
+
+    /// Persist the wiki jumplist via `save_nav_state` (contract §5) — on
+    /// quit and on leaving the campaign. Breadcrumbs persist empty: this
+    /// client tracks no breadcrumb trail yet (an honest absence, not a
+    /// stub — the Textual client never persisted nav in production at all).
+    fn save_nav(&mut self) {
+        if self.chrome.is_none() {
+            return;
+        }
+        let entries: Vec<String> = self
+            .views
+            .iter()
+            .find_map(|v| match v {
+                View::Wiki(wiki) => Some(wiki.jumplist.clone()),
+                View::Lobby(_) => None,
+            })
+            .unwrap_or_default();
+        if entries.is_empty() {
+            return;
+        }
+        let payload = serde_json::json!({"jumplist": entries, "breadcrumbs": []}).to_string();
+        let _ack = self.recording().save_nav_state(&payload);
+        // The ack is transcript-recorded; on the quit path there is no
+        // frame left to render a refusal into, and a system-level failure
+        // panics loudly inside the host itself (III.11).
     }
 
     /// Push (or reuse) a wiki view showing the loud campaign-load-failure
@@ -481,31 +762,329 @@ impl<H: Host> App<H> {
         self.views.push(View::Wiki(wiki));
     }
 
-    /// Whether a campaign view (wiki/watchlist) is anywhere on the stack.
+    /// Whether a campaign view is anywhere on the stack.
     fn in_campaign(&self) -> bool {
-        self.views
-            .iter()
-            .any(|v| matches!(v, View::Wiki(_) | View::Watchlist(_)))
+        self.views.iter().any(|v| matches!(v, View::Wiki(_)))
     }
 
-    /// Tab: toggle between the wiki and the watchlist view (campaign only).
-    fn toggle_watchlist(&mut self) {
-        match self.views.last() {
-            Some(View::Wiki(_)) => {
-                let raw = self.recording().watchlist_json();
-                self.views.push(View::Watchlist(WatchlistView::open(&raw)));
+    /// Pull + parse the paced-driver state (contract §1). A malformed
+    /// payload is a LOUD pretend-locked snapshot, never a ready default.
+    fn pacing_snapshot(&mut self) -> PacingSnapshot {
+        let raw = self.recording().pacing_state_json();
+        serde_json::from_str(&raw).unwrap_or_else(|_| PacingSnapshot::unreadable())
+    }
+
+    /// The Textual pre-check ladder (locked → awaiting_ack → busy,
+    /// `app.py:2219-2242`): `Some(refusal)` when a tick verb must not fire.
+    fn tick_refusal(snapshot: &PacingSnapshot) -> Option<String> {
+        if !snapshot.attached {
+            return Some("no paced driver attached".to_string());
+        }
+        if snapshot.locked {
+            let reason = snapshot.lock_reason.as_deref().unwrap_or("unknown");
+            return Some(format!("campaign ended — {reason}"));
+        }
+        if snapshot.awaiting_ack {
+            let summary = snapshot.pause_summary.as_deref().unwrap_or("autopause");
+            return Some(format!(
+                "autopause pending ({summary}) — press a to acknowledge"
+            ));
+        }
+        if snapshot.busy {
+            return Some("a run is already in progress — please wait".to_string());
+        }
+        None
+    }
+
+    /// `t` — advance exactly one tick (contract §1).
+    fn cmd_advance_tick(&mut self) {
+        let snapshot = self.pacing_snapshot();
+        if let Some(refusal) = Self::tick_refusal(&snapshot) {
+            self.status = Some(format!("status: {refusal}"));
+            return;
+        }
+        let raw = self.recording().advance_tick();
+        let value: serde_json::Value = match serde_json::from_str(&raw) {
+            Ok(value) => value,
+            Err(_) => {
+                self.status = Some("status: advance_tick UNREADABLE — malformed host data".into());
+                return;
             }
-            Some(View::Watchlist(_)) => {
-                self.views.pop();
+        };
+        if value.get("ok").and_then(serde_json::Value::as_bool) != Some(true) {
+            let error = value
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown error");
+            self.status = Some(format!("status: advance refused — {error}"));
+            return;
+        }
+        let tick = value
+            .pointer("/outcome/tick")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let paused = value
+            .pointer("/outcome/paused")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        self.refresh_after_tick(tick);
+        let suffix = if paused { " [PAUSED]" } else { "" };
+        self.status = Some(format!("status: tick {tick}{suffix}"));
+    }
+
+    /// `r` — run until autopause/lock/limit (contract §1). The host call
+    /// BLOCKS for the whole batch — zero incremental feedback is the
+    /// Textual ground truth, not an oversight.
+    fn cmd_run_until_paused(&mut self) {
+        let snapshot = self.pacing_snapshot();
+        if let Some(refusal) = Self::tick_refusal(&snapshot) {
+            self.status = Some(format!("status: {refusal}"));
+            return;
+        }
+        let raw = self.recording().run_until_paused();
+        let value: serde_json::Value = match serde_json::from_str(&raw) {
+            Ok(value) => value,
+            Err(_) => {
+                self.status =
+                    Some("status: run_until_paused UNREADABLE — malformed host data".into());
+                return;
             }
-            _ => {}
+        };
+        if value.get("ok").and_then(serde_json::Value::as_bool) != Some(true) {
+            let error = value
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown error");
+            self.status = Some(format!("status: run refused — {error}"));
+            return;
+        }
+        let last_tick = value
+            .get("outcomes")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|outcomes| outcomes.last())
+            .and_then(|outcome| outcome.get("tick"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        self.refresh_after_tick(last_tick);
+        // The post-run driver state picks the ending string (Textual's
+        // three-way `app.py:2299-2309` readout).
+        let after = self.pacing_snapshot();
+        self.status = Some(if after.locked {
+            let reason = after.lock_reason.as_deref().unwrap_or("unknown");
+            format!("status: ran to tick {last_tick} — campaign ended ({reason})")
+        } else if after.awaiting_ack {
+            let summary = after.pause_summary.as_deref().unwrap_or("autopause");
+            format!("status: ran to tick {last_tick} [PAUSED] ({summary})")
+        } else {
+            format!("status: ran to tick {last_tick} (stopped at the run limit)")
+        });
+    }
+
+    /// `a` — acknowledge a pending autopause (contract §1).
+    fn cmd_acknowledge_pause(&mut self) {
+        let snapshot = self.pacing_snapshot();
+        if !snapshot.awaiting_ack {
+            self.status = Some("status: no autopause pending".to_string());
+            return;
+        }
+        let raw = self.recording().acknowledge_pause();
+        let ok = serde_json::from_str::<serde_json::Value>(&raw)
+            .ok()
+            .and_then(|v| v.get("ok").and_then(serde_json::Value::as_bool))
+            .unwrap_or(false);
+        self.status = Some(if ok {
+            "autopause acknowledged — ready to advance".to_string()
+        } else {
+            let error = serde_json::from_str::<serde_json::Value>(&raw)
+                .ok()
+                .and_then(|v| {
+                    v.get("error")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string)
+                })
+                .unwrap_or_else(|| "unknown error".to_string());
+            format!("status: acknowledge refused — {error}")
+        });
+    }
+
+    /// F1–F9 — dispatch the verb at canonical slot `idx` (contract §3).
+    /// The honest target is the current dossier subject's id-part ONLY when
+    /// it is a real member of the row's `candidate_target_ids` — never
+    /// invented (`_honest_target_id`, `app.py:707-739`).
+    fn cmd_issue_verb(&mut self, idx: usize) {
+        let Some(chrome) = self.chrome.as_ref() else {
+            return;
+        };
+        if chrome.verbs.is_absent() || chrome.verbs.is_unreadable() {
+            self.status = Some("status: verb plate unavailable — no readable plate".to_string());
+            return;
+        }
+        let Some(row) = chrome.verbs.row(idx) else {
+            self.status = Some(format!(
+                "status: F{} refused — verb missing from the plate",
+                idx + 1
+            ));
+            return;
+        };
+        let verb = row.verb.clone();
+        if !row.eligible {
+            let reason = row
+                .reason
+                .clone()
+                .unwrap_or_else(|| "ineligible".to_string());
+            self.status = Some(format!("status: {verb} refused — {reason}"));
+            return;
+        }
+        let afford_note = (!row.can_afford).then(|| row.afford_note.clone()).flatten();
+        let target_id = self
+            .views
+            .iter()
+            .find_map(|v| match v {
+                View::Wiki(wiki) => wiki.current.clone(),
+                View::Lobby(_) => None,
+            })
+            .map(|subject| match subject.split_once('/') {
+                Some((_, id_part)) => id_part.to_string(),
+                None => subject,
+            })
+            .filter(|id_part| row.candidate_target_ids.iter().any(|c| c == id_part));
+        let args = serde_json::json!({
+            "verb": verb,
+            "target_id": target_id,
+            "target_community": null,
+        })
+        .to_string();
+        let raw = self.recording().issue_verb(&args);
+        let value: serde_json::Value = match serde_json::from_str(&raw) {
+            Ok(value) => value,
+            Err(_) => {
+                self.status = Some("status: issue_verb UNREADABLE — malformed host data".into());
+                return;
+            }
+        };
+        if value.get("ok").and_then(serde_json::Value::as_bool) == Some(true) {
+            let turn_id = value
+                .get("turn_id")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            let note = afford_note
+                .map(|note| format!(" · {note}"))
+                .unwrap_or_default();
+            self.status = Some(format!("status: {verb} queued (turn #{turn_id}){note}"));
+            // Textual refreshes the action bar alone on dispatch — effects
+            // land at the NEXT tick, not now.
+            let plate = self.recording().verb_plate_view_json();
+            if let Some(chrome) = self.chrome.as_mut() {
+                chrome.verbs = VerbPlateView::open(&plate);
+            }
+        } else {
+            let error = value
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown error");
+            self.status = Some(format!("status: {verb} refused — {error}"));
         }
     }
 
-    /// Pop back to the topmost wiki view if one exists below the top.
-    fn focus_wiki(&mut self) {
-        while matches!(self.views.last(), Some(View::Watchlist(_))) {
-            self.views.pop();
+    /// `P` (or `p` in the watchlist rail) — toggle a pin (contract §5).
+    /// `subject_override` carries the rail's highlighted row; `None` pins
+    /// the current dossier subject.
+    fn cmd_toggle_pin(&mut self, subject_override: Option<String>) {
+        let subject = subject_override.or_else(|| {
+            self.views.iter().find_map(|v| match v {
+                View::Wiki(wiki) => wiki.current.clone(),
+                View::Lobby(_) => None,
+            })
+        });
+        let Some(subject) = subject else {
+            self.status = Some("status: nothing to pin — no subject open".to_string());
+            return;
+        };
+        let already_pinned = self
+            .chrome
+            .as_ref()
+            .map(|chrome| {
+                chrome.watchlist.rows.iter().any(|row| {
+                    row.get("subject").and_then(serde_json::Value::as_str) == Some(&subject)
+                })
+            })
+            .unwrap_or(false);
+        let args = serde_json::json!({"subject": subject, "pinned": !already_pinned}).to_string();
+        let raw = self.recording().pin_watchlist(&args);
+        let ok = serde_json::from_str::<serde_json::Value>(&raw)
+            .ok()
+            .and_then(|v| v.get("ok").and_then(serde_json::Value::as_bool))
+            .unwrap_or(false);
+        if ok {
+            let refreshed = self.recording().watchlist_json();
+            if let Some(chrome) = self.chrome.as_mut() {
+                chrome.watchlist = WatchlistView::open(&refreshed);
+            }
+            let action = if already_pinned { "unpinned" } else { "pinned" };
+            self.status = Some(format!("status: {action} {subject}"));
+        } else {
+            let error = serde_json::from_str::<serde_json::Value>(&raw)
+                .ok()
+                .and_then(|v| {
+                    v.get("error")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string)
+                })
+                .unwrap_or_else(|| "unknown error".to_string());
+            self.status = Some(format!("status: pin refused — {error}"));
+        }
+    }
+
+    /// Refresh every chrome feed from the host (the post-bind pull and the
+    /// tail of the post-tick fanout share this).
+    fn refresh_chrome(&mut self) {
+        if self.chrome.is_none() {
+            return;
+        }
+        let endgame = self.recording().endgame_status_json();
+        let pacing = self.recording().pacing_state_json();
+        let plate = self.recording().verb_plate_view_json();
+        let rail = self.recording().chronicle_rail_json();
+        let watchlist = self.recording().watchlist_json();
+        if let Some(chrome) = self.chrome.as_mut() {
+            chrome.hud.update_endgame(&endgame);
+            chrome.hud.update_pacing(&pacing);
+            chrome.verbs = VerbPlateView::open(&plate);
+            chrome.chronicle.update_from_json(&rail);
+            chrome.watchlist = WatchlistView::open(&watchlist);
+        }
+    }
+
+    /// The post-tick refresh fanout, Textual's exact order (contract §6,
+    /// `app.py:2102-2150`): (1) known subjects, (2) HUD, (3) verb plate,
+    /// (4) chronicle, (5) watchlist, (6) re-fetch the open dossier WITHOUT
+    /// switching views.
+    fn refresh_after_tick(&mut self, tick: u64) {
+        let raw = self.recording().known_subjects_json();
+        let subjects: Vec<String> = serde_json::from_str(&raw).unwrap_or_default();
+        self.known = Some(subjects.into_iter().collect());
+        if let Some(chrome) = self.chrome.as_mut() {
+            chrome.hud.set_tick(tick);
+        }
+        self.refresh_chrome();
+        self.peek_cache = None; // a tick invalidates every cached stat plate
+        let current = self.views.iter().find_map(|v| match v {
+            View::Wiki(wiki) => wiki.current.clone(),
+            View::Lobby(_) => None,
+        });
+        if let Some(subject) = current {
+            let recording = RecordingHost {
+                inner: &self.host,
+                calls: &self.calls,
+            };
+            if let Some(View::Wiki(wiki)) =
+                self.views.iter_mut().find(|v| matches!(v, View::Wiki(_)))
+            {
+                // Re-opening the current subject refreshes the page without
+                // growing the jumplist (WikiView::open is idempotent for
+                // the current subject).
+                wiki.open(&BabylonTarget::Entity(subject), &recording);
+            }
         }
     }
 }
@@ -528,6 +1107,13 @@ pub fn key_event_from_name(name: &str) -> Option<(KeyCode, KeyModifiers)> {
             return None;
         };
         return Some((KeyCode::Char(c), KeyModifiers::CONTROL));
+    }
+    if let Some(rest) = name.strip_prefix('f') {
+        if let Ok(n) = rest.parse::<u8>() {
+            if (1..=12).contains(&n) {
+                return Some((KeyCode::F(n), KeyModifiers::NONE));
+            }
+        }
     }
     let code = match name {
         "enter" => KeyCode::Enter,

--- a/rust/crates/babylon-tui/src/app.rs
+++ b/rust/crates/babylon-tui/src/app.rs
@@ -74,19 +74,27 @@ struct PacingSnapshot {
     awaiting_ack: bool,
     pause_summary: Option<String>,
     busy: bool,
+    /// Never on the wire — set only by [`Self::unreadable`] so the refusal
+    /// ladder can name the parse failure AS a parse failure instead of
+    /// fabricating a "campaign ended" claim (verify-panel finding: a
+    /// confidently-wrong terminal-state readout violates III.11 as much as
+    /// a silent default does).
+    #[serde(default)]
+    unreadable: bool,
 }
 
 impl PacingSnapshot {
-    /// A parse failure is a LOUD refusal, never a fabricated ready state:
-    /// pretend-locked with the parse error as the reason.
+    /// A parse failure is a LOUD first-class refusal, never a fabricated
+    /// locked/ready state.
     fn unreadable() -> Self {
         Self {
             attached: true,
-            locked: true,
-            lock_reason: Some("pacing state UNREADABLE — malformed host data".to_string()),
+            locked: false,
+            lock_reason: None,
             awaiting_ack: false,
             pause_summary: None,
             busy: false,
+            unreadable: true,
         }
     }
 }
@@ -359,15 +367,33 @@ impl<H: Host> App<H> {
                     ])
                     .areas(mid_area);
                     chrome.hud.render(frame, hud_area);
-                    chrome.watchlist.render(frame, watch_area);
+                    chrome.watchlist.render(
+                        frame,
+                        watch_area,
+                        chrome.focus == ChromeFocus::Watchlist,
+                    );
                     wiki.render(frame, center_area, registry, &known);
-                    chrome.chronicle.render(frame, chron_area);
-                    chrome.verbs.render(frame, plate_area);
+                    chrome.chronicle.render(
+                        frame,
+                        chron_area,
+                        chrome.focus == ChromeFocus::Chronicle,
+                    );
+                    chrome.verbs.render(frame, plate_area, registry);
                     if let Some(text) = &status {
                         frame.render_widget(ratatui::text::Line::from(text.as_str()), status_area);
                     }
                 }
-                (Some(View::Lobby(lobby)), _) => lobby.render(frame, area),
+                (Some(View::Lobby(lobby)), _) => {
+                    if let Some(text) = &status {
+                        let [lobby_area, status_area] =
+                            Layout::vertical([Constraint::Min(3), Constraint::Length(1)])
+                                .areas(area);
+                        lobby.render(frame, lobby_area);
+                        frame.render_widget(ratatui::text::Line::from(text.as_str()), status_area);
+                    } else {
+                        lobby.render(frame, area);
+                    }
+                }
                 (Some(View::Wiki(wiki)), None) => wiki.render(frame, area, registry, &known),
                 (None, _) => unreachable!("ensure_root always seeds the lobby"),
             }
@@ -550,7 +576,9 @@ impl<H: Host> App<H> {
                 self.peek_target = self
                     .registry
                     .hit(ev.column, ev.row)
-                    .and_then(|(_, _, entity)| entity.clone());
+                    .and_then(|(_, _, entity)| entity.clone())
+                    // Verb rows are dispatch zones, not peekable entities.
+                    .filter(|entity| !entity.starts_with("verb:"));
             }
             MouseEventKind::Down(MouseButton::Left) => {
                 let target = self
@@ -558,6 +586,15 @@ impl<H: Host> App<H> {
                     .hit(ev.column, ev.row)
                     .and_then(|(_, _, entity)| entity.clone());
                 if let Some(subject) = target {
+                    // A click on a verb row dispatches exactly like its
+                    // F-key (plan Task 23's "F1–F9 + click dispatch").
+                    if let Some(slot) = subject
+                        .strip_prefix("verb:")
+                        .and_then(|raw| raw.parse::<usize>().ok())
+                    {
+                        self.cmd_issue_verb(slot);
+                        return false;
+                    }
                     return self.route(AppEvent::OpenSubject(subject));
                 }
             }
@@ -594,6 +631,9 @@ impl<H: Host> App<H> {
                     .and_then(|v| v.get("ok").and_then(serde_json::Value::as_bool))
                     .unwrap_or(false);
                 self.peek_target = None;
+                // A different campaign's stat plates must never serve from
+                // the previous bind's cache (verify-panel finding).
+                self.peek_cache = None;
                 if !ok {
                     // Loud failure page — an error is never an empty world
                     // (Constitution III.11); the ack carries the real error.
@@ -632,8 +672,15 @@ impl<H: Host> App<H> {
                     if let Some(View::Wiki(wiki)) = self.views.last_mut() {
                         // Seed the restored history BELOW the briefing visit
                         // (the briefing stays current, `[` walks into the
-                        // restored trail).
+                        // restored trail). A trailing restored entry equal
+                        // to the fresh briefing visit is dropped first —
+                        // without the dedupe every resume appends another
+                        // briefing entry and the persisted jumplist grows
+                        // without bound (verify-panel finding).
                         let mut entries = restored;
+                        if entries.last() == wiki.jumplist.first() {
+                            entries.pop();
+                        }
                         entries.append(&mut wiki.jumplist);
                         wiki.jumplist = entries;
                         wiki.jumplist_idx = wiki.jumplist.len().saturating_sub(1);
@@ -651,9 +698,17 @@ impl<H: Host> App<H> {
                 self.refresh_chrome();
                 false
             }
-            // M1 is read-only: the new-campaign write path lands in M2
-            // (plan Task 25 wires writes); until then the intent is a no-op.
-            AppEvent::NewCampaign => false,
+            // Campaign MINTING never made M2's write set (Task 25 is
+            // watchlist/nav): refuse loudly rather than no-op silently —
+            // minting stays on the Textual lobby until its own task lands.
+            AppEvent::NewCampaign => {
+                self.status = Some(
+                    "status: new-campaign minting is not wired in this client yet — \
+                     use the Textual lobby (babylon play)"
+                        .to_string(),
+                );
+                false
+            }
             AppEvent::OpenSubject(subject) => {
                 self.peek_target = None;
                 self.ensure_known();
@@ -689,14 +744,14 @@ impl<H: Host> App<H> {
                     }
                     false
                 } else {
-                    self.save_nav();
-                    true // q at the lobby root quits, like M0
+                    true // q at the lobby root quits, like M0 (nav already
+                         // saved when the campaign was left — the chrome is
+                         // always gone by the time the lobby is on top, so a
+                         // save call here could never fire; recorded in
+                         // contract §5: Back-to-lobby is the sole save point)
                 }
             }
-            AppEvent::Quit => {
-                self.save_nav();
-                true
-            }
+            AppEvent::Quit => true,
         }
     }
 
@@ -771,14 +826,24 @@ impl<H: Host> App<H> {
     /// payload is a LOUD pretend-locked snapshot, never a ready default.
     fn pacing_snapshot(&mut self) -> PacingSnapshot {
         let raw = self.recording().pacing_state_json();
+        if let Some(chrome) = self.chrome.as_mut() {
+            // One pull feeds BOTH consumers: the refusal ladder and the
+            // HUD's PACING line, which must never contradict each other.
+            chrome.hud.update_pacing(&raw);
+        }
         serde_json::from_str(&raw).unwrap_or_else(|_| PacingSnapshot::unreadable())
     }
 
     /// The Textual pre-check ladder (locked → awaiting_ack → busy,
     /// `app.py:2219-2242`): `Some(refusal)` when a tick verb must not fire.
     fn tick_refusal(snapshot: &PacingSnapshot) -> Option<String> {
+        if snapshot.unreadable {
+            return Some(
+                "pacing state UNREADABLE — malformed host data; refusing to tick".to_string(),
+            );
+        }
         if !snapshot.attached {
-            return Some("no paced driver attached".to_string());
+            return Some("no campaign attached".to_string());
         }
         if snapshot.locked {
             let reason = snapshot.lock_reason.as_deref().unwrap_or("unknown");
@@ -787,7 +852,7 @@ impl<H: Host> App<H> {
         if snapshot.awaiting_ack {
             let summary = snapshot.pause_summary.as_deref().unwrap_or("autopause");
             return Some(format!(
-                "autopause pending ({summary}) — press a to acknowledge"
+                "autopause pending ({summary}) — press 'a' to acknowledge"
             ));
         }
         if snapshot.busy {
@@ -819,10 +884,16 @@ impl<H: Host> App<H> {
             self.status = Some(format!("status: advance refused — {error}"));
             return;
         }
-        let tick = value
+        let Some(tick) = value
             .pointer("/outcome/tick")
             .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0);
+        else {
+            // An ok-envelope without a readable outcome is a malformed
+            // payload, never tick 0 (a fabricated counter is the exact
+            // failure III.11 exists to forbid).
+            self.status = Some("status: advance outcome UNREADABLE — malformed host data".into());
+            return;
+        };
         let paused = value
             .pointer("/outcome/paused")
             .and_then(serde_json::Value::as_bool)
@@ -858,13 +929,16 @@ impl<H: Host> App<H> {
             self.status = Some(format!("status: run refused — {error}"));
             return;
         }
-        let last_tick = value
+        let Some(last_tick) = value
             .get("outcomes")
             .and_then(serde_json::Value::as_array)
             .and_then(|outcomes| outcomes.last())
             .and_then(|outcome| outcome.get("tick"))
             .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0);
+        else {
+            self.status = Some("status: run outcomes UNREADABLE — malformed host data".into());
+            return;
+        };
         self.refresh_after_tick(last_tick);
         // The post-run driver state picks the ending string (Textual's
         // three-way `app.py:2299-2309` readout).
@@ -883,6 +957,14 @@ impl<H: Host> App<H> {
     /// `a` — acknowledge a pending autopause (contract §1).
     fn cmd_acknowledge_pause(&mut self) {
         let snapshot = self.pacing_snapshot();
+        if snapshot.unreadable {
+            self.status = Some(
+                "status: pacing state UNREADABLE — malformed host data; refusing to \
+                 acknowledge"
+                    .to_string(),
+            );
+            return;
+        }
         if !snapshot.awaiting_ack {
             self.status = Some("status: no autopause pending".to_string());
             return;
@@ -892,8 +974,14 @@ impl<H: Host> App<H> {
             .ok()
             .and_then(|v| v.get("ok").and_then(serde_json::Value::as_bool))
             .unwrap_or(false);
+        if ok {
+            // Refresh the HUD's PACING line immediately: the strip must
+            // never keep claiming a pending autopause the driver just
+            // cleared (verify-panel finding).
+            let _ = self.pacing_snapshot();
+        }
         self.status = Some(if ok {
-            "autopause acknowledged — ready to advance".to_string()
+            "status: autopause acknowledged — ready to advance".to_string()
         } else {
             let error = serde_json::from_str::<serde_json::Value>(&raw)
                 .ok()
@@ -915,8 +1003,12 @@ impl<H: Host> App<H> {
         let Some(chrome) = self.chrome.as_ref() else {
             return;
         };
-        if chrome.verbs.is_absent() || chrome.verbs.is_unreadable() {
-            self.status = Some("status: verb plate unavailable — no readable plate".to_string());
+        if chrome.verbs.is_absent() {
+            self.status = Some("status: no verb plate — no campaign bound".to_string());
+            return;
+        }
+        if chrome.verbs.is_unreadable() {
+            self.status = Some("status: verb plate UNREADABLE — malformed host data".to_string());
             return;
         }
         let Some(row) = chrome.verbs.row(idx) else {
@@ -1000,6 +1092,18 @@ impl<H: Host> App<H> {
             self.status = Some("status: nothing to pin — no subject open".to_string());
             return;
         };
+        // Pin direction derives from the rail's rows — over an UNREADABLE
+        // rail that derivation would silently claim "unpinned" and issue a
+        // spurious pin write (verify-panel finding): refuse instead.
+        if self
+            .chrome
+            .as_ref()
+            .map(|chrome| chrome.watchlist.parse_failed)
+            .unwrap_or(false)
+        {
+            self.status = Some("status: watchlist UNREADABLE — refusing pin writes".to_string());
+            return;
+        }
         let already_pinned = self
             .chrome
             .as_ref()
@@ -1018,7 +1122,9 @@ impl<H: Host> App<H> {
         if ok {
             let refreshed = self.recording().watchlist_json();
             if let Some(chrome) = self.chrome.as_mut() {
+                let kept = chrome.watchlist.selected;
                 chrome.watchlist = WatchlistView::open(&refreshed);
+                chrome.watchlist.selected = kept.min(chrome.watchlist.rows.len().saturating_sub(1));
             }
             let action = if already_pinned { "unpinned" } else { "pinned" };
             self.status = Some(format!("status: {action} {subject}"));
@@ -1051,7 +1157,11 @@ impl<H: Host> App<H> {
             chrome.hud.update_pacing(&pacing);
             chrome.verbs = VerbPlateView::open(&plate);
             chrome.chronicle.update_from_json(&rail);
+            // Highlight preservation across the rebuild (the Textual
+            // `_refresh_watchlist` idiom: previous index, clamped).
+            let kept = chrome.watchlist.selected;
             chrome.watchlist = WatchlistView::open(&watchlist);
+            chrome.watchlist.selected = kept.min(chrome.watchlist.rows.len().saturating_sub(1));
         }
     }
 

--- a/rust/crates/babylon-tui/src/app.rs
+++ b/rust/crates/babylon-tui/src/app.rs
@@ -92,6 +92,61 @@ impl<H: Host> Host for RecordingHost<'_, H> {
         self.record("watchlist_json");
         self.inner.watchlist_json()
     }
+
+    fn pacing_state_json(&self) -> String {
+        self.record("pacing_state_json");
+        self.inner.pacing_state_json()
+    }
+
+    fn advance_tick(&self) -> String {
+        self.record("advance_tick");
+        self.inner.advance_tick()
+    }
+
+    fn run_until_paused(&self) -> String {
+        self.record("run_until_paused");
+        self.inner.run_until_paused()
+    }
+
+    fn acknowledge_pause(&self) -> String {
+        self.record("acknowledge_pause");
+        self.inner.acknowledge_pause()
+    }
+
+    fn chronicle_rail_json(&self) -> String {
+        self.record("chronicle_rail_json");
+        self.inner.chronicle_rail_json()
+    }
+
+    fn verb_plate_view_json(&self) -> String {
+        self.record("verb_plate_view_json");
+        self.inner.verb_plate_view_json()
+    }
+
+    fn issue_verb(&self, args_json: &str) -> String {
+        self.record("issue_verb");
+        self.inner.issue_verb(args_json)
+    }
+
+    fn endgame_status_json(&self) -> String {
+        self.record("endgame_status_json");
+        self.inner.endgame_status_json()
+    }
+
+    fn pin_watchlist(&self, args_json: &str) -> String {
+        self.record("pin_watchlist");
+        self.inner.pin_watchlist(args_json)
+    }
+
+    fn nav_state_json(&self) -> String {
+        self.record("nav_state_json");
+        self.inner.nav_state_json()
+    }
+
+    fn save_nav_state(&self, nav_json: &str) -> String {
+        self.record("save_nav_state");
+        self.inner.save_nav_state(nav_json)
+    }
 }
 
 /// The client application: config + host seam + the M1 view stack.

--- a/rust/crates/babylon-tui/src/host.rs
+++ b/rust/crates/babylon-tui/src/host.rs
@@ -46,4 +46,83 @@ pub trait Host {
     fn watchlist_json(&self) -> String {
         "[]".to_string()
     }
+
+    // --- M2 "Playable" surface (contracts: docs/superpowers/specs/
+    // 2026-07-27-m2-seam-contracts.md). Write/tick verbs return an
+    // `{"ok": ...}` envelope mirroring `load_campaign`; multi-parameter
+    // verbs take ONE JSON object argument so every method fits the
+    // existing call0/call1 FFI helpers.
+
+    /// Paced-driver state for pre-checks + the HUD PACING line.
+    /// `attached=false` (all else false/null) = no campaign bound.
+    fn pacing_state_json(&self) -> String {
+        concat!(
+            r#"{"attached": false, "locked": false, "lock_reason": null,"#,
+            r#" "awaiting_ack": false, "pause_summary": null, "busy": false}"#
+        )
+        .to_string()
+    }
+
+    /// Advance one tick: `{"ok": true, "outcome": {tick, paused,
+    /// chronicle}}` or a loud refusal envelope. The default is
+    /// not-implemented so a host that forgot the tick surface can never
+    /// masquerade as a paused world.
+    fn advance_tick(&self) -> String {
+        r#"{"ok": false, "error": "advance_tick not implemented by this host"}"#.to_string()
+    }
+
+    /// Run until autopause/lock/limit: `{"ok": true, "outcomes": [...]}`.
+    /// BLOCKS for the whole batch (Textual ground truth: no streaming).
+    fn run_until_paused(&self) -> String {
+        r#"{"ok": false, "error": "run_until_paused not implemented by this host"}"#.to_string()
+    }
+
+    /// Clear a pending autopause: `{"ok": true}` / refusal envelope.
+    fn acknowledge_pause(&self) -> String {
+        r#"{"ok": false, "error": "acknowledge_pause not implemented by this host"}"#.to_string()
+    }
+
+    /// The render-ready chronicle rail (salience pre-computed host-side —
+    /// Rust renders, never ranks): `{"autopause_line": str|null,
+    /// "rows": [...]}`. Empty rows = honest absence.
+    fn chronicle_rail_json(&self) -> String {
+        r#"{"autopause_line": null, "rows": []}"#.to_string()
+    }
+
+    /// `VerbPlateView.model_dump_json()` or `null` (no session/org).
+    fn verb_plate_view_json(&self) -> String {
+        "null".to_string()
+    }
+
+    /// Queue a verb. Arg `{"verb", "target_id", "target_community"}`;
+    /// returns `{"ok": true, "turn_id": N}` or a refusal envelope
+    /// (player-reachable refusals never panic; system failures do).
+    fn issue_verb(&self, _args_json: &str) -> String {
+        r#"{"ok": false, "error": "issue_verb not implemented by this host"}"#.to_string()
+    }
+
+    /// `EndgameStatus.model_dump_json()` or `null` ONLY when no session
+    /// is bound (tick 0's all-zero axes payload is NOT absence).
+    fn endgame_status_json(&self) -> String {
+        "null".to_string()
+    }
+
+    /// Pin/unpin. Arg `{"subject", "pinned"}`; `{"ok": true, "pinned":
+    /// bool}` or a refusal envelope (capacity is player-reachable).
+    fn pin_watchlist(&self, _args_json: &str) -> String {
+        r#"{"ok": false, "error": "pin_watchlist not implemented by this host"}"#.to_string()
+    }
+
+    /// Persisted nav state `{"jumplist": [...], "breadcrumbs": [...]}`;
+    /// pulled after `load_campaign` (nav is campaign-scoped — never via
+    /// config_json, which predates selection).
+    fn nav_state_json(&self) -> String {
+        r#"{"jumplist": [], "breadcrumbs": []}"#.to_string()
+    }
+
+    /// Persist nav state (same shape as [`Self::nav_state_json`]);
+    /// called on leaving the campaign and on quit.
+    fn save_nav_state(&self, _nav_json: &str) -> String {
+        r#"{"ok": false, "error": "save_nav_state not implemented by this host"}"#.to_string()
+    }
 }

--- a/rust/crates/babylon-tui/src/views/chronicle.rs
+++ b/rust/crates/babylon-tui/src/views/chronicle.rs
@@ -42,8 +42,10 @@ pub(crate) const AMBER: Color = Color::Rgb(255, 140, 0);
 const TITLE: &str = "CHRONICLE";
 
 /// The honest-absence line for a totally empty rail (no rows, no banner) —
-/// the contract's own wording for a quiet tick (§2's `"quiet"` row example),
-/// reused here as the client-side absence sentinel.
+/// mirrors the Textual renderer's own quiet-wire wording as the client-side
+/// absence sentinel. (There is no `"quiet"` ROW kind: `chronicle_stream`
+/// never emits an empty bulletin, so a per-tick quiet row would be a dead
+/// variant behind a hand-built test shape — the M1 panel's exact class.)
 const ABSENCE_TEXT: &str = "the wire is quiet";
 
 /// The loud parse-failure line, matching the M1 `watchlist.rs`/`lobby.rs`
@@ -61,8 +63,6 @@ pub enum RowKind {
     Header,
     /// A salient event line; carries [`ChronicleRow::severity`].
     Event,
-    /// The honest-absence line for a quiet tick.
-    Quiet,
 }
 
 /// One event row's `"severity"` — a CLOSED vocabulary (mirrors the contract
@@ -84,7 +84,7 @@ pub enum Severity {
 #[derive(Debug, Deserialize)]
 pub struct ChronicleRow {
     /// The subject id this row navigates to on `Enter`, or `None` for a
-    /// non-navigable row (every `"header"`/`"quiet"` row, by contract).
+    /// non-navigable row (every `"header"` row, by contract).
     pub subject: Option<String>,
     /// The row's display kind.
     pub kind: RowKind,
@@ -150,7 +150,24 @@ impl ChronicleRail {
     pub fn update_from_json(&mut self, payload: &str) {
         match serde_json::from_str::<ChronicleRailPayload>(payload) {
             Ok(parsed) => {
-                self.cursor = first_navigable(&parsed.rows);
+                // Highlight preservation (the Textual idiom,
+                // `app.py:1690-1694`): keep the selected row across a
+                // refresh by re-resolving its subject against the new list,
+                // falling back to the first navigable row only when it is
+                // gone; clamp the scroll rather than snapping to the top.
+                let kept_subject = self
+                    .cursor
+                    .and_then(|index| self.rows.get(index))
+                    .and_then(|row| row.subject.clone());
+                self.cursor = kept_subject
+                    .and_then(|subject| {
+                        parsed
+                            .rows
+                            .iter()
+                            .position(|row| row.subject.as_deref() == Some(subject.as_str()))
+                    })
+                    .or_else(|| first_navigable(&parsed.rows));
+                self.scroll = self.scroll.min(parsed.rows.len().saturating_sub(1));
                 self.autopause_line = parsed.autopause_line;
                 self.rows = parsed.rows;
                 self.parse_failed = false;
@@ -160,9 +177,9 @@ impl ChronicleRail {
                 self.rows = Vec::new();
                 self.cursor = None;
                 self.parse_failed = true;
+                self.scroll = 0;
             }
         }
-        self.scroll = 0;
     }
 
     /// Move the cursor to the next navigable row in `direction` (`-1` up,
@@ -194,7 +211,8 @@ impl ChronicleRail {
 
     /// Route one key press: Up/Down move [`Self::cursor`] over navigable
     /// rows; Enter opens the highlighted row's subject (the same
-    /// [`AppEvent::OpenSubject`] the watchlist rail uses); Esc backs out.
+    /// [`AppEvent::OpenSubject`] the watchlist rail uses). Esc never reaches
+    /// this handler — the app shell defocuses the rail itself.
     pub fn handle_key(&mut self, code: KeyCode) -> Option<AppEvent> {
         match code {
             KeyCode::Up => {
@@ -210,7 +228,6 @@ impl ChronicleRail {
                 .and_then(|index| self.rows.get(index))
                 .and_then(|row| row.subject.clone())
                 .map(AppEvent::OpenSubject),
-            KeyCode::Esc => Some(AppEvent::Back),
             _ => None,
         }
     }
@@ -224,8 +241,13 @@ impl ChronicleRail {
     /// catches up to wherever [`Self::cursor`] last moved — the scroll
     /// offset is otherwise meaningless without a drawn area to scroll
     /// within.
-    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
-        let block = Block::bordered().title(TITLE);
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, focused: bool) {
+        let title = if focused {
+            format!("{TITLE} ●")
+        } else {
+            TITLE.to_string()
+        };
+        let block = Block::bordered().title(title);
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
@@ -270,7 +292,9 @@ impl ChronicleRail {
             .take(visible_rows)
         {
             let line = row_line(row);
-            lines.push(if Some(index) == self.cursor {
+            // The REVERSED cursor renders only on the FOCUSED rail — two
+            // panes must never both look focused (verify-panel finding).
+            lines.push(if focused && Some(index) == self.cursor {
                 highlighted(line)
             } else {
                 line
@@ -287,10 +311,6 @@ fn row_line(row: &ChronicleRow) -> Line<'static> {
             row.text.clone(),
             Style::new().fg(GOLD).add_modifier(Modifier::BOLD),
         )),
-        RowKind::Quiet => Line::from(Span::styled(
-            row.text.clone(),
-            Style::new().fg(CRIMSON).add_modifier(Modifier::BOLD),
-        )),
         RowKind::Event => event_line(row),
     }
 }
@@ -298,8 +318,8 @@ fn row_line(row: &ChronicleRow) -> Line<'static> {
 /// Build an `"event"` row's line: severity picks the text color (critical
 /// bold CRIMSON, warning module [`AMBER`], informational — or an absent
 /// severity — BONE), with an optional bold-GOLD actor prefix ahead of the
-/// text (a plain space separates them; the host's `text` field itself never
-/// includes the actor).
+/// text (`"{actor}: "`, the Textual `_event_line` separator; the host's
+/// `text` field itself never includes the actor).
 fn event_line(row: &ChronicleRow) -> Line<'static> {
     let (color, bold) = match row.severity {
         Some(Severity::Critical) => (CRIMSON, true),
@@ -313,7 +333,7 @@ fn event_line(row: &ChronicleRow) -> Line<'static> {
     match &row.actor {
         Some(actor) => Line::from(vec![
             Span::styled(
-                format!("{actor} "),
+                format!("{actor}: "),
                 Style::new().fg(GOLD).add_modifier(Modifier::BOLD),
             ),
             Span::styled(row.text.clone(), style),

--- a/rust/crates/babylon-tui/src/views/chronicle.rs
+++ b/rust/crates/babylon-tui/src/views/chronicle.rs
@@ -1,0 +1,368 @@
+//! The chronicle rail: a right-hand strip rendering the host's pre-salienced
+//! event history (design §7; contract `docs/superpowers/specs/
+//! 2026-07-27-m2-seam-contracts.md` §2, plan Task 22).
+//!
+//! **Salience ships as data the host pre-computes; Rust renders, never
+//! ranks.** The dedupe/volume-floor/autopause-scan rules all span ticks and
+//! live entirely behind [`crate::host::Host::chronicle_rail_json`] (mirrors
+//! `tui/app.py:1655-1694`'s pipeline) — this module only paints the
+//! render-ready rows the host hands it, in the order they arrive, plus a
+//! selectable cursor over the navigable ones.
+//!
+//! **Two distinct never-conflated states** (Constitution III.11): a
+//! genuinely empty rail (no rows, no autopause banner) renders the honest
+//! absence line the contract itself uses for a quiet tick, "the wire is
+//! quiet", in bold CRIMSON; a payload that fails to parse — including an
+//! unrecognized `"kind"`/`"severity"` value, since both are closed serde
+//! enums rather than open strings, so an unknown variant is a parse error
+//! rather than a silently dropped row — renders a DIFFERENT loud
+//! "UNREADABLE" line. The two must never look alike.
+
+use ratatui::crossterm::event::KeyCode;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Paragraph};
+use ratatui::Frame;
+use serde::Deserialize;
+
+use crate::theme::{BONE, CRIMSON, GOLD};
+use crate::views::msg::AppEvent;
+
+/// Reserved for the autopause indicator (`tui/theme.py:71-74`: `AMBER: Final
+/// = "#ff8c00"`, "Reserved for the autopause indicator... NOT a §9b role
+/// token"). Deliberately declared HERE rather than in `theme.rs` — the
+/// cross-language parity guard (`tests/unit/render/test_rust_theme_parity.py`)
+/// parses every `Color::Rgb` literal in `theme.rs` against the Python §9b
+/// palette and would fail on a constant with no §9b counterpart, so this
+/// module keeps its own copy instead of adding a fifth `theme.rs` constant.
+pub(crate) const AMBER: Color = Color::Rgb(255, 140, 0);
+
+/// The rail's title, per the contract's play-screen chrome (design §7).
+const TITLE: &str = "CHRONICLE";
+
+/// The honest-absence line for a totally empty rail (no rows, no banner) —
+/// the contract's own wording for a quiet tick (§2's `"quiet"` row example),
+/// reused here as the client-side absence sentinel.
+const ABSENCE_TEXT: &str = "the wire is quiet";
+
+/// The loud parse-failure line, matching the M1 `watchlist.rs`/`lobby.rs`
+/// "UNREADABLE" wording pattern.
+const UNREADABLE_TEXT: &str = "▌ chronicle UNREADABLE — malformed host data";
+
+/// One row's `"kind"` — a CLOSED vocabulary (mirrors the contract §2 table);
+/// an unrecognized value is a serde deserialization error, not a silently
+/// skipped row, so it surfaces through [`ChronicleRail::update_from_json`]
+/// as the loud `parse_failed` state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RowKind {
+    /// A non-navigable tick-header line (e.g. `"T0847"`).
+    Header,
+    /// A salient event line; carries [`ChronicleRow::severity`].
+    Event,
+    /// The honest-absence line for a quiet tick.
+    Quiet,
+}
+
+/// One event row's `"severity"` — a CLOSED vocabulary (mirrors the contract
+/// §2 table); same unknown-value-is-a-parse-error treatment as
+/// [`RowKind`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    /// Renders bold CRIMSON.
+    Critical,
+    /// Renders (non-bold) module `AMBER`.
+    Warning,
+    /// Renders (non-bold) [`BONE`].
+    Informational,
+}
+
+/// One row of [`crate::host::Host::chronicle_rail_json`]'s `"rows"` array,
+/// field-for-field per contract §2.
+#[derive(Debug, Deserialize)]
+pub struct ChronicleRow {
+    /// The subject id this row navigates to on `Enter`, or `None` for a
+    /// non-navigable row (every `"header"`/`"quiet"` row, by contract).
+    pub subject: Option<String>,
+    /// The row's display kind.
+    pub kind: RowKind,
+    /// The tick the row was generated at.
+    pub tick: u64,
+    /// Present only on `"event"` rows.
+    pub severity: Option<Severity>,
+    /// The bold-GOLD actor prefix (only ~6 `EventType`s ever carry one);
+    /// [`Self::text`] excludes it.
+    pub actor: Option<String>,
+    /// The row's body text.
+    pub text: String,
+}
+
+/// The wire shape of [`crate::host::Host::chronicle_rail_json`] (contract
+/// §2), used only as a `serde_json::from_str` target inside
+/// [`ChronicleRail::update_from_json`].
+#[derive(Debug, Deserialize)]
+struct ChronicleRailPayload {
+    autopause_line: Option<String>,
+    rows: Vec<ChronicleRow>,
+}
+
+/// The chronicle rail view: the host's render-ready row list, a selection
+/// cursor over the navigable (non-null-`subject`) rows, and the scroll
+/// offset that keeps the cursor on screen.
+#[derive(Debug, Default)]
+pub struct ChronicleRail {
+    /// The autopause banner line, or `None` when inactive (absence, never a
+    /// dimmed row — contract §2).
+    pub autopause_line: Option<String>,
+    /// The rail's rows, in host order (newest-first).
+    pub rows: Vec<ChronicleRow>,
+    /// Index into [`Self::rows`] of the highlighted navigable row, or `None`
+    /// when no row has a non-null `subject`.
+    pub cursor: Option<usize>,
+    /// `true` when the last [`Self::update_from_json`] payload failed to
+    /// parse — rendered loudly, never conflated with an honestly empty rail.
+    pub parse_failed: bool,
+    /// The index of the first visible row (scrolls to keep the cursor on
+    /// screen); irrelevant while [`Self::rows`] fits inside the last drawn
+    /// area.
+    scroll: usize,
+}
+
+/// The first row index with a non-null `subject`, or `None` if every row is
+/// non-navigable (mirrors the up/down skip rule).
+fn first_navigable(rows: &[ChronicleRow]) -> Option<usize> {
+    rows.iter().position(|row| row.subject.is_some())
+}
+
+impl ChronicleRail {
+    /// Parse a fresh `chronicle_rail_json()` payload, replacing the rail's
+    /// state wholesale.
+    ///
+    /// A well-formed payload (including a closed `"kind"`/`"severity"`
+    /// vocabulary on every row) replaces [`Self::rows`]/[`Self::autopause_line`]
+    /// and resets the cursor to the first navigable row. A malformed payload
+    /// — bad JSON, a missing field, or an unrecognized `"kind"`/`"severity"`
+    /// value — clears the rail and sets [`Self::parse_failed`] rather than
+    /// keeping stale rows next to a loud banner (Constitution III.11: an
+    /// unreadable payload is an ERROR, never a half-shown world).
+    pub fn update_from_json(&mut self, payload: &str) {
+        match serde_json::from_str::<ChronicleRailPayload>(payload) {
+            Ok(parsed) => {
+                self.cursor = first_navigable(&parsed.rows);
+                self.autopause_line = parsed.autopause_line;
+                self.rows = parsed.rows;
+                self.parse_failed = false;
+            }
+            Err(_) => {
+                self.autopause_line = None;
+                self.rows = Vec::new();
+                self.cursor = None;
+                self.parse_failed = true;
+            }
+        }
+        self.scroll = 0;
+    }
+
+    /// Move the cursor to the next navigable row in `direction` (`-1` up,
+    /// `1` down), skipping non-navigable rows and clamping (never wrapping)
+    /// at either end. A no-op when nothing is navigable.
+    fn move_cursor(&mut self, direction: i64) {
+        let Some(current) = self.cursor else {
+            return;
+        };
+        let mut index = current as i64;
+        // Bounded by `rows.len()`: each step moves `index` strictly toward
+        // one end of the vector, so it exits (via the bounds check below)
+        // in at most `rows.len()` iterations.
+        for _ in 0..self.rows.len() {
+            index += direction;
+            let Ok(candidate) = usize::try_from(index) else {
+                return;
+            };
+            match self.rows.get(candidate).map(|row| row.subject.is_some()) {
+                Some(true) => {
+                    self.cursor = Some(candidate);
+                    return;
+                }
+                Some(false) => continue,
+                None => return,
+            }
+        }
+    }
+
+    /// Route one key press: Up/Down move [`Self::cursor`] over navigable
+    /// rows; Enter opens the highlighted row's subject (the same
+    /// [`AppEvent::OpenSubject`] the watchlist rail uses); Esc backs out.
+    pub fn handle_key(&mut self, code: KeyCode) -> Option<AppEvent> {
+        match code {
+            KeyCode::Up => {
+                self.move_cursor(-1);
+                None
+            }
+            KeyCode::Down => {
+                self.move_cursor(1);
+                None
+            }
+            KeyCode::Enter => self
+                .cursor
+                .and_then(|index| self.rows.get(index))
+                .and_then(|row| row.subject.clone())
+                .map(AppEvent::OpenSubject),
+            KeyCode::Esc => Some(AppEvent::Back),
+            _ => None,
+        }
+    }
+
+    /// Render the rail into `area` of `frame`: a bordered panel titled
+    /// `"CHRONICLE"`, the autopause banner (if any) pinned as the first
+    /// line, then the row window `Self::scroll` selects, or one of the two
+    /// distinct absence/failure states in place of rows.
+    ///
+    /// Takes `&mut self` because drawing is also where `self.scroll`
+    /// catches up to wherever [`Self::cursor`] last moved — the scroll
+    /// offset is otherwise meaningless without a drawn area to scroll
+    /// within.
+    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+        let block = Block::bordered().title(TITLE);
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        if self.parse_failed {
+            let loud = Paragraph::new(UNREADABLE_TEXT).style(Style::new().fg(CRIMSON));
+            frame.render_widget(loud, inner);
+            return;
+        }
+
+        if self.rows.is_empty() && self.autopause_line.is_none() {
+            let absence = Paragraph::new(Span::styled(
+                ABSENCE_TEXT,
+                Style::new().fg(CRIMSON).add_modifier(Modifier::BOLD),
+            ));
+            frame.render_widget(absence, inner);
+            return;
+        }
+
+        let banner_height: u16 = if self.autopause_line.is_some() { 1 } else { 0 };
+        let visible_rows = usize::from(inner.height.saturating_sub(banner_height));
+
+        if let Some(cursor) = self.cursor {
+            if cursor < self.scroll {
+                self.scroll = cursor;
+            } else if visible_rows > 0 && cursor >= self.scroll + visible_rows {
+                self.scroll = cursor + 1 - visible_rows;
+            }
+        }
+
+        let mut lines: Vec<Line> = Vec::new();
+        if let Some(banner) = &self.autopause_line {
+            lines.push(Line::from(Span::styled(
+                banner.clone(),
+                Style::new().fg(AMBER).add_modifier(Modifier::BOLD),
+            )));
+        }
+        for (index, row) in self
+            .rows
+            .iter()
+            .enumerate()
+            .skip(self.scroll)
+            .take(visible_rows)
+        {
+            let line = row_line(row);
+            lines.push(if Some(index) == self.cursor {
+                highlighted(line)
+            } else {
+                line
+            });
+        }
+        frame.render_widget(Paragraph::new(lines), inner);
+    }
+}
+
+/// Build one row's display line per its `kind` (contract §2's color table).
+fn row_line(row: &ChronicleRow) -> Line<'static> {
+    match row.kind {
+        RowKind::Header => Line::from(Span::styled(
+            row.text.clone(),
+            Style::new().fg(GOLD).add_modifier(Modifier::BOLD),
+        )),
+        RowKind::Quiet => Line::from(Span::styled(
+            row.text.clone(),
+            Style::new().fg(CRIMSON).add_modifier(Modifier::BOLD),
+        )),
+        RowKind::Event => event_line(row),
+    }
+}
+
+/// Build an `"event"` row's line: severity picks the text color (critical
+/// bold CRIMSON, warning module [`AMBER`], informational — or an absent
+/// severity — BONE), with an optional bold-GOLD actor prefix ahead of the
+/// text (a plain space separates them; the host's `text` field itself never
+/// includes the actor).
+fn event_line(row: &ChronicleRow) -> Line<'static> {
+    let (color, bold) = match row.severity {
+        Some(Severity::Critical) => (CRIMSON, true),
+        Some(Severity::Warning) => (AMBER, false),
+        Some(Severity::Informational) | None => (BONE, false),
+    };
+    let mut style = Style::new().fg(color);
+    if bold {
+        style = style.add_modifier(Modifier::BOLD);
+    }
+    match &row.actor {
+        Some(actor) => Line::from(vec![
+            Span::styled(
+                format!("{actor} "),
+                Style::new().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(row.text.clone(), style),
+        ]),
+        None => Line::from(Span::styled(row.text.clone(), style)),
+    }
+}
+
+/// Re-style every span of `line` with [`Modifier::REVERSED`] added, keeping
+/// each span's own foreground color (reversed video swaps at the terminal,
+/// not in the stored `fg`/`bg`, so this never disturbs the color a test —
+/// or a future reader — expects a given span to carry).
+fn highlighted(line: Line<'static>) -> Line<'static> {
+    Line::from(
+        line.spans
+            .into_iter()
+            .map(|span| Span::styled(span.content, span.style.add_modifier(Modifier::REVERSED)))
+            .collect::<Vec<_>>(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_malformed_kind_fails_the_whole_payload() {
+        let mut rail = ChronicleRail::default();
+        rail.update_from_json(
+            r#"{"autopause_line": null, "rows": [
+                {"subject": null, "kind": "bogus", "tick": 1, "severity": null,
+                 "actor": null, "text": "x"}
+            ]}"#,
+        );
+        assert!(rail.parse_failed);
+        assert!(rail.rows.is_empty());
+    }
+
+    #[test]
+    fn cursor_starts_on_the_first_navigable_row() {
+        let mut rail = ChronicleRail::default();
+        rail.update_from_json(
+            r#"{"autopause_line": null, "rows": [
+                {"subject": null, "kind": "header", "tick": 1, "severity": null,
+                 "actor": null, "text": "T0001"},
+                {"subject": "organization/org-a", "kind": "event", "tick": 1,
+                 "severity": "informational", "actor": null, "text": "reports in"}
+            ]}"#,
+        );
+        assert_eq!(rail.cursor, Some(1));
+    }
+}

--- a/rust/crates/babylon-tui/src/views/hud.rs
+++ b/rust/crates/babylon-tui/src/views/hud.rs
@@ -49,7 +49,7 @@
 use std::collections::HashMap;
 
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::Paragraph;
 use ratatui::Frame;
@@ -58,18 +58,13 @@ use serde_json::Value;
 
 use crate::theme::{BONE, CRIMSON, DIM, GOLD};
 
-/// Reserved for the autopause indicator (mirrors `tui/theme.py:71-74`'s
-/// `AMBER = "#ff8c00"`). NOT a §9b role token — do NOT add this to
-/// `theme.rs`; the cross-language parity guard
-/// (`tests/unit/render/test_rust_theme_parity.py`) fails on any
-/// `Color::Rgb` constant there it can't match against
-/// `TRUECOLOR_PALETTE`. Declared locally in this module rather than
-/// shared, per the contract's own instruction (§2 makes the same call for
-/// the chronicle rail's copy) — each PACING/rail consumer owns its copy.
-const AMBER: Color = Color::Rgb(255, 140, 0);
+use crate::views::chronicle::AMBER;
 
-/// One gauge's width in glyphs (contract §4).
-const BAR_WIDTH: usize = 10;
+/// One gauge's width in glyphs — 8, not the contract's illustrative 10:
+/// five `"{ABBR} [########] "` units must fit an 80-column terminal
+/// (5 × 15 = 75 ≤ 80; at width 10 the fifth gauge clipped mid-bar, making
+/// a full bar indistinguishable from 7/10 — the verify panel's finding).
+const BAR_WIDTH: usize = 8;
 
 /// The five recognized endgame patterns, contract-fixed order (mirrors
 /// `endgame_detector.py:71-77`'s own `axis_progress()` key order, re-cited
@@ -418,15 +413,15 @@ mod tests {
 
     #[test]
     fn bar_glyphs_rounds_to_the_nearest_cell() {
-        assert_eq!(bar_glyphs(0.42), (4, 6));
-        assert_eq!(bar_glyphs(0.0), (0, 10));
-        assert_eq!(bar_glyphs(1.0), (10, 0));
+        assert_eq!(bar_glyphs(0.42), (3, 5));
+        assert_eq!(bar_glyphs(0.0), (0, 8));
+        assert_eq!(bar_glyphs(1.0), (8, 0));
     }
 
     #[test]
     fn bar_glyphs_clamps_an_out_of_range_progress() {
-        assert_eq!(bar_glyphs(-0.5), (0, 10));
-        assert_eq!(bar_glyphs(1.5), (10, 0));
+        assert_eq!(bar_glyphs(-0.5), (0, 8));
+        assert_eq!(bar_glyphs(1.5), (8, 0));
     }
 
     #[test]

--- a/rust/crates/babylon-tui/src/views/hud.rs
+++ b/rust/crates/babylon-tui/src/views/hud.rs
@@ -1,0 +1,441 @@
+//! The endgame HUD strip: a persistent top-of-screen status band (plan
+//! Task 24, contract `docs/superpowers/specs/2026-07-27-m2-seam-contracts.md`
+//! §4, §1).
+//!
+//! Ports the *display* semantics of `dashboard_view.py::render_hud_text`
+//! (Program 24 P4) over the M2 wire shapes the contract pins:
+//!
+//! - **Line 1** — `T+{tick}/{horizon_tick}` (mirrors `render_hud_text`'s
+//!   `counter`), appended with the recognized pattern's full label and
+//!   since-tick in bold CRIMSON when one is held. `tick` itself never
+//!   crosses on [`crate::host::Host::endgame_status_json`] — that payload
+//!   carries only the fixed `horizon_tick` — so the integrator threads it
+//!   in separately via [`HudStrip::set_tick`] on every post-tick refresh
+//!   (contract §6).
+//! - **Line 2** — the five endgame axis gauges, keyed by the FIXED
+//!   `AXIS_KEYS` order (mirrors `dashboard_view.py:36-42`'s
+//!   `_AXIS_ORDER`, itself citing `endgame_detector.py:71-77`'s own
+//!   `axis_progress()` key order) — NEVER the `axes` JSON object's own
+//!   iteration order (contract §4).
+//! - **Line 3** — the PACING state (contract §1; mirrors
+//!   `dashboard_view.py:154-163`'s branch order and wording verbatim).
+//!
+//! Two host feeds cross the wire independently
+//! ([`HudStrip::update_endgame`] from `endgame_status_json`,
+//! [`HudStrip::update_pacing`] from `pacing_state_json`) and each owns its
+//! own honest-absence / loud-failure reading (Constitution III.11), never
+//! conflated:
+//!
+//! - `endgame_status_json`'s `"null"` is the ONLY pre-bind absence (no
+//!   campaign chosen yet) and collapses the whole strip to one honest
+//!   line — a bound tick-0 all-zero-axes payload is a REAL status and
+//!   renders five empty bars, never the absence line (contract §4).
+//! - A payload that fails to parse opens the loud, distinct `UNREADABLE`
+//!   reading. For `endgame_status_json` this collapses the whole strip
+//!   (mirrors `WatchlistView`/`LobbyView`'s own parse-failure
+//!   short-circuit — with no readable horizon there is nothing sensible to
+//!   draw a counter or bars from); for `pacing_state_json` it is isolated
+//!   to line 3 only, since a malformed pacing payload says nothing about
+//!   whether the endgame feed is fine.
+//!
+//! [`HudStrip`] keeps its parsed state private (unlike the M1 views this
+//! mirrors, which expose their rows/selection as `pub` fields for direct
+//! inspection): M1 views are one-shot value bags reopened fresh from a
+//! single JSON pull, while this strip accumulates two independently
+//! updated feeds across the campaign's lifetime, so its internal
+//! bookkeeping (which of the three readings above is current) is not
+//! itself useful public API — only the rendered output is.
+
+use std::collections::HashMap;
+
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::theme::{BONE, CRIMSON, DIM, GOLD};
+
+/// Reserved for the autopause indicator (mirrors `tui/theme.py:71-74`'s
+/// `AMBER = "#ff8c00"`). NOT a §9b role token — do NOT add this to
+/// `theme.rs`; the cross-language parity guard
+/// (`tests/unit/render/test_rust_theme_parity.py`) fails on any
+/// `Color::Rgb` constant there it can't match against
+/// `TRUECOLOR_PALETTE`. Declared locally in this module rather than
+/// shared, per the contract's own instruction (§2 makes the same call for
+/// the chronicle rail's copy) — each PACING/rail consumer owns its copy.
+const AMBER: Color = Color::Rgb(255, 140, 0);
+
+/// One gauge's width in glyphs (contract §4).
+const BAR_WIDTH: usize = 10;
+
+/// The five recognized endgame patterns, contract-fixed order (mirrors
+/// `endgame_detector.py:71-77`'s own `axis_progress()` key order, re-cited
+/// by `dashboard_view.py:36-42`'s `_AXIS_ORDER`): `(id, full label,
+/// abbreviated label)`. `id` is both the `axes` JSON key and the
+/// `pattern` string value; the full label feeds line 1's pattern suffix
+/// ([`pattern_label`]); the 3-glyph abbreviation keeps line 2's five
+/// gauges inside an 80-column strip.
+///
+/// Indexed by THIS array, never by iterating the `axes` JSON object — a
+/// missing key reads honest `0.0` ([`axis_value`]), never a KeyError,
+/// never a different display order (contract §4).
+const AXIS_KEYS: [(&str, &str, &str); 5] = [
+    ("revolutionary_victory", "REVOLUTIONARY VICTORY", "REV"),
+    ("ecological_collapse", "ECOLOGICAL COLLAPSE", "ECO"),
+    ("fascist_consolidation", "FASCIST CONSOLIDATION", "FAS"),
+    ("red_ogv", "RED OGV", "OGV"),
+    ("fragmented_collapse", "FRAGMENTED COLLAPSE", "FRG"),
+];
+
+/// The honest pre-bind absence line — the ONLY reading for
+/// `endgame_status_json`'s `"null"` (contract §4; never used for a bound
+/// tick-0 all-zero payload, which is real data and renders five empty
+/// bars instead).
+const HUD_ABSENT_TEXT: &str = "hud: no campaign bound";
+
+/// The loud, distinct parse-failure line for `endgame_status_json`
+/// (mirrors `WatchlistView`/`LobbyView`'s own `"... UNREADABLE —
+/// malformed host data"` wording).
+const HUD_UNREADABLE_TEXT: &str = "▌ hud UNREADABLE — malformed host data";
+
+/// The loud, distinct parse-failure line for `pacing_state_json` —
+/// isolated to line 3 (see the module docs) rather than blanking the
+/// whole strip.
+const PACING_UNREADABLE_TEXT: &str = "PACING: UNREADABLE — malformed host data";
+
+/// `EndgameStatus.model_dump_json()`'s pinned shape (contract §4;
+/// `projection/endgame.py:34-57`), narrowed to the fields this strip
+/// actually renders. `outcome`/`game_over`/`locked` are real fields on the
+/// wire that no M2 HUD line reads yet; serde's default (no
+/// `deny_unknown_fields`) ignores them harmlessly rather than this struct
+/// carrying a dead placeholder for each.
+#[derive(Deserialize)]
+struct EndgameStatus {
+    /// The currently recognized pattern's id (one of [`AXIS_KEYS`]'s
+    /// five), or `None` — looked up through [`pattern_label`] for line 1's
+    /// suffix, never rendered as the raw id.
+    pattern: Option<String>,
+    /// The fixed campaign horizon tick — line 1's counter denominator.
+    horizon_tick: u64,
+    /// The tick `pattern` was first recognized; `None` when no pattern is
+    /// held. Only meaningful alongside a non-`None` `pattern` (contract
+    /// §4: a matched-but-not-held axis has no tracked since-tick of its
+    /// own).
+    since_tick: Option<u64>,
+    /// The detector's per-axis progress payload, verbatim — read ONLY
+    /// through [`axis_value`], keyed by [`AXIS_KEYS`], never iterated
+    /// directly (contract §4).
+    axes: HashMap<String, Value>,
+}
+
+/// `pacing_state_json`'s pinned shape (contract §1; mirrors
+/// `PacedDriverHandle`, `tui/app.py:525-582`).
+#[derive(Deserialize)]
+struct PacingState {
+    /// `false` when no campaign/driver is bound — all other fields are
+    /// false/`None` in that case (the host trait's own documented default,
+    /// `host.rs::Host::pacing_state_json`).
+    attached: bool,
+    /// Whether the paced driver is locked (a held endgame pattern past its
+    /// lock window).
+    locked: bool,
+    /// The human-readable reason for `locked`, when `locked` is true.
+    lock_reason: Option<String>,
+    /// Whether a completed run is awaiting player acknowledgement.
+    awaiting_ack: bool,
+    /// A short summary of the pending autopause, when `awaiting_ack` is
+    /// true.
+    pause_summary: Option<String>,
+    /// Whether a `run_until_paused` batch is already in flight.
+    busy: bool,
+}
+
+impl PacingState {
+    /// The state before any real `pacing_state_json` payload has arrived —
+    /// identical to the host trait's own default encoding (`attached:
+    /// false`, everything else false/`None`), so a fresh [`HudStrip`]
+    /// renders the same "no paced driver attached" line the host itself
+    /// would serve for an unbound session.
+    fn unattached() -> Self {
+        Self {
+            attached: false,
+            locked: false,
+            lock_reason: None,
+            awaiting_ack: false,
+            pause_summary: None,
+            busy: false,
+        }
+    }
+}
+
+/// The HUD's endgame reading: pre-bind absence, a loud parse failure, or a
+/// bound (possibly all-zero) status. See the module docs for why absence
+/// and failure are never conflated.
+enum EndgameSlot {
+    /// No campaign bound (`endgame_status_json` served JSON `null`).
+    Absent,
+    /// A malformed payload — loud, distinct from absence (III.11).
+    Unreadable,
+    /// A bound campaign's real status, possibly all-zero at tick 0.
+    Bound(EndgameStatus),
+}
+
+/// The HUD's pacing reading: a loud parse failure, or a bound state. There
+/// is no separate "absent" variant here — the host's own default payload
+/// (`attached: false`) already encodes "no driver wired" as ordinary data
+/// (see [`PacingState::unattached`]).
+enum PacingSlot {
+    /// A malformed payload — loud, distinct from the `attached: false`
+    /// reading (III.11).
+    Unreadable,
+    /// A bound (possibly unattached) pacing state.
+    Bound(PacingState),
+}
+
+/// The endgame HUD strip: a persistent 3-line top-of-screen band (plan
+/// Task 24). See the module docs for the per-line contract and the
+/// absence/failure reading each feed owns independently.
+pub struct HudStrip {
+    tick: u64,
+    endgame: EndgameSlot,
+    pacing: PacingSlot,
+}
+
+impl HudStrip {
+    /// A fresh strip before any host payload has arrived: tick `0`, no
+    /// campaign bound (the internal `EndgameSlot::Absent` reading), and
+    /// the pacing feed's own honest unattached default
+    /// (`PacingState::unattached`).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            tick: 0,
+            endgame: EndgameSlot::Absent,
+            pacing: PacingSlot::Bound(PacingState::unattached()),
+        }
+    }
+
+    /// Set the campaign's current committed tick (line 1's counter
+    /// numerator). The integrator calls this alongside
+    /// [`Self::update_endgame`] on every post-tick refresh (contract §6) —
+    /// `EndgameStatus` carries only the fixed `horizon_tick`, never the
+    /// live tick itself.
+    pub fn set_tick(&mut self, tick: u64) {
+        self.tick = tick;
+    }
+
+    /// Absorb a fresh `endgame_status_json` payload (contract §4).
+    ///
+    /// `"null"` is the honest pre-bind absence — never conflated with a
+    /// bound tick-0 all-zero-axes payload, which parses as a real
+    /// (internal) `EndgameStatus` and renders five empty bars. Anything
+    /// that fails to parse as either reading opens the loud, distinct
+    /// `Unreadable` state (Constitution III.11) rather than silently
+    /// defaulting to either honest one.
+    pub fn update_endgame(&mut self, payload: &str) {
+        self.endgame = match serde_json::from_str::<Option<EndgameStatus>>(payload) {
+            Ok(None) => EndgameSlot::Absent,
+            Ok(Some(status)) => EndgameSlot::Bound(status),
+            Err(_) => EndgameSlot::Unreadable,
+        };
+    }
+
+    /// Absorb a fresh `pacing_state_json` payload (contract §1). A payload
+    /// that fails to parse the pinned shape opens the loud `Unreadable`
+    /// pacing state, isolated to line 3 (see the module docs) — it says
+    /// nothing about whether the endgame feed is readable.
+    pub fn update_pacing(&mut self, payload: &str) {
+        self.pacing = match serde_json::from_str::<PacingState>(payload) {
+            Ok(state) => PacingSlot::Bound(state),
+            Err(_) => PacingSlot::Unreadable,
+        };
+    }
+
+    /// Render the strip into `area` of `frame`.
+    ///
+    /// Pre-bind absence or a parse failure on the endgame feed collapses
+    /// the whole strip to one line (see the module docs); otherwise all
+    /// three lines render, with line 3 reading its own independent
+    /// (internal) pacing reading.
+    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+        match &self.endgame {
+            EndgameSlot::Absent => {
+                frame.render_widget(Paragraph::new(HUD_ABSENT_TEXT), area);
+            }
+            EndgameSlot::Unreadable => {
+                let loud = Paragraph::new(HUD_UNREADABLE_TEXT)
+                    .style(Style::new().fg(CRIMSON).add_modifier(Modifier::BOLD));
+                frame.render_widget(loud, area);
+            }
+            EndgameSlot::Bound(status) => {
+                let lines = vec![
+                    tick_line(self.tick, status),
+                    axis_line(&status.axes),
+                    pacing_line(&self.pacing),
+                ];
+                frame.render_widget(Paragraph::new(Text::from(lines)), area);
+            }
+        }
+    }
+}
+
+impl Default for HudStrip {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Look up a recognized pattern id's full display label off [`AXIS_KEYS`],
+/// or `None` when `pattern` is `None` or (defensively) doesn't match any
+/// of the five recognized ids.
+fn pattern_label(pattern: Option<&str>) -> Option<&'static str> {
+    let id = pattern?;
+    AXIS_KEYS
+        .into_iter()
+        .find(|entry| entry.0 == id)
+        .map(|entry| entry.1)
+}
+
+/// Line 1: the `T+{tick}/{horizon_tick}` counter, plus the held pattern's
+/// full label and since-tick in bold CRIMSON when one is recognized.
+fn tick_line(tick: u64, status: &EndgameStatus) -> Line<'static> {
+    let counter = format!("T+{tick}/{}", status.horizon_tick);
+    match pattern_label(status.pattern.as_deref()) {
+        None => Line::from(counter),
+        Some(label) => {
+            let since = status
+                .since_tick
+                .map_or_else(|| "?".to_string(), |t| t.to_string());
+            Line::from(vec![
+                Span::raw(counter),
+                Span::styled(
+                    format!(" — {label} since T{since}"),
+                    Style::new().fg(CRIMSON).add_modifier(Modifier::BOLD),
+                ),
+            ])
+        }
+    }
+}
+
+/// Read one axis's progress off `EndgameStatus.axes`, honestly `0.0` when
+/// the key is absent or its value isn't numeric (mirrors
+/// `dashboard_view.py::_axis_value`, `dashboard_view.py:67-79`).
+fn axis_value(axes: &HashMap<String, Value>, key: &str) -> f64 {
+    axes.get(key).and_then(Value::as_f64).unwrap_or(0.0)
+}
+
+/// The filled/empty glyph counts for one [`BAR_WIDTH`]-cell bar, clamping
+/// `progress` defensively to `[0.0, 1.0]` before rounding — this renderer
+/// never trusts an upstream invariant it cannot itself verify (the same
+/// discipline `dashboard_view.py::_bar` documents for its own clamp).
+fn bar_glyphs(progress: f64) -> (usize, usize) {
+    let clamped = progress.clamp(0.0, 1.0);
+    let filled = (clamped * BAR_WIDTH as f64).round() as usize;
+    (filled, BAR_WIDTH - filled)
+}
+
+/// Line 2: the five endgame axis gauges, keyed by the fixed [`AXIS_KEYS`]
+/// order. An axis at progress `>= 1.0` is DERIVED-triggered (the
+/// detector's own documented invariant, contract §4) and renders bold
+/// CRIMSON end-to-end; otherwise GOLD fill on DIM empty.
+fn axis_line(axes: &HashMap<String, Value>) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    for (key, _full_label, abbrev) in AXIS_KEYS {
+        let progress = axis_value(axes, key);
+        let (filled, empty) = bar_glyphs(progress);
+        spans.push(Span::raw(format!("{abbrev} [")));
+        if progress >= 1.0 {
+            let triggered = Style::new().fg(CRIMSON).add_modifier(Modifier::BOLD);
+            spans.push(Span::styled("█".repeat(filled), triggered));
+            spans.push(Span::styled("-".repeat(empty), triggered));
+        } else {
+            spans.push(Span::styled("█".repeat(filled), Style::new().fg(GOLD)));
+            spans.push(Span::styled("-".repeat(empty), Style::new().fg(DIM)));
+        }
+        spans.push(Span::raw("] "));
+    }
+    Line::from(spans)
+}
+
+/// Line 3: the PACING state (contract §1, mirroring
+/// `dashboard_view.py:154-163`'s branch order and wording verbatim).
+fn pacing_line(slot: &PacingSlot) -> Line<'static> {
+    match slot {
+        PacingSlot::Unreadable => Line::from(Span::styled(
+            PACING_UNREADABLE_TEXT,
+            Style::new().fg(CRIMSON).add_modifier(Modifier::BOLD),
+        )),
+        PacingSlot::Bound(state) => {
+            if !state.attached {
+                Line::from("PACING: no paced driver attached")
+            } else if state.locked {
+                let reason = state.lock_reason.as_deref().unwrap_or("(no reason given)");
+                Line::from(Span::styled(
+                    format!("PACING: LOCKED — {reason}"),
+                    Style::new().fg(CRIMSON).add_modifier(Modifier::BOLD),
+                ))
+            } else if state.awaiting_ack {
+                let summary = state.pause_summary.as_deref().unwrap_or("(no summary)");
+                Line::from(Span::styled(
+                    format!("PACING: autopause pending ({summary}) — press 'a' to acknowledge"),
+                    Style::new().fg(AMBER),
+                ))
+            } else if state.busy {
+                Line::from("PACING: a run is already in progress")
+            } else {
+                Line::from(Span::styled("PACING: ready", Style::new().fg(BONE)))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn axis_value_reads_a_present_key() {
+        let mut axes = HashMap::new();
+        axes.insert("revolutionary_victory".to_string(), Value::from(0.5));
+        assert_eq!(axis_value(&axes, "revolutionary_victory"), 0.5);
+    }
+
+    #[test]
+    fn axis_value_defaults_a_missing_key_to_zero() {
+        let axes: HashMap<String, Value> = HashMap::new();
+        assert_eq!(axis_value(&axes, "fragmented_collapse"), 0.0);
+    }
+
+    #[test]
+    fn axis_value_defaults_a_non_numeric_value_to_zero() {
+        let mut axes = HashMap::new();
+        axes.insert("red_ogv".to_string(), Value::from("not a number"));
+        assert_eq!(axis_value(&axes, "red_ogv"), 0.0);
+    }
+
+    #[test]
+    fn bar_glyphs_rounds_to_the_nearest_cell() {
+        assert_eq!(bar_glyphs(0.42), (4, 6));
+        assert_eq!(bar_glyphs(0.0), (0, 10));
+        assert_eq!(bar_glyphs(1.0), (10, 0));
+    }
+
+    #[test]
+    fn bar_glyphs_clamps_an_out_of_range_progress() {
+        assert_eq!(bar_glyphs(-0.5), (0, 10));
+        assert_eq!(bar_glyphs(1.5), (10, 0));
+    }
+
+    #[test]
+    fn pattern_label_looks_up_a_recognized_id() {
+        assert_eq!(pattern_label(Some("red_ogv")), Some("RED OGV"));
+    }
+
+    #[test]
+    fn pattern_label_is_none_for_no_pattern() {
+        assert_eq!(pattern_label(None), None);
+    }
+}

--- a/rust/crates/babylon-tui/src/views/mod.rs
+++ b/rust/crates/babylon-tui/src/views/mod.rs
@@ -1,8 +1,12 @@
 //! Client views (M1): lobby, wiki, palette, watchlist, peek.
+//! M2 adds the play-screen chrome: chronicle rail, verb plate, HUD strip.
 
+pub mod chronicle;
+pub mod hud;
 pub mod lobby;
 pub mod msg;
 pub mod palette;
 pub mod peek;
+pub mod verbs;
 pub mod watchlist;
 pub mod wiki;

--- a/rust/crates/babylon-tui/src/views/verbs.rs
+++ b/rust/crates/babylon-tui/src/views/verbs.rs
@@ -1,0 +1,387 @@
+//! The verb plate: the nine Article V verbs, one bottom-of-screen plate
+//! (plan Task 23).
+//!
+//! Ports the *display* shape of `babylon.tui.verb_plate::render_verb_plate`
+//! over the wire shape `Host::verb_plate_view_json` serves (contract §3,
+//! `docs/superpowers/specs/2026-07-27-m2-seam-contracts.md`):
+//! `VerbPlateView.model_dump_json()` from
+//! `babylon.projection.verbs.view_models`, or the literal string `"null"`
+//! when no session/player org is bound.
+//!
+//! **Eligibility gates the row; affordability never hides one** (mirrors
+//! `verb_plate.py`'s own contract): an ineligible verb still renders, with
+//! its player-facing `reason`/`remedy` inline — never omitted; an
+//! eligible-but-unaffordable verb still renders as legal, with the
+//! `afford_note` riding along honestly rather than disabling the row.
+//!
+//! **Investigate's three sub-verbs surface faithfully, not collapsed**
+//! (Constitution Article V): the plate renders `Investigate(Territory)`,
+//! `Investigate(Org)`, `Investigate(Edge)` as three named lines, all three
+//! sharing the ONE `investigate` row's eligibility/cost/preview signal and
+//! F-key (mirrors `verb_plate.py:64-67,162-196` — the view-model does not
+//! yet carry independent per-sub-verb signals).
+//!
+//! **F-keys are POSITIONAL over the fixed nine-verb canonical order**
+//! (`CANONICAL_VERBS`, mirroring `preview.py::VERB_TO_ACTION_TYPE`'s own
+//! dict order), not over the raw payload array index: a well-formed payload
+//! ships all nine rows in that same order, so the two coincide, but a
+//! caller-truncated payload (fewer than nine rows) is matched back onto the
+//! canonical order **by verb name**, so a dropped verb always renders its
+//! loud missing-marker line at ITS canonical F-key slot regardless of where
+//! (or whether) the truncation happened to leave a gap in the array
+//! (mirrors `verb_plate.py:134-144,177-196`'s own by-name `by_verb` lookup).
+//!
+//! **Malformed JSON is a distinct loud state, never conflated with
+//! absence** (Constitution III.11): `"null"` opens the honest
+//! "no verb plate — no campaign bound" absence state; anything else that
+//! fails to parse as a `VerbPlateView` object opens the CRIMSON
+//! `UNREADABLE` state instead. Dispatch (`F1`-`F9` -> `issue_verb`) is
+//! integration wiring, not this module's concern — [`VerbPlateView::row`]
+//! exists so the app shell's key handler can read a row's `eligible`/
+//! `candidate_target_ids` for honest-target dispatch without touching JSON
+//! itself.
+
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Paragraph};
+use ratatui::Frame;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::theme::{BONE, CRIMSON, DIM};
+
+/// The nine canonical Article V verbs, in plate/F-key order (mirrors
+/// `preview.py::VERB_TO_ACTION_TYPE`'s own dict order). F-key `N` (1-indexed)
+/// binds to this order's `N - 1`th verb.
+const CANONICAL_VERBS: [&str; 9] = [
+    "educate",
+    "reproduce",
+    "attack",
+    "mobilize",
+    "campaign",
+    "aid",
+    "investigate",
+    "move",
+    "negotiate",
+];
+
+/// Investigate's three named sub-verbs, in Constitution Article V's own
+/// order (mirrors `verb_plate.py::INVESTIGATE_SUB_VERBS`).
+const INVESTIGATE_SUB_VERBS: [&str; 3] = ["Territory", "Org", "Edge"];
+
+/// The honest-absence line for `"null"` (no session / no player org bound).
+const ABSENCE_TEXT: &str = "▌ no verb plate — no campaign bound";
+
+/// The loud, distinct parse-failure line for a malformed payload — never
+/// conflated with [`ABSENCE_TEXT`] (Constitution III.11).
+const UNREADABLE_TEXT: &str = "▌ verb plate UNREADABLE — malformed host data";
+
+/// Deterministic consequence-preview estimates for one proposed verb.
+///
+/// Field shape pins to `babylon.projection.verbs.view_models.VerbPreview`.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct VerbPreview {
+    /// Estimated collective-identity delta, rounded to 4 places.
+    pub estimated_consciousness_delta: f64,
+    /// Estimated heat delta, rounded to 4 places.
+    pub estimated_heat_delta: f64,
+    /// Action-point cost of the verb.
+    pub action_point_cost: f64,
+    /// Rounded success estimate.
+    pub success_probability: f64,
+    /// The acting org's territories plus the explicit target, in that order.
+    pub affected_territory_ids: Vec<String>,
+    /// Player-facing caveats — honest, never suppressed.
+    pub warnings: Vec<String>,
+}
+
+/// One verb's parsed row, as served inside `VerbPlateView.verbs`.
+///
+/// Field shape pins to `babylon.projection.verbs.view_models.VerbRow`.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct VerbRowParsed {
+    /// The canonical verb name (e.g. `"educate"`).
+    pub verb: String,
+    /// Target-existence predicate result — the row is gated on this alone,
+    /// never on [`Self::can_afford`].
+    pub eligible: bool,
+    /// Player-facing reason when ineligible, else `None`.
+    pub reason: Option<String>,
+    /// Player-facing remedy when ineligible, else `None`.
+    pub remedy: Option<String>,
+    /// Affordability via the same check that gates submission.
+    pub can_afford: bool,
+    /// The affordability failure note, else `None`.
+    pub afford_note: Option<String>,
+    /// The target-less consequence preview, or `None` (an honest absence).
+    pub preview: Option<VerbPreview>,
+    /// The verb's own honest candidate target ids — a picker (or an F-key
+    /// handler deriving an honest target) reads this without touching the
+    /// graph itself. Empty for a self-targeting verb (`reproduce`).
+    pub candidate_target_ids: Vec<String>,
+}
+
+/// The raw `VerbPlateView` object shape, before it is re-keyed onto
+/// `CANONICAL_VERBS`' fixed slots.
+#[derive(Debug, Clone, Deserialize)]
+struct VerbPlateViewRaw {
+    /// The acting organization.
+    org_id: String,
+    /// The tick the plate was computed against.
+    tick: u64,
+    /// One row per canonical verb — not necessarily all nine, if a caller
+    /// truncated the view (see the module docs).
+    verbs: Vec<VerbRowParsed>,
+}
+
+/// The verb plate view: nine Article-V verbs (Investigate expanded to
+/// three), honest-absence and loud-unreadable states, and a row accessor
+/// for the app shell's F-key dispatch.
+pub struct VerbPlateView {
+    /// The acting organization; `None` in the absent/unreadable states.
+    org_id: Option<String>,
+    /// The tick the plate was computed against; `None` in the
+    /// absent/unreadable states.
+    tick: Option<u64>,
+    /// One slot per `CANONICAL_VERBS` entry (empty in the
+    /// absent/unreadable states); `None` marks a verb missing from a
+    /// caller-truncated payload.
+    slots: Vec<Option<VerbRowParsed>>,
+    /// `true` for the `"null"` honest-absence payload.
+    absent: bool,
+    /// `true` for a payload that failed to parse as a `VerbPlateView`.
+    unreadable: bool,
+}
+
+impl VerbPlateView {
+    /// Build a verb plate view from `Host::verb_plate_view_json`'s raw JSON.
+    ///
+    /// `"null"` opens the honest-absence state; anything that fails to
+    /// parse as JSON, or parses but does not match the `VerbPlateView`
+    /// object shape, opens the loud `unreadable` state instead — the two
+    /// are never conflated (Constitution III.11).
+    #[must_use]
+    pub fn open(raw: &str) -> Self {
+        let parsed: Value = match serde_json::from_str(raw) {
+            Ok(value) => value,
+            Err(_) => return Self::unreadable_state(),
+        };
+        if parsed.is_null() {
+            return Self::absent_state();
+        }
+        match serde_json::from_value::<VerbPlateViewRaw>(parsed) {
+            Ok(view) => Self::ready_state(view),
+            Err(_) => Self::unreadable_state(),
+        }
+    }
+
+    /// The honest-absence state: no rows, no org/tick.
+    fn absent_state() -> Self {
+        Self {
+            org_id: None,
+            tick: None,
+            slots: Vec::new(),
+            absent: true,
+            unreadable: false,
+        }
+    }
+
+    /// The loud parse-failure state: no rows, no org/tick.
+    fn unreadable_state() -> Self {
+        Self {
+            org_id: None,
+            tick: None,
+            slots: Vec::new(),
+            absent: false,
+            unreadable: true,
+        }
+    }
+
+    /// Re-keys a well-formed payload's rows onto `CANONICAL_VERBS`' fixed
+    /// nine slots by verb NAME (never by array position), so a
+    /// caller-truncated payload still slots every present row at its own
+    /// canonical F-key regardless of where the gap fell.
+    fn ready_state(view: VerbPlateViewRaw) -> Self {
+        let slots = CANONICAL_VERBS
+            .iter()
+            .map(|verb| view.verbs.iter().find(|row| row.verb == *verb).cloned())
+            .collect();
+        Self {
+            org_id: Some(view.org_id),
+            tick: Some(view.tick),
+            slots,
+            absent: false,
+            unreadable: false,
+        }
+    }
+
+    /// `true` when this view is the `"null"` honest-absence payload.
+    #[must_use]
+    pub fn is_absent(&self) -> bool {
+        self.absent
+    }
+
+    /// `true` when this view's payload failed to parse.
+    #[must_use]
+    pub fn is_unreadable(&self) -> bool {
+        self.unreadable
+    }
+
+    /// The row bound to F-key `idx + 1` (`idx` in `0..=8`, matching
+    /// `CANONICAL_VERBS`' order), or `None` when the view carries no rows
+    /// (absent/unreadable) or the payload was truncated and that verb is
+    /// missing. The app shell's F-key handler reads `eligible` and
+    /// `candidate_target_ids` off this for honest-target dispatch.
+    #[must_use]
+    pub fn row(&self, idx: usize) -> Option<&VerbRowParsed> {
+        self.slots.get(idx).and_then(Option::as_ref)
+    }
+
+    /// Builds the plate's eleven display lines (eight single-verb lines
+    /// plus Investigate's three sub-verb lines), in `CANONICAL_VERBS`
+    /// order. Always eleven lines regardless of truncation — a missing verb
+    /// contributes its loud marker line(s) in place of its normal line(s),
+    /// never fewer.
+    fn build_lines(&self) -> Vec<Line<'static>> {
+        let mut lines = Vec::with_capacity(11);
+        for (index, verb) in CANONICAL_VERBS.iter().enumerate() {
+            let fkey = index + 1;
+            let slot = self.slots.get(index).and_then(Option::as_ref);
+            if *verb == "investigate" {
+                for sub in INVESTIGATE_SUB_VERBS {
+                    let label = format!("Investigate({sub})");
+                    lines.push(match slot {
+                        Some(row) => verb_line(fkey, &label, row),
+                        None => missing_verb_line(verb),
+                    });
+                }
+            } else {
+                let label = capitalize(verb);
+                lines.push(match slot {
+                    Some(row) => verb_line(fkey, &label, row),
+                    None => missing_verb_line(verb),
+                });
+            }
+        }
+        lines
+    }
+
+    /// Renders the verb plate into `area`: the honest-absence line, the
+    /// loud unreadable line, or the eleven verb/sub-verb lines — laid out
+    /// in two side-by-side columns when `area` is too short to fit every
+    /// line in one.
+    pub fn render(&self, frame: &mut Frame, area: Rect) {
+        let title = match (&self.org_id, self.tick) {
+            (Some(org_id), Some(tick)) => format!("{org_id} — verb plate @ T{tick:04}"),
+            _ => "Verb Plate".to_string(),
+        };
+        let block = Block::bordered().title(title);
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        if self.unreadable {
+            let loud = Paragraph::new(UNREADABLE_TEXT).style(Style::new().fg(CRIMSON));
+            frame.render_widget(loud, inner);
+            return;
+        }
+        if self.absent {
+            let absence = Paragraph::new(ABSENCE_TEXT);
+            frame.render_widget(absence, inner);
+            return;
+        }
+
+        let lines = self.build_lines();
+        if usize::from(inner.height) >= lines.len() {
+            frame.render_widget(Paragraph::new(lines), inner);
+            return;
+        }
+
+        // Not enough rows to fit every line in one column: split into two
+        // side-by-side columns (11 lines max, so this never needs a third).
+        let mid = lines.len().div_ceil(2);
+        let (left, right) = lines.split_at(mid);
+        let columns = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(inner);
+        frame.render_widget(Paragraph::new(left.to_vec()), columns[0]);
+        frame.render_widget(Paragraph::new(right.to_vec()), columns[1]);
+    }
+}
+
+/// One verb (or Investigate sub-verb) line: `"F{fkey} {label}"`, styled and
+/// annotated per the row's eligibility/affordability.
+///
+/// Status semantics (a documented simplification of `verb_plate.py`'s own
+/// `✓`/`✗` + gold/crimson symbols, pinned by plan Task 23): eligible AND
+/// affordable renders plain [`BONE`]; eligible but NOT affordable renders
+/// [`BONE`] with the `afford_note` appended in [`DIM`] (never disabling the
+/// row); ineligible renders entirely in [`DIM`] with `(reason — remedy)`
+/// appended — visible, never hidden (Constitution III.11 / spec-116 FR-4.8).
+fn verb_line(fkey: usize, label: &str, row: &VerbRowParsed) -> Line<'static> {
+    let prefix = format!("F{fkey} {label}");
+    if !row.eligible {
+        let reason = row.reason.as_deref().unwrap_or("(no reason given)");
+        let remedy = row.remedy.as_deref().unwrap_or("(no remedy given)");
+        return Line::from(Span::styled(
+            format!("{prefix}  ({reason} — {remedy})"),
+            Style::new().fg(DIM),
+        ));
+    }
+    if !row.can_afford {
+        let note = row.afford_note.as_deref().unwrap_or("(unaffordable)");
+        return Line::from(vec![
+            Span::styled(prefix, Style::new().fg(BONE)),
+            Span::styled(format!("  {note}"), Style::new().fg(DIM)),
+        ]);
+    }
+    Line::from(Span::styled(prefix, Style::new().fg(BONE)))
+}
+
+/// The loud refusal for a canonical verb absent from a caller-truncated
+/// plate view (mirrors `verb_plate.py::_missing_verb_line`, `verb_plate.py:
+/// 134-144`): Article V's nine verbs are "always available", so a missing
+/// row is a caller bug, never silently dropped.
+fn missing_verb_line(verb: &str) -> Line<'static> {
+    Line::from(Span::styled(
+        format!("▌ {verb} — missing from plate view"),
+        Style::new().fg(CRIMSON).add_modifier(Modifier::BOLD),
+    ))
+}
+
+/// Capitalizes a canonical verb's first character for display (`"educate"`
+/// -> `"Educate"`). Every `CANONICAL_VERBS` entry is ASCII lowercase, so
+/// this never needs to handle multi-byte casing.
+fn capitalize(verb: &str) -> String {
+    let mut chars = verb.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_malformed_payload_opens_unreadable_not_absent() {
+        let view = VerbPlateView::open("not json");
+        assert!(view.is_unreadable());
+        assert!(!view.is_absent());
+    }
+
+    #[test]
+    fn null_opens_absent_not_unreadable() {
+        let view = VerbPlateView::open("null");
+        assert!(view.is_absent());
+        assert!(!view.is_unreadable());
+    }
+
+    #[test]
+    fn row_returns_none_in_the_absent_state() {
+        let view = VerbPlateView::open("null");
+        assert!(view.row(0).is_none());
+    }
+}

--- a/rust/crates/babylon-tui/src/views/verbs.rs
+++ b/rust/crates/babylon-tui/src/views/verbs.rs
@@ -49,6 +49,7 @@ use ratatui::Frame;
 use serde::Deserialize;
 use serde_json::Value;
 
+use crate::layout_registry::{LayoutRegistry, WidgetId};
 use crate::theme::{BONE, CRIMSON, DIM};
 
 /// The nine canonical Article V verbs, in plate/F-key order (mirrors
@@ -267,11 +268,19 @@ impl VerbPlateView {
         lines
     }
 
+    /// The verb slot index each of the eleven display lines dispatches
+    /// (Investigate's three sub-lines all share slot 6 / F7).
+    fn line_slots() -> [usize; 11] {
+        [0, 1, 2, 3, 4, 5, 6, 6, 6, 7, 8]
+    }
+
     /// Renders the verb plate into `area`: the honest-absence line, the
     /// loud unreadable line, or the eleven verb/sub-verb lines — laid out
     /// in two side-by-side columns when `area` is too short to fit every
-    /// line in one.
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    /// line in one. Each verb line's rect registers in `registry` as a
+    /// `"verb:{slot}"` pseudo-entity so a left-click dispatches exactly
+    /// like its F-key (plan Task 23's "F1–F9 + click dispatch").
+    pub fn render(&self, frame: &mut Frame, area: Rect, registry: &mut LayoutRegistry) {
         let title = match (&self.org_id, self.tick) {
             (Some(org_id), Some(tick)) => format!("{org_id} — verb plate @ T{tick:04}"),
             _ => "Verb Plate".to_string(),
@@ -292,7 +301,16 @@ impl VerbPlateView {
         }
 
         let lines = self.build_lines();
+        let slots = Self::line_slots();
         if usize::from(inner.height) >= lines.len() {
+            for (index, slot) in slots.iter().enumerate() {
+                let row_area = Rect::new(inner.x, inner.y + index as u16, inner.width, 1);
+                registry.register(
+                    WidgetId(1000 + *slot as u32),
+                    row_area,
+                    Some(format!("verb:{slot}")),
+                );
+            }
             frame.render_widget(Paragraph::new(lines), inner);
             return;
         }
@@ -305,6 +323,21 @@ impl VerbPlateView {
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
             .split(inner);
+        for (index, slot) in slots.iter().enumerate() {
+            let (column, line_index) = if index < mid {
+                (columns[0], index)
+            } else {
+                (columns[1], index - mid)
+            };
+            if u16::try_from(line_index).map(|i| i < column.height) == Ok(true) {
+                let row_area = Rect::new(column.x, column.y + line_index as u16, column.width, 1);
+                registry.register(
+                    WidgetId(1000 + *slot as u32),
+                    row_area,
+                    Some(format!("verb:{slot}")),
+                );
+            }
+        }
         frame.render_widget(Paragraph::new(left.to_vec()), columns[0]);
         frame.render_widget(Paragraph::new(right.to_vec()), columns[1]);
     }
@@ -331,12 +364,42 @@ fn verb_line(fkey: usize, label: &str, row: &VerbRowParsed) -> Line<'static> {
     }
     if !row.can_afford {
         let note = row.afford_note.as_deref().unwrap_or("(unaffordable)");
-        return Line::from(vec![
+        let mut spans = vec![
             Span::styled(prefix, Style::new().fg(BONE)),
             Span::styled(format!("  {note}"), Style::new().fg(DIM)),
-        ]);
+        ];
+        push_warnings(&mut spans, row);
+        return Line::from(spans);
     }
-    Line::from(Span::styled(prefix, Style::new().fg(BONE)))
+    let mut spans = vec![Span::styled(prefix, Style::new().fg(BONE))];
+    if let Some(preview) = &row.preview {
+        // The view-model's consequence preview renders, never parses-only:
+        // AP cost + success probability in DIM (the essentials the Textual
+        // plate's own preview text carries).
+        spans.push(Span::styled(
+            format!(
+                "  AP {:.0} · P{:.0}%",
+                preview.action_point_cost,
+                preview.success_probability * 100.0
+            ),
+            Style::new().fg(DIM),
+        ));
+    }
+    push_warnings(&mut spans, row);
+    Line::from(spans)
+}
+
+/// Append the row's preview `warnings` in CRIMSON — the view-model declares
+/// them honest-never-suppressed, so the plate must show them, not drop them.
+fn push_warnings(spans: &mut Vec<Span<'static>>, row: &VerbRowParsed) {
+    if let Some(preview) = &row.preview {
+        if !preview.warnings.is_empty() {
+            spans.push(Span::styled(
+                format!("  ⚠ {}", preview.warnings.join("; ")),
+                Style::new().fg(CRIMSON),
+            ));
+        }
+    }
 }
 
 /// The loud refusal for a canonical verb absent from a caller-truncated

--- a/rust/crates/babylon-tui/src/views/watchlist.rs
+++ b/rust/crates/babylon-tui/src/views/watchlist.rs
@@ -43,9 +43,11 @@ use crate::views::msg::AppEvent;
 /// client).
 const ABSENCE_TEXT: &str = "▌ watchlist — nothing pinned yet";
 
-/// The watchlist rail: pinned-subject rows, read-only in M1 (pin/unpin
-/// writes land in M2 — see `babylon.tui.watchlist`'s own module docs on the
-/// `WatchlistPersistence` seam).
+/// The watchlist rail: pinned-subject rows. Pin/unpin writes are LIVE as of
+/// M2 (`P` pins the current dossier; `p` toggles the highlighted row while
+/// the rail holds focus) — the writes cross through
+/// `crate::host::Host::pin_watchlist`; this view stays a pure renderer over
+/// `watchlist_json` pulls.
 pub struct WatchlistView {
     /// One JSON object per pinned subject, as served by
     /// [`crate::host::Host::watchlist_json`]. Each row is expected to carry
@@ -81,7 +83,8 @@ impl WatchlistView {
     /// Routes one key press: Up/Down move the selection (clamped, never
     /// wrapping); Enter opens the highlighted row's `"subject"` (`None` if
     /// the row list is empty, or the highlighted row has no string
-    /// `"subject"` field); Esc backs out of the rail.
+    /// `"subject"` field). Esc never reaches this handler — the app shell
+    /// defocuses the rail itself.
     pub fn handle_key(&mut self, code: KeyCode) -> Option<AppEvent> {
         match code {
             KeyCode::Up => {
@@ -100,16 +103,18 @@ impl WatchlistView {
                 .and_then(|row| row.get("subject"))
                 .and_then(Value::as_str)
                 .map(|subject| AppEvent::OpenSubject(subject.to_string())),
-            KeyCode::Esc => Some(AppEvent::Back),
             _ => None,
         }
     }
 
     /// Renders the watchlist rail: a bordered panel titled with the pin
     /// count, one line per pinned row, or the honest-absence line when
-    /// nothing is pinned.
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
-        let title = format!("Watchlist ({} pinned)", self.rows.len());
+    /// nothing is pinned. The selection highlight renders only while the
+    /// rail holds focus (`focused`) — two panes must never both look
+    /// focused.
+    pub fn render(&self, frame: &mut Frame, area: Rect, focused: bool) {
+        let marker = if focused { " ●" } else { "" };
+        let title = format!("Watchlist ({} pinned){marker}", self.rows.len());
         let block = Block::default().borders(Borders::ALL).title(title);
         let inner = block.inner(area);
         frame.render_widget(block, area);
@@ -132,7 +137,7 @@ impl WatchlistView {
             .iter()
             .enumerate()
             .map(|(index, row)| {
-                let style = if index == self.selected {
+                let style = if focused && index == self.selected {
                     Style::default().add_modifier(Modifier::REVERSED)
                 } else {
                     Style::default()

--- a/rust/crates/babylon-tui/tests/app_shell.rs
+++ b/rust/crates/babylon-tui/tests/app_shell.rs
@@ -106,15 +106,24 @@ fn lobby_to_briefing_to_back_to_quit() {
 
     // Host-call order is the seam contract: catalog once (root build),
     // the campaign BIND (the composition-root verb), known-subjects after
-    // the bind, then the briefing page read + its backlinks.
+    // the bind, the M2 nav restore, the briefing page read + backlinks,
+    // then the chrome's five post-bind pulls (contract §§1-5), and the
+    // nav save on leaving the campaign (q → lobby).
     assert_eq!(
         app.host_calls(),
         vec![
             "lobby_catalog_json".to_string(),
             "load_campaign".to_string(),
             "known_subjects_json".to_string(),
+            "nav_state_json".to_string(),
             "read_page_json".to_string(),
             "backlinks_json".to_string(),
+            "endgame_status_json".to_string(),
+            "pacing_state_json".to_string(),
+            "verb_plate_view_json".to_string(),
+            "chronicle_rail_json".to_string(),
+            "watchlist_json".to_string(),
+            "save_nav_state".to_string(),
         ]
     );
 }

--- a/rust/crates/babylon-tui/tests/chronicle_view.rs
+++ b/rust/crates/babylon-tui/tests/chronicle_view.rs
@@ -6,7 +6,7 @@
 //! banner wording — the banner is an opaque host-supplied string as far as
 //! this view is concerned, and plain ASCII keeps the `style_at` cell-mapping
 //! below exact (some emoji render double-width, which would misalign a
-//! byte-offset-to-cell lookup). The one exception is `"the wire is quiet"`,
+//! byte-offset-to-cell lookup). The one exception is the absence line,
 //! the contract's own honest-absence wording, which IS load-bearing and
 //! reproduced verbatim.
 
@@ -34,9 +34,7 @@ const MIXED_FIXTURE: &str = r#"{
          "text": "storms the compound"},
         {"subject": "organization/org-y", "kind": "event", "tick": 847,
          "severity": "informational", "actor": null,
-         "text": "logs a routine report"},
-        {"subject": null, "kind": "quiet", "tick": 846, "severity": null,
-         "actor": null, "text": "the wire is quiet"}
+         "text": "logs a routine report"}
     ]
 }"#;
 
@@ -58,8 +56,8 @@ const SKIP_FIXTURE: &str = r#"{
          "actor": null, "text": "T0010"},
         {"subject": "organization/org-a", "kind": "event", "tick": 10,
          "severity": "informational", "actor": null, "text": "first"},
-        {"subject": null, "kind": "quiet", "tick": 9, "severity": null,
-         "actor": null, "text": "the wire is quiet"},
+        {"subject": null, "kind": "header", "tick": 9, "severity": null,
+         "actor": null, "text": "T0009"},
         {"subject": "organization/org-b", "kind": "event", "tick": 9,
          "severity": "informational", "actor": null, "text": "second"}
     ]
@@ -80,7 +78,7 @@ fn draw(rail: &mut ChronicleRail, width: u16, height: u16) -> Terminal<TestBacke
     let backend = TestBackend::new(width, height);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
-        .draw(|frame| rail.render(frame, frame.area()))
+        .draw(|frame| rail.render(frame, frame.area(), true))
         .unwrap();
     terminal
 }
@@ -146,10 +144,6 @@ fn mixed_fixture_renders_exact_colors_including_module_amber_banner() {
     let (info_fg, info_mod) = style_at(&terminal, "logs a routine report");
     assert_eq!(info_fg, BONE, "informational severity is BONE");
     assert!(!info_mod.contains(Modifier::BOLD));
-
-    let (quiet_fg, quiet_mod) = style_at(&terminal, "the wire is quiet");
-    assert_eq!(quiet_fg, CRIMSON, "a quiet row is bold CRIMSON");
-    assert!(quiet_mod.contains(Modifier::BOLD));
 }
 
 #[test]
@@ -197,7 +191,7 @@ fn cursor_skips_null_subject_rows_and_enter_opens_the_highlighted_subject() {
     assert_eq!(rail.cursor, Some(1));
 
     assert!(rail.handle_key(KeyCode::Down).is_none());
-    // Index 2 is a quiet row (non-navigable) — Down must skip straight to 3.
+    // Index 2 is a tick header (non-navigable) — Down must skip straight to 3.
     assert_eq!(rail.cursor, Some(3));
 
     let event = rail.handle_key(KeyCode::Enter);
@@ -210,7 +204,7 @@ fn cursor_skips_null_subject_rows_and_enter_opens_the_highlighted_subject() {
     assert_eq!(
         rail.cursor,
         Some(1),
-        "Up skips back over the same quiet row"
+        "Up skips back over the same header row"
     );
 
     // Clamped, never wrapping, at the top navigable row.

--- a/rust/crates/babylon-tui/tests/chronicle_view.rs
+++ b/rust/crates/babylon-tui/tests/chronicle_view.rs
@@ -1,0 +1,237 @@
+//! Behavior tests for `babylon_tui::views::chronicle::ChronicleRail`
+//! (contract `docs/superpowers/specs/2026-07-27-m2-seam-contracts.md` §2,
+//! plan Task 22).
+//!
+//! Fixture text deliberately avoids the contract's literal emoji/em-dash
+//! banner wording — the banner is an opaque host-supplied string as far as
+//! this view is concerned, and plain ASCII keeps the `style_at` cell-mapping
+//! below exact (some emoji render double-width, which would misalign a
+//! byte-offset-to-cell lookup). The one exception is `"the wire is quiet"`,
+//! the contract's own honest-absence wording, which IS load-bearing and
+//! reproduced verbatim.
+
+use babylon_tui::theme::{BONE, CRIMSON, GOLD};
+use babylon_tui::views::chronicle::ChronicleRail;
+use babylon_tui::views::msg::AppEvent;
+use ratatui::backend::TestBackend;
+use ratatui::crossterm::event::KeyCode;
+use ratatui::style::{Color, Modifier};
+use ratatui::Terminal;
+
+/// Mirrors `chronicle::AMBER` (declared `pub(crate)` there on purpose — see
+/// that module's doc comment — so it isn't reachable from this external
+/// integration-test crate; this is the one place its literal value is
+/// duplicated).
+const AMBER: Color = Color::Rgb(255, 140, 0);
+
+const MIXED_FIXTURE: &str = r#"{
+    "autopause_line": "AUTOPAUSE - THIS CANNOT PASS UNREAD",
+    "rows": [
+        {"subject": null, "kind": "header", "tick": 847, "severity": null,
+         "actor": null, "text": "T0847"},
+        {"subject": "organization/org-x", "kind": "event", "tick": 847,
+         "severity": "critical", "actor": "The Vanguard",
+         "text": "storms the compound"},
+        {"subject": "organization/org-y", "kind": "event", "tick": 847,
+         "severity": "informational", "actor": null,
+         "text": "logs a routine report"},
+        {"subject": null, "kind": "quiet", "tick": 846, "severity": null,
+         "actor": null, "text": "the wire is quiet"}
+    ]
+}"#;
+
+const BANNER_ONLY_FIXTURE: &str = r#"{
+    "autopause_line": "AUTOPAUSE NOW",
+    "rows": [
+        {"subject": "organization/org-z", "kind": "event", "tick": 5,
+         "severity": "informational", "actor": null,
+         "text": "first event happens"}
+    ]
+}"#;
+
+const EMPTY_FIXTURE: &str = r#"{"autopause_line": null, "rows": []}"#;
+
+const SKIP_FIXTURE: &str = r#"{
+    "autopause_line": null,
+    "rows": [
+        {"subject": null, "kind": "header", "tick": 10, "severity": null,
+         "actor": null, "text": "T0010"},
+        {"subject": "organization/org-a", "kind": "event", "tick": 10,
+         "severity": "informational", "actor": null, "text": "first"},
+        {"subject": null, "kind": "quiet", "tick": 9, "severity": null,
+         "actor": null, "text": "the wire is quiet"},
+        {"subject": "organization/org-b", "kind": "event", "tick": 9,
+         "severity": "informational", "actor": null, "text": "second"}
+    ]
+}"#;
+
+const NO_BANNER_FIXTURE: &str = r#"{
+    "autopause_line": null,
+    "rows": [
+        {"subject": null, "kind": "header", "tick": 3, "severity": null,
+         "actor": null, "text": "T0003"},
+        {"subject": "organization/org-c", "kind": "event", "tick": 3,
+         "severity": "critical", "actor": null, "text": "no warnings here"}
+    ]
+}"#;
+
+/// Draws `rail` into a fresh `TestBackend` of the given size.
+fn draw(rail: &mut ChronicleRail, width: u16, height: u16) -> Terminal<TestBackend> {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| rail.render(frame, frame.area()))
+        .unwrap();
+    terminal
+}
+
+/// Dumps a `TestBackend` buffer's visible text, one `String` per row.
+fn buffer_lines(terminal: &Terminal<TestBackend>) -> Vec<String> {
+    let buffer = terminal.backend().buffer();
+    let area = buffer.area;
+    (area.top()..area.bottom())
+        .map(|y| {
+            (area.left()..area.right())
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+        })
+        .collect()
+}
+
+/// The `(fg, modifier)` style of `needle`'s first character, scanning the
+/// rendered buffer row by row. Panics if `needle` never appears.
+fn style_at(terminal: &Terminal<TestBackend>, needle: &str) -> (Color, Modifier) {
+    let buffer = terminal.backend().buffer();
+    let area = buffer.area;
+    for y in area.top()..area.bottom() {
+        let cells: Vec<&str> = (area.left()..area.right())
+            .map(|x| buffer[(x, y)].symbol())
+            .collect();
+        let row = cells.concat();
+        if let Some(byte_pos) = row.find(needle) {
+            let char_index = row[..byte_pos].chars().count();
+            let x = area.left() + char_index as u16;
+            let cell = &buffer[(x, y)];
+            return (cell.fg, cell.modifier);
+        }
+    }
+    panic!(
+        "substring {needle:?} not found in rendered buffer:\n{}",
+        buffer_lines(terminal).join("\n")
+    );
+}
+
+#[test]
+fn mixed_fixture_renders_exact_colors_including_module_amber_banner() {
+    let mut rail = ChronicleRail::default();
+    rail.update_from_json(MIXED_FIXTURE);
+    let terminal = draw(&mut rail, 60, 8);
+
+    let (banner_fg, banner_mod) = style_at(&terminal, "AUTOPAUSE");
+    assert_eq!(banner_fg, AMBER, "banner should carry module AMBER");
+    assert!(banner_mod.contains(Modifier::BOLD), "banner should be bold");
+
+    let (header_fg, header_mod) = style_at(&terminal, "T0847");
+    assert_eq!(header_fg, GOLD);
+    assert!(header_mod.contains(Modifier::BOLD));
+
+    let (actor_fg, actor_mod) = style_at(&terminal, "The Vanguard");
+    assert_eq!(actor_fg, GOLD, "actor prefix is bold GOLD");
+    assert!(actor_mod.contains(Modifier::BOLD));
+
+    let (critical_fg, critical_mod) = style_at(&terminal, "storms the compound");
+    assert_eq!(critical_fg, CRIMSON, "critical severity is bold CRIMSON");
+    assert!(critical_mod.contains(Modifier::BOLD));
+
+    let (info_fg, info_mod) = style_at(&terminal, "logs a routine report");
+    assert_eq!(info_fg, BONE, "informational severity is BONE");
+    assert!(!info_mod.contains(Modifier::BOLD));
+
+    let (quiet_fg, quiet_mod) = style_at(&terminal, "the wire is quiet");
+    assert_eq!(quiet_fg, CRIMSON, "a quiet row is bold CRIMSON");
+    assert!(quiet_mod.contains(Modifier::BOLD));
+}
+
+#[test]
+fn autopause_banner_renders_as_the_first_content_line() {
+    let mut rail = ChronicleRail::default();
+    rail.update_from_json(BANNER_ONLY_FIXTURE);
+    let terminal = draw(&mut rail, 50, 6);
+    let lines = buffer_lines(&terminal);
+
+    // lines[0] is the top border; lines[1] is the first content row.
+    assert!(lines[1].contains("AUTOPAUSE NOW"), "{lines:?}");
+    assert!(
+        !lines[1].contains("first event happens"),
+        "the banner must precede every row, not share its line: {lines:?}"
+    );
+}
+
+#[test]
+fn empty_rail_with_no_banner_renders_the_honest_absence_line() {
+    let mut rail = ChronicleRail::default();
+    rail.update_from_json(EMPTY_FIXTURE);
+    let terminal = draw(&mut rail, 50, 6);
+
+    let (fg, modifier) = style_at(&terminal, "the wire is quiet");
+    assert_eq!(fg, CRIMSON);
+    assert!(modifier.contains(Modifier::BOLD));
+}
+
+#[test]
+fn a_malformed_payload_renders_the_loud_unreadable_state() {
+    let mut rail = ChronicleRail::default();
+    rail.update_from_json("not json");
+    assert!(rail.parse_failed);
+
+    let terminal = draw(&mut rail, 50, 6);
+    let (fg, _) = style_at(&terminal, "UNREADABLE");
+    assert_eq!(fg, CRIMSON);
+}
+
+#[test]
+fn cursor_skips_null_subject_rows_and_enter_opens_the_highlighted_subject() {
+    let mut rail = ChronicleRail::default();
+    rail.update_from_json(SKIP_FIXTURE);
+    // Index 0 is the header (non-navigable); the cursor opens on index 1.
+    assert_eq!(rail.cursor, Some(1));
+
+    assert!(rail.handle_key(KeyCode::Down).is_none());
+    // Index 2 is a quiet row (non-navigable) — Down must skip straight to 3.
+    assert_eq!(rail.cursor, Some(3));
+
+    let event = rail.handle_key(KeyCode::Enter);
+    assert_eq!(
+        event,
+        Some(AppEvent::OpenSubject("organization/org-b".to_string()))
+    );
+
+    assert!(rail.handle_key(KeyCode::Up).is_none());
+    assert_eq!(
+        rail.cursor,
+        Some(1),
+        "Up skips back over the same quiet row"
+    );
+
+    // Clamped, never wrapping, at the top navigable row.
+    assert!(rail.handle_key(KeyCode::Up).is_none());
+    assert_eq!(rail.cursor, Some(1));
+}
+
+#[test]
+fn no_banner_means_no_amber_cell_anywhere_in_the_rail() {
+    let mut rail = ChronicleRail::default();
+    rail.update_from_json(NO_BANNER_FIXTURE);
+    let terminal = draw(&mut rail, 50, 6);
+    let buffer = terminal.backend().buffer();
+    let area = buffer.area;
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            assert_ne!(
+                buffer[(x, y)].fg,
+                AMBER,
+                "no autopause banner is active, so AMBER must not appear at ({x}, {y})"
+            );
+        }
+    }
+}

--- a/rust/crates/babylon-tui/tests/hud_view.rs
+++ b/rust/crates/babylon-tui/tests/hud_view.rs
@@ -1,0 +1,271 @@
+//! Behavior tests for `babylon_tui::views::hud::HudStrip` (plan Task 24,
+//! contract `docs/superpowers/specs/2026-07-27-m2-seam-contracts.md` §4,
+//! §1).
+//!
+//! Layout note: line 2's five gauges render in the fixed `AXIS_KEYS` order
+//! (REV, ECO, FAS, OGV, FRG), each as a 17-cell block — `"{ABBREV} ["` (5
+//! cells) + a 10-cell bar + `"] "` (2 cells) — so REV's bar sits at
+//! columns 5..15, ECO's at 22..32, FAS's at 39..49, OGV's at 56..66, and
+//! FRG's at 73..83 on row 1 of the strip. Several tests below index those
+//! columns directly rather than searching for them, since they are
+//! pinned by `hud.rs`'s own module docs, not incidental.
+
+use babylon_tui::theme::{BONE, CRIMSON, DIM, GOLD};
+use babylon_tui::views::hud::HudStrip;
+use ratatui::backend::TestBackend;
+use ratatui::style::Modifier;
+use ratatui::Terminal;
+
+/// Contract §4's own tick-0 example: a bound campaign with every axis at
+/// honest `0.0` progress — real data, NOT the pre-bind absence.
+const ALL_ZERO_AXES: &str = r#"{"pattern": null, "outcome": "in_progress", "game_over": false,
+ "horizon_tick": 27040, "since_tick": null, "locked": false,
+ "axes": {"revolutionary_victory": 0.0, "ecological_collapse": 0.0,
+          "fascist_consolidation": 0.0, "red_ogv": 0.0,
+          "fragmented_collapse": 0.0}}"#;
+
+/// An `endgame_status_json` payload with exactly one axis key present —
+/// every other axis is entirely ABSENT from the object (not merely
+/// zeroed), exercising the honest-missing-key fallback alongside whatever
+/// `axis_value`/`progress` the test wants to isolate.
+fn payload_with_one_axis(axis_key: &str, axis_value: f64) -> String {
+    format!(
+        r#"{{"pattern": null, "outcome": "in_progress", "game_over": false,
+ "horizon_tick": 27040, "since_tick": null, "locked": false,
+ "axes": {{"{axis_key}": {axis_value}}}}}"#
+    )
+}
+
+/// A payload where `pattern` is currently recognized and held.
+fn payload_with_pattern(pattern: &str, since_tick: u64, axis_key: &str, axis_value: f64) -> String {
+    format!(
+        r#"{{"pattern": "{pattern}", "outcome": "{pattern}", "game_over": false,
+ "horizon_tick": 27040, "since_tick": {since_tick}, "locked": true,
+ "axes": {{"{axis_key}": {axis_value}}}}}"#
+    )
+}
+
+/// Dumps a `TestBackend` buffer's visible text, one line per row.
+fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+    let buffer = terminal.backend().buffer();
+    let area = buffer.area;
+    let mut out = String::new();
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            out.push_str(buffer[(x, y)].symbol());
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// Renders `strip` into a backend wide enough for all five gauges (85
+/// cells, see the module docs) plus headroom, and tall enough for the
+/// 3-line strip.
+fn draw(strip: &mut HudStrip) -> Terminal<TestBackend> {
+    let backend = TestBackend::new(100, 4);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| strip.render(frame, frame.area()))
+        .unwrap();
+    terminal
+}
+
+#[test]
+fn tick_zero_all_zero_axes_renders_five_empty_bars_not_absence() {
+    let mut strip = HudStrip::new();
+    strip.set_tick(0);
+    strip.update_endgame(ALL_ZERO_AXES);
+    let text = buffer_text(&draw(&mut strip));
+    assert!(text.contains("T+0/27040"), "{text}");
+    assert!(!text.contains("no campaign bound"), "{text}");
+    for abbrev in ["REV", "ECO", "FAS", "OGV", "FRG"] {
+        let marker = format!("{abbrev} [----------]");
+        assert!(text.contains(&marker), "missing {marker} in:\n{text}");
+    }
+}
+
+#[test]
+fn null_payload_renders_the_honest_absence_line() {
+    let mut strip = HudStrip::new();
+    strip.update_endgame("null");
+    let text = buffer_text(&draw(&mut strip));
+    assert!(text.contains("hud: no campaign bound"), "{text}");
+}
+
+#[test]
+fn absence_is_the_strips_default_before_any_update() {
+    let mut strip = HudStrip::new();
+    let text = buffer_text(&draw(&mut strip));
+    assert!(text.contains("hud: no campaign bound"), "{text}");
+}
+
+#[test]
+fn a_partial_progress_axis_renders_proportionally_filled_gold_cells() {
+    let mut strip = HudStrip::new();
+    strip.update_endgame(&payload_with_one_axis("revolutionary_victory", 0.42));
+    let terminal = draw(&mut strip);
+    let buffer = terminal.backend().buffer();
+    // REV's bar occupies columns 5..15; round(0.42 * 10) == 4 filled cells.
+    for x in 5..9 {
+        assert_eq!(buffer[(x, 1)].symbol(), "█", "x={x}");
+        assert_eq!(buffer[(x, 1)].fg, GOLD, "x={x}");
+    }
+    for x in 9..15 {
+        assert_eq!(buffer[(x, 1)].symbol(), "-", "x={x}");
+        assert_eq!(buffer[(x, 1)].fg, DIM, "x={x}");
+    }
+}
+
+#[test]
+fn a_triggered_axis_renders_bold_crimson_and_the_pattern_suffix_appears_on_line_one() {
+    let mut strip = HudStrip::new();
+    strip.set_tick(600);
+    strip.update_endgame(&payload_with_pattern(
+        "revolutionary_victory",
+        500,
+        "revolutionary_victory",
+        1.0,
+    ));
+    let terminal = draw(&mut strip);
+    let buffer = terminal.backend().buffer();
+    let text = buffer_text(&terminal);
+    assert!(text.contains("T+600/27040"), "{text}");
+    assert!(text.contains("REVOLUTIONARY VICTORY since T500"), "{text}");
+    // REV's bar (columns 5..15) is fully filled and triggered: bold CRIMSON
+    // end to end, no GOLD/DIM split.
+    for x in 5..15 {
+        assert_eq!(buffer[(x, 1)].symbol(), "█", "x={x}");
+        assert_eq!(buffer[(x, 1)].fg, CRIMSON, "x={x}");
+        assert!(
+            buffer[(x, 1)].modifier.contains(Modifier::BOLD),
+            "x={x} should be bold"
+        );
+    }
+}
+
+#[test]
+fn a_missing_axis_key_renders_an_honest_empty_bar() {
+    let mut strip = HudStrip::new();
+    // "red_ogv" (the OGV gauge) is entirely absent from this fixture.
+    strip.update_endgame(&payload_with_one_axis("revolutionary_victory", 0.0));
+    let terminal = draw(&mut strip);
+    let buffer = terminal.backend().buffer();
+    // OGV's bar occupies columns 56..66.
+    for x in 56..66 {
+        assert_eq!(
+            buffer[(x, 1)].symbol(),
+            "-",
+            "missing-key axis should read honest 0.0 (empty), x={x}"
+        );
+        assert_eq!(buffer[(x, 1)].fg, DIM, "x={x}");
+    }
+}
+
+#[test]
+fn pacing_unattached_renders_its_exact_line() {
+    let mut strip = HudStrip::new();
+    strip.update_endgame(ALL_ZERO_AXES);
+    strip.update_pacing(
+        r#"{"attached": false, "locked": false, "lock_reason": null,
+        "awaiting_ack": false, "pause_summary": null, "busy": false}"#,
+    );
+    let text = buffer_text(&draw(&mut strip));
+    assert!(text.contains("PACING: no paced driver attached"), "{text}");
+}
+
+#[test]
+fn pacing_locked_renders_its_exact_line_bold_crimson() {
+    let mut strip = HudStrip::new();
+    strip.update_endgame(ALL_ZERO_AXES);
+    strip.update_pacing(
+        r#"{"attached": true, "locked": true, "lock_reason": "pattern held",
+        "awaiting_ack": false, "pause_summary": null, "busy": false}"#,
+    );
+    let terminal = draw(&mut strip);
+    let text = buffer_text(&terminal);
+    assert!(text.contains("PACING: LOCKED — pattern held"), "{text}");
+    let buffer = terminal.backend().buffer();
+    let x = text.lines().nth(2).unwrap().find('P').unwrap() as u16;
+    assert_eq!(buffer[(x, 2)].fg, CRIMSON);
+    assert!(buffer[(x, 2)].modifier.contains(Modifier::BOLD));
+}
+
+#[test]
+fn pacing_awaiting_ack_renders_its_exact_line_in_amber() {
+    let mut strip = HudStrip::new();
+    strip.update_endgame(ALL_ZERO_AXES);
+    strip.update_pacing(
+        r#"{"attached": true, "locked": false, "lock_reason": null,
+        "awaiting_ack": true, "pause_summary": "3 events", "busy": false}"#,
+    );
+    let terminal = draw(&mut strip);
+    let text = buffer_text(&terminal);
+    assert!(
+        text.contains("PACING: autopause pending (3 events) — press 'a' to acknowledge"),
+        "{text}"
+    );
+    let buffer = terminal.backend().buffer();
+    let x = text.lines().nth(2).unwrap().find('P').unwrap() as u16;
+    assert_eq!(buffer[(x, 2)].fg, ratatui::style::Color::Rgb(255, 140, 0));
+}
+
+#[test]
+fn pacing_busy_renders_its_exact_line() {
+    let mut strip = HudStrip::new();
+    strip.update_endgame(ALL_ZERO_AXES);
+    strip.update_pacing(
+        r#"{"attached": true, "locked": false, "lock_reason": null,
+        "awaiting_ack": false, "pause_summary": null, "busy": true}"#,
+    );
+    let text = buffer_text(&draw(&mut strip));
+    assert!(
+        text.contains("PACING: a run is already in progress"),
+        "{text}"
+    );
+}
+
+#[test]
+fn pacing_ready_renders_its_exact_line_in_bone() {
+    let mut strip = HudStrip::new();
+    strip.update_endgame(ALL_ZERO_AXES);
+    strip.update_pacing(
+        r#"{"attached": true, "locked": false, "lock_reason": null,
+        "awaiting_ack": false, "pause_summary": null, "busy": false}"#,
+    );
+    let terminal = draw(&mut strip);
+    let text = buffer_text(&terminal);
+    assert!(text.contains("PACING: ready"), "{text}");
+    let buffer = terminal.backend().buffer();
+    let x = text.lines().nth(2).unwrap().find('P').unwrap() as u16;
+    assert_eq!(buffer[(x, 2)].fg, BONE);
+}
+
+#[test]
+fn a_malformed_endgame_payload_renders_the_loud_unreadable_line() {
+    let mut strip = HudStrip::new();
+    strip.update_endgame("not json");
+    let terminal = draw(&mut strip);
+    let text = buffer_text(&terminal);
+    assert!(text.contains("hud UNREADABLE"), "{text}");
+    let buffer = terminal.backend().buffer();
+    let x = text.lines().next().unwrap().find('▌').unwrap() as u16;
+    assert_eq!(buffer[(x, 0)].fg, CRIMSON);
+}
+
+#[test]
+fn a_malformed_pacing_payload_renders_the_loud_unreadable_pacing_line_only() {
+    let mut strip = HudStrip::new();
+    strip.update_endgame(ALL_ZERO_AXES);
+    strip.update_pacing("not json");
+    let terminal = draw(&mut strip);
+    let text = buffer_text(&terminal);
+    // Lines 1-2 still render normally — a broken pacing feed says nothing
+    // about whether the endgame feed is readable.
+    assert!(text.contains("T+0/27040"), "{text}");
+    assert!(text.contains("REV [----------]"), "{text}");
+    assert!(text.contains("PACING: UNREADABLE"), "{text}");
+    let buffer = terminal.backend().buffer();
+    let x = text.lines().nth(2).unwrap().find('P').unwrap() as u16;
+    assert_eq!(buffer[(x, 2)].fg, CRIMSON);
+}

--- a/rust/crates/babylon-tui/tests/hud_view.rs
+++ b/rust/crates/babylon-tui/tests/hud_view.rs
@@ -5,8 +5,9 @@
 //! Layout note: line 2's five gauges render in the fixed `AXIS_KEYS` order
 //! (REV, ECO, FAS, OGV, FRG), each as a 17-cell block — `"{ABBREV} ["` (5
 //! cells) + a 10-cell bar + `"] "` (2 cells) — so REV's bar sits at
-//! columns 5..15, ECO's at 22..32, FAS's at 39..49, OGV's at 56..66, and
-//! FRG's at 73..83 on row 1 of the strip. Several tests below index those
+//! columns 5..13, ECO's at 20..28, FAS's at 35..43, OGV's at 50..58, and
+//! FRG's at 65..73 on row 1 of the strip (8-cell bars — five 15-column
+//! units fit an 80-column terminal). Several tests below index those
 //! columns directly rather than searching for them, since they are
 //! pinned by `hud.rs`'s own module docs, not incidental.
 
@@ -80,7 +81,7 @@ fn tick_zero_all_zero_axes_renders_five_empty_bars_not_absence() {
     assert!(text.contains("T+0/27040"), "{text}");
     assert!(!text.contains("no campaign bound"), "{text}");
     for abbrev in ["REV", "ECO", "FAS", "OGV", "FRG"] {
-        let marker = format!("{abbrev} [----------]");
+        let marker = format!("{abbrev} [--------]");
         assert!(text.contains(&marker), "missing {marker} in:\n{text}");
     }
 }
@@ -106,12 +107,12 @@ fn a_partial_progress_axis_renders_proportionally_filled_gold_cells() {
     strip.update_endgame(&payload_with_one_axis("revolutionary_victory", 0.42));
     let terminal = draw(&mut strip);
     let buffer = terminal.backend().buffer();
-    // REV's bar occupies columns 5..15; round(0.42 * 10) == 4 filled cells.
-    for x in 5..9 {
+    // REV's bar occupies columns 5..13; round(0.42 * 8) == 3 filled cells.
+    for x in 5..8 {
         assert_eq!(buffer[(x, 1)].symbol(), "█", "x={x}");
         assert_eq!(buffer[(x, 1)].fg, GOLD, "x={x}");
     }
-    for x in 9..15 {
+    for x in 8..13 {
         assert_eq!(buffer[(x, 1)].symbol(), "-", "x={x}");
         assert_eq!(buffer[(x, 1)].fg, DIM, "x={x}");
     }
@@ -132,9 +133,9 @@ fn a_triggered_axis_renders_bold_crimson_and_the_pattern_suffix_appears_on_line_
     let text = buffer_text(&terminal);
     assert!(text.contains("T+600/27040"), "{text}");
     assert!(text.contains("REVOLUTIONARY VICTORY since T500"), "{text}");
-    // REV's bar (columns 5..15) is fully filled and triggered: bold CRIMSON
+    // REV's bar (columns 5..13) is fully filled and triggered: bold CRIMSON
     // end to end, no GOLD/DIM split.
-    for x in 5..15 {
+    for x in 5..13 {
         assert_eq!(buffer[(x, 1)].symbol(), "█", "x={x}");
         assert_eq!(buffer[(x, 1)].fg, CRIMSON, "x={x}");
         assert!(
@@ -151,8 +152,8 @@ fn a_missing_axis_key_renders_an_honest_empty_bar() {
     strip.update_endgame(&payload_with_one_axis("revolutionary_victory", 0.0));
     let terminal = draw(&mut strip);
     let buffer = terminal.backend().buffer();
-    // OGV's bar occupies columns 56..66.
-    for x in 56..66 {
+    // OGV's bar occupies columns 50..58.
+    for x in 50..58 {
         assert_eq!(
             buffer[(x, 1)].symbol(),
             "-",
@@ -263,9 +264,25 @@ fn a_malformed_pacing_payload_renders_the_loud_unreadable_pacing_line_only() {
     // Lines 1-2 still render normally — a broken pacing feed says nothing
     // about whether the endgame feed is readable.
     assert!(text.contains("T+0/27040"), "{text}");
-    assert!(text.contains("REV [----------]"), "{text}");
+    assert!(text.contains("REV [--------]"), "{text}");
     assert!(text.contains("PACING: UNREADABLE"), "{text}");
     let buffer = terminal.backend().buffer();
     let x = text.lines().nth(2).unwrap().find('P').unwrap() as u16;
     assert_eq!(buffer[(x, 2)].fg, CRIMSON);
+}
+
+#[test]
+fn all_five_gauges_fit_an_eighty_column_terminal() {
+    let mut strip = HudStrip::new();
+    strip.update_endgame(ALL_ZERO_AXES);
+    let backend = TestBackend::new(80, 3);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| strip.render(frame, frame.area()))
+        .unwrap();
+    let text = buffer_text(&terminal);
+    // The fifth gauge must render COMPLETE — a clipped bar would make a
+    // full 8/8 visually indistinguishable from a partial one (the exact
+    // III.11 hazard the 8-cell width exists to prevent).
+    assert!(text.contains("FRG [--------]"), "{text}");
 }

--- a/rust/crates/babylon-tui/tests/play_flow.rs
+++ b/rust/crates/babylon-tui/tests/play_flow.rs
@@ -1,0 +1,354 @@
+//! Scripted-flow integration tests for the M2 play screen (plan Tasks
+//! 21/23/25): tick controls with the Textual pre-check ladder, F-key verb
+//! dispatch with honest targeting, and watchlist pin writes — driven
+//! through the same key handlers the interactive loop uses, against a
+//! stateful fake host speaking the contract's exact JSON shapes
+//! (`docs/superpowers/specs/2026-07-27-m2-seam-contracts.md`).
+
+use std::cell::RefCell;
+
+use babylon_tui::app::{key_event_from_name, App};
+use babylon_tui::config::AppConfig;
+use babylon_tui::host::Host;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::Terminal;
+
+/// A stateful M2 host double: a tick counter, a pin set, and scripted
+/// pacing state, all behind `RefCell` (Host methods take `&self`).
+struct PlayHost {
+    tick: RefCell<u64>,
+    pins: RefCell<Vec<String>>,
+    locked: RefCell<bool>,
+    awaiting_ack: RefCell<bool>,
+    advance_calls: RefCell<u32>,
+    issue_args: RefCell<Vec<String>>,
+    ack_calls: RefCell<u32>,
+}
+
+impl PlayHost {
+    fn new() -> Self {
+        Self {
+            tick: RefCell::new(3),
+            pins: RefCell::new(Vec::new()),
+            locked: RefCell::new(false),
+            awaiting_ack: RefCell::new(false),
+            advance_calls: RefCell::new(0),
+            issue_args: RefCell::new(Vec::new()),
+            ack_calls: RefCell::new(0),
+        }
+    }
+
+    fn outcome_json(tick: u64) -> String {
+        format!(
+            r#"{{"tick": {tick}, "paused": false, "chronicle": [{{"tick": {tick}, "event_type": "mass_awakening", "summary": "stirring", "data": {{}}, "class_names": null, "org_names": null}}]}}"#
+        )
+    }
+}
+
+impl Host for PlayHost {
+    fn lobby_catalog_json(&self) -> String {
+        r#"[{"campaign_id":"c1","name":"campaign-a3f9b2c1d0e5","codename":"Wayne County","tick":3,
+            "status":"ACTIVE","defines_hash":"dh1","engine_version":"ev1"}]"#
+            .to_string()
+    }
+
+    fn load_campaign(&self, campaign_id: &str) -> String {
+        let tick = *self.tick.borrow();
+        format!(r#"{{"ok": true, "campaign_id": "{campaign_id}", "tick": {tick}}}"#)
+    }
+
+    fn read_page_json(&self, subject: &str) -> String {
+        match subject {
+            "briefing/c1" => serde_json::to_string("# Briefing\n\nSee [[Detroit]].").unwrap(),
+            _ => "null".to_string(),
+        }
+    }
+
+    fn known_subjects_json(&self) -> String {
+        r#"["Detroit"]"#.to_string()
+    }
+
+    fn pacing_state_json(&self) -> String {
+        format!(
+            r#"{{"attached": true, "locked": {locked}, "lock_reason": {reason}, "awaiting_ack": {ack}, "pause_summary": {summary}, "busy": false}}"#,
+            locked = self.locked.borrow(),
+            reason = if *self.locked.borrow() {
+                r#""REVOLUTIONARY_VICTORY""#
+            } else {
+                "null"
+            },
+            ack = self.awaiting_ack.borrow(),
+            summary = if *self.awaiting_ack.borrow() {
+                r#""1 critical event""#
+            } else {
+                "null"
+            },
+        )
+    }
+
+    fn advance_tick(&self) -> String {
+        *self.advance_calls.borrow_mut() += 1;
+        let tick = {
+            let mut tick = self.tick.borrow_mut();
+            *tick += 1;
+            *tick
+        };
+        format!(
+            r#"{{"ok": true, "outcome": {outcome}}}"#,
+            outcome = Self::outcome_json(tick)
+        )
+    }
+
+    fn run_until_paused(&self) -> String {
+        let first = {
+            let mut tick = self.tick.borrow_mut();
+            *tick += 2;
+            *tick - 1
+        };
+        *self.awaiting_ack.borrow_mut() = true;
+        format!(
+            r#"{{"ok": true, "outcomes": [{a}, {b}]}}"#,
+            a = Self::outcome_json(first),
+            b = Self::outcome_json(first + 1)
+        )
+    }
+
+    fn acknowledge_pause(&self) -> String {
+        *self.ack_calls.borrow_mut() += 1;
+        *self.awaiting_ack.borrow_mut() = false;
+        r#"{"ok": true}"#.to_string()
+    }
+
+    fn chronicle_rail_json(&self) -> String {
+        let tick = *self.tick.borrow();
+        format!(
+            r#"{{"autopause_line": null, "rows": [{{"subject": null, "kind": "header", "tick": {tick}, "severity": null, "actor": null, "text": "T{tick:04}"}}]}}"#
+        )
+    }
+
+    fn verb_plate_view_json(&self) -> String {
+        // One eligible row (educate, F1) + reproduce; the other 7 verbs are
+        // deliberately absent — the plate renders loud missing markers, and
+        // dispatch on a present row still works.
+        r#"{"kind": "verb_plate", "org_id": "org-1", "tick": 3, "verbs": [
+            {"verb": "educate", "eligible": true, "reason": null, "remedy": null,
+             "can_afford": true, "afford_note": null, "preview": null,
+             "candidate_target_ids": ["Detroit"]},
+            {"verb": "reproduce", "eligible": true, "reason": null, "remedy": null,
+             "can_afford": true, "afford_note": null, "preview": null,
+             "candidate_target_ids": []}
+        ]}"#
+        .to_string()
+    }
+
+    fn issue_verb(&self, args_json: &str) -> String {
+        self.issue_args.borrow_mut().push(args_json.to_string());
+        r#"{"ok": true, "turn_id": 7}"#.to_string()
+    }
+
+    fn endgame_status_json(&self) -> String {
+        r#"{"pattern": null, "outcome": "unresolved", "game_over": false,
+            "horizon_tick": 5200, "since_tick": null, "locked": false,
+            "axes": {"revolutionary_victory": 0.1, "ecological_collapse": 0.0,
+                     "fascist_consolidation": 0.0, "red_ogv": 0.0,
+                     "fragmented_collapse": 0.0}}"#
+            .to_string()
+    }
+
+    fn watchlist_json(&self) -> String {
+        let rows: Vec<serde_json::Value> = self
+            .pins
+            .borrow()
+            .iter()
+            .map(|subject| serde_json::json!({"subject": subject}))
+            .collect();
+        serde_json::to_string(&rows).unwrap()
+    }
+
+    fn pin_watchlist(&self, args_json: &str) -> String {
+        let value: serde_json::Value = serde_json::from_str(args_json).unwrap();
+        let subject = value["subject"].as_str().unwrap().to_string();
+        let pinned = value["pinned"].as_bool().unwrap();
+        let mut pins = self.pins.borrow_mut();
+        if pinned {
+            pins.push(subject);
+        } else {
+            pins.retain(|s| s != &subject);
+        }
+        format!(r#"{{"ok": true, "pinned": {pinned}}}"#)
+    }
+}
+
+fn play_app() -> App<PlayHost> {
+    let cfg = AppConfig::from_json(
+        r#"{"campaign_id":"c1","campaign_name":"Wayne County","render_tier":"glyph",
+            "tutorial_enabled":false,"narrator_enabled":false,"headless":true}"#,
+    )
+    .expect("fixture config parses");
+    App::new(cfg, PlayHost::new())
+}
+
+fn press(app: &mut App<PlayHost>, name: &str) -> bool {
+    let (code, modifiers) = key_event_from_name(name).expect("known key name");
+    app.handle_key(code, modifiers)
+}
+
+fn render(app: &mut App<PlayHost>, terminal: &mut Terminal<TestBackend>) -> Buffer {
+    app.render_frame(terminal).expect("frame renders");
+    terminal.backend().buffer().clone()
+}
+
+fn buffer_text(buffer: &Buffer) -> String {
+    let area = buffer.area;
+    (0..area.height)
+        .map(|row| {
+            (0..area.width)
+                .map(|col| buffer[(col, row)].symbol())
+                .collect::<String>()
+                .trim_end()
+                .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Bind the campaign and land on the composed play screen.
+fn bound_app(terminal: &mut Terminal<TestBackend>) -> App<PlayHost> {
+    let mut app = play_app();
+    render(&mut app, terminal);
+    assert!(!press(&mut app, "enter"));
+    app
+}
+
+#[test]
+fn the_play_screen_composes_all_chrome_after_bind() {
+    let mut terminal = Terminal::new(TestBackend::new(100, 32)).expect("backend");
+    let mut app = bound_app(&mut terminal);
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(frame.contains("T+3/5200"), "HUD counter missing:\n{frame}");
+    assert!(
+        frame.contains("PACING: ready"),
+        "pacing line missing:\n{frame}"
+    );
+    assert!(
+        frame.contains("CHRONICLE"),
+        "chronicle rail missing:\n{frame}"
+    );
+    assert!(frame.contains("F1 Educate"), "verb plate missing:\n{frame}");
+    assert!(
+        frame.contains("Briefing"),
+        "center dossier missing:\n{frame}"
+    );
+}
+
+#[test]
+fn t_advances_one_tick_and_refreshes_the_chrome() {
+    let mut terminal = Terminal::new(TestBackend::new(100, 32)).expect("backend");
+    let mut app = bound_app(&mut terminal);
+    assert!(!press(&mut app, "t"));
+    assert_eq!(*app.host_ref().advance_calls.borrow(), 1);
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(
+        frame.contains("status: tick 4"),
+        "tick ack missing:\n{frame}"
+    );
+    assert!(frame.contains("T+4/5200"), "HUD not refreshed:\n{frame}");
+    assert!(frame.contains("T0004"), "chronicle not refreshed:\n{frame}");
+}
+
+#[test]
+fn a_locked_driver_refuses_t_before_the_host_is_ever_asked_to_advance() {
+    let mut terminal = Terminal::new(TestBackend::new(100, 32)).expect("backend");
+    let mut app = bound_app(&mut terminal);
+    *app.host_ref().locked.borrow_mut() = true;
+    assert!(!press(&mut app, "t"));
+    assert_eq!(
+        *app.host_ref().advance_calls.borrow(),
+        0,
+        "the pre-check ladder must refuse BEFORE the advance call"
+    );
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(
+        frame.contains("campaign ended — REVOLUTIONARY_VICTORY"),
+        "locked refusal missing:\n{frame}"
+    );
+}
+
+#[test]
+fn r_runs_the_batch_and_a_acknowledges_the_autopause() {
+    let mut terminal = Terminal::new(TestBackend::new(100, 32)).expect("backend");
+    let mut app = bound_app(&mut terminal);
+    assert!(!press(&mut app, "r"));
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(
+        frame.contains("ran to tick 5 [PAUSED] (1 critical event)"),
+        "run readout missing:\n{frame}"
+    );
+    // A second tick verb refuses while the ack is pending.
+    assert!(!press(&mut app, "t"));
+    assert_eq!(*app.host_ref().advance_calls.borrow(), 0);
+    // Acknowledge clears it.
+    assert!(!press(&mut app, "a"));
+    assert_eq!(*app.host_ref().ack_calls.borrow(), 1);
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(
+        frame.contains("autopause acknowledged — ready to advance"),
+        "ack readout missing:\n{frame}"
+    );
+}
+
+#[test]
+fn f1_dispatches_educate_with_no_invented_target() {
+    let mut terminal = Terminal::new(TestBackend::new(100, 32)).expect("backend");
+    let mut app = bound_app(&mut terminal);
+    assert!(!press(&mut app, "f1"));
+    let args = app.host_ref().issue_args.borrow().clone();
+    assert_eq!(args.len(), 1);
+    let value: serde_json::Value = serde_json::from_str(&args[0]).unwrap();
+    assert_eq!(value["verb"], "educate");
+    // The briefing subject's id-part ("c1") is NOT a candidate target —
+    // the honest target is null, never invented.
+    assert!(value["target_id"].is_null());
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(
+        frame.contains("educate queued (turn #7)"),
+        "queue ack missing:\n{frame}"
+    );
+}
+
+#[test]
+fn f3_on_a_missing_verb_slot_refuses_loudly_without_a_host_call() {
+    let mut terminal = Terminal::new(TestBackend::new(100, 32)).expect("backend");
+    let mut app = bound_app(&mut terminal);
+    assert!(!press(&mut app, "f3"));
+    assert!(app.host_ref().issue_args.borrow().is_empty());
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(
+        frame.contains("F3 refused — verb missing"),
+        "missing-slot refusal absent:\n{frame}"
+    );
+}
+
+#[test]
+fn capital_p_pins_the_current_dossier_and_the_rail_rerenders() {
+    let mut terminal = Terminal::new(TestBackend::new(100, 32)).expect("backend");
+    let mut app = bound_app(&mut terminal);
+    assert!(!press(&mut app, "P"));
+    assert_eq!(
+        app.host_ref().pins.borrow().as_slice(),
+        ["briefing/c1"],
+        "pin write missing"
+    );
+    let frame = buffer_text(&render(&mut app, &mut terminal));
+    assert!(
+        frame.contains("status: pinned briefing/c1"),
+        "pin ack missing:\n{frame}"
+    );
+    // A second P unpins (idempotent toggle over the rail's own rows).
+    assert!(!press(&mut app, "P"));
+    assert!(
+        app.host_ref().pins.borrow().is_empty(),
+        "unpin write missing"
+    );
+}

--- a/rust/crates/babylon-tui/tests/play_flow.rs
+++ b/rust/crates/babylon-tui/tests/play_flow.rs
@@ -293,8 +293,15 @@ fn r_runs_the_batch_and_a_acknowledges_the_autopause() {
     assert_eq!(*app.host_ref().ack_calls.borrow(), 1);
     let frame = buffer_text(&render(&mut app, &mut terminal));
     assert!(
-        frame.contains("autopause acknowledged — ready to advance"),
+        frame.contains("status: autopause acknowledged — ready to advance"),
         "ack readout missing:\n{frame}"
+    );
+    // The HUD's PACING line must agree with the status line — a strip
+    // still claiming a pending autopause after the ack would be two
+    // contradictory readings of the same driver state (verify panel).
+    assert!(
+        !frame.contains("autopause pending"),
+        "HUD kept a stale pending-autopause claim:\n{frame}"
     );
 }
 

--- a/rust/crates/babylon-tui/tests/verb_plate_view.rs
+++ b/rust/crates/babylon-tui/tests/verb_plate_view.rs
@@ -6,6 +6,7 @@
 //! (including explicit `null`s), canonical verb order `educate, reproduce,
 //! attack, mobilize, campaign, aid, investigate, move, negotiate`.
 
+use babylon_tui::layout_registry::LayoutRegistry;
 use babylon_tui::views::verbs::VerbPlateView;
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
@@ -159,8 +160,9 @@ fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
 fn render_single_column(view: &VerbPlateView) -> String {
     let backend = TestBackend::new(80, 15);
     let mut terminal = Terminal::new(backend).unwrap();
+    let mut registry = LayoutRegistry::new();
     terminal
-        .draw(|frame| view.render(frame, frame.area()))
+        .draw(|frame| view.render(frame, frame.area(), &mut registry))
         .unwrap();
     buffer_text(&terminal)
 }
@@ -290,8 +292,9 @@ fn two_column_layout_still_shows_every_line_when_area_is_too_short() {
     let backend = TestBackend::new(100, 8);
     let mut terminal = Terminal::new(backend).unwrap();
     let view = VerbPlateView::open(&full_fixture());
+    let mut registry = LayoutRegistry::new();
     terminal
-        .draw(|frame| view.render(frame, frame.area()))
+        .draw(|frame| view.render(frame, frame.area(), &mut registry))
         .unwrap();
     let text = buffer_text(&terminal);
     assert!(text.contains("F1 Educate"), "{text}");

--- a/rust/crates/babylon-tui/tests/verb_plate_view.rs
+++ b/rust/crates/babylon-tui/tests/verb_plate_view.rs
@@ -1,0 +1,301 @@
+//! Behavior tests for `babylon_tui::views::verbs::VerbPlateView`.
+//!
+//! Fixtures are built to contract §3's own shape
+//! (`docs/superpowers/specs/2026-07-27-m2-seam-contracts.md`):
+//! `VerbPlateView.model_dump_json()` — every `VerbRow` key present
+//! (including explicit `null`s), canonical verb order `educate, reproduce,
+//! attack, mobilize, campaign, aid, investigate, move, negotiate`.
+
+use babylon_tui::views::verbs::VerbPlateView;
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+use serde_json::{json, Value};
+
+/// One well-formed `VerbRow` object, every key present per the contract's
+/// `extra='forbid'` pydantic model (a real payload never omits a key, even
+/// when its value is `null`).
+#[allow(clippy::too_many_arguments)]
+fn row(
+    verb: &str,
+    eligible: bool,
+    reason: Option<&str>,
+    remedy: Option<&str>,
+    can_afford: bool,
+    afford_note: Option<&str>,
+    candidate_target_ids: Vec<&str>,
+) -> Value {
+    json!({
+        "verb": verb,
+        "eligible": eligible,
+        "reason": reason,
+        "remedy": remedy,
+        "can_afford": can_afford,
+        "afford_note": afford_note,
+        "preview": {
+            "estimated_consciousness_delta": 0.01,
+            "estimated_heat_delta": 0.01,
+            "action_point_cost": 1.0,
+            "success_probability": 0.7,
+            "affected_territory_ids": [],
+            "warnings": []
+        },
+        "candidate_target_ids": candidate_target_ids
+    })
+}
+
+/// All nine rows, in canonical order, wrapping into a full `VerbPlateView`
+/// payload. `attack` is ineligible (reason+remedy); `mobilize` is eligible
+/// but unaffordable (afford_note); `investigate` carries two candidate
+/// target ids for the [`VerbPlateView::row`] accessor test.
+fn full_fixture_rows() -> Vec<Value> {
+    vec![
+        row("educate", true, None, None, true, None, vec![]),
+        row("reproduce", true, None, None, true, None, vec![]),
+        row(
+            "attack",
+            false,
+            Some("target destroyed"),
+            Some("scout a new target"),
+            true,
+            None,
+            vec![],
+        ),
+        row(
+            "mobilize",
+            true,
+            None,
+            None,
+            false,
+            Some("short 2 AP"),
+            vec!["territory/26163"],
+        ),
+        row(
+            "campaign",
+            true,
+            None,
+            None,
+            true,
+            None,
+            vec!["social_class/proletariat"],
+        ),
+        row(
+            "aid",
+            true,
+            None,
+            None,
+            true,
+            None,
+            vec!["social_class/proletariat"],
+        ),
+        row(
+            "investigate",
+            true,
+            None,
+            None,
+            true,
+            None,
+            vec!["territory/26163", "organization/org-x"],
+        ),
+        row(
+            "move",
+            true,
+            None,
+            None,
+            true,
+            None,
+            vec!["territory/26163"],
+        ),
+        row(
+            "negotiate",
+            true,
+            None,
+            None,
+            true,
+            None,
+            vec!["organization/org-x"],
+        ),
+    ]
+}
+
+fn plate_json(verbs: Vec<Value>) -> String {
+    json!({
+        "kind": "verb_plate",
+        "org_id": "organization/vanguard",
+        "tick": 42,
+        "verbs": verbs
+    })
+    .to_string()
+}
+
+fn full_fixture() -> String {
+    plate_json(full_fixture_rows())
+}
+
+/// A caller-truncated payload: `negotiate` (the ninth canonical verb)
+/// dropped entirely, leaving eight rows.
+fn truncated_fixture() -> String {
+    let mut rows = full_fixture_rows();
+    rows.pop(); // drops "negotiate"
+    plate_json(rows)
+}
+
+/// Dumps a `TestBackend` buffer's visible text, one line per row, for
+/// substring assertions (matches the crate's existing test convention).
+fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+    let buffer = terminal.backend().buffer();
+    let area = buffer.area;
+    let mut out = String::new();
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            out.push_str(buffer[(x, y)].symbol());
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// Renders `view` into a backend tall enough (13 inner rows after the
+/// 2-row border) that all 11 plate lines fit in a single column.
+fn render_single_column(view: &VerbPlateView) -> String {
+    let backend = TestBackend::new(80, 15);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| view.render(frame, frame.area()))
+        .unwrap();
+    buffer_text(&terminal)
+}
+
+#[test]
+fn all_nine_verbs_render_with_positional_f_key_labels() {
+    let view = VerbPlateView::open(&full_fixture());
+    let text = render_single_column(&view);
+    assert!(text.contains("F1 Educate"), "{text}");
+    assert!(text.contains("F2 Reproduce"), "{text}");
+    assert!(text.contains("F3 Attack"), "{text}");
+    assert!(text.contains("F4 Mobilize"), "{text}");
+    assert!(text.contains("F5 Campaign"), "{text}");
+    assert!(text.contains("F6 Aid"), "{text}");
+    assert!(text.contains("F8 Move"), "{text}");
+    assert!(text.contains("F9 Negotiate"), "{text}");
+}
+
+#[test]
+fn investigate_expands_to_three_sub_verb_lines_sharing_f7() {
+    let view = VerbPlateView::open(&full_fixture());
+    let text = render_single_column(&view);
+    assert!(text.contains("F7 Investigate(Territory)"), "{text}");
+    assert!(text.contains("F7 Investigate(Org)"), "{text}");
+    assert!(text.contains("F7 Investigate(Edge)"), "{text}");
+}
+
+#[test]
+fn an_ineligible_row_shows_its_reason_and_remedy_never_hidden() {
+    let view = VerbPlateView::open(&full_fixture());
+    let text = render_single_column(&view);
+    assert!(text.contains("F3 Attack"), "{text}");
+    assert!(text.contains("target destroyed"), "{text}");
+    assert!(text.contains("scout a new target"), "{text}");
+}
+
+#[test]
+fn an_unaffordable_row_stays_plain_and_shows_its_afford_note() {
+    let view = VerbPlateView::open(&full_fixture());
+    let text = render_single_column(&view);
+    assert!(text.contains("F4 Mobilize"), "{text}");
+    assert!(text.contains("short 2 AP"), "{text}");
+    // Unaffordable never means the same thing as ineligible: no
+    // reason/remedy parenthetical rides along an affordability note.
+    assert!(!text.contains("F4 Mobilize  ("), "{text}");
+}
+
+#[test]
+fn a_truncated_eight_row_payload_shows_a_loud_missing_marker() {
+    let view = VerbPlateView::open(&truncated_fixture());
+    let text = render_single_column(&view);
+    assert!(
+        text.contains("negotiate — missing from plate view"),
+        "{text}"
+    );
+    // Every other verb still renders normally.
+    assert!(text.contains("F1 Educate"), "{text}");
+    assert!(text.contains("F8 Move"), "{text}");
+}
+
+#[test]
+fn a_truncated_payloads_missing_verb_has_no_row_at_its_canonical_slot() {
+    let view = VerbPlateView::open(&truncated_fixture());
+    // "negotiate" is CANONICAL_VERBS[8] -> F9 -> row(8).
+    assert!(view.row(8).is_none());
+    // Every other slot is still populated.
+    assert!(view.row(0).is_some());
+}
+
+#[test]
+fn null_payload_renders_the_honest_absence_line() {
+    let view = VerbPlateView::open("null");
+    assert!(view.is_absent());
+    assert!(!view.is_unreadable());
+    let text = render_single_column(&view);
+    assert!(text.contains("no verb plate — no campaign bound"), "{text}");
+}
+
+#[test]
+fn garbage_payload_renders_the_loud_unreadable_state_not_absence() {
+    let view = VerbPlateView::open("not json at all");
+    assert!(view.is_unreadable());
+    assert!(!view.is_absent());
+    let text = render_single_column(&view);
+    assert!(text.contains("UNREADABLE"), "{text}");
+    assert!(!text.contains("no campaign bound"), "{text}");
+}
+
+#[test]
+fn well_formed_json_with_the_wrong_shape_is_also_unreadable() {
+    // Valid JSON, but not a VerbPlateView object (missing every required
+    // key) — still a loud parse failure, never a fabricated empty plate.
+    let view = VerbPlateView::open(r#"{"foo": "bar"}"#);
+    assert!(view.is_unreadable());
+}
+
+#[test]
+fn row_accessor_returns_parsed_candidate_target_ids() {
+    let view = VerbPlateView::open(&full_fixture());
+    // "investigate" is CANONICAL_VERBS[6] -> F7 -> row(6).
+    let investigate_row = view.row(6).expect("investigate row present");
+    assert_eq!(investigate_row.verb, "investigate");
+    assert_eq!(
+        investigate_row.candidate_target_ids,
+        vec![
+            "territory/26163".to_string(),
+            "organization/org-x".to_string()
+        ]
+    );
+    assert!(investigate_row.eligible);
+}
+
+#[test]
+fn reproduce_row_has_empty_candidate_target_ids_self_targeting() {
+    let view = VerbPlateView::open(&full_fixture());
+    // "reproduce" is CANONICAL_VERBS[1] -> F2 -> row(1).
+    let reproduce_row = view.row(1).expect("reproduce row present");
+    assert_eq!(reproduce_row.verb, "reproduce");
+    assert!(reproduce_row.candidate_target_ids.is_empty());
+}
+
+#[test]
+fn two_column_layout_still_shows_every_line_when_area_is_too_short() {
+    // Inner height after the 2-row border is 6 — fewer than the 11 plate
+    // lines (one column can't fit them all), but enough for the two-column
+    // fallback's taller side (ceil(11/2) == 6) to show everything.
+    let backend = TestBackend::new(100, 8);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let view = VerbPlateView::open(&full_fixture());
+    terminal
+        .draw(|frame| view.render(frame, frame.area()))
+        .unwrap();
+    let text = buffer_text(&terminal);
+    assert!(text.contains("F1 Educate"), "{text}");
+    assert!(text.contains("F6 Aid"), "{text}");
+    assert!(text.contains("F9 Negotiate"), "{text}");
+    assert!(text.contains("F7 Investigate(Edge)"), "{text}");
+}

--- a/rust/crates/babylon-tui/tests/watchlist_view.rs
+++ b/rust/crates/babylon-tui/tests/watchlist_view.rs
@@ -105,18 +105,12 @@ fn enter_on_a_row_with_no_subject_field_emits_nothing() {
 }
 
 #[test]
-fn esc_emits_back() {
-    let mut view = WatchlistView::open(TWO_PINS_JSON);
-    assert_eq!(view.handle_key(KeyCode::Esc), Some(AppEvent::Back));
-}
-
-#[test]
 fn render_shows_the_pin_count_title_and_row_fields() {
     let view = WatchlistView::open(TWO_PINS_JSON);
     let backend = TestBackend::new(50, 12);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
-        .draw(|frame| view.render(frame, frame.area()))
+        .draw(|frame| view.render(frame, frame.area(), true))
         .unwrap();
     let text = buffer_text(&terminal);
     assert!(text.contains("Watchlist (2 pinned)"), "{text}");
@@ -131,7 +125,7 @@ fn render_shows_the_honest_absence_line_and_zero_pin_count() {
     let backend = TestBackend::new(50, 12);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
-        .draw(|frame| view.render(frame, frame.area()))
+        .draw(|frame| view.render(frame, frame.area(), true))
         .unwrap();
     let text = buffer_text(&terminal);
     assert!(text.contains("Watchlist (0 pinned)"), "{text}");

--- a/src/babylon/cli/play.py
+++ b/src/babylon/cli/play.py
@@ -445,6 +445,7 @@ def _run_rust_client(*, narrator_enabled: bool, tutorial_enabled: bool | None) -
         ),
         driver_factory=_driver_factory,
         watchlist_persistence=catalog,
+        nav_persistence=catalog,
     )
     config_json = json.dumps(
         {

--- a/src/babylon/tui/host.py
+++ b/src/babylon/tui/host.py
@@ -29,6 +29,18 @@ through the ``campaign_loader`` the constructor now accepts, builds the
 paced driver through the optional ``driver_factory``, and binds both via
 :meth:`bind_session` — closing the gap where ``bind_session`` shipped
 with zero production caller.
+
+**M2 "Playable" surface** (contracts:
+``docs/superpowers/specs/2026-07-27-m2-seam-contracts.md``): the eleven
+write/tick methods below (:meth:`pacing_state_json` through
+:meth:`save_nav_state`) widen the seam from read-only to playable. Every
+one still crosses only JSON-encoded primitives; write/tick verbs return an
+``{"ok": ...}`` envelope mirroring :meth:`load_campaign`'s own convention.
+A player-reachable refusal (a Rust-side pre-check that somehow still
+raced, a watchlist at capacity, an ineligible verb) is caught and encoded
+as ``{"ok": False, "error": ...}``; a system-level failure is never
+caught, and propagates to panic loudly (Constitution III.11) — the two
+classes are handled differently on purpose, per method docstring below.
 """
 
 from __future__ import annotations
@@ -37,14 +49,38 @@ import json
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from babylon.models.event_severity import resolve_severity
 from babylon.tui.campaign_menu import operation_codename
+from babylon.tui.chronicle import (
+    _WIRE_QUIET,
+    CHRONICLE_ROW_CEILING,
+    chronicle_stream,
+    resolve_actor,
+    resolve_navigable_subject,
+)
+from babylon.tui.chronicle_salience import (
+    apply_volume_floors,
+    compute_autopause_state,
+    dedupe_consecutive,
+    render_autopause_indicator,
+)
 from babylon.tui.shell.backlinks import build_backlink_index
-from babylon.tui.watchlist import load_watchlist
+from babylon.tui.watchlist import load_watchlist, save_watchlist
 
 if TYPE_CHECKING:
+    from babylon.projection.endgame import EndgameStatus
+    from babylon.projection.verbs.view_models import VerbPlateView
     from babylon.projection.view_models import ProjectionRecord
-    from babylon.tui.app import CampaignHandle, CampaignLoader, DriverFactory, PacedDriverHandle
+    from babylon.tui.app import (
+        CampaignHandle,
+        CampaignLoader,
+        DriverFactory,
+        PacedDriverHandle,
+        TickOutcome,
+    )
     from babylon.tui.campaign_menu import CampaignCatalog
+    from babylon.tui.chronicle import ChronicleEvent, TickBulletin
+    from babylon.tui.nav import NavPersistence
     from babylon.tui.watchlist import WatchlistPersistence
 
 __all__ = ["RustClientHost"]
@@ -77,6 +113,14 @@ class RustClientHost:
         ``ArchiveApp(watchlist_persistence=...)`` accepts on the Textual
         path. ``None`` (the default) is an honest "no watchlist store wired"
         — :meth:`watchlist_json` then always serves ``"[]"``.
+    :param nav_persistence: The nav shell's cross-session store (see
+        :mod:`babylon.tui.nav`) — M2's fresh wiring (Task 25): Textual never
+        wired nav persistence in production at all (``app.py`` boots a
+        throwaway ``uuid4`` + ``InMemoryNavPersistence``), so there is no
+        Textual seam to mirror here, unlike ``watchlist_persistence``.
+        ``None`` (the default) is an honest "no nav store wired" —
+        :meth:`nav_state_json` then always serves an empty jumplist and
+        breadcrumb trail.
     """
 
     def __init__(
@@ -88,6 +132,7 @@ class RustClientHost:
         campaign_loader: CampaignLoader | None = None,
         driver_factory: DriverFactory | None = None,
         watchlist_persistence: WatchlistPersistence | None = None,
+        nav_persistence: NavPersistence | None = None,
     ) -> None:
         self._catalog = catalog
         self._defines_hash = defines_hash
@@ -95,6 +140,7 @@ class RustClientHost:
         self._campaign_loader = campaign_loader
         self._driver_factory = driver_factory
         self._watchlist_persistence = watchlist_persistence
+        self._nav_persistence = nav_persistence
         #: The bound campaign session (``None`` until :meth:`bind_session`).
         self.session: CampaignHandle | None = None
         #: The bound paced tick driver (``None`` until :meth:`bind_session`).
@@ -105,6 +151,12 @@ class RustClientHost:
         self._backlink_cache_key: tuple[UUID, int] | None = None
         #: The cached backlink index for :attr:`_backlink_cache_key`.
         self._backlink_index_cache: dict[str, list[str]] = {}
+        #: The host's own running chronicle accumulator (Task 22) — mirrors
+        #: :attr:`~babylon.tui.app.ArchiveApp._chronicle_history`, capped at
+        #: :data:`~babylon.tui.chronicle.CHRONICLE_ROW_CEILING`; reset by
+        #: :meth:`bind_session` (a fresh/resumed campaign never inherits a
+        #: prior session's rail).
+        self._chronicle_history: tuple[ChronicleEvent, ...] = ()
 
     def lobby_catalog_json(self) -> str:
         """The lobby catalog as a JSON array string.
@@ -158,8 +210,11 @@ class RustClientHost:
             verbatim, never caught and re-encoded as a fabricated failure
             payload: the Rust seam propagates Python exceptions loudly by
             design (M1).
-        :returns: ``json.dumps({"ok": True, "campaign_id": campaign_id})``
-            on success.
+        :returns: ``json.dumps({"ok": True, "campaign_id": campaign_id,
+            "tick": <session tick>})`` on success — the tick rides the ack
+            so the Rust HUD's ``T+{tick}`` counter is honest for a RESUMED
+            campaign (a zeroed counter over a tick-300 session would be a
+            fabricated value, III.11).
         """
         if self._campaign_loader is None:
             msg = (
@@ -171,7 +226,7 @@ class RustClientHost:
         campaign = self._campaign_loader(UUID(campaign_id))
         driver = self._driver_factory(campaign) if self._driver_factory is not None else None
         self.bind_session(campaign, driver)
-        return json.dumps({"ok": True, "campaign_id": campaign_id})
+        return json.dumps({"ok": True, "campaign_id": campaign_id, "tick": campaign.tick})
 
     def bind_session(self, session: CampaignHandle, driver: PacedDriverHandle | None) -> None:
         """Bind the booted campaign session and its paced driver.
@@ -186,6 +241,11 @@ class RustClientHost:
         """
         self.session = session
         self.driver = driver
+        #: A freshly-bound (or re-bound) session never inherits a prior
+        #: session's chronicle rail (Task 22) — reset alongside the handles
+        #: themselves, not left for the first :meth:`chronicle_rail_json`
+        #: call to notice a stale history.
+        self._chronicle_history = ()
 
     def read_page(self, subject: str) -> str | None:
         """Read one baked vault page for the bound campaign — read-only.
@@ -334,3 +394,423 @@ class RustClientHost:
             return json.dumps([])
         state = load_watchlist(self._watchlist_persistence, str(self.session.session_id))
         return json.dumps([{"subject": subject} for subject in state.pinned_ids])
+
+    # --- M2 "Playable" surface (Tasks 21-25; contracts: docs/superpowers/
+    # specs/2026-07-27-m2-seam-contracts.md). ------------------------------
+
+    def pacing_state_json(self) -> str:
+        """Paced-driver state for Rust's own pre-checks + the HUD PACING line (Task 21).
+
+        :returns: ``json.dumps`` of a dict literal in the contract's own
+            key order — ``attached``, ``locked``, ``lock_reason``,
+            ``awaiting_ack``, ``pause_summary``, ``busy`` — mirroring
+            :class:`~babylon.tui.app.PacedDriverHandle` (primitives only; a
+            :class:`~babylon.models.enums.events.GameOutcome` IS a ``str``,
+            so ``lock_reason`` crosses with no cast). ``attached=False``
+            (every other field ``False``/``None``) when no paced driver is
+            bound — no campaign bound at all, or a ``driver_factory`` was
+            never wired (a legal M1 answer).
+        """
+        if self.driver is None:
+            return json.dumps(
+                {
+                    "attached": False,
+                    "locked": False,
+                    "lock_reason": None,
+                    "awaiting_ack": False,
+                    "pause_summary": None,
+                    "busy": False,
+                }
+            )
+        return json.dumps(
+            {
+                "attached": True,
+                "locked": self.driver.locked,
+                "lock_reason": self.driver.lock_reason,
+                "awaiting_ack": self.driver.awaiting_ack,
+                "pause_summary": self.driver.pause_summary,
+                "busy": self.driver.busy,
+            }
+        )
+
+    def _accumulate_chronicle(self, events: tuple[ChronicleEvent, ...]) -> None:
+        """Append ``events`` onto the host's own running chronicle rail, capped.
+
+        Mirrors :meth:`~babylon.tui.app.ArchiveApp._refresh_chronicle`'s own
+        accumulator (``app.py:1663-1694``): growing across ticks, capped at
+        :data:`~babylon.tui.chronicle.CHRONICLE_ROW_CEILING`, reset only by
+        :meth:`bind_session`.
+
+        :param events: one tick's chronicle events, chronological.
+        """
+        combined = (*self._chronicle_history, *events)
+        self._chronicle_history = combined[-CHRONICLE_ROW_CEILING:]
+
+    @staticmethod
+    def _tick_outcome(result: TickOutcome) -> dict[str, object]:
+        """Hand-build one ``{"tick", "paused", "chronicle"}`` outcome dict.
+
+        :attr:`~babylon.game.session.TickAdvanceResult`'s own ``__slots__``
+        is alphabetical and it is NOT pydantic — this dict literal's key
+        order is the contract's own (``tick``, ``paused``, ``chronicle``),
+        never derived by introspecting ``result``. ``world``/``events``/
+        ``autosaved``/``determinism_hash`` are deliberately excluded (the
+        contract's narrower seam).
+
+        :param result: one resolved tick (:class:`~babylon.tui.app.TickOutcome`).
+        :returns: the hand-built outcome dict; ``chronicle`` entries are each
+            :meth:`~pydantic.BaseModel.model_dump` (``mode="json"``) of one
+            :class:`~babylon.tui.chronicle.ChronicleEvent`, declaration order
+            (``tick``, ``event_type``, ``summary``, ``data``, ``class_names``,
+            ``org_names``).
+        """
+        return {
+            "tick": result.tick,
+            "paused": result.paused,
+            "chronicle": [event.model_dump(mode="json") for event in result.chronicle],
+        }
+
+    def advance_tick(self) -> str:
+        """Advance the bound campaign exactly one tick (Task 21).
+
+        Delegates to :meth:`~babylon.tui.app.PacedDriverHandle.advance_once`
+        — the same seam Textual's own ``t`` binding drives
+        (:meth:`~babylon.tui.app.ArchiveApp.action_advance_tick`). Rust
+        pre-checks :meth:`pacing_state_json`'s ``locked``/``awaiting_ack``/
+        ``busy`` flags, in that exact order, before ever calling this method
+        (the contract's own "established pre-check pattern, NOT exception
+        translation") — a :class:`~babylon.game.pacing.PacingError` that
+        still escapes here is therefore a BUG, never a player-reachable
+        refusal, and is never caught: it propagates and panics loudly
+        (Constitution III.11).
+
+        This tick's chronicle feeds :meth:`_accumulate_chronicle` BEFORE
+        serialization, so :meth:`chronicle_rail_json`'s next call already
+        reflects it.
+
+        :returns: ``json.dumps({"ok": True, "outcome": {...}})`` — see
+            :meth:`_tick_outcome` for ``outcome``'s own shape — or a loud
+            refusal envelope when no paced driver is attached (no campaign
+            bound, or a ``driver_factory`` was never wired).
+        """
+        if self.driver is None:
+            return json.dumps(
+                {
+                    "ok": False,
+                    "error": "advance_tick: no paced driver attached — no live campaign bound",
+                }
+            )
+        result = self.driver.advance_once()
+        self._accumulate_chronicle(result.chronicle)
+        return json.dumps({"ok": True, "outcome": self._tick_outcome(result)})
+
+    def run_until_paused(self) -> str:
+        """Auto-advance until an autopause/lock/limit, in one blocking call (Task 21).
+
+        Delegates to
+        :meth:`~babylon.tui.app.PacedDriverHandle.run_until_paused` — the
+        SAME blocking call Textual's own ``r`` binding wraps in a worker
+        (:meth:`~babylon.tui.app.ArchiveApp.action_run_until_paused`). This
+        seam has no incremental FFI callback to report through, so the
+        whole batch resolves before this method returns at all — the
+        Textual ground truth this contract deliberately preserves (no
+        streaming, no spinner).
+
+        :returns: ``json.dumps({"ok": True, "outcomes": [...]})`` — one
+            outcome object (:meth:`_tick_outcome`'s shape) per resolved
+            tick, in order — or a loud refusal envelope when no paced
+            driver is attached. As with :meth:`advance_tick`, a
+            :class:`~babylon.game.pacing.PacingError` escaping past Rust's
+            own pre-check is a bug and is never caught.
+        """
+        if self.driver is None:
+            return json.dumps(
+                {
+                    "ok": False,
+                    "error": "run_until_paused: no paced driver attached — no live campaign bound",
+                }
+            )
+        outcomes: list[dict[str, object]] = []
+        for result in self.driver.run_until_paused():
+            self._accumulate_chronicle(result.chronicle)
+            outcomes.append(self._tick_outcome(result))
+        return json.dumps({"ok": True, "outcomes": outcomes})
+
+    def acknowledge_pause(self) -> str:
+        """Clear a pending autopause, permitting the next advance (Task 21).
+
+        Rust pre-checks ``awaiting_ack`` (via :meth:`pacing_state_json`)
+        before ever calling this method, mirroring
+        :meth:`~babylon.tui.app.ArchiveApp.action_acknowledge_pause`'s own
+        pre-check. Delegates to
+        :meth:`~babylon.tui.app.PacedDriverHandle.acknowledge_pause` with no
+        catch around it — the same "pre-check pattern, NOT exception
+        translation" as :meth:`advance_tick`: a
+        :class:`~babylon.game.pacing.PacingError` that still escapes here is
+        a bug, never a player-reachable refusal.
+
+        :returns: ``json.dumps({"ok": True})`` on success, or a loud refusal
+            envelope when no paced driver is attached.
+        """
+        if self.driver is None:
+            return json.dumps({"ok": False, "error": "acknowledge_pause: no paced driver attached"})
+        self.driver.acknowledge_pause()
+        return json.dumps({"ok": True})
+
+    def chronicle_rail_json(self) -> str:
+        """The render-ready chronicle rail: pre-computed salience, Rust only renders (Task 22).
+
+        Runs the EXACT Textual repaint pipeline
+        (:meth:`~babylon.tui.app.ArchiveApp._populate_chronicle_options`):
+        :func:`~babylon.tui.chronicle_salience.dedupe_consecutive` of
+        :func:`~babylon.tui.chronicle_salience.apply_volume_floors` over the
+        host's own accumulated :attr:`_chronicle_history`, then
+        :func:`~babylon.tui.chronicle_salience.compute_autopause_state` over
+        that same salient list, then
+        :func:`~babylon.tui.chronicle.chronicle_stream` (capped at
+        :data:`~babylon.tui.chronicle.CHRONICLE_ROW_CEILING`) to regroup into
+        dated bulletins.
+
+        Rows are hand-built straight from the bulletins (NOT
+        :func:`~babylon.tui.chronicle.chronicle_rows`, which returns
+        :class:`~rich.text.Text` — the wrong shape to cross the FFI) via
+        :meth:`_bulletin_rows`: a bulletin with events contributes its own
+        non-navigable ``"header"`` row (``"T{tick:04d}"``) followed by one
+        ``"event"`` row per event (:func:`~babylon.tui.chronicle.
+        resolve_navigable_subject` for ``subject``,
+        :func:`~babylon.models.event_severity.resolve_severity` for
+        ``severity``, :func:`~babylon.tui.chronicle.resolve_actor` for
+        ``actor``, the bare ``event.summary`` for ``text`` — the actor
+        prefix stays OUT of ``text``, unlike
+        :func:`~babylon.tui.chronicle._event_line`'s rendered form); a quiet
+        bulletin (no events) contributes its own single ``"quiet"`` row
+        instead — never both, mirroring
+        :func:`~babylon.tui.chronicle.chronicle_rows`'s own per-bulletin
+        dispatch.
+
+        :returns: ``json.dumps({"autopause_line": str | None, "rows": [...]})``.
+            ``autopause_line`` is
+            :func:`~babylon.tui.chronicle_salience.render_autopause_indicator`'s
+            plain text (``Text.plain``), or ``None`` when inactive — an
+            absence, never a dimmed row (Constitution III.11). ``rows`` is
+            ``[]`` for both an unbound host and a bound one with a
+            genuinely empty history — Rust renders its own honest-absence
+            line for either case; this method never fabricates a
+            placeholder row.
+        """
+        salient = dedupe_consecutive(apply_volume_floors(self._chronicle_history))
+        indicator = render_autopause_indicator(compute_autopause_state(salient))
+        autopause_line = indicator.plain if indicator is not None else None
+        rows: list[dict[str, object]] = []
+        for bulletin in chronicle_stream(salient, limit=CHRONICLE_ROW_CEILING):
+            rows.extend(self._bulletin_rows(bulletin))
+        return json.dumps({"autopause_line": autopause_line, "rows": rows})
+
+    @staticmethod
+    def _bulletin_rows(bulletin: TickBulletin) -> list[dict[str, object]]:
+        """One :class:`~babylon.tui.chronicle.TickBulletin`'s own contract rows.
+
+        Split out of :meth:`chronicle_rail_json` so the per-bulletin
+        header/event/quiet dispatch is directly unit-testable against a
+        hand-built :class:`~babylon.tui.chronicle.TickBulletin` — mirrors
+        :func:`~babylon.tui.chronicle.chronicle_rows`'s own per-bulletin
+        dispatch (a quiet bulletin contributes ONE row, never a header +
+        zero event rows).
+
+        :param bulletin: one dated bulletin, as produced by
+            :func:`~babylon.tui.chronicle.chronicle_stream`.
+        :returns: ``[quiet_row]`` for an empty bulletin, else
+            ``[header_row, *event_rows]``.
+        """
+        if not bulletin.events:
+            return [
+                {
+                    "subject": None,
+                    "kind": "quiet",
+                    "tick": bulletin.tick,
+                    "severity": None,
+                    "actor": None,
+                    "text": _WIRE_QUIET,
+                }
+            ]
+        rows: list[dict[str, object]] = [
+            {
+                "subject": None,
+                "kind": "header",
+                "tick": bulletin.tick,
+                "severity": None,
+                "actor": None,
+                "text": f"T{bulletin.tick:04d}",
+            }
+        ]
+        for event in bulletin.events:
+            rows.append(
+                {
+                    "subject": resolve_navigable_subject(event),
+                    "kind": "event",
+                    "tick": bulletin.tick,
+                    "severity": resolve_severity(event.event_type).tier,
+                    "actor": resolve_actor(event),
+                    "text": event.summary,
+                }
+            )
+        return rows
+
+    def verb_plate_view_json(self) -> str:
+        """The bound campaign's live verb plate, as JSON (Task 23).
+
+        Thin passthrough to
+        :meth:`~babylon.tui.app.CampaignHandle.verb_plate_view` — the same
+        live, compute-fresh-every-call projection
+        :meth:`~babylon.tui.app.ArchiveApp._refresh_action_bar` already
+        renders.
+
+        :returns: :meth:`~pydantic.BaseModel.model_dump_json` of the
+            resolved :class:`~babylon.projection.verbs.view_models.VerbPlateView`,
+            or the literal ``"null"`` when no session is bound or the
+            campaign's graph carries no player-org pointer — never a
+            fabricated plate (Constitution III.11).
+        """
+        if self.session is None:
+            return "null"
+        view: VerbPlateView | None = self.session.verb_plate_view()
+        if view is None:
+            return "null"
+        return view.model_dump_json()
+
+    def issue_verb(self, args_json: str) -> str:
+        """Queue one Article V verb through the real write path (Task 23).
+
+        :param args_json: ``{"verb": str, "target_id": str | None,
+            "target_community": str | None}`` — Rust has already derived an
+            honest ``target_id`` exactly like
+            :func:`~babylon.tui.app._honest_target_id` (never invented; see
+            the contract's own note) before calling this method, so this
+            host method threads whatever it receives straight through with
+            no second-guessing.
+        :returns: ``json.dumps({"ok": True, "turn_id": int})`` on success, or
+            a refusal envelope when no session is bound OR
+            :meth:`~babylon.tui.app.CampaignHandle.issue_verb` itself raises
+            one of the three player-reachable refusal types
+            (``RuntimeError``/``ValueError``/``KeyError`` — mirrors
+            :meth:`~babylon.tui.app.ArchiveApp.action_issue_verb`'s own
+            catch list exactly); any OTHER exception type propagates and
+            panics loudly (Constitution III.11 — a system-level failure,
+            never laundered into a fabricated refusal).
+        """
+        if self.session is None:
+            return json.dumps(
+                {"ok": False, "error": "issue_verb: no live campaign attached — nothing to act on"}
+            )
+        args = json.loads(args_json)
+        verb = args["verb"]
+        target_id = args.get("target_id")
+        target_community = args.get("target_community")
+        try:
+            turn_id = self.session.issue_verb(
+                verb, target_id=target_id, target_community=target_community
+            )
+        except (RuntimeError, ValueError, KeyError) as exc:
+            return json.dumps({"ok": False, "error": str(exc)})
+        return json.dumps({"ok": True, "turn_id": turn_id})
+
+    def endgame_status_json(self) -> str:
+        """The bound campaign's live endgame-progress status, as JSON (Task 24).
+
+        :returns: the literal ``"null"`` ONLY when no session is bound (the
+            lobby) — tick 0 of a bound campaign is a real all-zero-axes
+            payload, never absence. Otherwise
+            :meth:`~pydantic.BaseModel.model_dump_json` of the resolved
+            :class:`~babylon.projection.endgame.EndgameStatus`, or
+            ``"null"`` when this composition root's own
+            :meth:`~babylon.tui.app.CampaignHandle.endgame_status` chose not
+            to wire a live projection (a test double — never true for a real
+            :class:`~babylon.game.session.GameSession`).
+        """
+        if self.session is None:
+            return "null"
+        status: EndgameStatus | None = self.session.endgame_status()
+        if status is None:
+            return "null"
+        return status.model_dump_json()
+
+    def pin_watchlist(self, args_json: str) -> str:
+        """Pin or unpin one subject, persisting through the M1 watchlist store (Task 25).
+
+        :param args_json: ``{"subject": str, "pinned": bool}``.
+        :returns: ``json.dumps({"ok": True, "pinned": bool})`` on success —
+            FIFO pin order, idempotent both ways, persisted via the SAME
+            :func:`~babylon.tui.watchlist.load_watchlist`/
+            :func:`~babylon.tui.watchlist.save_watchlist` path
+            :meth:`watchlist_json` already reads. A refusal envelope when no
+            session/watchlist store is bound, or when
+            :meth:`~babylon.tui.watchlist.WatchlistState.pin`'s capacity
+            :class:`ValueError` fires (the ONE player-reachable refusal
+            here, mirroring
+            :meth:`~babylon.tui.app.ArchiveApp.action_toggle_pin`'s own
+            catch) — never a fabricated silent no-op (Constitution III.11).
+        """
+        if self.session is None or self._watchlist_persistence is None:
+            return json.dumps(
+                {"ok": False, "error": "pin_watchlist: no live campaign/watchlist store attached"}
+            )
+        args = json.loads(args_json)
+        subject = args["subject"]
+        pinned = bool(args["pinned"])
+        session_id = str(self.session.session_id)
+        state = load_watchlist(self._watchlist_persistence, session_id)
+        try:
+            state = state.pin(subject) if pinned else state.unpin(subject)
+        except ValueError as exc:
+            return json.dumps({"ok": False, "error": str(exc)})
+        save_watchlist(self._watchlist_persistence, session_id, state)
+        return json.dumps({"ok": True, "pinned": pinned})
+
+    def nav_state_json(self) -> str:
+        """The bound campaign's persisted nav state, as JSON (Task 25).
+
+        Campaign-scoped (keyed by the bound session's own ``session_id``) —
+        pulled fresh after :meth:`load_campaign`, never through the
+        pre-bind ``config_json`` (the contract's own RECORDED DEVIATION:
+        nav state is campaign-scoped, and ``config_json`` is built before a
+        campaign is even chosen — ``play.py:449-458``). Only ENTRIES
+        persist: cursor/capacity are reconstructed on restore, mirroring
+        :meth:`~babylon.tui.nav.NavShell.restore`/
+        :meth:`~babylon.tui.nav.JumplistState.restore`.
+
+        :returns: ``json.dumps({"jumplist": [...], "breadcrumbs": [...]})``
+            — both ``[]`` when no session/nav store is bound, or the store
+            honestly has nothing recorded yet.
+        """
+        if self.session is None or self._nav_persistence is None:
+            return json.dumps({"jumplist": [], "breadcrumbs": []})
+        session_id = self.session.session_id
+        return json.dumps(
+            {
+                "jumplist": list(self._nav_persistence.load_jumplist(session_id)),
+                "breadcrumbs": list(self._nav_persistence.load_breadcrumbs(session_id)),
+            }
+        )
+
+    def save_nav_state(self, nav_json: str) -> str:
+        """Persist nav state — same shape as :meth:`nav_state_json` (Task 25).
+
+        Called by the Rust shell on leaving the campaign (Back to lobby)
+        and on quit. Textual never wired nav persistence in production at
+        all (the contract's own RECORDED DEVIATION — ``app.py:1185-1187``
+        boots a throwaway ``uuid4`` + ``InMemoryNavPersistence``), so this
+        is fresh wiring on both sides, not a port.
+
+        :param nav_json: ``{"jumplist": [...], "breadcrumbs": [...]}``.
+        :returns: ``json.dumps({"ok": True})`` on success, or a refusal
+            envelope when no session/nav store is bound.
+        """
+        if self.session is None or self._nav_persistence is None:
+            return json.dumps(
+                {"ok": False, "error": "save_nav_state: no live campaign/nav store attached"}
+            )
+        nav = json.loads(nav_json)
+        session_id = self.session.session_id
+        self._nav_persistence.save_jumplist(session_id, tuple(nav["jumplist"]))
+        self._nav_persistence.save_breadcrumbs(session_id, tuple(nav["breadcrumbs"]))
+        return json.dumps({"ok": True})

--- a/src/babylon/tui/host.py
+++ b/src/babylon/tui/host.py
@@ -52,7 +52,6 @@ from uuid import UUID
 from babylon.models.event_severity import resolve_severity
 from babylon.tui.campaign_menu import operation_codename
 from babylon.tui.chronicle import (
-    _WIRE_QUIET,
     CHRONICLE_ROW_CEILING,
     chronicle_stream,
     resolve_actor,
@@ -193,7 +192,7 @@ class RustClientHost:
         composition: resolves ``campaign_id`` through :attr:`_campaign_loader`
         (:data:`~babylon.tui.app.CampaignLoader`), builds the paced driver
         through :attr:`_driver_factory` when one was wired (``None``
-        otherwise — legal for M1's read-only surface), and binds both
+        otherwise — reads still serve, tick verbs refuse), and binds both
         through :meth:`bind_session` — closing the gap where
         ``bind_session`` shipped with zero production caller and every M1
         read method served absence against a never-bound session.
@@ -369,7 +368,8 @@ class RustClientHost:
         return view.model_dump_json()
 
     def watchlist_json(self) -> str:
-        """The bound campaign's persisted watchlist rows, read-only.
+        """The bound campaign's persisted watchlist rows (writes cross
+        through :meth:`pin_watchlist`).
 
         Hydrates via :func:`~babylon.tui.watchlist.load_watchlist` over
         :attr:`_watchlist_persistence` — the SAME seam/function
@@ -611,28 +611,23 @@ class RustClientHost:
         """One :class:`~babylon.tui.chronicle.TickBulletin`'s own contract rows.
 
         Split out of :meth:`chronicle_rail_json` so the per-bulletin
-        header/event/quiet dispatch is directly unit-testable against a
-        hand-built :class:`~babylon.tui.chronicle.TickBulletin` — mirrors
-        :func:`~babylon.tui.chronicle.chronicle_rows`'s own per-bulletin
-        dispatch (a quiet bulletin contributes ONE row, never a header +
-        zero event rows).
+        header/event dispatch is directly unit-testable against a
+        hand-built :class:`~babylon.tui.chronicle.TickBulletin`.
+
+        There is deliberately NO ``"quiet"`` row kind:
+        :func:`~babylon.tui.chronicle.chronicle_stream` never emits an
+        empty bulletin ("only ticks actually present in ``events`` produce
+        a bulletin" — its own contract), so a quiet branch here would be
+        dead code behind a hand-built test shape — the exact green-test-
+        over-dead-feature class the M1 verify panel caught. An empty RAIL
+        (no rows at all) is the honest-absence state and renders
+        client-side.
 
         :param bulletin: one dated bulletin, as produced by
-            :func:`~babylon.tui.chronicle.chronicle_stream`.
-        :returns: ``[quiet_row]`` for an empty bulletin, else
-            ``[header_row, *event_rows]``.
+            :func:`~babylon.tui.chronicle.chronicle_stream` — always
+            carries at least one event.
+        :returns: ``[header_row, *event_rows]``.
         """
-        if not bulletin.events:
-            return [
-                {
-                    "subject": None,
-                    "kind": "quiet",
-                    "tick": bulletin.tick,
-                    "severity": None,
-                    "actor": None,
-                    "text": _WIRE_QUIET,
-                }
-            ]
         rows: list[dict[str, object]] = [
             {
                 "subject": None,
@@ -758,8 +753,12 @@ class RustClientHost:
         subject = args["subject"]
         pinned = bool(args["pinned"])
         session_id = str(self.session.session_id)
-        state = load_watchlist(self._watchlist_persistence, session_id)
         try:
+            # Hydration sits INSIDE the catch: a persisted list drifted past
+            # today's capacity raises the same player-reachable ValueError
+            # class as an over-capacity pin, and neither may crash the
+            # client (verify-panel note).
+            state = load_watchlist(self._watchlist_persistence, session_id)
             state = state.pin(subject) if pinned else state.unpin(subject)
         except ValueError as exc:
             return json.dumps({"ok": False, "error": str(exc)})

--- a/tests/unit/cli/test_play.py
+++ b/tests/unit/cli/test_play.py
@@ -377,7 +377,8 @@ class TestClientRustLane:
 
         campaign_id = UUID("00000000-0000-0000-0000-000000000009")
         result = json.loads(host.load_campaign(str(campaign_id)))
-        assert result == {"ok": True, "campaign_id": str(campaign_id)}
+        # M2: the ack carries the session tick (honest HUD counter on resume).
+        assert result == {"ok": True, "campaign_id": str(campaign_id), "tick": 0}
         # bind_session actually took effect: reads no longer serve absence.
         assert json.loads(host.read_page_json("county/26163")) == "# Wayne County"
         assert host.session is not None

--- a/tests/unit/tui/test_host_contract.py
+++ b/tests/unit/tui/test_host_contract.py
@@ -189,7 +189,9 @@ class TestLoadCampaign:
             campaign_loader=lambda _campaign_id: campaign,  # type: ignore[arg-type, return-value]
         )
         result = json.loads(host.load_campaign(str(_SESSION_ID)))
-        assert result == {"ok": True, "campaign_id": str(_SESSION_ID)}
+        # The tick rides the ack so a RESUMED campaign's HUD counter is
+        # honest from the first frame (M2 seam contract).
+        assert result == {"ok": True, "campaign_id": str(_SESSION_ID), "tick": campaign.tick}
         assert host.session is campaign  # type: ignore[comparison-overlap]
         assert host.driver is None  # no driver_factory wired: a legal M1 answer.
         # bind_session actually took effect: reads no longer serve absence.

--- a/tests/unit/tui/test_rust_client_ffi.py
+++ b/tests/unit/tui/test_rust_client_ffi.py
@@ -51,6 +51,37 @@ class _FakeHost:
     def watchlist_json(self) -> str:
         return "[]"
 
+    # --- M2 surface (contract: 2026-07-27-m2-seam-contracts.md). The shell
+    # pulls all of these on bind + saves nav on quit, so the fake must speak
+    # them (a missing method would raise → panic across the FFI, III.11).
+
+    def pacing_state_json(self) -> str:
+        return json.dumps(
+            {
+                "attached": False,
+                "locked": False,
+                "lock_reason": None,
+                "awaiting_ack": False,
+                "pause_summary": None,
+                "busy": False,
+            }
+        )
+
+    def chronicle_rail_json(self) -> str:
+        return json.dumps({"autopause_line": None, "rows": []})
+
+    def verb_plate_view_json(self) -> str:
+        return "null"
+
+    def endgame_status_json(self) -> str:
+        return "null"
+
+    def nav_state_json(self) -> str:
+        return json.dumps({"jumplist": [], "breadcrumbs": []})
+
+    def save_nav_state(self, nav_json: str) -> str:
+        return json.dumps({"ok": True})
+
 
 def _config(**overrides: object) -> str:
     cfg: dict[str, object] = {
@@ -86,10 +117,19 @@ def test_run_headless_scripted_flow_lobby_to_briefing_to_quit() -> None:
     assert "Wayne County" in transcript["frames"][0]
     assert "Briefing" in transcript["frames"][1]
     assert "CAMPAIGNS" in transcript["frames"][2]
+    # M2: the bind pulls nav state + the five chrome feeds after the page
+    # read, and leaving the campaign (first q) persists nav.
     assert transcript["host_calls"] == [
         "lobby_catalog_json",
         "load_campaign",
         "known_subjects_json",
+        "nav_state_json",
         "read_page_json",
         "backlinks_json",
+        "endgame_status_json",
+        "pacing_state_json",
+        "verb_plate_view_json",
+        "chronicle_rail_json",
+        "watchlist_json",
+        "save_nav_state",
     ]

--- a/tests/unit/tui/test_rust_host_m2.py
+++ b/tests/unit/tui/test_rust_host_m2.py
@@ -582,18 +582,18 @@ class TestChronicleRail:
             "text": "stirring",
         }
 
-    def test_quiet_row_shape(self) -> None:
-        rows = RustClientHost._bulletin_rows(TickBulletin(tick=846, events=()))
-        assert rows == [
-            {
-                "subject": None,
-                "kind": "quiet",
-                "tick": 846,
-                "severity": None,
-                "actor": None,
-                "text": "the wire is quiet",
-            }
-        ]
+    def test_no_quiet_kind_exists(self) -> None:
+        """chronicle_stream never emits an empty bulletin (its own
+        documented contract), so the rail has NO "quiet" row kind — an
+        empty rail is the client-side honest-absence state. This pin keeps
+        the dead variant from quietly returning."""
+        rows = RustClientHost._bulletin_rows(
+            TickBulletin(
+                tick=846,
+                events=(_event(tick=846, event_type=EventType.UPRISING, summary="x"),),
+            )
+        )
+        assert {row["kind"] for row in rows} == {"header", "event"}
 
     def test_reset_on_rebind(self) -> None:
         driver1 = _FakeDriver(

--- a/tests/unit/tui/test_rust_host_m2.py
+++ b/tests/unit/tui/test_rust_host_m2.py
@@ -1,0 +1,976 @@
+"""Contract for the M2 "Playable" RustClientHost surface (Tasks 21-25, ADR150).
+
+Companion to ``test_host_contract.py`` (the M0/M1 lobby + read surface):
+this module exercises the eleven write/tick methods
+``docs/superpowers/specs/2026-07-27-m2-seam-contracts.md`` pins —
+:meth:`~babylon.tui.host.RustClientHost.pacing_state_json` through
+:meth:`~babylon.tui.host.RustClientHost.save_nav_state`. Unit tier only (no
+Postgres): ``_FakeDriver``/``_FakeOutcome`` mirror
+``tests/unit/game/test_pacing.py``'s own ``_FakeAdvancer``/``_FakeOutcome``
+convention one layer up (faking the DRIVER seam the host calls, not the
+advancer underneath it); ``_FakeSession`` mirrors this module's own
+``test_host_contract.py`` sibling's ``_FakeCampaign`` convention (only the
+``CampaignHandle`` members the M2 write methods actually call).
+
+The verb-resolution mirror (``TestVerbResolutionMirror``) rebuilds
+``tests/integration/archive/test_verb_resolution.py``'s minimal in-process
+graph/journal fixture locally (that module is ``pytest.mark.integration``;
+this one stays unit-tier) to pin the contract's own RECORDED DEVIATION: no
+"remaining actions decrement" assertion exists in production
+(``OODAProfile.action_points``/``enforce_action_points`` are declared but
+never called on the live path — the dead-feature anti-pattern
+``CLAUDE.md``'s vocabulary-sentinel section documents) — only the two REAL
+behaviors that integration test pins: a submitted verb reaches
+``turn_resolution.action_phase_results`` after ``OODASystem().step``, and
+an unaffordable submission is refused before the queue.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+
+from babylon.config.defines import GameDefines
+from babylon.engine.context import TickContext
+from babylon.engine.systems.ooda import OODASystem
+from babylon.models.enums import OrgType
+from babylon.models.enums.events import EventType, GameOutcome
+from babylon.models.enums.topology import NodeType
+from babylon.projection.endgame import EndgameStatus
+from babylon.projection.verbs.submit import build_player_actions, submit_verb
+from babylon.projection.verbs.view_models import VerbPlateView, VerbPreview, VerbRow
+from babylon.topology import BabylonGraph
+from babylon.tui.app import PacedDriverHandle, TickOutcome
+from babylon.tui.campaign_menu import InMemoryCampaignCatalog
+from babylon.tui.chronicle import CHRONICLE_ROW_CEILING, ChronicleEvent, TickBulletin
+from babylon.tui.host import RustClientHost
+from babylon.tui.nav import InMemoryNavPersistence
+from babylon.tui.watchlist import DEFAULT_WATCHLIST_CAPACITY, InMemoryWatchlistPersistence
+
+pytestmark = [pytest.mark.unit]
+
+_DEFINES_HASH = "cafebabe" * 8
+_ENGINE_VERSION = "9.9.9"
+_SESSION_ID = UUID("00000000-0000-0000-0000-0000000000f2")
+
+
+# --------------------------------------------------------------------------- #
+# Fakes.                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class _FakeOutcome:
+    """A minimal ``TickOutcome`` double — ``tick``/``paused``/``chronicle``
+    only (the narrower seam :class:`~babylon.tui.app.PacedDriverHandle`
+    actually needs, one layer up from ``test_pacing.py``'s own fuller
+    ``TickOutcomeLike`` double)."""
+
+    tick: int
+    paused: bool = False
+    chronicle: tuple[ChronicleEvent, ...] = ()
+
+
+@dataclass
+class _FakeDriver:
+    """A minimal ``PacedDriverHandle`` double — scripted outcomes, no real
+    ``PacedTickDriver`` machinery (mirrors ``test_pacing.py``'s own
+    ``_FakeAdvancer`` convention one layer up: this fakes the seam the host
+    actually calls)."""
+
+    outcomes: list[_FakeOutcome] = field(default_factory=list)
+    locked: bool = False
+    lock_reason: str | None = None
+    awaiting_ack: bool = False
+    busy: bool = False
+    pause_summary: str | None = None
+    advance_calls: int = field(default=0, init=False)
+    acknowledge_calls: int = field(default=0, init=False)
+
+    def advance_once(self) -> _FakeOutcome:
+        self.advance_calls += 1
+        return self.outcomes.pop(0)
+
+    def run_until_paused(self) -> tuple[_FakeOutcome, ...]:
+        results = tuple(self.outcomes)
+        self.outcomes = []
+        return results
+
+    def acknowledge_pause(self) -> None:
+        self.acknowledge_calls += 1
+        self.awaiting_ack = False
+
+
+class _FakeSession:
+    """A minimal ``CampaignHandle`` double covering only what the M2 write
+    methods call (mirrors ``test_host_contract.py``'s own ``_FakeCampaign``
+    convention: only the members actually exercised)."""
+
+    def __init__(
+        self,
+        *,
+        session_id: UUID = _SESSION_ID,
+        verb_plate_view: VerbPlateView | None = None,
+        endgame_status: EndgameStatus | None = None,
+        issue_verb_result: object = 1,
+    ) -> None:
+        self.session_id = session_id
+        self._verb_plate_view = verb_plate_view
+        self._endgame_status = endgame_status
+        self._issue_verb_result = issue_verb_result
+        self.issue_verb_calls: list[tuple[str, str | None, str | None]] = []
+
+    def verb_plate_view(self) -> VerbPlateView | None:
+        return self._verb_plate_view
+
+    def endgame_status(self) -> EndgameStatus | None:
+        return self._endgame_status
+
+    def issue_verb(
+        self,
+        action_id: str,
+        *,
+        target_id: str | None = None,
+        target_community: str | None = None,
+    ) -> int:
+        self.issue_verb_calls.append((action_id, target_id, target_community))
+        if isinstance(self._issue_verb_result, BaseException):
+            raise self._issue_verb_result
+        assert isinstance(self._issue_verb_result, int)
+        return self._issue_verb_result
+
+
+def _event(
+    *, tick: int, event_type: EventType, summary: str, data: dict[str, Any] | None = None
+) -> ChronicleEvent:
+    return ChronicleEvent(tick=tick, event_type=event_type, summary=summary, data=data or {})
+
+
+def _verb_plate_view() -> VerbPlateView:
+    preview = VerbPreview(
+        estimated_consciousness_delta=0.01,
+        estimated_heat_delta=0.01,
+        action_point_cost=1.0,
+        success_probability=0.7,
+        affected_territory_ids=(),
+        warnings=(),
+    )
+    row = VerbRow(
+        verb="educate",
+        eligible=True,
+        reason=None,
+        remedy=None,
+        can_afford=True,
+        afford_note=None,
+        preview=preview,
+        candidate_target_ids=(),
+    )
+    return VerbPlateView(org_id="rev_workers", tick=3, verbs=(row,))
+
+
+def _endgame_status() -> EndgameStatus:
+    return EndgameStatus(
+        pattern=None,
+        outcome=GameOutcome.UNRESOLVED,
+        game_over=False,
+        horizon_tick=5200,
+        since_tick=None,
+        locked=False,
+        axes={
+            "revolutionary_victory": 0.1,
+            "ecological_collapse": 0.0,
+            "fascist_consolidation": 0.0,
+            "red_ogv": 0.0,
+            "fragmented_collapse": 0.0,
+        },
+    )
+
+
+def _host(
+    *,
+    session: object | None = None,
+    driver: object | None = None,
+    watchlist_persistence: InMemoryWatchlistPersistence | None = None,
+    nav_persistence: InMemoryNavPersistence | None = None,
+) -> RustClientHost:
+    host = RustClientHost(
+        InMemoryCampaignCatalog(),
+        defines_hash=_DEFINES_HASH,
+        engine_version=_ENGINE_VERSION,
+        watchlist_persistence=watchlist_persistence,
+        nav_persistence=nav_persistence,
+    )
+    if session is not None:
+        host.bind_session(session, driver)  # type: ignore[arg-type]
+    return host
+
+
+# --------------------------------------------------------------------------- #
+# Fake seam conformance (mirrors test_pacing.py's own TestSeams).             #
+# --------------------------------------------------------------------------- #
+
+
+class TestFakeSeamConformance:
+    def test_fake_outcome_satisfies_tick_outcome(self) -> None:
+        assert isinstance(_FakeOutcome(tick=1), TickOutcome)
+
+    def test_fake_driver_satisfies_paced_driver_handle(self) -> None:
+        assert isinstance(_FakeDriver(), PacedDriverHandle)
+
+
+# --------------------------------------------------------------------------- #
+# (a) advance_tick.                                                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestAdvanceTick:
+    def test_no_driver_attached_is_a_refusal(self) -> None:
+        payload = json.loads(_host().advance_tick())
+        assert payload == {
+            "ok": False,
+            "error": "advance_tick: no paced driver attached — no live campaign bound",
+        }
+
+    def test_session_bound_but_no_driver_factory_is_still_a_refusal(self) -> None:
+        # A legal M1 state (session bound, driver never wired) must not be
+        # confused with "attached" — the same driver-is-None check governs.
+        payload = json.loads(_host(session=_FakeSession()).advance_tick())
+        assert payload["ok"] is False
+
+    def test_success_envelope_and_exact_key_order(self) -> None:
+        chronicle = (_event(tick=5, event_type=EventType.UPRISING, summary="revolt"),)
+        driver = _FakeDriver(outcomes=[_FakeOutcome(tick=5, paused=False, chronicle=chronicle)])
+        host = _host(session=_FakeSession(), driver=driver)
+
+        raw = host.advance_tick()
+        payload = json.loads(raw)
+
+        assert payload["ok"] is True
+        assert list(payload["outcome"].keys()) == ["tick", "paused", "chronicle"]
+        assert payload["outcome"]["tick"] == 5
+        assert payload["outcome"]["paused"] is False
+        assert len(payload["outcome"]["chronicle"]) == 1
+        assert payload["outcome"]["chronicle"][0]["event_type"] == "uprising"
+        # Belt-and-suspenders: pin the RAW string's own key sequence too, not
+        # just the round-tripped dict's (json.loads already preserves
+        # insertion order in CPython, but the contract asks for both).
+        start = raw.index('"outcome"')
+        assert (
+            raw.index('"tick"', start)
+            < raw.index('"paused"', start)
+            < raw.index('"chronicle"', start)
+        )
+
+    def test_advance_calls_the_driver_exactly_once(self) -> None:
+        driver = _FakeDriver(outcomes=[_FakeOutcome(tick=1)])
+        host = _host(session=_FakeSession(), driver=driver)
+        host.advance_tick()
+        assert driver.advance_calls == 1
+
+
+# --------------------------------------------------------------------------- #
+# (b) run_until_paused.                                                        #
+# --------------------------------------------------------------------------- #
+
+
+class TestRunUntilPaused:
+    def test_no_driver_attached_is_a_refusal(self) -> None:
+        payload = json.loads(_host().run_until_paused())
+        assert payload == {
+            "ok": False,
+            "error": "run_until_paused: no paced driver attached — no live campaign bound",
+        }
+
+    def test_returns_one_outcome_per_tick_in_order(self) -> None:
+        driver = _FakeDriver(
+            outcomes=[
+                _FakeOutcome(tick=1, paused=False),
+                _FakeOutcome(tick=2, paused=False),
+                _FakeOutcome(tick=3, paused=True),
+            ]
+        )
+        host = _host(session=_FakeSession(), driver=driver)
+
+        payload = json.loads(host.run_until_paused())
+
+        assert payload["ok"] is True
+        assert [o["tick"] for o in payload["outcomes"]] == [1, 2, 3]
+        assert [o["paused"] for o in payload["outcomes"]] == [False, False, True]
+        for outcome in payload["outcomes"]:
+            assert list(outcome.keys()) == ["tick", "paused", "chronicle"]
+
+
+# --------------------------------------------------------------------------- #
+# (c) pacing_state_json.                                                       #
+# --------------------------------------------------------------------------- #
+
+
+class TestPacingStateJson:
+    def test_no_driver_is_the_unattached_shape(self) -> None:
+        assert json.loads(_host().pacing_state_json()) == {
+            "attached": False,
+            "locked": False,
+            "lock_reason": None,
+            "awaiting_ack": False,
+            "pause_summary": None,
+            "busy": False,
+        }
+
+    def test_key_order(self) -> None:
+        payload = json.loads(_host().pacing_state_json())
+        assert list(payload.keys()) == [
+            "attached",
+            "locked",
+            "lock_reason",
+            "awaiting_ack",
+            "pause_summary",
+            "busy",
+        ]
+
+    def test_ready_driver(self) -> None:
+        host = _host(session=_FakeSession(), driver=_FakeDriver())
+        payload = json.loads(host.pacing_state_json())
+        assert payload == {
+            "attached": True,
+            "locked": False,
+            "lock_reason": None,
+            "awaiting_ack": False,
+            "pause_summary": None,
+            "busy": False,
+        }
+
+    def test_locked_driver(self) -> None:
+        driver = _FakeDriver(locked=True, lock_reason="RED_OGV")
+        host = _host(session=_FakeSession(), driver=driver)
+        payload = json.loads(host.pacing_state_json())
+        assert payload["locked"] is True
+        assert payload["lock_reason"] == "RED_OGV"
+
+    def test_awaiting_ack_driver(self) -> None:
+        driver = _FakeDriver(awaiting_ack=True, pause_summary="tick 3: uprising")
+        host = _host(session=_FakeSession(), driver=driver)
+        payload = json.loads(host.pacing_state_json())
+        assert payload["awaiting_ack"] is True
+        assert payload["pause_summary"] == "tick 3: uprising"
+
+    def test_busy_driver(self) -> None:
+        driver = _FakeDriver(busy=True)
+        host = _host(session=_FakeSession(), driver=driver)
+        assert json.loads(host.pacing_state_json())["busy"] is True
+
+
+# --------------------------------------------------------------------------- #
+# (d) acknowledge_pause.                                                       #
+# --------------------------------------------------------------------------- #
+
+
+class TestAcknowledgePause:
+    def test_no_driver_attached_is_a_refusal(self) -> None:
+        assert json.loads(_host().acknowledge_pause()) == {
+            "ok": False,
+            "error": "acknowledge_pause: no paced driver attached",
+        }
+
+    def test_success_clears_the_pending_ack(self) -> None:
+        driver = _FakeDriver(awaiting_ack=True, pause_summary="tick 3: uprising")
+        host = _host(session=_FakeSession(), driver=driver)
+
+        result = json.loads(host.acknowledge_pause())
+
+        assert result == {"ok": True}
+        assert driver.acknowledge_calls == 1
+        assert driver.awaiting_ack is False
+
+
+# --------------------------------------------------------------------------- #
+# (e) chronicle rail — accumulator, pipeline order, autopause, row shapes.     #
+# --------------------------------------------------------------------------- #
+
+
+class TestChronicleRail:
+    def test_unbound_host_is_honest_absence(self) -> None:
+        assert json.loads(_host().chronicle_rail_json()) == {"autopause_line": None, "rows": []}
+
+    def test_bound_host_with_no_ticks_yet_is_empty_rows(self) -> None:
+        host = _host(session=_FakeSession(), driver=_FakeDriver())
+        assert json.loads(host.chronicle_rail_json()) == {"autopause_line": None, "rows": []}
+
+    def test_two_ticks_accumulate(self) -> None:
+        driver = _FakeDriver(
+            outcomes=[
+                _FakeOutcome(
+                    tick=1,
+                    chronicle=(
+                        _event(
+                            tick=1,
+                            event_type=EventType.MASS_AWAKENING,
+                            summary="stirring",
+                            data={"target_id": "C001"},
+                        ),
+                    ),
+                ),
+                _FakeOutcome(
+                    tick=2,
+                    chronicle=(_event(tick=2, event_type=EventType.UPRISING, summary="revolt"),),
+                ),
+            ]
+        )
+        host = _host(session=_FakeSession(), driver=driver)
+
+        host.advance_tick()
+        host.advance_tick()
+
+        payload = json.loads(host.chronicle_rail_json())
+        headers = [row for row in payload["rows"] if row["kind"] == "header"]
+        assert {h["tick"] for h in headers} == {1, 2}
+
+    def test_cap_respected(self) -> None:
+        # Distinct per-tick node_ids keep every event's dedup key unique:
+        # chronicle_subject's precedence walk reads node_id (target_id is
+        # only the class-scoped NAVIGABLE-subject field, not a dedup field),
+        # and without it every row keys as "mass_awakening:global" and
+        # tick-independent dedupe_consecutive collapses the whole run to one
+        # row before the cap could ever be observed.
+        total_ticks = CHRONICLE_ROW_CEILING + 5
+        driver = _FakeDriver(
+            outcomes=[
+                _FakeOutcome(
+                    tick=t,
+                    chronicle=(
+                        _event(
+                            tick=t,
+                            event_type=EventType.MASS_AWAKENING,
+                            summary=f"s{t}",
+                            data={"target_id": f"C{t:03d}", "node_id": f"C{t:03d}"},
+                        ),
+                    ),
+                )
+                for t in range(1, total_ticks + 1)
+            ]
+        )
+        host = _host(session=_FakeSession(), driver=driver)
+        for _ in range(total_ticks):
+            host.advance_tick()
+
+        payload = json.loads(host.chronicle_rail_json())
+        event_rows = [row for row in payload["rows"] if row["kind"] == "event"]
+        assert len(event_rows) == CHRONICLE_ROW_CEILING
+        ticks_present = {row["tick"] for row in event_rows}
+        assert min(ticks_present) == total_ticks - CHRONICLE_ROW_CEILING + 1
+        assert max(ticks_present) == total_ticks
+
+    def test_pipeline_runs_volume_floors_before_dedupe(self) -> None:
+        """Two ORGANIZATIONAL_ACTION events in one tick, plus a
+        distinguishing third event. The PRODUCTION order
+        (``dedupe_consecutive(apply_volume_floors(history))``) rolls the
+        pair up into ONE "2 organizational actions" card BEFORE dedupe ever
+        runs. The WRONG order (dedupe first) would instead leave a "1
+        organizational action" card, since ``aggregate_organizational_actions``
+        aggregates whatever survived dedupe's own (unrelated) collapse —
+        this fixture is engineered so the two orders diverge, pinning that
+        floors really does run first.
+        """
+        org_a = _event(tick=9, event_type=EventType.ORGANIZATIONAL_ACTION, summary="org acted (a)")
+        org_b = _event(tick=9, event_type=EventType.ORGANIZATIONAL_ACTION, summary="org acted (b)")
+        other = _event(
+            tick=9,
+            event_type=EventType.MASS_AWAKENING,
+            summary="stirring",
+            data={"target_id": "C001"},
+        )
+        driver = _FakeDriver(outcomes=[_FakeOutcome(tick=9, chronicle=(org_a, org_b, other))])
+        host = _host(session=_FakeSession(), driver=driver)
+
+        host.advance_tick()
+        payload = json.loads(host.chronicle_rail_json())
+
+        rollup_rows = [
+            row
+            for row in payload["rows"]
+            if row["kind"] == "event" and "organizational action" in row["text"]
+        ]
+        assert len(rollup_rows) == 1
+        assert rollup_rows[0]["text"] == "2 organizational actions this tick"
+
+    def test_autopause_line_present_iff_critical_event_in_salient_window(self) -> None:
+        driver = _FakeDriver(
+            outcomes=[
+                _FakeOutcome(
+                    tick=1,
+                    chronicle=(_event(tick=1, event_type=EventType.UPRISING, summary="revolt"),),
+                )
+            ]
+        )
+        host = _host(session=_FakeSession(), driver=driver)
+        assert json.loads(host.chronicle_rail_json())["autopause_line"] is None
+
+        host.advance_tick()
+        payload = json.loads(host.chronicle_rail_json())
+        assert payload["autopause_line"] == "⏸ AUTOPAUSE — THIS CANNOT PASS UNREAD"
+
+    def test_autopause_line_absent_with_no_critical_event(self) -> None:
+        driver = _FakeDriver(
+            outcomes=[
+                _FakeOutcome(
+                    tick=1,
+                    chronicle=(
+                        _event(
+                            tick=1,
+                            event_type=EventType.MASS_AWAKENING,
+                            summary="stirring",
+                            data={"target_id": "C001"},
+                        ),
+                    ),
+                )
+            ]
+        )
+        host = _host(session=_FakeSession(), driver=driver)
+        host.advance_tick()
+        assert json.loads(host.chronicle_rail_json())["autopause_line"] is None
+
+    def test_header_row_shape(self) -> None:
+        rows = RustClientHost._bulletin_rows(
+            TickBulletin(
+                tick=847,
+                events=(
+                    _event(
+                        tick=847,
+                        event_type=EventType.MASS_AWAKENING,
+                        summary="stirring",
+                        data={"target_id": "C001"},
+                    ),
+                ),
+            )
+        )
+        assert rows[0] == {
+            "subject": None,
+            "kind": "header",
+            "tick": 847,
+            "severity": None,
+            "actor": None,
+            "text": "T0847",
+        }
+
+    def test_event_row_shape(self) -> None:
+        rows = RustClientHost._bulletin_rows(
+            TickBulletin(
+                tick=847,
+                events=(
+                    _event(
+                        tick=847,
+                        event_type=EventType.MASS_AWAKENING,
+                        summary="stirring",
+                        data={"target_id": "C001"},
+                    ),
+                ),
+            )
+        )
+        # MASS_AWAKENING is CROSSING + INTRA_LEVEL => "informational" via
+        # resolve_severity (the production path); _LEGACY_HAND_TIERS' old
+        # "warning" row is retired drift documentation, not the contract.
+        assert rows[1] == {
+            "subject": "social_class/C001",
+            "kind": "event",
+            "tick": 847,
+            "severity": "informational",
+            "actor": "the Periphery Proletariat",
+            "text": "stirring",
+        }
+
+    def test_quiet_row_shape(self) -> None:
+        rows = RustClientHost._bulletin_rows(TickBulletin(tick=846, events=()))
+        assert rows == [
+            {
+                "subject": None,
+                "kind": "quiet",
+                "tick": 846,
+                "severity": None,
+                "actor": None,
+                "text": "the wire is quiet",
+            }
+        ]
+
+    def test_reset_on_rebind(self) -> None:
+        driver1 = _FakeDriver(
+            outcomes=[
+                _FakeOutcome(
+                    tick=1,
+                    chronicle=(_event(tick=1, event_type=EventType.UPRISING, summary="revolt"),),
+                )
+            ]
+        )
+        host = _host(session=_FakeSession(), driver=driver1)
+        host.advance_tick()
+        assert json.loads(host.chronicle_rail_json())["rows"]
+
+        host.bind_session(_FakeSession(session_id=UUID(int=99)), _FakeDriver())  # type: ignore[arg-type]
+
+        assert json.loads(host.chronicle_rail_json()) == {"autopause_line": None, "rows": []}
+
+
+# --------------------------------------------------------------------------- #
+# (f) verb_plate_view_json.                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestVerbPlateViewJson:
+    def test_unbound_host_is_null(self) -> None:
+        assert _host().verb_plate_view_json() == "null"
+
+    def test_no_plate_wired_is_null(self) -> None:
+        host = _host(session=_FakeSession(verb_plate_view=None))
+        assert host.verb_plate_view_json() == "null"
+
+    def test_bound_session_round_trips_the_real_view_model(self) -> None:
+        view = _verb_plate_view()
+        host = _host(session=_FakeSession(verb_plate_view=view))
+
+        payload = json.loads(host.verb_plate_view_json())
+
+        assert payload["kind"] == "verb_plate"
+        assert payload["org_id"] == "rev_workers"
+        assert payload["tick"] == 3
+        assert payload["verbs"][0]["verb"] == "educate"
+        assert payload["verbs"][0]["preview"]["action_point_cost"] == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# (g) issue_verb.                                                              #
+# --------------------------------------------------------------------------- #
+
+
+class TestIssueVerb:
+    def test_no_session_is_a_refusal(self) -> None:
+        args = json.dumps({"verb": "educate", "target_id": None, "target_community": None})
+        payload = json.loads(_host().issue_verb(args))
+        assert payload == {
+            "ok": False,
+            "error": "issue_verb: no live campaign attached — nothing to act on",
+        }
+
+    def test_success_envelope_threads_the_args_through(self) -> None:
+        session = _FakeSession(issue_verb_result=17)
+        host = _host(session=session)
+        args = json.dumps({"verb": "educate", "target_id": "sc-x", "target_community": None})
+
+        payload = json.loads(host.issue_verb(args))
+
+        assert payload == {"ok": True, "turn_id": 17}
+        assert session.issue_verb_calls == [("educate", "sc-x", None)]
+
+    @pytest.mark.parametrize(
+        "exc",
+        [RuntimeError("institutional macro-action"), ValueError("cannot afford"), KeyError("nope")],
+    )
+    def test_each_caught_exception_type_is_a_refusal(self, exc: Exception) -> None:
+        session = _FakeSession(issue_verb_result=exc)
+        host = _host(session=session)
+        args = json.dumps({"verb": "attack", "target_id": None, "target_community": None})
+
+        payload = json.loads(host.issue_verb(args))
+
+        assert payload["ok"] is False
+        assert payload["error"]
+
+    def test_an_uncaught_exception_type_propagates(self) -> None:
+        session = _FakeSession(issue_verb_result=TypeError("not one of the three"))
+        host = _host(session=session)
+        args = json.dumps({"verb": "attack", "target_id": None, "target_community": None})
+
+        with pytest.raises(TypeError, match="not one of the three"):
+            host.issue_verb(args)
+
+
+# --------------------------------------------------------------------------- #
+# (h) endgame_status_json.                                                     #
+# --------------------------------------------------------------------------- #
+
+
+class TestEndgameStatusJson:
+    def test_unbound_host_is_null(self) -> None:
+        assert _host().endgame_status_json() == "null"
+
+    def test_bound_session_with_no_projection_wired_is_null(self) -> None:
+        host = _host(session=_FakeSession(endgame_status=None))
+        assert host.endgame_status_json() == "null"
+
+    def test_bound_session_round_trips_the_real_status_model(self) -> None:
+        status = _endgame_status()
+        host = _host(session=_FakeSession(endgame_status=status))
+
+        payload = json.loads(host.endgame_status_json())
+
+        assert payload["pattern"] is None
+        assert payload["game_over"] is False
+        assert payload["horizon_tick"] == 5200
+        assert payload["axes"]["revolutionary_victory"] == 0.1
+
+
+# --------------------------------------------------------------------------- #
+# (i) pin_watchlist.                                                           #
+# --------------------------------------------------------------------------- #
+
+
+class TestPinWatchlist:
+    def test_no_session_or_store_is_a_refusal(self) -> None:
+        args = json.dumps({"subject": "county/26163", "pinned": True})
+        payload = json.loads(_host().pin_watchlist(args))
+        assert payload["ok"] is False
+
+    def test_no_watchlist_store_wired_is_a_refusal(self) -> None:
+        args = json.dumps({"subject": "county/26163", "pinned": True})
+        payload = json.loads(_host(session=_FakeSession()).pin_watchlist(args))
+        assert payload["ok"] is False
+
+    def test_pin_then_unpin_round_trips(self) -> None:
+        persistence = InMemoryWatchlistPersistence()
+        host = _host(session=_FakeSession(), watchlist_persistence=persistence)
+
+        pin_payload = json.loads(
+            host.pin_watchlist(json.dumps({"subject": "county/26163", "pinned": True}))
+        )
+        assert pin_payload == {"ok": True, "pinned": True}
+        assert json.loads(host.watchlist_json()) == [{"subject": "county/26163"}]
+
+        unpin_payload = json.loads(
+            host.pin_watchlist(json.dumps({"subject": "county/26163", "pinned": False}))
+        )
+        assert unpin_payload == {"ok": True, "pinned": False}
+        assert json.loads(host.watchlist_json()) == []
+
+    def test_pin_is_idempotent(self) -> None:
+        persistence = InMemoryWatchlistPersistence()
+        host = _host(session=_FakeSession(), watchlist_persistence=persistence)
+        args = json.dumps({"subject": "county/26163", "pinned": True})
+
+        host.pin_watchlist(args)
+        second = json.loads(host.pin_watchlist(args))
+
+        assert second == {"ok": True, "pinned": True}
+        assert json.loads(host.watchlist_json()) == [{"subject": "county/26163"}]
+
+    def test_unpin_is_idempotent(self) -> None:
+        persistence = InMemoryWatchlistPersistence()
+        host = _host(session=_FakeSession(), watchlist_persistence=persistence)
+        args = json.dumps({"subject": "county/26163", "pinned": False})
+
+        first = json.loads(host.pin_watchlist(args))
+
+        assert first == {"ok": True, "pinned": False}
+        assert json.loads(host.watchlist_json()) == []
+
+    def test_capacity_value_error_is_a_refusal(self) -> None:
+        persistence = InMemoryWatchlistPersistence()
+        host = _host(session=_FakeSession(), watchlist_persistence=persistence)
+        for i in range(DEFAULT_WATCHLIST_CAPACITY):
+            host.pin_watchlist(json.dumps({"subject": f"county/{i:05d}", "pinned": True}))
+
+        payload = json.loads(
+            host.pin_watchlist(json.dumps({"subject": "county/overflow", "pinned": True}))
+        )
+
+        assert payload["ok"] is False
+        assert "capacity" in payload["error"]
+        # The refused pin never landed.
+        assert len(json.loads(host.watchlist_json())) == DEFAULT_WATCHLIST_CAPACITY
+
+
+# --------------------------------------------------------------------------- #
+# (j) nav_state_json / save_nav_state.                                        #
+# --------------------------------------------------------------------------- #
+
+
+class TestNavState:
+    def test_unbound_host_is_empty(self) -> None:
+        assert json.loads(_host().nav_state_json()) == {"jumplist": [], "breadcrumbs": []}
+
+    def test_no_persistence_wired_is_empty(self) -> None:
+        host = _host(session=_FakeSession())
+        assert json.loads(host.nav_state_json()) == {"jumplist": [], "breadcrumbs": []}
+
+    def test_save_nav_state_no_session_is_a_refusal(self) -> None:
+        args = json.dumps({"jumplist": [], "breadcrumbs": []})
+        payload = json.loads(_host().save_nav_state(args))
+        assert payload["ok"] is False
+
+    def test_round_trip_via_in_memory_nav_persistence(self) -> None:
+        persistence = InMemoryNavPersistence()
+        host = _host(session=_FakeSession(), nav_persistence=persistence)
+        nav = {"jumplist": ["county/26163", "org/uaw-9999"], "breadcrumbs": ["county/26163"]}
+
+        save_result = json.loads(host.save_nav_state(json.dumps(nav)))
+
+        assert save_result == {"ok": True}
+        assert json.loads(host.nav_state_json()) == nav
+
+    def test_duplicates_are_allowed_not_deduped(self) -> None:
+        # Only the watchlist enforces uniqueness — jumplist/breadcrumb rows
+        # allow duplicates; the round-trip must NOT assert dedup.
+        persistence = InMemoryNavPersistence()
+        host = _host(session=_FakeSession(), nav_persistence=persistence)
+        nav = {"jumplist": ["a", "a", "b"], "breadcrumbs": ["a", "a"]}
+
+        host.save_nav_state(json.dumps(nav))
+
+        assert json.loads(host.nav_state_json()) == nav
+
+
+# --------------------------------------------------------------------------- #
+# (k) Verb-resolution mirror (contract §3's RECORDED DEVIATION).              #
+# --------------------------------------------------------------------------- #
+
+_ORG = "rev_workers"
+_COMMUNITY = "comm_detroit"
+
+
+class _TurnJournal:
+    """Structural ``TurnSink`` — plays the ``game_turn`` table's role
+    in-memory (rebuilt locally, per this unit-tier module's own docstring —
+    the source ``test_verb_resolution.py`` is ``pytest.mark.integration``)."""
+
+    def __init__(self) -> None:
+        self.rows: list[dict[str, Any]] = []
+
+    def submit_turn(
+        self,
+        session_id: UUID,
+        tick: int,
+        org_id: str,
+        verb: str,
+        *,
+        action_type: str | None = None,
+        target_id: str | None = None,
+        target_community: str | None = None,
+        params_json: dict[str, Any] | None = None,
+    ) -> int:
+        self.rows.append(
+            {
+                "session_id": session_id,
+                "tick": tick,
+                "org_id": org_id,
+                "verb": verb,
+                "action_type": action_type,
+                "target_id": target_id,
+                "target_community": target_community,
+                "params_json": params_json,
+            }
+        )
+        return len(self.rows)
+
+
+class _VerbResolutionSession:
+    """A ``CampaignHandle`` double whose ``issue_verb`` really queues
+    through :func:`~babylon.projection.verbs.submit.submit_verb` — mirrors
+    ``GameSession.issue_verb``'s own real write path, minus the registry
+    persona gate (which needs no live registry row for this fixture's
+    org/verb)."""
+
+    def __init__(
+        self, *, session_id: UUID, tick: int, graph: BabylonGraph, journal: _TurnJournal
+    ) -> None:
+        self.session_id = session_id
+        self.tick = tick
+        self._graph = graph
+        self._journal = journal
+
+    def issue_verb(
+        self,
+        action_id: str,
+        *,
+        target_id: str | None = None,
+        target_community: str | None = None,
+    ) -> int:
+        return submit_verb(
+            self._journal,
+            session_id=self.session_id,
+            tick=self.tick,
+            org_id=_ORG,
+            verb=action_id,
+            graph=self._graph,
+            target_id=target_id,
+            target_community=target_community,
+        )
+
+
+def _verb_graph() -> BabylonGraph:
+    """One player faction with a community in reach (OODA-minimal shape) —
+    same fixture shape as ``test_verb_resolution.py``'s own ``_graph``."""
+    graph = BabylonGraph()
+    graph.add_node(
+        _ORG,
+        NodeType.ORGANIZATION,
+        id=_ORG,
+        org_type=OrgType.POLITICAL_FACTION.value,
+        territory_ids=["detroit"],
+        consciousness_tendency="revolutionary",
+        cadre_level=0.6,
+        cohesion=0.6,
+        budget=50.0,
+        heat=0.1,
+    )
+    graph.add_node(
+        _COMMUNITY,
+        NodeType.COMMUNITY,
+        id=_COMMUNITY,
+        collective_identity=0.3,
+        ideological_contestation=0.2,
+        heat=0.0,
+        infrastructure=0.5,
+    )
+    graph.add_node("detroit", NodeType.TERRITORY)
+    return graph
+
+
+def _ooda_services() -> MagicMock:
+    services = MagicMock()
+    services.defines = GameDefines()
+    services.event_bus = MagicMock()
+    return services
+
+
+class TestVerbResolutionMirror:
+    """See this module's own docstring: the RECORDED DEVIATION fixture —
+    no "remaining actions decrement" assertion (that counter is dormant in
+    production); only the two REAL behaviors the integration test pins."""
+
+    def test_a_submitted_verb_reaches_turn_resolution_through_the_engine(self) -> None:
+        graph = _verb_graph()
+        journal = _TurnJournal()
+        session = _VerbResolutionSession(
+            session_id=_SESSION_ID, tick=1, graph=graph, journal=journal
+        )
+        host = _host(session=session)
+
+        args = json.dumps({"verb": "educate", "target_id": _COMMUNITY, "target_community": None})
+        payload = json.loads(host.issue_verb(args))
+        assert payload["ok"] is True
+
+        player_actions = build_player_actions(journal.rows)
+        context = TickContext(tick=1, persistent_data={"player_actions": player_actions})
+        OODASystem().step(graph, _ooda_services(), context)
+
+        resolution = context.persistent_data["turn_resolution"]
+        ours = [r for r in resolution["action_phase_results"] if r["action"]["org_id"] == _ORG]
+        assert ours, "the queued player action must resolve in the action phase"
+        assert any(r["action"]["action_type"] == "educate" for r in ours)
+
+    def test_an_unaffordable_submission_is_refused_before_the_queue(self) -> None:
+        graph = _verb_graph()
+        graph.update_node(_ORG, budget=0.0, cadre_level=0.0, cohesion=0.0)
+        journal = _TurnJournal()
+        session = _VerbResolutionSession(
+            session_id=_SESSION_ID, tick=1, graph=graph, journal=journal
+        )
+        host = _host(session=session)
+
+        args = json.dumps({"verb": "educate", "target_id": _COMMUNITY, "target_community": None})
+        payload = json.loads(host.issue_verb(args))
+
+        assert payload["ok"] is False
+        assert "Cannot afford" in payload["error"]
+        assert journal.rows == []


### PR DESCRIPTION
## Raster cutover M2 — the client becomes playable (Amendment AC / ADR150)

Plan Tasks 21–26 (`docs/superpowers/plans/2026-07-26-ratatui-client.md`), contracts pinned first in `docs/superpowers/specs/2026-07-27-m2-seam-contracts.md` from a six-scout sweep of the real Python estates.

### What lands
- **Host seam +11 methods, both sides** — `pacing_state_json` / `advance_tick` / `run_until_paused` / `acknowledge_pause` (ok-envelopes; hand-built `{tick, paused, chronicle}` order — `TickAdvanceResult.__slots__` is alphabetical, never introspected), host-owned chronicle accumulator → `chronicle_rail_json` (salience ships as render-ready data; Rust renders, never ranks), `verb_plate_view_json`, `issue_verb` (catches ONLY the Textual refusal trio), `endgame_status_json`, `pin_watchlist`, `nav_state_json` / `save_nav_state`. Every method fits the existing call0/call1 FFI helpers via the single-JSON-arg convention — zero new PyO3 plumbing.
- **The play screen** — HUD strip (tick/horizon counter, five 8-cell endgame gauges, PACING line), watchlist rail left, dossier center, chronicle rail right, verb plate bottom (F1–F9 **and click** dispatch, preview AP·P% + CRIMSON warnings), one status line. Tab focus cycle with a visible ● marker; Esc defocuses a rail.
- **Tick controls** through the Textual pre-check ladder (locked → awaiting_ack → busy, verbatim refusal strings); the 6-step post-tick refresh fanout in Textual's exact order; honest-target verb dispatch (the `_honest_target_id` port — a target is passed only when it is a real member of `candidate_target_ids`).
- **Watchlist pin writes + nav persistence** — FIFO/idempotent pins through the same store the reads use; nav restore rides a post-bind pull, saves dedupe/cap at the nav capacity and check their ack.

### Recorded deviations (scout-driven, in the contract doc)
1. **No "remaining actions" assertion** — the plan's Task-23 test spec named a dormant feature (`enforce_action_points` has no production caller); the contract test mirrors `test_verb_resolution.py`'s two real behaviors instead.
2. **Envelopes, not `-> None`** — the sketch's void `pin_watchlist` would crash the client on the player-reachable capacity ValueError.
3. **Nav restore never via `config_json`** (it predates campaign selection); post-bind pull, Back-to-lobby is the sole save point.
4. **No `quiet` row kind** — `chronicle_stream` never emits an empty bulletin; the variant would be dead code behind a hand-built test shape.

### Verification
- **43-finding 3-lens Opus verify panel, fully remediated** (headlines: Esc from a focused rail tore down the whole campaign; parse failures masqueraded as "campaign ended"; the fifth HUD gauge clipped at 80 cols into a lying bar; resumed campaigns grew the persisted jumplist without bound).
- **Real-vault smoke through the production composition root**: 5 real engine ticks with the autopause/ack ladder exercised by real critical events, a real verb queued, pin persistence proven across sessions, nav saved on exit.
- Gates: `mise run rust:check` green (336 tests, clippy -D all-features, rustdoc); 93 seam-adjacent Python tests green; `test:unit` green modulo the 16 pre-existing unmounted-drive environment failures (CI provisions the DB artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)