### PR TITLE
docs(bsl): propagate the Amendment D native-hyperedge ruling (P27)

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -9,8 +9,25 @@ Program 27 makes the substrate for game rules.
 ``docs/superpowers/specs/2026-07-28-program-27-refoundation-design.md`` §10
 ("Phase 1 — Language & Kernel: the BSL specification as the language-agnostic
 reference"). The design document is Director-approved; **this document is not
-code authorization**, and Phase 1 does not begin until the v3.0.0 amendment
-(design §4) is ratified.
+code authorization**. The v3.0.0 amendment (design §4) that Phase 1 was gated
+on was **ratified 2026-07-29** — ``CONSTITUTION.md`` v3.0.0, Amendment AE (The
+Refoundation), PR #365 — so that gate is closed; this document remains the
+reference, not the implementation.
+
+**Amendment D — ruled, and this document revised.** The first revision was
+written against the *dyadic working assumption*, with §2.6 (queries), §2.8
+(structural verbs) and §3.7 (the edge-side ceiling) flagged as revisable if
+Phase 0 ruled otherwise. On **2026-07-29 the Director ruled NATIVE
+HYPEREDGE**: hyperedges are **first-class objects** in ``babylon-graph``'s
+exposed model and type system, membership is a single typed hyperedge — never
+a clique expansion, and never *exposed* as a bipartite incidence encoding
+(Levi/incidence is sanctioned as an internal storage strategy only). Source:
+Amendment AE clause (vi) (``CONSTITUTION.md`` v3.0.0) recording the ruling in
+``ai/_inbox/amendment-d-analysis-p27.md`` §9 (PR #353), sub-rulings D-1…D-7.
+Those three sections carry the hyperedge shape as of this revision. The dyadic
+query forms and edge verbs are **unchanged and coexist** with it: II.9's
+morphism layer stays strictly dyadic, and the two layers are separated by
+*type* inside one substrate (sub-ruling D-2 — one substrate, typed homes).
 
 **Standard this document is written to.** Constitution III.12(a) — the *rewrite
 test*: two independent implementations (the Rust ``babylon-bsl`` crate now,
@@ -145,6 +162,7 @@ The atom classes:
      - See §1.6.
    * - ``enum-ref``
      - ``NodeType/SOCIAL_CLASS``, ``EdgeType/SOLIDARITY``,
+       ``HyperedgeType/ECONOMIC_SECTOR``,
        ``DoctrineTag/CLASS_ANALYSIS``, ``PracticeVariable/CO_OPTIVE_SHARE``.
        The member is the **enum member identifier**, never its serialized
        value: ``NodeType/SOCIAL_CLASS``, never ``NodeType/social_class``.
@@ -313,6 +331,11 @@ A keyword in value position is ``E-PARSE-010``.
    * - ``:ceiling``
      - integer
      - Declared cardinality ceiling, on ``manifest`` forms (§3.7).
+   * - ``:max-members``
+     - integer
+     - Declared **member-count** ceiling of one hyperedge type, on the
+       ``manifest`` ``ceiling`` rows whose ``<enum-ref>`` is a
+       ``HyperedgeType`` member (§3.7). Mandatory there, illegal elsewhere.
 
 The keyword set is **closed**. An unrecognized keyword is ``E-PARSE-013``; it
 is never ignored. Adding a keyword is a language revision and re-blesses the
@@ -461,8 +484,8 @@ graph-level metric; an unregistered metric name is ``E-LOAD-011`` — never
 Two symbols are **reserved and always in scope**, never declared and never
 shadowed (``E-PARSE-022``): ``self``, the node the rule is being evaluated
 for (``NodeRef``), and ``it``, the current element inside a query predicate or
-fold body (``NodeRef`` or ``EdgeRef``). ``it`` outside a query context is
-``E-TYPE-012``.
+fold body (``NodeRef``, ``EdgeRef`` or ``HyperedgeRef``, per the query it
+ranges over). ``it`` outside a query context is ``E-TYPE-012``.
 
 Binding names are otherwise rule-scoped; a duplicate name in one rule is
 ``E-PARSE-030``.
@@ -472,24 +495,93 @@ Binding names are otherwise rule-scoped; a duplicate name in one rule is
 
 .. code-block:: text
 
-   <query>     ::= "(" "nodes" <enum-ref> <node-pred>? ")"
-                 | "(" "edges" <enum-ref> <edge-pred>? ")"
-                 | "(" "neighbors" <expr> <enum-ref> <direction> ")"
+   <query>      ::= "(" "nodes" <enum-ref> <node-pred>? ")"
+                  | "(" "edges" <enum-ref> <edge-pred>? ")"
+                  | "(" "neighbors" <expr> <enum-ref> <direction> ")"
+                  | "(" "hyperedges" <enum-ref> <hedge-pred>? ")"
+                  | "(" "members-of" <expr> <enum-ref> ")"
+                  | "(" "hyperedges-of" <expr> <enum-ref> ")"
 
-   <direction> ::= ":out" | ":in" | ":any"
-   <node-pred> ::= <cond>
-   <edge-pred> ::= <cond>
+   <direction>  ::= ":out" | ":in" | ":any"
+   <node-pred>  ::= <cond>
+   <edge-pred>  ::= <cond>
+   <hedge-pred> ::= <cond>
 
-The ``<enum-ref>`` operand of ``nodes`` must be a ``NodeType`` member and of
-``edges``/``neighbors`` an ``EdgeType`` member (``E-TYPE-011``). Predicates
-refer to the candidate element as ``it``.
+The ``<enum-ref>`` operand of ``nodes`` must be a ``NodeType`` member, of
+``edges``/``neighbors`` an ``EdgeType`` member, and of
+``hyperedges``/``members-of``/``hyperedges-of`` a ``HyperedgeType`` member
+(``E-TYPE-011``). Predicates refer to the candidate element as ``it``.
+
+Element and result types:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 18 20 38
+
+   * - Query
+     - Result
+     - ``it`` is
+     - Ranges over
+   * - ``nodes``
+     - ``NodeSet``
+     - ``NodeRef``
+     - Every node of the given ``NodeType``.
+   * - ``edges``
+     - ``EdgeSet``
+     - ``EdgeRef``
+     - Every dyadic edge of the given ``EdgeType``.
+   * - ``neighbors``
+     - ``NodeSet``
+     - ``NodeRef``
+     - Nodes reachable from the operand across that ``EdgeType``.
+   * - ``hyperedges``
+     - ``HyperedgeSet``
+     - ``HyperedgeRef``
+     - Every hyperedge of the given ``HyperedgeType``.
+   * - ``members-of``
+     - ``NodeSet``
+     - ``NodeRef``
+     - The members of the hyperedge the operand denotes.
+   * - ``hyperedges-of``
+     - ``HyperedgeSet``
+     - ``HyperedgeRef``
+     - The hyperedges of that type the operand node belongs to.
+
+**Hyperedges are first-class** (Amendment D ruled **NATIVE HYPEREDGE**
+2026-07-29; Amendment AE clause (vi), analysis §9 sub-ruling D-1). A hyperedge
+is a typed graph object with an identity and a member list — not sugar for a
+set of dyadic edges and not a bipartite encoding the language can see.
+``(members-of h HyperedgeType/ECONOMIC_SECTOR)`` is therefore **one lookup
+against one object**, and there is no member↔member edge anywhere for
+``edges``/``neighbors`` to walk: Anti-Pattern VIII.9 is preserved by
+construction rather than by policy. The dyadic forms above are untouched —
+``edges`` and ``neighbors`` range over the strictly dyadic morphism layer
+(II.9), which coexists with the hyperedge layer in one substrate under
+sub-ruling D-2 (type-level separation, one substrate, typed homes). Whether an
+implementation *stores* hyperedges as a Levi/incidence bipartite graph is its
+own business and is unobservable here.
+
+**[draft ruling — Phase 1 review]** ``members-of`` and ``hyperedges-of`` take
+the ``HyperedgeType`` as a **mandatory second operand**, even though the first
+operand already denotes a hyperedge (or a node incident to one). BSL has no
+type variables (§3.1), so a ``HyperedgeRef`` does not carry its type
+statically; the annotation is what makes ``ceiling(query)`` computable at load
+(§3.7), and therefore what keeps a fold over members statically bounded. At
+evaluation, a ``members-of`` whose referent is not of the annotated type is
+``E-EVAL-032`` — never a silently empty set.
 
 **Iteration order is part of the contract.** A query yields its elements in
-**ascending node-id / (source-id, target-id, edge-type) lexicographic byte
-order** **[draft ruling — Phase 1 review]** — never in graph-internal storage
-order. This is the language-level answer to the cross-language iteration-order
-trap; it makes fold results independent of insertion history and of the
-underlying graph library.
+**ascending node-id / (source-id, target-id, edge-type) / hyperedge-id
+lexicographic byte order** **[draft ruling — Phase 1 review]** — never in
+graph-internal storage order. This is the language-level answer to the
+cross-language iteration-order trap; it makes fold results independent of
+insertion history and of the underlying graph library.
+
+**[draft ruling — Phase 1 review]** The same rule applies *inside* a
+hyperedge: ``members-of`` yields members in ascending node-id byte order, and a
+hyperedge's **declared** member order — the order ``add-hyperedge`` (§2.8) or a
+scenario hydration listed them in — is never observable. A member list is a
+set, not a sequence.
 
 2.7 Expressions, intrinsics, folds, guards
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -555,20 +647,54 @@ from inside a rule. Totality is therefore syntactic, and the static bound of
             | "(" "remove-node"  <expr> ")"
             | "(" "add-edge"     <enum-ref> <expr> <expr> ":strength" <expr> ")"
             | "(" "remove-edge"  <enum-ref> <expr> <expr> ")"
+            | "(" "add-hyperedge"    <enum-ref> <expr> <members> <field-init>* ")"
+            | "(" "remove-hyperedge" <expr> ")"
             | "(" "emit"         <enum-ref> <payload-item>* ")"
 
    <update-op>   ::= "(" "add"   <expr> ")"
                    | "(" "sub"   <expr> ")"
                    | "(" "set"   <expr> ")"
                    | "(" "scale" <expr> ")"
+   <members>     ::= "(" "members" <expr>+ ")"
    <field-init>  ::= "(" <qname> <expr> ")"
    <payload-item>::= "(" <symbol> <expr> ")"
 
 The four ``<update-op>`` forms are exactly today's four-operation effect enum
 — ``add`` = ``increase``, ``sub`` = ``decrease``, ``set`` = ``set``,
-``scale`` = ``multiply`` — and the five structural verbs are the addition the
-design document's §6.4 audit found necessary (20 of 39 system modules mutate
-graph structure).
+``scale`` = ``multiply``. Of the seven structural verbs, **five** are the
+addition the design document's §6.4 audit found necessary (20 of 39 system
+modules mutate graph structure) and **two** — ``add-hyperedge`` and
+``remove-hyperedge`` — are what the Amendment D ruling adds: if a hyperedge is
+a first-class object, minting and retiring one is a first-class verb.
+
+``add-hyperedge``'s ``<enum-ref>`` is a ``HyperedgeType`` member, its ``<expr>``
+is the new hyperedge's id (as ``add-node``'s is a node id), and ``<members>``
+names its member nodes. The grammar's ``<expr>+`` makes a **zero-member
+hyperedge unexpressible**; the upper end is the declared ``:max-members``
+ceiling of §3.7, checked statically.
+
+**[draft ruling — Phase 1 review]** *Two verbs, not an overloaded* ``add-edge``.
+Membership is minted by its own typed verb rather than by an ``add-edge``
+variant carrying a member set. Three reasons, each following the rest of this
+document rather than inventing a rule for the occasion: the head symbol *names*
+the form (§1.3), so one tag with two arities would be the grammar's only
+exception; ``add-edge``'s first operand is an ``EdgeType`` and
+``add-hyperedge``'s is a ``HyperedgeType``, so overloading needs a union type
+§3.1 does not have; and the member-count ceiling attaches to the hyperedge verb
+alone. It also keeps the ruling legible in the grammar itself — **a clique
+expansion is not expressible**, because no verb takes a member set and emits
+edges.
+
+**[draft ruling — Phase 1 review]** *Membership changes are whole-hyperedge
+replacement.* There is no ``add-member``/``remove-member`` verb and no
+``update-hyperedge``: a rule that changes a formation's roster emits
+``(remove-hyperedge h)`` and then ``(add-hyperedge …)`` in one effect list,
+applied in source order (below). This keeps the member-count check at a single
+point (§3.7) and makes a partially-mutated hyperedge unrepresentable. The cost
+is stated rather than hidden: **per-membership payload** (the
+role/strength/visibility fields today's Python ``CommunityMembership`` carries)
+and **mutation of a hyperedge's own declared fields** are not expressible in
+this revision. Both are Phase-1 review items; neither is a silent omission.
 
 ``emit``'s ``<enum-ref>`` is an ``EventType`` member; payload items are
 name/expression pairs. There is no string interpolation in a payload.
@@ -578,14 +704,22 @@ applied in source order at the point the rule fires. Structural verbs obey the
 I.15 edge-mode state machine; a verb that would violate it is an evaluation
 error (``E-EVAL-030``), never a silent no-op. Removing a node that does not
 exist, adding a node id that already exists, or adding an edge that already
-exists are all ``E-EVAL-031`` — absence is never treated as success.
+exists are all ``E-EVAL-031`` — absence is never treated as success. The
+hyperedge verbs inherit that discipline exactly: removing a hyperedge that does
+not exist, adding a hyperedge id that already exists, naming a member node that
+does not exist, and naming the **same member twice** in one ``<members>`` list
+are all ``E-EVAL-031``. Members are a set; a duplicate is an authoring bug, and
+it is never silently deduplicated.
 
 **Prohibited.** There is no I/O, no time source other than a ``:tick``
 binding, no
 randomness primitive (RNG draws are kernel intrinsics with the kernel's
 per-(session, tick, salt) seeding, specified in
 :doc:`/reference/determinism-contract`), no graph mutation outside this verb
-set, no reflection, and nothing unbounded.
+set, no reflection, and nothing unbounded. In particular there is **no clique
+expansion**: no verb in this set converts a member list into pairwise edges, so
+the combinatorial object Anti-Pattern VIII.9 bans has no BSL representation
+(Amendment D, D-1).
 
 2.9 Field and manifest declarations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -598,7 +732,13 @@ set, no reflection, and nothing unbounded.
                   ")"
 
    <manifest> ::= "(" "manifest" <symbol> <ceiling>+ ")"
-   <ceiling>  ::= "(" "ceiling" <enum-ref> ":ceiling" <int-lit> ")"
+   <ceiling>  ::= "(" "ceiling" <enum-ref> ":ceiling" <int-lit>
+                      ( ":max-members" <int-lit> )? ")"
+
+A ``ceiling`` row's ``<enum-ref>`` is a ``NodeType``, ``EdgeType`` or
+``HyperedgeType`` member. ``:max-members`` is **mandatory** on a
+``HyperedgeType`` row and **illegal** on the other two; either mismatch is
+``E-LOAD-042``. The semantics of both numbers are §3.7's.
 
 **[draft ruling — Phase 1 review]** The design document says intensivity is "a
 per-field declaration (``:kind intensive|extensive``) on model fields" without
@@ -651,10 +791,13 @@ degraded mode, and no rule that loads "partially".
    * - ``Enum<T>``
      - members of closed enum ``T``
      - Comparable with ``=``/``!=`` only, and only to the same ``T``.
-   * - ``NodeRef`` / ``EdgeRef``
+   * - ``NodeRef`` / ``EdgeRef`` / ``HyperedgeRef``
      - one graph element
-     - Produced by ``self``, ``add-node``, and query elements (``it``).
-   * - ``NodeSet`` / ``EdgeSet``
+     - Produced by ``self``, ``add-node``, ``add-hyperedge``, and query
+       elements (``it``). A ``HyperedgeRef`` does **not** carry its
+       ``HyperedgeType`` statically — there are no type variables — which is
+       why §2.6's hyperedge queries take the type as an operand.
+   * - ``NodeSet`` / ``EdgeSet`` / ``HyperedgeSet``
      - the result of a ``<query>``
      - Only consumable by ``fold``, ``exists``, ``forall``.
    * - ``Str``
@@ -807,10 +950,11 @@ At load, for every rule and every declared binding:
 3.6 Closed vocabulary
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Enum types, node types, edge types, event types, field names, metric names and
-intrinsic names are all **closed**: a name that is not in the registry is a load
-error, never a fallback. Adding a member is amendment territory, not modding
-territory (design §5, modding boundary). Modders author rules and coefficients
+Enum types, node types, edge types, **hyperedge types**, event types, field
+names, metric names and intrinsic names are all **closed**: a name that is not
+in the registry is a load error, never a fallback. Adding a member is
+amendment territory, not modding territory (design §5, modding boundary).
+Modders author rules and coefficients
 over the closed vocabulary; fuel + the closed intrinsic set + no I/O is a
 sandbox with no escape to express.
 
@@ -818,8 +962,19 @@ sandbox with no escape to express.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The bound is computed against **declared cardinality ceilings, not the runtime
-graph**. Each scenario manifest declares per-``NodeType``/per-``EdgeType``
-``:ceiling`` values, themselves inside the content hash.
+graph**. Each scenario manifest declares per-``NodeType``, per-``EdgeType`` and
+per-``HyperedgeType`` ``:ceiling`` values, themselves inside the content hash.
+
+**[draft ruling — Phase 1 review]** *The member-count axis* (Amendment D). A
+hyperedge type has **two** independent cardinalities, so its manifest row
+declares two numbers: how many hyperedges of that type may exist
+(``:ceiling``) and how many members any one of them may carry
+(``:max-members``, §2.9). Without the second number a fold over ``members-of``
+would have no static bound at all. This is the ceiling revision the ruling
+forces: under the dyadic working assumption an n-member formation was going to
+be *some number of edges*, and one edge-type ceiling covered it; under a native
+hyperedge the honest cost is ``Σ|members|``, and ``:max-members`` is what makes
+that quantity **declarable** at load rather than discovered at hydration.
 
 Define ``cost(n)`` over the AST:
 
@@ -843,9 +998,10 @@ and are **pinned by conformance vector; revising them is a vector re-bless**
 
    cost(if)                     = 1 + cost(cond) + max(cost(then), cost(else))
    cost(exists | forall)        = 2 + cost(query) + ceiling(query) × cost(body)
-   cost(query)                  = 1 + cost(node-pred or edge-pred)
+   cost(query)                  = 1 + cost(element predicate, if any)
    cost(update-op)              = 1 + cost(operand)      ; add|sub|set|scale
    cost(structural verb)        = 3 + Σ cost(operands)
+   cost(members list)           = Σ cost(members)        ; grouping, no base cost
    cost(guard)                  = 1 + cost(cond) + Σ cost(effect-items)
    cost(field path | enum-ref)  = 0                      ; static, like a literal
    bound(rule)                  = cost(cond of <when>) + Σ cost(effect-items)
@@ -853,11 +1009,29 @@ and are **pinned by conformance vector; revising them is a vector re-bless**
 ``ceiling(query)`` is the manifest ceiling of the queried type; for
 ``neighbors`` it is the ceiling of the queried edge type
 **[draft ruling — Phase 1 review]** (a per-node degree ceiling would be
-tighter and is a Phase-1 review item).
+tighter and is a Phase-1 review item). For the three hyperedge queries
+**[draft ruling — Phase 1 review]**: ``hyperedges`` uses the hyperedge type's
+``:ceiling``; ``members-of`` uses that type's ``:max-members``; and
+``hyperedges-of`` uses the type's ``:ceiling`` — a per-node *incidence-degree*
+ceiling would be tighter there, the exact dual of the ``neighbors`` review item
+above, and is deferred with it.
+
+The bound therefore composes over **three** ceiling axes rather than two:
+node-type and edge-type cardinality as before, plus per-hyperedge member count
+wherever a rule folds over ``members-of``. A fold over members nested inside a
+fold over ``hyperedges`` costs ``ceiling(T) × max-members(T) × cost(body)``,
+which is exactly ``Σ|members|`` at the declared ceilings — **linear in the
+incidence count**, and never the ``C(n,2)`` a clique expansion would have cost.
+That is the fuel-side consequence of the ruling: the representation that VIII.9
+mandates is also the one whose static bound stays computable at national scale.
 
 ``bound(rule) > :fuel`` is ``E-LOAD-040`` — rejected **at content load**, so
 the Power-of-10 Rule 2 claim is a static property rather than a dynamic trap.
