### PR TITLE
feat(rust): materialize babylon-graph — the native-hyperedge GraphSubstrate trait (P27 Phase 1 Task 11)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -113,6 +113,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "babylon-graph"
+version = "0.1.0"
+dependencies = [
+ "babylon-kernel",
+ "pretty_assertions",
+]
+
+[[package]]
 name = "babylon-kernel"
 version = "0.1.0"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/babylon-kernel",
+    "crates/babylon-graph",
     "crates/babylon-bsl",
     "crates/babylon-md",
     "crates/babylon-tui",

--- a/rust/crates/babylon-graph/Cargo.toml
+++ b/rust/crates/babylon-graph/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "babylon-graph"
+description = "Graph substrate trait boundary (Program 27, native-hyperedge — see src/substrate.rs)"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+babylon-kernel = { path = "../babylon-kernel" }
+
+[dev-dependencies]
+pretty_assertions = "1"

--- a/rust/crates/babylon-graph/src/lib.rs
+++ b/rust/crates/babylon-graph/src/lib.rs
@@ -1,0 +1,22 @@
+//! The graph substrate crate (spec §6, crate table). **Amendment D ruled
+//! NATIVE HYPEREDGE** (2026-07-29; Amendment AE clause (vi),
+//! `ai/_inbox/amendment-d-analysis-p27.md` §9): hyperedges are first-class
+//! objects in this crate's exposed model and type system — membership is one
+//! typed hyperedge, never a clique expansion, and never *exposed* as a
+//! bipartite incidence encoding. Levi/incidence is a permitted INTERNAL
+//! storage strategy (what `hypergraph-rs` implements); nothing in the exposed
+//! API reveals it. The strictly dyadic morphism API (II.9) lives alongside it
+//! in the same trait, separated by type (D-2).
+//!
+//! This crate exposes ONLY the [`substrate::GraphSubstrate`] trait plus a
+//! [`placeholder::PlaceholderGraph`] toy implementation sufficient to let
+//! downstream crates (`babylon-bsl`'s typed structural verbs, the conformance
+//! corpus) compile and typecheck against a real trait object today. The
+//! concrete production storage type is Phase 2 work. Do not build production
+//! logic against `PlaceholderGraph` — it is a compile-target, not a
+//! foundation.
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+
+pub mod placeholder;
+pub mod substrate;

