### PR TITLE
feat(render): M4 Task 35 — the pixel tier (contract §7)

### DIFF
--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -17,8 +17,14 @@ meta:
     seams; four-kind glyph floor; hypergraph 3D + contradiction-field
     surface behind the raster feature (wheel carries it unconditionally);
     camera = discrete deterministic client state. 26-finding 3-lens Opus
-    panel fully remediated (5ddd3508). Tasks 35 (pixel tier — contract §7
-    rules GO with a FontSize prerequisite) + 36 (close-out smoke) remain;
+    panel fully remediated (5ddd3508). Task 35 EXECUTED post-merge
+    (feature/ratatui-m4-pixel): FontSize prerequisite closed end-to-end —
+    TIOCGWINSZ cell-size probe, probe-time demotion (kitty+cells only),
+    [render] round-trip, render_config_json call0 read at bind through
+    the recording seam, kitty-only StatefulProtocol pixel path (chafa-free
+    ratatui-image, hypergraph-rs raster-png render_pixels), declared
+    client re-guard; deviations §9.15-21. Owner-terminal smoke folded
+    into Task 36 (close-out) — blocking for calling the tier DONE;
     BD GATE 3 still pending (the Director's ceremony); interface master
     plan drafted (reports/interface-master-plan.md, 7 Director rulings
     requested) — Wave 1 (keybar/help/mouse parity) recommended to pre-empt

--- a/docs/superpowers/specs/2026-07-27-m4-topology-contracts.md
+++ b/docs/superpowers/specs/2026-07-27-m4-topology-contracts.md
@@ -303,3 +303,44 @@ twice-bitten gotcha). This is planned drift, not regression.
 14. Test-fixture community ids (`union_local` etc.) are wire-unreachable
     (`PaohEdge.community_id` is `CommunityType`-typed) — cosmetic in
     pass-through tests, noted for the next fixture touch.
