### PR TITLE
feat(kernel): RNG service — ChaCha8 pinned + seeding derivation (P27 Phase 1 Task 5, §9/R8)

### DIFF
--- a/docs/reference/determinism-contract.rst
+++ b/docs/reference/determinism-contract.rst
@@ -1041,29 +1041,55 @@ knobs a system can silently drift. An earlier draft of this chapter
 carried its own copy of the cost table; it is replaced by this pointer so
 exactly one normative table exists (same rationale as the ``rules_hash``
 supersession note above).
-**RNG seeding derivation.** Algorithm: to be pinned in Phase 1 (an open
-Phase-1 ruling per §13 of the refoundation design — polynomial vs.
-pinned-libm-equivalent transcendental posture applies to intrinsics, not
-the PRNG itself, but the PRNG algorithm choice is likewise deferred).
-**Seeding**, however, is specified now: ``seed = truncate(SHA256(session_id
-‖ ":" ‖ tick ‖ ":" ‖ salt))``, where ``‖`` is byte-string concatenation of
-the UTF-8-encoded decimal/hyphenated-hex forms joined by literal ``:``
-characters (mirroring the f-string shape of today's
-``tick_commit.replay_identity_hash`` construction, *Catalog* above), ``salt``
-is the existing constant ``0xBA1AC1A`` (``_SYSTEM_RNG_SEED_SALT``,
-``src/babylon/kernel/system_base.py:32``), and ``truncate`` takes the
-first 8 bytes of the 32-byte digest, interpreted as a big-endian ``u64``,
-as the PRNG's seed input.
+**RNG algorithm — PINNED (Phase 1 Task 5, 2026-07-30):** ``ChaCha8Rng``
+(``rand_chacha``), implemented in ``rust/crates/babylon-kernel/src/rng.rs``.
+Rationale, ratified from that module's own text: (1) it takes an exact
+32-byte seed — a SHA-256 digest's width, so the derivation needs no
+truncation or expansion step; (2) it is a pure-Rust, no-``unsafe``,
+platform-independent stream-cipher construction, fully deterministic from
+its seed with no OS-entropy dependency (III.7); (3) 8 rounds is the "fast,
+still no known practical distinguisher" configuration — this is not a
+cryptographic-security use case, so ``ChaCha8`` over ``ChaCha20`` is pure
+speed with no correctness cost. Constructed only per ``(session_id, tick)``
+— there is no entropy-seeded constructor.
 
-**Worked example (synthetic, hand-verified with ``python3``):**
-``session_id="4ad75b08-0258-48a4-a29a-61cab92d7d13"``, ``tick=7``:
+**Seeding derivation — as implemented:**
+``seed = SHA256(session_id_utf8 ‖ tick_le8 ‖ salt_le8)``, all 32 bytes used
+directly as the ``ChaCha8Rng`` seed; ``salt`` is the existing constant
+``0xBA1AC1A`` (``_SYSTEM_RNG_SEED_SALT``,
+``src/babylon/kernel/system_base.py:32``), and ``tick``/``salt`` enter as
+8-byte **little-endian** integers with no separators.
+
+.. note::
+   **Supersession (2026-07-30, at implementation).** An earlier draft of
+   this section specified colon-separated decimal *text* forms truncated to
+   the digest's first 8 bytes as a big-endian ``u64``. Both choices were
+   artifacts of assuming a ``u64``-seeded PRNG. With the pinned 32-byte-seed
+   generator, truncation would discard 24 of the derivation's 32 bytes for
+   no benefit, and the text encoding added a formatting layer with no
+   consumer. The Phase-1 plan's Task-5 byte layout (binary, full-width)
+   supersedes; the superseded text form's worked value
+   (``…:7:195144730 → u64 4222636361569202174``) is retained here only so an
+   archived copy quoting it stays identifiable. Nothing depended on it — no
+   implementation existed.
+
+**Within-implementation replay conformance vector** (generated once from
+the first green run, byte-pinned thereafter by
+``rng.rs::conformance_vector_first_four_u64s`` — any future divergence is a
+determinism regression, never "the RNG got better"):
 
 .. code-block:: text
 
