### PR TITLE
fix(tests): retention no-op pin becomes relative (CI isolation under pytest-randomly)

### DIFF
--- a/tests/integration/persistence/test_retention.py
+++ b/tests/integration/persistence/test_retention.py
@@ -90,11 +90,17 @@ class TestEnforceSingleLiveSession:
         finally:
             enforce_single_live_session(pg_pool, keep=uuid.uuid4(), archive_root=tmp_path)
 
-    def test_single_live_session_is_a_no_op(
+    def test_enforcement_is_idempotent_second_pass_is_a_no_op(
         self, runtime: PostgresRuntime, pg_pool: Any, tmp_path: Path
     ) -> None:
+        """After one enforcement the census IS one live session, so a second
+        pass purges nothing. Stated relatively (first pass cleans whatever
+        sibling suites left live in the shared CI database — the absolute
+        'nothing else is live' assumption was ordering-dependent under
+        pytest-randomly and failed in CI the moment a leftover existed)."""
         keep = _boot_session(runtime, "solo")
         try:
+            enforce_single_live_session(pg_pool, keep=keep, archive_root=tmp_path)
             assert enforce_single_live_session(pg_pool, keep=keep, archive_root=tmp_path) == ()
             assert _live(runtime, keep)
         finally:

--- a/tests/integration/persistence/test_trace_view_columns_v2.py
+++ b/tests/integration/persistence/test_trace_view_columns_v2.py
@@ -74,7 +74,13 @@ def _apply_spec_065_migrations(pool) -> None:
     """
     from tests.integration.persistence.migration_healing import apply_migrations_healing
 
-    apply_migrations_healing(pool, glob_pattern="002[0-3]_*.sql")
+    # FULL chain, not the 0020-0023 subset: the subset assumed 0010-0015
+    # (which CREATE dynamic_hex_state) had already run — always true on the
+    # long-lived dev DB, but on CI's fresh per-job database it was a
+    # pytest-randomly coin flip (UndefinedTable twice on unlucky seeds; the
+    # maiden gated runs passed on lucky ones). ensure_ddl_applied is
+    # digest-stamped, so the full chain is a fast no-op when already applied.
+    apply_migrations_healing(pool)
 
 
 def test_view_exposes_22_column_contract(pool) -> None:


### PR DESCRIPTION
The maiden GATED run of the retention suite failed in CI: `test_single_live_session_is_a_no_op` asserted enforcement returns `()` against a database only its own session touched — an absolute-isolation assumption broken by sibling suites' leftovers under pytest-randomly ordering. The pin is now the stronger relative property (enforcement is **idempotent**: second pass purges nothing), green both ordered and randomized.

**Process note**: PR #392 merged AT 05:12 while pg-integration failed AT 05:07 — on the unprotected `dev`, auto-merge does not wait for non-required checks. Until protection exists (Director's call, #382), the loop now merges MANUALLY after verifying checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)