+
+### Task 35 execution round (the pixel tier landing)
+
+15. **Kitty-only pixel path — no ratatui-image Halfblocks lane.** §7's
+    "Halfblocks is the universal floor" described the crate's landscape,
+    not a requirement: OUR universal floor is the Tier-0 braille glyph
+    canon (ADR097 D1), already built and strictly richer than halfblock
+    cells. `pixel_decision()` engages `StatefulProtocolType::Kitty` or
+    renders the glyph floor — a ratatui-image Halfblocks path would be a
+    second, worse floor.
+16. **Demotion happens at PROBE TIME, re-guarded at consumption.**
+    `derive_tiers` now yields PIXEL only for kitty + known cell size;
+    sixel and missing-FontSize verdicts persist `tier = "glyph"` with the
+    degradation declared in the doctor verdict. The client's declared
+    arms (`pixel_decision`) therefore only fire on a hand-edited config —
+    both layers declare, neither trusts (III.11).
+17. **Cell size via one `TIOCGWINSZ` ioctl** (`ws_xpixel/ws_ypixel ÷
+    cols/rows`), not an escape-sequence round trip; zero/absent pixel
+    fields read as honest `None`. POSIX-only by construction (Amendment
+    AA disclosure: Windows cell-size probing is a post-1.0 item).
+18. **The recorded verdict crosses at BIND, not boot** —
+    `render_config_json` is fetched where `PlayChrome` materializes,
+    through the recording seam (the transcript's host-call log attests
+    it; `app_shell.rs`'s order pin gained the entry). The transcript
+    GOLDEN did not drift: it pins frames only, and a glyph-default
+    session renders identically — verified against the regenerated
+    file, not assumed.
+19. **ratatui-image ships chafa by default** — `chafa-dyn` (a native C
+    library via pkg-config) is in the crate's default feature set; the
+    dep is declared `default-features = false, features = ["crossterm"]`
+    to keep the client C-toolchain-free (the babylon-md syntect
+    precedent). `image` 0.25 is types-only (no codecs).
+20. **The `from_query_stdio` sentinel gained comment-awareness** after
+    firing on its own citation in `config.rs`'s docs — the same
+    `//`-blanking the hypergraph ban already had, with a mutation case
+    proving a comment citation is legal while adjacent code still fires.
+21. **Owner-terminal live smoke remains OPEN** (§7: non-blocking for the
+    build, blocking for calling the tier DONE) — folded into Task 36's
+    close-out smoke: `babylon doctor` in the Director's kitty terminal,
+    then `babylon play --client rust` → topology pane renders the pixel
+    plate (or a declared degradation, never silence).

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -111,9 +111,11 @@ version = "0.1.0"
 dependencies = [
  "babylon-md",
  "hypergraph-rs",
+ "image",
  "insta",
  "pulldown-cmark",
  "ratatui",
+ "ratatui-image",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -135,6 +137,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bincode"
@@ -173,6 +185,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +222,26 @@ name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "castaway"
@@ -263,7 +307,7 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -345,7 +389,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -498,7 +542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -531,6 +575,15 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -602,6 +655,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +719,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -769,6 +839,7 @@ dependencies = [
  "h3o",
  "indexmap",
  "ndarray",
+ "png",
  "rand 0.10.2",
  "rand_core 0.10.1",
  "rand_pcg",
@@ -780,10 +851,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "icy_sixel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85518b9086bf01117761b90e7691c0ef3236fa8adfb1fb44dd248fe5f87215d5"
+dependencies = [
+ "quantette",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+]
 
 [[package]]
 name = "indexmap"
@@ -919,6 +1013,12 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1019,7 +1119,17 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1076,7 +1186,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1200,12 +1310,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
 dependencies = [
  "approx 0.5.1",
+ "bytemuck",
  "fast-srgb8",
  "libm",
  "palette_derive",
@@ -1378,6 +1495,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1527,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -1457,6 +1596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
 name = "pyo3"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1659,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "quantette"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98fecda8b16396ff9adac67644a523dd1778c42b58606a29df5c31ca925d174"
+dependencies = [
+ "bitvec",
+ "bytemuck",
+ "image",
+ "libm",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "palette",
+ "rand 0.9.5",
+ "rand_xoshiro",
+ "rayon",
+ "ref-cast",
+ "wide",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,12 +1709,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
+ "libc",
+ "rand_chacha",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1564,10 +1746,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
 name = "rand_core"
@@ -1592,6 +1793,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1642,6 +1852,23 @@ dependencies = [
  "crossterm",
  "instability",
  "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-image"
+version = "11.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000b7a22eae639460bc6ec8bb1cc689ecae5b0ed21935cd7d7dd52d38270c86"
+dependencies = [
+ "base64-simd",
+ "icy_sixel",
+ "image",
+ "rand 0.8.7",
+ "ratatui",
+ "rustix 0.38.44",
+ "self_cell",
+ "thiserror 1.0.69",
+ "windows",
 ]
 
 [[package]]
@@ -1742,6 +1969,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,6 +2063,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1823,8 +2083,8 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1861,6 +2121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629516c85c29fe757770fa03f2074cf1eac43d44c02a3de9fc2ef7b0e207dfdd"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +2143,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -2130,6 +2405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,8 +2425,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2156,9 +2437,9 @@ checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
  "bitflags 2.13.1",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2470,6 +2751,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "vte"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,6 +2917,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ca908d26e4786149c48efcf6c0ea09ab0e06d1fe3c17dc1b4b0f1ca4a7e788"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,7 +2948,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2661,10 +2958,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2674,6 +3044,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2691,6 +3125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,6 +3147,26 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zmij"

--- a/rust/crates/babylon-tui-python/src/lib.rs
+++ b/rust/crates/babylon-tui-python/src/lib.rs
@@ -149,6 +149,10 @@ impl Host for PyHost {
     fn field_state_json(&self) -> String {
         self.call0("field_state_json")
     }
+
+    fn render_config_json(&self) -> String {
+        self.call0("render_config_json")
+    }
 }
 
 /// Run the client. Headless configs render the initial frame, replay the

--- a/rust/crates/babylon-tui/Cargo.toml
+++ b/rust/crates/babylon-tui/Cargo.toml
@@ -11,7 +11,12 @@ license.workspace = true
 # clean Phase R + Phase I state (raster/cells3d goldens frozen); the remote
 # was created by the ADR150 owner ceremony 2026-07-27 (public repo — cargo
 # fetches anonymously, so no deploy key is needed; see ADR150).
-raster = ["dep:hypergraph-rs"]
+# Task 35 (contract §7 + §5.3): the pixel tier rides the SAME feature —
+# ratatui-image's StatefulProtocol::new construction path (zero terminal
+# queries; Picker::from_query_stdio* is sentinel-banned) over the git-dep's
+# raster-png `render_pixels`. `image` default-features off: only the
+# in-memory RgbImage/DynamicImage types are needed, no codecs.
+raster = ["dep:hypergraph-rs", "dep:ratatui-image", "dep:image"]
 
 [dependencies]
 # default-features off: highlight-code pulls syntect/onig (a native C
@@ -28,7 +33,14 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "2"
 unicode-width = "0.2"
-hypergraph-rs = { git = "https://github.com/percy-raskova/hypergraph-rs.git", rev = "0c95db0663737b492af27f85e70b223833a18c2e", default-features = false, features = ["cells3d"], optional = true }
+hypergraph-rs = { git = "https://github.com/percy-raskova/hypergraph-rs.git", rev = "0c95db0663737b492af27f85e70b223833a18c2e", default-features = false, features = ["cells3d", "raster-png"], optional = true }
+# default-features off: the default set pulls chafa-dyn — a NATIVE C
+# library via pkg-config — for its chafa halfblock backend; this client is
+# C-toolchain-free (the babylon-md syntect precedent + AA disclosure) and
+# only uses the pure-Rust kitty StatefulProtocol path. `crossterm` matches
+# ratatui's own backend here; image codecs come from our `image` dep pin.
+ratatui-image = { version = "11", default-features = false, features = ["crossterm"], optional = true }
+image = { version = "0.25", default-features = false, optional = true }
 
 [dev-dependencies]
 insta = { version = "1", features = ["filters"] }

--- a/rust/crates/babylon-tui/src/app.rs
+++ b/rust/crates/babylon-tui/src/app.rs
@@ -280,6 +280,11 @@ impl<H: Host> Host for RecordingHost<'_, H> {
         self.inner.field_state_json()
     }
 
+    fn render_config_json(&self) -> String {
+        self.record("render_config_json");
+        self.inner.render_config_json()
+    }
+
     fn new_campaign(&self) -> String {
         self.record("new_campaign");
         self.inner.new_campaign()
@@ -1050,6 +1055,14 @@ impl<H: Host> App<H> {
                 let mut chrome = PlayChrome::new();
                 chrome.hud.set_tick(tick);
                 chrome.home_subject = home_subject;
+                // Task 35 (contract §7): read the recorded [render] verdict
+                // ONCE, at bind — `babylon doctor` probed it; the client
+                // honors the record and never re-probes (ADR097 D4). Goes
+                // through the recording seam so the transcript's host-call
+                // log attests the read like every other host touch.
+                chrome.topology.render_settings = crate::config::RenderSettings::from_json(
+                    &self.recording().render_config_json(),
+                );
                 self.chrome = Some(chrome);
                 // Tutorial arming state resets on every bind (the M2
                 // `_chronicle_history` precedent): a new campaign's

--- a/rust/crates/babylon-tui/src/config.rs
+++ b/rust/crates/babylon-tui/src/config.rs
@@ -3,13 +3,53 @@
 use serde::Deserialize;
 
 /// Rendering tier the client runs at (design §5: glyph floor, pixel gated).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RenderTier {
     /// Universal glyph-cell tier (every terminal).
+    #[default]
     Glyph,
-    /// Pixel tier (kitty/sixel capable terminals; gated at runtime).
+    /// Pixel tier (kitty-capable terminals; gated at runtime — Task 35).
     Pixel,
+}
+
+/// The recorded `[render]` verdict, fetched ONCE from the host at boot via
+/// `render_config_json` (Task 35, contract §7). `babylon doctor` probes;
+/// the client honors the record and NEVER re-probes (ADR097 D4 — the
+/// `Picker::from_query_stdio*` path is sentinel-banned). Defaults are the
+/// glyph floor: honest absence of a probe is a glyph session.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
+pub struct RenderSettings {
+    /// The persisted tier verdict.
+    #[serde(default)]
+    pub tier: RenderTier,
+    /// The probed pixel protocol (`"kitty"`/`"sixel"`), if any. Only
+    /// `"kitty"` can engage the pixel path (ADR099: sixel is not a target).
+    #[serde(default)]
+    pub pixel_protocol: Option<String>,
+    /// Terminal cell width in pixels — `StatefulProtocol`'s FontSize.
+    #[serde(default)]
+    pub cell_width: Option<u16>,
+    /// Terminal cell height in pixels.
+    #[serde(default)]
+    pub cell_height: Option<u16>,
+    /// Whether the probe ran inside tmux (threaded into the kitty
+    /// protocol's tmux passthrough mode).
+    #[serde(default)]
+    pub in_tmux: bool,
+}
+
+impl RenderSettings {
+    /// Parse a `render_config_json` reply. `"null"` (a host with no
+    /// recorded probe — the trait default) is the glyph floor; malformed
+    /// non-null JSON is a protocol bug and fails LOUDLY (the
+    /// `AppConfig::from_json` precedent — no fallback that would silently
+    /// masquerade a seam defect as a glyph session, III.11).
+    pub fn from_json(raw: &str) -> Self {
+        serde_json::from_str::<Option<Self>>(raw)
+            .expect("render_config_json returned malformed JSON — host/client seam defect")
+            .unwrap_or_default()
+    }
 }
 
 /// Malformed client config crossing the FFI.
@@ -194,5 +234,49 @@ mod tests {
                 "headless":true,"headless_size":[2000,2000]}"#
         )
         .is_err());
+    }
+
+    // --- Task 35 (contract §7): the recorded [render] verdict crossing
+    // the seam as `render_config_json`.
+
+    #[test]
+    fn render_settings_null_is_the_glyph_floor() {
+        // The Host trait default ("no probe recorded") parses to defaults.
+        assert_eq!(RenderSettings::from_json("null"), RenderSettings::default());
+        assert_eq!(RenderSettings::default().tier, RenderTier::Glyph);
+    }
+
+    #[test]
+    fn render_settings_full_payload_round_trips() {
+        let settings = RenderSettings::from_json(
+            r#"{"tier":"pixel","palette":"truecolor","pixel_protocol":"kitty",
+                "cell_width":9,"cell_height":18,"in_tmux":false}"#,
+        );
+        assert_eq!(settings.tier, RenderTier::Pixel);
+        assert_eq!(settings.pixel_protocol.as_deref(), Some("kitty"));
+        assert_eq!(
+            (settings.cell_width, settings.cell_height),
+            (Some(9), Some(18))
+        );
+        assert!(!settings.in_tmux);
+    }
+
+    #[test]
+    fn render_settings_honest_absence_fields_parse_as_none() {
+        // The Python host serializes null for unknown facts — never zero.
+        let settings = RenderSettings::from_json(
+            r#"{"tier":"glyph","palette":"256","pixel_protocol":null,
+                "cell_width":null,"cell_height":null,"in_tmux":false}"#,
+        );
+        assert_eq!(settings.pixel_protocol, None);
+        assert_eq!((settings.cell_width, settings.cell_height), (None, None));
+    }
+
+    #[test]
+    #[should_panic(expected = "seam defect")]
+    fn render_settings_malformed_reply_fails_loud() {
+        // III.11: a malformed seam reply is a defect, never silently a
+        // glyph session (the AppConfig loud-parse precedent).
+        let _ = RenderSettings::from_json("not json");
     }
 }

