### PR TITLE
fix(config): one canonical defines_hash (Program 27 §7)

### DIFF
--- a/src/babylon/cli/play.py
+++ b/src/babylon/cli/play.py
@@ -76,7 +76,6 @@ above — a pinned subject now survives a quit/resume of the same campaign.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import sys
@@ -323,16 +322,16 @@ def _defines_hash(defines: GameDefines) -> str:
     """A deterministic fingerprint of one ``GameDefines`` snapshot.
 
     Stamped on every campaign the lobby mints (``CampaignCatalog.
-    create_campaign``'s ``defines_hash``) — sha256 of the canonically
-    (key-sorted) serialized coefficients, the same "hash a canonical
-    string" shape :func:`babylon.game.session._replay_identity_hash`
-    already uses, not a second ad hoc scheme.
+    create_campaign``'s ``defines_hash``) — delegates to
+    :func:`babylon.config.defines.canonical_defines_hash`, the one canonical
+    implementation (Program 27 spec §7).
 
     :param defines: the coefficients to fingerprint.
     :returns: a hex digest.
     """
-    canonical = json.dumps(defines.model_dump(mode="json"), sort_keys=True)
-    return hashlib.sha256(canonical.encode()).hexdigest()
+    from babylon.config.defines import canonical_defines_hash
+
+    return canonical_defines_hash(defines)
 
 
 def _bake_briefing(materializer: VaultMaterializer, session: GameSession) -> None:

--- a/src/babylon/config/defines/__init__.py
+++ b/src/babylon/config/defines/__init__.py
@@ -12,6 +12,7 @@ re-exports below.
 from __future__ import annotations
 
 from babylon.config.defines._assembler import GameDefines
