### PR TITLE
feat(kernel): grid-quantized scalars + Currency i128 (P27 Phase 1 Task 3, §6.1)

### DIFF
--- a/docs/reference/determinism-contract.rst
+++ b/docs/reference/determinism-contract.rst
@@ -1076,6 +1076,77 @@ of the refoundation design), not byte-identical replay — this is the
 compensating instrument, and it is explicitly weaker than stream-compatible
 comparison, stated plainly rather than hidden.
 
+Currency Operator Semantics (Rust Kernel Reference)
+------------------------------------------------------
+
+**Status: normative as of Phase 1 Task 3 (2026-07-30) — implemented in**
+``rust/crates/babylon-kernel/src/currency.rs``. Added per that task's Step-5
+cross-check: this document pinned ``Currency``'s hash *encoding* (i128
+micro-units as decimal strings — the *P27 Tick Hash* chapter) but not its
+operator *algebra*, and the plan forbids silently diverging code from spec.
+The four spec-pinned operators (refoundation design §6.1):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Operator
+     - Result
+     - Rule
+   * - ``Currency ± Currency``
+     - ``Currency``
+     - checked i128 add/sub; overflow is a loud III.11 failure, never
+       wrapping or saturating
+   * - ``Currency × Coefficient``
+     - ``Currency``
+     - integer-numerator multiply (below), then one half-even division by
+       ``10⁶``
+   * - ``Currency ÷ Currency``
+     - ``Coefficient``
+     - i256 intermediate ``(a × 10⁶) / b``, half-even; out-of-``[0,1]``
+       result is a loud caller bug
+   * - ``Currency ÷ integer``
+     - ``Currency``
+     - half-even division
+
+**The integer-numerator multiply.** ``Coefficient`` is grid-quantized on
+construction, so its exact value is the rational ``n / 10⁶`` with integer
+``n ∈ [0, 10⁶]``. The multiply recovers ``n`` (``round(coeff × 10⁶)`` —
+exact by construction for a grid value), computes ``value × n`` in checked
+i128, and divides by ``10⁶`` half-even in one step. The i128 side is
+**never cast to f64**, which would silently lose precision above 2⁵³
+(≈ 9.0e15 micro-units) — inside the nationwide-scale headroom i128 exists
+to provide.
+
+**Half-even (banker's) rounding division**, the ``round_half_even`` kernel
+intrinsic (§6.2): with ``q = n / d`` (truncating) and ``r = n % d``, compare
+``|2r|`` to ``|d|`` — less keeps ``q``; greater steps ``q`` one toward the
+true quotient; equal (an exact tie) keeps ``q`` if even, else steps.
+
+**Worked examples (hand-verified, pinned as Rust unit tests in
+``currency.rs``):**
+
+.. code-block:: text
+
+   3 micro-units × Coefficient(0.5):
+     n = 500_000; product = 1_500_000
+     half_even(1_500_000 / 1_000_000): q=1, r=500_000, 2r == d (tie), q odd
+     -> 2 micro-units          (1.5 rounds to the even neighbor 2)
+
+   Currency(1_000_000) ÷ Currency(3_000_000):
+     i256: (1_000_000 × 1_000_000) / 3_000_000 -> q=333_333, 2r < d
+     -> Coefficient(0.333333)  (the 10⁻⁶-grid value)
+
+   5 micro-units ÷ 2:
+     q=2, r=1, 2r == d (tie), q even -> 2   (2.5 rounds to even 2)
+
+**Sign domain (OPEN question, carried from the Phase-1 plan):** the Python
+reference constrains ``Currency`` non-negative; the Rust representation is
+signed i128 (intermediate deltas are naturally signed) and does not
+re-impose non-negativity at the type level. If ruled otherwise, the fix is
+a boundary wrapper, not an operator change — the algebra above is
+sign-complete as specified.
+
 Known Discrepancies
 -----------------------
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
 name = "babylon-kernel"
 version = "0.1.0"
 dependencies = [
+ "bnum",
  "pretty_assertions",
  "sha2",
 ]
@@ -249,6 +250,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bnum"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
 
 [[package]]
 name = "bumpalo"

--- a/rust/crates/babylon-kernel/Cargo.toml
+++ b/rust/crates/babylon-kernel/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
+bnum = "0.13"
 sha2 = "0.10"
 
 [dev-dependencies]

--- a/rust/crates/babylon-kernel/src/currency.rs
+++ b/rust/crates/babylon-kernel/src/currency.rs
@@ -1,0 +1,293 @@
+//! `Currency`: i128 fixed-point micro-units (spec §6.1). Overflow is a loud
+//! III.11 failure — `checked_*` everywhere, never wrapping or saturating.
+//!
+//! Sign domain (OPEN — flagged in the Phase-1 plan's open questions): the
+//! Python model constrains `Currency` non-negative
+//! (`models/types.py::Currency`, `Field(ge=0.0)`); this port keeps the
+//! underlying representation signed (`i128`) because intermediate deltas
+//! (e.g. a dispossession transfer) are naturally signed, and does NOT
+//! re-impose non-negativity as a type invariant here. If the Director or a
+//! later review wants non-negativity enforced at the type level, that is a
+//! narrow follow-up (a `NonNegativeCurrency` boundary wrapper), not a
+//! redesign of this module.
+//!
+//! The four operators below are the spec-pinned set, byte-specified in
+//! ``docs/reference/determinism-contract.rst`` (*Currency Operator
+//! Semantics*): `± Currency`, `× Coefficient` (half-even),
+//! `÷ Currency → Coefficient` (i256 intermediate, half-even),
+//! `÷ integer` (half-even).
+use crate::scalars::Coefficient;
+use bnum::types::I256;
+
+/// A loud, non-recoverable-by-the-algebra overflow (III.11: run-time loud
+/// failure — the caller is expected to let this propagate, per spec §9
+/// "checked-arithmetic overflow panics with context").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CurrencyOverflow {
+    /// The operator that overflowed, for the failure message.
+    pub op: &'static str,
+}
+
+/// Fixed-point currency: the value in micro-units (1 unit = 1,000,000
+/// micro-units).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Currency(i128);
+
+const MICRO: i128 = 1_000_000;
+const MICRO_F64: f64 = 1_000_000.0;
+
+impl Currency {
+    /// Wrap a raw micro-unit amount.
+    #[must_use]
+    pub fn from_micro_units(micro: i128) -> Self {
+        Self(micro)
+    }
+
+    /// The raw micro-unit amount.
+    #[must_use]
+    pub fn micro_units(self) -> i128 {
+        self.0
+    }
+
+    /// `Currency + Currency → Currency` (checked; spec §6.1).
+    ///
+    /// # Errors
+    /// Returns [`CurrencyOverflow`] if the sum leaves the i128 range —
+    /// loud, never wrapping (III.11).
+    pub fn checked_add(self, other: Self) -> Result<Self, CurrencyOverflow> {
+        self.0
+            .checked_add(other.0)
+            .map(Self)
+            .ok_or(CurrencyOverflow {
+                op: "Currency + Currency",
+            })
+    }
+
+    /// `Currency - Currency → Currency` (checked; spec §6.1).
+    ///
+    /// # Errors
+    /// Returns [`CurrencyOverflow`] if the difference leaves the i128
+    /// range — loud, never wrapping (III.11).
+    pub fn checked_sub(self, other: Self) -> Result<Self, CurrencyOverflow> {
+        self.0
+            .checked_sub(other.0)
+            .map(Self)
+            .ok_or(CurrencyOverflow {
+                op: "Currency - Currency",
+            })
+    }
+
+    /// `Currency × Coefficient → Currency`, rounded half-even to
+    /// micro-units.
+    ///
+    /// `Coefficient` lives on the 10⁻⁶ grid, so its exact value is the
+    /// rational `numerator / 1_000_000` with an integer numerator in
+    /// `[0, 1_000_000]`. This implementation recovers that integer
+    /// numerator, multiplies the two integer representations directly
+    /// (never casting the i128 side to `f64`, which loses precision above
+    /// 2⁵³ ≈ 9.0e15 micro-units — well inside the nationwide-scale headroom
+    /// §6.1 pins i128 for), and divides back down by `1_000_000` half-even
+    /// in one step.
+    ///
+    /// # Errors
+    /// Returns [`CurrencyOverflow`] if the pre-rounding product leaves the
+    /// i128 range.
+    pub fn mul_coefficient(self, coeff: Coefficient) -> Result<Self, CurrencyOverflow> {
+        // Grid-safe recovery of the integer numerator: coeff ∈ [0,1] on the
+        // 10⁻⁶ grid, so coeff·10⁶ is integer-valued up to float error and
+        // bounded by 1_000_000 — the round+cast is exact by construction.
+        #[allow(clippy::cast_possible_truncation)]
+        let numerator = (coeff.get() * MICRO_F64).round() as i128;
+        let product = self.0.checked_mul(numerator).ok_or(CurrencyOverflow {
+            op: "Currency * Coefficient (pre-round)",
+        })?;
+        Ok(Self(round_half_even_div(product, MICRO)))
+    }
+
+    /// `Currency ÷ Currency → Coefficient`, i256 intermediate, half-even.
+    ///
+    /// # Panics
+    /// Panics if `other` is zero (division by zero), or if the true ratio
+    /// falls outside `Coefficient`'s `[0, 1]` domain — both are III.11
+    /// caller bugs (the algebra must guarantee `0 ≤ self/other ≤ 1` before
+    /// invoking this projection), not recoverable conditions.
+    #[must_use]
+    pub fn div_currency(self, other: Self) -> Coefficient {
+        let numerator = I256::from(self.0) * I256::from(MICRO);
+        let ratio = round_half_even_div_i256(numerator, I256::from(other.0));
+        let as_i128: i128 = ratio
+            .try_into()
+            .expect("i256 intermediate must fit i128 for a [0,1] ratio");
+        // as_i128 ∈ [0, 1_000_000] for an in-domain ratio — exact in f64.
+        #[allow(clippy::cast_precision_loss)]
+        let value = as_i128 as f64 / MICRO_F64;
+        Coefficient::new(value).expect("out-of-[0,1] Currency ratio: III.11 caller bug")
+    }
+
+    /// `Currency ÷ integer → Currency`, half-even.
+    ///
+    /// # Panics
+    /// Panics if `divisor` is zero — a III.11 caller bug, not a
+    /// recoverable condition.
+    #[must_use]
+    pub fn div_integer(self, divisor: i128) -> Self {
+        Self(round_half_even_div(self.0, divisor))
+    }
+}
+
+/// Half-even (banker's) rounding integer division — the `round_half_even`
+/// kernel intrinsic (spec §6.2), pinned here for `Currency`'s own operators;
+/// re-exported at crate root for BSL's numeric-annex use once Phase 2 wires
+/// it as a callable intrinsic.
+///
+/// # Panics
+/// Panics if `denominator` is zero, or on the (unreachable-for-`MICRO`)
+/// `2 × remainder` overflow.
+#[must_use]
+pub fn round_half_even_div(numerator: i128, denominator: i128) -> i128 {
+    let q = numerator / denominator;
+    let r = numerator % denominator;
+    let twice_r = r
+        .checked_mul(2)
+        .expect("round_half_even_div: 2*remainder overflow");
+    match twice_r.abs().cmp(&denominator.abs()) {
+        std::cmp::Ordering::Less => q,
+        std::cmp::Ordering::Greater => q + numerator.signum() * denominator.signum(),
+        std::cmp::Ordering::Equal => {
+            if q % 2 == 0 {
+                q
+            } else {
+                q + numerator.signum() * denominator.signum()
+            }
+        }
+    }
+}
+
+/// The same half-even division at i256 width, for `div_currency`'s
+/// intermediate — kept private: the public intrinsic surface is the i128
+/// form above.
+fn round_half_even_div_i256(numerator: I256, denominator: I256) -> I256 {
+    let q = numerator / denominator;
+    let r = numerator % denominator;
+    let two = I256::from(2_i128);
+    let twice_r = r * two; // i256 headroom: cannot overflow for i128-derived inputs
+    let step = numerator.signum() * denominator.signum();
+    match twice_r.abs().cmp(&denominator.abs()) {
+        std::cmp::Ordering::Less => q,
+        std::cmp::Ordering::Greater => q + step,
+        std::cmp::Ordering::Equal => {
+            if q % two == I256::ZERO {
+                q
+            } else {
+                q + step
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{round_half_even_div, Currency, CurrencyOverflow};
+    use crate::scalars::Coefficient;
+
+    #[test]
+    fn add_overflow_is_loud_not_wrapping() {
+        let max = Currency::from_micro_units(i128::MAX);
+        let one = Currency::from_micro_units(1);
+        assert_eq!(
+            max.checked_add(one),
+            Err(CurrencyOverflow {
+                op: "Currency + Currency"
+            })
+        );
+    }
+
+    #[test]
+    fn sub_underflow_is_loud_not_wrapping() {
+        let min = Currency::from_micro_units(i128::MIN);
+        let one = Currency::from_micro_units(1);
+        assert_eq!(
+            min.checked_sub(one),
+            Err(CurrencyOverflow {
+                op: "Currency - Currency"
+            })
+        );
+    }
+
+    #[test]
+    fn round_half_even_div_ties_to_even() {
+        assert_eq!(round_half_even_div(5, 2), 2); // 2.5 -> 2 (even)
+        assert_eq!(round_half_even_div(7, 2), 4); // 3.5 -> 4 (even)
+        assert_eq!(round_half_even_div(-5, 2), -2); // -2.5 -> -2 (even)
+        assert_eq!(round_half_even_div(-7, 2), -4); // -3.5 -> -4 (even)
+    }
+
+    #[test]
+    fn round_half_even_div_off_tie_rounds_to_nearest() {
+        assert_eq!(round_half_even_div(7, 3), 2); // 2.33 -> 2
+        assert_eq!(round_half_even_div(8, 3), 3); // 2.67 -> 3
+        assert_eq!(round_half_even_div(-8, 3), -3);
+    }
+
+    #[test]
+    fn div_integer_matches_round_half_even() {
+        let c = Currency::from_micro_units(5);
+        assert_eq!(c.div_integer(2), Currency::from_micro_units(2));
+    }
+
+    #[test]
+    fn mul_coefficient_is_exact_integer_arithmetic() {
+        // 10.000000 units × 0.5 = 5.000000 units, exactly.
+        let c = Currency::from_micro_units(10 * 1_000_000);
+        let half = Coefficient::new(0.5).unwrap();
+        assert_eq!(c.mul_coefficient(half).unwrap().micro_units(), 5_000_000);
+    }
+
+    #[test]
+    fn mul_coefficient_half_even_on_the_micro_unit_tie() {
+        // 1 micro-unit × 0.5 = 0.5 micro-units -> 0 (even), not 1.
+        let c = Currency::from_micro_units(1);
+        let half = Coefficient::new(0.5).unwrap();
+        assert_eq!(c.mul_coefficient(half).unwrap().micro_units(), 0);
+        // 3 micro-units × 0.5 = 1.5 -> 2 (even), not 1.
+        let c3 = Currency::from_micro_units(3);
+        assert_eq!(c3.mul_coefficient(half).unwrap().micro_units(), 2);
+    }
+
+    #[test]
+    fn mul_coefficient_survives_beyond_f64_exact_range() {
+        // 2^53 + 1 micro-units is exactly the value an f64 path would
+        // silently round; the integer path must not.
+        let beyond = Currency::from_micro_units((1_i128 << 53) + 1);
+        let one = Coefficient::new(1.0).unwrap();
+        assert_eq!(
+            beyond.mul_coefficient(one).unwrap().micro_units(),
+            (1_i128 << 53) + 1
+        );
+    }
+
+    #[test]
+    fn div_currency_yields_the_grid_ratio() {
+        let a = Currency::from_micro_units(1_000_000); // 1.0
+        let b = Currency::from_micro_units(3_000_000); // 3.0
+        let ratio = a.div_currency(b);
+        // 1/3 on the 10⁻⁶ grid, half-even: 333333.33... -> 333333.
+        assert!((ratio.get() - 0.333_333).abs() < 1e-12);
+    }
+
+    #[test]
+    fn div_currency_of_equal_values_is_exactly_one() {
+        let a = Currency::from_micro_units(7_654_321);
+        assert!((a.div_currency(a).get() - 1.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn div_currency_survives_i128_scale_numerators() {
+        // self × 10⁶ overflows i128 for large self — the i256 intermediate
+        // is load-bearing, not decorative.
+        let big = Currency::from_micro_units(i128::MAX / 2);
+        let bigger = Currency::from_micro_units(i128::MAX);
+        let ratio = big.div_currency(bigger);
+        assert!((ratio.get() - 0.5).abs() < 1e-6);
+    }
+}

--- a/rust/crates/babylon-kernel/src/grid.rs
+++ b/rust/crates/babylon-kernel/src/grid.rs
@@ -1,0 +1,66 @@
+//! The Program 27 quantization retraction (`THE_FORMALISM` II.1, `L-GRID`):
+//! ports `babylon.kernel.math.quantize` byte-for-byte. `ROUND_HALF_UP`, ties
+//! away from zero, on the 10⁻⁶ grid.
+//!
+//! This is a **cross-language conformance surface**: the test vector below
+//! was verified against the live Python (`babylon.kernel.math.quantize`)
+//! on 2026-07-30 before this file was written — transcription discipline,
+//! not assumption.
+
+/// Decimal digits of the grid: values live on multiples of 10⁻⁶.
+pub const GRID_PRECISION: u32 = 6;
+const GRID: f64 = 1_000_000.0; // 10^GRID_PRECISION
+
+/// Snap `value` onto the 10⁻⁶ grid, `ROUND_HALF_UP` (ties away from zero) —
+/// the exact algorithm in `src/babylon/kernel/math.py::quantize`.
+#[must_use]
+pub fn quantize(value: f64) -> f64 {
+    if value >= 0.0 {
+        (value * GRID + 0.5).floor() / GRID
+    } else {
+        -((-value * GRID + 0.5).floor()) / GRID
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::quantize;
+
+    /// Cross-language conformance vector: expected values computed by
+    /// running `babylon.kernel.math.quantize` in Python (verified
+    /// 2026-07-30: `0.123456789 -> 0.123457`, `-0.123456789 -> -0.123457`,
+    /// `0.0 -> 0.0`, `1.0000005 -> 1.000001`, `-1.0000005 -> -1.000001`).
+    #[test]
+    fn matches_the_python_quantize_conformance_vector() {
+        let cases: &[(f64, f64)] = &[
+            (0.123_456_789, 0.123_457),
+            (-0.123_456_789, -0.123_457),
+            (0.0, 0.0),
+            (1.000_000_5, 1.000_001), // half-away-from-zero tie
+            (-1.000_000_5, -1.000_001),
+        ];
+        for &(input, expected) in cases {
+            assert!(
+                (quantize(input) - expected).abs() < 1e-12,
+                "quantize({input}) = {}, expected {expected}",
+                quantize(input)
+            );
+        }
+    }
+
+    #[test]
+    fn is_idempotent() {
+        // L-GRID: q ∘ q = q
+        let v = 0.987_654_321;
+        assert!((quantize(quantize(v)) - quantize(v)).abs() < 1e-15);
+    }
+
+    #[test]
+    fn negative_zero_input_stays_on_the_grid() {
+        // -0.0 >= 0.0 is true in IEEE-754, so it takes the positive branch;
+        // the output is 0.0 (positive), not -0.0 — pinned so the tick hash's
+        // bit-pattern encoding never sees a quantized -0.0.
+        let q = quantize(-0.0);
+        assert_eq!(q.to_bits(), 0.0_f64.to_bits());
+    }
+}

--- a/rust/crates/babylon-kernel/src/lib.rs
+++ b/rust/crates/babylon-kernel/src/lib.rs
@@ -3,3 +3,13 @@
 //! public item is doc-commented (`RUSTDOCFLAGS='-D warnings' cargo doc` gate).
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
+
+pub mod currency;
+pub mod grid;
+pub mod scalars;
+
+pub use currency::{round_half_even_div, Currency, CurrencyOverflow};
+pub use grid::{quantize, GRID_PRECISION};
+pub use scalars::{
+    Balance, Coefficient, Ideology, Intensity, OutOfBoundsError, Probability, Ratio,
+};

--- a/rust/crates/babylon-kernel/src/scalars.rs
+++ b/rust/crates/babylon-kernel/src/scalars.rs
@@ -1,0 +1,152 @@
+//! Grid-quantized bounded scalar sorts (`THE_FORMALISM` II.1): `Probability`,
+//! `Intensity`, `Coefficient` on `𝔾 ∩ [0,1]`; `Ideology`, `Balance` on
+//! `𝔾 ∩ [-1,1]`; `Ratio` on `𝔾 ∩ (0,∞)`. Construction quantizes and
+//! validates (the Gatekeeper pattern, ported from Pydantic's
+//! `AfterValidator`) — an out-of-range value is a loud `Err`, never
+//! silently clamped.
+use crate::grid::quantize;
+
+/// A scalar out of its sort's declared bound (III.11 load-time rejection).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OutOfBoundsError {
+    /// The already-quantized value that failed the bound.
+    pub value: f64,
+    /// The sort's inclusive lower bound (exclusive for `Ratio`).
+    pub lower: f64,
+    /// The sort's inclusive upper bound (`f64::INFINITY` for `Ratio`).
+    pub upper: f64,
+}
+
+macro_rules! bounded_scalar {
+    ($name:ident, $lower:expr, $upper:expr) => {
+        #[doc = concat!("Grid-quantized scalar on 𝔾 ∩ [", stringify!($lower), ", ", stringify!($upper), "].")]
+        #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+        pub struct $name(f64);
+
+        impl $name {
+            /// Quantize and validate `value`.
+            ///
+            /// # Errors
+            /// Returns [`OutOfBoundsError`] if the quantized value falls
+            /// outside the sort's declared bound (III.11) — never clamps.
+            pub fn new(value: f64) -> Result<Self, OutOfBoundsError> {
+                let q = quantize(value);
+                if !($lower..=$upper).contains(&q) {
+                    return Err(OutOfBoundsError {
+                        value: q,
+                        lower: $lower,
+                        upper: $upper,
+                    });
+                }
+                Ok(Self(q))
+            }
+
+            /// The quantized inner value.
+            #[must_use]
+            pub fn get(self) -> f64 {
+                self.0
+            }
+        }
+    };
+}
+
+bounded_scalar!(Probability, 0.0, 1.0);
+bounded_scalar!(Intensity, 0.0, 1.0);
+bounded_scalar!(Coefficient, 0.0, 1.0);
+bounded_scalar!(Ideology, -1.0, 1.0);
+bounded_scalar!(Balance, -1.0, 1.0);
+
+/// Grid-quantized scalar on `𝔾 ∩ (0, ∞)` — open lower bound, unbounded
+/// above. Hand-rolled rather than macro-generated: the macro's bounds
+/// assume a finite closed interval; `Ratio`'s law is "finite and strictly
+/// positive after quantization". A positive input below `5e-7` quantizes
+/// to `0.0` and is therefore rejected — loudly, per III.11, because a
+/// ratio the grid cannot represent is not a ratio the algebra may use.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct Ratio(f64);
+
+impl Ratio {
+    /// Quantize and validate `value`.
+    ///
+    /// # Errors
+    /// Returns [`OutOfBoundsError`] if the quantized value is not finite
+    /// and strictly positive (III.11) — never clamps.
+    pub fn new(value: f64) -> Result<Self, OutOfBoundsError> {
+        let q = quantize(value);
+        if !q.is_finite() || q <= 0.0 {
+            return Err(OutOfBoundsError {
+                value: q,
+                lower: 0.0,
+                upper: f64::INFINITY,
+            });
+        }
+        Ok(Self(q))
+    }
+
+    /// The quantized inner value.
+    #[must_use]
+    pub fn get(self) -> f64 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Balance, Coefficient, Ideology, Probability, Ratio};
+
+    #[test]
+    fn probability_rejects_out_of_range() {
+        assert!(Probability::new(1.5).is_err());
+        assert!(Probability::new(-0.001).is_err());
+    }
+
+    #[test]
+    fn probability_quantizes_on_construction() {
+        let p = Probability::new(0.123_456_789).unwrap();
+        assert!((p.get() - 0.123_457).abs() < 1e-12);
+    }
+
+    #[test]
+    fn quantization_happens_before_the_bounds_check() {
+        // 1.0000004 quantizes DOWN to 1.0 — legal. 1.0000005 quantizes UP
+        // to 1.000001 — rejected. The order (quantize, then check) is the
+        // Python Gatekeeper's order and is observable exactly here.
+        assert!(Probability::new(1.000_000_4).is_ok());
+        assert!(Probability::new(1.000_000_5).is_err());
+    }
+
+    #[test]
+    fn signed_sorts_accept_the_full_interval() {
+        assert!(Ideology::new(-1.0).is_ok());
+        assert!(Ideology::new(1.0).is_ok());
+        assert!(Ideology::new(-1.000_001).is_err());
+        assert!(Balance::new(-0.5).is_ok());
+    }
+
+    #[test]
+    fn ratio_lower_bound_is_open() {
+        assert!(Ratio::new(0.0).is_err());
+        assert!(Ratio::new(-1.0).is_err());
+        assert!(Ratio::new(1e-6).is_ok()); // the smallest grid-representable ratio
+    }
+
+    #[test]
+    fn ratio_rejects_what_the_grid_cannot_represent() {
+        // 4e-7 quantizes to 0.0: strictly positive input, but not a
+        // representable positive ratio — loud rejection, never a silent 0.
+        assert!(Ratio::new(4e-7).is_err());
+    }
+
+    #[test]
+    fn ratio_rejects_non_finite() {
+        assert!(Ratio::new(f64::INFINITY).is_err());
+        assert!(Ratio::new(f64::NAN).is_err());
+    }
+
+    #[test]
+    fn coefficient_shares_the_unit_interval_law() {
+        assert!(Coefficient::new(0.0).is_ok());
+        assert!(Coefficient::new(1.0).is_ok());
+        assert!(Coefficient::new(1.000_001).is_err());
+    }
+}


### PR DESCRIPTION
P27 Phase 1 Task 3 — the kernel's scalar foundation, prerequisite for Tasks 4–7. First substantive `babylon-kernel` code, following the Rust-first inversion the Director prompted this morning.

## What lands

- **`grid.rs`** — `babylon.kernel.math.quantize` ported byte-for-byte (ROUND_HALF_UP, ties away from zero, 10⁻⁶ grid). Conformance vector **verified against the live Python before the Rust was written**; a `-0.0` pin keeps the tick hash's bit-pattern encoding clean.
- **`scalars.rs`** — the six bounded sorts. Construction quantizes *then* validates (the Gatekeeper order, pinned at the `1.0000004`/`1.0000005` boundary); never clamps. `Ratio` is hand-rolled: open lower bound, and a positive input the grid rounds to zero is **rejected loudly** rather than becoming a silent 0.
- **`currency.rs`** — i128 micro-units, four spec-pinned operators: checked ±, ×Coefficient via integer-numerator multiply (the i128 side never touches f64 — pinned by a beyond-2⁵³ test), ÷Currency at i256 width (`bnum`; pinned at i128::MAX scale where the intermediate genuinely cannot fit i128), ÷integer half-even. `round_half_even_div` is the exposed §6.2 intrinsic.

## Step-5 cross-check (the plan forbids skipping it)

The determinism contract pinned Currency's hash *encoding* but not its operator *algebra* — a genuine gap. Closed with a normative **Currency Operator Semantics** chapter: operator table + hand-verified worked examples that are simultaneously the unit tests.

## Deviations from the drafted code, recorded

pedantic requires `# Errors`/`# Panics` docs and `RangeInclusive::contains` the draft lacked; rustfmt oscillates on multi-line `concat!` in a macro body (collapsed); `bnum` is 0.13 not 0.11; `div_currency` gets a real half-even i256 division (the draft's plain `/` truncated — a genuine rounding bug in the plan); `Ratio`'s grid-underflow rejection is new.

## Gates

22 kernel tests green; `mise run rust:check` (fmt + clippy pedantic `-D warnings` + test + doc) green across the workspace. Note: touches `determinism-contract.rst` adjacent to PR #418's edits — merge after #418, trivial or no conflict expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)