### PR TITLE
feat(tui,game): adaptive card ceiling + quiet-tick drift beats — the density lane completes (Standard §5)

### DIFF
--- a/reports/loop-digest.md
+++ b/reports/loop-digest.md
@@ -96,3 +96,10 @@ Standard + Constitution; director-gate issues for reserved lines; digest per ite
 - **Second narration-golden ceremony** `blessed(unit-b-severity-reclassification)`: the reclassified tiers surface in Wayne's early ticks — same events, same deltas, only severity strings moved; the golden estate caught it exactly as designed, twice in one night.
 - 2513 tests green; byte-gates green.
 - **Next (part 4)**: Unit C (adaptive card ceiling) + Unit D (narrator quiet-tick beats over axis_progress/FieldDerivative deltas); then the verb 3×3 + G3 lane (Standard first-moves item 3).
+
+## 2026-07-30 — Iteration 9 (part 4): the density lane COMPLETES
+
+- **Unit C — the adaptive card ceiling**: the flat 1-informational-per-tick cap starved quiet ticks of the only content they had. Now deterministic-adaptive: loud ticks (any critical/warning present) keep the tight cap; quiet ticks admit 3 informational cards. Slow structural background stays legible without loud ticks losing focus.
+- **Unit D — quiet-tick narrator beats**: `_narrator_beat` reads the tick-summary row the session already computes; an eventless tick's prompt carries the DECLARED structural keys (consciousness, wealth, crisis share, price/fictitious logs, imperial rent, solidarity census) — "structural drift only: …" — deterministically, absent keys never fabricated, undeclared keys never leaking. The register (rulings 26/27) stays the LLM layer's concern; this is the substrate it reads.
+- **The density lane (Standard first-moves item 2) is DONE across four PRs**: the NarrationEnvelope estate (#394), TERMINAL_APPROACH + census 26→16 (#395), the wire-reaching classification + census 22-with-distinction (#396), and this part. Two golden ceremonies + one transcript regeneration caught every drift by design.
+- **Next**: the verb 3×3 + G3 lane (first-moves item 3) — DRAFT the Article V matrix for Director RATIFICATION (#378's own protocol; never self-ratified), charter the G3 cost/efficacy lever behind it.

--- a/src/babylon/game/session.py
+++ b/src/babylon/game/session.py
@@ -460,7 +460,26 @@ _DASHBOARD_ECONOMY_ID: Final[str] = "USA"
 _PLAYER_AGENT_TYPE: Final[str] = "organizer"
 
 
-def _narrator_beat(tick: int, chronicle: tuple[ChronicleEvent, ...]) -> tuple[str, str]:
+#: The DECLARED structural keys a quiet-tick beat may carry (Unit D,
+#: Standard §5): the slow axes whose drift is the story when nothing fires.
+#: A key absent here never enters a prompt — widening is a deliberate
+#: narration change, not a side effect of the summary row growing.
+_QUIET_BEAT_KEYS: tuple[str, ...] = (
+    "avg_consciousness",
+    "avg_wealth",
+    "crisis_pop_share",
+    "fictitious_log",
+    "imperial_rent",
+    "price_log",
+    "solidarity_edge_count",
+)
+
+
+def _narrator_beat(
+    tick: int,
+    chronicle: tuple[ChronicleEvent, ...],
+    deltas: Mapping[str, Any] | None = None,
+) -> tuple[str, str]:
     """The ``(system, prompt)`` pair one committed tick schedules narration with.
 
     Minimal and honest by deliberate scope choice: built ONLY from this
@@ -481,7 +500,21 @@ def _narrator_beat(tick: int, chronicle: tuple[ChronicleEvent, ...]) -> tuple[st
         "and write one brief, grounded prose beat. Never invent facts beyond "
         "what is given."
     )
-    body = "; ".join(event.summary for event in chronicle) if chronicle else "no events recorded"
+    if chronicle:
+        body = "; ".join(event.summary for event in chronicle)
+    elif deltas:
+        # Unit D (Standard §5): a quiet tick's story IS the slow drift —
+        # the declared structural keys from the summary row the session
+        # already computes, rendered deterministically. Never fabricated:
+        # absent/None keys simply do not appear.
+        drift = ", ".join(
+            f"{key} {deltas[key]}"
+            for key in _QUIET_BEAT_KEYS  # loop bound: len(_QUIET_BEAT_KEYS)
+            if isinstance(deltas.get(key), int | float) and not isinstance(deltas.get(key), bool)
+        )
+        body = f"structural drift only: {drift}" if drift else "no events recorded"
+    else:
+        body = "no events recorded"
     prompt = f"Tick {tick} committed. {body}."
     return system, prompt
 
@@ -1548,7 +1581,7 @@ class GameSession:
                 )
             )
         if self._narrator is not None:
-            system, prompt = _narrator_beat(next_tick, chronicle)
+            system, prompt = _narrator_beat(next_tick, chronicle, deltas=summary_kwargs)
             self._narrator.schedule(_NARRATOR_SUBJECT, next_tick, system=system, prompt=prompt)
         if self._progress_store is not None:
             self._progress_store.record_progress(self.session_id, last_tick=next_tick)

--- a/src/babylon/tui/chronicle_salience.py
+++ b/src/babylon/tui/chronicle_salience.py
@@ -296,7 +296,14 @@ bucket. Critical and warning are never capped by :func:`cap_narrative_events`
 — their repetition is :func:`dedupe_consecutive`'s job."""
 
 NARRATIVE_EVENT_CEILING_PER_TICK: Final[int] = 1
-"""At most this many informational-tier events render per tick."""
+"""At most this many informational-tier events render on a LOUD tick (one
+carrying any critical/warning content — the loud content owns the screen)."""
+
+QUIET_TICK_NARRATIVE_CEILING: Final[int] = 3
+"""The adaptive half (Standard §5, the ruling-12 density fix): on a QUIET
+tick — no critical or warning event — informational texture is the only
+signal the tick has, so the ceiling rises. Deterministic: a pure function
+of the tick's own event mix, never of wall-clock or render state."""
 
 
 def cap_narrative_events(events: Sequence[ChronicleEvent]) -> tuple[ChronicleEvent, ...]:
@@ -311,14 +318,27 @@ def cap_narrative_events(events: Sequence[ChronicleEvent]) -> tuple[ChronicleEve
     :param events: the events to filter, any order/tick mix.
     :returns: the filtered events, original relative order preserved.
     """
+    # First pass: a tick is LOUD when any of its events resolves above the
+    # narrative tier — those ticks keep the tight cap; quiet ticks admit
+    # QUIET_TICK_NARRATIVE_CEILING (the adaptive half, Standard §5).
+    loud_ticks: set[int] = {
+        event.tick
+        for event in events
+        if classify_event_salience(event.event_type).tier != NARRATIVE_TIER
+    }
     kept: list[ChronicleEvent] = []
     narrative_count_by_tick: dict[int, int] = {}
     for event in events:
         if classify_event_salience(event.event_type).tier != NARRATIVE_TIER:
             kept.append(event)
             continue
+        ceiling = (
+            NARRATIVE_EVENT_CEILING_PER_TICK
+            if event.tick in loud_ticks
+            else QUIET_TICK_NARRATIVE_CEILING
+        )
         count = narrative_count_by_tick.get(event.tick, 0)
-        if count < NARRATIVE_EVENT_CEILING_PER_TICK:
+        if count < ceiling:
             kept.append(event)
         narrative_count_by_tick[event.tick] = count + 1
     return tuple(kept)
@@ -370,9 +390,8 @@ def apply_volume_floors(events: Sequence[ChronicleEvent]) -> tuple[ChronicleEven
     informational-tier per-tick cap.
 
     The two floors touch disjoint event types (:func:`aggregate_organizational_actions`
-    only ever touches ``ORGANIZATIONAL_ACTION``, which has no declared
-    classification row and so resolves to the unclassified **warning** tier
-    — never :data:`NARRATIVE_TIER`), so applying them in either order yields
+    only ever touches ``ORGANIZATIONAL_ACTION``, classified ACT at the
+    **warning** floor — never :data:`NARRATIVE_TIER`), so applying them in either order yields
     the same result; this composes them in the order a caller would normally
     want them evaluated.
 

--- a/tests/unit/game/test_session.py
+++ b/tests/unit/game/test_session.py
@@ -1902,3 +1902,45 @@ def test_three_tick_wayne_narration_matches_the_golden() -> None:
     golden_path = Path("tests/baselines/narration/wayne_3tick.jsonl")
     assert golden_path.exists(), f"golden missing: {golden_path} (ceremony required)"
     assert lines == golden_path.read_text(encoding="utf-8").splitlines()
+
+
+class TestQuietTickNarratorBeat:
+    """Unit D (Standard §5): quiet ticks carry structural drift, not silence.
+
+    The dossier's fix: point the narrator at the deltas the session already
+    computes so slow structural change is legible on ticks where nothing
+    fires. Deterministic template only — the register (rulings 26/27) is
+    the LLM layer's concern, never this function's.
+    """
+
+    def test_quiet_tick_prompt_carries_structural_drift(self) -> None:
+        system, prompt = session_module._narrator_beat(
+            9,
+            (),
+            deltas={"avg_consciousness": 0.41, "imperial_rent": 119.64, "phase": "x"},
+        )
+        assert "structural drift" in prompt
+        assert "avg_consciousness 0.41" in prompt
+        assert "imperial_rent 119.64" in prompt
+        assert "phase" not in prompt  # non-structural keys never leak in
+
+    def test_loud_tick_prompt_is_unchanged_event_summaries(self) -> None:
+        from babylon.tui.chronicle import ChronicleEvent
+
+        chronicle = (
+            ChronicleEvent(
+                tick=9,
+                event_type=EventType.UPRISING,
+                summary="uprising at C001",
+                data={},
+            ),
+        )
+        _system, prompt = session_module._narrator_beat(
+            9, chronicle, deltas={"avg_consciousness": 0.41}
+        )
+        assert "uprising at C001" in prompt
+        assert "structural drift" not in prompt
+
+    def test_quiet_tick_without_deltas_keeps_the_honest_default(self) -> None:
+        _system, prompt = session_module._narrator_beat(9, ())
+        assert "no events recorded" in prompt

--- a/tests/unit/tui/test_chronicle_salience.py
+++ b/tests/unit/tui/test_chronicle_salience.py
@@ -19,6 +19,7 @@ from babylon.models.event_severity import SEVERITY_BY_EVENT
 from babylon.tui.chronicle import ChronicleEvent
 from babylon.tui.chronicle_salience import (
     NARRATIVE_EVENT_CEILING_PER_TICK,
+    QUIET_TICK_NARRATIVE_CEILING,
     AutopauseState,
     aggregate_organizational_actions,
     apply_volume_floors,
@@ -296,24 +297,22 @@ class TestAutopause:
 class TestVolumeFloors:
     """Narrative (informational) per-tick cap; ORGANIZATIONAL_ACTION rollup."""
 
-    def test_three_informational_events_in_one_tick_cap_to_one_card(self) -> None:
-        events = [
-            _event(5, EventType.SURPLUS_EXTRACTION, summary="a", source_id="c1"),
-            _event(5, EventType.SURPLUS_EXTRACTION, summary="b", source_id="c2"),
-            _event(5, EventType.SURPLUS_EXTRACTION, summary="c", source_id="c3"),
-        ]
+    def test_quiet_tick_informationals_cap_to_the_quiet_ceiling(self) -> None:
+        # Adaptive (Standard §5): a tick with ONLY informational content is
+        # quiet — the raised ceiling applies (loud-tick tightness is pinned
+        # in TestAdaptiveNarrativeCeiling).
+        events = [_event(5, EventType.SURPLUS_EXTRACTION, source_id=f"c{i}") for i in range(5)]
         capped = cap_narrative_events(events)
-        assert len(capped) == NARRATIVE_EVENT_CEILING_PER_TICK == 1
-        assert capped[0].summary == "a"
+        assert len(capped) == QUIET_TICK_NARRATIVE_CEILING
 
     def test_the_cap_is_per_tick_not_global(self) -> None:
         events = [
-            _event(5, EventType.SURPLUS_EXTRACTION, source_id="c1"),
-            _event(5, EventType.SURPLUS_EXTRACTION, source_id="c2"),
+            *(_event(5, EventType.SURPLUS_EXTRACTION, source_id=f"c{i}") for i in range(4)),
             _event(6, EventType.SURPLUS_EXTRACTION, source_id="c1"),
         ]
         capped = cap_narrative_events(events)
-        assert len(capped) == 2
+        # tick 5 (quiet) caps at the quiet ceiling; tick 6 keeps its one.
+        assert len(capped) == QUIET_TICK_NARRATIVE_CEILING + 1
         assert {e.tick for e in capped} == {5, 6}
 
     def test_critical_and_warning_events_are_never_capped(self) -> None:
@@ -370,3 +369,47 @@ class TestVolumeFloors:
         org_cards = [e for e in floored if e.event_type == EventType.ORGANIZATIONAL_ACTION]
         assert len(org_cards) == 1
         assert org_cards[0].data["count"] == 4
+
+
+class TestAdaptiveNarrativeCeiling:
+    """The adaptive card ceiling (Standard §5, dossier ruling-12 free half).
+
+    The 1-informational-per-tick cap was a flat display-density rule; on a
+    QUIET tick (no critical/warning content) it starved the screen of the
+    only texture the tick had. Adaptive: loud ticks keep the tight cap (the
+    loud content owns the screen); quiet ticks admit
+    QUIET_TICK_NARRATIVE_CEILING informational cards so slow structural
+    background stays legible. Deterministic — a pure function of the tick's
+    own event mix.
+    """
+
+    def test_quiet_tick_admits_the_raised_ceiling(self) -> None:
+        events = [_event(5, EventType.SURPLUS_EXTRACTION, source_id=f"c{i}") for i in range(5)]
+        floored = apply_volume_floors(events)
+        assert len(floored) == QUIET_TICK_NARRATIVE_CEILING
+
+    def test_loud_tick_keeps_the_tight_cap(self) -> None:
+        events = [
+            _event(5, EventType.UPRISING),
+            *(_event(5, EventType.SURPLUS_EXTRACTION, source_id=f"c{i}") for i in range(5)),
+        ]
+        floored = apply_volume_floors(events)
+        informational = [e for e in floored if e.event_type == EventType.SURPLUS_EXTRACTION]
+        assert len(informational) == NARRATIVE_EVENT_CEILING_PER_TICK
+        assert any(e.event_type == EventType.UPRISING for e in floored)
+
+    def test_ticks_are_independent(self) -> None:
+        events = [
+            _event(1, EventType.UPRISING),
+            _event(1, EventType.SURPLUS_EXTRACTION, source_id="a"),
+            _event(1, EventType.SURPLUS_EXTRACTION, source_id="b"),
+            _event(2, EventType.SURPLUS_EXTRACTION, source_id="c"),
+            _event(2, EventType.SURPLUS_EXTRACTION, source_id="d"),
+        ]
+        floored = apply_volume_floors(events)
+        tick1_info = [
+            e for e in floored if e.tick == 1 and e.event_type == EventType.SURPLUS_EXTRACTION
+        ]
+        tick2_info = [e for e in floored if e.tick == 2]
+        assert len(tick1_info) == 1  # loud tick: tight cap
+        assert len(tick2_info) == 2  # quiet tick: both admitted (under the raised ceiling)


### PR DESCRIPTION
## What

Iteration 9 part 4 — the density lane's final two units:

- **Unit C, the adaptive card ceiling** (`tui/chronicle_salience.py`): loud ticks (any critical/warning content) keep the tight 1-informational cap — the loud content owns the screen; quiet ticks admit `QUIET_TICK_NARRATIVE_CEILING` (3) cards so the only texture the tick has isn't starved. Deterministic — a pure function of the tick's own event mix. Two flat-cap pins moved consciously; loud-tightness and per-tick independence pinned fresh.
- **Unit D, quiet-tick narrator beats** (`game/session.py::_narrator_beat`): an eventless tick's prompt carries the DECLARED structural keys from the tick-summary row the session already computes ("structural drift only: avg_consciousness 0.41, imperial_rent 119.64, …") — absent/None keys never fabricated, undeclared keys never leak (widening `_QUIET_BEAT_KEYS` is a deliberate narration change). Loud ticks byte-unchanged. The register (rulings 26/27) remains the LLM layer's concern — this is the deterministic substrate it reads.

With #394 (NarrationEnvelope), #395 (TERMINAL_APPROACH, census 26→16), and #396 (the wire-reaching classification), **the density lane — the Standard's first-moves item 2 — is complete.**

## Verification

TDD red-first both units; 1197 game+projection + 668 tui suites green; `qa:regression` 11/11 byte-identical + determinism leg; vault byte-gate byte-identical; narration + transcript goldens unchanged (no severity moves this part).

Tracked on #380/#381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)