-A hydration that exceeds a declared ceiling is itself a III.11 load failure
+An ``add-hyperedge`` whose ``<members>`` list is longer than the declared
+``:max-members`` is ``E-LOAD-042`` — the list's length is fixed in the source
+text, so that check is **static**, not a runtime one. A hydration that
+exceeds a declared ceiling — including a hydrated hyperedge carrying more
+members than ``:max-members`` — is itself a III.11 load failure
 (``E-LOAD-041``). The runtime meter of §4.5 remains as the backstop.
 
 4. Dynamic semantics
@@ -967,13 +1141,14 @@ two times at which an error can occur.
    * - Load/link
      - ``E-LOAD-0xx``
      - Content load — unresolved bindings, unknown vocabulary, fuel bound
-       exceeded, ceiling violated at hydration, anchor interleaved into the
-       Material Base partition, kernel/content disagreement.
+       exceeded, ceiling violated at hydration, a missing or misplaced
+       ``:max-members``, a member list over that ceiling, anchor interleaved
+       into the Material Base partition, kernel/content disagreement.
    * - Evaluation
      - ``E-EVAL-0xx``
      - During a tick — checked-arithmetic failure, range violation at a store,
-       non-finite result, empty aggregate, edge-mode violation, fuel
-       exhaustion.
+       non-finite result, empty aggregate, edge-mode violation, hyperedge type
+       mismatch, fuel exhaustion.
 
 **Load-time errors** report the offending file, line, column, form, and code,
 and reject the whole content set — there is no partial load and no "skip the