+from babylon.config.defines._hash import canonical_defines_hash
 from babylon.config.defines.capital_vol2 import CapitalVolumeIIDefines
 from babylon.config.defines.capital_vol3 import CapitalVolumeIIIDefines
 from babylon.config.defines.consciousness import (
@@ -143,4 +144,5 @@ __all__ = [
     "VeilDefines",
     "VitalityDefines",
     "WorkingDayDefines",
+    "canonical_defines_hash",
 ]

--- a/src/babylon/config/defines/_hash.py
+++ b/src/babylon/config/defines/_hash.py
@@ -1,0 +1,26 @@
+"""The single canonical defines-hash (Program 27 spec §7, III.12(a)).
+
+Byte layout: ``model_dump(mode="json")`` → ``json.dumps(payload,
+sort_keys=True, separators=(",", ":"), ensure_ascii=True)`` → UTF-8 →
+SHA-256 full 64-hex. No ``default=`` fallback: a non-JSON-native value in
+the schema raises ``TypeError`` loudly (III.11) instead of hashing an
+implementation-defined ``str()``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from babylon.config.defines._assembler import GameDefines
+
+
+def canonical_defines_hash(defines: GameDefines) -> str:
+    """Compute the one canonical fingerprint of a ``GameDefines`` snapshot.
+
+    :param defines: the coefficients to fingerprint.
+    :returns: a 64-character lowercase hex SHA-256 digest.
+    """
+    payload = defines.model_dump(mode="json")
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/src/babylon/engine/headless_runner/runner.py
+++ b/src/babylon/engine/headless_runner/runner.py
@@ -955,14 +955,14 @@ def _resolve_defines(config: SimulationRunConfig) -> Any:
 
 
 def _defines_hash(defines: Any) -> str:
-    """SHA-256 over the canonical model_dump() of a GameDefines instance."""
-    try:
-        payload = defines.model_dump(mode="json")
-    except AttributeError:
-        payload = {"_repr": repr(defines)}
-    return hashlib.sha256(
-        json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
-    ).hexdigest()
+    """SHA-256 over the canonical model_dump() of a GameDefines instance.
+
+    Delegates to :func:`babylon.config.defines.canonical_defines_hash` — the
+    one canonical implementation (Program 27 spec §7).
+    """
+    from babylon.config.defines import canonical_defines_hash
+
+    return canonical_defines_hash(defines)
 
 
 def _sqlite_sha256(path: Path) -> str:

--- a/tests/baselines/bernie_valve.json
+++ b/tests/baselines/bernie_valve.json
@@ -1,8 +1,8 @@
 {
   "scenario": "bernie_valve",
   "description": "The hope valve, both routings: entryism, derecognition, and the topology-routed disillusion windows (U13 golden, ADR140)",
-  "generated_at": "2026-07-28T03:46:12+00:00",
-  "defines_hash": "a88f4b473efa828a",
+  "generated_at": "2026-07-29T15:38:10+00:00",
+  "defines_hash": "cdb80d5c850d8d323fab5335f5b397106e44b551c39f7af35f84dfdc3d89f487",
   "max_ticks": 52,
   "checkpoints": [
     {

--- a/tests/baselines/debs.json
+++ b/tests/baselines/debs.json
@@ -1,8 +1,8 @@
 {
   "scenario": "debs",
   "description": "The independent line under FPTP: the spoiler tax and the accumulation the ballot cannot touch (U13 golden, ADR140)",
-  "generated_at": "2026-07-28T03:46:11+00:00",
-  "defines_hash": "b3f87e7479ceeef3",
+  "generated_at": "2026-07-29T15:38:10+00:00",
+  "defines_hash": "ed2288309c57317928755f813174a5136b8663a8ec8dab4a2c6aa6e3a6953e17",
   "max_ticks": 52,
   "checkpoints": [
     {

--- a/tests/baselines/fascist_bifurcation.json
+++ b/tests/baselines/fascist_bifurcation.json
@@ -1,8 +1,8 @@
 {
   "scenario": "fascist_bifurcation",
   "description": "Consciousness routing to national identity",
-  "generated_at": "2026-07-28T03:46:08+00:00",
-  "defines_hash": "11c8e0dbd20226d4",
+  "generated_at": "2026-07-29T15:38:07+00:00",
+  "defines_hash": "feda9d56049a18bb03602a26bba01db0a22b1c9de7353b9c971416b83c9df5ce",
   "max_ticks": 52,
   "checkpoints": [
     {

--- a/tests/baselines/glut.json
+++ b/tests/baselines/glut.json
@@ -1,8 +1,8 @@
 {
   "scenario": "glut",
   "description": "High extraction with metabolic overshoot",
-  "generated_at": "2026-07-28T03:46:08+00:00",
-  "defines_hash": "4d3a4ec608f82a34",
+  "generated_at": "2026-07-29T15:38:07+00:00",
+  "defines_hash": "3db481ffc25300afadf1b03bbe0ba4de67ad7e6eaa65e56a6b47099daf9510d1",
   "max_ticks": 52,
   "checkpoints": [
     {

--- a/tests/baselines/imperial_circuit.json
+++ b/tests/baselines/imperial_circuit.json
@@ -1,8 +1,8 @@
 {
   "scenario": "imperial_circuit",
   "description": "4-node default scenario",
-  "generated_at": "2026-07-28T03:46:07+00:00",
-  "defines_hash": "fddb578589309f12",
+  "generated_at": "2026-07-29T15:38:06+00:00",
+  "defines_hash": "8dd57c6fd76f2553429ab92ad6b7cfa00712f2646a88b23e9d116c000a642285",
   "max_ticks": 52,
   "checkpoints": [
     {

--- a/tests/baselines/mitterrand.json
+++ b/tests/baselines/mitterrand.json
@@ -1,8 +1,8 @@
 {
   "scenario": "mitterrand",
   "description": "Reform in office on the Wayne terrain: the 24-item burst, the O'Connor spiral, the forced austerity turn (U13 golden, ADR140)",
-  "generated_at": "2026-07-28T03:46:09+00:00",
-  "defines_hash": "e304a705e3a85bff",
+  "generated_at": "2026-07-29T15:38:08+00:00",
+  "defines_hash": "b236bf1e495aa9a47018f450f7c2fe5bf8e16ef1ab8bbbc0d70c3818ea728f76",
   "max_ticks": 52,
   "checkpoints": [
     {

--- a/tests/baselines/single_county.json
+++ b/tests/baselines/single_county.json
@@ -1,8 +1,8 @@
 {
   "scenario": "single_county",
   "description": "Wayne-seeded minimal county: Vol III financial layer, MELT path, and distribution identity all fire",
-  "generated_at": "2026-07-28T03:46:09+00:00",
-  "defines_hash": "8c1081bf52561705",
+  "generated_at": "2026-07-29T15:38:07+00:00",
+  "defines_hash": "9ea37bc77922b81da75064c705ddde3a8dc4c2d25498195df3994c085bfea4ec",
   "max_ticks": 52,
   "checkpoints": [
     {

--- a/tests/baselines/starvation.json
+++ b/tests/baselines/starvation.json
@@ -1,8 +1,8 @@
 {
   "scenario": "starvation",
   "description": "Low extraction efficiency stress",
-  "generated_at": "2026-07-28T03:46:08+00:00",
-  "defines_hash": "b7799f47996dea86",
+  "generated_at": "2026-07-29T15:38:07+00:00",
+  "defines_hash": "921e6d0440d5936fc5aec8d7008116a46aca5b22b1d6cdc60c2ad415bc4533b6",
   "max_ticks": 52,
   "checkpoints": [
     {

--- a/tests/baselines/syriza.json
+++ b/tests/baselines/syriza.json
@@ -1,8 +1,8 @@
 {
   "scenario": "syriza",
   "description": "The captured governance road: capitulate with dual-power organs live; the PASOK slow bleed (U13 golden, ADR140)",
-  "generated_at": "2026-07-28T03:46:10+00:00",
-  "defines_hash": "474a699b846aba5d",
+  "generated_at": "2026-07-29T15:38:08+00:00",
+  "defines_hash": "0c9c18b5cad7edd51161bb513435a14c6c327f485a888c8bd8248427393cf91d",
   "max_ticks": 52,
   "checkpoints": [
     {

--- a/tests/baselines/two_node.json
+++ b/tests/baselines/two_node.json
@@ -1,8 +1,8 @@
 {
   "scenario": "two_node",
   "description": "Minimal worker vs owner",
-  "generated_at": "2026-07-28T03:46:07+00:00",
-  "defines_hash": "8c1081bf52561705",
+  "generated_at": "2026-07-29T15:38:06+00:00",
+  "defines_hash": "9ea37bc77922b81da75064c705ddde3a8dc4c2d25498195df3994c085bfea4ec",
   "max_ticks": 52,
   "checkpoints": [
     {

--- a/tests/baselines/weimar.json
+++ b/tests/baselines/weimar.json
@@ -1,8 +1,8 @@
 {
   "scenario": "weimar",
   "description": "Fascist consolidation through the ballot: a real desperation vote perturbs the state apparatus (U13 golden, ADR140)",
-  "generated_at": "2026-07-28T03:46:10+00:00",
-  "defines_hash": "104cac2559b91d1c",
+  "generated_at": "2026-07-29T15:38:09+00:00",
+  "defines_hash": "6e001dff6fa186fd6b56a5eabea8f1b0c9c936b9e2c62711d8c4c3948f969bf0",
   "max_ticks": 52,
   "checkpoints": [
     {

--- a/tests/unit/config/test_defines_hash.py
+++ b/tests/unit/config/test_defines_hash.py
@@ -1,0 +1,48 @@
+"""Contract tests for the single canonical defines-hash (Program 27 spec §7)."""
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+from babylon.config.defines import GameDefines, canonical_defines_hash
+
+
+def test_canonical_hash_is_full_sha256_hex() -> None:
+    h = canonical_defines_hash(GameDefines())
+    assert len(h) == 64
+    assert h == h.lower()
+    int(h, 16)  # raises if not hex
+
+
+def test_canonical_hash_matches_specified_byte_layout() -> None:
+    """The byte layout is the spec, not the implementation (III.12(a))."""
+    defines = GameDefines()
+    payload = defines.model_dump(mode="json")
+    expected = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+    assert canonical_defines_hash(defines) == expected
+
+
+def test_canonical_hash_is_stable_across_calls() -> None:
+    d1, d2 = GameDefines(), GameDefines()
+    assert canonical_defines_hash(d1) == canonical_defines_hash(d2)
+
+
+def test_all_production_call_sites_delegate_to_canonical() -> None:
+    """runner.py, play.py, and regression_test.py must all produce the
+    canonical value — the drift this task retires (spec §7)."""
+    from babylon.cli.play import _defines_hash as play_hash
+    from babylon.engine.headless_runner.runner import _defines_hash as runner_hash
+
+    sys.path.insert(0, str(Path(__file__).parents[3] / "tools"))
+    from regression_test import hash_defines as regression_hash
+
+    defines = GameDefines()
+    canonical = canonical_defines_hash(defines)
+    assert play_hash(defines) == canonical
+    assert runner_hash(defines) == canonical
+    assert regression_hash(defines) == canonical

--- a/tests/unit/test_public_import_surface.py
+++ b/tests/unit/test_public_import_surface.py
@@ -82,6 +82,9 @@ EXPECTED_DEFINES_PUBLIC: frozenset[str] = frozenset(
         "WorkingDayDefines",
         # 1 assembler facade
         "GameDefines",
+        # 1 canonical hash function (Program 27 Phase 0 Task 1, spec §7 —
+        # the single defines_hash implementation all call sites delegate to)
+        "canonical_defines_hash",
     }
 )
 

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 
 import argparse
 import csv
-import hashlib
 import io
 import json
 import os
@@ -339,14 +338,19 @@ class DenseTrace:
 def hash_defines(defines: GameDefines) -> str:
     """Generate hash of GameDefines for change detection.
 
+    Delegates to :func:`babylon.config.defines.canonical_defines_hash` — the
+    one canonical implementation (Program 27 spec §7). Full 64-hex; the
+    former 16-char truncation is retired.
+
     Args:
         defines: GameDefines instance
 
     Returns:
-        SHA256 hash string (first 16 chars)
+        SHA256 hash string (64 hex chars)
     """
-    json_str = defines.model_dump_json(indent=None)
-    return hashlib.sha256(json_str.encode()).hexdigest()[:16]
+    from babylon.config.defines import canonical_defines_hash
+
+    return canonical_defines_hash(defines)
 
 
 def get_entity_value(state: Any, entity_id: str, field: str, default: float = 0.0) -> float:


### PR DESCRIPTION
Unifies the three mutually inconsistent `defines_hash` implementations
(`runner.py` sorted-keys+`default=str`, `play.py` sorted-keys no default,
`regression_test.py` field-declaration order + 16-hex truncation) onto one
canonical function: `babylon.config.defines.canonical_defines_hash`.

**Byte layout** (Program 27 spec §7, III.12(a)): `defines.model_dump(mode="json")`
-> `json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)`
-> UTF-8 -> SHA-256, full 64-hex. No `default=str` fallback — a non-JSON-native
value in the schema now raises `TypeError` loudly (III.11) instead of hashing
an implementation-defined `str()`.

- New: `src/babylon/config/defines/_hash.py` (re-exported from the package
  `__init__.py`).
- `runner.py::_defines_hash`, `play.py::_defines_hash`,
  `regression_test.py::hash_defines` now all delegate to it (names/signatures
  kept so callers don't churn).
- New contract test: `tests/unit/config/test_defines_hash.py` (4 tests,
  passing) — pins the byte layout, hex format, stability, and that all three
  call sites agree.
- `tests/baselines/*.json` (11 files) restamped — `defines_hash` field only
  (16-hex truncated -> full 64-hex canonical) + `generated_at`; verified via
  `git diff` that zero dense-CSV/checkpoint cells moved.
- Stored-value disposition: `rg defines_hash src/babylon/persistence/
  src/babylon/game/` found only stamp/store/pass-through call sites (no
  runtime comparison of a stored hash against a freshly computed one) —
  stamp-only, legacy 16-hex campaign rows are declared invalidated, nothing to
  repair.

**Verification:**
- `pytest tests/unit/config/test_defines_hash.py` — 4 passed
- `mise run qa:regression` — 11/11 byte-identical after regeneration
- `mise run qa:vault-regression-ci` — single_county PASS (separate estate,
  unaffected — never stamped `defines_hash`)
- `ruff check`/`ruff format --check`/`mypy` clean on all touched files

Baseline ceremony: `Baselines: blessed(defines-hash-unification)`, message
generated via `tools/generate_ceremony_message.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)