### PR TITLE
feat(game): standing orders — the verb persists (ADR176 ruling 22)

### DIFF
--- a/reports/loop-digest.md
+++ b/reports/loop-digest.md
@@ -121,3 +121,9 @@ Standard + Constitution; director-gate issues for reserved lines; digest per ite
 - **The fabrications named by the dossier now have measured replacements**; consumer wiring (the hydrator reading mask + share keys) is design-gated on the P27 multi-res shape and tracked on #379.
 - **Iteration 11 chartered: STANDING ORDERS** (ruling 22) — the pacing model's prerequisite, not a convenience: without verb persistence, 5,200 ticks = 5,200 forced selections and the 30-hour floor is unreachable. Declared deterministic repetition with material interrupts, in the session/pacing layer, coefficient-free per ruling 24.
 - Session tally: **16 PRs merged**; lanes complete: sentinels, density, spatial data; verbs await #398's ratification; rulings 25/28/32/33 + 18 (data half) + 12 (projection half) implemented.
+
+## 2026-07-30 — Iteration 11: the verb persists
+
+- **STANDING ORDERS live** (ruling 22 — the pacing model's prerequisite, per the dossier's own finding: without persistence, 5,200 ticks are 5,200 forced selections and the 30-hour floor is unreachable). An order re-submits through the SAME pending-turns path a hand verb takes (zero new resolver surface, byte-identical mechanics); a fresh player verb suppresses without canceling; interrupts are material and deterministic — target-gone and autopause — never a cooldown coefficient (ruling 24); every interruption surfaces legibly. Session-lifetime in this cut (store persistence lands with the client's orders UI).
+- Poetic confirmation: the first red run failed because Wayne's tick 1 fires a REAL autopause that canceled the test's order — the interrupt worked before its own pin existed.
+- Byte-gates green. #380's ruling-22 consequence lands with the PR; remaining #380: the three restoration channels (ruling 23).

--- a/src/babylon/game/session.py
+++ b/src/babylon/game/session.py
@@ -90,6 +90,7 @@ from babylon.engine.services import ServiceContainer
 from babylon.engine.simulation_engine import _DEFAULT_SYSTEMS, SimulationEngine
 from babylon.game.actions.player_driver import issue_action
 from babylon.game.chronicle_adapter import chronicle_events_from_bus
+from babylon.game.standing_orders import StandingOrder
 from babylon.kernel.event_bus import Event
 from babylon.models.config import SimulationConfig
 from babylon.models.enums import CommunityType
@@ -752,6 +753,13 @@ class GameSession:
         #: attribute + a log line, never an event); refreshed at
         #: checkpoint cadence by advance_tick, None when disk is healthy.
         self.last_disk_warning: str | None = None
+        #: ADR176 ruling 22: active standing orders by org (session-lifetime
+        #: in this cut — resume drops them, loudly). See
+        #: :mod:`babylon.game.standing_orders`.
+        self._standing_orders: dict[str, StandingOrder] = {}
+        #: The most recently interrupted order and WHY (the honesty gate) —
+        #: an attribute + a log line, never an event.
+        self.last_interrupted_order: tuple[StandingOrder, str] | None = None
         self.scenario_name = scenario_name
         self._store = store
         self._rng_seed = rng_seed
@@ -772,6 +780,59 @@ class GameSession:
             if endgame_detector is not None
             else EndgameDetector(defines=services.defines)
         )
+
+    @property
+    def standing_orders(self) -> tuple[StandingOrder, ...]:
+        """The active standing orders, deterministic (org_id) order."""
+        return tuple(self._standing_orders[k] for k in sorted(self._standing_orders))
+
+    def place_standing_order(self, order: StandingOrder) -> None:
+        """Place (or replace) an org's standing order (ruling 22)."""
+        self._standing_orders[order.org_id] = order
+
+    def cancel_standing_order(self, org_id: str) -> None:
+        """Cancel an org's standing order; unknown org is a silent no-op
+        (canceling nothing is what the player asked for)."""
+        self._standing_orders.pop(org_id, None)
+
+    def _interrupt_order(self, order: StandingOrder, reason: str) -> None:
+        self._standing_orders.pop(order.org_id, None)
+        self.last_interrupted_order = (order, reason)
+        _LOG.warning("standing order interrupted (%s): %s %s", reason, order.org_id, order.verb)
+
+    def _submit_standing_orders(self, next_tick: int, pending: list[dict[str, Any]]) -> None:
+        """Re-submit each active order through the SAME pending-turns path.
+
+        A fresh player verb for the same org suppresses (never cancels) the
+        order this tick; a target absent from the graph is a MATERIAL
+        interrupt (ruling 22/24: declared, deterministic, coefficient-free).
+        """
+        fresh_orgs = {str(turn.get("org_id")) for turn in pending}
+        for org_id in sorted(self._standing_orders):  # loop bound: active orders
+            order = self._standing_orders[org_id]
+            if order.target_id is not None and order.target_id not in self.graph.nodes:
+                self._interrupt_order(order, f"target {order.target_id} left the graph")
+                continue
+            if order.org_id in fresh_orgs:
+                continue
+            self._store.submit_turn(
+                self.session_id,
+                next_tick,
+                order.org_id,
+                order.verb,
+                action_type=order.action_type,
+                target_id=order.target_id,
+                target_community=order.target_community,
+            )
+            pending.append(
+                {
+                    "org_id": order.org_id,
+                    "verb": order.verb,
+                    "action_type": order.action_type,
+                    "target_id": order.target_id,
+                    "target_community": order.target_community,
+                }
+            )
 
     def read_page(self, subject: str) -> str | None:
         """Read one REAL baked vault page for this campaign (Unit C2).
@@ -1488,6 +1549,7 @@ class GameSession:
         """
         next_tick = self.tick + 1
         pending = self._store.get_pending_turns(self.session_id, next_tick)
