### PR TITLE
fix(tui-rs): floor height 30 → 24 — the Director's fullscreen laptop was locked out

### DIFF
--- a/docs/superpowers/specs/2026-07-28-interface-wave1-contracts.md
+++ b/docs/superpowers/specs/2026-07-28-interface-wave1-contracts.md
@@ -172,3 +172,16 @@ plate clips at 80×24 with the tutorial strip up).
    omitting them parses to the LOUD `parse_failed` state, which is the
    III.11 design working (caught writing the U6 fixture; recorded so
    the next fixture author doesn't re-learn it).
+7. **The floor's height axis dropped 30 → 24 (Director field report,
+   2026-07-28)**: a fullscreen 1366×768 laptop terminal at 151×27 was
+   locked out of the game entirely — on that hardware no resize can
+   reach 30 rows without shrinking the font, which inverts ruling 1's
+   intent (refuse cramped mush, not refuse real machines). Density
+   stays DESIGNED to 100×30 (`headless_size` default unchanged, no
+   golden drift); the §1 verb-plate invariant is re-established at
+   every admitted height by clamping the tutorial strip band against
+   the play chrome's fixed rows (`PLAY_CHROME_MIN_ROWS` = 18: HUD 3 +
+   mid-min 5 + plate 8 + status 1 + keybar 1) — the strip yields, the
+   plate never clips. Width stays 100 (the 24-column rails need it).
+   The Director's exact geometry is pinned forever:
+   `floor_guard.rs::the_directors_fullscreen_laptop_geometry_renders`.

--- a/reports/interface-master-plan.md
+++ b/reports/interface-master-plan.md
@@ -146,8 +146,12 @@ row-compaction (demand-driven; wait for evidence).
 ## 5. Director rulings — ALL SEVEN RULED (2026-07-27/28)
 
 1. **Minimum terminal size: 100×30 declared floor** (with a graceful
-   too-small notice below it). Density is designed to 100×30; the D5/D6
-   math is recomputed against it — the verb-plate Min-constraint fix
+   too-small notice below it). *Amended 2026-07-28 (Director field
+   report — a fullscreen 151×27 laptop terminal was locked out): the
+   GUARD floor is 100×24; density stays designed to 100×30, and the
+   verb-plate invariant holds at every admitted height via the tutorial
+   strip clamp (Wave 1 contract §7.7).* Density is designed to 100×30;
+   the D5/D6 math is recomputed against it — the verb-plate Min-constraint fix
    stays release-blocking regardless (resize mid-session can still
    squeeze the solver).
 2. **Terminal grammar is the legitimate successor** to the DESIGN_BIBLE's