--- a/rust/crates/babylon-graph/src/placeholder.rs
+++ b/rust/crates/babylon-graph/src/placeholder.rs
@@ -1,0 +1,214 @@
+//! `PlaceholderGraph`: an in-memory `HashMap`-backed toy [`GraphSubstrate`]
+//! implementation. **This is NOT the production graph storage** — it exists
+//! solely so Tasks 16/17 of the Phase-1 plan (BSL's typed structural verbs,
+//! the conformance corpus) have something real to typecheck and run against
+//! before the concrete Phase-2 storage lands. It DOES honor the Amendment D
+//! shape the trait fixes (hyperedges are their own objects with their own id
+//! space, members are a sorted set, no pairwise expansion anywhere), because
+//! that shape is ruled, not provisional. Deleting this module and swapping in
+//! the production storage is expected, low-risk churn — nothing outside this
+//! crate and its direct test dependents should assume its internals.
+use crate::substrate::{GraphError, GraphSubstrate, HyperedgeId, NodeId};
+use std::collections::HashMap;
+
+/// A toy substrate. See the module documentation: compile-target, not a
+/// foundation.
+#[derive(Debug, Default)]
+pub struct PlaceholderGraph {
+    nodes: HashMap<NodeId, &'static str>,
+    attributes: HashMap<(NodeId, &'static str), f64>,
+    /// Hyperedge id -> (type, sorted member list). Stored as ONE record per
+    /// hyperedge — the toy analogue of a first-class object. A production
+    /// store may instead keep incidence edges (Levi); callers cannot tell.
+    hyperedges: HashMap<HyperedgeId, (&'static str, Vec<NodeId>)>,
+    next_id: u64,
+    next_hyperedge_id: u64,
+}
+
+impl PlaceholderGraph {
+    /// An empty substrate.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl GraphSubstrate for PlaceholderGraph {
+    fn add_node(&mut self, node_type: &'static str) -> Result<NodeId, GraphError> {
+        let id = NodeId(self.next_id);
+        self.next_id += 1;
+        self.nodes.insert(id, node_type);
+        Ok(id)
+    }
+
+    fn remove_node(&mut self, id: NodeId) -> Result<(), GraphError> {
+        self.nodes
+            .remove(&id)
+            .map(|_| ())
+            .ok_or_else(|| GraphError {
+                message: format!("no such node: {id:?}"),
+            })
+    }
+
+    fn add_edge(
+        &mut self,
+        _edge_type: &'static str,
+        from: NodeId,
+        to: NodeId,
+    ) -> Result<(), GraphError> {
+        if !self.node_exists(from) || !self.node_exists(to) {
+            return Err(GraphError {
+                message: "edge endpoint does not exist".into(),
+            });
+        }
+        Ok(()) // placeholder: no edge storage at all, deliberately (see module doc)
+    }
+
+    fn remove_edge(
+        &mut self,
+        _edge_type: &'static str,
+        _from: NodeId,
+        _to: NodeId,
+    ) -> Result<(), GraphError> {
+        Ok(())
+    }
+
+    fn update_node(
+        &mut self,
+        id: NodeId,
+        attribute: &'static str,
+        value: f64,
+    ) -> Result<(), GraphError> {
+        if !self.node_exists(id) {
+            return Err(GraphError {
+                message: format!("no such node: {id:?}"),
+            });
+        }
+        self.attributes.insert((id, attribute), value);
+        Ok(())
+    }
+
+    fn node_exists(&self, id: NodeId) -> bool {
+        self.nodes.contains_key(&id)
+    }
+
+    fn add_hyperedge(
+        &mut self,
+        hyperedge_type: &'static str,
+        members: &[NodeId],
+    ) -> Result<HyperedgeId, GraphError> {
+        if members.is_empty() {
+            return Err(GraphError {
+                message: "hyperedge must have at least one member".into(),
+            });
+        }
+        let mut sorted: Vec<NodeId> = members.to_vec();
+        sorted.sort_unstable();
+        if sorted.windows(2).any(|w| w[0] == w[1]) {
+            return Err(GraphError {
+                message: "duplicate member in hyperedge".into(),
+            });
+        }
+        if let Some(missing) = sorted.iter().find(|n| !self.node_exists(**n)) {
+            return Err(GraphError {
+                message: format!("no such member node: {missing:?}"),
+            });
+        }
+        let id = HyperedgeId(self.next_hyperedge_id);
+        self.next_hyperedge_id += 1;
+        self.hyperedges.insert(id, (hyperedge_type, sorted));
+        Ok(id)
+    }
+
+    fn remove_hyperedge(&mut self, id: HyperedgeId) -> Result<(), GraphError> {
+        self.hyperedges
+            .remove(&id)
+            .map(|_| ())
+            .ok_or_else(|| GraphError {
+                message: format!("no such hyperedge: {id:?}"),
+            })
+    }
+
+    fn members_of(&self, id: HyperedgeId) -> Result<Vec<NodeId>, GraphError> {
+        self.hyperedges
+            .get(&id)
+            .map(|(_, members)| members.clone()) // already sorted at insert
+            .ok_or_else(|| GraphError {
+                message: format!("no such hyperedge: {id:?}"),
+            })
+    }
+
+    fn hyperedges_of(&self, node: NodeId, hyperedge_type: &'static str) -> Vec<HyperedgeId> {
+        let mut found: Vec<HyperedgeId> = self
+            .hyperedges
+            .iter()
+            .filter(|(_, (ty, members))| *ty == hyperedge_type && members.contains(&node))
+            .map(|(id, _)| *id)
+            .collect();
+        found.sort_unstable();
+        found
+    }
+
+    fn hyperedge_exists(&self, id: HyperedgeId) -> bool {
+        self.hyperedges.contains_key(&id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GraphSubstrate, NodeId, PlaceholderGraph};
+
+    #[test]
+    fn add_then_update_then_read_back() {
+        let mut graph = PlaceholderGraph::new();
+        let node = graph.add_node("social_class").unwrap();
+        graph.update_node(node, "wealth", 42.0).unwrap();
+        assert_eq!(graph.attributes.get(&(node, "wealth")), Some(&42.0));
+    }
+
+    #[test]
+    fn edge_to_nonexistent_node_is_a_loud_error() {
+        let mut graph = PlaceholderGraph::new();
+        let node = graph.add_node("territory").unwrap();
+        assert!(graph.add_edge("adjacency", node, NodeId(9999)).is_err());
+    }
+
+    #[test]
+    fn hyperedge_members_come_back_sorted_not_in_declared_order() {
+        // Amendment D / BSL D25: declared member order is unobservable.
+        let mut graph = PlaceholderGraph::new();
+        let first = graph.add_node("social_class").unwrap();
+        let second = graph.add_node("social_class").unwrap();
+        let third = graph.add_node("social_class").unwrap();
+        let sector = graph
+            .add_hyperedge("economic_sector", &[third, first, second])
+            .unwrap();
+        assert_eq!(
+            graph.members_of(sector).unwrap(),
+            vec![first, second, third]
+        );
+    }
+
+    #[test]
+    fn duplicate_member_is_a_loud_error() {
+        let mut graph = PlaceholderGraph::new();
+        let member = graph.add_node("social_class").unwrap();
+        assert!(graph
+            .add_hyperedge("economic_sector", &[member, member])
+            .is_err());
+    }
+
+    #[test]
+    fn a_hyperedge_mints_no_pairwise_edges() {
+        // VIII.9 by construction: n members cost one object, not C(n,2) edges.
+        let mut graph = PlaceholderGraph::new();
+        let first = graph.add_node("social_class").unwrap();
+        let second = graph.add_node("social_class").unwrap();
+        let sector = graph
+            .add_hyperedge("economic_sector", &[first, second])
+            .unwrap();
+        assert_eq!(graph.hyperedges_of(first, "economic_sector"), vec![sector]);
+        // the dyadic half is untouched by minting a hyperedge
+        assert_eq!(graph.hyperedges.len(), 1);
+    }
+}

--- a/rust/crates/babylon-graph/src/substrate.rs
+++ b/rust/crates/babylon-graph/src/substrate.rs
@@ -1,0 +1,137 @@
+//! The `GraphSubstrate` trait: the typed-verb surface BSL's structural
+//! effects compile against (`docs/reference/bsl-language.rst` §2.6 queries,
+//! §2.8 verbs), independent of the underlying storage.
+//!
+//! **Two typed halves, one substrate (Amendment D, sub-ruling D-2).** The
+//! dyadic half (`add_edge`/`remove_edge`) is II.9's strictly dyadic morphism
+//! layer. The hyperedge half (`add_hyperedge`/`remove_hyperedge`/
+//! `members_of`/`hyperedges_of`) is Amendment D's first-class membership
+//! layer. A dyadic caller cannot be handed a hyperedge and vice versa —
+//! II.7's "MUST remain separate" is enforced by the type system rather than
+//! by two libraries.
+//!
+//! **Silent on representation, loud on shape.** No adjacency iteration order
+//! and no storage type is exposed; a Levi/incidence bipartite store is
+//! permitted and unobservable. What IS exposed, because the ruling fixes it:
+//! a hyperedge has an identity and a member list, and there is no method
+//! anywhere that expands a member list into pairwise edges (VIII.9).
+
+/// Opaque node identity — a newtype so no caller depends on it being an
+/// integer index vs. a UUID vs. anything else the concrete shape picks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct NodeId(pub u64);
+
+/// Opaque hyperedge identity. **Distinct from [`NodeId`] on purpose**: a
+/// hyperedge is a first-class object, not a node with a member set stashed in
+/// its attributes (the shape D-4 explicitly declines to ratify for
+/// `ECONOMIC_SECTOR`). Two id types is what makes the dyadic/hyperedge
+/// separation type-level rather than conventional.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct HyperedgeId(pub u64);
+
+/// A structural-verb failure. Loud by construction (III.11): every fallible
+/// method on [`GraphSubstrate`] returns one rather than silently coercing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphError {
+    /// Human-readable cause, suitable for surfacing to a BSL diagnostic.
+    pub message: String,
+}
+
+/// The typed structural-verb surface a `GraphSubstrate` implementation
+/// provides. `node_type`/`edge_type`/`hyperedge_type` are `&'static str` here
+/// (the closed `NodeType`/`EdgeType`/`HyperedgeType` enums are a
+/// `babylon-domain` concern, Phase 2/3; this trait is domain-agnostic on
+/// purpose so it compiles before those enums port).
+pub trait GraphSubstrate {
+    // ---- dyadic half (II.9 morphism layer) ----
+
+    /// Mint one typed node.
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if the implementation cannot allocate the node
+    /// (for example, an exhausted identity space).
+    fn add_node(&mut self, node_type: &'static str) -> Result<NodeId, GraphError>;
+
+    /// Remove a node.
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if `id` names no node in this substrate.
+    fn remove_node(&mut self, id: NodeId) -> Result<(), GraphError>;
+
+    /// Mint one typed dyadic edge.
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if either endpoint does not exist.
+    fn add_edge(
+        &mut self,
+        edge_type: &'static str,
+        from: NodeId,
+        to: NodeId,
+    ) -> Result<(), GraphError>;
+
+    /// Remove one typed dyadic edge.
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if the implementation cannot service the
+    /// removal (for example, an unknown endpoint under a stricter store).
+    fn remove_edge(
+        &mut self,
+        edge_type: &'static str,
+        from: NodeId,
+        to: NodeId,
+    ) -> Result<(), GraphError>;
+
+    /// Update a single attribute on a node under the I.15 edge-mode state
+    /// machine's constraints — this trait method does NOT itself enforce
+    /// I.15 (that is a `babylon-domain` law over the concrete shape); it is
+    /// the mechanical write point I.15's checker wraps.
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if `id` names no node in this substrate.
+    fn update_node(
+        &mut self,
+        id: NodeId,
+        attribute: &'static str,
+        value: f64,
+    ) -> Result<(), GraphError>;
+
+    /// Whether `id` names a live node.
+    fn node_exists(&self, id: NodeId) -> bool;
+
+    // ---- hyperedge half (Amendment D: first-class membership) ----
+
+    /// Mint one typed hyperedge over `members`. The member list is a SET:
+    /// a repeated [`NodeId`], an unknown [`NodeId`], or an empty list is a
+    /// loud error (BSL `E-EVAL-031`), never deduplicated or ignored. Cost is
+    /// `members.len()` incidences — never `C(n,2)` edges.
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if `members` is empty, contains a duplicate, or
+    /// names a node that does not exist.
+    fn add_hyperedge(
+        &mut self,
+        hyperedge_type: &'static str,
+        members: &[NodeId],
+    ) -> Result<HyperedgeId, GraphError>;
+
+    /// Remove one hyperedge whole. There is deliberately no `remove_member`:
+    /// membership change is whole-hyperedge replacement (BSL invariant S-10).
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if `id` names no hyperedge in this substrate.
+    fn remove_hyperedge(&mut self, id: HyperedgeId) -> Result<(), GraphError>;
+
+    /// Members of one hyperedge, in **ascending [`NodeId`] order** — declared
+    /// member order is never observable (BSL §2.6 draft ruling D25).
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if `id` names no hyperedge in this substrate.
+    fn members_of(&self, id: HyperedgeId) -> Result<Vec<NodeId>, GraphError>;
+
+    /// The hyperedges of the given type a node belongs to, in ascending
+    /// [`HyperedgeId`] order.
+    fn hyperedges_of(&self, node: NodeId, hyperedge_type: &'static str) -> Vec<HyperedgeId>;
+
+    /// Whether `id` names a live hyperedge.
+    fn hyperedge_exists(&self, id: HyperedgeId) -> bool;
+}


### PR DESCRIPTION
## The first real Rust engine code since the scaffolds

The spine audit found there was **no `babylon-graph` crate at all** — `babylon-kernel` and `babylon-bsl` are five-line shells, Tasks 3–17 unstarted — while Task 11's trait sat **fully drafted and copy-pasteable** in the Phase-1 plan (`…2026-07-29-program-27-phase-1-language-and-kernel.md:1588-1947`). It named materializing it the cheapest available P27 Phase 1 advance. This lands it.

### Amendment D's shape, as ruled

- **Hyperedges are first-class in the exposed model** — a typed object with its own identity and member list, never a clique expansion (VIII.9 by construction), never exposed as bipartite incidence. `HyperedgeId` is a **distinct newtype** from `NodeId` on purpose: two id types are what make the dyadic/hyperedge separation *type-level* rather than conventional (D-2 satisfies II.7 without needing two libraries).
- The strictly dyadic morphism half (II.9) lives alongside it in the same trait.
- **Levi/incidence stays a permitted internal storage strategy** — nothing in the API reveals it; no adjacency order and no storage type is exposed.
- `members_of` returns an owned `Vec` in **ascending `NodeId` order** — declared member order is unobservable (BSL D25), and an iterator would leak the store's ordering into the signature. `remove_hyperedge` takes the whole object: there is deliberately **no `remove_member`** (BSL S-10 — membership change is whole-hyperedge replacement).

`PlaceholderGraph` is a `HashMap`-backed toy, documented at module level as a compile-target for Tasks 16/17 and never a production candidate — but it honors the ruled shape, because that shape is ruled, not provisional. It stores no dyadic edges at all, deliberately.

### Evidence

Five tests, all green: attribute round-trip; a loud error on an edge to a nonexistent node; **members returned sorted rather than in declared order**; a duplicate member as a loud error; and **a hyperedge minting no pairwise edges** — n members cost one object, not `C(n,2)`, the arithmetic reason Amendment D is a *fuel* ruling as well as an ontology ruling. `mise run rust:check` (fmt + clippy `-D warnings` + test + doc) green across the workspace.

### Deviation from the drafted code, recorded

The draft omits the `# Errors` doc sections `clippy::pedantic` requires, and its test bindings trip `many_single_char_names` — **as written it would have failed the gate.** Both fixed here; the trait surface is otherwise verbatim.

### Still deliberately undecided (Phase 2/3)

The concrete storage type, adjacency iteration order at the storage level, the closed `NodeType`/`EdgeType`/`HyperedgeType` enums, and whether `babylon-graph` consumes `hypergraph-rs` or reimplements its `NodeKind`/`MembershipEdge` pattern (#282, UNRESOLVED — **this crate's existence is what forces that question into the open**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)