### PR TITLE
fix(cli): terminal takeover for the Rust client lane — Gate 3 blocker

### DIFF
--- a/src/babylon/cli/play.py
+++ b/src/babylon/cli/play.py
@@ -79,6 +79,8 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import sys
+from contextlib import contextmanager
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -87,7 +89,7 @@ from uuid import UUID
 import typer
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
     from typing import Any
 
     from babylon.config.defines import GameDefines
@@ -395,6 +397,63 @@ def _tutorial_progress_factory(
     return _factory
 
 
+@contextmanager
+def _terminal_takeover() -> Iterator[None]:
+    """Make the terminal the Rust client's alone for the duration.
+
+    Gate 3 blocker (2026-07-27): the root logger's console handler kept
+    writing to the tty while the Rust client painted the alternate screen
+    — dulwich emitted records on every vault touch, and the immediate-mode
+    client only repaints on input, so one stray line corrupted the frame
+    until the next keypress. The Textual ``App`` captured stdout/stderr
+    and print output implicitly while running; this is the Rust lane's
+    explicit equivalent:
+
+    - every root handler that streams to the terminal is detached (file
+      handlers keep recording everything — nothing is silenced, only
+      re-routed);
+    - ``sys.stdout``/``sys.stderr`` are redirected into
+      ``LOG_DIR/client-capture.log`` so stray ``print``s (and the FFI
+      panic path's ``PyErr::print`` traceback) land somewhere auditable.
+
+    The Rust client writes the TUI through the RAW file descriptor, so
+    redirecting the PYTHON stream objects never touches its rendering.
+    Both the handlers and the streams restore on every exit path — a
+    panicking client still hands back a console that logs.
+    """
+    import logging
+
+    from babylon.config.base import BaseConfig
+
+    root = logging.getLogger()
+    tty_streams = {
+        stream
+        for stream in (sys.stdout, sys.stderr, sys.__stdout__, sys.__stderr__)
+        if stream is not None
+    }
+    detached = [
+        handler
+        for handler in root.handlers
+        if isinstance(handler, logging.StreamHandler)
+        and not isinstance(handler, logging.FileHandler)
+        and getattr(handler, "stream", None) in tty_streams
+    ]
+    for handler in detached:
+        root.removeHandler(handler)
+    BaseConfig.LOG_DIR.mkdir(parents=True, exist_ok=True)
+    outer_stdout, outer_stderr = sys.stdout, sys.stderr
+    with open(BaseConfig.LOG_DIR / "client-capture.log", "a", encoding="utf-8") as capture:
+        sys.stdout = capture
+        sys.stderr = capture
+        try:
+            yield
+        finally:
+            sys.stdout = outer_stdout
+            sys.stderr = outer_stderr
+            for handler in detached:
+                root.addHandler(handler)
+
+
 def _run_rust_client(*, narrator_enabled: bool, tutorial_enabled: bool | None) -> None:
     """Boot the Rust/Ratatui client lane (M0 lobby hello-frame + M1 read wiring).
 
@@ -481,7 +540,8 @@ def _run_rust_client(*, narrator_enabled: bool, tutorial_enabled: bool | None) -
             "headless": False,
         }
     )
-    babylon_tui.run(host, config_json)
+    with _terminal_takeover():
+        babylon_tui.run(host, config_json)
 
 
 def run(

--- a/tests/unit/cli/test_play.py
+++ b/tests/unit/cli/test_play.py
@@ -372,6 +372,70 @@ class TestClientRustLane:
         # The textual app must never boot on the rust lane.
         assert _captured == []
 
+    def test_rust_lane_takes_over_the_terminal_during_run(
+        self, monkeypatch: pytest.MonkeyPatch, _patched_composition_root: None
+    ) -> None:
+        """Gate 3 blocker (2026-07-27): while ``babylon_tui.run`` owns the
+        terminal, NOTHING Python-side may write to it — dulwich DEBUG
+        records sprayed over the alternate screen on every vault touch,
+        and the immediate-mode client only repaints on input, so one
+        stray line wrecks the frame until the next keypress. The Textual
+        App captured stdout/logging implicitly; the Rust lane must do it
+        explicitly: console logging handlers detached and
+        ``sys.stdout``/``sys.stderr`` redirected for exactly the run."""
+        import logging
+        import sys
+
+        root = logging.getLogger()
+        console = logging.StreamHandler(sys.stdout)
+        root.addHandler(console)
+        outer_stdout, outer_stderr = sys.stdout, sys.stderr
+        seen: dict[str, object] = {}
+
+        def fake_run(_host: object, _config_json: str) -> None:
+            seen["console_detached"] = console not in logging.getLogger().handlers
+            seen["stdout_redirected"] = sys.stdout is not outer_stdout
+            seen["stderr_redirected"] = sys.stderr is not outer_stderr
+
+        try:
+            monkeypatch.setitem(sys.modules, "babylon_tui", SimpleNamespace(run=fake_run))
+            play_cmd.run(client=play_cmd.ClientKind.RUST, narrator_enabled=False)
+            assert seen == {
+                "console_detached": True,
+                "stdout_redirected": True,
+                "stderr_redirected": True,
+            }
+            assert console in root.handlers, "console handler restored after the run"
+            assert sys.stdout is outer_stdout and sys.stderr is outer_stderr
+        finally:
+            root.removeHandler(console)
+
+    def test_rust_lane_restores_the_terminal_when_the_client_raises(
+        self, monkeypatch: pytest.MonkeyPatch, _patched_composition_root: None
+    ) -> None:
+        """A panicking client (PanicException reaches this seam, the M1
+        III.11 path) must still hand back a working console — handlers
+        and streams restore on the raise path too."""
+        import logging
+        import sys
+
+        root = logging.getLogger()
+        console = logging.StreamHandler(sys.stdout)
+        root.addHandler(console)
+        outer_stdout = sys.stdout
+
+        def raising_run(_host: object, _config_json: str) -> None:
+            raise RuntimeError("client died mid-frame")
+
+        try:
+            monkeypatch.setitem(sys.modules, "babylon_tui", SimpleNamespace(run=raising_run))
+            with pytest.raises(RuntimeError, match="client died mid-frame"):
+                play_cmd.run(client=play_cmd.ClientKind.RUST, narrator_enabled=False)
+            assert console in root.handlers
+            assert sys.stdout is outer_stdout
+        finally:
+            root.removeHandler(console)
+
     def test_rust_host_load_campaign_binds_a_real_session(
         self, monkeypatch: pytest.MonkeyPatch, _patched_composition_root: None
     ) -> None:


### PR DESCRIPTION
## Summary

The Director's Gate 3 playthrough hit a screen-wide log spray: the root logger's **console handler kept streaming to the tty while the Rust client painted the alternate screen**. dulwich (the vault's git backend) logs on every page bake/read, and the immediate-mode client only repaints on input — one stray record corrupts the frame until the next keypress. Textual's `App` captured stdout/stderr implicitly; the Rust lane never took over that duty.

`_terminal_takeover()` now wraps `babylon_tui.run`: console-streaming root handlers detached (file handlers keep recording everything — re-routed, never silenced), `sys.stdout`/`sys.stderr` redirected to `LOG_DIR/client-capture.log` (stray prints and the FFI panic path's `PyErr::print` stay auditable), both restored on every exit path including the raising one. The Rust TUI paints through the raw fd and is untouched.

## Verification

- TDD: both pins written red first (takeover active during run; restore on raise)
- `tests/unit/cli/test_play.py` 22/22; mypy clean; full `mise run check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)