### PR TITLE
feat(kernel): the P27 tick content hash — the gate that can see the graph

### DIFF
--- a/ai/decisions/ADR179_topology_spine_director_rulings.yaml
+++ b/ai/decisions/ADR179_topology_spine_director_rulings.yaml
@@ -1,0 +1,137 @@
+id: ADR179
+title: "Topology spine — Director rulings on ADJACENCY, hash naming, graph storage, and topology persistence"
+status: accepted
+date: 2026-07-30
+supersedes: []
+superseded_by: []
+related:
+  - ADR172  # Amendment AE — Rust is the engine language
+  - ADR176  # ruling 31, checkpoint-only hydration (BINDING)
+  - ADR178  # C4 — all lanes run
+  - ADR173  # no imposed functional forms
+
+context: >
+  reports/social-topology-spine-dossier.md §8 reserved five questions to the
+  Director. Four were put to her on 2026-07-30 while Lane B (the tick content
+  hash, PR #416) was in flight; Lane D was fully blocked on the first. Her
+  answers are recorded verbatim in each ruling's `director_words`. Two answers
+  went beyond the options offered — T2 delegated the choice with a constraint,
+  and T4 named a mechanism (a dedicated Postgres object, ideally AGE-queryable)
+  that none of the offered options contained. Both are recorded as given, not
+  normalized into the menu they were asked from.
+
+rulings:
+  - id: T1
+    subject: "ADJACENCY producer — derive now, FULLY LIVE"
+    director_words: "Derive now, fully live"
+    decision: >
+      Build the ADJACENCY producer from the Phase 0-D pinned TIGER county
+      adjacency estate AND wire its readers in the same motion. Spatial
+      contiguity becomes live physics. The agent had recommended a shadow-first
+      landing to avoid baseline movement; the Director chose the fuller option,
+      so the baseline drift is EXPECTED and declared, not a surprise.
+    consequences:
+      - "Lane D unblocks immediately; every spatial algorithm gains a real substrate."
+      - >
+        Moves baselines — one declared §6.5 ceremony, drift table attributed to
+        spatial contiguity entering the physics. This is a PHYSICS change, so
+        the ceremony must say so plainly rather than describing it as a data
+        addition.
+      - >
+        The dossier recorded ADJACENCY as having readers and no writer; those
+        readers stop being dead code, which means their behavior becomes
+        load-bearing for the first time and needs its own tests, not just the
+        producer's.
+    open: >
+      Which readers are in scope for "fully live" is an engineering call left
+      to the implementing PR, but every reader activated must be named in the
+      ceremony body.
+
+  - id: T2
+    subject: "The two hashes — rename the old one; no accumulated debt"
+    director_words: "whatever you recommend just keep it consistent, dont accumulate technical debt, do it correctly"
+    decision: >
+      Delegated to the agent with a binding constraint (consistency, no debt,
+      correctness). The agent's recommendation therefore governs and is hereby
+      the ruling: KEEP BOTH hashes with honest names —
+      `tick_commit.determinism_hash` is renamed `replay_identity_hash`, the new
+      per-tick graph digest lands as `content_hash`, and Constitution III.7's
+      wording is repointed at the content hash. III.7's own text ("a
+      deterministic SHA-256 hash of its inputs: World state + player actions +
+      random seed") already describes the content hash and never described the
+      session-identity formula.
+    rationale: >
+      The "keep both, keep names" option was rejected under the no-debt
+      constraint: a field named `determinism_hash` that cannot detect a
+      determinism failure is precisely the mislabeling that kept this gap
+      invisible. "Upgrade in place" was rejected because it destroys the
+      replay-identity role — two sessions with identical state would collide.
+    consequences:
+      - "A migration renaming the column, plus a rename sweep across both tick loops."
+      - "Constitution III.7 text change — a constitutional edit, so it rides its own PR."
+      - "The Python-era `babylon_meta.campaign.content_digest` NULL note is superseded."
+
+  - id: T3
+    subject: "babylon-graph storage — consume hypergraph-rs, with the gap acknowledged"
+    director_words: "i choose 2 but be aware hypergraph-rs may not be copmletely one-for-one swappable for xgi. i still may need to develop that repository"
+    decision: >
+      babylon-graph's concrete storage CONSUMES hypergraph-rs rather than
+      reimplementing native-hyperedge storage in-tree. The Director attached an
+      explicit caveat: hypergraph-rs is not necessarily a one-for-one
+      replacement for xgi, and she may still need to develop that repository.
+      Adopting it is therefore a decision to INVEST in the sibling repo, not an
+      assumption that it is already sufficient.
+    consequences:
+      - >
+        Amendment AE's charter for hypergraph-rs expands beyond client-side
+        raster. This ADR is the disclosure; if the expansion needs constitutional
+        text, that is an amendment, not an improvisation.
+      - >
+        The `GraphSubstrate` trait (PR #415, merged) is now load-bearing as an
+        INSULATION layer, not just a compile target: wherever hypergraph-rs
+        falls short of xgi's model, the shortfall must be absorbed behind the
+        trait or fixed upstream — never leaked into engine code.
+      - >
+        Phase 2 must open with a written xgi-vs-hypergraph-rs capability
+        delta before any storage code lands, so "may not be one-for-one" becomes
+        an enumerated list rather than a caveat.
+    open: "The capability delta is unwritten. It gates Phase 2 storage work."
+
+  - id: T4
+    subject: "Topology persistence — a dedicated Postgres object, ideally AGE-queryable"
+    director_words: "this should be stored in postgres as a dedicated object and ideally even queryable with Apache AGE in Postgres"
+    decision: >
+      The social topology is persisted as a DEDICATED Postgres object rather
+      than being reconstructed from per-entity tables, and the aspiration is
+      that it be queryable as a graph via the Apache AGE extension. This
+      supersedes all three options the agent offered (checkpoint-only,
+      every-tick, interactive-only) — none of them proposed a graph-native
+      store.
+    binding_vs_aspirational: >
+      BINDING: a dedicated topology object in Postgres. ASPIRATIONAL ("ideally"):
+      AGE queryability. If AGE proves infeasible, the dedicated object still
+      ships; the fallback is not "reconstruct from entity tables."
+    feasibility_verified_2026_07_30:
+      - "Apache AGE 1.6.0 supports PostgreSQL 17, which is our pinned major."
+      - >
+        The runtime image is already custom-built (docker/postgres/Dockerfile)
+        and already installs three extensions (postgis, vector, uuid-ossp), so
+        adding one more is a known-shaped change, not new ground.
+      - >
+        NOT yet verified: AGE + PostGIS coexistence in one image, AGE's
+        interaction with the digest-pinned CI container, and whether AGE has an
+        upgrade script path. These are the real risks and must be settled before
+        the extension is added to the schema bootstrap.
+    consequences:
+      - "Cadence (every tick vs checkpoint-only) is now an open sub-question — the ruling named the SHAPE, not the frequency. ADR176 ruling 31's checkpoint-only hydration is the presumptive default until ruled otherwise."
+      - "Closes the dossier's R2 'two runtimes lying past each other' finding by construction: there is one topology object, not two divergent persistence paths."
+
+agent_decided_not_reserved:
+  note: >
+    Recorded here for traceability because they change a cross-implementation
+    byte contract, but they are engineering calls made under standing autonomy,
+    not Director rulings.
+  items:
+    - "The P27 tick hash's worked example contradicted its own Booleans rule (quoted \"true\" vs bare true). The normative prose governs; the example was corrected from 248 bytes/ea6f1d10… to 246 bytes/b256dbbc…. Nothing depended on the old value."
+    - "Three encoding rules were missing from the spec and were added after hashing live graphs: `null` for unset optionals, canonical member ordering for sets, and loud failure for non-string enum values and non-string record keys."
+    - "`legal_authorities` is a frozenset ON A NODE — a second live instance of the shape Amendment D sub-ruling D-4 declined to grandfather for ECONOMIC_SECTOR. Recorded as evidence, not acted on."

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -805,3 +805,8 @@ decisions:
     status: accepted
     date: '2026-07-30'
     file: ADR178_calibration_class_and_cooptation_ownership.yaml
+  ADR179_topology_spine_director_rulings:
+    title: 'Director rulings live session 2026-07-30 (topology spine batch, dossier §8): ADJACENCY derived NOW and FULLY LIVE from the pinned TIGER estate (physics change, declared baseline ceremony — Lane D unblocked); the two hashes KEEP BOTH with honest names (determinism_hash -> replay_identity_hash, new content_hash, Constitution III.7 repointed) under a delegated no-technical-debt constraint; babylon-graph storage CONSUMES hypergraph-rs with the Director''s explicit caveat that it may not be one-for-one swappable for xgi and that repository may still need development (GraphSubstrate trait becomes an insulation layer; Phase 2 opens with a written capability delta); and the social topology is persisted as a DEDICATED POSTGRES OBJECT, ideally queryable via Apache AGE — superseding all three cadence options offered, closing R2 by construction (AGE 1.6.0/PG17 verified compatible; PostGIS coexistence unverified)'
+    status: accepted
+    date: '2026-07-30'
+    file: ADR179_topology_spine_director_rulings.yaml

--- a/docs/reference/determinism-contract.rst
+++ b/docs/reference/determinism-contract.rst
@@ -841,6 +841,31 @@ reading aid):**
   exactly as declared (e.g. ``NodeType.SOCIAL_CLASS`` → ``"social_class"``,
   ``EdgeType.EXPLOITATION`` → ``"EXPLOITATION"``) — whichever casing the
   enum declares, reproduced verbatim, never re-cased.
+- **``null`` (added 2026-07-30, at first implementation):** an unset optional
+  field is the bare JSON literal ``null`` (a Rust ``Option::None`` serializes
+  to exactly this). An optional field that is unset is real state — the live
+  graph carries many (``county_fips``, ``aligned_faction_id``) — and this rule
+  does **not** reopen the stringly-fallback ban below, which targets values
+  whose *type* has no rule: hashing ``null`` explicitly makes a wrongly
+  defaulted field **more** visible, since ``null`` and ``0.0`` are different
+  bytes. Records carry their full declared field set, so "key absent" and "key
+  present, null" never both occur for the same field.
+- **Sets (added 2026-07-30):** a set-valued field serializes as an array of its
+  members in ascending canonical-serialization order (sort the members' own
+  encoded forms, which yields a total order regardless of member type). Set
+  iteration order is hash-seed dependent in Python and is not a property any
+  implementation could reproduce. Found by hashing live graphs: the
+  ``legal_authorities`` node attribute is a ``frozenset`` — the same
+  set-stashed-in-a-node-attribute shape Amendment D sub-ruling D-4 declined to
+  grandfather for ``ECONOMIC_SECTOR``. This rule mirrors ``babylon-graph``'s
+  ``members_of``, which likewise returns members sorted, never as declared.
+- **Non-string-valued enum members are a load failure (added 2026-07-30):** an
+  ``IntEnum`` would hash as a bare integer and silently alias a genuine integer
+  field, and its numbering is an internal detail no port should be required to
+  reproduce. Only string-valued members may enter the hash.
+- **Non-string record keys are a load failure (added 2026-07-30):** canonical
+  key ordering is undefined for a mixed-type key set, so the byte output would
+  silently depend on insertion order.
 - **Ban on stringly fallbacks:** a field encountered during serialization
   that has no encoding rule above (i.e. not one of int / ``i128`` / ``f64``
   / bool / enum-or-string / array / nested record) is a **hash-time load

--- a/docs/reference/determinism-contract.rst
+++ b/docs/reference/determinism-contract.rst
@@ -862,11 +862,27 @@ reading aid):**
    canonical bytes (one unbroken line; wrapped here for readability):
    {"actions":[],"edges":[{"edge_type":"EXPLOITATION","source_id":"C001",
    "target_id":"C002","value_flow":"4029000000000000"}],"nodes":[{"active":
-   "true","node_id":"C001","node_type":"social_class","wealth":
+   true,"node_id":"C001","node_type":"social_class","wealth":
    "4059000000000000"}],"rng_seed":2010,"tick":1}
 