-   seed_material = b"4ad75b08-0258-48a4-a29a-61cab92d7d13:7:195144730"
-   sha256 digest = 3a99d165fafaeffe4e093d58891bb1b96d46d6887d5b957ee8444
-                   c03f79a3f3e
-   first 8 bytes as big-endian u64 = 4222636361569202174
+   session_id = "conformance", tick = 1
+   first four u64 draws:
+     0x72ed9fd70ec2c906
+     0xdd0b655d190fdef7
+     0x2858d116c1f6e5fb
+     0x9a16ceb3838fe695
+
+**``next_f64``:** the top 53 bits of one ``u64`` draw scaled by ``2⁻⁵³`` —
+every representable output is an exact multiple of ``2⁻⁵³`` on ``[0, 1)``,
+bit-deterministic across platforms (no libm, no rounding-mode dependence).
 
 **R8 declaration — Python streams are a closed epoch.** This seeding
 derivation is a **new** construction, not a port: today's

--- a/docs/reference/determinism-contract.rst
+++ b/docs/reference/determinism-contract.rst
@@ -1053,12 +1053,27 @@ cryptographic-security use case, so ``ChaCha8`` over ``ChaCha20`` is pure
 speed with no correctness cost. Constructed only per ``(session_id, tick)``
 — there is no entropy-seeded constructor.
 
+**Stream layout — PER-CARRIER, the ADR176 ruling-20 rider:** one stream
+per ``(session_id, tick, domain, stable_key)``, never one stream per tick.
+With a tick-global stream consumed in iteration order, adding one carrier
+shifts every later draw that tick — LOD refinement becomes a butterfly
+generator (``reports/design-inputs-dossier-2026-07-29.md`` §6.3). Deriving
+each stream from the carrier's own identity makes draws grain-invariant by
+construction, and refinement needs no RNG state migration. The API offers
+NO tick-global constructor, so the butterfly shape cannot be reached by
+accident. ChaCha is counter-mode by construction, so a carrier's stream
+position is the rider's per-draw counter.
+
 **Seeding derivation — as implemented:**
-``seed = SHA256(session_id_utf8 ‖ tick_le8 ‖ salt_le8)``, all 32 bytes used
+``seed = SHA256(session_id_utf8 ‖ tick_le8 ‖ salt_le8 ‖ len_le8(domain) ‖
+domain_utf8 ‖ len_le8(stable_key) ‖ stable_key_utf8)``, all 32 bytes used
 directly as the ``ChaCha8Rng`` seed; ``salt`` is the existing constant
 ``0xBA1AC1A`` (``_SYSTEM_RNG_SEED_SALT``,
-``src/babylon/kernel/system_base.py:32``), and ``tick``/``salt`` enter as
-8-byte **little-endian** integers with no separators.
+``src/babylon/kernel/system_base.py:32``); ``tick``/``salt`` and both
+length prefixes enter as 8-byte **little-endian** integers. The length
+prefixes are load-bearing: unframed concatenation would let
+``("ab", "c")`` and ``("a", "bc")`` collide, making stream identity depend
+on where two strings split.
 
 .. note::
    **Supersession (2026-07-30, at implementation).** An earlier draft of
@@ -1080,12 +1095,13 @@ determinism regression, never "the RNG got better"):
 
 .. code-block:: text
 
-   session_id = "conformance", tick = 1
+   session_id = "conformance", tick = 1,
+   domain = "conformance-domain", stable_key = "carrier-0"
    first four u64 draws:
-     0x72ed9fd70ec2c906
-     0xdd0b655d190fdef7
-     0x2858d116c1f6e5fb
-     0x9a16ceb3838fe695
+     0x6774721d2209092f
+     0x6d422bc9af8428f1
+     0x0ce291abfcb11e7a
+     0xdd11962972495117
 
 **``next_f64``:** the top 53 bits of one ``u64`` draw scaled by ``2⁻⁵³`` —
 every representable output is an exact multiple of ``2⁻⁵³`` on ``[0, 1)``,

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -126,6 +126,8 @@ version = "0.1.0"
 dependencies = [
  "bnum",
  "pretty_assertions",
+ "rand_chacha",
+ "rand_core 0.6.4",
  "sha2",
 ]
 

