### PR TITLE
feat(tui): client logging estate — log4rs sink + capture rotation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,10 @@ lives in-tree at `rust/` and IS `babylon play` — the only terminal client sinc
 (Director ruling 2026-07-28: Textual deleted outright, no deprecation window; the `--client` flag
 is gone). Since the M7 packaging flip the `babylon-tui` wheel is a DEFAULT dependency (every
 `uv sync` builds it — needs cargo; after Rust edits run `uvx maturin develop` in `rust/`;
-`mise run rust:check` is its gate).
+`mise run rust:check` is its gate). Client logs (Director directive 2026-07-28): everything under
+`~/.local/share/babylon/logs/` — `babylon.log` (Python, JSONL DEBUG), `rust-client.log` (the Rust
+client via `babylon_tui::logging` log4rs, DEBUG), `client-capture.log` (raw stdio captured during
+play) — all 10 MB size-rotated.
 
 ## Engine
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -35,6 +35,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi-to-tui"
 version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +78,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -113,6 +131,8 @@ dependencies = [
  "hypergraph-rs",
  "image",
  "insta",
+ "log",
+ "log4rs",
  "pulldown-cmark",
  "ratatui",
  "ratatui-image",
@@ -127,6 +147,7 @@ name = "babylon-tui-python"
 version = "0.1.0"
 dependencies = [
  "babylon-tui",
+ "log",
  "pyo3",
  "ratatui",
  "serde_json",
@@ -286,6 +307,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +350,12 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -490,6 +528,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.119",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -851,6 +890,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icy_sixel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1108,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "log-mdc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
+
+[[package]]
+name = "log4rs"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e947bb896e702c711fccc2bf02ab2abb6072910693818d1d6b07ee2b9dfd86c"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "chrono",
+ "derive_more",
+ "fnv",
+ "log",
+ "log-mdc",
+ "mock_instant",
+ "parking_lot",
+ "thiserror 2.0.19",
+ "thread-id",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "lru"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1210,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "mock_instant"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb517913cfcfb9eeda59f36020269075a152701a01606c612f547e4890be399"
 
 [[package]]
 name = "moxcms"
@@ -2546,6 +2641,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2010d27add3f3240c1fef7959f46c814487b216baee662af53be645ba7831c07"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,6 +2824,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"

--- a/rust/crates/babylon-tui-python/Cargo.toml
+++ b/rust/crates/babylon-tui-python/Cargo.toml
@@ -11,6 +11,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 babylon-tui = { path = "../babylon-tui", features = ["raster"] }
+# host-call flight record (Director directive 2026-07-28) — the facade
+# only; the sink lives in babylon-tui::logging.
+log = "0.4"
 pyo3 = { version = "0.29", features = ["extension-module"] }
 ratatui = "0.30"
 serde_json = "1"

--- a/rust/crates/babylon-tui-python/src/lib.rs
+++ b/rust/crates/babylon-tui-python/src/lib.rs
@@ -27,14 +27,19 @@ impl PyHost {
     /// a Python `PanicException` — after `TerminalSession`'s Drop has
     /// restored the terminal — so the player sees the real failure.
     fn call0(&self, name: &str) -> String {
+        log::debug!(target: "host", "call {name}");
         Python::attach(|py| {
             match self
                 .obj
                 .call_method0(py, name)
                 .and_then(|v| v.extract::<String>(py))
             {
-                Ok(value) => value,
+                Ok(value) => {
+                    log::debug!(target: "host", "reply {name}: {} bytes", value.len());
+                    value
+                }
                 Err(error) => {
+                    log::error!(target: "host", "host method {name} raised");
                     error.print(py);
                     panic!("host method {name} raised — traceback above (III.11 loud failure)")
                 }
@@ -45,14 +50,19 @@ impl PyHost {
     /// Call a one-string-arg host method returning a JSON string; raises
     /// loudly exactly like [`Self::call0`].
     fn call1(&self, name: &str, arg: &str) -> String {
+        log::debug!(target: "host", "call {name}({arg})");
         Python::attach(|py| {
             match self
                 .obj
                 .call_method1(py, name, (arg,))
                 .and_then(|v| v.extract::<String>(py))
             {
-                Ok(value) => value,
+                Ok(value) => {
+                    log::debug!(target: "host", "reply {name}: {} bytes", value.len());
+                    value
+                }
                 Err(error) => {
+                    log::error!(target: "host", "host method {name}({arg}) raised");
                     error.print(py);
                     panic!("host method {name} raised — traceback above (III.11 loud failure)")
                 }
@@ -175,6 +185,22 @@ impl Host for PyHost {
 fn run(py: Python<'_>, host: Py<PyAny>, config_json: &str) -> PyResult<String> {
     let cfg = AppConfig::from_json(config_json)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    // Client logging (Director directive 2026-07-28): install the rolling
+    // file sink IFF the composition root passed a directory — the headless
+    // harness never does, so the goldens' world has no logger at all. A
+    // broken sink is a loud boot failure, never a silent no-log session.
+    if let Some(dir) = cfg.log_dir.as_deref() {
+        babylon_tui::logging::init_file_logging(std::path::Path::new(dir), &cfg.log_level)
+            .map_err(pyo3::exceptions::PyRuntimeError::new_err)?;
+        log::info!(
+            target: "boot",
+            "babylon-tui boot: campaign={:?} tier={:?} tutorial={} narrator={}",
+            cfg.campaign_id,
+            cfg.render_tier,
+            cfg.tutorial_enabled,
+            cfg.narrator_enabled
+        );
+    }
     let py_host = PyHost { obj: host };
     let headless = cfg.headless;
     let headless_size = cfg.headless_size;

--- a/rust/crates/babylon-tui/Cargo.toml
+++ b/rust/crates/babylon-tui/Cargo.toml
@@ -24,6 +24,20 @@ raster = ["dep:hypergraph-rs", "dep:ratatui-image", "dep:image"]
 # no highlighting needed; keeps the client C-toolchain-free (AA disclosure:
 # also removes the classic MSVC cross-compile failure point).
 babylon-md = { path = "../babylon-md", default-features = false }
+# Client logging estate (Director directive 2026-07-28): log4rs is the Rust
+# log4j — programmatic config, size-triggered rolling, fixed-window archive
+# caps. default-features off keeps the graph to exactly the pieces the
+# file-only sink uses (a console appender is the PR #318 frame-corruption
+# class; gzip would pull flate2 for nothing). Pure Rust — the client stays
+# C-toolchain-free (AA disclosure).
+log = "0.4"
+log4rs = { version = "1", default-features = false, features = [
+    "rolling_file_appender",
+    "compound_policy",
+    "size_trigger",
+    "fixed_window_roller",
+    "pattern_encoder",
+] }
 pulldown-cmark = "0.13"
 ratatui = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/rust/crates/babylon-tui/src/app.rs
+++ b/rust/crates/babylon-tui/src/app.rs
@@ -2398,12 +2398,25 @@ pub fn run_interactive<H: Host>(mut app: App<H>) -> std::io::Result<Vec<String>>
         app.drain_host_calls();
         match event::read()? {
             Event::Key(key) => {
+                // Flight record (Director directive 2026-07-28): every
+                // input the dispatcher sees, at the single seam it enters.
+                // No-op unless the composition root installed the sink.
+                log::debug!(target: "input", "key {:?} mods={:?}", key.code, key.modifiers);
                 if app.handle_key(key.code, key.modifiers) {
+                    log::info!(target: "input", "quit via key {:?}", key.code);
                     break;
                 }
             }
             Event::Mouse(mouse) => {
+                log::debug!(
+                    target: "input",
+                    "mouse {:?} @({},{})",
+                    mouse.kind,
+                    mouse.column,
+                    mouse.row
+                );
                 if app.handle_mouse(mouse) {
+                    log::info!(target: "input", "quit via mouse");
                     break;
                 }
             }

--- a/rust/crates/babylon-tui/src/config.rs
+++ b/rust/crates/babylon-tui/src/config.rs
@@ -125,6 +125,25 @@ pub struct AppConfig {
     /// report), so defaulted fixtures render the full designed chrome.
     #[serde(default = "default_headless_size")]
     pub headless_size: (u16, u16),
+    /// Sink directory for the client's rolling `rust-client.log`
+    /// (Director directive 2026-07-28; `crate::logging`). The Python
+    /// composition root passes its own `BaseConfig.LOG_DIR` so both
+    /// halves of the client log into ONE directory. Absent (the headless
+    /// harness) means logging is never installed — transcript goldens
+    /// cannot drift.
+    #[serde(default)]
+    pub log_dir: Option<String>,
+    /// Root level for the client log (`error|warn|info|debug|trace`).
+    /// DEBUG by the Director's word ("right now in debug mode we want
+    /// everything"); unknown values fail loudly at init, never silently
+    /// downgrade.
+    #[serde(default = "default_log_level")]
+    pub log_level: String,
+}
+
+/// [`AppConfig::log_level`]'s default — see that field's doc.
+fn default_log_level() -> String {
+    "debug".to_owned()
 }
 
 /// [`AppConfig::headless_size`]'s default: the 100×30 DENSITY-DESIGN size
@@ -223,6 +242,32 @@ mod tests {
         )
         .unwrap();
         assert_eq!(sized_cfg.headless_size, (120, 50));
+    }
+
+    #[test]
+    fn log_sink_fields_parse_and_default() {
+        // Director directive 2026-07-28: the interactive lane threads the
+        // Python LOG_DIR + a debug default; the harness omits both and
+        // logging stays uninstalled.
+        let cfg = AppConfig::from_json(
+            r#"{"campaign_id":"c1","campaign_name":"W","render_tier":"glyph",
+                "tutorial_enabled":true,"narrator_enabled":false,
+                "log_dir":"/home/p/.local/share/babylon/logs","log_level":"info"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.log_dir.as_deref(),
+            Some("/home/p/.local/share/babylon/logs")
+        );
+        assert_eq!(cfg.log_level, "info");
+
+        let bare = AppConfig::from_json(
+            r#"{"campaign_id":"c1","campaign_name":"W","render_tier":"glyph",
+                "tutorial_enabled":true,"narrator_enabled":false}"#,
+        )
+        .unwrap();
+        assert!(bare.log_dir.is_none());
+        assert_eq!(bare.log_level, "debug");
     }
 
     #[test]

--- a/rust/crates/babylon-tui/src/lib.rs
+++ b/rust/crates/babylon-tui/src/lib.rs
@@ -7,6 +7,7 @@ pub mod app;
 pub mod config;
 pub mod host;
 pub mod layout_registry;
+pub mod logging;
 pub mod md_style;
 #[cfg(feature = "raster")]
 pub mod raster_bridge;

--- a/rust/crates/babylon-tui/src/logging.rs
+++ b/rust/crates/babylon-tui/src/logging.rs
@@ -1,0 +1,140 @@
+//! File-only client logging (Director directive 2026-07-28).
+//!
+//! The Python half of the client already logs the way the Director asked
+//! for — `babylon.config.logging_config`: JSON-lines, DEBUG, 10 MB
+//! size-rotation with capped archives. This module is the Rust half's
+//! equivalent, built on `log4rs` (the Rust log4j: programmatic config,
+//! size-triggered rolling, fixed-window archives), sinking into the SAME
+//! player log directory the Python side owns
+//! (`babylon.config.base.BaseConfig.LOG_DIR`, threaded across the FFI as
+//! `AppConfig::log_dir`).
+//!
+//! **File-only, never the terminal.** A console appender here would be
+//! exactly the frame-corruption class the terminal-takeover fix killed
+//! (PR #318): the client paints the alternate screen and repaints only on
+//! input, so one stray line wrecks the frame until the next keypress.
+//!
+//! **Off in the harness.** The headless BDD harness passes no `log_dir`,
+//! so the global logger is never installed and every `log::debug!` in the
+//! client compiles to a no-op behind `max_level = Off` — transcript
+//! goldens cannot drift, and the interactive lane loses nothing.
+//!
+//! **No wall-clock in client source.** Timestamps come from log4rs's own
+//! pattern encoder inside the appender; this crate's source stays free of
+//! `Instant`/`SystemTime` (the raster-lane discipline).
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use log::LevelFilter;
+use log4rs::append::rolling_file::policy::compound::roll::fixed_window::FixedWindowRoller;
+use log4rs::append::rolling_file::policy::compound::trigger::size::SizeTrigger;
+use log4rs::append::rolling_file::policy::compound::CompoundPolicy;
+use log4rs::append::rolling_file::RollingFileAppender;
+use log4rs::config::{Appender, Config, Root};
+use log4rs::encode::pattern::PatternEncoder;
+
+/// Rotation trigger: matches the Python estate's `MAIN_LOG_MAX_BYTES`
+/// discipline (10 MB per file).
+const LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Archive window: `rust-client.1.log` .. `rust-client.5.log`, oldest
+/// dropped (matches the Python estate's `backupCount`).
+const LOG_ARCHIVES: u32 = 5;
+
+/// One-shot guard: the `log` crate's global logger can only ever be
+/// installed once per process; a second `init_file_logging` call (a
+/// relaunch through the same interpreter) is a no-op success.
+static INIT: OnceLock<()> = OnceLock::new();
+
+/// Install the rolling-file logger writing `rust-client.log` under
+/// `log_dir`.
+///
+/// `level` is one of `error|warn|info|debug|trace` — anything else is a
+/// config defect and fails loudly BEFORE touching global state (validated
+/// even on the idempotent path, so a bad level never rides in silently
+/// behind an earlier successful init).
+pub fn init_file_logging(log_dir: &Path, level: &str) -> Result<(), String> {
+    let level_filter = parse_level(level)?;
+    if INIT.get().is_some() {
+        return Ok(());
+    }
+    let roll_pattern = log_dir.join("rust-client.{}.log");
+    let roller = FixedWindowRoller::builder()
+        .build(
+            roll_pattern
+                .to_str()
+                .ok_or_else(|| format!("log dir is not valid UTF-8: {}", log_dir.display()))?,
+            LOG_ARCHIVES,
+        )
+        .map_err(|e| format!("log roller config: {e}"))?;
+    let policy = CompoundPolicy::new(Box::new(SizeTrigger::new(LOG_MAX_BYTES)), Box::new(roller));
+    let appender = RollingFileAppender::builder()
+        .encoder(Box::new(PatternEncoder::new(
+            "{d(%Y-%m-%dT%H:%M:%S%.3f)} [{l}] {t} — {m}{n}",
+        )))
+        .build(log_dir.join("rust-client.log"), Box::new(policy))
+        .map_err(|e| format!("log appender: {e}"))?;
+    let config = Config::builder()
+        .appender(Appender::builder().build("file", Box::new(appender)))
+        .build(Root::builder().appender("file").build(level_filter))
+        .map_err(|e| format!("log config: {e}"))?;
+    log4rs::init_config(config).map_err(|e| format!("log init: {e}"))?;
+    let _ = INIT.set(());
+    install_panic_hook();
+    Ok(())
+}
+
+/// Parse the level string; unknown levels are a loud config defect.
+fn parse_level(level: &str) -> Result<LevelFilter, String> {
+    match level {
+        "error" => Ok(LevelFilter::Error),
+        "warn" => Ok(LevelFilter::Warn),
+        "info" => Ok(LevelFilter::Info),
+        "debug" => Ok(LevelFilter::Debug),
+        "trace" => Ok(LevelFilter::Trace),
+        other => Err(format!(
+            "unknown log_level {other:?} (expected error|warn|info|debug|trace)"
+        )),
+    }
+}
+
+/// Log a panic before it unwinds — the crash itself must reach the sink
+/// (the FFI turns the unwind into a Python `PanicException` after the
+/// terminal restores; this line is the client-side flight record of it).
+fn install_panic_hook() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        log::error!(target: "panic", "client panic: {info}");
+        log::logger().flush();
+        previous(info);
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_unknown_level_fails_loudly_even_after_init() {
+        // Validation precedes the idempotency check, so this holds no
+        // matter which test installed the global logger first.
+        let err = init_file_logging(Path::new("/nonexistent"), "loudest").unwrap_err();
+        assert!(err.contains("unknown log_level"));
+    }
+
+    #[test]
+    fn init_writes_the_sink_and_reinit_is_a_noop_success() {
+        let dir = std::env::temp_dir().join(format!("babylon-tui-logtest-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("test log dir");
+        init_file_logging(&dir, "debug").expect("first init");
+        log::debug!(target: "test", "sink probe line");
+        log::logger().flush();
+        let sink = dir.join("rust-client.log");
+        let written = std::fs::read_to_string(&sink).expect("sink exists");
+        assert!(written.contains("sink probe line"));
+        // Second init: the global logger is already installed — Ok, not Err.
+        init_file_logging(&dir, "debug").expect("re-init is a no-op success");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/babylon/cli/play.py
+++ b/src/babylon/cli/play.py
@@ -107,6 +107,20 @@ if TYPE_CHECKING:
 #: belong in ``GameDefines``).
 _CAMPAIGN_START_YEAR = 2010
 
+#: Root level for the Rust client's own ``rust-client.log`` sink (Director
+#: directive 2026-07-28: "right now in debug mode we want everything" —
+#: crossing the FFI as ``AppConfig::log_level``; ``babylon_tui::logging``
+#: fails loudly on an unknown value). Infrastructure verbosity, not a
+#: gameplay coefficient — deliberately NOT a ``GameDefines`` entry.
+_CLIENT_LOG_LEVEL = "debug"
+
+#: Size cap for ``client-capture.log`` (the terminal-takeover raw
+#: stdout/stderr capture, PR #318). The capture is an append-mode raw
+#: stream — ``logging.handlers`` rotation can't wrap it — so
+#: :func:`_rotate_capture` applies the same 10 MB discipline the rotating
+#: estates use, with one archived predecessor.
+_CAPTURE_LOG_MAX_BYTES = 10 * 1024 * 1024
+
 #: Leontief calculator sessions opened for interactive campaigns
 #: (``_build_economics_overrides`` hands ownership to the caller; the
 #: headless runner closes its one session in a ``finally`` — the CLI's
@@ -595,6 +609,30 @@ def _tutorial_progress_factory(
     return _factory
 
 
+def _rotate_capture(path: Path, cap_bytes: int = _CAPTURE_LOG_MAX_BYTES) -> None:
+    """Archive ``client-capture.log`` once it reaches the cap (Director
+    directive 2026-07-28: every client log rotates at a reasonable size).
+
+    The capture is a raw append-mode stream fed by ``sys.stdout``/``stderr``
+    redirection — ``logging.handlers.RotatingFileHandler`` can't wrap it —
+    so this applies the estate's 10 MB discipline by hand at session start:
+    at or over the cap, the file becomes ``client-capture.log.1``
+    (replacing any previous archive) and the session opens a fresh capture.
+
+    :param path: the capture file (need not exist — a fresh install has
+        neither the file nor the directory yet).
+    :param cap_bytes: rotation threshold, default
+        :data:`_CAPTURE_LOG_MAX_BYTES`.
+    """
+    try:
+        size = path.stat().st_size
+    except FileNotFoundError:
+        return
+    if size < cap_bytes:
+        return
+    path.replace(path.with_name(path.name + ".1"))
+
+
 @contextmanager
 def _terminal_takeover() -> Iterator[None]:
     """Make the terminal the Rust client's alone for the duration.
@@ -629,6 +667,7 @@ def _terminal_takeover() -> Iterator[None]:
         for stream in (sys.stdout, sys.stderr, sys.__stdout__, sys.__stderr__)
         if stream is not None
     }
+    _rotate_capture(BaseConfig.LOG_DIR / "client-capture.log")
     detached = [
         handler
         for handler in root.handlers
@@ -740,6 +779,9 @@ def _run_rust_client(*, narrator_enabled: bool, tutorial_enabled: bool | None) -
         tutorial_progress_factory=_tutorial_progress_factory(tutorial_enabled, steps),
         render_config=render_cfg,
     )
+    from babylon.config.base import BaseConfig
+
+    BaseConfig.LOG_DIR.mkdir(parents=True, exist_ok=True)
     config_json = json.dumps(
         {
             "campaign_id": "",
@@ -748,6 +790,11 @@ def _run_rust_client(*, narrator_enabled: bool, tutorial_enabled: bool | None) -
             "tutorial_enabled": tutorial_enabled is not False,
             "narrator_enabled": narrator_enabled,
             "headless": False,
+            # Director directive 2026-07-28: the Rust half logs into the
+            # SAME estate as the Python half — babylon_tui::logging
+            # installs a rolling rust-client.log here at boot.
+            "log_dir": str(BaseConfig.LOG_DIR),
+            "log_level": _CLIENT_LOG_LEVEL,
         }
     )
     with _terminal_takeover():

--- a/tests/unit/cli/test_play.py
+++ b/tests/unit/cli/test_play.py
@@ -306,6 +306,35 @@ def test_tutorial_steps_skips_the_two_pre_shell_beats() -> None:
     assert "begin_the_operation" not in ids
 
 
+class TestCaptureRotation:
+    """``client-capture.log`` rotates at the cap (Director directive
+    2026-07-28) — the one raw append stream in the log estate gets the
+    same size discipline as the rotating handlers."""
+
+    def test_at_or_over_the_cap_archives_to_dot_one(self, tmp_path: Path) -> None:
+        capture = tmp_path / "client-capture.log"
+        capture.write_text("x" * 100, encoding="utf-8")
+        play_cmd._rotate_capture(capture, cap_bytes=100)
+        assert not capture.exists()
+        assert (tmp_path / "client-capture.log.1").read_text(encoding="utf-8") == "x" * 100
+
+    def test_rotation_replaces_a_previous_archive(self, tmp_path: Path) -> None:
+        capture = tmp_path / "client-capture.log"
+        capture.write_text("new", encoding="utf-8")
+        (tmp_path / "client-capture.log.1").write_text("old", encoding="utf-8")
+        play_cmd._rotate_capture(capture, cap_bytes=1)
+        assert (tmp_path / "client-capture.log.1").read_text(encoding="utf-8") == "new"
+
+    def test_under_the_cap_keeps_appending(self, tmp_path: Path) -> None:
+        capture = tmp_path / "client-capture.log"
+        capture.write_text("small", encoding="utf-8")
+        play_cmd._rotate_capture(capture, cap_bytes=10_000)
+        assert capture.read_text(encoding="utf-8") == "small"
+
+    def test_a_missing_file_or_directory_is_a_quiet_noop(self, tmp_path: Path) -> None:
+        play_cmd._rotate_capture(tmp_path / "absent" / "client-capture.log")
+
+
 class TestClientRustLane:
     """M0 Task 7 → M7 cutover (ADR150): the rust lane — now the ONLY lane
     (Director ruling 2026-07-28: Textual deleted outright, ``--client`` gone).
@@ -364,6 +393,34 @@ class TestClientRustLane:
         # campaign-loading seam — the M1 wiring closing the gap where
         # RustClientHost.bind_session had zero production caller.
         assert callable(host.load_campaign)
+
+    def test_rust_config_carries_the_log_sink(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        _patched_composition_root: None,
+    ) -> None:
+        """Director directive 2026-07-28: the Rust half logs into the SAME
+        LOG_DIR estate as the Python half — the composition root passes the
+        sink directory + a debug level across the FFI
+        (``babylon_tui::logging`` installs the rolling file appender; the
+        headless harness passes neither, so goldens never see a logger)."""
+        import json
+        import sys
+
+        monkeypatch.setenv("BABYLON_CONFIG_DIR", str(tmp_path))
+
+        handoffs: list[tuple[object, str]] = []
+        fake = SimpleNamespace(run=lambda host, config_json: handoffs.append((host, config_json)))
+        monkeypatch.setitem(sys.modules, "babylon_tui", fake)
+
+        play_cmd.run(narrator_enabled=False)
+
+        from babylon.config.base import BaseConfig
+
+        cfg = json.loads(handoffs[0][1])
+        assert cfg["log_dir"] == str(BaseConfig.LOG_DIR)
+        assert cfg["log_level"] == "debug"
 
     def test_rust_lane_honors_a_recorded_pixel_verdict(
         self,

--- a/tests/unit/tui/test_rust_client_ffi.py
+++ b/tests/unit/tui/test_rust_client_ffi.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -138,6 +139,30 @@ def test_default_config_keeps_tutorial_disabled() -> None:
 def test_run_headless_renders_and_records_calls() -> None:
     transcript = json.loads(babylon_tui.run(_FakeHost(), _config()))
     assert "lobby_catalog_json" in transcript["host_calls"]
+    assert "Wayne County" in transcript["frames"][0]
+
+
+def test_a_log_dir_in_config_materializes_the_rust_sink(tmp_path: Path) -> None:
+    """Director directive 2026-07-28 (``babylon_tui::logging``): a config
+    carrying ``log_dir`` installs the rolling file sink through the REAL
+    FFI — the boot line and the host-call flight record land in
+    ``rust-client.log``. Configs without the key (every other test here)
+    never install a logger, which is what keeps transcript goldens clean.
+
+    One process-global caveat pinned deliberately: the `log` crate's
+    logger installs once per process, so this test also proves a SECOND
+    run with a different dir is a quiet no-op success, not a crash."""
+    sink_dir = tmp_path / "logs"
+    sink_dir.mkdir()
+    babylon_tui.run(_FakeHost(), _config(log_dir=str(sink_dir), log_level="debug"))
+    written = (sink_dir / "rust-client.log").read_text(encoding="utf-8")
+    assert "babylon-tui boot" in written
+    assert "call lobby_catalog_json" in written
+    # Re-run with a different sink: the global logger already exists —
+    # boot must not crash (OnceLock no-op), frames still render.
+    other = tmp_path / "other"
+    other.mkdir()
+    transcript = json.loads(babylon_tui.run(_FakeHost(), _config(log_dir=str(other))))
     assert "Wayne County" in transcript["frames"][0]
 
 


### PR DESCRIPTION
## Client logging estate (Director directive 2026-07-28)

> "we should be utilising log4rs or whatever the Rust equivalent of log4j is... reasonably rotating basis with reasonable file sizes and right now in debug mode we want ***everything***"

The Python half already had the discipline (JSONL, DEBUG, 10 MB rotation). This lands the missing Rust half plus the one uncapped file:

- **`babylon_tui::logging`** — log4rs (programmatic config, no YAML discovery): rolling `rust-client.log` in the SAME `LOG_DIR` as the Python estate, 10 MB × 5 archives, pattern-encoded, **file-only** (a console appender is the PR #318 frame-corruption class). OnceLock idempotent init; unknown level = loud refusal validated even on the no-op path; panic hook logs before the unwind crosses the FFI.
- **Flight record at the seams**: boot config line, every host call + reply size (the PyHost choke point), every key/mouse event at the dispatcher.
- **Harness-safe by construction**: logging installs IFF `AppConfig.log_dir` is present; the headless harness passes neither key — transcript goldens never see a logger.
- **`client-capture.log` now rotates** at 10 MB (`_rotate_capture`; it was the estate's one append-forever stream).
- **Proof through the real wheel**: `test_a_log_dir_in_config_materializes_the_rust_sink` — boot line + host-call record in the sink via the actual FFI, second init a quiet no-op. Doubles as a stale-wheel canary.
- log4rs `default-features=false` (pure Rust — C-toolchain-free per Amendment AA); no `Instant`/`SystemTime` in client source (raster-lane discipline).

## Gates
- `mise run rust:check` green (fmt, clippy, 79 tests incl. 3 new, doc)
- `mise run check` green (full fast gate, CHECK_EXIT=0 marker verified)
- Scoped: 31 green across `test_play.py` + `test_rust_client_ffi.py`
- No `tests/baselines/**` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)