-   len(canonical bytes) = 248
-   sha256 = ea6f1d10c6a6fc97d1481158ae1bbfc6b978e80584d984cccf6525af1023470f
+   len(canonical bytes) = 246
+   sha256 = b256dbbca591c5af2b8cb23b9c4027ed1ac657d10b1e669aadb05670cd75d4a0
+
+.. note::
+   **Correction (2026-07-30, at first implementation).** As first published,
+   this example rendered the boolean ``active`` as the *quoted* string
+   ``"true"`` (248 bytes,
+   ``ea6f1d10c6a6fc97d1481158ae1bbfc6b978e80584d984cccf6525af1023470f``),
+   contradicting the *Booleans* rule above — and inconsistent with how the
+   same example renders integers (``"tick":1``, bare). The published digest
+   was self-consistent only in the sense that it re-derived the slip. The
+   normative prose governs: booleans are bare JSON literals, so the canonical
+   form is the 246-byte string shown. Nothing depended on the superseded
+   value — the hash had no implementation at the time — and both forms are
+   recorded here so a reader meeting the old digest in an archived document
+   can identify it. The example is now executable rather than hand-verified:
+   it is pinned byte-for-byte by
+   ``tests/unit/kernel/test_tick_hash.py::TestTheWorkedExample``.
 
 **Chaining:** none, matching the established precedent of every other hash
 in this document (*Catalog of Constitutional Hashes* above) — a fresh,

--- a/reports/social-topology-spine-dossier.md
+++ b/reports/social-topology-spine-dossier.md
@@ -236,9 +236,22 @@ test fixture value, demonstrating that nothing anywhere enforces derivation.
 
 So the hash chain proves **replay lineage** (same session+tick+seed reproduces the same label) and
 says nothing about **state content**. An edge-attribute loss, a dropped node, or corrupted
-`node_state` would pass every gate we have. A real content digest exists only as a forward P27
+`node_state` would pass this hash unchanged. A real content digest exists only as a forward P27
 concept (`docs/reference/determinism-contract.rst`), and its column
 `babylon_meta.campaign.content_digest` is documented to "stay honestly NULL in the Python era."
+
+> **Correction (2026-07-30, on implementing R1).** This section originally said such a loss "would
+> pass **every gate we have**." That overstated the gap, and the sharper statement is more useful.
+> The dense goldens are a second, independent gate, and they *do* see topology — but only
+> **WorldState's** projection of it. `_dense_header` (`tools/regression_test.py:434-473`) derives
+> its columns from `state.entities`, `state.relationships`, and `state.territories`, so a dropped
+> entity or relationship changes the header and fails the byte comparison, and `_dense_row` raises
+> loudly if the set drifts mid-run. What is genuinely invisible is anything living **only on the
+> `BabylonGraph`**: the harness contains no `to_graph`/`from_graph` call anywhere, so graph-only
+> attributes, node types, edge types outside the projected set, and (once they exist) hyperedges
+> never reach a gate at all. That is a narrower hole than first stated and a more precise brief for
+> the content hash — which is why it hashes the *graph*, not the WorldState projection. The claim
+> about `determinism_hash` itself is unchanged and was always the load-bearing one.
 
 **This is the audit's most actionable finding**, and it is exactly the artifact the rewrite test
 demands: a content digest is what would let us prove a Rust rewrite correct.

--- a/src/babylon/kernel/tick_hash.py
+++ b/src/babylon/kernel/tick_hash.py
@@ -38,6 +38,19 @@ Encoding rules, in one place
   characters, sidestepping cross-language shortest-round-trip disagreement on
   ties, ``-0.0``, and subnormals.
 - **Booleans** are bare ``true``/``false``.
+- **``None``** is the bare literal ``null``. An optional field that is unset is
+  real state, and ``null`` is unambiguous in every JSON implementation
+  (a Rust ``Option::None`` serializes to exactly this). This does **not**
+  reopen the stringly-fallback hazard: that ban is on values whose type has no
+  rule, and hashing ``null`` explicitly makes a wrongly-defaulted field *more*
+  visible, not less — ``null`` and ``0.0`` are different bytes.
+- **Sets** (``set``/``frozenset``) become their members in ascending
+  canonical-serialization order. Python's set iteration order is hash-seed
+  dependent and is not a property any port could reproduce.
+- **Enum members** are their declared string value, never re-cased. A
+  non-string-valued member (an ``IntEnum``) is a loud failure: it would hash as
+  a bare integer, silently aliasing a genuine integer field, and its numbering
+  is an internal detail no port should have to reproduce.
 - **Anything else** is a loud :class:`TickHashEncodingError` (III.11) — there is
   no ``default=str`` fallback, which is exactly the hazard
   ``conservation_audit.py``'s hash carries today.
@@ -50,6 +63,7 @@ import json
 import math
 import struct
 from collections.abc import Mapping, Sequence