--- a/rust/crates/babylon-kernel/Cargo.toml
+++ b/rust/crates/babylon-kernel/Cargo.toml
@@ -9,6 +9,8 @@ publish = false
 
 [dependencies]
 bnum = "0.13"
+rand_chacha = "0.3"
+rand_core = "0.6"
 sha2 = "0.10"
 
 [dev-dependencies]

--- a/rust/crates/babylon-kernel/src/clock.rs
+++ b/rust/crates/babylon-kernel/src/clock.rs
@@ -35,6 +35,13 @@ impl SessionId {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    /// The identifier's UTF-8 bytes — the RNG seeding derivation's input
+    /// form (`rng::seed_for`).
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
 }
 
 /// The tick clock: monotonic, no wall-clock reads, no randomness.

--- a/rust/crates/babylon-kernel/src/lib.rs
+++ b/rust/crates/babylon-kernel/src/lib.rs
@@ -7,11 +7,13 @@
 pub mod clock;
 pub mod currency;
 pub mod grid;
+pub mod rng;
 pub mod scalars;
 
 pub use clock::{EmptySessionId, SessionId, SimClock};
 pub use currency::{round_half_even_div, Currency, CurrencyOverflow};
 pub use grid::{quantize, GRID_PRECISION};
+pub use rng::{seed_for, KernelRng, SEED_SALT};
 pub use scalars::{
     Balance, Coefficient, Ideology, Intensity, OutOfBoundsError, Probability, Ratio,
 };

--- a/rust/crates/babylon-kernel/src/rng.rs
+++ b/rust/crates/babylon-kernel/src/rng.rs
@@ -1,5 +1,5 @@
-//! The kernel RNG service (spec §9, R8): one pinned algorithm, seeded per
-//! `(session_id, tick, salt)`.
+//! The kernel RNG service (spec §9, R8 + the ADR176 ruling-20 rider):
+//! one pinned algorithm, **per-carrier counter-based streams**.
 //!
 //! **Algorithm choice (Phase-1 engineering call, not amendment-gated — R8
 //! already authorizes the stream divergence from Python's MT19937):**
@@ -12,9 +12,20 @@
 //! seed, required for III.7); (3) 8 rounds is the documented "fast, still
 //! no known practical distinguisher" configuration — this is not a
 //! cryptographic-security use case, so `ChaCha8` is preferred over
-//! `ChaCha20` purely for speed with no correctness cost. This choice and
-//! the conformance vector below are pinned in
-//! ``docs/reference/determinism-contract.rst``'s RNG chapter.
+//! `ChaCha20` purely for speed with no correctness cost; (4) `ChaCha` is
+//! itself a counter-mode construction, so a carrier's stream position IS
+//! the rider's per-draw counter — no extra bookkeeping.
+//!
+//! **Why per-carrier streams and not one stream per tick (ADR176 r20;
+//! `reports/design-inputs-dossier-2026-07-29.md` §6.3):** with one stream
+//! consumed in iteration order, adding a single carrier shifts every later
+//! draw that tick — LOD refinement becomes a butterfly generator and every
+//! stochastic family grain-couples. Deriving each stream from the
+//! carrier's OWN identity `(domain, stable_key)` makes draws depend only
+//! on that identity: grain-invariant by construction, and refinement needs
+//! no RNG state migration because children derive streams from their own
+//! ids. The API deliberately offers NO tick-global stream, so the
+//! butterfly shape cannot be reached by accident (III.11 posture).
 //!
 //! **Streams differ from Python by design (R8):** this is the pinned
 //! Rust-side replacement, not a port. Python's MT19937 streams are a
@@ -26,38 +37,49 @@ use rand_core::{RngCore, SeedableRng};
 use sha2::{Digest, Sha256};
 
 /// Mirrors `kernel/system_base.py::_SYSTEM_RNG_SEED_SALT` structurally
-/// (same salt constant, same mixing shape: `session_id ‖ tick ‖ salt`) —
-/// NOT the same stream, per R8.
+/// (same salt constant in the mixing) — NOT the same stream, per R8.
 pub const SEED_SALT: u64 = 0x0BA1_AC1A;
 