--- a/rust/crates/babylon-tui/src/host.rs
+++ b/rust/crates/babylon-tui/src/host.rs
@@ -176,4 +176,15 @@ pub trait Host {
     fn field_state_json(&self) -> String {
         "null".to_string()
     }
+
+    // --- M4 Task 35: the pixel tier (contract §7).
+
+    /// The recorded `[render]` verdict as one JSON object (`{"tier",
+    /// "palette", "pixel_protocol", "cell_width", "cell_height",
+    /// "in_tmux"}`), or `null` — no probe recorded, the glyph floor.
+    /// Fetched ONCE at boot; the client NEVER re-probes (ADR097 D4 —
+    /// `babylon doctor` probes, runtime honors the record).
+    fn render_config_json(&self) -> String {
+        "null".to_string()
+    }
 }

--- a/rust/crates/babylon-tui/src/views/topology.rs
+++ b/rust/crates/babylon-tui/src/views/topology.rs
@@ -540,9 +540,77 @@ pub struct TopologyView {
     pub field_idx: usize,
     /// Glyph-floor vertical scroll (Up/Down in `Glyph2d`; reset on `g`).
     pub scroll: u16,
+    /// The recorded `[render]` verdict, fetched once at campaign bind
+    /// (Task 35, contract §7) — drives [`pixel_decision`]. Default = the
+    /// glyph floor (no probe recorded).
+    pub render_settings: crate::config::RenderSettings,
     #[cfg(feature = "raster")]
     /// Camera state (contract §6: discrete, deterministic, client-only).
     pub camera: crate::scene3d::CameraState,
+}
+
+/// What the 3D blit path does with the recorded `[render]` verdict
+/// (Task 35, contract §7). Pure policy, computed per frame — testable
+/// without the raster feature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PixelDecision {
+    /// Engage the kitty pixel plate: `StatefulProtocol::new` over the
+    /// recorded FontSize — zero terminal queries (ADR097 D4).
+    Pixel {
+        /// Terminal cell width in pixels (FontSize width).
+        font_w: u16,
+        /// Terminal cell height in pixels (FontSize height).
+        font_h: u16,
+        /// Kitty tmux passthrough mode, from the recorded probe.
+        in_tmux: bool,
+    },
+    /// Render the Tier-0 braille glyph floor. `declared` carries the
+    /// degradation line to paint on the pane when the RECORD promised
+    /// pixel but the promise cannot be kept (III.11: declared, never
+    /// silent); `None` = glyph is simply the recorded tier (canon, not a
+    /// degradation — ADR097 D1).
+    GlyphFloor {
+        /// The declared-degradation line, if degradation occurred.
+        declared: Option<&'static str>,
+    },
+}
+
+/// Resolve the recorded verdict into the frame's blit path. The probe
+/// already demotes sixel/missing-FontSize verdicts to glyph
+/// (`derive_tiers`), so the non-`None` `declared` arms below only fire on
+/// a hand-edited config — the client re-guards rather than trusting the
+/// file (contract §7: sixel NEVER constructs, missing FontSize NEVER
+/// probes).
+pub fn pixel_decision(settings: &crate::config::RenderSettings) -> PixelDecision {
+    use crate::config::RenderTier;
+
+    if settings.tier != RenderTier::Pixel {
+        return PixelDecision::GlyphFloor { declared: None };
+    }
+    match settings.pixel_protocol.as_deref() {
+        Some("kitty") => match (settings.cell_width, settings.cell_height) {
+            (Some(w), Some(h)) if w > 0 && h > 0 => PixelDecision::Pixel {
+                font_w: w,
+                font_h: h,
+                in_tmux: settings.in_tmux,
+            },
+            _ => PixelDecision::GlyphFloor {
+                declared: Some(
+                    "▌ pixel tier recorded without cell pixel size — glyph floor \
+                     (re-run `babylon doctor`; contract §7 FontSize)",
+                ),
+            },
+        },
+        Some("sixel") => PixelDecision::GlyphFloor {
+            declared: Some("▌ sixel recorded — not a target (ADR099); glyph floor"),
+        },
+        _ => PixelDecision::GlyphFloor {
+            declared: Some(
+                "▌ pixel tier recorded without a protocol — glyph floor \
+                 (re-run `babylon doctor`)",
+            ),
+        },
+    }
 }
 
 impl TopologyView {
@@ -964,14 +1032,80 @@ impl TopologyView {
         if inner.width == 0 || inner.height == 0 {
             return;
         }
-        let grid = hypergraph_rs::raster::rasterize(
-            scene,
-            &self.camera.camera(),
-            inner.width,
-            inner.height,
-        );
-        crate::raster_bridge::blit_rect(&grid, frame.buffer_mut(), inner);
+        match pixel_decision(&self.render_settings) {
+            PixelDecision::Pixel {
+                font_w,
+                font_h,
+                in_tmux,
+            } => {
+                // Task 35 (contract §7): rasterize the SAME scene at true
+                // pixel resolution (`raster-png`'s `render_pixels` — the
+                // shared geometry core, only the target resolution differs)
+                // and hand it to ratatui-image's query-free construction
+                // path. A fresh protocol per frame: the camera is discrete
+                // keypress-driven state, so every redraw is a new image
+                // (no persistent encode state to keep coherent).
+                let px_w = u32::from(inner.width) * u32::from(font_w);
+                let px_h = u32::from(inner.height) * u32::from(font_h);
+                let plate = hypergraph_rs::raster::png::render_pixels(
+                    scene,
+                    &self.camera.camera(),
+                    px_w,
+                    px_h,
+                );
+                let mut protocol = ratatui_image::protocol::StatefulProtocol::new(
+                    pixel_plate_to_image(&plate),
+                    ratatui_image::FontSize::new(font_w, font_h),
+                    None,
+                    ratatui_image::protocol::StatefulProtocolType::Kitty(
+                        ratatui_image::protocol::kitty::StatefulKitty::new(1, in_tmux),
+                    ),
+                );
+                let widget = ratatui_image::StatefulImage::<
+                    ratatui_image::protocol::StatefulProtocol,
+                >::new();
+                frame.render_stateful_widget(widget, inner, &mut protocol);
+            }
+            PixelDecision::GlyphFloor { declared } => {
+                let grid = hypergraph_rs::raster::rasterize(
+                    scene,
+                    &self.camera.camera(),
+                    inner.width,
+                    inner.height,
+                );
+                crate::raster_bridge::blit_rect(&grid, frame.buffer_mut(), inner);
+                if let Some(line) = declared {
+                    // Declared degradation (III.11): paint the reason over
+                    // the bottom row of the pane, never a silent fallback.
+                    let bottom = Rect {
+                        x: inner.x,
+                        y: inner.y + inner.height - 1,
+                        width: inner.width,
+                        height: 1,
+                    };
+                    frame.render_widget(
+                        Paragraph::new(line)
+                            .style(ratatui::style::Style::default().fg(crate::theme::CRIMSON)),
+                        bottom,
+                    );
+                }
+            }
+        }
     }
+}
+
+/// Convert a `render_pixels` plate (row-major `Rgb` per pixel, fully
+/// defined — the Tier-1 glyph-floor analogue) into the `DynamicImage`
+/// ratatui-image consumes. Pure, byte-order-pinned by the unit test below.
+#[cfg(feature = "raster")]
+fn pixel_plate_to_image(plate: &hypergraph_rs::raster::png::PixelBuffer) -> image::DynamicImage {
+    let mut raw = Vec::with_capacity((plate.w * plate.h * 3) as usize);
+    for hypergraph_rs::raster::Rgb(r, g, b) in &plate.px {
+        raw.extend([*r, *g, *b]);
+    }
+    let buffer = image::RgbImage::from_raw(plate.w, plate.h, raw)
+        .expect("PixelBuffer invariant px.len() == w*h violated — hypergraph-rs defect");
+    image::DynamicImage::ImageRgb8(buffer)
 }
 
 /// Extract the `(r, g, b)` of a `theme.rs` constant for the raster lane.
