### PR TITLE
feat(kernel): deterministic sim clock + correlation id (P27 Phase 1 Task 4, §6.5)

### DIFF
--- a/rust/crates/babylon-kernel/src/clock.rs
+++ b/rust/crates/babylon-kernel/src/clock.rs
@@ -1,0 +1,141 @@
+//! Deterministic sim clock + per-tick correlation id (spec §6.5 — replaces
+//! Python's `uuid4()` per-tick id, which was log-only and non-deterministic
+//! by construction; this replacement is strictly better for the same job).
+//!
+//! No wall-clock reads, no randomness: the correlation id is a pure
+//! function of `(session_id, tick)`, so two replays of the same session
+//! produce identical log correlation — which is the point.
+
+/// Opaque session identifier — a validated non-empty string, not a raw
+/// `String`, so an empty session id is a construction-time error (III.11).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionId(String);
+
+/// The construction-time rejection of an empty session id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EmptySessionId;
+
+impl SessionId {
+    /// Validate and wrap a session identifier.
+    ///
+    /// # Errors
+    /// Returns [`EmptySessionId`] if `id` is the empty string — a loud
+    /// III.11 construction failure, because an empty id would silently
+    /// collapse every session's correlation ids into one namespace.
+    pub fn new(id: impl Into<String>) -> Result<Self, EmptySessionId> {
+        let id = id.into();
+        if id.is_empty() {
+            return Err(EmptySessionId);
+        }
+        Ok(Self(id))
+    }
+
+    /// The validated identifier.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// The tick clock: monotonic, no wall-clock reads, no randomness.
+#[derive(Debug, Clone)]
+pub struct SimClock {
+    session_id: SessionId,
+    tick: u64,
+}
+
+impl SimClock {
+    /// A fresh clock at tick 0 for the given session.
+    #[must_use]
+    pub fn new(session_id: SessionId) -> Self {
+        Self {
+            session_id,
+            tick: 0,
+        }
+    }
+
+    /// Advance one tick; returns the new tick number.
+    ///
+    /// # Panics
+    /// Panics on u64 overflow — unreachable for any campaign (a 10-year
+    /// campaign is 520 ticks; u64 holds 1.8e19), but checked rather than
+    /// wrapped because a silently restarted tick counter would corrupt
+    /// every downstream correlation (III.11).
+    pub fn advance(&mut self) -> u64 {
+        self.tick = self
+            .tick
+            .checked_add(1)
+            .expect("SimClock::advance: tick counter overflow");
+        self.tick
+    }
+
+    /// The current tick number.
+    #[must_use]
+    pub fn tick(&self) -> u64 {
+        self.tick
+    }
+
+    /// The clock's session.
+    #[must_use]
+    pub fn session_id(&self) -> &SessionId {
+        &self.session_id
+    }
+
+    /// Deterministic per-tick correlation id — a pure function of
+    /// `(session_id, tick)`, never a UUID. Zero-padded to ten digits so
+    /// ids sort lexicographically in tick order in any log viewer.
+    #[must_use]
+    pub fn correlation_id(&self) -> String {
+        format!("{}-{:010}", self.session_id.0, self.tick)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EmptySessionId, SessionId, SimClock};
+
+    #[test]
+    fn correlation_id_is_a_pure_function_of_session_and_tick() {
+        let clock_a = SimClock {
+            session_id: SessionId::new("abc").unwrap(),
+            tick: 3,
+        };
+        let clock_b = SimClock {
+            session_id: SessionId::new("abc").unwrap(),
+            tick: 3,
+        };
+        assert_eq!(clock_a.correlation_id(), clock_b.correlation_id());
+    }
+
+    #[test]
+    fn correlation_id_sorts_lexicographically_in_tick_order() {
+        let mut clock = SimClock::new(SessionId::new("s").unwrap());
+        let mut previous = clock.correlation_id();
+        for _ in 0..12 {
+            clock.advance();
+            let current = clock.correlation_id();
+            assert!(previous < current, "{previous} !< {current}");
+            previous = current;
+        }
+    }
+
+    #[test]
+    fn advance_is_monotonic_and_never_resets() {
+        let mut clock = SimClock::new(SessionId::new("s").unwrap());
+        assert_eq!(clock.advance(), 1);
+        assert_eq!(clock.advance(), 2);
+        assert_eq!(clock.tick(), 2);
+    }
+
+    #[test]
+    fn empty_session_id_is_a_loud_construction_error() {
+        assert_eq!(SessionId::new(""), Err(EmptySessionId));
+    }
+
+    #[test]
+    fn different_sessions_never_share_a_correlation_id() {
+        let a = SimClock::new(SessionId::new("a").unwrap());
+        let b = SimClock::new(SessionId::new("b").unwrap());
+        assert_ne!(a.correlation_id(), b.correlation_id());
+    }
+}

--- a/rust/crates/babylon-kernel/src/lib.rs
+++ b/rust/crates/babylon-kernel/src/lib.rs
@@ -4,10 +4,12 @@
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
 
+pub mod clock;
 pub mod currency;
 pub mod grid;
 pub mod scalars;
 
+pub use clock::{EmptySessionId, SessionId, SimClock};
 pub use currency::{round_half_even_div, Currency, CurrencyOverflow};
 pub use grid::{quantize, GRID_PRECISION};
 pub use scalars::{


### PR DESCRIPTION
P27 Phase 1 Task 4, continuing the kernel run. Rebased on #419's merge (the anticipated one-file `lib.rs` overlap, resolved alphabetized).

Replaces the Python `uuid4()`-per-tick correlation id — log-only and non-deterministic by construction — with a pure function of `(session_id, tick)`. Two replays of one session now produce identical log correlation, which is the point.

Beyond the plan's draft, each recorded in the commit:
- `SessionId` validates non-empty at construction — an empty id would silently collapse every session's correlation ids into one namespace (III.11).
- `advance()` is `checked_add`, not `+=` — unreachable at u64 width, but a silently wrapped tick counter is the wrong failure mode for the thing every downstream correlation hangs off.
- The id zero-pads to ten digits so it sorts lexicographically in tick order in any log viewer — pinned by a test.

27 kernel tests green (5 new); `mise run rust:check` green across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)