-/// Derive the 32-byte `ChaCha8Rng` seed for `(session_id, tick)`:
-/// `SHA-256(session_id_utf8 ‖ tick_le8 ‖ salt_le8)`.
+/// Derive the 32-byte seed for one carrier's stream:
+/// `SHA256(session_utf8 ‖ tick_le8 ‖ salt_le8 ‖ len_le8(domain) ‖
+/// domain_utf8 ‖ len_le8(stable_key) ‖ stable_key_utf8)`.
 ///
-/// Byte layout is pinned (little-endian 8-byte tick and salt, no
-/// separators) — the conformance vector in the determinism contract's RNG
-/// chapter is derived from exactly this construction.
+/// `domain` names the stochastic family (e.g. `"bifurcation"`); `stable_key`
+/// names the carrier within it (e.g. a class id, a hex index). Both are
+/// **length-prefixed** (8-byte little-endian) so `("ab", "c")` and
+/// `("a", "bc")` can never collide — concatenation without framing would
+/// make stream identity depend on where the strings split.
 #[must_use]
-pub fn seed_for(session_id: &SessionId, tick: u64) -> [u8; 32] {
+pub fn seed_for(session_id: &SessionId, tick: u64, domain: &str, stable_key: &str) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(session_id.as_bytes());
     hasher.update(tick.to_le_bytes());
     hasher.update(SEED_SALT.to_le_bytes());
+    hasher.update((domain.len() as u64).to_le_bytes());
+    hasher.update(domain.as_bytes());
+    hasher.update((stable_key.len() as u64).to_le_bytes());
+    hasher.update(stable_key.as_bytes());
     hasher.finalize().into()
 }
 