+        self._submit_standing_orders(next_tick, pending)
         player_actions = build_player_actions(pending)
         context = TickContext(tick=next_tick, persistent_data={"player_actions": player_actions})
 
@@ -1588,6 +1650,12 @@ class GameSession:
 
         self.tick = next_tick
         paused = self._pause_predicate(events)
+        if paused:
+            # Ruling 22: an autopause is a MATERIAL interrupt — something
+            # demanded the player's attention, and persistence must not
+            # talk over it. Every active order cancels, legibly.
+            for org_id in sorted(self._standing_orders):  # loop bound: active orders
+                self._interrupt_order(self._standing_orders[org_id], "autopause fired")
         autosaved = is_checkpoint_tick(next_tick)
         if autosaved:
             # ADR176 ruling 32's mid-run soft warning, at checkpoint cadence

--- a/src/babylon/game/standing_orders.py
+++ b/src/babylon/game/standing_orders.py
@@ -1,0 +1,55 @@
+"""Standing orders — the verb persists (ADR176 ruling 22).
+
+The pacing model's prerequisite, not a convenience (the dossier's own
+finding): the T1 decision cadence (one real choice per 4-8 ticks across a
+5,200-tick century) presupposes that a chosen verb PERSISTS between
+decisions. This module is that persistence — declared, deterministic, and
+amendment-free:
+
+- An order re-submits its verb each tick through the SAME pending-turns
+  path a hand-submitted verb takes (``submit_turn`` -> ``get_pending_turns``
+  -> the OODA resolvers) — zero new resolver surface, byte-identical
+  mechanics. A fresh player verb for the same org SUPPRESSES the order
+  that tick (the player's live hand always wins) without canceling it.
+- Interrupts are MATERIAL and deterministic — never a ``cooldown_ticks``
+  coefficient (ruling 24's coefficient-free law): the order's target
+  leaving the graph cancels it; an autopause cancels every active order
+  (something demanded the player's attention — persistence must not talk
+  over it). An interrupted order surfaces legibly
+  (:attr:`~babylon.game.session.GameSession.last_interrupted_order` + a
+  log line): the honesty gate — the player always learns WHY their
+  standing order stopped.
+
+Orders are session-lifetime in this first cut: they do NOT survive a
+quit or crash-resume (there is no persisted record to restore — a fresh
+session simply starts with none). Store-side persistence lands with the
+client's orders UI train.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class StandingOrder(BaseModel):
+    """One org's persistent verb (the ``submit_turn`` shape, frozen).
+
+    :param org_id: The organization holding the order.
+    :param verb: The verb re-submitted each tick.
+    :param action_type: Optional resolver action type (``submit_turn``'s own
+        optional).
+    :param target_id: Optional target node — when set, the node leaving the
+        graph is a material interrupt.
+    :param target_community: Optional community target (pass-through).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    org_id: str
+    verb: str
+    action_type: str | None = None
+    target_id: str | None = None
+    target_community: str | None = None
+
+
+__all__ = ["StandingOrder"]

--- a/tests/unit/game/test_session.py
+++ b/tests/unit/game/test_session.py
@@ -1944,3 +1944,89 @@ class TestQuietTickNarratorBeat:
     def test_quiet_tick_without_deltas_keeps_the_honest_default(self) -> None:
         _system, prompt = session_module._narrator_beat(9, ())
         assert "no events recorded" in prompt