+from enum import Enum
 
 __all__ = [
     "Micros",
@@ -100,6 +114,31 @@ def _encode_float(value: float, *, field: str) -> str:
     return struct.pack(">d", value).hex()
 
 
+def _encode_enum(value: Enum, *, field: str) -> str:
+    """Render an enum member as its declared value, never re-cased.
+
+    ``NodeType.SOCIAL_CLASS`` → ``"social_class"``, ``EdgeType.EXPLOITATION``
+    → ``"EXPLOITATION"`` — whichever casing the enum itself declares.
+
+    :param value: the enum member.
+    :param field: the field name, for error messages.
+    :returns: the member's declared string value.
+    :raises TickHashEncodingError: if the member's value is not a string.
+        An ``IntEnum`` would otherwise hash as a bare integer and silently
+        alias a genuine integer field, and its numbering is an internal
+        detail no port should be required to reproduce.
+    """
+    member_value = value.value
+    if not isinstance(member_value, str):
+        raise TickHashEncodingError(
+            f"field {field!r} holds {type(value).__name__}."
+            f"{value.name}, whose value is {type(member_value).__name__}, "
+            "not a string; only string-valued enum members may enter the "
+            "tick hash"
+        )
+    return member_value
+
+
 def _encode_value(value: object, *, field: str) -> object:
     """Convert one value to its canonical JSON-ready form.
 
@@ -109,10 +148,14 @@ def _encode_value(value: object, *, field: str) -> object:
     :raises TickHashEncodingError: if no encoding rule covers ``value``.
     """
     # Order matters: `bool` is a subclass of `int`, and `Micros` is too.
+    if value is None:
+        return None
     if isinstance(value, bool):
         return value
     if isinstance(value, Micros):
         return str(int(value))
+    if isinstance(value, Enum):
+        return _encode_enum(value, field=field)
     if isinstance(value, int):
         return value
     if isinstance(value, float):
@@ -123,10 +166,33 @@ def _encode_value(value: object, *, field: str) -> object:
         return _encode_record(value)
     if isinstance(value, (list, tuple)):
         return [_encode_value(item, field=field) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return _encode_set(value, field=field)
     raise TickHashEncodingError(
         f"field {field!r} holds {type(value).__name__}, for which there is "
         "no encoding rule; the tick hash has no stringly fallback"
     )
+
+
+def _encode_set(value: set[object] | frozenset[object], *, field: str) -> list[object]:
+    """Render a set as its members in canonical order.
+
+    Python's set iteration order is hash-seed dependent and is never a
+    property a port could reproduce, so the members are sorted by their own
+    canonical serialization — a total order that works regardless of member
+    type, unlike sorting the raw members (which raises on a mixed-type set).
+
+    This mirrors the rule ``babylon-graph``'s ``members_of`` already enforces
+    for hyperedge members: membership is a set, and declared order is
+    unobservable.
+
+    :param value: the set to encode.
+    :param field: the field name, for error messages.
+    :returns: the encoded members in ascending canonical-serialization order.
+    :raises TickHashEncodingError: propagated from any member with no rule.
+    """
+    encoded = [_encode_value(member, field=field) for member in value]
+    return sorted(encoded, key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")))
 
 
 def _encode_record(record: Mapping[str, object]) -> dict[str, object]:
@@ -137,7 +203,16 @@ def _encode_record(record: Mapping[str, object]) -> dict[str, object]:
 
     :param record: the node, edge, or action record.
     :returns: the same mapping with every value canonically encoded.
+    :raises TickHashEncodingError: if any key is not a string — ``sort_keys``
+        cannot order a mixed-type key set, so the byte output would depend on
+        insertion order.
     """
+    for key in record:
+        if not isinstance(key, str):
+            raise TickHashEncodingError(
+                f"record key {key!r} is {type(key).__name__}, not str; "
+                "canonical key ordering is undefined for non-string keys"
+            )
     return {key: _encode_value(value, field=key) for key, value in record.items()}
 
 

--- a/src/babylon/kernel/tick_hash.py
+++ b/src/babylon/kernel/tick_hash.py
@@ -1,0 +1,235 @@
+"""The P27 tick hash — one canonical per-tick **content** fingerprint.
+
+Normative specification: ``docs/reference/determinism-contract.rst``, chapter
+*The P27 Tick Hash*. This module is the Python reference implementation of that
+byte layout; ``babylon-kernel`` (Rust) is required to produce the identical
+digest from the identical state, so **every byte here is contract**, not
+convenience (Constitution III.7).
+
+Why this exists alongside ``tick_commit.determinism_hash``
+-----------------------------------------------------------
+
+Today's ``determinism_hash`` is ``sha256(f"{session_id}:{tick}:{rng_seed}")`` —
+three scalars, **no world state at all**. It proves *replay lineage* (the same
+session+tick+seed reproduces the same label) and is structurally incapable of
+noticing a dropped node, a lost edge, or a corrupted attribute. This hash is
+the other half: it says nothing about run identity (the session id is
+deliberately not an input) and everything about content.
+
+The two are **additive, not substitutes**. Whether the older hash is renamed or
+upgraded in place is a reserved Director question
+(``reports/social-topology-spine-dossier.md`` §8 Q2); nothing in this module
+touches it.
+
+Encoding rules, in one place
+-----------------------------
+
+- **Keys** sort alphabetically, recursively, at every nesting level.
+- **Nodes** sort ascending by ``node_id`` (string comparison); **edges** by
+  ``(source_id, target_id)``. Graph-backend iteration order is unspecified and
+  must never reach the digest.
+- **Actions** keep their given order — the sequence in which actions applied is
+  itself state, not an artifact of storage.
+- **Integers** are bare JSON numbers; **fixed-point micro-unit currency**
+  (:class:`Micros`) is a decimal **string**, because a JSON number is an
+  IEEE-754 ``f64`` in every mainstream library and would silently round an
+  ``i128``.
+- **Floats** are the raw big-endian IEEE-754 bit pattern as 16 lowercase hex
+  characters, sidestepping cross-language shortest-round-trip disagreement on
+  ties, ``-0.0``, and subnormals.
+- **Booleans** are bare ``true``/``false``.
+- **Anything else** is a loud :class:`TickHashEncodingError` (III.11) — there is
+  no ``default=str`` fallback, which is exactly the hazard
+  ``conservation_audit.py``'s hash carries today.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import struct
+from collections.abc import Mapping, Sequence
+
+__all__ = [
+    "Micros",
+    "TickHashEncodingError",
+    "canonical_tick_bytes",
+    "compute_tick_hash",
+]
+
+
+class Micros(int):
+    """A fixed-point currency value in micro-units, encoded as a decimal string.
+
+    Python's ``int`` is arbitrary-precision, so a plain ``int`` would serialize
+    losslessly *here* while a Rust ``serde_json`` ``i128`` would not. Tagging
+    the value at the call site keeps the distinction explicit and type-checked
+    rather than inferred from magnitude, which would make the encoding depend
+    on the data.
+
+    :param value: the micro-unit amount.
+    """
+
+    __slots__ = ()
+
+
+class TickHashEncodingError(TypeError):
+    """A value reached the hash with no encoding rule (Constitution III.11).
+
+    Deliberately fatal: coercing an unknown value to its ``str()`` would let a
+    schema change slip through the one gate meant to catch it.
+    """
+
+
+def _encode_float(value: float, *, field: str) -> str:
+    """Render an ``f64`` as its big-endian bit pattern in lowercase hex.
+
+    :param value: the float to encode.
+    :param field: the field name, for error messages.
+    :returns: exactly 16 lowercase hex characters.
+    :raises TickHashEncodingError: if ``value`` is NaN, which has many bit
+        patterns and no meaningful equality, and so cannot participate in a
+        change-detection hash.
+    """
+    if math.isnan(value):
+        raise TickHashEncodingError(
+            f"field {field!r} is NaN; NaN has no canonical bit pattern and "
+            "cannot enter the tick hash"
+        )
+    return struct.pack(">d", value).hex()
+
+
+def _encode_value(value: object, *, field: str) -> object:
+    """Convert one value to its canonical JSON-ready form.
+
+    :param value: the value to encode.
+    :param field: the field name that held it, for error messages.
+    :returns: a value ``json.dumps`` renders per the spec's byte layout.
+    :raises TickHashEncodingError: if no encoding rule covers ``value``.
+    """
+    # Order matters: `bool` is a subclass of `int`, and `Micros` is too.
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, Micros):
+        return str(int(value))
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return _encode_float(value, field=field)
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        return _encode_record(value)
+    if isinstance(value, (list, tuple)):
+        return [_encode_value(item, field=field) for item in value]
+    raise TickHashEncodingError(
+        f"field {field!r} holds {type(value).__name__}, for which there is "
+        "no encoding rule; the tick hash has no stringly fallback"
+    )
+
+
+def _encode_record(record: Mapping[str, object]) -> dict[str, object]:
+    """Encode every field of one record.
+
+    Key *ordering* is left to ``json.dumps(sort_keys=True)`` so that sorting
+    happens in exactly one place, recursively, for records at any depth.
+
+    :param record: the node, edge, or action record.
+    :returns: the same mapping with every value canonically encoded.
+    """
+    return {key: _encode_value(value, field=key) for key, value in record.items()}
+
+
+def _sort_key_node(node: Mapping[str, object]) -> str:
+    """Sort key for nodes: ascending ``node_id``, string comparison.
+
+    :param node: the node record.
+    :returns: the node's identifier.
+    :raises TickHashEncodingError: if the record carries no ``node_id``, which
+        would otherwise make the ordering — and so the digest — arbitrary.
+    """
+    node_id = node.get("node_id")
+    if not isinstance(node_id, str):
+        raise TickHashEncodingError(
+            "every node record needs a string 'node_id' to order the tick "
+            f"hash deterministically; got {node_id!r}"
+        )
+    return node_id
+
+
+def _sort_key_edge(edge: Mapping[str, object]) -> tuple[str, str]:
+    """Sort key for edges: ascending ``(source_id, target_id)``.
+
+    :param edge: the edge record.
+    :returns: the endpoint pair.
+    :raises TickHashEncodingError: if either endpoint is missing or not a string.
+    """
+    source, target = edge.get("source_id"), edge.get("target_id")
+    if not isinstance(source, str) or not isinstance(target, str):
+        raise TickHashEncodingError(
+            "every edge record needs string 'source_id' and 'target_id' to "
+            f"order the tick hash deterministically; got {source!r}, {target!r}"
+        )
+    return (source, target)
+
+
+def canonical_tick_bytes(
+    *,
+    tick: int,
+    rng_seed: int,
+    nodes: Sequence[Mapping[str, object]],
+    edges: Sequence[Mapping[str, object]],
+    actions: Sequence[Mapping[str, object]],
+) -> bytes:
+    """Serialize one tick's content to its canonical bytes.
+
+    Exposed alongside :func:`compute_tick_hash` because a digest mismatch
+    between two implementations is undiagnosable without the bytes that
+    produced it — this is the artifact a Rust port diffs against.
+
+    :param tick: the current tick index.
+    :param rng_seed: the session's fixed RNG seed. Note this is the *seed*, not
+        the session identifier, which never enters the hash.
+    :param nodes: every graph node, in any order.
+    :param edges: every graph edge, in any order.
+    :param actions: the actions applied this tick, **in application order**.
+    :returns: the exact UTF-8 bytes the digest is taken over.
+    :raises TickHashEncodingError: if any value has no encoding rule, or a node
+        or edge record lacks the identifiers its ordering needs.
+    """
+    payload = {
+        "tick": tick,
+        "rng_seed": rng_seed,
+        "nodes": [_encode_record(node) for node in sorted(nodes, key=_sort_key_node)],
+        "edges": [_encode_record(edge) for edge in sorted(edges, key=_sort_key_edge)],
+        "actions": [_encode_record(action) for action in actions],
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode(
+        "utf-8"
+    )
+
+
+def compute_tick_hash(
+    *,
+    tick: int,
+    rng_seed: int,
+    nodes: Sequence[Mapping[str, object]],
+    edges: Sequence[Mapping[str, object]],
+    actions: Sequence[Mapping[str, object]],
+) -> str:
+    """Compute the canonical per-tick content hash.
+
+    :param tick: the current tick index.
+    :param rng_seed: the session's fixed RNG seed.
+    :param nodes: every graph node, in any order.
+    :param edges: every graph edge, in any order.
+    :param actions: the actions applied this tick, in application order.
+    :returns: a 64-character lowercase hex SHA-256 digest.
+    :raises TickHashEncodingError: propagated from :func:`canonical_tick_bytes`.
+    """
+    return hashlib.sha256(
+        canonical_tick_bytes(
+            tick=tick, rng_seed=rng_seed, nodes=nodes, edges=edges, actions=actions
+        )
+    ).hexdigest()

--- a/tests/baselines/bernie_valve.json
+++ b/tests/baselines/bernie_valve.json
@@ -1,7 +1,7 @@
 {
   "scenario": "bernie_valve",
   "description": "The hope valve, both routings: entryism, derecognition, and the topology-routed disillusion windows (U13 golden, ADR140)",
-  "generated_at": "2026-07-30T12:58:37+00:00",
+  "generated_at": "2026-07-30T13:44:20+00:00",
   "defines_hash": "714afc29dbe334442421457247807c46393f028bbf62751286acf07f2850ee6c",
   "max_ticks": 52,
   "checkpoints": [
@@ -15,7 +15,8 @@
       "exploitation_tension": 0.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "aafbfa74e49e99e145b981fe0455c14c1b5498898826775033ccda3f1c4a79ac"
     },
     {
       "tick": 10,
@@ -27,7 +28,8 @@
       "exploitation_tension": 1.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "d156df6fba4fd72d0449fdcb5f112e7b2e54c150a4737a8bf216de08b059309d"
     },
     {
       "tick": 20,
@@ -39,7 +41,8 @@
       "exploitation_tension": 1.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "ba0c75f9099cd65d3dbe4f5570ca4d5efc5b122bd05c20553a28c37386e9d1ee"
     },
     {
       "tick": 30,
@@ -51,7 +54,8 @@
       "exploitation_tension": 1.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "809ad054b0de270a87dd0616c076f6378e3f0d5acd4b672419daed587a3eb52e"
     },
     {
       "tick": 40,
@@ -63,7 +67,8 @@
       "exploitation_tension": 1.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "351a44ae828e13db7a3963e642f4b5cef7ead11e74a168e05de1338255101cc9"
     },
     {
       "tick": 50,
@@ -75,7 +80,8 @@
       "exploitation_tension": 1.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "f3dd569a2c5ebf1b200e0123d38f4c8f7b31b63978c33fd6d39682e2ab0297a7"
     },
     {
       "tick": 52,
@@ -87,7 +93,8 @@
       "exploitation_tension": 1.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "ab53c1434cd28bf1e436ddfbc41b9b5664b1bd405ce512c1e37fd07eacc7906a"
     }
   ],
   "final_outcome": "SURVIVED",

--- a/tests/baselines/debs.json
+++ b/tests/baselines/debs.json
@@ -1,7 +1,7 @@
 {
   "scenario": "debs",
   "description": "The independent line under FPTP: the spoiler tax and the accumulation the ballot cannot touch (U13 golden, ADR140)",
-  "generated_at": "2026-07-30T12:58:37+00:00",
+  "generated_at": "2026-07-30T13:44:19+00:00",
   "defines_hash": "956a5d9a03931c7d86b347c326456d5a654b9c5007b8267c3320e77118e13b4e",
   "max_ticks": 52,
   "checkpoints": [
@@ -15,7 +15,8 @@
       "exploitation_tension": 0.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "29825383f01388edaa5352697d091f23ef8cc7d15b3710b8e52639eadae8a36a"
     },
     {
       "tick": 10,
@@ -27,7 +28,8 @@
       "exploitation_tension": 0.597245,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.309634,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "2ad79c5a7a45e1bb6486d3269cfd377a85da98450ff69f2d593452b589c926a8"
     },
     {
       "tick": 20,
@@ -39,7 +41,8 @@
       "exploitation_tension": 0.573103,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.3559,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "534733b911927c2e415168f32a7cc35422b16d73ffcaf60adb758cd4576772b7"
     },
     {
       "tick": 30,
@@ -51,7 +54,8 @@
       "exploitation_tension": 0.676735,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.377538,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "8e5596ef9713a73f3c926901644c7daf51719a3ecc18785e578de3eb255732a8"
     },
     {
       "tick": 40,
@@ -63,7 +67,8 @@
       "exploitation_tension": 0.736203,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.390312,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "c5025cbd3949b66f9500af9e4ad70e284435c8509cf3c23bf6529cad8a165ef2"
     },
     {
       "tick": 50,
@@ -75,7 +80,8 @@
       "exploitation_tension": 0.774723,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.395808,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "57ec4c19cf1057fb30dda3c20ce4246849e978aedbbd278d40becbafb137ca5b"
     },
     {
       "tick": 52,
@@ -87,7 +93,8 @@
       "exploitation_tension": 0.78085,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.396524,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "b4ce1d0b7ca045bd41c514edd4df35cf661889da5f05be248af05ca4808bb213"
     }
   ],
   "final_outcome": "SURVIVED",

--- a/tests/baselines/fascist_bifurcation.json
+++ b/tests/baselines/fascist_bifurcation.json
@@ -1,7 +1,7 @@
 {
   "scenario": "fascist_bifurcation",
   "description": "Consciousness routing to national identity",
-  "generated_at": "2026-07-30T12:58:34+00:00",
+  "generated_at": "2026-07-30T13:44:17+00:00",
   "defines_hash": "75b073c5b6ddb401f878de3b786dab34d839b99a62f1d48d76a28c574d906e01",
   "max_ticks": 52,
   "checkpoints": [
@@ -15,7 +15,8 @@
       "exploitation_tension": 0.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "394fef99caa0f7aff4c68cb263dd3974985594808524cec869adc6141112b894"
     },
     {
       "tick": 10,
@@ -27,7 +28,8 @@
       "exploitation_tension": 0.966425,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "fde969c176c8b93c832536cef7ff265210570af9ada9142f9d4f34511de1982f"
     },
     {
       "tick": 20,
@@ -39,7 +41,8 @@
       "exploitation_tension": 0.979025,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "dac4bc1a1c9b885a837cb85ef711ccdb90e7c42ce48f6c82aed6012afc2943c8"
     },
     {
       "tick": 30,
@@ -51,7 +54,8 @@
       "exploitation_tension": 0.984081,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "01f0c9f506111dd968752957d90c0dd8f26e8b532787a6f2af776978d2c37c69"
     },
     {
       "tick": 40,
@@ -63,7 +67,8 @@
       "exploitation_tension": 0.987022,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "d48da96072129451861701301aaf362674ea47a6490eb21c0b069ffb535f793d"
     },
     {
       "tick": 50,
@@ -75,7 +80,8 @@
       "exploitation_tension": 0.989007,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "4ab2e790024fb4b980ceee66e153304d1ea3663c835263231d070191294ddc03"
     },
     {
       "tick": 52,
@@ -87,7 +93,8 @@
       "exploitation_tension": 0.989331,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "9f41a9cb2f166cce8470cf377c70dd77d9487698ed365617d3c67ed9023d4046"
     }
   ],
   "final_outcome": "SURVIVED",

--- a/tests/baselines/glut.json
+++ b/tests/baselines/glut.json
@@ -1,7 +1,7 @@
 {
   "scenario": "glut",
   "description": "High extraction with metabolic overshoot",
-  "generated_at": "2026-07-30T12:58:34+00:00",
+  "generated_at": "2026-07-30T13:44:17+00:00",
   "defines_hash": "6e56da3142bd192b9ed964adbd1371d5fe4f1a914fba4a307054d195e75d93f0",
   "max_ticks": 52,
   "checkpoints": [
@@ -15,7 +15,8 @@
       "exploitation_tension": 0.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "394fef99caa0f7aff4c68cb263dd3974985594808524cec869adc6141112b894"
     },
     {
       "tick": 10,
@@ -27,7 +28,8 @@
       "exploitation_tension": 0.966425,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "23d9c6af8eed597cbe7bdc7f4fc44f1cb78ff8940325144a3c9bd33118fa37cc"
     },
     {
       "tick": 20,
@@ -39,7 +41,8 @@
       "exploitation_tension": 0.979025,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "95aa138c7522d044b034b852d8126a7fdef5e6acf5ef462a08fa9279a05973bd"
     },
     {
       "tick": 30,
@@ -51,7 +54,8 @@
       "exploitation_tension": 0.984081,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "0f6d78fbf1eac1f0e80b16a1cfa39efc3af43bcaad99ce7178c8937a3ed4db22"
     },
     {
       "tick": 40,
@@ -63,7 +67,8 @@
       "exploitation_tension": 0.987022,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "cf98509675e57cb608057857c056df7a3d89656d20734d8de0797628b774de37"
     },
     {
       "tick": 50,
@@ -75,7 +80,8 @@
       "exploitation_tension": 0.989007,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "30028e17a2adb398bd47f93aa664499c8d3875e930403b97ad8972685ce7372e"
     },
     {
       "tick": 52,
@@ -87,7 +93,8 @@
       "exploitation_tension": 0.989331,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "905f8041ab22ff10ebef8f727ae88c02045d41092e590bb73c202781012a8b49"
     }
   ],
   "final_outcome": "SURVIVED",

--- a/tests/baselines/imperial_circuit.json
+++ b/tests/baselines/imperial_circuit.json
@@ -1,7 +1,7 @@
 {
   "scenario": "imperial_circuit",
   "description": "4-node default scenario",
-  "generated_at": "2026-07-30T12:58:33+00:00",
+  "generated_at": "2026-07-30T13:44:16+00:00",
   "defines_hash": "c83b2fc44c56a4b1208355ac82de23cf5de34b74158f4f41dfdd3ffa54072abd",
   "max_ticks": 52,
   "checkpoints": [
@@ -15,7 +15,8 @@
       "exploitation_tension": 0.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "394fef99caa0f7aff4c68cb263dd3974985594808524cec869adc6141112b894"
     },
     {
       "tick": 10,
@@ -27,7 +28,8 @@
       "exploitation_tension": 0.966425,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "39a2f75c2e1b1cd9e77259d288686f70a935a830d3e8e98b13a0ee0e7e637be8"
     },
     {
       "tick": 20,
@@ -39,7 +41,8 @@
       "exploitation_tension": 0.979025,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "0fa4aeffc3bc48f8bf4cddcecb7f1df4710d6587e5e9cf4e4b216512b5078d19"
     },
     {
       "tick": 30,
@@ -51,7 +54,8 @@
       "exploitation_tension": 0.984081,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "7c6efdb0640fe6e518f357cff425b5fe71cc6bd8f4b0f394588cbaf56bc42c37"
     },
     {
       "tick": 40,
@@ -63,7 +67,8 @@
       "exploitation_tension": 0.987022,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "350f713f231dfff28b0714fd9b1da5887ff8128b48c433458e87fb409d05897d"
     },
     {
       "tick": 50,
@@ -75,7 +80,8 @@
       "exploitation_tension": 0.989007,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "8e2a997976071c77d6223c71d7dc84f5dc3925f63b82733a6548fc60ce677e7b"
     },
     {
       "tick": 52,
@@ -87,7 +93,8 @@
       "exploitation_tension": 0.989331,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "ada56defdbb0a283befe452d10593501c2736c8ed35e4232ac4e49d5b486a472"
     }
   ],
   "final_outcome": "SURVIVED",

--- a/tests/baselines/mitterrand.json
+++ b/tests/baselines/mitterrand.json
@@ -1,7 +1,7 @@
 {
   "scenario": "mitterrand",
   "description": "Reform in office on the Wayne terrain: the 24-item burst, the O'Connor spiral, the forced austerity turn (U13 golden, ADR140)",
-  "generated_at": "2026-07-30T12:58:35+00:00",
+  "generated_at": "2026-07-30T13:44:18+00:00",
   "defines_hash": "60e65db5256c6c06f106254dc3da9b36423a8ba333c5fcb59b5818a338c384d0",
   "max_ticks": 52,
   "checkpoints": [
@@ -15,7 +15,8 @@
       "exploitation_tension": 0.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "0ca361cd5e30127efa3a93371129b6965bdaff62be0e4450387e7538b153f799"
     },
     {
       "tick": 10,
@@ -27,7 +28,8 @@
       "exploitation_tension": 0.521088,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "ab0c8475807f5aa0a98b6b9263806360af462ae15aa0726a72bfa71e7352d57f"
     },
     {
       "tick": 20,
@@ -39,7 +41,8 @@
       "exploitation_tension": 0.969655,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "15775eb0b66637a900702b2b2b6eea98b214828954aebc8e19eef129d4f56f28"
     },
     {
       "tick": 30,
@@ -51,7 +54,8 @@
       "exploitation_tension": 0.969655,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "82ae16a0fd2d21a33b42911cfb4f82997026d8f34e9ee8c2c24a2b77d8e13372"
     },
     {
       "tick": 40,
@@ -63,7 +67,8 @@
       "exploitation_tension": 0.969655,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "548314ade808c3a166454837cf6cdc7614f76b25b742e679b8b8f081baed768e"
     },
     {
       "tick": 50,
@@ -75,7 +80,8 @@
       "exploitation_tension": 0.969655,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "9406d430d0884b7a9c06f107eb6ab16ba5d66c7fc72a8acdeb5db06d4f682c75"
     },
     {
       "tick": 52,
@@ -87,7 +93,8 @@
       "exploitation_tension": 0.969655,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "37a5a3e80ffd13b8da10a87d976aad95780d5776a66fbfd422ef103c815b0d3b"
     }
   ],
   "final_outcome": "SURVIVED",

--- a/tests/baselines/single_county.json
+++ b/tests/baselines/single_county.json
@@ -1,7 +1,7 @@
 {
   "scenario": "single_county",
   "description": "Wayne-seeded minimal county: Vol III financial layer, MELT path, and distribution identity all fire",
-  "generated_at": "2026-07-30T12:58:35+00:00",
+  "generated_at": "2026-07-30T13:44:17+00:00",
   "defines_hash": "4af1178032a2b420376e35c7a98ac2b151ea8fb9ee68636d1560528d5fd927d4",
   "max_ticks": 52,
   "checkpoints": [
@@ -15,7 +15,8 @@
       "exploitation_tension": 0.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "c9efeb48b2071297fd4fa2c4693364232ccc21a11390e01921028a0da9d3ea22"
     },
     {
       "tick": 10,
@@ -27,7 +28,8 @@
       "exploitation_tension": 0.230773,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "87c9c37cc4ffc0c6f0186f69935311d85c42ab308959f0255084805710094b3f"
     },
     {
       "tick": 20,
@@ -39,7 +41,8 @@
       "exploitation_tension": 0.306311,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "095ab03c01f3409d30d8db07d714f9b05bdc140822eca9489542f3c997399430"
     },
     {
       "tick": 30,
@@ -51,7 +54,8 @@
       "exploitation_tension": 0.412649,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "653ed3e4610633426c09264cf1c74979d3e63097ca4867a238038fb026032c3e"
     },
     {
       "tick": 40,
@@ -63,7 +67,8 @@
       "exploitation_tension": 0.495817,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "b1f93ace19cc17d8d15f0f81a5399ed04c0c924c1588cbde35ec179ed9110059"
     },
     {
       "tick": 50,
@@ -75,7 +80,8 @@
       "exploitation_tension": 0.560263,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "30c0280713c7a466c487f4273cda6a60387b3768a3a3c16ef9ac517d3ebfcb4b"
     },
     {
       "tick": 52,
@@ -87,7 +93,8 @@
       "exploitation_tension": 0.571239,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "90bfc08e4149669bef65c05329b7a856a7c2b20c0a8282f17b50fa3607d6fd71"
     }
   ],
   "final_outcome": "SURVIVED",

--- a/tests/baselines/starvation.json
+++ b/tests/baselines/starvation.json
@@ -1,7 +1,7 @@
 {
   "scenario": "starvation",
   "description": "Low extraction efficiency stress",
-  "generated_at": "2026-07-30T12:58:34+00:00",
+  "generated_at": "2026-07-30T13:44:16+00:00",
   "defines_hash": "3f9d2ea0d149b678d720bcbfd1678384640b9f1daf2b984b96c2c0899966432c",
   "max_ticks": 52,
   "checkpoints": [
@@ -15,7 +15,8 @@
       "exploitation_tension": 0.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "394fef99caa0f7aff4c68cb263dd3974985594808524cec869adc6141112b894"
     },
     {
       "tick": 10,
@@ -27,7 +28,8 @@
       "exploitation_tension": 0.966425,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "6da788e690b44a24a6632da97764fd65dfd72080df818283711de7476d9ad7e9"
     },
     {
       "tick": 20,
@@ -39,7 +41,8 @@
       "exploitation_tension": 0.979025,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "1ef17d077c117e3788a59337142a58ba818bff19e9c97c68ea7ec070c3f437b1"
     },
     {
       "tick": 30,
@@ -51,7 +54,8 @@
       "exploitation_tension": 0.984081,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "01705cb2fc37361e014c4939afe2535fbe3c43e848367f47fa8694e95d9536f3"
     },
     {
       "tick": 40,
@@ -63,7 +67,8 @@
       "exploitation_tension": 0.987022,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "418ccadfe0b2b21e8a4f1953790104d27860a50ea8c356e177b993f515c8e424"
     },
     {
       "tick": 50,
@@ -75,7 +80,8 @@
       "exploitation_tension": 0.989007,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "653c3dfdb8ae88ea1b3b0896ed8745e07ae591d999a03f948fc5985da257b350"
     },
     {
       "tick": 52,
@@ -87,7 +93,8 @@
       "exploitation_tension": 0.989331,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "1ec18b916f5bf53ed963329a31512040454e445bafd920ed3b0aa6f00ddb163c"
     }
   ],
   "final_outcome": "SURVIVED",

--- a/tests/baselines/syriza.json
+++ b/tests/baselines/syriza.json
@@ -1,7 +1,7 @@
 {
   "scenario": "syriza",
   "description": "The captured governance road: capitulate with dual-power organs live; the PASOK slow bleed (U13 golden, ADR140)",
-  "generated_at": "2026-07-30T12:58:36+00:00",
+  "generated_at": "2026-07-30T13:44:18+00:00",
   "defines_hash": "d35993bdd1f572322d9ec2997a6078b62f595e57d25e07465afdfb8ee60aac8d",
   "max_ticks": 52,
   "checkpoints": [
@@ -15,7 +15,8 @@
       "exploitation_tension": 0.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "1449467219ca0e52b2072821d398acb991ac6d174d2f1abbab1bc3159751c500"
     },
     {
       "tick": 10,
@@ -27,7 +28,8 @@
       "exploitation_tension": 0.521088,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "599d7260d97baf39ed50ad4d0194f1341fc4c97c5276695e027ad4095432f2d2"
     },
     {
       "tick": 20,
@@ -39,7 +41,8 @@
       "exploitation_tension": 0.969655,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "4dc92d5609ea5d2dbaa908c4fe0a4e98be47dbcce03544177d8f640e61a4b8e7"
     },
     {
       "tick": 30,
@@ -51,7 +54,8 @@
       "exploitation_tension": 0.969655,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "3c0423059b059a26efdfd8839ccf0cfaf50bc8b60737640a503910a13be136d3"
     },
     {
       "tick": 40,
@@ -63,7 +67,8 @@
       "exploitation_tension": 0.969655,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "4628fd94b5ae39a6dbfd9e269b347d481b5b89021907d4c7c3e5abf4acf4d388"
     },
     {
       "tick": 50,
@@ -75,7 +80,8 @@
       "exploitation_tension": 0.969655,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "873b24fb881f00b6fc3eaeac8e97eecde3842d20ff9d1dea6c07fbad9bacc721"
     },
     {
       "tick": 52,
@@ -87,7 +93,8 @@
       "exploitation_tension": 0.969655,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": false
+      "p_w_active": false,
+      "graph_hash": "457e9adef86889aea04375e8865b6ada1eb767b099e4fd6d844c02bdfe752ec4"
     }
   ],
   "final_outcome": "SURVIVED",

--- a/tests/baselines/two_node.json
+++ b/tests/baselines/two_node.json
@@ -1,7 +1,7 @@
 {
   "scenario": "two_node",
   "description": "Minimal worker vs owner",
-  "generated_at": "2026-07-30T12:58:34+00:00",
+  "generated_at": "2026-07-30T13:44:16+00:00",
   "defines_hash": "4af1178032a2b420376e35c7a98ac2b151ea8fb9ee68636d1560528d5fd927d4",
   "max_ticks": 52,
   "checkpoints": [
@@ -15,7 +15,8 @@
       "exploitation_tension": 0.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "c3e0805834f1626d0046589691430d6affb5348cca2ed8a9599ca809543392e2"
     },
     {
       "tick": 10,
@@ -27,7 +28,8 @@
       "exploitation_tension": 0.219244,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "5cf041702b539fb5e119bc3e58e805c092b4a5840f2c7e271371a26b53c1ac11"
     },
     {
       "tick": 20,
@@ -39,7 +41,8 @@
       "exploitation_tension": 0.317864,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "283215e33477d159260cbe0e2e781d71740fd2d651a205fd8fa0d14fa946949a"
     },
     {
       "tick": 30,
@@ -51,7 +54,8 @@
       "exploitation_tension": 0.421818,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "93cef7e0598cd3e71e59692147d6b3a590c97e97daf5afd201647cde4a585172"
     },
     {
       "tick": 40,
@@ -63,7 +67,8 @@
       "exploitation_tension": 0.499951,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "6f5c7c422a2a70471d944a8c263c8620e5de435c1ac089b1c1bc2a09f02822e0"
     },
     {
       "tick": 50,
@@ -75,7 +80,8 @@
       "exploitation_tension": 0.557852,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "19b877e0ecd6ce6443751c97cb0ef46baa2f65dea06d2d996271537cd09a5f11"
     },
     {
       "tick": 52,
@@ -87,7 +93,8 @@
       "exploitation_tension": 0.567399,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.2,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "f101b88afb2c398aef6864f52f071ac5b1a09b65be3cb6183d2e211e16b56fa1"
     }
   ],
   "final_outcome": "SURVIVED",

--- a/tests/baselines/weimar.json
+++ b/tests/baselines/weimar.json
@@ -1,7 +1,7 @@
 {
   "scenario": "weimar",
   "description": "Fascist consolidation through the ballot: a real desperation vote perturbs the state apparatus (U13 golden, ADR140)",
-  "generated_at": "2026-07-30T12:58:36+00:00",
+  "generated_at": "2026-07-30T13:44:19+00:00",
   "defines_hash": "a0f75e1df8b88416b001338b8b6001ec99bd58b6e40b128b2745e0817699281a",
   "max_ticks": 52,
   "checkpoints": [
@@ -15,7 +15,8 @@
       "exploitation_tension": 0.0,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.0,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "3929c782bd005fadb05fcb8bb94c02364b56edea5e6fa696464b495b32eb9e3c"
     },
     {
       "tick": 10,
@@ -27,7 +28,8 @@
       "exploitation_tension": 0.754959,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.4071,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "d342035b6ec3acef1c609439e52970da87aba3a96c61b042778cbf40aeb364aa"
     },
     {
       "tick": 20,
@@ -39,7 +41,8 @@
       "exploitation_tension": 0.983308,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.438303,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "d0b26787fa2116f20ea57b2ea3c13d539c9d6ac88a650da97e70a389d5051c1f"
     },
     {
       "tick": 30,
@@ -51,7 +54,8 @@
       "exploitation_tension": 0.983308,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.449277,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "f0344ab9b8a8715adfad1a7175c5b03155e302db9ad0cbdce37a11d374220814"
     },
     {
       "tick": 40,
@@ -63,7 +67,8 @@
       "exploitation_tension": 0.983308,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.453103,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "4b1aeb7b443299aa7e32fa5da6984b8d61204f0ddcf373ef08d3379ea30cce72"
     },
     {
       "tick": 50,
@@ -75,7 +80,8 @@
       "exploitation_tension": 0.983308,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.454433,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "f2eef785b82136bacdbb7869a070173c1a9c47970a7f5f0f806768b29df82f9f"
     },
     {
       "tick": 52,
@@ -87,7 +93,8 @@
       "exploitation_tension": 0.983308,
       "p_w_consciousness": 0.0,
       "p_w_p_revolution": 0.454567,
-      "p_w_active": true
+      "p_w_active": true,
+      "graph_hash": "eaab0bce72c6d0301315528c72f681fa6cd1b4266de3033b0faf77ecea1c8b22"
     }
   ],
   "final_outcome": "SURVIVED",

--- a/tests/unit/kernel/test_tick_hash.py
+++ b/tests/unit/kernel/test_tick_hash.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import hashlib
 import struct
+from enum import Enum, IntEnum
 
 import pytest
 
@@ -287,7 +288,106 @@ class TestBooleanEncoding:
         assert as_bool != as_int
 
 
+class TestNoneEncoding:
+    """``None`` is the bare literal ``null``.
+
+    An optional field that is unset is real state — the live graph is full of
+    them (``county_fips``, ``aligned_faction_id``) — and ``null`` is
+    unambiguous in every JSON implementation. This is the rule the spec
+    originally omitted, found by hashing an actual graph."""
+
+    def test_none_is_a_bare_null(self) -> None:
+        out = canonical_tick_bytes(
+            tick=0, rng_seed=0, nodes=[{"node_id": "A", "county_fips": None}], edges=[], actions=[]
+        )
+        assert b'"county_fips":null' in out
+
+    def test_null_is_distinguishable_from_a_defaulted_zero(self) -> None:
+        # The reason hashing null does not hide the `data.get(field, 0.0)`
+        # bug class it might look like it hides: it makes it *visible*.
+        unset = compute_tick_hash(
+            tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": None}], edges=[], actions=[]
+        )
+        defaulted = compute_tick_hash(
+            tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": 0.0}], edges=[], actions=[]
+        )
+        assert unset != defaulted
+
+    def test_null_is_distinguishable_from_the_empty_string(self) -> None:
+        unset = compute_tick_hash(
+            tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": None}], edges=[], actions=[]
+        )
+        empty = compute_tick_hash(
+            tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": ""}], edges=[], actions=[]
+        )
+        assert unset != empty
+
+
 class TestStringAndEnumEncoding:
+    def test_string_valued_enum_encodes_as_its_declared_value(self) -> None:
+        class NodeKind(Enum):
+            SOCIAL_CLASS = "social_class"
+
+        out = canonical_tick_bytes(
+            tick=0,
+            rng_seed=0,
+            nodes=[{"node_id": "A", "node_type": NodeKind.SOCIAL_CLASS}],
+            edges=[],
+            actions=[],
+        )
+        assert b'"node_type":"social_class"' in out
+
+    def test_enum_value_casing_is_reproduced_not_normalized(self) -> None:
+        class EdgeKind(Enum):
+            EXPLOITATION = "EXPLOITATION"
+
+        out = canonical_tick_bytes(
+            tick=0,
+            rng_seed=0,
+            nodes=[],
+            edges=[{"source_id": "A", "target_id": "B", "edge_type": EdgeKind.EXPLOITATION}],
+            actions=[],
+        )
+        assert b'"edge_type":"EXPLOITATION"' in out
+
+    def test_a_string_valued_enum_hashes_as_its_plain_string(self) -> None:
+        # A port that stores the type as a plain string must agree with one
+        # that stores it as an enum; the enum is our representation, not
+        # content.
+        class NodeKind(Enum):
+            SOCIAL_CLASS = "social_class"
+
+        as_enum = compute_tick_hash(
+            tick=0,
+            rng_seed=0,
+            nodes=[{"node_id": "A", "node_type": NodeKind.SOCIAL_CLASS}],
+            edges=[],
+            actions=[],
+        )
+        as_string = compute_tick_hash(
+            tick=0,
+            rng_seed=0,
+            nodes=[{"node_id": "A", "node_type": "social_class"}],
+            edges=[],
+            actions=[],
+        )
+        assert as_enum == as_string
+
+    def test_int_valued_enum_is_a_loud_failure(self) -> None:
+        # It would hash as a bare integer, silently aliasing a genuine
+        # integer field, and its numbering is an internal detail.
+        class Tier(IntEnum):
+            FIRST = 1
+
+        with pytest.raises(TickHashEncodingError, match="not a string"):
+            canonical_tick_bytes(
+                tick=0,
+                rng_seed=0,
+                nodes=[{"node_id": "A", "tier": Tier.FIRST}],
+                edges=[],
+                actions=[],
+            )
+
     def test_enum_member_names_are_reproduced_verbatim_never_recased(self) -> None:
         out = canonical_tick_bytes(
             tick=0,
@@ -323,13 +423,16 @@ class TestBanOnStringlyFallbacks:
                 tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": Opaque()}], edges=[], actions=[]
             )
 
-    def test_none_raises_rather_than_becoming_null(self) -> None:
-        # A missing value must be an absent key or a real encodable default —
-        # silently hashing `null` is how the graph round-trip's
-        # `data.get(field, 0.0)` bug class hides.
-        with pytest.raises(TickHashEncodingError, match="no encoding rule"):
+    def test_non_string_record_keys_raise(self) -> None:
+        # sort_keys cannot order a mixed-type key set, so the byte output
+        # would silently depend on insertion order.
+        with pytest.raises(TickHashEncodingError, match="canonical key ordering"):
             canonical_tick_bytes(
-                tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": None}], edges=[], actions=[]
+                tick=0,
+                rng_seed=0,
+                nodes=[{"node_id": "A", "attrs": {1: "x"}}],
+                edges=[],
+                actions=[],
             )
 
     def test_the_error_names_the_offending_field_and_type(self) -> None:

--- a/tests/unit/kernel/test_tick_hash.py
+++ b/tests/unit/kernel/test_tick_hash.py
@@ -440,13 +440,13 @@ class TestBanOnStringlyFallbacks:
             canonical_tick_bytes(
                 tick=0,
                 rng_seed=0,
-                nodes=[{"node_id": "A", "unhashable_field": {1, 2}}],
+                nodes=[{"node_id": "A", "unhashable_field": complex(1, 2)}],
                 edges=[],
                 actions=[],
             )
         message = str(caught.value)
         assert "unhashable_field" in message
-        assert "set" in message
+        assert "complex" in message
 
 
 class TestWhatIsDeliberatelyNotInTheHash:

--- a/tests/unit/kernel/test_tick_hash.py
+++ b/tests/unit/kernel/test_tick_hash.py
@@ -1,0 +1,415 @@
+"""Byte-level pins for the P27 tick hash (``docs/reference/determinism-contract.rst``,
+*The P27 Tick Hash* chapter).
+
+This is a **cross-implementation byte contract**, not an implementation detail:
+the Rust kernel is required to compute the identical digest from the identical
+state (Constitution III.7; user-CLAUDE.md contract rule 4, "contracts must be
+language-agnostic to the byte"). Every test here therefore pins *bytes or a
+digest*, never "whatever the implementation produces" — a test that merely
+round-trips through our own encoder would prove nothing about a port.
+
+The encoding rules under test come from the spec chapter's *Ordering*, *Float
+and int encodings*, and *Ban on stringly fallbacks* sections.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+
+import pytest
+
+from babylon.kernel.tick_hash import (
+    Micros,
+    TickHashEncodingError,
+    canonical_tick_bytes,
+    compute_tick_hash,
+)
+
+
+class TestTheWorkedExample:
+    """The spec chapter's worked example, byte-for-byte.
+
+    **Spec-defect note (2026-07-30).** The chapter's published example
+    rendered the boolean ``active`` as the *quoted* string ``"true"``, which
+    contradicts its own normative rule ("the literal ASCII tokens ``true`` /
+    ``false`` (JSON's own literals)") and is inconsistent with how the same
+    example renders integers (``"tick":1``, bare). The published sha merely
+    re-derived that slip. The normative prose wins: bools are bare JSON
+    literals, so the canonical bytes are 246 long, not 248. The spec's example
+    was corrected in the same commit as this test.
+    """
+
+    EXPECTED_BYTES = (
+        b'{"actions":[],"edges":[{"edge_type":"EXPLOITATION","source_id":"C001",'
+        b'"target_id":"C002","value_flow":"4029000000000000"}],"nodes":[{"active":'
+        b'true,"node_id":"C001","node_type":"social_class","wealth":'
+        b'"4059000000000000"}],"rng_seed":2010,"tick":1}'
+    )
+    EXPECTED_SHA = "b256dbbca591c5af2b8cb23b9c4027ed1ac657d10b1e669aadb05670cd75d4a0"
+
+    @staticmethod
+    def _example() -> dict[str, object]:
+        return {
+            "tick": 1,
+            "rng_seed": 2010,
+            "nodes": [
+                {
+                    "node_id": "C001",
+                    "node_type": "social_class",
+                    "wealth": 100.0,
+                    "active": True,
+                }
+            ],
+            "edges": [
+                {
+                    "edge_type": "EXPLOITATION",
+                    "source_id": "C001",
+                    "target_id": "C002",
+                    "value_flow": 12.5,
+                }
+            ],
+            "actions": [],
+        }
+
+    def test_canonical_bytes_match_the_spec(self) -> None:
+        assert canonical_tick_bytes(**self._example()) == self.EXPECTED_BYTES
+
+    def test_byte_length_is_246(self) -> None:
+        # Pinned separately: a length change is the cheapest signal that an
+        # encoding rule drifted, and it is what a Rust port compares first.
+        assert len(canonical_tick_bytes(**self._example())) == 246
+
+    def test_digest_matches_the_spec(self) -> None:
+        assert compute_tick_hash(**self._example()) == self.EXPECTED_SHA
+
+    def test_digest_is_sha256_of_the_canonical_bytes(self) -> None:
+        payload = self._example()
+        assert (
+            compute_tick_hash(**payload)
+            == hashlib.sha256(canonical_tick_bytes(**payload)).hexdigest()
+        )
+
+
+class TestOrdering:
+    """*Ordering*: keys alphabetical recursively, nodes by ``node_id``, edges
+    by ``(source_id, target_id)`` — never backend iteration order."""
+
+    def test_keys_sort_alphabetically_regardless_of_insertion_order(self) -> None:
+        forward = canonical_tick_bytes(
+            tick=0,
+            rng_seed=0,
+            nodes=[{"node_id": "A", "node_type": "territory", "zeta": 1, "alpha": 2}],
+            edges=[],
+            actions=[],
+        )
+        reversed_insertion = canonical_tick_bytes(
+            tick=0,
+            rng_seed=0,
+            nodes=[{"alpha": 2, "zeta": 1, "node_type": "territory", "node_id": "A"}],
+            edges=[],
+            actions=[],
+        )
+        assert forward == reversed_insertion
+        assert b'"alpha":2,"node_id":"A","node_type":"territory","zeta":1' in forward
+
+    def test_key_sorting_is_recursive_through_nested_records(self) -> None:
+        nested = canonical_tick_bytes(
+            tick=0,
+            rng_seed=0,
+            nodes=[{"node_id": "A", "attrs": {"zeta": 1, "alpha": 2}}],
+            edges=[],
+            actions=[],
+        )
+        assert b'"attrs":{"alpha":2,"zeta":1}' in nested
+
+    def test_nodes_sort_ascending_by_node_id_as_strings(self) -> None:
+        # String comparison, not numeric: "C10" sorts before "C9".
+        out = canonical_tick_bytes(
+            tick=0,
+            rng_seed=0,
+            nodes=[{"node_id": "C9"}, {"node_id": "C10"}, {"node_id": "C1"}],
+            edges=[],
+            actions=[],
+        )
+        assert out.index(b'"C1"') < out.index(b'"C10"') < out.index(b'"C9"')
+
+    def test_edges_sort_by_source_then_target(self) -> None:
+        out = canonical_tick_bytes(
+            tick=0,
+            rng_seed=0,
+            nodes=[],
+            edges=[
+                {"source_id": "B", "target_id": "A"},
+                {"source_id": "A", "target_id": "Z"},
+                {"source_id": "A", "target_id": "B"},
+            ],
+            actions=[],
+        )
+        assert out == (
+            b'{"actions":[],"edges":['
+            b'{"source_id":"A","target_id":"B"},'
+            b'{"source_id":"A","target_id":"Z"},'
+            b'{"source_id":"B","target_id":"A"}],'
+            b'"nodes":[],"rng_seed":0,"tick":0}'
+        )
+
+    def test_action_order_is_preserved_not_sorted(self) -> None:
+        # Actions are a *sequence of events applied this tick*; their order is
+        # itself state. The spec's Ordering section sorts nodes and edges only.
+        forward = canonical_tick_bytes(
+            tick=0, rng_seed=0, nodes=[], edges=[], actions=[{"verb": "B"}, {"verb": "A"}]
+        )
+        assert forward.index(b'"B"') < forward.index(b'"A"')
+
+
+class TestFloatEncoding:
+    """*IEEE-754 f64*: raw big-endian bit pattern, 16 lowercase hex chars.
+
+    The whole point of the departure from shortest-round-trip decimal is
+    cross-language byte agreement on the awkward values, so those are what we
+    pin."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [100.0, 12.5, 0.0, -0.0, 1e-308, 5e-324, 1.7976931348623157e308, 0.1, -1.5],
+    )
+    def test_float_is_the_big_endian_bit_pattern(self, value: float) -> None:
+        expected = struct.pack(">d", value).hex()
+        out = canonical_tick_bytes(
+            tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": value}], edges=[], actions=[]
+        )
+        assert f'"v":"{expected}"'.encode() in out
+        assert len(expected) == 16
+
+    def test_negative_zero_is_distinguishable_from_positive_zero(self) -> None:
+        # A shortest-round-trip decimal encoder can render both as "0.0"; the
+        # bit-pattern rule exists precisely so this distinction survives.
+        positive = compute_tick_hash(
+            tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": 0.0}], edges=[], actions=[]
+        )
+        negative = compute_tick_hash(
+            tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": -0.0}], edges=[], actions=[]
+        )
+        assert positive != negative
+
+    def test_hex_is_lowercase(self) -> None:
+        out = canonical_tick_bytes(
+            tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": 255.5}], edges=[], actions=[]
+        )
+        assert b'"v":"406ff00000000000"' in out
+
+    def test_nan_is_a_loud_failure(self) -> None:
+        # NaN has multiple bit patterns and no meaningful equality; it must
+        # never silently enter a change-detection hash.
+        with pytest.raises(TickHashEncodingError, match="NaN"):
+            canonical_tick_bytes(
+                tick=0,
+                rng_seed=0,
+                nodes=[{"node_id": "A", "v": float("nan")}],
+                edges=[],
+                actions=[],
+            )
+
+
+class TestIntegerAndCurrencyEncoding:
+    """*Integers* stay bare decimal; *Currency* i128 micro-units become
+    decimal **strings** so no JSON f64 ever touches them."""
+
+    def test_plain_integers_are_bare_json_numbers(self) -> None:
+        out = canonical_tick_bytes(
+            tick=7, rng_seed=42, nodes=[{"node_id": "A", "count": -13}], edges=[], actions=[]
+        )
+        assert b'"count":-13' in out
+        assert b'"rng_seed":42' in out
+        assert b'"tick":7' in out
+
+    def test_micros_are_decimal_strings_never_bare_numbers(self) -> None:
+        out = canonical_tick_bytes(
+            tick=0,
+            rng_seed=0,
+            nodes=[{"node_id": "A", "wealth": Micros(1234567)}],
+            edges=[],
+            actions=[],
+        )
+        assert b'"wealth":"1234567"' in out
+
+    def test_micros_survive_beyond_f64_exact_integer_range(self) -> None:
+        # 2**53 + 1 is the canonical value an f64 cannot represent; a Rust
+        # serde_json bare-number encoding would silently round it.
+        beyond = 2**53 + 1
+        out = canonical_tick_bytes(
+            tick=0,
+            rng_seed=0,
+            nodes=[{"node_id": "A", "wealth": Micros(beyond)}],
+            edges=[],
+            actions=[],
+        )
+        assert f'"wealth":"{beyond}"'.encode() in out
+        assert float(beyond) != beyond or True  # documents why: f64 cannot hold it
+
+    def test_negative_micros_keep_a_single_leading_minus(self) -> None:
+        out = canonical_tick_bytes(
+            tick=0,
+            rng_seed=0,
+            nodes=[{"node_id": "A", "wealth": Micros(-42)}],
+            edges=[],
+            actions=[],
+        )
+        assert b'"wealth":"-42"' in out
+
+
+class TestBooleanEncoding:
+    """*Booleans*: bare ``true``/``false``, not ``"True"``/``"False"``, and not
+    ``defines_hash``'s bool-as-int hazard."""
+
+    def test_true_is_a_bare_json_literal(self) -> None:
+        out = canonical_tick_bytes(
+            tick=0, rng_seed=0, nodes=[{"node_id": "A", "active": True}], edges=[], actions=[]
+        )
+        assert b'"active":true' in out
+
+    def test_false_is_a_bare_json_literal(self) -> None:
+        out = canonical_tick_bytes(
+            tick=0, rng_seed=0, nodes=[{"node_id": "A", "active": False}], edges=[], actions=[]
+        )
+        assert b'"active":false' in out
+
+    def test_bool_never_degrades_to_an_integer(self) -> None:
+        # `bool` is a subclass of `int` in Python; an isinstance-ordering bug
+        # would render True as 1 and match a genuine integer field.
+        as_bool = compute_tick_hash(
+            tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": True}], edges=[], actions=[]
+        )
+        as_int = compute_tick_hash(
+            tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": 1}], edges=[], actions=[]
+        )
+        assert as_bool != as_int
+
+
+class TestStringAndEnumEncoding:
+    def test_enum_member_names_are_reproduced_verbatim_never_recased(self) -> None:
+        out = canonical_tick_bytes(
+            tick=0,
+            rng_seed=0,
+            nodes=[{"node_id": "A", "node_type": "social_class"}],
+            edges=[{"source_id": "A", "target_id": "B", "edge_type": "EXPLOITATION"}],
+            actions=[],
+        )
+        assert b'"node_type":"social_class"' in out
+        assert b'"edge_type":"EXPLOITATION"' in out
+
+    def test_non_ascii_is_escaped_so_the_byte_stream_stays_ascii(self) -> None:
+        # ensure_ascii keeps the hashed bytes independent of any host's
+        # Unicode normalization posture.
+        out = canonical_tick_bytes(
+            tick=0, rng_seed=0, nodes=[{"node_id": "Ω"}], edges=[], actions=[]
+        )
+        assert b"\\u03a9" in out
+        out.decode("ascii")  # raises if a raw multibyte sequence leaked in
+
+
+class TestBanOnStringlyFallbacks:
+    """*Ban on stringly fallbacks* (Constitution III.11): a value with no
+    encoding rule is a hash-time load failure, never ``str(obj)``."""
+
+    def test_unknown_type_raises_rather_than_stringifying(self) -> None:
+        class Opaque:
+            def __str__(self) -> str:
+                return "looks-harmless"
+
+        with pytest.raises(TickHashEncodingError, match="no encoding rule"):
+            canonical_tick_bytes(
+                tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": Opaque()}], edges=[], actions=[]
+            )
+
+    def test_none_raises_rather_than_becoming_null(self) -> None:
+        # A missing value must be an absent key or a real encodable default —
+        # silently hashing `null` is how the graph round-trip's
+        # `data.get(field, 0.0)` bug class hides.
+        with pytest.raises(TickHashEncodingError, match="no encoding rule"):
+            canonical_tick_bytes(
+                tick=0, rng_seed=0, nodes=[{"node_id": "A", "v": None}], edges=[], actions=[]
+            )
+
+    def test_the_error_names_the_offending_field_and_type(self) -> None:
+        with pytest.raises(TickHashEncodingError) as caught:
+            canonical_tick_bytes(
+                tick=0,
+                rng_seed=0,
+                nodes=[{"node_id": "A", "unhashable_field": {1, 2}}],
+                edges=[],
+                actions=[],
+            )
+        message = str(caught.value)
+        assert "unhashable_field" in message
+        assert "set" in message
+
+
+class TestWhatIsDeliberatelyNotInTheHash:
+    def test_session_id_is_not_an_input(self) -> None:
+        # The spec is explicit: "the session identifier never enters this
+        # hash, keeping it independent of run identity, unlike
+        # tick_commit.determinism_hash today". Passing one is a signature
+        # error, not a silently-ignored kwarg.
+        with pytest.raises(TypeError):
+            compute_tick_hash(  # type: ignore[call-arg]
+                tick=0,
+                rng_seed=0,
+                nodes=[],
+                edges=[],
+                actions=[],
+                session_id="deadbeef",
+            )
+
+    def test_two_sessions_with_identical_state_hash_identically(self) -> None:
+        # The positive statement of the same rule, and the property that makes
+        # this hash able to detect a topology loss that determinism_hash cannot.
+        state = {
+            "tick": 5,
+            "rng_seed": 2010,
+            "nodes": [{"node_id": "A", "wealth": 1.0}],
+            "edges": [],
+            "actions": [],
+        }
+        assert compute_tick_hash(**state) == compute_tick_hash(**state)
+
+
+class TestItDetectsWhatDeterminismHashCannot:
+    """The reason this exists (dossier R1): today's gate cannot see topology."""
+
+    BASE: dict[str, object] = {
+        "tick": 5,
+        "rng_seed": 2010,
+        "nodes": [
+            {"node_id": "A", "node_type": "social_class", "wealth": 100.0},
+            {"node_id": "B", "node_type": "social_class", "wealth": 50.0},
+        ],
+        "edges": [{"source_id": "A", "target_id": "B", "edge_type": "EXPLOITATION"}],
+        "actions": [],
+    }
+
+    def test_a_dropped_edge_moves_the_hash(self) -> None:
+        lost = {**self.BASE, "edges": []}
+        assert compute_tick_hash(**lost) != compute_tick_hash(**self.BASE)  # type: ignore[arg-type]
+
+    def test_a_dropped_node_moves_the_hash(self) -> None:
+        lost = {**self.BASE, "nodes": [self.BASE["nodes"][0]]}  # type: ignore[index]
+        assert compute_tick_hash(**lost) != compute_tick_hash(**self.BASE)  # type: ignore[arg-type]
+
+    def test_a_single_changed_attribute_moves_the_hash(self) -> None:
+        drifted = {
+            **self.BASE,
+            "nodes": [
+                {"node_id": "A", "node_type": "social_class", "wealth": 100.000001},
+                {"node_id": "B", "node_type": "social_class", "wealth": 50.0},
+            ],
+        }
+        assert compute_tick_hash(**drifted) != compute_tick_hash(**self.BASE)  # type: ignore[arg-type]
+
+    def test_an_edge_retargeted_to_a_different_node_moves_the_hash(self) -> None:
+        retargeted = {
+            **self.BASE,
+            "edges": [{"source_id": "B", "target_id": "A", "edge_type": "EXPLOITATION"}],
+        }
+        assert compute_tick_hash(**retargeted) != compute_tick_hash(**self.BASE)  # type: ignore[arg-type]

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -73,6 +73,7 @@ from shared import (
 from babylon.config.defines import GameDefines
 from babylon.engine.simulation_engine import step
 from babylon.engine.trace_format import format_trace_value, trace_rows_to_csv_bytes
+from babylon.kernel.tick_hash import compute_tick_hash
 
 # Constants
 BASELINE_DIR: Final[Path] = Path(__file__).parent.parent / "tests" / "baselines"
@@ -293,6 +294,7 @@ class CheckpointData:
     p_w_consciousness: float
     p_w_p_revolution: float
     p_w_active: bool
+    graph_hash: str
 
 
 @dataclass
@@ -919,12 +921,57 @@ def check_dead_columns(
     return findings
 
 
-def capture_checkpoint(state: Any, tick: int) -> CheckpointData:
+def graph_content_hash(state: Any, tick: int, rng_seed: int) -> str:
+    """The P27 tick content hash over this state's full graph projection.
+
+    Why this exists alongside the dense trace: the dense golden's columns are
+    derived from ``state.entities``/``state.relationships`` and pin ten
+    hand-picked entity fields and three edge fields
+    (``_DENSE_ENTITY_FIELDS``/``_DENSE_EDGE_FIELDS``). ``to_graph()`` emits
+    **every** field of every node and edge — thirty-odd per social class,
+    including node/edge *types* — so this hash covers the attributes and the
+    typed structure the column contract never looks at.
+
+    What it still does not cover, stated so nobody over-reads a green gate:
+    the harness never holds the *live* graph a tick mutates (``step()`` builds
+    and discards it internally), so this is the WorldState→graph projection,
+    not in-tick graph-only state. Closing that needs the engine to expose the
+    graph it ticks — the G-row the topology dossier records. Graph *metadata*
+    (``g.graph``: economy, event log, opposition states) is also excluded,
+    because the spec's field set is nodes/edges/actions; four scenarios that
+    differ only in economy therefore share a tick-0 hash and diverge once they
+    tick.
+
+    Args:
+        state: WorldState at ``tick``.
+        tick: Current tick number.
+        rng_seed: The scenario's fixed RNG seed.
+
+    Returns:
+        A 64-character lowercase hex SHA-256 digest.
+
+    Raises:
+        TickHashEncodingError: If any node or edge attribute has no encoding
+            rule — loud by design (Constitution III.11); this is how the
+            frozenset-valued ``legal_authorities`` attribute was found.
+    """
+    graph = state.to_graph()
+    nodes = [{"node_id": str(node_id), **data} for node_id, data in graph.nodes(data=True)]
+    edges = [
+        {"source_id": str(source), "target_id": str(target), **data}
+        for source, target, data in graph.edges(data=True)
+    ]
+    return compute_tick_hash(tick=tick, rng_seed=rng_seed, nodes=nodes, edges=edges, actions=[])
+
+
+def capture_checkpoint(state: Any, tick: int, rng_seed: int = 0) -> CheckpointData:
     """Capture state at a checkpoint tick.
 
     Args:
         state: WorldState
         tick: Current tick number
+        rng_seed: The scenario's fixed RNG seed, an input to the graph
+            content hash.
 
     Returns:
         CheckpointData instance
@@ -932,6 +979,7 @@ def capture_checkpoint(state: Any, tick: int) -> CheckpointData:
     p_w = state.entities.get(PERIPHERY_WORKER_ID)
 
     return CheckpointData(
+        graph_hash=graph_content_hash(state, tick, rng_seed),
         tick=tick,
         p_w_wealth=get_entity_value(state, PERIPHERY_WORKER_ID, "wealth"),
         p_c_wealth=get_entity_value(state, COMPRADOR_ID, "wealth"),
@@ -989,9 +1037,10 @@ def _run_scenario_ticks(
     checkpoints: list[CheckpointData] = []
     ticks_survived = 0
     final_outcome = "SURVIVED"
+    seed = int(sim_config.rng_seed)
 
     # Capture initial state
-    checkpoints.append(capture_checkpoint(state, 0))
+    checkpoints.append(capture_checkpoint(state, 0, seed))
 
     dense_header: list[str] = []
     dense_rows: list[list[str]] = []
@@ -1014,7 +1063,7 @@ def _run_scenario_ticks(
 
         # Checkpoint at intervals
         if tick % CHECKPOINT_INTERVAL == 0 or tick == max_ticks:
-            checkpoints.append(capture_checkpoint(state, tick))
+            checkpoints.append(capture_checkpoint(state, tick, seed))
 
         if capture_dense:
             dense_rows.append(
@@ -1025,7 +1074,7 @@ def _run_scenario_ticks(
         p_w = state.entities.get(PERIPHERY_WORKER_ID)
         if p_w and is_dead(p_w):
             final_outcome = "DIED"
-            checkpoints.append(capture_checkpoint(state, tick))
+            checkpoints.append(capture_checkpoint(state, tick, seed))
             break
 
     baseline = BaselineData(
@@ -1131,6 +1180,7 @@ def load_baseline(path: Path) -> BaselineData:
             p_w_consciousness=cp["p_w_consciousness"],
             p_w_p_revolution=cp["p_w_p_revolution"],
             p_w_active=cp["p_w_active"],
+            graph_hash=cp["graph_hash"],
         )
         for cp in data["checkpoints"]
     ]
@@ -1188,6 +1238,18 @@ def compare_checkpoints(
     # Compare bool fields
     if expected.p_w_active != actual.p_w_active:
         diffs.append(f"p_w_active: {expected.p_w_active} != {actual.p_w_active}")
+
+    # The graph content hash is compared EXACTLY — no tolerance. It is a
+    # change-detection digest over the full node/edge projection, so "close"
+    # is not a meaningful relation on it, and a single drifted attribute
+    # anywhere in the graph must fail rather than round away.
+    if expected.graph_hash != actual.graph_hash:
+        diffs.append(
+            f"graph_hash: {expected.graph_hash[:16]}… != {actual.graph_hash[:16]}… "
+            "(graph content drifted; the float fields above may still match — "
+            "this hash covers every node/edge attribute, not just the ten the "
+            "dense columns pin)"
+        )
 
     return diffs
 


### PR DESCRIPTION
Lane B of the multi-lane sequence (ADR178 C4), and R1 of `reports/social-topology-spine-dossier.md` — which called this "the highest-priority correctness item in the estate" and the rewrite-test artifact.

## What was wrong

`tick_commit.determinism_hash` is `sha256(session_id:tick:rng_seed)` — three scalars, no world state. It proves replay *lineage* and is structurally blind to a dropped node, a lost edge, or a corrupted attribute.

## What this adds

1. **`babylon.kernel.tick_hash`** — the Python reference implementation of the byte layout already specified in the determinism contract's *P27 Tick Hash* chapter, so the Rust kernel inherits a spec **with executable goldens** rather than a promise. Every test pins bytes or a digest; none round-trips through our own encoder, which would prove nothing about a port.
2. **Wired into `qa:regression`** — one `graph_hash` per checkpoint, compared *exactly* (no tolerance; "close" is meaningless for a change-detection digest). Proved live by corrupting a baseline and watching the scenario fail with a diagnostic message.

## Coverage, honestly bounded

The dense goldens pin ten hand-picked entity fields and three edge fields. `to_graph()` emits ~30 attributes per social class plus node and edge **types**, so this covers structure the column contract never looks at.

It does **not** cover in-tick graph-only state — the harness never holds the live graph a tick mutates (`step()` builds and discards it internally). Graph metadata is excluded too, per the spec's nodes/edges/actions field set. This is stated in the code and the ceremony so a green gate is not over-read.

## Spec defects found by implementing it

- **The worked example contradicted its own rule.** It rendered a boolean as the quoted string `"true"` while rendering integers bare; its published sha only re-derived the slip. Corrected to 246 bytes / `b256dbbc…`, with the superseded digest recorded so it stays identifiable. Nothing depended on it — there was no implementation.
- **Three rules were missing entirely**, found by hashing real graphs: `null` for unset optionals, canonical ordering for sets, and loud failure for non-string enum values and record keys. All are now normative in the contract.
- **A second live instance of the D-4 shape**: `legal_authorities` is a `frozenset` **on a node** — the same set-stashed-in-a-node-attribute pattern Amendment D declined to grandfather for `ECONOMIC_SECTOR`.

## A correction to my own audit

The dossier claimed a lost node or edge "would pass every gate we have." That overstated it: the dense goldens derive their header from WorldState topology, so a dropped entity *does* fail the byte comparison. What is genuinely invisible is graph-only state — a narrower hole and a sharper brief. Corrected in place.

## Gates

- `mise run qa:regression` — 11/11 + the two-process determinism leg, which is independent evidence for the set-ordering rule (those processes run with different `PYTHONHASHSEED`).
- 221 kernel unit tests; lint + format + mypy clean.
- Baseline drift is **purely additive**, verified not asserted: one key added per checkpoint, 77 new cells, **zero** pre-existing values moved, every `defines_hash` byte-identical. Ceremony `blessed(graph-content-hash-field)`.

Does not presuppose the reserved question of whether `determinism_hash` is renamed or upgraded in place (dossier §8 Q2) — `determinism_hash` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)