### PR TITLE
feat(tools): ensemble table in ceremony messages (P27 §8)

### DIFF
--- a/tests/unit/tools/test_generate_ceremony_message.py
+++ b/tests/unit/tools/test_generate_ceremony_message.py
@@ -15,13 +15,16 @@ the real ``tests/baselines/**`` estate.
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
-TOOLS_DIR = Path(__file__).resolve().parents[3] / "tools"
+REPO = Path(__file__).resolve().parents[3]
+TOOLS_DIR = REPO / "tools"
+TOOL_SCRIPT = TOOLS_DIR / "generate_ceremony_message.py"
 sys.path.insert(0, str(TOOLS_DIR))
 
 from check_baseline_ceremony import (  # type: ignore[import-not-found]  # noqa: E402
@@ -207,3 +210,105 @@ class TestMainCli:
         not_a_repo = tmp_path / "plain"
         not_a_repo.mkdir()
         assert main(["--slug", "x", "--summary", "y", "--repo", str(not_a_repo)]) == 2
+
+
+class TestEnsembleReportTable:
+    """P27 §8 extension: an optional second Markdown table for stochastic
+    families, rendered from ``--ensemble-report <path.json>``. The
+    deterministic drift-table output must stay byte-unchanged when the flag
+    is absent."""
+
+    def test_ensemble_report_renders_second_table(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        (repo / "tests/baselines").mkdir(parents=True)
+        (repo / "tests/baselines/glut.csv").write_text(_CSV_HEADER + "0,1.0,0.0\n")
+        _git(repo, "add", "tests/baselines/glut.csv")
+
+        report = tmp_path / "ensemble.json"
+        report.write_text(
+            json.dumps(
+                {
+                    "families": [
+                        {
+                            "family": "electoral.turnout",
+                            "n": 32,
+                            "envelope": "outcome counts within +/-2 of reference",
+                            "observed": "REVOLUTIONARY_VICTORY 3/32 (ref 4/32)",
+                            "pass": True,
+                        }
+                    ]
+                }
+            )
+        )
+        out = subprocess.run(
+            [
+                sys.executable,
+                str(TOOL_SCRIPT),
+                "--slug",
+                "test-slug",
+                "--summary",
+                "test",
+                "--repo",
+                str(repo),
+                "--ensemble-report",
+                str(report),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert out.returncode == 0, out.stderr
+        assert "electoral.turnout" in out.stdout
+        assert "Baselines: blessed(test-slug)" in out.stdout
+        assert message_declares_ceremony(out.stdout)
+
+    def test_without_flag_output_shape_unchanged(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        (repo / "tests/baselines").mkdir(parents=True)
+        (repo / "tests/baselines/glut.csv").write_text(_CSV_HEADER + "0,1.0,0.0\n")
+        _git(repo, "add", "tests/baselines/glut.csv")
+
+        out = subprocess.run(
+            [
+                sys.executable,
+                str(TOOL_SCRIPT),
+                "--slug",
+                "test-slug",
+                "--summary",
+                "test",
+                "--repo",
+                str(repo),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert out.returncode == 0, out.stderr
+        assert "ensemble" not in out.stdout.lower()
+
+    def test_malformed_family_row_fails_loudly(self, tmp_path: Path) -> None:
+        """III.11: a family row missing a required key must error, not
+        silently render a partial/blank row."""
+        repo = _init_repo(tmp_path)
+        (repo / "tests/baselines").mkdir(parents=True)
+        (repo / "tests/baselines/glut.csv").write_text(_CSV_HEADER + "0,1.0,0.0\n")
+        _git(repo, "add", "tests/baselines/glut.csv")
+
+        report = tmp_path / "ensemble.json"
+        report.write_text(json.dumps({"families": [{"family": "electoral.turnout", "n": 32}]}))
+        out = subprocess.run(
+            [
+                sys.executable,
+                str(TOOL_SCRIPT),
+                "--slug",
+                "test-slug",
+                "--summary",
+                "test",
+                "--repo",
+                str(repo),
+                "--ensemble-report",
+                str(report),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert out.returncode == 2
+        assert "envelope" in out.stderr or "pass" in out.stderr

--- a/tools/generate_ceremony_message.py
+++ b/tools/generate_ceremony_message.py
@@ -26,10 +26,17 @@ The generated message is not auto-committed: print it, review it, paste it
 ``tests/baselines/**`` itself — read-only over the working tree and git
 history.
 
+Optionally, ``--ensemble-report <path.json>`` (P27 spec §8) inserts a second
+Markdown table for stochastic families between the drift table and the
+trailer — one row per ``{family, n, envelope, observed, pass}`` object in the
+report's top-level ``families`` list. A malformed row (missing any of those
+keys) fails loudly (exit 2) rather than rendering a partial table. Without
+the flag, output is byte-unchanged from before it existed.
+
 Run: ``python3 tools/generate_ceremony_message.py --slug <slug> --summary
 "<what and why>"`` with baseline changes staged. Exit codes: 0 = message
-printed, 1 = no staged baseline changes to describe, 2 = usage or git
-failure.
+printed, 1 = no staged baseline changes to describe, 2 = usage, git, or
+ensemble-report failure.
 """
 
 from __future__ import annotations
@@ -37,10 +44,15 @@ from __future__ import annotations
 import argparse
 import csv
 import io
+import json
 import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+
+# The four required keys of one ensemble-family row (P27 spec §8). Fail loudly
+# (III.11) on anything missing rather than rendering a partial/blank row.
+_ENSEMBLE_FAMILY_KEYS = ("family", "n", "envelope", "observed", "pass")
 
 # Reuse the governed prefix + trailer grammar from the validator so the two
 # tools can never silently drift apart on what counts as "in scope" or
@@ -214,11 +226,59 @@ def build_drift_table(rows: list[DriftRow]) -> str:
     return "\n".join(lines)
 
 
-def build_ceremony_message(slug: str, summary: str, rows: list[DriftRow]) -> str:
-    """Assemble the full commit-message skeleton (subject/body/trailer)."""
+def load_ensemble_families(path: Path) -> list[dict[str, object]]:
+    """Load + schema-check ``--ensemble-report`` JSON (P27 spec §8).
+
+    Raises ``ValueError`` with a precise message on any malformed row —
+    III.11 loud failure, never a silently partial table.
+    """
+    data = json.loads(path.read_text())
+    families = data.get("families")
+    if not isinstance(families, list):
+        raise ValueError(f"ensemble report {path} has no top-level 'families' list")
+    for i, family in enumerate(families):
+        if not isinstance(family, dict):
+            raise ValueError(f"ensemble report {path} families[{i}] is not an object")
+        missing = [key for key in _ENSEMBLE_FAMILY_KEYS if key not in family]
+        if missing:
+            raise ValueError(
+                f"ensemble report {path} families[{i}] missing required key(s): "
+                f"{', '.join(missing)}"
+            )
+    return families
+
+
+def build_ensemble_table(families: list[dict[str, object]]) -> str:
+    """Render the second Markdown table for stochastic families."""
+    header = "| family | N | envelope | observed | pass |"
+    divider = "| --- | --- | --- | --- | --- |"
+    lines = [header, divider]
+    for family in families:
+        lines.append(
+            f"| {family['family']} | {family['n']} | {family['envelope']} | "
+            f"{family['observed']} | {family['pass']} |"
+        )
+    return "\n".join(lines)
+
+
+def build_ceremony_message(
+    slug: str,
+    summary: str,
+    rows: list[DriftRow],
+    ensemble_families: list[dict[str, object]] | None = None,
+) -> str:
+    """Assemble the full commit-message skeleton (subject/body/trailer).
+
+    When ``ensemble_families`` is given, a second Markdown table is inserted
+    between the drift table and the trailer; the drift-table-only path is
+    byte-unchanged from before this parameter existed.
+    """
     subject = f"test(baselines): {summary}"
     body = build_drift_table(rows)
     trailer = f"Baselines: blessed({slug})"
+    if ensemble_families:
+        ensemble_table = build_ensemble_table(ensemble_families)
+        return f"{subject}\n\n{body}\n\n{ensemble_table}\n\n{trailer}\n"
     return f"{subject}\n\n{body}\n\n{trailer}\n"
 
 
@@ -242,7 +302,25 @@ def main(argv: list[str] | None = None) -> int:
         default=Path.cwd(),
         help="repository root (default: current directory)",
     )
+    parser.add_argument(
+        "--ensemble-report",
+        type=Path,
+        default=None,
+        help=(
+            "path to a JSON report with a 'families' list of stochastic-family "
+            "rows ({family, n, envelope, observed, pass}); when given, a second "
+            "Markdown table is inserted between the drift table and the trailer"
+        ),
+    )
     args = parser.parse_args(argv)
+
+    ensemble_families: list[dict[str, object]] | None = None
+    if args.ensemble_report is not None:
+        try:
+            ensemble_families = load_ensemble_families(args.ensemble_report)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            print(f"generate_ceremony_message: {exc}", file=sys.stderr)
+            return 2
 
     try:
         paths = staged_baseline_paths(args.repo)
@@ -263,7 +341,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"generate_ceremony_message: git failed: {exc.stderr.strip()}", file=sys.stderr)
         return 2
 
-    message = build_ceremony_message(args.slug, args.summary, rows)
+    message = build_ceremony_message(args.slug, args.summary, rows, ensemble_families)
     assert message_declares_ceremony(message), (
         "generated message failed its own trailer grammar — this is a bug in "
         "generate_ceremony_message.py, not a usage error"


### PR DESCRIPTION
## Summary
- Program 27 Phase 0, Task 14: extend `tools/generate_ceremony_message.py` with an optional `--ensemble-report <path.json>` flag that inserts a second Markdown table (`| family | N | envelope | observed | pass |`) between the drift table and the `Baselines: blessed(...)` trailer.
- Malformed family rows (missing any of `family`/`n`/`envelope`/`observed`/`pass`) fail loudly at exit 2 (III.11) rather than rendering a partial table.
- Output is byte-unchanged when the flag is absent — deterministic drift-table path untouched.
- Tooling change, exempt from Program 27's no-new-engine-features rule.

## Test plan
- [x] `PYTHONPATH="$PWD/src" .venv/bin/python -m pytest tests/unit/tools/test_generate_ceremony_message.py -v` — 14 passed (3 new: renders second table, unchanged shape without flag, loud failure on malformed row)
- [x] `python3 tools/check_baseline_ceremony.py --help` — checker CLI unaffected
- [x] `ruff check` on both changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)