@@ -1054,5 +1188,113 @@ mod view_state_tests {
         assert_eq!(view.scroll, 1);
         assert_eq!(view.handle_key(KeyCode::Up), TopologyAction::Handled);
         assert_eq!(view.scroll, 0);
+    }
+
+    /// Task 35 (contract §7): the pixel-path policy table. The probe
+    /// already demotes bad verdicts, so the declared arms are the
+    /// client-side re-guard against hand-edited config.
+    #[test]
+    fn pixel_decision_policy_table() {
+        use crate::config::{RenderSettings, RenderTier};
+
+        // Recorded glyph: the floor, no degradation line (canon, not
+        // degradation — ADR097 D1).
+        assert_eq!(
+            pixel_decision(&RenderSettings::default()),
+            PixelDecision::GlyphFloor { declared: None }
+        );
+        // The one engaging shape: pixel + kitty + both cell dimensions.
+        let good = RenderSettings {
+            tier: RenderTier::Pixel,
+            pixel_protocol: Some("kitty".to_string()),
+            cell_width: Some(9),
+            cell_height: Some(18),
+            in_tmux: false,
+        };
+        assert_eq!(
+            pixel_decision(&good),
+            PixelDecision::Pixel {
+                font_w: 9,
+                font_h: 18,
+                in_tmux: false
+            }
+        );
+        // Kitty without cell dimensions: declared degrade (FontSize gap).
+        let no_cells = RenderSettings {
+            cell_width: None,
+            cell_height: None,
+            ..good.clone()
+        };
+        match pixel_decision(&no_cells) {
+            PixelDecision::GlyphFloor {
+                declared: Some(line),
+            } => assert!(line.contains("cell pixel size"), "{line}"),
+            other => panic!("expected declared glyph floor, got {other:?}"),
+        }
+        // A zero dimension is as unusable as an absent one.
+        let zero_cells = RenderSettings {
+            cell_width: Some(0),
+            cell_height: Some(18),
+            ..good.clone()
+        };
+        assert!(matches!(
+            pixel_decision(&zero_cells),
+            PixelDecision::GlyphFloor { declared: Some(_) }
+        ));
+        // Sixel: never constructs (ADR099), declared.
+        let sixel = RenderSettings {
+            pixel_protocol: Some("sixel".to_string()),
+            ..good.clone()
+        };
+        match pixel_decision(&sixel) {
+            PixelDecision::GlyphFloor {
+                declared: Some(line),
+            } => assert!(line.contains("not a target"), "{line}"),
+            other => panic!("expected declared glyph floor, got {other:?}"),
+        }
+        // Pixel tier with no protocol at all: declared.
+        let no_proto = RenderSettings {
+            pixel_protocol: None,
+            ..good
+        };
+        assert!(matches!(
+            pixel_decision(&no_proto),
+            PixelDecision::GlyphFloor { declared: Some(_) }
+        ));
+        // tmux passthrough flag threads through to the kitty constructor.
+        let tmuxed = RenderSettings {
+            tier: RenderTier::Pixel,
+            pixel_protocol: Some("kitty".to_string()),
+            cell_width: Some(8),
+            cell_height: Some(16),
+            in_tmux: true,
+        };
+        assert_eq!(
+            pixel_decision(&tmuxed),
+            PixelDecision::Pixel {
+                font_w: 8,
+                font_h: 16,
+                in_tmux: true
+            }
+        );
+    }
+
+    /// Task 35: the plate-to-image conversion is byte-order-pinned —
+    /// row-major, RGB triples, dimensions preserved.
+    #[cfg(feature = "raster")]
+    #[test]
+    fn pixel_plate_converts_row_major_rgb() {
+        use hypergraph_rs::raster::png::PixelBuffer;
+        use hypergraph_rs::raster::Rgb;
+
+        let plate = PixelBuffer {
+            w: 2,
+            h: 1,
+            px: vec![Rgb(1, 2, 3), Rgb(4, 5, 6)],
+        };
+        let img = pixel_plate_to_image(&plate);
+        assert_eq!((img.width(), img.height()), (2, 1));
+        let rgb = img.to_rgb8();
+        assert_eq!(rgb.as_raw(), &[1, 2, 3, 4, 5, 6]);
     }
 }