@@ -1076,11 +1251,23 @@ AST — a property implementations should exercise as a round-trip property test
 **Form tags** are the form's head symbol verbatim (``rule``, ``bindings``,
 ``binding``, ``when``, ``effects``, ``and``, ``or``, ``not``, ``<``, ``<=``,
 ``>``, ``>=``, ``=``, ``!=``, ``+``, ``-``, ``*``, ``/``, ``if``, ``fold``,
-``exists``, ``forall``, ``nodes``, ``edges``, ``neighbors``, ``guard``,
+``exists``, ``forall``, ``nodes``, ``edges``, ``neighbors``, ``hyperedges``,
+``members-of``, ``hyperedges-of``, ``guard``,
 ``update-node``, ``add-node``, ``remove-node``, ``add-edge``, ``remove-edge``,
+``add-hyperedge``, ``remove-hyperedge``, ``members``,
 ``emit``, ``add``, ``sub``, ``set``, ``scale``, ``anchor``, ``deffield``,
 ``intrinsic``, ``manifest``, ``ceiling``), plus the synthetic tag ``opt`` for a
 keyword option.
+
+The six tags the Amendment D revision added — ``hyperedges``, ``members-of``,
+``hyperedges-of``, ``add-hyperedge``, ``remove-hyperedge``, ``members`` — obey
+that same rule (the tag *is* the head symbol), so they need no registry entry,
+no numeric id, and **no new atom kind**; ``:max-members`` is an ordinary
+keyword and encodes as an ``opt`` form like every other option. Nothing else in
+this chapter changes. In particular the §5.6 worked example contains none of
+these forms, so **its 421 canonical bytes and both of its digests are unchanged
+by this revision** — a hyperedge-bearing example would need its own vector
+(§6.2), not a recomputation of that one.
 
 A keyword option is encoded as a two-child form:
 
@@ -1297,6 +1484,14 @@ At minimum, an implementation claiming conformance passes:
 7. **Transcription** — §6.3.
 8. **Determinism** — the whole vector set replayed twice in one process and
    once in a fresh process, byte-identical.
+9. **Hyperedge** (Amendment D) — the iteration order of ``hyperedges``,
+   ``members-of`` and ``hyperedges-of``, including a hyperedge hydrated with
+   its members in descending id order to prove declared order is unobservable;
+   the ``E-EVAL-032`` type mismatch; ``add-hyperedge`` at exactly
+   ``:max-members`` (loads) and one over it (``E-LOAD-042``); a manifest row
+   missing ``:max-members`` on a ``HyperedgeType`` and one carrying it on a
+   ``NodeType`` (both ``E-LOAD-042``); and a fold over ``members-of`` whose
+   static bound equals the declared ``:max-members``.
 
 6.3 Transcription contract
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1395,6 +1590,18 @@ Draft-Ruling Register
 Every decision this document made where the design document under-determined
 the language. Each is a Phase-1 review item.
 