+
+
+class TestStandingOrders:
+    """Ruling 22: the verb PERSISTS — declared deterministic repetition with
+    material interrupts. Without this, 5,200 ticks are 5,200 forced
+    selections and the 30-hour floor is unreachable (the dossier's T1
+    cadence presupposes persistence). Mechanics are byte-identical: an
+    order re-submits through the SAME pending-turns path a hand-submitted
+    verb takes — zero new resolver surface. Interrupts are MATERIAL and
+    deterministic (never a cooldown define, ruling 24): the target leaving
+    the graph, or an autopause demanding the player's attention.
+    """
+
+    def _session(self) -> tuple[Any, Any]:
+        store = _FakeStore()
+        session = create_new_campaign(store, scenario=WayneCountyScenario())
+        # Persistence-across-ticks is under test — mute the autopause gate
+        # (its cancel behavior has its own dedicated pin below).
+        session._pause_predicate = lambda _events: False
+        return store, session
+
+    def test_order_resubmits_its_verb_every_tick(self) -> None:
+        from babylon.game.standing_orders import StandingOrder
+
+        store, session = self._session()
+        session.place_standing_order(
+            StandingOrder(org_id="ORG001", verb="educate", target_id="C001")
+        )
+        session.advance_tick()
+        session.advance_tick()
+        educate_calls = [c for c in store.submit_turn_calls if c["verb"] == "educate"]
+        assert len(educate_calls) == 2
+        assert {c["tick"] for c in educate_calls} == {1, 2}
+
+    def test_fresh_player_verb_suppresses_the_order_that_tick(self) -> None:
+        from babylon.game.standing_orders import StandingOrder
+
+        class _StoreWithFreshTurn(_FakeStore):
+            def get_pending_turns(self, session_id: UUID, tick: int) -> list[dict[str, Any]]:
+                super().get_pending_turns(session_id, tick)
+                return [{"org_id": "ORG001", "verb": "agitate", "target_id": None}]
+
+        store = _StoreWithFreshTurn()
+        session = create_new_campaign(store, scenario=WayneCountyScenario())
+        session._pause_predicate = lambda _events: False
+        session.place_standing_order(
+            StandingOrder(org_id="ORG001", verb="educate", target_id="C001")
+        )
+        session.advance_tick()
+        assert not [c for c in store.submit_turn_calls if c["verb"] == "educate"]
+        assert session.standing_orders  # suppressed, NOT canceled
+
+    def test_target_gone_interrupts_legibly(self) -> None:
+        from babylon.game.standing_orders import StandingOrder
+
+        store, session = self._session()
+        session.place_standing_order(
+            StandingOrder(org_id="ORG001", verb="educate", target_id="NO_SUCH_NODE")
+        )
+        session.advance_tick()
+        assert not session.standing_orders
+        assert not [c for c in store.submit_turn_calls if c["verb"] == "educate"]
+        interrupted = session.last_interrupted_order
+        assert interrupted is not None
+        assert interrupted[0].org_id == "ORG001"
+        assert "target" in interrupted[1].lower()
+
+    def test_autopause_cancels_active_orders(self) -> None:
+        from babylon.game.standing_orders import StandingOrder
+
+        store, session = self._session()
+        session._pause_predicate = lambda _events: True  # force an autopause
+        session.place_standing_order(
+            StandingOrder(org_id="ORG001", verb="educate", target_id="C001")
+        )
+        session.advance_tick()
+        assert not session.standing_orders
+        interrupted = session.last_interrupted_order
+        assert interrupted is not None
+        assert "autopause" in interrupted[1].lower()
+
+    def test_no_orders_is_the_byte_identical_path(self) -> None:
+        store, session = self._session()
+        before = len(store.submit_turn_calls)
+        session.advance_tick()
+        assert len(store.submit_turn_calls) == before


### PR DESCRIPTION
## What

Iteration 11 — **ruling 22, the pacing prerequisite**. The dossier's finding: the T1 decision cadence (one real choice per 4–8 ticks across a 5,200-tick century) presupposes the chosen verb PERSISTS — without it the 30-hour floor is unreachable.

- `StandingOrder` (the `submit_turn` shape, frozen) + `place/cancel/standing_orders` on `GameSession`.
- Each tick an active order re-submits through the **same pending-turns path** a hand-submitted verb takes — zero new resolver surface, byte-identical mechanics. A fresh player verb for the same org **suppresses without canceling** (the live hand always wins).
- Interrupts are **material and deterministic** — the target leaving the graph; an autopause (something demanded the player's attention — persistence must not talk over it) — never a `cooldown_ticks` coefficient (ruling 24). Every interruption surfaces legibly (`last_interrupted_order` + log): the player always learns WHY.
- Session-lifetime in this cut (documented plainly); store persistence lands with the client's orders UI train.

## Verification

TDD red-first (five pins: persistence, suppression, target-gone legibility, autopause cancel, no-order byte-identical). The first red run itself proved the autopause interrupt: Wayne's tick 1 fires a real one that canceled the test's order before the dedicated pin existed. 367 game+cli green; `qa:regression` 11/11 byte-identical + determinism leg; vault byte-gate green.

Tracked on #380 (ruling 22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)