--- a/rust/crates/babylon-tui/src/app.rs
+++ b/rust/crates/babylon-tui/src/app.rs
@@ -345,7 +345,7 @@ pub struct App<H: Host> {
     /// appended in this milestone — host-side material verbs are the
     /// host's own log, not the client's to report.
     chrome_verbs: Vec<String>,
-    /// `true` while the terminal is below the declared 100×30 floor
+    /// `true` while the terminal is below the declared 100×24 floor
     /// (Wave 1 contract §1, Director ruling 1) — set by every
     /// [`Self::render_frame`], read by the input handlers so no key or
     /// click mutates state against an invisible UI (only the quit set
@@ -355,12 +355,27 @@ pub struct App<H: Host> {
 
 /// The declared minimum terminal width (Wave 1 contract §1, ruling 1).
 /// Display constants, not `GameDefines` — no gameplay meaning (the
-/// `PAGE_SCROLL` precedent). The recon arithmetic of record: at 100×30
-/// the 11-line verb plate fits EXACTLY even under the tutorial strip's
-/// 40% clamp; at 80×24 it clips three Article-V verbs.
+/// `PAGE_SCROLL` precedent). Density is DESIGNED to 100×30 (the recon
+/// arithmetic of record: there the verb plate fits even with the
+/// tutorial strip at its full 40% ceiling), but the GUARD floor is
+/// lower: the Director's 2026-07-28 field report — a fullscreen 151×27
+/// laptop terminal locked out of the game entirely — ruled the 30-row
+/// floor too aggressive for real hardware. The §1 invariant (the verb
+/// plate never clips) is re-established at every admitted height by
+/// clamping the tutorial strip band against `PLAY_CHROME_MIN_ROWS`
+/// (private, this module) instead: the strip (compressible prose)
+/// yields, the plate never does.
 pub const FLOOR_WIDTH: u16 = 100;
-/// The declared minimum terminal height (see [`FLOOR_WIDTH`]).
-pub const FLOOR_HEIGHT: u16 = 30;
+/// The declared minimum terminal height (see [`FLOOR_WIDTH`]): the
+/// classic 24-row terminal floor.
+pub const FLOOR_HEIGHT: u16 = 24;
+
+/// The play chrome's fixed vertical budget below the tutorial strip:
+/// HUD 3 + mid-region minimum 5 + verb plate 8 + status 1 + keybar 1.
+/// The strip band is clamped to `height − PLAY_CHROME_MIN_ROWS` so these
+/// rows survive at every height the floor guard admits (≥ 6 strip rows
+/// remain at the 24-row floor).
+const PLAY_CHROME_MIN_ROWS: u16 = 18;
 
 /// Render the too-small notice — the ONLY surface below the floor.
 fn render_floor_notice(frame: &mut ratatui::Frame<'_>, area: Rect, width: u16, height: u16) {
@@ -542,7 +557,7 @@ impl<H: Host> App<H> {
     /// 0.29-era shape of the same contract).
     pub fn render_frame<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> Result<(), B::Error> {
         self.ensure_root();
-        // The 100×30 floor guard (Wave 1 contract §1, ruling 1): below the
+        // The 100×24 floor guard (Wave 1 contract §1, ruling 1): below the
         // declared floor NOTHING but the notice renders and the input
         // handlers swallow everything outside the quit set — the layout
         // arithmetic below the floor cannibalizes real chrome (the verb
@@ -646,7 +661,12 @@ impl<H: Host> App<H> {
                     // since the wiki laid out its link-hit rects against
                     // the FULL area).
                     let (strip_area, chrome_area) = if tutorial_visible {
-                        let strip_height = tutorial.height_for(area.width, area.height);
+                        // Clamped so the fixed chrome below always keeps its
+                        // rows — the strip yields, the verb plate never
+                        // clips (the §1 invariant at the 24-row floor).
+                        let strip_height = tutorial
+                            .height_for(area.width, area.height)
+                            .min(area.height.saturating_sub(PLAY_CHROME_MIN_ROWS));
                         let [strip_area, chrome_area] = Layout::vertical([
                             Constraint::Length(strip_height),
                             Constraint::Min(0),

--- a/rust/crates/babylon-tui/src/config.rs
+++ b/rust/crates/babylon-tui/src/config.rs
@@ -120,16 +120,18 @@ pub struct AppConfig {
     /// `docs/superpowers/specs/2026-07-27-m3-tutorial-contracts.md` §5: the
     /// harness passes `[120, 50]`, the Python pilot's own `_PILOT_SIZE`, so
     /// frame-text checks assert against an un-clipped viewport). Defaults
-    /// to the DECLARED FLOOR (Wave 1 contract §1, Director ruling 1:
-    /// 100×30) — the old M0 `80×24` default sits BELOW the floor and
-    /// would render every defaulted fixture the too-small notice.
+    /// to the 100×30 density-design size (Wave 1 contract §1 — the guard
+    /// floor itself is 100×24 since the Director's 2026-07-28 field
+    /// report), so defaulted fixtures render the full designed chrome.
     #[serde(default = "default_headless_size")]
     pub headless_size: (u16, u16),
 }
 
-/// [`AppConfig::headless_size`]'s default: the declared 100×30 floor
-/// (`babylon_tui::app::{FLOOR_WIDTH, FLOOR_HEIGHT}` — kept in lockstep by
-/// `floor_guard.rs`'s at-floor test rendering with a defaulted config).
+/// [`AppConfig::headless_size`]'s default: the 100×30 DENSITY-DESIGN size
+/// — deliberately ABOVE the 100×24 guard floor
+/// (`babylon_tui::app::{FLOOR_WIDTH, FLOOR_HEIGHT}`), so defaulted
+/// fixtures render the full designed chrome; the floor itself is pinned
+/// by `floor_guard.rs`.
 fn default_headless_size() -> (u16, u16) {
     (100, 30)
 }
@@ -204,7 +206,7 @@ mod tests {
 
     #[test]
     fn headless_size_defaults_to_the_declared_floor_and_can_be_overridden() {
-        // Wave 1 contract §1 (ruling 1): the default IS the 100×30 floor —
+        // Wave 1 contract §1 (ruling 1): the default is the 100×30 design size —
         // a below-floor default would render every defaulted fixture the
         // too-small notice instead of its actual surface.
         let default_cfg = AppConfig::from_json(

--- a/rust/crates/babylon-tui/tests/floor_guard.rs
+++ b/rust/crates/babylon-tui/tests/floor_guard.rs
@@ -1,9 +1,12 @@
-//! The 100×30 declared-floor guard (Wave 1 contract §1, Director ruling 1).
+//! The 100×24 declared-floor guard (Wave 1 contract §1, Director ruling 1;
+//! height amended 30→24 per the Director's 2026-07-28 field report — a
+//! fullscreen 151×27 laptop terminal was locked out of the game).
 //!
-//! Below the floor the client renders ONLY the too-small notice — the recon
-//! arithmetic of record shows the 11-line verb plate clips three Article-V
-//! verbs at 80×24 under the tutorial strip's 40% clamp, and the ruled fix
-//! is the floor, not plate pagination. The guard swallows every key except
+//! Below the floor the client renders ONLY the too-small notice. Density is
+//! designed to 100×30; below it the tutorial strip band is clamped against
+//! the play chrome's fixed rows (`PLAY_CHROME_MIN_ROWS`) so the verb plate
+//! never clips — the strip yields, not the plate (the §1 invariant,
+//! re-established at the lower floor). The guard swallows every key except
 //! the quit set (no hidden state mutation against an invisible UI) and
 //! lifts with all state intact on the next at-floor render.
 
@@ -44,7 +47,7 @@ fn render(app: &mut App<FakeHost>, terminal: &mut Terminal<TestBackend>) {
 }
 
 #[test]
-fn below_floor_renders_only_the_too_small_notice() {
+fn below_floor_width_renders_only_the_too_small_notice() {
     let mut app = test_app();
     let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("backend");
     render(&mut app, &mut terminal);
@@ -54,7 +57,7 @@ fn below_floor_renders_only_the_too_small_notice() {
         "the notice must name the condition:\n{frame}"
     );
     assert!(
-        frame.contains("100x30") && frame.contains("80x24"),
+        frame.contains("100x24") && frame.contains("80x24"),
         "the notice must name the floor AND the current size:\n{frame}"
     );
     assert!(
@@ -64,9 +67,22 @@ fn below_floor_renders_only_the_too_small_notice() {
 }
 
 #[test]
+fn below_floor_height_renders_only_the_too_small_notice() {
+    let mut app = test_app();
+    let mut terminal = Terminal::new(TestBackend::new(120, 23)).expect("backend");
+    render(&mut app, &mut terminal);
+    let frame = buffer_text(&terminal);
+    assert!(
+        frame.contains("terminal too small") && frame.contains("120x23"),
+        "23 rows is below the floor on the height axis alone:\n{frame}"
+    );
+    assert!(!frame.contains("CAMPAIGNS"));
+}
+
+#[test]
 fn at_floor_renders_the_normal_surface() {
     let mut app = test_app();
-    let mut terminal = Terminal::new(TestBackend::new(100, 30)).expect("backend");
+    let mut terminal = Terminal::new(TestBackend::new(100, 24)).expect("backend");
     render(&mut app, &mut terminal);
     let frame = buffer_text(&terminal);
     assert!(
@@ -76,6 +92,21 @@ fn at_floor_renders_the_normal_surface() {
     assert!(
         !frame.contains("terminal too small"),
         "no notice at the floor:\n{frame}"
+    );
+}
+
+#[test]
+fn the_directors_fullscreen_laptop_geometry_renders() {
+    // The 2026-07-28 field report verbatim: a fullscreen 1366×768 laptop
+    // terminal at 151×27 was refused by the old 30-row floor. That
+    // geometry must render, permanently.
+    let mut app = test_app();
+    let mut terminal = Terminal::new(TestBackend::new(151, 27)).expect("backend");
+    render(&mut app, &mut terminal);
+    let frame = buffer_text(&terminal);
+    assert!(
+        frame.contains("CAMPAIGNS") && !frame.contains("terminal too small"),
+        "151x27 must never be locked out again:\n{frame}"
     );
 }
 


### PR DESCRIPTION
Field report 2026-07-28: `babylon play --client rust` refused a fullscreen 151×27 terminal (1366×768 laptop) — on that hardware 30 rows is unreachable without shrinking the font, which inverts ruling 1's intent (refuse cramped mush, not refuse real machines).

- Guard floor: **100×24** (width stays 100 — the 24-col rails need it; height drops to the classic terminal minimum).
- Density stays **designed to 100×30**: `headless_size` default unchanged → zero golden/transcript drift.
- The §1 verb-plate invariant (the reason 30 was chosen) is re-established at every admitted height: the tutorial strip band is clamped against the play chrome's fixed 18 rows (`PLAY_CHROME_MIN_ROWS` = HUD 3 + mid-min 5 + plate 8 + status 1 + keybar 1) — the strip yields, the plate never clips, ≥6 strip rows remain at the floor.
- New pins: height-axis-only guard case (120×23), at-floor 100×24, and `the_directors_fullscreen_laptop_geometry_renders` (151×27, permanent).
- Recorded as Wave 1 contract §7.7 + a master-plan ruling-1 amendment.

`mise run rust:check` green; all babylon-tui suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)