### PR TITLE
docs(p27): IX.1 step-3 Amendment AE propagation sweep

### DIFF
--- a/ai/architecture.yaml
+++ b/ai/architecture.yaml
@@ -16,6 +16,20 @@ meta:
     - "ai/dpg-patterns.yaml - DearPyGui development patterns"
 
 # =============================================================================
+# ENGINE LANGUAGE (Amendment AE / ADR172, ratified 2026-07-29)
+# =============================================================================
+# Rust is the engine language; engine crates land in-tree at rust/ (alongside
+# the existing babylon-tui/babylon-md client crates, Amendment AC). Python
+# survives as the data-build pipeline (ADR098 parquet -> reference-DB estate),
+# the out-of-process AI observer, and the engine-decoupled CLI periphery. The
+# Python engine (SimulationEngine, src/babylon/engine/, and the
+# systems_execution block later in this file) freezes at the
+# p27-python-freeze executable pin and is reference-only past that tag.
+# The engine/topology sections below predate the amendment and describe the
+# pre-freeze Python reference implementation, not the Rust kernel (Program 27
+# Phase 1 — not yet executed as of this note).
+
+# =============================================================================
 # THE EMBEDDED TRINITY
 # =============================================================================
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -3,6 +3,11 @@
 Owner-ratified 2026-07-20 (spec: docs/superpowers/specs/2026-07-20-versioning-rigor-design.md).
 Commitizen enforces commit form; this doc defines what versions MEAN and how releases happen.
 
+**Supersession note (2026-07-29, Amendment AE / ADR172):** v1.0 is redefined as the
+**Rust engine's** release (Program 27 Refoundation), not the earlier Python "playable
+archive" release; save-compat semver resets with it. The MAJOR/MINOR/PATCH policy and
+ceremony below are unchanged in substance and apply to that release.
+
 ## The axis: player saves
 
 - **MAJOR** — an existing save/campaign cannot load without migration. Examples: Ledger


### PR DESCRIPTION
## Summary

IX.1 step-3 propagation sweep for Amendment AE (Constitution v3.0.0, ADR172,
ratified 2026-07-29). CONSTITUTION.md, CLAUDE.md, and NORTH_STAR.md were
already swept in PR #365 (merged to dev) — this PR brings the remaining
dependent docs in line.

- **`docs/versioning.md`** — added a supersession note: v1.0 is now the
  **Rust engine's** release (Program 27 Refoundation), not the earlier Python
  "playable archive" release, per AE clause (ix). The MAJOR/MINOR/PATCH
  save-compat policy and release ceremony are unchanged in substance.
- **`ai/architecture.yaml`** — added a top-level note recording the AE
  engine-language binding (Rust is the engine language; engine crates land
  in-tree at `rust/`; Python survives as data-build pipeline + out-of-process
  AI observer + CLI periphery, frozen at `p27-python-freeze`) and flagging
  that the file's existing engine/topology sections describe the pre-freeze
  Python reference implementation, not the not-yet-built Rust kernel. The
  stale ADR032-era `systems_execution` block itself was left untouched per
  the task scope.
- **`ai/wiring-doctrine.md`** — read in full; no engine-language or v1.0
  claims contradicted by AE (the doctrine is language-agnostic: typed wiring
  motions over the graph/opposition/coefficient registries). Left untouched.
- **`CONTRIBUTORS.md`** — read in full; governance/branch-model doc citing
  only Amendment AD, no engine-language or v1.0-definition claims to
  supersede. Left untouched.
- **Repo-wide grep** for "Python is/stays/remains the engine" phrasing (and
  variants) turned up nothing beyond the four already-swept files and
  immutable-history locations (`ai/state.yaml` log entry, `ai/_inbox` drafts,
  `docs/superpowers/specs/**`) — none of those touched, per the one-normative-
  home principle and the immutable-history rule.

No ideological/theory-line content was touched or found contradicted in this
sweep.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('ai/architecture.yaml'))"` — valid YAML
- [x] Pre-commit hooks (yamllint, markdownlint, commitizen, baseline-ceremony) passed on commit
- [x] Diff reviewed — docs-only, no code/behavior changes; nothing under `tests/baselines/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)