--- a/rust/crates/babylon-tui/tests/app_shell.rs
+++ b/rust/crates/babylon-tui/tests/app_shell.rs
@@ -107,8 +107,10 @@ fn lobby_to_briefing_to_back_to_quit() {
     // Host-call order is the seam contract: catalog once (root build),
     // the campaign BIND (the composition-root verb), known-subjects after
     // the bind, the M2 nav restore, the briefing page read + backlinks,
-    // then the chrome's five post-bind pulls (contract §§1-5), and the
-    // nav save on leaving the campaign (q → lobby).
+    // the recorded-[render] read at chrome build (Task 35 §7 — once per
+    // bind, never a re-probe), then the chrome's five post-bind pulls
+    // (contract §§1-5), and the nav save on leaving the campaign (q →
+    // lobby).
     assert_eq!(
         app.host_calls(),
         vec![
@@ -118,6 +120,7 @@ fn lobby_to_briefing_to_back_to_quit() {
             "nav_state_json".to_string(),
             "read_page_json".to_string(),
             "backlinks_json".to_string(),
+            "render_config_json".to_string(),
             "endgame_status_json".to_string(),
             "pacing_state_json".to_string(),
             "verb_plate_view_json".to_string(),

--- a/src/babylon/cli/play.py
+++ b/src/babylon/cli/play.py
@@ -510,7 +510,17 @@ def _run_rust_client(*, narrator_enabled: bool, tutorial_enabled: bool | None) -
     from babylon.config.defines import GameDefines
     from babylon.game.session import ensure_schema, open_runtime
     from babylon.persistence.babylon_meta import BabylonMetaStore
+    from babylon.render.config import (
+        read_render_config,
+        render_config_path,
+        resolve_active_tier,
+    )
     from babylon.tui.host import RustClientHost
+
+    # Task 35 (contract §7): the recorded [render] verdict is read ONCE here
+    # — `babylon doctor` probes, runtime honors the record (ADR097 D4).
+    # A missing config reads back as the glyph-floor defaults.
+    render_cfg = read_render_config(render_config_path(os.environ))
 
     runtime = open_runtime()
     ensure_schema(runtime)
@@ -529,12 +539,13 @@ def _run_rust_client(*, narrator_enabled: bool, tutorial_enabled: bool | None) -
         nav_persistence=catalog,
         tutorial_steps=steps,
         tutorial_progress_factory=_tutorial_progress_factory(tutorial_enabled, steps),
+        render_config=render_cfg,
     )
     config_json = json.dumps(
         {
             "campaign_id": "",
             "campaign_name": "Lobby",
-            "render_tier": "glyph",
+            "render_tier": resolve_active_tier(None, render_cfg).value,
             "tutorial_enabled": tutorial_enabled is not False,
             "narrator_enabled": narrator_enabled,
             "headless": False,

--- a/src/babylon/render/capability.py
+++ b/src/babylon/render/capability.py
@@ -35,15 +35,19 @@ class CapabilityReport(BaseModel):
     in_tmux: bool
     is_tty: bool
     pixel_protocol: str | None
+    cell_width: int | None
+    cell_height: int | None
 
 
 @runtime_checkable
 class TerminalQuerier(Protocol):
-    """Injection seam for the two facts a probe cannot read from env alone."""
+    """Injection seam for the facts a probe cannot read from env alone."""
 
     def is_a_tty(self) -> bool: ...
 
     def detect_pixel_protocol(self) -> str | None: ...
+
+    def detect_cell_size(self) -> tuple[int, int] | None: ...
 
 
 def probe(env: Mapping[str, str], queries: TerminalQuerier) -> CapabilityReport:
@@ -55,11 +59,16 @@ def probe(env: Mapping[str, str], queries: TerminalQuerier) -> CapabilityReport:
     in_tmux = "TMUX" in env or term.startswith(("tmux", "screen"))
     is_tty = queries.is_a_tty()
 
-    # Guard: only consult the pixel query on a real TTY outside tmux. Non-TTY
+    # Guard: only consult the pixel queries on a real TTY outside tmux. Non-TTY
     # (CI/pipes) and tmux passthrough are treated as honest glyph (III.11).
+    # Cell size shares the guard: it exists solely to serve the pixel path
+    # (contract §7's FontSize prerequisite), so it is only meaningful where a
+    # pixel protocol could be too.
     pixel_protocol: str | None = None
+    cell_size: tuple[int, int] | None = None
     if is_tty and not in_tmux:
         pixel_protocol = queries.detect_pixel_protocol()
+        cell_size = queries.detect_cell_size()
 
     return CapabilityReport(
         term=term,
@@ -69,18 +78,36 @@ def probe(env: Mapping[str, str], queries: TerminalQuerier) -> CapabilityReport:
         in_tmux=in_tmux,
         is_tty=is_tty,
         pixel_protocol=pixel_protocol,
+        cell_width=cell_size[0] if cell_size else None,
+        cell_height=cell_size[1] if cell_size else None,
     )
 
 
 def derive_tiers(report: CapabilityReport) -> tuple[RenderTier, PaletteTier]:
-    """Map a report to the persisted (render tier, palette tier) pair."""
-    tier = RenderTier.PIXEL if report.pixel_protocol else RenderTier.GLYPH
+    """Map a report to the persisted (render tier, palette tier) pair.
+
+    Task 35 (contract §7): the pixel tier requires BOTH a kitty protocol and
+    known cell pixel dimensions — ``StatefulProtocol::new`` needs a FontSize,
+    and re-probing at runtime is banned (ADR097 D4). Sixel is recorded as
+    evidence but never yields the pixel tier (ADR099: sixel is not a target).
+    """
+    pixel_capable = (
+        report.pixel_protocol == "kitty"
+        and report.cell_width is not None
+        and report.cell_height is not None
+    )
+    tier = RenderTier.PIXEL if pixel_capable else RenderTier.GLYPH
     palette = PaletteTier.TRUECOLOR if report.truecolor else PaletteTier.DEGRADED_256
     return tier, palette
 
 
 def verdict_lines(report: CapabilityReport, tier: RenderTier, palette: PaletteTier) -> list[str]:
     """Human-readable doctor verdict — degradation is always stated aloud."""
+    cell = (
+        f"{report.cell_width}x{report.cell_height}px"
+        if report.cell_width is not None and report.cell_height is not None
+        else "unknown"
+    )
     lines = [
         f"render tier: {tier.value}",
         f"palette: {palette.value}",
@@ -88,7 +115,8 @@ def verdict_lines(report: CapabilityReport, tier: RenderTier, palette: PaletteTi
             f"evidence: TERM={report.term or '(unset)'} "
             f"COLORTERM={report.colorterm or '(unset)'} "
             f"tty={report.is_tty} tmux={report.in_tmux} "
-            f"pixel-protocol={report.pixel_protocol or 'none'}"
+            f"pixel-protocol={report.pixel_protocol or 'none'} "
+            f"cell={cell}"
         ),
     ]
     if palette is PaletteTier.DEGRADED_256:
@@ -100,6 +128,21 @@ def verdict_lines(report: CapabilityReport, tier: RenderTier, palette: PaletteTi
         lines.append(
             "note: degraded — no pixel protocol; Tier-0 glyph canon carries all "
             "information (ADR097 D1)."
+        )
+    if tier is RenderTier.GLYPH and report.pixel_protocol == "sixel":
+        lines.append(
+            "note: degraded — sixel detected but sixel is not a target (ADR099); "
+            "Tier-0 glyph floor."
+        )
+    if (
+        tier is RenderTier.GLYPH
+        and report.pixel_protocol == "kitty"
+        and (report.cell_width is None or report.cell_height is None)
+    ):
+        lines.append(
+            "note: degraded — kitty detected but the terminal cell pixel size is "
+            "unknown; the pixel tier needs it for FontSize (contract §7), so the "
+            "glyph floor carries the session."
         )
     return lines
 
@@ -137,3 +180,32 @@ class TextualImageQuerier:
             logger.debug("pixel-protocol detection failed; treating as glyph", exc_info=True)
             return None
         return None
+
+    def detect_cell_size(self) -> tuple[int, int] | None:
+        """Terminal cell pixel dimensions via ``TIOCGWINSZ`` (Task 35, §7).
+
+        ``struct winsize`` carries ``ws_xpixel``/``ws_ypixel`` alongside the
+        row/col counts; one ioctl, no escape-sequence round trip. Terminals
+        that do not fill the pixel fields report 0 — honest ``None`` (the
+        probe verdict then demotes to glyph, declared aloud). POSIX-only by
+        construction; Windows support is a post-1.0 obligation (Amendment AA)
+        and off-POSIX this degrades to ``None``, never raises.
+        """
+        try:
+            import fcntl
+            import struct
+            import termios
+
+            packed = fcntl.ioctl(
+                sys.stdout.fileno(), termios.TIOCGWINSZ, struct.pack("HHHH", 0, 0, 0, 0)
+            )
+            rows, cols, xpixel, ypixel = struct.unpack("HHHH", packed)
+        except ImportError:
+            logger.debug("termios/fcntl unavailable; cell size unknown")
+            return None
+        except OSError:
+            logger.debug("TIOCGWINSZ failed; cell size unknown", exc_info=True)
+            return None
+        if rows == 0 or cols == 0 or xpixel == 0 or ypixel == 0:
+            return None
+        return (xpixel // cols, ypixel // rows)

--- a/src/babylon/render/config.py
+++ b/src/babylon/render/config.py
@@ -20,12 +20,23 @@ from babylon.render.tiers import PaletteTier, RenderTier
 
 
 class RenderConfig(BaseModel):
-    """The runtime-visible slice of ``[render]``."""
+    """The runtime-visible slice of ``[render]``.
+
+    Task 35 (contract §7): the pixel facts round-trip so
+    ``render_config_json`` can carry them to the Rust client without any
+    runtime re-probe (ADR097 D4). ``None`` is honest absence — the persisted
+    sentinels are ``""`` for the protocol and ``0`` for the cell dimensions
+    (TOML has no null).
+    """
 
     model_config = ConfigDict(frozen=True)
 
     tier: RenderTier = RenderTier.GLYPH
     palette: PaletteTier = PaletteTier.DEGRADED_256
+    pixel_protocol: str | None = None
+    cell_width: int | None = None
+    cell_height: int | None = None
+    in_tmux: bool = False
 
 
 def render_config_path(env: Mapping[str, str]) -> Path:
@@ -43,7 +54,16 @@ def read_render_config(config_path: Path) -> RenderConfig:
     render = data.get("render", {})
     tier_raw = render.get("tier", RenderTier.GLYPH.value)
     palette_raw = render.get("palette", PaletteTier.DEGRADED_256.value)
-    return RenderConfig(tier=RenderTier(tier_raw), palette=PaletteTier(palette_raw))
+    cell_width = int(render.get("cell_width", 0)) or None
+    cell_height = int(render.get("cell_height", 0)) or None
+    return RenderConfig(
+        tier=RenderTier(tier_raw),
+        palette=PaletteTier(palette_raw),
+        pixel_protocol=str(render.get("pixel_protocol", "")) or None,
+        cell_width=cell_width,
+        cell_height=cell_height,
+        in_tmux=bool(render.get("in_tmux", False)),
+    )
 
 
 def write_render_section(
@@ -66,6 +86,8 @@ def write_render_section(
     render["truecolor"] = report.truecolor
     render["pixel_protocol"] = report.pixel_protocol or ""
     render["in_tmux"] = report.in_tmux
+    render["cell_width"] = report.cell_width or 0
+    render["cell_height"] = report.cell_height or 0
     document["render"] = render
 
     config_path.write_text(tomlkit.dumps(document), encoding="utf-8")

--- a/src/babylon/tui/host.py
+++ b/src/babylon/tui/host.py
@@ -66,6 +66,7 @@ from typing import TYPE_CHECKING, Protocol
 from uuid import UUID
 
 from babylon.models.event_severity import resolve_severity
+from babylon.render.config import RenderConfig
 from babylon.tui.campaign_menu import CampaignMenu, operation_codename
 from babylon.tui.chronicle import (
     CHRONICLE_ROW_CEILING,
@@ -212,6 +213,7 @@ class RustClientHost:
         nav_persistence: NavPersistence | None = None,
         tutorial_steps: Sequence[TutorialStepSource] | None = None,
         tutorial_progress_factory: TutorialProgressFactory | None = None,
+        render_config: RenderConfig | None = None,
     ) -> None:
         if tutorial_progress_factory is not None and tutorial_steps is None:
             msg = (
@@ -236,6 +238,12 @@ class RustClientHost:
         self._nav_persistence = nav_persistence
         self._tutorial_steps = tutorial_steps
         self._tutorial_progress_factory = tutorial_progress_factory
+        #: The recorded ``[render]`` verdict (Task 35, contract §7) — read
+        #: once by the composition root via
+        #: :func:`babylon.render.config.read_render_config`; ``None`` means
+        #: no probe was ever recorded and :meth:`render_config_json` reports
+        #: the glyph-floor defaults (ADR097 D4: runtime never re-probes).
+        self._render_config = render_config if render_config is not None else RenderConfig()
         #: The lobby mint's own controller (§2) — built lazily, once, by
         #: :meth:`new_campaign` (mirrors ``ArchiveApp``'s own
         #: ``campaign_menu`` object, but this host has no constructor
@@ -1055,6 +1063,32 @@ class RustClientHost:
         if field_view is None:
             return "null"
         return field_view.model_dump_json()
+
+    def render_config_json(self) -> str:
+        """The recorded ``[render]`` verdict, as one JSON object (Task 35, §7).
+
+        The client reads this ONCE at boot and never re-probes (ADR097 D4:
+        ``babylon doctor`` probes; runtime honors the record). ``null`` cell
+        dimensions and protocol are honest absence — the Rust side treats
+        anything short of ``kitty`` + both cell dimensions as the glyph
+        floor, with the degradation declared on the pane (never silent).
+
+        :returns: ``{"tier", "palette", "pixel_protocol", "cell_width",
+            "cell_height", "in_tmux"}`` from the injected
+            :class:`~babylon.render.config.RenderConfig` (glyph-floor
+            defaults when the composition root had no recorded probe).
+        """
+        cfg = self._render_config
+        return json.dumps(
+            {
+                "tier": cfg.tier.value,
+                "palette": cfg.palette.value,
+                "pixel_protocol": cfg.pixel_protocol,
+                "cell_width": cfg.cell_width,
+                "cell_height": cfg.cell_height,
+                "in_tmux": cfg.in_tmux,
+            }
+        )
 
     def issue_verb(self, args_json: str) -> str:
         """Queue one Article V verb through the real write path (Task 23).

--- a/tests/unit/cli/test_play.py
+++ b/tests/unit/cli/test_play.py
@@ -28,6 +28,7 @@ already fakes ``play_cmd.run`` one layer up.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -345,12 +346,20 @@ class TestClientRustLane:
             play_cmd.run(client=play_cmd.ClientKind.RUST)
 
     def test_rust_composes_host_and_hands_off_to_babylon_tui_run(
-        self, monkeypatch: pytest.MonkeyPatch, _patched_composition_root: None
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        _patched_composition_root: None,
     ) -> None:
         import json
         import sys
 
         from babylon.tui.host import RustClientHost
+
+        # Task 35: the composition root now reads the recorded [render]
+        # config — pin the config dir so the DEV MACHINE's real probe
+        # verdict can never leak into this test (empty dir = glyph floor).
+        monkeypatch.setenv("BABYLON_CONFIG_DIR", str(tmp_path))
 
         handoffs: list[tuple[object, str]] = []
         fake = SimpleNamespace(run=lambda host, config_json: handoffs.append((host, config_json)))
@@ -371,6 +380,45 @@ class TestClientRustLane:
         assert callable(host.load_campaign)
         # The textual app must never boot on the rust lane.
         assert _captured == []
+
+    def test_rust_lane_honors_a_recorded_pixel_verdict(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        _patched_composition_root: None,
+    ) -> None:
+        """Task 35 (contract §7): `babylon doctor` probes once; the rust
+        lane reads the record — render_tier crosses as "pixel" and the
+        host's render_config_json carries the FontSize facts verbatim."""
+        import json
+        import sys
+
+        from babylon.tui.host import RustClientHost
+
+        (tmp_path / "config.toml").write_text(
+            "[render]\n"
+            'tier = "pixel"\n'
+            'palette = "truecolor"\n'
+            'pixel_protocol = "kitty"\n'
+            "cell_width = 9\n"
+            "cell_height = 18\n"
+            "in_tmux = false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("BABYLON_CONFIG_DIR", str(tmp_path))
+
+        handoffs: list[tuple[object, str]] = []
+        fake = SimpleNamespace(run=lambda host, config_json: handoffs.append((host, config_json)))
+        monkeypatch.setitem(sys.modules, "babylon_tui", fake)
+
+        play_cmd.run(client=play_cmd.ClientKind.RUST, narrator_enabled=False)
+
+        host, config_json = handoffs[0]
+        assert isinstance(host, RustClientHost)
+        assert json.loads(config_json)["render_tier"] == "pixel"
+        payload = json.loads(host.render_config_json())
+        assert payload["pixel_protocol"] == "kitty"
+        assert (payload["cell_width"], payload["cell_height"]) == (9, 18)
 
     def test_rust_lane_takes_over_the_terminal_during_run(
         self, monkeypatch: pytest.MonkeyPatch, _patched_composition_root: None

--- a/tests/unit/render/test_capability.py
+++ b/tests/unit/render/test_capability.py
@@ -23,9 +23,16 @@ from babylon.render.tiers import PaletteTier, RenderTier
 class FakeQuerier:
     """Stand-in for a real terminal: fully caller-controlled."""
 
-    def __init__(self, *, is_tty: bool, protocol: str | None) -> None:
+    def __init__(
+        self,
+        *,
+        is_tty: bool,
+        protocol: str | None,
+        cell_size: tuple[int, int] | None = None,
+    ) -> None:
         self._is_tty = is_tty
         self._protocol = protocol
+        self._cell_size = cell_size
 
     def is_a_tty(self) -> bool:
         return self._is_tty
@@ -33,19 +40,79 @@ class FakeQuerier:
     def detect_pixel_protocol(self) -> str | None:
         return self._protocol
 
+    def detect_cell_size(self) -> tuple[int, int] | None:
+        return self._cell_size
 
-def _probe(env: Mapping[str, str], *, is_tty: bool, protocol: str | None) -> CapabilityReport:
-    querier: TerminalQuerier = FakeQuerier(is_tty=is_tty, protocol=protocol)
+
+def _probe(
+    env: Mapping[str, str],
+    *,
+    is_tty: bool,
+    protocol: str | None,
+    cell_size: tuple[int, int] | None = None,
+) -> CapabilityReport:
+    querier: TerminalQuerier = FakeQuerier(is_tty=is_tty, protocol=protocol, cell_size=cell_size)
     return probe(env, querier)
 
 
-def test_kitty_truecolor_tty_is_pixel_truecolor() -> None:
+def test_kitty_truecolor_tty_with_cell_size_is_pixel_truecolor() -> None:
     report = _probe(
-        {"TERM": "xterm-kitty", "COLORTERM": "truecolor"}, is_tty=True, protocol="kitty"
+        {"TERM": "xterm-kitty", "COLORTERM": "truecolor"},
+        is_tty=True,
+        protocol="kitty",
+        cell_size=(9, 18),
     )
     assert report.truecolor is True
     assert report.pixel_protocol == "kitty"
+    assert (report.cell_width, report.cell_height) == (9, 18)
     assert derive_tiers(report) == (RenderTier.PIXEL, PaletteTier.TRUECOLOR)
+
+
+def test_kitty_without_cell_size_demotes_to_glyph_and_declares_it() -> None:
+    # Contract §7 (Task 35): the pixel tier's FontSize prerequisite — kitty
+    # with unknown cell pixel dimensions cannot construct a StatefulProtocol
+    # without re-probing, so the VERDICT is glyph, declared aloud.
+    report = _probe(
+        {"TERM": "xterm-kitty", "COLORTERM": "truecolor"},
+        is_tty=True,
+        protocol="kitty",
+        cell_size=None,
+    )
+    assert report.pixel_protocol == "kitty"
+    assert report.cell_width is None
+    tier, palette = derive_tiers(report)
+    assert tier is RenderTier.GLYPH
+    joined = "\n".join(verdict_lines(report, tier, palette))
+    assert "cell pixel size" in joined
+    assert "degraded" in joined.lower()
+
+
+def test_sixel_demotes_to_glyph_with_declared_note() -> None:
+    # ADR099: sixel is not a target — recorded as evidence, never a pixel tier.
+    report = _probe(
+        {"TERM": "foot", "COLORTERM": "truecolor"},
+        is_tty=True,
+        protocol="sixel",
+        cell_size=(8, 16),
+    )
+    assert report.pixel_protocol == "sixel"
+    tier, palette = derive_tiers(report)
+    assert tier is RenderTier.GLYPH
+    joined = "\n".join(verdict_lines(report, tier, palette))
+    assert "sixel" in joined
+    assert "not a target" in joined
+
+
+def test_cell_size_not_consulted_off_tty_or_inside_tmux() -> None:
+    non_tty = _probe({"TERM": "xterm-kitty"}, is_tty=False, protocol=None, cell_size=(9, 18))
+    assert (non_tty.cell_width, non_tty.cell_height) == (None, None)
+    tmuxed = _probe(
+        {"TERM": "tmux-256color", "TMUX": "/tmp/tmux-1000/default,1,0"},
+        is_tty=True,
+        protocol="kitty",
+        cell_size=(9, 18),
+    )
+    assert (tmuxed.cell_width, tmuxed.cell_height) == (None, None)
 
 
 def test_gnome_vte_256_no_pixel_is_glyph_truecolor() -> None:

--- a/tests/unit/render/test_config.py
+++ b/tests/unit/render/test_config.py
@@ -30,6 +30,8 @@ def _report(**kw: object) -> CapabilityReport:
         "in_tmux": False,
         "is_tty": True,
         "pixel_protocol": None,
+        "cell_width": None,
+        "cell_height": None,
     }
     base.update(kw)
     return CapabilityReport(**base)  # type: ignore[arg-type]
@@ -43,10 +45,32 @@ def test_read_missing_config_returns_defaults(tmp_path: Path) -> None:
 
 def test_round_trip_write_then_read(tmp_path: Path) -> None:
     path = tmp_path / "config.toml"
-    write_render_section(path, _report(truecolor=True), RenderTier.PIXEL, PaletteTier.TRUECOLOR)
+    write_render_section(
+        path,
+        _report(truecolor=True, pixel_protocol="kitty", cell_width=9, cell_height=18),
+        RenderTier.PIXEL,
+        PaletteTier.TRUECOLOR,
+    )
     cfg = read_render_config(path)
     assert cfg.tier is RenderTier.PIXEL
     assert cfg.palette is PaletteTier.TRUECOLOR
+    # Task 35: the pixel-tier facts round-trip so render_config_json can
+    # carry them to the client without any re-probe (ADR097 D4).
+    assert cfg.pixel_protocol == "kitty"
+    assert (cfg.cell_width, cfg.cell_height) == (9, 18)
+    assert cfg.in_tmux is False
+
+
+def test_read_back_defaults_when_pixel_fields_absent(tmp_path: Path) -> None:
+    # A pre-Task-35 [render] table (tier/palette only) reads back with honest
+    # absence for the pixel facts — never a fabricated cell size.
+    path = tmp_path / "config.toml"
+    path.write_text('[render]\ntier = "glyph"\npalette = "256"\n', encoding="utf-8")
+    cfg = read_render_config(path)
+    assert cfg.pixel_protocol is None
+    assert cfg.cell_width is None
+    assert cfg.cell_height is None
+    assert cfg.in_tmux is False
 
 
 def test_write_preserves_foreign_tables(tmp_path: Path) -> None:
@@ -64,6 +88,10 @@ def test_write_preserves_foreign_tables(tmp_path: Path) -> None:
     assert data["render"]["tier"] == "glyph"
     assert data["render"]["palette"] == "256"
     assert data["render"]["probed_term"] == "xterm-256color"
+    # Task 35: cell pixel dimensions persist (0 = honestly unknown; TOML has
+    # no null and the pixel_protocol="" precedent is the same convention).
+    assert data["render"]["cell_width"] == 0
+    assert data["render"]["cell_height"] == 0
 
 
 def test_rewrite_updates_render_only(tmp_path: Path) -> None:

--- a/tests/unit/render/test_doctor.py
+++ b/tests/unit/render/test_doctor.py
@@ -10,9 +10,16 @@ from babylon.render.doctor import run_render_probe
 
 
 class _Q:
-    def __init__(self, *, is_tty: bool, protocol: str | None) -> None:
+    def __init__(
+        self,
+        *,
+        is_tty: bool,
+        protocol: str | None,
+        cell_size: tuple[int, int] | None = None,
+    ) -> None:
         self._is_tty = is_tty
         self._protocol = protocol
+        self._cell_size = cell_size
 
     def is_a_tty(self) -> bool:
         return self._is_tty
@@ -20,14 +27,19 @@ class _Q:
     def detect_pixel_protocol(self) -> str | None:
         return self._protocol
 
+    def detect_cell_size(self) -> tuple[int, int] | None:
+        return self._cell_size
+
 
 def test_run_render_probe_persists_and_reports(tmp_path: Path) -> None:
     path = tmp_path / "config.toml"
-    queries: TerminalQuerier = _Q(is_tty=True, protocol="kitty")
+    queries: TerminalQuerier = _Q(is_tty=True, protocol="kitty", cell_size=(9, 18))
     lines = run_render_probe({"TERM": "xterm-kitty", "COLORTERM": "truecolor"}, queries, path)
     data = tomllib.loads(path.read_text(encoding="utf-8"))
     assert data["render"]["tier"] == "pixel"
     assert data["render"]["palette"] == "truecolor"
+    assert data["render"]["cell_width"] == 9
+    assert data["render"]["cell_height"] == 18
     assert any("render tier: pixel" in line for line in lines)
 
 

--- a/tests/unit/sentinels/test_raster_bans.py
+++ b/tests/unit/sentinels/test_raster_bans.py
@@ -96,11 +96,19 @@ def hypergraph_rs_ban_violations(src_root: Path) -> list[str]:
 
 def stdio_probe_ban_violations(crates_root: Path) -> list[str]:
     """Return one ``file:line`` message per ``from_query_stdio`` reference
-    found anywhere under ``crates_root`` (§7)."""
+    found anywhere under ``crates_root`` (§7).
+
+    Comment-aware, mirroring :func:`hypergraph_rs_ban_violations`: a
+    ``//``/``//!``/``///`` line may legitimately DISCUSS the ban
+    (``config.rs``'s ``RenderSettings`` doc cites it) — the ban targets
+    CODE references (Task 35 hit: the checker fired on its own citation).
+    """
     violations: list[str] = []
     for path in _rs_files(crates_root):
         lines = path.read_text(encoding="utf-8").splitlines()
         for lineno, line in enumerate(lines, start=1):
+            if line.lstrip().startswith("//"):
+                continue
             if _STDIO_PROBE_BAN in line:
                 rel = path.relative_to(crates_root)
                 violations.append(f"{rel}:{lineno}: banned {_STDIO_PROBE_BAN!r} — {line.strip()}")
@@ -213,3 +221,20 @@ def test_stdio_probe_ban_checker_ignores_clean_source(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert stdio_probe_ban_violations(tmp_path) == []
+
+
+def test_stdio_probe_ban_checker_ignores_comments_but_not_adjacent_code(tmp_path: Path) -> None:
+    """A doc comment CITING the ban is legal (`config.rs` does); the same
+    string on a code line in the same file still fires — comment-awareness
+    must never blank the whole file (mutation validation, Task 35 hit)."""
+    crate_src = tmp_path / "some-crate" / "src"
+    crate_src.mkdir(parents=True)
+    (crate_src / "picker.rs").write_text(
+        "/// The `Picker::from_query_stdio*` path is sentinel-banned.\n"
+        "// from_query_stdio is banned here too\n"
+        "let picker = Picker::from_query_stdio()?;\n",
+        encoding="utf-8",
+    )
+    violations = stdio_probe_ban_violations(tmp_path)
+    assert len(violations) == 1
+    assert ":3:" in violations[0]

--- a/tests/unit/tui/test_host_contract.py
+++ b/tests/unit/tui/test_host_contract.py
@@ -369,3 +369,47 @@ class TestWatchlistJson:
             {"subject": "org/uaw-9999"},
             {"subject": "county/26163"},
         ]
+
+
+class TestRenderConfigJson:
+    """Task 35 (contract §7): the recorded ``[render]`` verdict crosses the
+    seam as one call0 JSON payload — the client never re-probes (ADR097 D4)."""
+
+    def test_default_host_reports_glyph_with_honest_absence(self) -> None:
+        # No recorded config injected: glyph floor, every pixel fact null/false
+        # (III.11 — absence, never fabricated cell dimensions).
+        payload = json.loads(_host().render_config_json())
+        assert payload == {
+            "tier": "glyph",
+            "palette": "256",
+            "pixel_protocol": None,
+            "cell_width": None,
+            "cell_height": None,
+            "in_tmux": False,
+        }
+
+    def test_recorded_pixel_config_round_trips(self) -> None:
+        from babylon.render.config import RenderConfig
+        from babylon.render.tiers import PaletteTier, RenderTier
+
+        host = RustClientHost(
+            _catalog(),
+            defines_hash=_DEFINES_HASH,
+            engine_version=_ENGINE_VERSION,
+            render_config=RenderConfig(
+                tier=RenderTier.PIXEL,
+                palette=PaletteTier.TRUECOLOR,
+                pixel_protocol="kitty",
+                cell_width=9,
+                cell_height=18,
+            ),
+        )
+        payload = json.loads(host.render_config_json())
+        assert payload == {
+            "tier": "pixel",
+            "palette": "truecolor",
+            "pixel_protocol": "kitty",
+            "cell_width": 9,
+            "cell_height": 18,
+            "in_tmux": False,
+        }

--- a/tests/unit/tui/test_rust_client_ffi.py
+++ b/tests/unit/tui/test_rust_client_ffi.py
@@ -94,6 +94,12 @@ class _FakeHost:
     def new_campaign(self) -> str:
         return json.dumps({"ok": False, "error": "new_campaign not implemented on _FakeHost"})
 
+    # --- M4 Task 35 surface: the bind-time recorded-[render] read. `null`
+    # = no probe recorded — the client parses it to the glyph floor.
+
+    def render_config_json(self) -> str:
+        return "null"
+
 
 def _config(**overrides: object) -> str:
     cfg: dict[str, object] = {
@@ -138,7 +144,9 @@ def test_run_headless_scripted_flow_lobby_to_briefing_to_quit() -> None:
     assert "Briefing" in transcript["frames"][1]
     assert "CAMPAIGNS" in transcript["frames"][2]
     # M2: the bind pulls nav state + the five chrome feeds after the page
-    # read, and leaving the campaign (first q) persists nav.
+    # read — plus the Task 35 recorded-[render] read at chrome build (once
+    # per bind, never a re-probe) — and leaving the campaign (first q)
+    # persists nav.
     assert transcript["host_calls"] == [
         "lobby_catalog_json",
         "load_campaign",
@@ -146,6 +154,7 @@ def test_run_headless_scripted_flow_lobby_to_briefing_to_quit() -> None:
         "nav_state_json",
         "read_page_json",
         "backlinks_json",
+        "render_config_json",
         "endgame_status_json",
         "pacing_state_json",
         "verb_plate_view_json",


### PR DESCRIPTION
## Summary

Task 35 lands the **kitty pixel tier** end-to-end over the recorded `[render]` verdict — the contract §7 FontSize prerequisite closed on both sides of the FFI, zero terminal re-probes anywhere (ADR097 D4).

**Python (probe → record → seam):**
- `CapabilityReport`/`TerminalQuerier` gain cell pixel dimensions via one `TIOCGWINSZ` ioctl (no escape round-trip; off-POSIX → honest `None`)
- `derive_tiers` demotes at probe time: PIXEL only for kitty + known cell size; sixel records as evidence but verdicts glyph with a declared 'not a target (ADR099)' note
- `[render]` persists + round-trips the pixel facts; `RustClientHost.render_config_json` (call0) carries them; `play.py` resolves `render_tier` from the record instead of the hardcoded literal
- Tests pin `BABYLON_CONFIG_DIR` so a dev machine's real probe can't leak into the suite

**Rust (record → decision → plate):**
- `RenderSettings` fetched ONCE at campaign bind through the recording seam (transcripts attest it); `pixel_decision()` is the pure policy table with a unit-tested 7-row truth table
- Engaging shape: `StatefulProtocol::new` (query-free) over `hypergraph-rs raster-png render_pixels` at true pixel resolution; every degraded shape paints a CRIMSON declared line (III.11), never silence
- `ratatui-image` pinned **default-features off** — the default set pulls chafa (native C via pkg-config); this client stays C-toolchain-free
- `from_query_stdio` sentinel gained comment-awareness (fired on its own citation) + a mutation case

**Deviations:** contract §9.15–21. **Owner smoke** (kitty terminal: `babylon doctor` → `babylon play --client rust` → topology pixel plate) folds into Task 36 — blocking for calling the tier DONE, not for this build.

**Local-only red (not this PR):** `check:catalog` + 2 catalog-DB probes fail locally against the trade lane's re-deployed live reference DB (`fact_ricci_unequal_exchange_gvc` awaits its catalog row — that lane's owner-gated item). CI's own data artifacts are unaffected.

Gates: mypy strict, `rust:check` (workspace + no-feature legs + docs), 14k unit locally (minus the cross-lane catalog pair), harness 17/17 ×2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)