### PR TITLE
feat(projection): tension + fog county lens producers (ADR170) + M5 contract amendment

### DIFF
--- a/ai/decisions/ADR170_tension_lens_ruling.yaml
+++ b/ai/decisions/ADR170_tension_lens_ruling.yaml
@@ -1,0 +1,71 @@
+ADR170_tension_lens_ruling:
+  status: "accepted"
+  date: "2026-07-28"
+  title: >
+    The map tension lens is county_extraction (the Fundamental Theorem
+    localized): Director-ruled four-question slate — Candidate 1
+    principal with candidates 2/3 shadow-chartered, US-internal
+    reference frame, diverging w rendering (crimson Phi-source <-> gold
+    Phi-recipient), national-oppression overlay chartered as a
+    Director-gated seed. The choropleth producer computes w at
+    PROJECTION time; BoundOpposition/shadow registration is a separate
+    engine-train W-D motion.
+  context: |
+    The Director's 2026-07-28 directive on the M5 map tension lens:
+    nationwide scope (not tri-county), Lawverian dialectics over the
+    D = (A, Abar, w, T, sigma) primitive, everything justifiable in
+    actual Marxism. Deliverable: reports/spatial-tension-proposal.md
+    (PR #326) — six readers over the local marxists.org mirror (Marx
+    Capital I ch25 / III ch14, Engels, Lenin Imperialism + Development
+    of Capitalism in Russia, Stalin 1938, Mao On Contradiction) + MIM
+    Theory #10 OCR + the project formalism, Opus synthesis
+    (wf_7f6f62d8-b47). Three candidates were derived, all plain
+    BoundOpposition rows over the existing generator — no new sorts, no
+    new primitives, NORTH_STAR "closed for v1.0" untouched.
+  decision: |
+    The Director ruled the four-question slate (answers = the four
+    recommended options, confirmed after a mis-clicked dialog):
+    - LENS: Candidate 1 (county_extraction) is the principal aspect.
+      Per county: a = theta*(v+s) (wage entitlement at the national
+      norm), b = v (wage commanded); w = (b-a)/(a+b) in [-1,1]. The
+      witness sign IS the political content — which side of the
+      wage-form counit defect the county sits on. Candidates 2
+      (county_closure — reserve army vs absorptive margin; Stalin
+      geography-never-determines encoded as bounded multiplier nu<1)
+      and 3 (county_seam — Mao town/country over ADJACENCY) register
+      shadow=True on the ADR077 ladder. C3 is BLOCKED on a
+      county-adjacency producer (wiring-doctrine blocking-dependency
+      citation); C2 needs per-county population+biocapacity columns —
+      III.11: honest absence, never a k_sum proxy.
+    - THETA FRAME: US-internal ratio-of-sums (Sum v / Sum(v+s) over US
+      counties) — the map renders the intra-core distribution of
+      imperial rent (the labor-aristocracy geography), not the world
+      frame.
+    - RENDERING: diverging channel — the lens value is w itself on a
+      crimson (Phi-source, bled) <-> gold (Phi-recipient, bribed) ramp;
+      the (1-w)/2 Lenin damping factor DROPS as redundant (direction is
+      on screen, magnitude is not conflated with a poverty map).
+    - NAT-OP OVERLAY: chartered as a Director-gated research seed (MIM:
+      real, non-contiguous, NOT derivable from c/v/s — deriving it from
+      economic magnitudes alone is theoretically false). The map ships
+      with the absence declared.
+    Defaults taken (conservative, Director-overridable): continuous gap
+    rather than nodal-point proximity; hex_count never a weight (the
+    intensive-aggregation variance error); the promotion target is
+    sigma_phi (+) sigma_seam with kappa as a bounded multiplier inside
+    the measure — never (x), which would let geography veto extraction.
+    IMPLEMENTATION SPLIT: the choropleth tension producer computes
+    theta and per-county w at PROJECTION time from county ledger sums
+    (a read — the engine tick hash is untouched, qa:regression cannot
+    drift). The constitutional W-D motion (BoundOpposition rows,
+    coupling rows county_extraction --feeds--> imperial and county_seam
+    --constrains--> county_extraction, shadow_opposition_states
+    routing, promotion ceremony) is chartered engine-train work with
+    its own sentinel rows, NOT smuggled into the lens producer.
+  consequences:
+    positive:
+      - "The M5 tension lens renders the quantity the engine's rupture condition actually tests (phi_class is the wage-form counit defect) — the map cannot lie to the player at the moment of decision"
+      - "Deliberately not a poverty map: Appalachia/Delta/Rio Grande Valley/reservation counties run crimson (Phi-source), DC/Manhattan/Santa Clara run gold (Phi-recipient) — Lenin's bribery asymmetry rendered honestly"
+    negative:
+      - "Chartered, not built: the engine-train shadow registration for all three candidates; the county-adjacency producer C3 needs; the national-oppression overlay seed (Director-gated, needs a real reference dataset); the theta world-frame variant is closed for v1.0"
+  file: ADR170_tension_lens_ruling.yaml

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -758,3 +758,8 @@ decisions:
     status: accepted
     date: '2026-07-15'
     file: ADR073_doctrine_system.yaml