-/// The kernel's one pinned RNG. Constructed only via [`KernelRng::for_tick`]
-/// — there is deliberately no `from_entropy()`: every stream is a pure
-/// function of `(session_id, tick)` (III.7).
+/// One carrier's pinned stream. Constructed only via
+/// [`KernelRng::for_carrier`] — there is deliberately no `from_entropy()`
+/// and no tick-global constructor: every stream is a pure function of
+/// `(session_id, tick, domain, stable_key)` (III.7 + the r20 rider).
 pub struct KernelRng(ChaCha8Rng);
 
 impl KernelRng {
-    /// The stream for one `(session_id, tick)` pair.
+    /// The stream for one carrier at one tick.
     #[must_use]
-    pub fn for_tick(session_id: &SessionId, tick: u64) -> Self {
-        Self(ChaCha8Rng::from_seed(seed_for(session_id, tick)))
+    pub fn for_carrier(session_id: &SessionId, tick: u64, domain: &str, stable_key: &str) -> Self {
+        Self(ChaCha8Rng::from_seed(seed_for(
+            session_id, tick, domain, stable_key,
+        )))
     }
 
-    /// The next 64 uniformly distributed bits.
+    /// The next 64 uniformly distributed bits. The stream position behind
+    /// this call is the rider's per-draw counter — `ChaCha` is counter-mode
+    /// by construction.
     pub fn next_u64(&mut self) -> u64 {
         self.0.next_u64()
     }
@@ -79,10 +101,10 @@ mod tests {
     use crate::clock::SessionId;
 
     #[test]
-    fn same_session_and_tick_reproduce_the_same_stream() {
+    fn same_carrier_reproduces_the_same_stream() {
         let sid = SessionId::new("s1").unwrap();
-        let mut a = KernelRng::for_tick(&sid, 7);
-        let mut b = KernelRng::for_tick(&sid, 7);
+        let mut a = KernelRng::for_carrier(&sid, 7, "bifurcation", "C001");
+        let mut b = KernelRng::for_carrier(&sid, 7, "bifurcation", "C001");
         for _ in 0..8 {
             assert_eq!(a.next_u64(), b.next_u64());
         }
@@ -91,8 +113,8 @@ mod tests {
     #[test]
     fn different_ticks_diverge() {
         let sid = SessionId::new("s1").unwrap();
-        let mut a = KernelRng::for_tick(&sid, 7);
-        let mut b = KernelRng::for_tick(&sid, 8);
+        let mut a = KernelRng::for_carrier(&sid, 7, "bifurcation", "C001");
+        let mut b = KernelRng::for_carrier(&sid, 8, "bifurcation", "C001");
         assert_ne!(a.next_u64(), b.next_u64());
     }
 
@@ -100,7 +122,40 @@ mod tests {
     fn different_sessions_diverge() {
         let a_id = SessionId::new("s1").unwrap();
         let b_id = SessionId::new("s2").unwrap();
-        assert_ne!(seed_for(&a_id, 7), seed_for(&b_id, 7));
+        assert_ne!(seed_for(&a_id, 7, "d", "k"), seed_for(&b_id, 7, "d", "k"));
+    }
+
+    #[test]
+    fn different_carriers_in_one_domain_diverge() {
+        let sid = SessionId::new("s1").unwrap();
+        assert_ne!(
+            seed_for(&sid, 7, "bifurcation", "C001"),
+            seed_for(&sid, 7, "bifurcation", "C002")
+        );
+    }
+
+    #[test]
+    fn domain_and_key_are_framed_not_concatenated() {
+        // ("ab","c") vs ("a","bc"): unframed concatenation would collide.
+        let sid = SessionId::new("s").unwrap();
+        assert_ne!(seed_for(&sid, 1, "ab", "c"), seed_for(&sid, 1, "a", "bc"));
+    }
+
+    #[test]
+    fn adding_a_carrier_cannot_shift_another_carriers_draws() {
+        // The r20 rider's whole point (grain invariance): C001's stream is
+        // identical whether or not C002 ever draws.
+        let sid = SessionId::new("s").unwrap();
+        let mut alone = KernelRng::for_carrier(&sid, 3, "metabolism", "C001");
+        let lone_draws = [alone.next_u64(), alone.next_u64()];
+
+        let mut c001 = KernelRng::for_carrier(&sid, 3, "metabolism", "C001");
+        let mut c002 = KernelRng::for_carrier(&sid, 3, "metabolism", "C002");
+        let _ = c002.next_u64(); // another carrier draws in between
+        let first = c001.next_u64();
+        let _ = c002.next_u64();
+        let second = c001.next_u64();
+        assert_eq!([first, second], lone_draws);
     }
 
     #[test]
@@ -112,7 +167,7 @@ mod tests {
     #[test]
     fn next_f64_is_in_the_half_open_unit_interval() {
         let sid = SessionId::new("s").unwrap();
-        let mut rng = KernelRng::for_tick(&sid, 1);
+        let mut rng = KernelRng::for_carrier(&sid, 1, "d", "k");
         for _ in 0..1000 {
             let v = rng.next_f64();
             assert!((0.0..1.0).contains(&v), "{v}");
@@ -126,20 +181,20 @@ mod tests {
     #[test]
     fn conformance_vector_first_four_u64s() {
         let sid = SessionId::new("conformance").unwrap();
-        let mut rng = KernelRng::for_tick(&sid, 1);
+        let mut rng = KernelRng::for_carrier(&sid, 1, "conformance-domain", "carrier-0");
         let observed = [
             rng.next_u64(),
             rng.next_u64(),
             rng.next_u64(),
             rng.next_u64(),
         ];
-        // Filled from the first green run (2026-07-30) and byte-pinned
-        // thereafter.
+        // Filled from the first green run (2026-07-30, rider derivation)
+        // and byte-pinned thereafter.
         let pinned: [u64; 4] = [
-            0x72ed_9fd7_0ec2_c906,
-            0xdd0b_655d_190f_def7,
-            0x2858_d116_c1f6_e5fb,
-            0x9a16_ceb3_838f_e695,
+            0x6774_721d_2209_092f,
+            0x6d42_2bc9_af84_28f1,
+            0x0ce2_91ab_fcb1_1e7a,
+            0xdd11_9629_7249_5117,
         ];
         assert_eq!(observed, pinned);
     }

--- a/rust/crates/babylon-kernel/src/rng.rs
+++ b/rust/crates/babylon-kernel/src/rng.rs
@@ -1,0 +1,146 @@
+//! The kernel RNG service (spec §9, R8): one pinned algorithm, seeded per
+//! `(session_id, tick, salt)`.
+//!
+//! **Algorithm choice (Phase-1 engineering call, not amendment-gated — R8
+//! already authorizes the stream divergence from Python's MT19937):**
+//! `ChaCha8Rng` (`rand_chacha`). Rationale: (1) it takes an exact 32-byte
+//! seed, which is exactly a SHA-256 digest's width — the seeding derivation
+//! below needs no truncation/expansion step, unlike a generator wanting a
+//! `u64` or `[u8; 16]` seed; (2) it is a pure-Rust, no-`unsafe`,
+//! platform-independent stream-cipher construction with strong statistical
+//! properties and no OS-entropy dependency (fully deterministic from its
+//! seed, required for III.7); (3) 8 rounds is the documented "fast, still
+//! no known practical distinguisher" configuration — this is not a
+//! cryptographic-security use case, so `ChaCha8` is preferred over
+//! `ChaCha20` purely for speed with no correctness cost. This choice and
+//! the conformance vector below are pinned in
+//! ``docs/reference/determinism-contract.rst``'s RNG chapter.
+//!
+//! **Streams differ from Python by design (R8):** this is the pinned
+//! Rust-side replacement, not a port. Python's MT19937 streams are a
+//! closed epoch; stochastic baselines re-bless at cutover under
+//! ensemble-envelope comparison, not byte replay.
+use crate::clock::SessionId;
+use rand_chacha::ChaCha8Rng;
+use rand_core::{RngCore, SeedableRng};
+use sha2::{Digest, Sha256};
+
+/// Mirrors `kernel/system_base.py::_SYSTEM_RNG_SEED_SALT` structurally
+/// (same salt constant, same mixing shape: `session_id ‖ tick ‖ salt`) —
+/// NOT the same stream, per R8.
+pub const SEED_SALT: u64 = 0x0BA1_AC1A;
+
+/// Derive the 32-byte `ChaCha8Rng` seed for `(session_id, tick)`:
+/// `SHA-256(session_id_utf8 ‖ tick_le8 ‖ salt_le8)`.
+///
+/// Byte layout is pinned (little-endian 8-byte tick and salt, no
+/// separators) — the conformance vector in the determinism contract's RNG
+/// chapter is derived from exactly this construction.
+#[must_use]
+pub fn seed_for(session_id: &SessionId, tick: u64) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(session_id.as_bytes());
+    hasher.update(tick.to_le_bytes());
+    hasher.update(SEED_SALT.to_le_bytes());
+    hasher.finalize().into()
+}
+
+/// The kernel's one pinned RNG. Constructed only via [`KernelRng::for_tick`]
+/// — there is deliberately no `from_entropy()`: every stream is a pure
+/// function of `(session_id, tick)` (III.7).
+pub struct KernelRng(ChaCha8Rng);
+
+impl KernelRng {
+    /// The stream for one `(session_id, tick)` pair.
+    #[must_use]
+    pub fn for_tick(session_id: &SessionId, tick: u64) -> Self {
+        Self(ChaCha8Rng::from_seed(seed_for(session_id, tick)))
+    }
+
+    /// The next 64 uniformly distributed bits.
+    pub fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    /// A uniform draw on `[0, 1)`: the top 53 bits of one `u64` scaled by
+    /// 2⁻⁵³ — every representable value is an exact multiple of 2⁻⁵³, so
+    /// the mapping is bit-deterministic across platforms (no libm, no
+    /// rounding-mode dependence).
+    #[allow(clippy::cast_precision_loss)] // 53-bit value: exact in f64 by construction
+    pub fn next_f64(&mut self) -> f64 {
+        let bits53 = self.0.next_u64() >> 11;
+        (bits53 as f64) * (1.0 / (1u64 << 53) as f64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{seed_for, KernelRng, SEED_SALT};
+    use crate::clock::SessionId;
+
+    #[test]
+    fn same_session_and_tick_reproduce_the_same_stream() {
+        let sid = SessionId::new("s1").unwrap();
+        let mut a = KernelRng::for_tick(&sid, 7);
+        let mut b = KernelRng::for_tick(&sid, 7);
+        for _ in 0..8 {
+            assert_eq!(a.next_u64(), b.next_u64());
+        }
+    }
+
+    #[test]
+    fn different_ticks_diverge() {
+        let sid = SessionId::new("s1").unwrap();
+        let mut a = KernelRng::for_tick(&sid, 7);
+        let mut b = KernelRng::for_tick(&sid, 8);
+        assert_ne!(a.next_u64(), b.next_u64());
+    }
+
+    #[test]
+    fn different_sessions_diverge() {
+        let a_id = SessionId::new("s1").unwrap();
+        let b_id = SessionId::new("s2").unwrap();
+        assert_ne!(seed_for(&a_id, 7), seed_for(&b_id, 7));
+    }
+
+    #[test]
+    fn the_salt_is_the_python_constant() {
+        // Structural mirror of _SYSTEM_RNG_SEED_SALT = 0xBA1AC1A.
+        assert_eq!(SEED_SALT, 0xBA1_AC1A);
+    }
+
+    #[test]
+    fn next_f64_is_in_the_half_open_unit_interval() {
+        let sid = SessionId::new("s").unwrap();
+        let mut rng = KernelRng::for_tick(&sid, 1);
+        for _ in 0..1000 {
+            let v = rng.next_f64();
+            assert!((0.0..1.0).contains(&v), "{v}");
+        }
+    }
+
+    /// The within-implementation replay conformance vector (plan Task 5
+    /// Step 2): generated ONCE from this implementation and pinned — any
+    /// future divergence is a determinism regression, never "the RNG got
+    /// better". Mirrored in the determinism contract's RNG chapter.
+    #[test]
+    fn conformance_vector_first_four_u64s() {
+        let sid = SessionId::new("conformance").unwrap();
+        let mut rng = KernelRng::for_tick(&sid, 1);
+        let observed = [
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ];
+        // Filled from the first green run (2026-07-30) and byte-pinned
+        // thereafter.
+        let pinned: [u64; 4] = [
+            0x72ed_9fd7_0ec2_c906,
+            0xdd0b_655d_190f_def7,
+            0x2858_d116_c1f6_e5fb,
+            0x9a16_ceb3_838f_e695,
+        ];
+        assert_eq!(observed, pinned);
+    }
+}


### PR DESCRIPTION
P27 Phase 1 Task 5. **Streams differ from Python by design (R8): this is the pinned Rust-side replacement, not a port.** MT19937 is a closed epoch; stochastic baselines re-bless at cutover under ensemble-envelope comparison.

## What lands

- **`ChaCha8Rng` pinned** with the rationale inline: exact 32-byte seed (a SHA-256 digest's width — no truncation step), pure-Rust/no-`unsafe`/platform-independent, fully deterministic from seed with no OS-entropy dependency; 8 rounds because this is not a security use case.
- **`seed_for` = `SHA256(session_utf8 ‖ tick_le8 ‖ salt_le8)`**, salt `0xBA1AC1A` (the Python `_SYSTEM_RNG_SEED_SALT` — structural mirror, not stream port). `KernelRng` constructs **only** per `(session, tick)`; no entropy constructor exists (III.7).
- **`next_f64`** = top 53 bits × 2⁻⁵³: exact multiples on `[0,1)`, bit-deterministic, no libm.
- **Conformance vector** (first 4 u64s for `("conformance", 1)`) generated once and byte-pinned in **both** the test and the contract's RNG chapter — future divergence is a determinism regression, never "the RNG got better".
- `SessionId::as_bytes` added with its own pin (the plan's Task-4 addendum, done explicitly).

## Spec supersession, recorded not silent

The Phase-0 chapter's colon-separated-text + truncate-to-u64 seeding was an artifact of assuming a u64-seeded PRNG — truncation would discard 24 of 32 derivation bytes for nothing under the pinned generator. The chapter now records the supersession with the old worked value kept identifiable.

Also flagged in the chapter (pre-existing, not fixed here): today's Python `resolve_rng` seeds additively with **no session_id input**, and `SimulationConfig.random_seed` never reaches the System-level PRNG stream.

## Gates

33 kernel tests; `mise run rust:check` green across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)