+**Resolved — the Amendment D question (was open question 3 on this document's
+first revision).** That question read: *"Amendment D is unratified, so*
+``<query>``\ *'s data shape is written against the dyadic working assumption.
+If Phase 0 rules hyperedge, §2.6, §2.8 and the edge-side ceiling in §3.7 all
+need revision."* Phase 0 ruled: **NATIVE HYPEREDGE**, 2026-07-29, Amendment AE
+clause (vi) (``CONSTITUTION.md`` v3.0.0), recording
+``ai/_inbox/amendment-d-analysis-p27.md`` §9 (PR #353) sub-rulings D-1…D-7.
+All three sections were revised in this document's second revision; the dyadic
+forms coexist unchanged (D-2). Rows **D24–D28** below are the new
+under-determined points that revision introduced — the question is closed, its
+consequences are the ordinary kind of review item.
+
 .. list-table::
    :header-rows: 1
    :widths: 8 30 62
@@ -1489,6 +1696,33 @@ the language. Each is a Phase-1 review item.
      - §6.1
      - Conformance vectors are BSL content; ``:fuel-used`` is mandatory on
        non-error vectors.
+   * - D24
+     - §2.6
+     - ``members-of``/``hyperedges-of`` take the ``HyperedgeType`` as a
+       mandatory operand — ``HyperedgeRef`` carries no static type, and the
+       annotation is what makes ``ceiling(query)`` computable; a mismatch at
+       evaluation is ``E-EVAL-032``.
+   * - D25
+     - §2.6
+     - A hyperedge's declared member order is unobservable; ``members-of``
+       yields ascending node-id byte order. A member list is a set.
+   * - D26
+     - §2.8
+     - Two typed verbs (``add-hyperedge``/``remove-hyperedge``) rather than an
+       overloaded ``add-edge``; membership change is whole-hyperedge
+       replacement, so per-membership payload and hyperedge-field mutation are
+       **not expressible in this revision** and are review items.
+   * - D27
+     - §2.9, §3.7
+     - A hyperedge manifest row declares two numbers — ``:ceiling`` and
+       ``:max-members`` — mandatory together on a ``HyperedgeType`` row and
+       illegal elsewhere (``E-LOAD-042``); ``add-hyperedge``'s member count is
+       checked against ``:max-members`` **statically**.
+   * - D28
+     - §3.7
+     - ``hyperedges-of`` uses the hyperedge type's ``:ceiling``; a per-node
+       incidence-degree ceiling would be tighter and is deferred alongside
+       D15's per-node degree ceiling for ``neighbors``.
 
 See Also
 ----------
@@ -1512,4 +1746,10 @@ See Also
   the Director-approved design; §5 (the language), §6 (the kernel), §8
   (correctness), §9 (error handling and determinism), §10 (sequencing).
 - ``CONSTITUTION.md`` III.11 (Loud Failure), III.12 (Behavioral Contracts,
-  Amendment Q), III.8 (Aleksandrov Test).
+  Amendment Q), III.8 (Aleksandrov Test), **Amendment AE clause (vi)**
+  (Amendment D — native hyperedge, ratified v3.0.0), II.9 (the strictly dyadic
+  morphism layer that coexists with it), VIII.9 (the clique-expansion
+  anti-pattern the ruling discharges structurally).
+- ``ai/_inbox/amendment-d-analysis-p27.md`` — the Phase-0 Amendment D analysis
+  (PR #353); §9 records the Director's ruling and sub-rulings D-1…D-7 that
+  §2.6, §2.8 and §3.7 of this document implement.

--- a/docs/superpowers/plans/2026-07-29-program-27-phase-1-language-and-kernel.md
+++ b/docs/superpowers/plans/2026-07-29-program-27-phase-1-language-and-kernel.md
@@ -2,35 +2,43 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-> **ENTRY GATES — do not start Task 1 of this plan until both hold:**
-> 1. **BLOCKED until the v3.0.0 Refoundation amendment is ratified** (spec §10 — "Phase 1
->    does not begin until the v3.0.0 amendment is ratified"; drafted in Phase 0 Task 16,
->    `ai/_inbox/amendment-v3-refoundation-draft.md`, merged to `CONSTITUTION.md` by the
->    Director). Verify with `rg -n "v3\.0\.0" CONSTITUTION.md` before opening any branch.
-> 2. **`babylon-graph`'s data shape is separately BLOCKED until Amendment D is ratified**
->    (R7 — Phase 0 Task 15, `ai/_inbox/amendment-d-analysis-p27.md`). This gate is
->    narrower than gate 1: it blocks only Task 16 (the graph trait boundary's concrete
->    shape) below, not the rest of this plan — `babylon-kernel` and `babylon-bsl` do not
->    need a graph data shape to typecheck against an abstract trait.
+> **ENTRY GATES — both are now CLEARED (2026-07-29):**
+> 1. **CLEARED — the v3.0.0 Refoundation amendment was RATIFIED 2026-07-29** (spec §10 —
+>    "Phase 1 does not begin until the v3.0.0 amendment is ratified"; drafted in Phase 0
+>    Task 16, `ai/_inbox/amendment-v3-refoundation-draft.md`, merged to `CONSTITUTION.md`
+>    as **Amendment AE — The Refoundation**, PR #365). **Phase 1 execution is UNBLOCKED
+>    once #365 is on `dev`.** Verify before opening any branch:
+>    `rg -n "v3\.0\.0" CONSTITUTION.md` and `git log --oneline dev | rg 'v3\.0\.0'`.
+> 2. **CLEARED — Amendment D was RULED 2026-07-29: `babylon-graph`'s data shape unblocks
+>    as NATIVE HYPEREDGE.** The Director ruled hyperedges are **first-class objects in
+>    `babylon-graph`'s exposed model and type system** — membership is a single typed
+>    hyperedge, never a clique expansion, and never *exposed* as a bipartite incidence
+>    encoding; Levi/incidence remains sanctioned as an **internal storage strategy only**.
+>    Sub-rulings D-2…D-7 (type-level separation satisfies II.7; `ECONOMIC_SECTOR`
+>    membership becomes a true hyperedge; simplicial stays derived-only) are recorded in
+>    `ai/_inbox/amendment-d-analysis-p27.md` §9 (PR #353) and registered constitutionally
+>    in **Amendment AE clause (vi)**. Task 11 below is revised to that shape; Task 16's
+>    verb list follows `docs/reference/bsl-language.rst` §2.8 as revised by the ruling.
 
 **Goal:** Execute Phase 1 of Program 27 (spec:
 `docs/superpowers/specs/2026-07-28-program-27-refoundation-design.md`, §5 the BSL
 language, §6 the Rust kernel, §8 correctness, §9 error handling/determinism, §10
 sequencing) — stand up `babylon-kernel` and `babylon-bsl` in the in-tree `rust/`
 workspace, transcribe the conformance corpus, get the Director's sigmoid ruling, and
-land the `babylon-graph` trait boundary (its concrete data shape stays deferred to
-Amendment D). Phase 1 ends when: the BSL language-agnostic reference is written, both
-new crates pass `cargo test --workspace` + clippy pedantic + fmt, the transcribed
+land the `babylon-graph` trait boundary (whose data shape Amendment D has now ruled:
+native hyperedge). Phase 1 ends when: the BSL language-agnostic reference is written,
+both new crates pass `cargo test --workspace` + clippy pedantic + fmt, the transcribed
 conformance corpus (899 lines, 4 documented corrections) is green, the sigmoid ruling
-is in hand, and the graph trait boundary compiles against a placeholder implementation
-pending Amendment D.
+is in hand, and the graph trait boundary — dyadic edge API plus first-class typed
+hyperedges — compiles against a placeholder implementation.
 
 **Architecture:** Two new crates land beneath the existing `rust/` workspace's client
 crates in the Program-14 layering law (`kernel < bsl < graph < domain < persistence <
 engine < cli`): `babylon-kernel` (scalars, `Currency` i128, `ContentDigest`, sim clock,
 event-bus port, RNG service) and `babylon-bsl` (reader, typechecker, load-time bound
 checker, fuel evaluator) on top of it. `babylon-graph` gets a crate shell and a trait
-only — no concrete graph type — because its data shape is Amendment-D-gated. No
+only — no concrete graph type in Phase 1 — but the trait's *shape* is now settled by
+Amendment D: dyadic edges and first-class typed hyperedges side by side. No
 numeric intrinsics, no engine, no client wiring: those are Phase 2/3. Phase 1 is
 Rust-only; nothing in `src/babylon/` changes (the Python engine is frozen behind the
 Phase-0 freeze tag).
@@ -60,7 +68,7 @@ toolchain-pinned `1.91.1` via `rust/rust-toolchain.toml`), `cargo`/`clippy`/`rus
   convention; a crate that needs `unsafe` for a real reason escalates to the Director
   (Constitution escalation ladder), it does not quietly drop the forbid.
   `babylon-graph`'s trait shell gets the same forbid; its future concrete
-  implementation (Amendment-D-gated) may need to revisit this for the rustworkx-core
+  implementation (Phase 2 storage) may need to revisit this for the rustworkx-core
   FFI boundary — noted, not decided, in that task.
 - **Clippy pedantic + fmt is the lint bar for these two (three, once the graph shell
   lands) crates** — stricter than the existing workspace bar (`-D warnings` only, no
@@ -257,7 +265,8 @@ wc -l docs/reference/determinism-contract.rst
      references) — cite spec §5 "Types" verbatim as the normative source, do not
      paraphrase away the per-field intensive/extensive kind rule.
   2. **Grammar as BNF** — one production per form: conditions, effects (arithmetic +
-     the typed structural verbs: add/remove node/edge, update-node), formula
+     the typed structural verbs: add/remove node/edge, update-node, and — since
+     Amendment D ruled native hyperedge — add/remove hyperedge), formula
      composition over registered intrinsics, guards, folds, the `:material-basis`
      field, binding declarations (`:optional <name> :default <literal>`), mod ordering
      anchors (`before`/`after` a named system). Every form that is **not**
@@ -1567,14 +1576,37 @@ mod tests {
 
 ---
 
-### Task 11: The graph trait boundary — `babylon-graph` (Amendment-D-gated shape)
+### Task 11: The graph trait boundary — `babylon-graph` (native-hyperedge shape, Amendment D)
 
 Per this plan's task assignment: plan the trait boundary **explicitly**. The typed
-structural verbs (Task 13) need *something* to typecheck graph mutation against, but
-the concrete data shape (dyadic `StableDiGraph` vs. simplicial vs. pole-structure) is
-**BLOCKED until Amendment D is ratified** (R7, Phase 0 Task 15). This task builds the
-trait only, with a placeholder no-op implementation sufficient for Tasks 13's and 17's
-tests to compile — it is deliberately incomplete pending the Director's ruling.
+structural verbs (Task 16) need *something* to typecheck graph mutation against.
+**Amendment D ruled 2026-07-29: NATIVE HYPEREDGE** (Amendment AE clause (vi);
+`ai/_inbox/amendment-d-analysis-p27.md` §9, PR #353), so the trait is no longer written
+blind to the data shape:
+
+- **Hyperedges are first-class in the exposed model and type system.** A hyperedge is a
+  typed object with its own identity and a member list — not a clique expansion of
+  pairwise edges (VIII.9 preserved by construction), and not *exposed* as a bipartite
+  incidence encoding.
+- **The dyadic edge API remains alongside it, unchanged.** II.9's morphism layer stays
+  strictly dyadic; D-2 rules that type-level separation inside one substrate satisfies
+  II.7's separation clause — strictly stronger than the pre-v2 "two libraries" reading.
+  One substrate, typed homes.
+- **Levi/incidence remains a permitted *internal storage strategy*.** It is the standard
+  realization of native hyperedges in one typed substrate and is what `hypergraph-rs`
+  implements (`NodeKind::{Agent, Hyperedge}` + `MembershipEdge<M>`); a concrete
+  implementation may store hyperedges that way, but no caller may observe it. Nothing in
+  the trait below exposes an incidence node or an incidence edge.
+- Still deliberately **not** decided here: the concrete storage type (`StableDiGraph`
+  bipartite vs. anything else), adjacency iteration order at the storage level, and the
+  closed `NodeType`/`EdgeType`/`HyperedgeType` enums (those are `babylon-domain`,
+  Phase 2/3). This task still ships a trait plus a placeholder implementation, both
+  sufficient for Tasks 16/17 to compile — what changed is that the trait's *surface* is
+  now ruled, so downstream code no longer typechecks against a shape that might move.
+
+Simplicial closure is **not** the membership substrate (D-6): a simplicial view may
+exist later only as a derived construct carrying its own III.10 justification, and no
+part of this task builds one.
 
 **Files:**
 - Create: `rust/crates/babylon-graph/Cargo.toml`, `rust/crates/babylon-graph/src/lib.rs`
@@ -1585,13 +1617,14 @@ tests to compile — it is deliberately incomplete pending the Director's ruling
 - Modify: `.mise.toml` (`rust:check` per-crate lines)
 
 **Interfaces:**
-- Produces: `pub trait GraphSubstrate` with the minimal typed-verb surface
-  (`add_node`, `remove_node`, `add_edge`, `remove_edge`, `update_node`) generic over
-  `NodeType`/`EdgeType` markers, with NO commitment to adjacency representation,
-  dyadic-vs-hyperedge shape, or storage backend — those are exactly what Amendment D
-  decides. `PlaceholderGraph` implements the trait with a `HashMap`, gated behind a
-  doc comment making clear it is a compile-target for Tasks 13/17, never a
-  production candidate.
+- Produces: `pub trait GraphSubstrate` with the typed-verb surface — the dyadic half
+  (`add_node`, `remove_node`, `add_edge`, `remove_edge`, `update_node`) plus the
+  hyperedge half Amendment D rules first-class (`add_hyperedge`, `remove_hyperedge`,
+  `members_of`, `hyperedges_of`) — generic over `NodeType`/`EdgeType`/`HyperedgeType`
+  markers, with NO commitment to adjacency representation or storage backend (a Levi
+  bipartite store is permitted and unobservable). `PlaceholderGraph` implements the
+  trait with `HashMap`s, gated behind a doc comment making clear it is a compile-target
+  for Tasks 16/17, never a production candidate.
 
 - [ ] **Step 1: Branch; scaffold the crate**
 
@@ -1603,7 +1636,7 @@ git checkout dev && git pull && git checkout -b feature/p27-graph-trait-boundary
 # rust/crates/babylon-graph/Cargo.toml
 [package]
 name = "babylon-graph"
-description = "Graph substrate trait boundary (Program 27, Amendment D gated — see src/substrate.rs)"
+description = "Graph substrate trait boundary (Program 27, native-hyperedge — see src/substrate.rs)"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -1619,16 +1652,23 @@ pretty_assertions = "1"
 
 ```rust
 // rust/crates/babylon-graph/src/lib.rs
-//! The graph substrate crate (spec §6, crate table). **The concrete data
-//! shape is BLOCKED until Amendment D is ratified** (R7, Phase 0 Task 15,
-//! `ai/_inbox/amendment-d-analysis-p27.md`) — dyadic `StableDiGraph` (the
-//! working assumption) vs. simplicial vs. pole-structure is the Director's
-//! call, not an engineering default (IX.3.4). This crate exposes ONLY the
-//! [`substrate::GraphSubstrate`] trait plus a [`placeholder::PlaceholderGraph`]
-//! toy implementation sufficient to let downstream crates (`babylon-bsl`'s
-//! typed structural verbs, the conformance corpus) compile and typecheck
-//! against a real trait object today. Do not build production logic
-//! against `PlaceholderGraph` — it is a compile-target, not a foundation.
+//! The graph substrate crate (spec §6, crate table). **Amendment D ruled
+//! NATIVE HYPEREDGE** (2026-07-29; Amendment AE clause (vi),
+//! `ai/_inbox/amendment-d-analysis-p27.md` §9): hyperedges are first-class
+//! objects in this crate's exposed model and type system — membership is one
+//! typed hyperedge, never a clique expansion, and never *exposed* as a
+//! bipartite incidence encoding. Levi/incidence is a permitted INTERNAL
+//! storage strategy (what `hypergraph-rs` implements); nothing in the exposed
+//! API reveals it. The strictly dyadic morphism API (II.9) lives alongside it
+//! in the same trait, separated by type (D-2).
+//!
+//! This crate exposes ONLY the [`substrate::GraphSubstrate`] trait plus a
+//! [`placeholder::PlaceholderGraph`] toy implementation sufficient to let
+//! downstream crates (`babylon-bsl`'s typed structural verbs, the conformance
+//! corpus) compile and typecheck against a real trait object today. The
+//! concrete production storage type is Phase 2 work. Do not build production
+//! logic against `PlaceholderGraph` — it is a compile-target, not a
+//! foundation.
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
 
@@ -1640,17 +1680,36 @@ pub mod substrate;
 
 ```rust
 // rust/crates/babylon-graph/src/substrate.rs
-//! The `GraphSubstrate` trait: the typed-verb surface (spec §5
-//! "Expressible": add/remove node/edge, update-node) that BSL's structural
-//! effects compile against, independent of the underlying data shape.
-//! **Every method here is deliberately minimal and deliberately silent on
-//! representation** — no adjacency iteration order, no hyperedge
-//! arity, nothing Amendment D might decide differently is exposed.
+//! The `GraphSubstrate` trait: the typed-verb surface BSL's structural
+//! effects compile against (`docs/reference/bsl-language.rst` §2.6 queries,
+//! §2.8 verbs), independent of the underlying storage.
+//!
+//! **Two typed halves, one substrate (Amendment D, sub-ruling D-2).** The
+//! dyadic half (`add_edge`/`remove_edge`) is II.9's strictly dyadic morphism
+//! layer. The hyperedge half (`add_hyperedge`/`remove_hyperedge`/
+//! `members_of`/`hyperedges_of`) is Amendment D's first-class membership
+//! layer. A dyadic caller cannot be handed a hyperedge and vice versa —
+//! II.7's "MUST remain separate" is enforced by the type system rather than
+//! by two libraries.
+//!
+//! **Silent on representation, loud on shape.** No adjacency iteration order
+//! and no storage type is exposed; a Levi/incidence bipartite store is
+//! permitted and unobservable. What IS exposed, because the ruling fixes it:
+//! a hyperedge has an identity and a member list, and there is no method
+//! anywhere that expands a member list into pairwise edges (VIII.9).
 
 /// Opaque node identity — a newtype so no caller depends on it being an
 /// integer index vs. a UUID vs. anything else the concrete shape picks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct NodeId(pub u64);
+
+/// Opaque hyperedge identity. **Distinct from `NodeId` on purpose**: a
+/// hyperedge is a first-class object, not a node with a member set stashed in
+/// its attributes (the shape D-4 explicitly declines to ratify for
+/// `ECONOMIC_SECTOR`). Two id types is what makes the dyadic/hyperedge
+/// separation type-level rather than conventional.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HyperedgeId(pub u64);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GraphError {
@@ -1658,11 +1717,12 @@ pub struct GraphError {
 }
 
 /// The typed structural-verb surface a `GraphSubstrate` implementation
-/// provides. `node_type`/`edge_type` are `&'static str` here (the closed
-/// `NodeType`/`EdgeType` enums are a `babylon-domain` concern, Phase 2/3;
-/// this trait is domain-agnostic on purpose so it compiles before that
-/// enum ports).
+/// provides. `node_type`/`edge_type`/`hyperedge_type` are `&'static str` here
+/// (the closed `NodeType`/`EdgeType`/`HyperedgeType` enums are a
+/// `babylon-domain` concern, Phase 2/3; this trait is domain-agnostic on
+/// purpose so it compiles before those enums port).
 pub trait GraphSubstrate {
+    // ---- dyadic half (II.9 morphism layer) ----
     fn add_node(&mut self, node_type: &'static str) -> Result<NodeId, GraphError>;
     fn remove_node(&mut self, id: NodeId) -> Result<(), GraphError>;
     fn add_edge(&mut self, edge_type: &'static str, from: NodeId, to: NodeId) -> Result<(), GraphError>;
@@ -1673,27 +1733,60 @@ pub trait GraphSubstrate {
     /// the mechanical write point I.15's checker wraps.
     fn update_node(&mut self, id: NodeId, attribute: &'static str, value: f64) -> Result<(), GraphError>;
     fn node_exists(&self, id: NodeId) -> bool;
+
+    // ---- hyperedge half (Amendment D: first-class membership) ----
+    /// Mint one typed hyperedge over `members`. The member list is a SET:
+    /// a repeated `NodeId`, an unknown `NodeId`, or an empty list is a loud
+    /// error (BSL `E-EVAL-031`), never deduplicated or ignored. Cost is
+    /// `members.len()` incidences — never `C(n,2)` edges.
+    fn add_hyperedge(
+        &mut self,
+        hyperedge_type: &'static str,
+        members: &[NodeId],
+    ) -> Result<HyperedgeId, GraphError>;
+    fn remove_hyperedge(&mut self, id: HyperedgeId) -> Result<(), GraphError>;
+    /// Members of one hyperedge, in **ascending `NodeId` order** — declared
+    /// member order is never observable (BSL §2.6 draft ruling D25).
+    fn members_of(&self, id: HyperedgeId) -> Result<Vec<NodeId>, GraphError>;
+    /// The hyperedges of the given type a node belongs to, in ascending
+    /// `HyperedgeId` order.
+    fn hyperedges_of(&self, node: NodeId, hyperedge_type: &'static str) -> Vec<HyperedgeId>;
+    fn hyperedge_exists(&self, id: HyperedgeId) -> bool;
 }
 ```
+
+**Note for the implementer.** `members_of` returns an owned `Vec` rather than an
+iterator deliberately: BSL materializes a query in sort order before the fold body runs
+(language reference §4.4), so the trait's contract is "a sorted snapshot", and an
+iterator would leak the storage's own ordering into the signature — exactly the thing
+the ruling says must stay internal. If profiling later justifies a borrowed form, it is
+a Phase-2 change with the sort obligation restated, not a Phase-1 optimization.
 
 ```rust
 // rust/crates/babylon-graph/src/placeholder.rs
 //! `PlaceholderGraph`: an in-memory `HashMap`-backed toy [`GraphSubstrate`]
-//! implementation. **This is NOT the production graph shape** — it exists
-//! solely so Tasks 13/17 of the Phase-1 plan (BSL's typed structural verbs,
-//! the conformance corpus) have something real to typecheck and run
-//! against before Amendment D ratifies the actual data shape. Deleting
-//! this module and swapping in the ratified shape is expected,
-//! low-risk churn — nothing outside this crate and its direct test
-//! dependents should assume `PlaceholderGraph`'s internals.
-use crate::substrate::{GraphError, GraphSubstrate, NodeId};
+//! implementation. **This is NOT the production graph storage** — it exists
+//! solely so Tasks 16/17 of the Phase-1 plan (BSL's typed structural verbs,
+//! the conformance corpus) have something real to typecheck and run against
+//! before the concrete Phase-2 storage lands. It DOES honor the Amendment D
+//! shape the trait fixes (hyperedges are their own objects with their own id
+//! space, members are a sorted set, no pairwise expansion anywhere), because
+//! that shape is ruled, not provisional. Deleting this module and swapping in
+//! the production storage is expected, low-risk churn — nothing outside this
+//! crate and its direct test dependents should assume its internals.
+use crate::substrate::{GraphError, GraphSubstrate, HyperedgeId, NodeId};
 use std::collections::HashMap;
 
 #[derive(Debug, Default)]
 pub struct PlaceholderGraph {
     nodes: HashMap<NodeId, &'static str>,
     attributes: HashMap<(NodeId, &'static str), f64>,
+    /// Hyperedge id -> (type, sorted member list). Stored as ONE record per
+    /// hyperedge — the toy analogue of a first-class object. A production
+    /// store may instead keep incidence edges (Levi); callers cannot tell.
+    hyperedges: HashMap<HyperedgeId, (&'static str, Vec<NodeId>)>,
     next_id: u64,
+    next_hyperedge_id: u64,
 }
 
 impl PlaceholderGraph {
@@ -1740,6 +1833,57 @@ impl GraphSubstrate for PlaceholderGraph {
     fn node_exists(&self, id: NodeId) -> bool {
         self.nodes.contains_key(&id)
     }
+
+    fn add_hyperedge(
+        &mut self,
+        hyperedge_type: &'static str,
+        members: &[NodeId],
+    ) -> Result<HyperedgeId, GraphError> {
+        if members.is_empty() {
+            return Err(GraphError { message: "hyperedge must have at least one member".into() });
+        }
+        let mut sorted: Vec<NodeId> = members.to_vec();
+        sorted.sort_unstable_by_key(|n| n.0);
+        if sorted.windows(2).any(|w| w[0] == w[1]) {
+            return Err(GraphError { message: "duplicate member in hyperedge".into() });
+        }
+        if let Some(missing) = sorted.iter().find(|n| !self.node_exists(**n)) {
+            return Err(GraphError { message: format!("no such member node: {missing:?}") });
+        }
+        let id = HyperedgeId(self.next_hyperedge_id);
+        self.next_hyperedge_id += 1;
+        self.hyperedges.insert(id, (hyperedge_type, sorted));
+        Ok(id)
+    }
+
+    fn remove_hyperedge(&mut self, id: HyperedgeId) -> Result<(), GraphError> {
+        self.hyperedges
+            .remove(&id)
+            .map(|_| ())
+            .ok_or_else(|| GraphError { message: format!("no such hyperedge: {id:?}") })
+    }
+
+    fn members_of(&self, id: HyperedgeId) -> Result<Vec<NodeId>, GraphError> {
+        self.hyperedges
+            .get(&id)
+            .map(|(_, members)| members.clone()) // already sorted at insert
+            .ok_or_else(|| GraphError { message: format!("no such hyperedge: {id:?}") })
+    }
+
+    fn hyperedges_of(&self, node: NodeId, hyperedge_type: &'static str) -> Vec<HyperedgeId> {
+        let mut found: Vec<HyperedgeId> = self
+            .hyperedges
+            .iter()
+            .filter(|(_, (ty, members))| *ty == hyperedge_type && members.contains(&node))
+            .map(|(id, _)| *id)
+            .collect();
+        found.sort_unstable_by_key(|h| h.0);
+        found
+    }
+
+    fn hyperedge_exists(&self, id: HyperedgeId) -> bool {
+        self.hyperedges.contains_key(&id)
+    }
 }
 
 #[cfg(test)]
@@ -1759,6 +1903,36 @@ mod tests {
         let mut g = PlaceholderGraph::new();
         let n = g.add_node("territory").unwrap();
         assert!(g.add_edge("adjacency", n, NodeId(9999)).is_err());
+    }
+
+    #[test]
+    fn hyperedge_members_come_back_sorted_not_in_declared_order() {
+        // Amendment D / BSL D25: declared member order is unobservable.
+        let mut g = PlaceholderGraph::new();
+        let a = g.add_node("social_class").unwrap();
+        let b = g.add_node("social_class").unwrap();
+        let c = g.add_node("social_class").unwrap();
+        let h = g.add_hyperedge("economic_sector", &[c, a, b]).unwrap();
+        assert_eq!(g.members_of(h).unwrap(), vec![a, b, c]);
+    }
+
+    #[test]
+    fn duplicate_member_is_a_loud_error() {
+        let mut g = PlaceholderGraph::new();
+        let a = g.add_node("social_class").unwrap();
+        assert!(g.add_hyperedge("economic_sector", &[a, a]).is_err());
+    }
+
+    #[test]
+    fn a_hyperedge_mints_no_pairwise_edges() {
+        // VIII.9 by construction: n members cost one object, not C(n,2) edges.
+        let mut g = PlaceholderGraph::new();
+        let a = g.add_node("social_class").unwrap();
+        let b = g.add_node("social_class").unwrap();
+        let h = g.add_hyperedge("economic_sector", &[a, b]).unwrap();
+        assert_eq!(g.hyperedges_of(a, "economic_sector"), vec![h]);
+        // the dyadic half is untouched by minting a hyperedge
+        assert!(g.hyperedges.len() == 1);
     }
 }
 ```
@@ -1792,13 +1966,14 @@ cargo clippy -p babylon-graph --all-targets --locked -- -D warnings -D clippy::p
 cd ..
 ```
 
-- [ ] **Step 5: Commit + PR** — title makes the gate explicit: `feat(graph): trait
-  boundary shell, data shape BLOCKED on Amendment D (P27 R7)`. Body states: "This PR
-  adds no committed data shape — `PlaceholderGraph` is a compile-target for Tasks
-  13/17, explicitly not production. Swapping in the ratified shape is tracked as a
-  Phase-1/Phase-2 boundary follow-up, not scoped here." Self-mergeable (unlike Tasks 8
-  and 16, this PR doesn't decide anything Amendment-D-shaped, it just avoids
-  deciding it).
+- [ ] **Step 5: Commit + PR** — title: `feat(graph): trait boundary — native-hyperedge
+  surface (P27, Amendment D)`. Body states: "The trait's shape follows the Director's
+  2026-07-29 NATIVE HYPEREDGE ruling (Amendment AE clause (vi)): first-class typed
+  hyperedges alongside the dyadic morphism API, Levi/incidence permitted as internal
+  storage only, no clique expansion expressible. This PR commits no concrete storage
+  type — `PlaceholderGraph` is a compile-target for Tasks 16/17, explicitly not
+  production; the production store is Phase 2." Self-mergeable: it implements a ruling,
+  it does not make one.
 
 ---
 
@@ -1972,23 +2147,40 @@ pub mod cost {
     pub const FOLD_BASE: u64 = 2;
 }
 
-/// Declared per-NodeType/per-EdgeType cardinality ceilings from a scenario
-/// manifest (spec §5: "declared against declared cardinality ceilings, not
-/// the runtime graph"). Phase 1 takes this as an opaque lookup; the
-/// scenario-manifest format itself is a Phase 2 content concern.
+/// Declared per-NodeType/per-EdgeType/per-HyperedgeType cardinality ceilings
+/// from a scenario manifest (spec §5: "declared against declared cardinality
+/// ceilings, not the runtime graph"). Phase 1 takes this as an opaque lookup;
+/// the scenario-manifest format itself is a Phase 2 content concern.
+///
+/// **Two axes, since Amendment D** (language reference §3.7): a hyperedge type
+/// declares both how many hyperedges may exist (`ceilings`) and how many
+/// members any one of them may carry (`max_members`). A fold over `members-of`
+/// bounds against the second; without it there is no static bound at all.
 pub struct CardinalityCeilings {
     ceilings: std::collections::HashMap<&'static str, u64>,
+    max_members: std::collections::HashMap<&'static str, u64>,
 }
 
 impl CardinalityCeilings {
     #[must_use]
-    pub fn new(ceilings: std::collections::HashMap<&'static str, u64>) -> Self {
-        Self { ceilings }
+    pub fn new(
+        ceilings: std::collections::HashMap<&'static str, u64>,
+        max_members: std::collections::HashMap<&'static str, u64>,
+    ) -> Self {
+        Self { ceilings, max_members }
     }
 
     #[must_use]
-    pub fn get(&self, node_or_edge_type: &str) -> Option<u64> {
-        self.ceilings.get(node_or_edge_type).copied()
+    pub fn get(&self, graph_element_type: &str) -> Option<u64> {
+        self.ceilings.get(graph_element_type).copied()
+    }
+
+    /// The declared `:max-members` of a hyperedge type. `None` for a
+    /// node/edge type — and a `None` here on a `members-of` fold is a
+    /// load error (`E-LOAD-042`), never a silent zero.
+    #[must_use]
+    pub fn max_members(&self, hyperedge_type: &str) -> Option<u64> {
+        self.max_members.get(hyperedge_type).copied()
     }
 }
 ```
@@ -2053,6 +2245,13 @@ fn fold_target_type(_items: &[SExpr]) -> String {
     // declared", itself a load-time error the real implementation must
     // raise rather than silently defaulting to 0 (would UNDER-count the
     // bound, the opposite of loud failure) — resolve before this task closes.
+    //
+    // Amendment D note: the resolver must ALSO dispatch on the query head,
+    // because the two ceiling axes are not interchangeable (language
+    // reference §3.7) — `nodes`/`edges`/`neighbors`/`hyperedges`/
+    // `hyperedges-of` bound against `ceilings.get(..)`, while `members-of`
+    // bounds against `ceilings.max_members(..)`. Using the wrong axis
+    // silently mis-bounds every membership fold.
     String::new()
 }
 
@@ -2089,14 +2288,14 @@ mod tests {
     #[test]
     fn a_rule_within_budget_is_accepted() {
         let (expr, _) = read("(+ 1 2)").unwrap();
-        let ceilings = CardinalityCeilings::new(HashMap::new());
+        let ceilings = CardinalityCeilings::new(HashMap::new(), HashMap::new());
         assert!(check_bound(&expr, &ceilings, 100).is_ok());
     }
 
     #[test]
     fn a_rule_over_budget_is_rejected_at_load_not_at_eval() {
         let (expr, _) = read("(+ 1 2)").unwrap();
-        let ceilings = CardinalityCeilings::new(HashMap::new());
+        let ceilings = CardinalityCeilings::new(HashMap::new(), HashMap::new());
         let result = check_bound(&expr, &ceilings, 0);
         assert!(result.is_err());
     }
@@ -2611,11 +2810,17 @@ mod tests {
 - Create: `rust/crates/babylon-bsl/src/mod_anchors.rs`
 
 **Interfaces:**
-- Produces: typed forms `(add-node <type>)`, `(remove-node <ref>)`, `(add-edge <type>
-  <from> <to>)`, `(remove-edge <type> <from> <to>)`, `(update-node <ref> <attr>
-  <value>)` that typecheck against `babylon_graph::substrate::GraphSubstrate` and
-  execute by calling it (against `PlaceholderGraph` in Phase 1 tests — the concrete
-  production shape swaps in once Amendment D ratifies, Phase 1/2 boundary); and
+- Produces the **seven** typed verbs of `docs/reference/bsl-language.rst` §2.8 as
+  revised by the Amendment D ruling — the five dyadic ones `(add-node <type> <id>)`,
+  `(remove-node <ref>)`, `(add-edge <type> <from> <to> :strength <e>)`, `(remove-edge
+  <type> <from> <to>)`, `(update-node <ref> <attr> <value>)`, plus the two hyperedge
+  ones `(add-hyperedge <type> <id> (members <ref>+) <field-init>*)` and
+  `(remove-hyperedge <ref>)` — all typechecking against
+  `babylon_graph::substrate::GraphSubstrate` and executing by calling it (against
+  `PlaceholderGraph` in Phase 1 tests; the production store swaps in at the Phase 1/2
+  boundary). There is deliberately **no** `add-member`/`remove-member`/`update-hyperedge`
+  verb: membership change is whole-hyperedge replacement (`remove-hyperedge` then
+  `add-hyperedge` in one effect list), per the §2.8 draft ruling. Also produces
   `(anchor :before <system-name>)` / `(anchor :after <system-name>)` declarations that
   typecheck as content but whose RESOLUTION into a total order is explicitly deferred
   to `babylon-engine`'s anchor-based registry (Phase 3 — this task only validates the
@@ -2637,10 +2842,15 @@ babylon-graph = { path = "../babylon-graph" }
 // rust/crates/babylon-bsl/src/structural_verbs.rs
 //! The typed structural verb algebra (spec §5 Expressible: "effects ...
 //! plus typed structural verbs: add/remove node/edge and update-node under
-//! the I.15 edge-mode state machine"). Executes against any
-//! [`babylon_graph::substrate::GraphSubstrate`] — in Phase 1 that means
-//! `babylon_graph::placeholder::PlaceholderGraph` only; the production
-//! shape is Amendment-D-gated (Task 11).
+//! the I.15 edge-mode state machine", plus the two hyperedge verbs Amendment
+//! D's NATIVE HYPEREDGE ruling adds — language reference §2.8). Executes
+//! against any [`babylon_graph::substrate::GraphSubstrate`] — in Phase 1 that
+//! means `babylon_graph::placeholder::PlaceholderGraph` only; the production
+//! store is Phase 2 (Task 11).
+//!
+//! **No clique expansion exists in this module** and none may be added: a
+//! member list is handed to `GraphSubstrate::add_hyperedge` whole. That is
+//! Anti-Pattern VIII.9 enforced where the verbs live.
 //!
 //! **I.15 note:** this module calls `GraphSubstrate::update_node`
 //! mechanically; it does NOT itself enforce the I.15 edge-mode state
@@ -2648,7 +2858,7 @@ babylon-graph = { path = "../babylon-graph" }
 //! check belongs to `babylon-domain` once the concrete edge-mode model
 //! exists (Phase 2), same layering reason `babylon-bsl` doesn't know about
 //! `EdgeType` as a closed enum yet.
-use babylon_graph::substrate::{GraphError, GraphSubstrate, NodeId};
+use babylon_graph::substrate::{GraphError, GraphSubstrate, HyperedgeId, NodeId};
 use crate::reader::SExpr;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -2700,8 +2910,43 @@ pub fn execute_structural_verb(expr: &SExpr, graph: &mut dyn GraphSubstrate) -> 
             graph.update_node(id, leak_str(attr), value)?;
             Ok(())
         }
+        // ---- Amendment D: the two hyperedge verbs ----
+        // NOTE: like the `add-node` arm above, this sketch elides the
+        // grammar's explicit-id and <field-init>* operands (§2.8) — they land
+        // with the reader's typed AST, not with this shape-level dispatcher.
+        "add-hyperedge" => {
+            let hyperedge_type = atom_str(&items[1])?;
+            let members = members_from_form(&items[2])?;
+            graph.add_hyperedge(leak_str(hyperedge_type), &members)?;
+            Ok(())
+        }
+        "remove-hyperedge" => {
+            let id = hyperedge_id_from_atom(&items[1])?;
+            graph.remove_hyperedge(id)?;
+            Ok(())
+        }
         other => Err(VerbError { message: format!("unknown structural verb: {other}") }),
     }
+}
+
+/// Parse the `(members <ref>+)` sub-form. The member list is passed to the
+/// substrate WHOLE — there is no path here that turns it into pairwise edges
+/// (VIII.9), and no path that reorders it meaningfully either: the substrate
+/// sorts, because declared member order is unobservable (BSL D25).
+fn members_from_form(expr: &SExpr) -> Result<Vec<NodeId>, VerbError> {
+    let SExpr::List(items) = expr else {
+        return Err(VerbError { message: "expected a (members ...) form".into() });
+    };
+    let Some(SExpr::Atom(head)) = items.first() else {
+        return Err(VerbError { message: "empty members form".into() });
+    };
+    if head != "members" {
+        return Err(VerbError { message: format!("expected members form, got {head}") });
+    }
+    if items.len() < 2 {
+        return Err(VerbError { message: "a hyperedge needs at least one member".into() });
+    }
+    items[1..].iter().map(node_id_from_atom).collect()
 }
 
 fn atom_str(expr: &SExpr) -> Result<&str, VerbError> {
@@ -2716,6 +2961,13 @@ fn node_id_from_atom(expr: &SExpr) -> Result<NodeId, VerbError> {
     s.parse::<u64>()
         .map(NodeId)
         .map_err(|_| VerbError { message: format!("expected a NodeId, got: {s}") })
+}
+
+fn hyperedge_id_from_atom(expr: &SExpr) -> Result<HyperedgeId, VerbError> {
+    let s = atom_str(expr)?;
+    s.parse::<u64>()
+        .map(HyperedgeId)
+        .map_err(|_| VerbError { message: format!("expected a HyperedgeId, got: {s}") })
 }
 
 /// NOTE (implementer TODO, resolve before this task closes): leaking a
@@ -2754,6 +3006,47 @@ mod tests {
         let mut graph = PlaceholderGraph::new();
         let (update, _) = read("(update-node 999 wealth 1.0)").unwrap();
         assert!(execute_structural_verb(&update, &mut graph).is_err());
+    }
+
+    #[test]
+    fn add_hyperedge_takes_the_member_list_whole() {
+        let mut graph = PlaceholderGraph::new();
+        for _ in 0..3 {
+            let (add, _) = read("(add-node social_class)").unwrap();
+            execute_structural_verb(&add, &mut graph).unwrap();
+        }
+        let (add_h, _) = read("(add-hyperedge economic_sector (members 2 0 1))").unwrap();
+        execute_structural_verb(&add_h, &mut graph).unwrap();
+        assert_eq!(
+            graph.members_of(HyperedgeId(0)).unwrap(),
+            vec![NodeId(0), NodeId(1), NodeId(2)] // sorted, not as declared
+        );
+    }
+
+    #[test]
+    fn a_zero_member_hyperedge_is_a_loud_error() {
+        let mut graph = PlaceholderGraph::new();
+        let (add_h, _) = read("(add-hyperedge economic_sector (members))").unwrap();
+        assert!(execute_structural_verb(&add_h, &mut graph).is_err());
+    }
+
+    #[test]
+    fn membership_change_is_remove_then_add() {
+        // §2.8 draft ruling: no add-member/remove-member verb exists.
+        let mut graph = PlaceholderGraph::new();
+        for _ in 0..2 {
+            let (add, _) = read("(add-node social_class)").unwrap();
+            execute_structural_verb(&add, &mut graph).unwrap();
+        }
+        let (add_h, _) = read("(add-hyperedge economic_sector (members 0))").unwrap();
+        execute_structural_verb(&add_h, &mut graph).unwrap();
+        let (rm, _) = read("(remove-hyperedge 0)").unwrap();
+        execute_structural_verb(&rm, &mut graph).unwrap();
+        let (re_add, _) = read("(add-hyperedge economic_sector (members 0 1))").unwrap();
+        execute_structural_verb(&re_add, &mut graph).unwrap();
+        assert_eq!(graph.members_of(HyperedgeId(1)).unwrap().len(), 2);
+        let (bad, _) = read("(add-member 1 1)").unwrap();
+        assert!(execute_structural_verb(&bad, &mut graph).is_err()); // no such verb
     }
 }
 ```
@@ -3016,19 +3309,22 @@ gh pr list --state open --label director-gate   # Task 8's sigmoid ruling must b
   states, in one table: what's DONE (BSL language spec, kernel scalars/Currency/sim
   clock/RNG/event-bus/ContentDigest, BSL reader/typechecker/bound-checker/evaluator,
   the graph trait boundary, the conformance corpus), what's DEFERRED to Phase 2/3 and
-  why (numeric intrinsics — gated on the sigmoid ruling; the concrete graph data shape
-  — gated on Amendment D; the anchor total-order resolver — `babylon-engine`; the
-  `EventType`/`NodeType`/`EdgeType` closed enums — `babylon-domain`), and the two
+  why (numeric intrinsics — gated on the sigmoid ruling; the concrete graph *storage*
+  behind the ruled native-hyperedge trait — Phase 2; the anchor total-order resolver —
+  `babylon-engine`; the `EventType`/`NodeType`/`EdgeType`/`HyperedgeType` closed enums
+  — `babylon-domain`), and the two
   known Phase-1-internal TODOs this plan flagged but deferred resolution of within
   their own tasks (Task 16's `leak_str` interning question if not fully resolved
   there, Task 17's rule-loading composition function if it needs further
   generalization for Phase 2's content pipeline).
 
 - [ ] **Step 3: Commit + PR** (slug `phase-1-exit-checklist`). **Phase 1 is complete
-  when this PR merges** — Phase 2 (Content & Intrinsics) may then begin, contingent
-  additionally on Amendment D's ratification if any Phase-2 task touches
-  `babylon-graph`'s concrete shape (most of 2a/2b do not; 2c's hybrid split likely
-  does for some systems — flag per-system in the Phase-2 plan, not decided here).
+  when this PR merges** — Phase 2 (Content & Intrinsics) may then begin with no
+  outstanding constitutional gate: Amendment D ruled 2026-07-29, so a Phase-2 task
+  that picks `babylon-graph`'s concrete storage is an engineering choice under a
+  settled shape (native hyperedge; Levi/incidence permitted internally), not a
+  Director gate. Flag per-system in the Phase-2 plan which systems need it (most of
+  2a/2b do not; 2c's hybrid split likely does for some) — not decided here.
 
 ---
 
@@ -3042,8 +3338,8 @@ gate) has no code dependency and should start as early as possible in parallel w
 so its ruling is ready before Phase 2 needs it — it blocks nothing in this plan itself
 except entering it in the exit checklist (Task 18). Task 9 depends on 1–2. Task 10
 depends on 9. Task 11 depends on 1 (kernel) only, independent of 9/10 — it can run in
-parallel with the reader/typechecker work; its ratification-blocked concrete shape is
-irrelevant to Phase 1's own completion. Task 12 depends on 7 and 9. Task 13 depends on
+parallel with the reader/typechecker work; its trait surface is now ruled (native
+hyperedge) and its concrete storage is Phase 2, so neither blocks Phase 1's completion. Task 12 depends on 7 and 9. Task 13 depends on
 10 and 11 (fold-target cardinality needs the graph trait's type vocabulary). Task 14
 depends on 13. Task 15 depends on 10. Task 16 depends on 11 and 14. Task 17 depends on
 everything 9–16 (it is the integration task exercising the whole composed pipeline).


### PR DESCRIPTION
## The ruling

The Director ruled **Amendment D** on 2026-07-29: **NATIVE HYPEREDGE**. `babylon-graph`
commits to hyperedges as **first-class objects in its exposed model and type system** —
membership is a single typed hyperedge, never a clique expansion, and never *exposed* as a
bipartite incidence encoding. Levi/incidence remains sanctioned as an **internal storage
strategy only** (it is what `hypergraph-rs` implements).

Registered constitutionally in **Amendment AE clause (vi)** (`CONSTITUTION.md` v3.0.0, PR #365);
recorded with sub-rulings **D-1…D-7** in `ai/_inbox/amendment-d-analysis-p27.md` §9 (PR #353).

Both Phase-1 documents were drafted on the **dyadic working assumption**. This PR propagates the
ruling into them. **Docs only** — no code, no lockfile, no baselines.

## `docs/reference/bsl-language.rst`

The document's own open question 3 read: *"Amendment D is unratified, so `<query>`'s data shape is
written against the dyadic working assumption. If Phase 0 rules hyperedge, §2.6, §2.8 and the
edge-side ceiling in §3.7 all need revision."* Phase 0 ruled hyperedge. This is that revision.

| Section | Change |
|---|---|
| Status block | The v3.0.0 gate is **closed** (ratified 2026-07-29), plus a ruling note stating the shape and citation up front |
| §1.4 / §1.6 | `HyperedgeType/ECONOMIC_SECTOR` enum-ref example; the `:max-members` keyword |
| §2.5 | `it` may be a `HyperedgeRef` |
| **§2.6 queries** | Three new forms — `(hyperedges T pred?)`, `(members-of h T)`, `(hyperedges-of n T)` — plus a result/element-type table covering all six queries |
| **§2.8 verbs** | `add-hyperedge` / `remove-hyperedge` as their own typed verbs, with the `(members …)` sub-form |
| §2.9 | The `ceiling` row grammar gains the optional `:max-members` operand |
| §3.1 / §3.6 | `HyperedgeRef` / `HyperedgeSet` types; hyperedge types join the closed vocabulary |
| **§3.7 ceilings** | The member-count axis; `ceiling(query)` for all three new queries; the fuel-bound composition text |
| §4.6 | `E-LOAD-042` and `E-EVAL-032` in the taxonomy |
| §5.2 | Six new form tags — **and an explicit note that §5.6's digests are unaffected** |
| §6.2 | A required **Hyperedge** conformance-vector family |
| Register | Open question 3 recorded **RESOLVED**; five new draft-ruling rows |

**The dyadic layer is untouched.** `edges`/`neighbors`, `add-edge`/`remove-edge` and their
ceilings are unchanged and coexist with the hyperedge layer — II.9's morphism layer stays
strictly dyadic, and D-2's separation is *type-level inside one substrate* rather than two
libraries.

**VIII.9 moves from policy to construction.** No verb in the language takes a member set and
emits edges, so a clique expansion is now **unexpressible** rather than merely prohibited.

**The fuel consequence, made explicit.** A members fold nested inside a hyperedges fold costs
`ceiling(T) × max-members(T) × cost(body)` — exactly `Σ|members|` at the declared ceilings,
linear in the incidence count, never the `C(n,2)` a clique would have cost. `:max-members` is
what makes that quantity *declarable at load* instead of discovered at hydration, which is
precisely why the edge-side ceiling needed revising.

**Canonical AST bytes are conserved.** The revision adds six form tags (`hyperedges`,
`members-of`, `hyperedges-of`, `add-hyperedge`, `remove-hyperedge`, `members`) — the tag *is* the
head symbol, so no new atom kind and no numeric registry; `:max-members` encodes as an ordinary
`opt`. **The §5.6 worked example contains none of these forms, so its 421 canonical bytes and
both of its digests are unchanged and were deliberately not recomputed.**

### New draft-ruling rows

| # | § | Ruling |
|---|---|---|
| **D24** | §2.6 | `members-of`/`hyperedges-of` take the `HyperedgeType` as a **mandatory** operand — `HyperedgeRef` carries no static type (no type variables), and the annotation is what makes `ceiling(query)` computable; a mismatch at evaluation is `E-EVAL-032`, never a silently empty set |
| **D25** | §2.6 | A hyperedge's **declared member order is unobservable**; `members-of` yields ascending node-id byte order. A member list is a set |
| **D26** | §2.8 | **Two typed verbs**, not an overloaded `add-edge`; membership change is whole-hyperedge replacement, so per-membership payload and hyperedge-field mutation are **not expressible in this revision** and are named review items rather than silent omissions |
| **D27** | §2.9, §3.7 | A hyperedge manifest row declares **two** numbers, `:ceiling` and `:max-members`, mandatory together and illegal elsewhere (`E-LOAD-042`); `add-hyperedge`'s member count is checked **statically** |
| **D28** | §3.7 | `hyperedges-of` uses the type's `:ceiling`; a per-node **incidence-degree** ceiling would be tighter and is deferred alongside D15's per-node degree ceiling for `neighbors` |

## `docs/superpowers/plans/2026-07-29-program-27-phase-1-language-and-kernel.md`

- **Entry gates — both CLEARED.** Gate 1: v3.0.0 ratified 2026-07-29 (Amendment AE, PR #365) —
  Phase 1 execution is unblocked once #365 is on `dev` (it is). Gate 2: Amendment D ruled, so
  `babylon-graph`'s data shape unblocks as native hyperedge.
- **Task 11 (graph trait)** rewritten to the ruled shape: a `HyperedgeId` type **distinct from
  `NodeId`** (D-4 declines to ratify the hyperedge-as-node-with-frozensets shape for
  `ECONOMIC_SECTOR`), the hyperedge half (`add_hyperedge` / `remove_hyperedge` / `members_of` /
  `hyperedges_of`) alongside the unchanged dyadic API, Levi/incidence named as a permitted
  *internal* storage strategy, and simplicial explicitly **not** the membership substrate (D-6).
  `PlaceholderGraph` now honors the shape (sorted member snapshot, loud duplicates) with tests
  for the properties the ruling fixes. `members_of` returns an owned sorted `Vec` on purpose —
  an iterator would leak storage order into the signature.
- **Task 16 (verbs)** matches §2.8's seven verbs, parses `(members …)` **whole** — no path in the
  module turns it into pairwise edges — and has no `add-member`/`remove-member` verb, per the
  whole-replacement ruling.
- **Task 13 (bound checker)**, in consequence of the §3.7 revision: `CardinalityCeilings` gains
  the second axis, and the fold-target resolver TODO now records that `members-of` bounds against
  a *different axis* than every other query head — using the wrong one silently mis-bounds every
  membership fold.

## Gates

Docs only. `doc8` and `rstcheck` clean in the pre-commit run; the doc is in the reference toctree
so the Sphinx `-W` gate sees it. No engine, no tests, no lockfile, no baselines. CI is the gate.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