+  ADR170_tension_lens_ruling:
+    title: 'The map tension lens is county_extraction (Fundamental Theorem localized): Director-ruled slate — Candidate 1 principal (w=(b-a)/(a+b) vs US-internal ratio-of-sums theta), candidates 2/3 shadow-chartered (C3 blocked on county adjacency, C2 on population/biocapacity columns), diverging crimson<->gold w rendering with the (1-w)/2 damping dropped, nat-op overlay a Director-gated seed; producer computes at projection time, BoundOpposition registration = chartered engine-train W-D motion'
+    status: accepted
+    date: '2026-07-28'
+    file: ADR170_tension_lens_ruling.yaml

--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -5,6 +5,34 @@ meta:
   version: "2.59.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
   updated: "2026-07-28"
   truth_status: |
+    (2026-07-28 TENSION-LENS RULING EXECUTED — ADR170 + producers on
+    feature/m5-lens-producers) The Director ruled the map tension lens
+    four-question slate over reports/spatial-tension-proposal.md (PR
+    #326; 6 classics readers + Opus synthesis, wf_7f6f62d8-b47):
+    Candidate 1 county_extraction PRINCIPAL (w=(phi-theta)/(phi+theta),
+    US-internal ratio-of-sums theta), candidates 2/3 shadow-CHARTERED
+    to the engine train (C3 blocked on county adjacency, C2 on
+    population/biocapacity columns), rendering = DIVERGING crimson<->
+    gold w channel ((1-w)/2 damping dropped), nat-op overlay = seed —
+    then the Director SUPERSEDED the seed ruling: the national-
+    oppression research program is RUNNING NOW (wf_7f080a2d-cbe, 8
+    readers incl. Stalin 1913/Lenin 1914 self-det/MIM OCR trio/ERoL NCM
+    corpus + 3-critic adversarial pass -> proposal for Director ruling).
+    PRODUCERS BUILT (TDD, 20 tests): projection/topology/tension.py
+    county_tension_cells (graph-first, v recovered as s/e from
+    co-present TickDynamics stamps, poisoned 0.0 fallbacks = absence)
+    + projection/fog/county_status.py county_fog_status (reach wins,
+    read_intel ages, explicit unknown). M5 contract AMENDED: all
+    county-grain lenses graph-first (3-scout recon wf_e7c72977-b24
+    proved the hex-ledger view is tri-county tick-0-frozen at best;
+    dynamic_hex_state never re-written by GameSession.advance_tick),
+    five SS6 deviations record chartered W-C follow-ups (Vol2
+    nationwide v, INVESTIGATE intel stash + action_result read path —
+    zero production callers today, WKT bulk ingest). M6 contract
+    PINNED + merged (#325). Trade worktree CLOSED, 5 merged remote
+    branches deleted, local dev synced (Director consolidation
+    directive).
+    PREVIOUS (same day):
     (2026-07-28 P26 TRADE TRAIN CLOSED — U5 engine train + U6 phase 2
     EXECUTED on 101-trade-activation; ADR166-169; PR #315 carries U0-U6
     complete) The playable game has grounded international trade

--- a/docs/superpowers/specs/2026-07-28-m5-maps-contracts.md
+++ b/docs/superpowers/specs/2026-07-28-m5-maps-contracts.md
@@ -27,16 +27,30 @@ host."
   `{"tier", "lens", "verified_tick", "bands": [[threshold|null, role]...],
   "cells": [{"region_id", "value": float|null, "wkt": str|null,
   "centroid": [lon, lat]|null}...]}`.
-  - `bands` ships the `map_room._band_color` table AS DATA (plan ruling:
-    bands are data, not Rust literals): `[[null,"panel"],[1.0,"dim"],
-    [2.0,"gold"],[null,"crimson"]]` — null threshold on the absence row
-    and the open-ended top band; roles are §9b tokens the client maps to
-    its parity-guarded constants.
-  - `cells` values: lens `value` = exploitation rate from
-    `county_choropleth_cells` (county tier — reads the registered
-    `v_county_value_aggregate`) / `state_choropleth_cells_from_hex_rows`
-    (state tier — reads `v_hex_state_asof` rows ONLY; the producer's own
-    multi-tick ValueError guard is the spec-089 discipline, kept).
+  - `bands` ships AS DATA per lens (plan ruling: bands are data, not
+    Rust literals). Lens `value` keeps the `map_room._band_color` table:
+    `[[null,"panel"],[1.0,"dim"],[2.0,"gold"],[null,"crimson"]]`. Lens
+    `tension` ships the DIVERGING table over `w ∈ [-1,1]` (ADR170
+    ruling 3): `[[null,"panel"],[-0.15,"crimson"],[0.15,"dim"],
+    [null,"gold"]]` — negative = Φ-source (bled), positive = Φ-recipient
+    (bribed). Lens `fog` ships the status table
+    `[["exact","gold"],["approximate","dim"],["unknown","panel"]]`
+    (categorical, not thresholds). Roles are §9b tokens the client maps
+    to its parity-guarded constants.
+  - `cells` values — **GRAPH-FIRST at county grain (amended 2026-07-28,
+    supersedes the ledger-view rows; §6 records why)**: lens `value` =
+    `tick_exploitation_rate` read per county-bearing territory node
+    (inf-is-present convention kept); lens `tension` =
+    `projection.topology.tension.county_tension_cells(graph)` (the
+    ADR170 `county_extraction` witness — `v` recovered as `s/e` from the
+    co-present `tick_total_surplus`/`tick_exploitation_rate` stamps,
+    ratio-of-sums θ, poisoned `0.0` fallbacks = absence); lens `fog` =
+    `projection.fog.county_status.county_fog_status(graph,
+    player_org_id, ledger, tick, ...)` with the three defines-fed
+    epistemic_horizon bounds. State tier aggregates the SAME graph
+    attrs by `county_fips[:2]` ratio-of-sums; the hex-ledger views
+    (`v_county_value_aggregate` / `v_hex_state_asof`) are recorded as a
+    tri-county tick-0 enrichment path, NOT wired this milestone.
   - `wkt` comes from `persistence.tiger_ingestion.
     fetch_county_geometries_wkt(pool, geoids)` — **the first production
     caller of that wired-but-unconsumed seam** (county tier only; state
@@ -44,14 +58,23 @@ host."
     dissolving state boundaries from county WKT is real work with no
     consumer pull yet). EPSG:4269 ≈ WGS84 for CONUS; the client treats
     lon/lat as plain x/y (equirectangular — honest at county scale).
-- **LENS DISCLOSURE (Director-visible, the §9.9 pattern):** only the
-  `value` lens has a producer anywhere in the codebase. `tension` and
-  `fog` return cells with `value: null` for every region plus the
-  envelope's `"lens_absent_reason"` string naming the missing producer
-  ("no tension scalar exists on DynamicHexState"; "the epistemic fog
-  package is not wired to choropleth cells") — rendered as a declared
-  absence banner, never fabricated data (III.11 / Mock Doctrine).
-  Landing either producer is engine-train work outside M5's charter.
+- **LENS RULINGS (amended 2026-07-28 — the Director's four-question
+  slate, ADR170, supersedes the original absence disclosure):** all
+  three lenses have producers. `tension` = `county_extraction`
+  principal (candidates 2/3 shadow-chartered to the engine train);
+  θ is US-INTERNAL; rendering is the diverging `w` channel (the
+  `(1-w)/2` damping DROPPED as redundant); the national-oppression
+  overlay is a chartered Director-gated seed — its absence from this
+  map is DECLARED in the envelope (`"overlay_absent": "national
+  oppression overlay chartered, not derivable from c/v/s"`), pending
+  the national-oppression research program. `lens_absent_reason`
+  remains the envelope's honest-absence channel for the cases that
+  stay real: a graph with zero data-bearing counties (tension), and
+  the fog `approximate` tier being structurally unreachable until the
+  INVESTIGATE intel-stash + `action_result` read-path wiring lands on
+  the modern runtime (chartered W-C motion — the modern path has ZERO
+  `persist_action_results` callers; the harness pins the absence, pin
+  goes red when the wiring lands).
 - **EA tier**: `ea_choropleth_cells` returns None by design (no bridge)
   — the envelope for `tier: "ea"` is `"null"` absence; the client's tier
   cycle SKIPS ea until a producer exists (recorded here, not a bug).
@@ -146,4 +169,44 @@ note lands with the M5 close-out. No sibling-repo work this milestone.
 
 ## 6. Deviations discovered during implementation
 
-(recorded as they arise)
+- **2026-07-28 — county tier goes GRAPH-FIRST (supersedes §1's original
+  `county_choropleth_cells`-over-`v_county_value_aggregate` ruling).**
+  The 3-scout data-path recon (wf_e7c72977-b24) proved the hex-ledger
+  view is NOT a nationwide source: `dynamic_hex_state` is written ONLY
+  at tick 0, ONLY for the tri-county hydration set, ONLY when the TIGER
+  drive symlink resolves at campaign creation — and
+  `GameSession.advance_tick` never re-writes hex rows (no
+  `hex_state_rows` in the envelope), so `v_county_value_aggregate` is
+  frozen at tick 0 or empty. The live nationwide medium is the GRAPH:
+  `USScenario` seeds 3,153 county territories and TickDynamics stamps
+  the `tick_*` block per county-bearing territory. The ledger views
+  keep their existing consumers/tests untouched.
+- **2026-07-28 — the tension v-pole is RECOVERED, not stamped.** No
+  nationwide per-territory `v` write exists (the one real writer,
+  `Vol2CirculationStep`, is tri-county-locked; employment is never
+  written — the Program-17 100k-placeholder gap). Where
+  `tick_exploitation_rate` (e) and `tick_total_surplus` (s) are
+  co-present and positive, `v = s/e` is exact; elsewhere the county is
+  honestly absent. Extending `Vol2CirculationStep` past the tri-county
+  fixture is chartered wiring-doctrine work (W-C), not M5's.
+- **2026-07-28 — fog ships reach-complete, ledger-empty.** The
+  `county_fog_status` producer is fully built and tested, but the
+  modern runtime has no INVESTIGATE intel-stash writer and no
+  `action_result` read path (`persist_action_results`: zero production
+  callers) — so live campaigns pass an empty `IntelLedger` and the
+  `approximate` tier is structurally dead until that chartered W-C
+  wiring lands. Reach (`organizing_reach` over PRESENCE/TENANCY/
+  SOLIDARITY with the epistemic_horizon defines) is fully live.
+- **2026-07-28 — nationwide WKT needs a bulk ingest at first use.** The
+  reference data genuinely carries 3,222 county geometries
+  (`dim_county_geometry`), but the live Postgres
+  `immutable_reference_tiger_county` table only ever receives the
+  hydration set's rows (≤3) — Task 37's first call must bulk-ingest via
+  `ingest_tiger_counties_from_sqlite` (or read the reference DB
+  directly) rather than assume the table is populated.
+- **2026-07-28 — tension/fog band thresholds are module presentation
+  constants** (the `map_room._band_color` precedent), NOT `GameDefines`
+  entries — they are projection presentation data, not simulation
+  coefficients; folding the lens tables into a defines category is
+  deferred to a declared sweep (avoids a defines_hash-only ceremony
+  for band edges).

--- a/src/babylon/projection/fog/county_status.py
+++ b/src/babylon/projection/fog/county_status.py
@@ -1,0 +1,85 @@
+"""Per-county epistemic fog status — the map's fog lens producer.
+
+One verdict per county, rolled up from the two existing, already-tested
+primitives (spec-117 §5a's ledger model, Constitution III.11): organizing
+reach wins outright (the same precedence rule
+:func:`~babylon.projection.fog.filter.apply_fog` enforces per field), and
+everything outside reach is judged by
+:func:`~babylon.projection.fog.ledger.read_intel`'s aged tier over the
+``territory:political`` field group. A county that exists but was never
+observed gets a keyed, explicit ``"unknown"`` — never omitted, never a stale
+color. Territories without a ``county_fips`` have no county identity and are
+never emitted.
+
+Pure function of ``(graph, ledger, tick)`` — the engine is untouched and the
+player's knowledge never enters the tick hash (fog is EPISTEMIC, the engine
+is MATERIAL). Types against
+:class:`~babylon.kernel.graph_protocol.GraphProtocol` only, like its
+siblings in this package.
+"""
+
+from __future__ import annotations
+
+from babylon.kernel.graph_protocol import GraphProtocol
+from babylon.models.enums import NodeType
+from babylon.projection.fog.filter import political_field_group
+from babylon.projection.fog.ledger import IntelLedger, VisibilityTier, read_intel
+from babylon.projection.fog.reach import organizing_reach
+
+__all__ = ["county_fog_status"]
+
+#: Most-informed-wins rank for the multi-territory-county fold: any single
+#: territory in reach lights its whole county ``exact``.
+_TIER_RANK: dict[VisibilityTier, int] = {"exact": 2, "approximate": 1, "unknown": 0}
+
+
+def county_fog_status(
+    graph: GraphProtocol,
+    player_org_id: str | None,
+    ledger: IntelLedger,
+    tick: int,
+    *,
+    radius: int,
+    staleness_ticks: int,
+    unknown_ticks: int,
+) -> dict[str, VisibilityTier]:
+    """Roll the fog model up to one epistemic tier per county.
+
+    :param graph: Any graph-protocol implementer; read-only.
+    :param player_org_id: The session's canonical player org, or ``None``
+        (no org — reach is empty and every county is judged by the ledger
+        alone, the reach primitive's own sentinel convention).
+    :param ledger: The session's intel ledger (event-sourced from
+        INVESTIGATE results; an empty ledger is honest — everything outside
+        reach is ``"unknown"``).
+    :param tick: The current tick intel ages against.
+    :param radius: SOLIDARITY-hop radius for
+        :func:`~babylon.projection.fog.reach.organizing_reach`
+        (``GameDefines.epistemic_horizon.organizing_reach_radius``).
+    :param staleness_ticks: Age bound for ``"exact"`` intel
+        (``GameDefines.epistemic_horizon.intel_staleness_ticks``).
+    :param unknown_ticks: Age bound past which intel is ``"unknown"``
+        (``GameDefines.epistemic_horizon.intel_unknown_ticks``).
+    :returns: ``county_fips -> tier`` for every county-bearing territory in
+        the graph; counties absent from the graph are absent from the dict
+        (honest absence), counties present but unobserved are explicit
+        ``"unknown"`` entries.
+    """
+    reach = organizing_reach(graph, player_org_id, radius)
+    field_group = political_field_group(NodeType.TERRITORY.value)
+
+    status: dict[str, VisibilityTier] = {}
+    for node in graph.query_nodes(node_type=NodeType.TERRITORY.value):
+        fips = node.get_attr("county_fips")
+        if fips is None:
+            continue
+        tier: VisibilityTier
+        if node.id in reach:
+            tier = "exact"
+        else:
+            tier = read_intel(
+                ledger, node.id, field_group, tick, staleness_ticks, unknown_ticks
+            ).tier
+        if fips not in status or _TIER_RANK[tier] > _TIER_RANK[status[fips]]:
+            status[fips] = tier
+    return status

--- a/src/babylon/projection/topology/tension.py
+++ b/src/babylon/projection/topology/tension.py
@@ -1,0 +1,119 @@
+"""The county tension lens producer — ``county_extraction`` rendered (ADR170).
+
+The Director-ruled principal opposition for the map's tension lens
+(``reports/spatial-tension-proposal.md``, rulings 2026-07-28): per county the
+poles are ``a = theta * (v + s)`` (the wage entitlement at the national norm)
+and ``b = v`` (the wage actually commanded), with witness
+``w = (b - a) / (a + b)``. Dividing through by the county's new value
+``(v + s)`` gives the equivalent form computed here::
+
+    phi   = v / (v + s) = 1 / (1 + e)          # the county wage share
+    theta = sum(v) / sum(v + s)                # RATIO OF SUMS, never a mean
+    w     = (phi - theta) / (phi + theta)      # in [-1, 1]
+
+``w < 0`` is a net Phi-SOURCE (bled; crimson), ``w > 0`` a net Phi-RECIPIENT
+(bribed; gold) — the diverging channel IS the ruled rendering, so ``w`` ships
+raw and no damping factor is applied.
+
+**Data honesty (Constitution III.11).** The extensive poles are recovered
+from the TickDynamics stamps every county-bearing territory may carry:
+``e = tick_exploitation_rate`` and ``s = tick_total_surplus`` give
+``v = s / e``. The stamp block writes ``0.0`` for BOTH when a county's
+``TensorRegistry`` was never hydrated (``graph_bridge.py``'s no-hydration
+fallback), so a contribution requires ``s > 0 and e > 0`` — the poisoned
+fallback surfaces as ``w=None`` (absence), never a fabricated zero. A graph
+with NO data-bearing county yields ``None`` outright: no norm exists, the
+whole lens is absent (the envelope's ``lens_absent_reason`` case).
+
+Computed at PROJECTION time from the graph — the engine tick hash is
+untouched; the constitutional ``BoundOpposition``/shadow registration is the
+chartered engine-train W-𝔇 motion, deliberately NOT this module (ADR170).
+Like :mod:`babylon.projection.fog.reach`, this module types against
+:class:`~babylon.kernel.graph_protocol.GraphProtocol` only.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from babylon.kernel.graph_protocol import GraphProtocol
+from babylon.models.enums import NodeType
+
+__all__ = ["TensionCell", "county_tension_cells"]
+
+#: Below this, ``phi + theta`` is treated as the degenerate all-bled-dry
+#: limit and ``w`` collapses to ``0.0`` — the shared measure kernel's own
+#: ``a + b <= 1e-9`` honest-degeneracy convention
+#: (:func:`babylon.formulas.contradiction.calculate_wealth_asymmetry_gap`).
+_DEGENERATE_EPS = 1e-9
+
+
+class TensionCell(BaseModel):
+    """One tension-lens cell: a county FIPS and its witness value.
+
+    :param region_id: The county's 5-digit FIPS code.
+    :param w: The ruled witness ``(phi - theta)/(phi + theta)`` in
+        ``[-1, 1]`` — negative = Phi-source (crimson), positive =
+        Phi-recipient (gold) — or ``None`` when the county carries no
+        honest data this tick (absence, never a fabricated zero).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    region_id: str = Field(min_length=1)
+    w: float | None = None
+
+
+def county_tension_cells(graph: GraphProtocol) -> tuple[TensionCell, ...] | None:
+    """Derive one :class:`TensionCell` per county-bearing territory group.
+
+    Folds every ``territory`` node carrying a ``county_fips``: extensive
+    ``v = s/e`` and ``s`` SUM within a county before the share is taken
+    (the intensive-aggregation law — never a mean of territory shares),
+    ``theta`` is the ratio of sums across all data-bearing counties, and
+    every known county is emitted — data-bearing counties with their
+    witness, the rest with ``w=None``.
+
+    :param graph: Any :class:`~babylon.kernel.graph_protocol.GraphProtocol`
+        implementer; read-only.
+    :returns: Cells sorted by FIPS, or ``None`` when no county carries
+        honest data (no norm exists — whole-lens absence).
+    """
+    v_by_county: dict[str, float] = {}
+    new_value_by_county: dict[str, float] = {}
+    all_counties: set[str] = set()
+
+    for node in graph.query_nodes(node_type=NodeType.TERRITORY.value):
+        fips = node.get_attr("county_fips")
+        if fips is None:
+            continue
+        all_counties.add(fips)
+        e = node.get_attr("tick_exploitation_rate")
+        s = node.get_attr("tick_total_surplus")
+        if not isinstance(e, (int, float)) or not isinstance(s, (int, float)):
+            continue
+        if s <= 0.0 or e <= 0.0:
+            # Includes the stamp block's 0.0 no-hydration fallback — poisoned
+            # data reads as absence, never as zero tension.
+            continue
+        v = s / e  # 0.0 at e=inf: the bled-dry limit is a PRESENT value.
+        v_by_county[fips] = v_by_county.get(fips, 0.0) + v
+        new_value_by_county[fips] = new_value_by_county.get(fips, 0.0) + v + s
+
+    if not v_by_county:
+        return None
+
+    total_v = sum(v_by_county[f] for f in sorted(v_by_county))
+    total_new_value = sum(new_value_by_county[f] for f in sorted(new_value_by_county))
+    theta = total_v / total_new_value
+
+    cells: list[TensionCell] = []
+    for fips in sorted(all_counties):
+        if fips not in v_by_county:
+            cells.append(TensionCell(region_id=fips, w=None))
+            continue
+        phi = v_by_county[fips] / new_value_by_county[fips]
+        denom = phi + theta
+        w = 0.0 if denom <= _DEGENERATE_EPS else (phi - theta) / denom
+        cells.append(TensionCell(region_id=fips, w=max(-1.0, min(1.0, w))))
+    return tuple(cells)

--- a/tests/unit/projection/fog/test_county_status.py
+++ b/tests/unit/projection/fog/test_county_status.py
@@ -1,0 +1,127 @@
+"""Contract tests for the per-county fog-status rollup (the fog lens producer).
+
+One epistemic verdict per county: ``"exact"`` inside organizing reach (reach
+wins outright — the same precedence rule ``apply_fog`` enforces per field),
+else the intel ledger's aged tier via ``read_intel`` over the
+``territory:political`` field group. A genuinely-existing county with no data
+still gets a keyed, explicit ``"unknown"`` — never omitted, never a stale
+color (spec-117 §5a / Constitution III.11). Territories without a
+``county_fips`` have no county identity and are never emitted.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from babylon.models.enums import NodeType
+from babylon.projection.fog.ledger import IntelEntry, IntelLedger
+from babylon.topology.graph import BabylonGraph
+
+pytestmark = pytest.mark.unit
+
+_STALENESS = 5
+_UNKNOWN = 20
+
+
+def _graph() -> BabylonGraph:
+    """ORG1 has presence in T1 (county 26163). T2 (01001) and T3 (02002) are
+    out of reach; TX carries no county_fips at all."""
+    g = BabylonGraph()
+    g.add_node("ORG1", NodeType.ORGANIZATION, name="Player Org")
+    g.add_node("T1", NodeType.TERRITORY, name="Wayne", county_fips="26163")
+    g.add_node("T2", NodeType.TERRITORY, name="Autauga", county_fips="01001")
+    g.add_node("T3", NodeType.TERRITORY, name="Anchorage", county_fips="02002")
+    g.add_node("TX", NodeType.TERRITORY, name="Abstract")
+    g.add_edge("ORG1", "T1", "presence")
+    return g
+
+
+def _ledger(node_id: str, tick_observed: int) -> IntelLedger:
+    return IntelLedger(
+        entries=(
+            IntelEntry(
+                node_id=node_id,
+                field_group="territory:political",
+                tick_observed=tick_observed,
+                value_snapshot={"heat": 0.4},
+            ),
+        )
+    )
+
+
+def _status(ledger: IntelLedger, tick: int, player_org_id: str | None = "ORG1") -> dict[str, str]:
+    from babylon.projection.fog.county_status import county_fog_status
+
+    return county_fog_status(
+        _graph(),
+        player_org_id,
+        ledger,
+        tick,
+        radius=1,
+        staleness_ticks=_STALENESS,
+        unknown_ticks=_UNKNOWN,
+    )
+
+
+class TestCountyFogStatus:
+    """Contract of ``county_fog_status(...) -> dict[county_fips, tier]``."""
+
+    def test_in_reach_county_is_exact(self) -> None:
+        assert _status(IntelLedger(), tick=100)["26163"] == "exact"
+
+    def test_never_observed_out_of_reach_county_is_keyed_unknown(self) -> None:
+        """Present in the dict with an explicit \"unknown\" — never omitted."""
+        status = _status(IntelLedger(), tick=100)
+
+        assert status["01001"] == "unknown"
+        assert status["02002"] == "unknown"
+
+    def test_fresh_intel_is_exact(self) -> None:
+        status = _status(_ledger("T2", tick_observed=98), tick=100)
+
+        assert status["01001"] == "exact"
+
+    def test_stale_intel_is_approximate(self) -> None:
+        status = _status(_ledger("T2", tick_observed=90), tick=100)
+
+        assert status["01001"] == "approximate"
+
+    def test_ancient_intel_is_unknown(self) -> None:
+        status = _status(_ledger("T2", tick_observed=10), tick=100)
+
+        assert status["01001"] == "unknown"
+
+    def test_reach_wins_over_any_ledger_state(self) -> None:
+        """T1 is in reach; even ancient intel about it cannot demote it."""
+        status = _status(_ledger("T1", tick_observed=0), tick=100)
+
+        assert status["26163"] == "exact"
+
+    def test_no_player_org_falls_back_to_pure_ledger_aging(self) -> None:
+        """player_org_id=None -> empty reach (the reach primitive's own
+        sentinel) -> every county is judged by the ledger alone."""
+        status = _status(_ledger("T2", tick_observed=98), tick=100, player_org_id=None)
+
+        assert status["26163"] == "unknown"
+        assert status["01001"] == "exact"
+
+    def test_territory_without_county_fips_is_never_emitted(self) -> None:
+        status = _status(IntelLedger(), tick=100)
+
+        assert set(status) == {"26163", "01001", "02002"}
+
+    def test_empty_graph_returns_empty_dict(self) -> None:
+        from babylon.projection.fog.county_status import county_fog_status
+
+        assert (
+            county_fog_status(
+                BabylonGraph(),
+                None,
+                IntelLedger(),
+                0,
+                radius=1,
+                staleness_ticks=_STALENESS,
+                unknown_ticks=_UNKNOWN,
+            )
+            == {}
+        )

--- a/tests/unit/projection/topology/test_tension.py
+++ b/tests/unit/projection/topology/test_tension.py
@@ -1,0 +1,241 @@
+"""Contract tests for the county tension lens producer (ADR170).
+
+The Director-ruled ``county_extraction`` opposition, computed at PROJECTION
+time from the graph's own TickDynamics stamps: per data-bearing county the
+wage share ``phi = 1/(1+e)`` (``e`` = ``tick_exploitation_rate``), the
+national norm ``theta = sum(v)/sum(v+s)`` (a RATIO OF SUMS, never a mean of
+shares), and the witness ``w = (phi - theta)/(phi + theta)`` — algebraically
+identical to the proposal's ``(b-a)/(a+b)`` with ``a = theta*(v+s)``,
+``b = v``. The extensive ``v`` is recovered as ``s/e`` from the co-present
+``tick_total_surplus`` stamp; a county missing either stamp — or carrying the
+stamp block's own ``0.0`` no-hydration fallback — is HONESTLY ABSENT
+(``w=None``), never a fabricated zero (Constitution III.11).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from babylon.models.enums import NodeType
+from babylon.topology.graph import BabylonGraph
+
+pytestmark = pytest.mark.unit
+
+
+def _graph_with(counties: list[dict[str, object]]) -> BabylonGraph:
+    """A graph of territory nodes, one per entry; ``fips=None`` omits the
+    attribute entirely (an abstract territory with no county identity)."""
+    g = BabylonGraph()
+    for i, spec in enumerate(counties):
+        attrs: dict[str, object] = {"name": f"County {i}"}
+        if spec.get("fips") is not None:
+            attrs["county_fips"] = spec["fips"]
+        for key in ("tick_exploitation_rate", "tick_total_surplus"):
+            if key in spec:
+                attrs[key] = spec[key]
+        g.add_node(f"T{i}", NodeType.TERRITORY, **attrs)
+    return g
+
+
+class TestCountyTensionCells:
+    """Contract of ``county_tension_cells(graph)``."""
+
+    def test_two_county_pinned_math(self) -> None:
+        """e=4 -> phi=0.2, s=800 -> v=200; e=1 -> phi=0.5, s=500 -> v=500.
+        theta = (200+500)/(1000+1000) = 0.35;
+        w_A = (0.2-0.35)/(0.2+0.35), w_B = (0.5-0.35)/(0.5+0.35)."""
+        from babylon.projection.topology.tension import county_tension_cells
+
+        cells = county_tension_cells(
+            _graph_with(
+                [
+                    {"fips": "01001", "tick_exploitation_rate": 4.0, "tick_total_surplus": 800.0},
+                    {"fips": "02002", "tick_exploitation_rate": 1.0, "tick_total_surplus": 500.0},
+                ]
+            )
+        )
+
+        assert cells is not None
+        by_fips = {c.region_id: c.w for c in cells}
+        assert by_fips["01001"] == pytest.approx(-0.15 / 0.55)
+        assert by_fips["02002"] == pytest.approx(0.15 / 0.85)
+
+    def test_signs_source_negative_recipient_positive(self) -> None:
+        """The witness sign is the political content: the higher-exploitation
+        county (thin wage share) reads NEGATIVE (Phi-source, crimson); the
+        wage-heavy county reads POSITIVE (Phi-recipient, gold)."""
+        from babylon.projection.topology.tension import county_tension_cells
+
+        cells = county_tension_cells(
+            _graph_with(
+                [
+                    {"fips": "01001", "tick_exploitation_rate": 4.0, "tick_total_surplus": 800.0},
+                    {"fips": "02002", "tick_exploitation_rate": 1.0, "tick_total_surplus": 500.0},
+                ]
+            )
+        )
+
+        assert cells is not None
+        by_fips = {c.region_id: c.w for c in cells}
+        assert by_fips["01001"] is not None and by_fips["01001"] < 0
+        assert by_fips["02002"] is not None and by_fips["02002"] > 0
+
+    def test_single_data_bearing_county_is_the_norm_itself(self) -> None:
+        """With one county, theta == phi, so w == 0 exactly — the map of
+        deviation renders equilibrium as zero (Mao: unevenness is the
+        figure, not the ground)."""
+        from babylon.projection.topology.tension import county_tension_cells
+
+        cells = county_tension_cells(
+            _graph_with(
+                [{"fips": "01001", "tick_exploitation_rate": 2.0, "tick_total_surplus": 100.0}]
+            )
+        )
+
+        assert cells is not None
+        assert cells[0].w == pytest.approx(0.0)
+
+    def test_zero_fallback_stamps_are_absence_not_zero_tension(self) -> None:
+        """The stamp block writes ``0.0`` for both attrs when the county's
+        TensorRegistry was never hydrated — that poisoned fallback must
+        surface as w=None, never as a computed cell."""
+        from babylon.projection.topology.tension import county_tension_cells
+
+        cells = county_tension_cells(
+            _graph_with(
+                [
+                    {"fips": "01001", "tick_exploitation_rate": 0.0, "tick_total_surplus": 0.0},
+                    {"fips": "02002", "tick_exploitation_rate": 1.0, "tick_total_surplus": 500.0},
+                ]
+            )
+        )
+
+        assert cells is not None
+        by_fips = {c.region_id: c.w for c in cells}
+        assert by_fips["01001"] is None
+
+    def test_missing_either_stamp_is_absence(self) -> None:
+        from babylon.projection.topology.tension import county_tension_cells
+
+        cells = county_tension_cells(
+            _graph_with(
+                [
+                    {"fips": "01001", "tick_exploitation_rate": 2.0},
+                    {"fips": "02002", "tick_total_surplus": 500.0},
+                    {"fips": "03003", "tick_exploitation_rate": 1.0, "tick_total_surplus": 400.0},
+                ]
+            )
+        )
+
+        assert cells is not None
+        by_fips = {c.region_id: c.w for c in cells}
+        assert by_fips["01001"] is None
+        assert by_fips["02002"] is None
+        assert by_fips["03003"] is not None
+
+    def test_no_data_bearing_county_returns_none(self) -> None:
+        """Zero data-bearing counties -> no theta exists -> the WHOLE lens is
+        honestly absent (None), the envelope's lens_absent_reason case."""
+        from babylon.projection.topology.tension import county_tension_cells
+
+        cells = county_tension_cells(
+            _graph_with(
+                [
+                    {"fips": "01001"},
+                    {"fips": "02002", "tick_exploitation_rate": 0.0, "tick_total_surplus": 0.0},
+                ]
+            )
+        )
+
+        assert cells is None
+
+    def test_graph_without_county_territories_returns_none(self) -> None:
+        from babylon.projection.topology.tension import county_tension_cells
+
+        assert county_tension_cells(_graph_with([{"fips": None}])) is None
+        assert county_tension_cells(BabylonGraph()) is None
+
+    def test_infinite_exploitation_rate_is_the_bled_dry_limit(self) -> None:
+        """e=inf means v=0 (all new value is surplus): phi=0, w=-1 exactly —
+        a PRESENT value (the value lens's own inf-is-present convention),
+        never absence."""
+        from babylon.projection.topology.tension import county_tension_cells
+
+        cells = county_tension_cells(
+            _graph_with(
+                [
+                    {
+                        "fips": "01001",
+                        "tick_exploitation_rate": float("inf"),
+                        "tick_total_surplus": 800.0,
+                    },
+                    {"fips": "02002", "tick_exploitation_rate": 1.0, "tick_total_surplus": 500.0},
+                ]
+            )
+        )
+
+        assert cells is not None
+        by_fips = {c.region_id: c.w for c in cells}
+        assert by_fips["01001"] == pytest.approx(-1.0)
+
+    def test_multi_territory_county_sums_extensives_before_the_share(self) -> None:
+        """Two territories in one county: v and s SUM (extensive) before phi
+        is taken — never a mean of the two territories' shares (the
+        intensive-aggregation law)."""
+        from babylon.projection.topology.tension import county_tension_cells
+
+        # Split county 01001: (e=4, s=400) + (e=4, s=400) == one (e=4, s=800).
+        split = county_tension_cells(
+            _graph_with(
+                [
+                    {"fips": "01001", "tick_exploitation_rate": 4.0, "tick_total_surplus": 400.0},
+                    {"fips": "01001", "tick_exploitation_rate": 4.0, "tick_total_surplus": 400.0},
+                    {"fips": "02002", "tick_exploitation_rate": 1.0, "tick_total_surplus": 500.0},
+                ]
+            )
+        )
+        merged = county_tension_cells(
+            _graph_with(
+                [
+                    {"fips": "01001", "tick_exploitation_rate": 4.0, "tick_total_surplus": 800.0},
+                    {"fips": "02002", "tick_exploitation_rate": 1.0, "tick_total_surplus": 500.0},
+                ]
+            )
+        )
+
+        assert split is not None and merged is not None
+        assert split == merged
+
+    def test_cells_sorted_by_fips_and_bounded(self) -> None:
+        from babylon.projection.topology.tension import county_tension_cells
+
+        cells = county_tension_cells(
+            _graph_with(
+                [
+                    {"fips": "55555", "tick_exploitation_rate": 9.0, "tick_total_surplus": 900.0},
+                    {"fips": "01001", "tick_exploitation_rate": 0.5, "tick_total_surplus": 100.0},
+                    {"fips": "26163", "tick_exploitation_rate": 2.0, "tick_total_surplus": 600.0},
+                ]
+            )
+        )
+
+        assert cells is not None
+        assert [c.region_id for c in cells] == ["01001", "26163", "55555"]
+        for cell in cells:
+            if cell.w is not None:
+                assert -1.0 <= cell.w <= 1.0
+                assert math.isfinite(cell.w)
+
+    def test_deterministic_across_repeated_calls(self) -> None:
+        from babylon.projection.topology.tension import county_tension_cells
+
+        g = _graph_with(
+            [
+                {"fips": "01001", "tick_exploitation_rate": 4.0, "tick_total_surplus": 800.0},
+                {"fips": "02002", "tick_exploitation_rate": 1.0, "tick_total_surplus": 500.0},
+            ]
+        )
+
+        assert county_tension_cells(g) == county_tension_cells(g)


### PR DESCRIPTION
Executes the Director's four-question tension-lens slate (2026-07-28) and the M5 pre-train ruling ("build tension/fog producers first").

- **ADR170** records the slate: `county_extraction` principal (candidates 2/3 shadow-chartered — C3 blocked on a county-adjacency producer, C2 on population/biocapacity columns), US-internal θ, diverging crimson↔gold `w` rendering with the `(1−w)/2` damping dropped, nat-op overlay superseded into the running research program (wf_7f080a2d-cbe).
- **`county_tension_cells`** (`projection/topology/tension.py`): graph-first, `w=(φ−θ)/(φ+θ)` with `v` recovered as `s/e` from the co-present TickDynamics stamps; ratio-of-sums θ; the stamp block's 0.0 no-hydration fallback and missing stamps surface as honest absence; whole-lens `None` when no county bears data. 11 contract tests incl. pinned two-county math, the bled-dry `e=inf → w=−1` limit, and the extensive-sums-before-shares law.
- **`county_fog_status`** (`projection/fog/county_status.py`): one epistemic tier per county from the existing spec-117 primitives — reach wins outright, `read_intel` ages the rest, unobserved counties get explicit `"unknown"`. 9 contract tests.
- **M5 contract amended**: all county-grain lenses go graph-first (the 3-scout recon proved the hex-ledger view is tri-county tick-0-frozen at best); per-lens band tables (diverging tension, categorical fog); five §6 deviations record the superseded rulings and chartered W-C follow-ups (nationwide Vol2 `v`, INVESTIGATE intel-stash + `action_result` read path — zero production callers today, WKT bulk ingest).

Gates: `mise run check` green (14,340 passed), vocabulary sentinel clean. Engine untouched — pure projection reads, tick hash unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)