### PR TITLE
feat(bsl): typechecker slice — the §3.4 aggregation law + exemption ledger (P27 Phase 1 Task 10)

### DIFF
--- a/rust/crates/babylon-bsl/src/exemptions.rs
+++ b/rust/crates/babylon-bsl/src/exemptions.rs
@@ -1,0 +1,41 @@
+//! Exemptions from the intensivity aggregation law (§3.4), mirroring the
+//! governance shape of Python's `SentinelExemption`
+//! (`babylon.sentinels.exemptions`): every row needs a reason, an owner,
+//! and a date, and adding one takes the same sign-off as a sentinel
+//! exemption. An exemption suppresses `E-TYPE-041/042/043` **for the named
+//! field only** and is itself content, inside `rules_hash`.
+//!
+//! This ledger starts EMPTY in Phase 1 — no BSL content exists yet to need
+//! an exemption. Phase 2's transcription work is expected to populate it,
+//! never this crate's own tasks.
+
+/// One declared exemption row.
+#[derive(Debug, Clone)]
+pub struct IntensiveAggregationExemption {
+    /// The exempted field, by its BSL name (kebab-case).
+    pub field_name: &'static str,
+    /// Why the aggregation law does not apply — mandatory, never empty.
+    pub reason: &'static str,
+    /// Who signed the row off.
+    pub owner: &'static str,
+    /// Sign-off date, ISO 8601.
+    pub date: &'static str,
+}
+
+/// The declared ledger (spec §5). Empty until Phase 2 content needs a row.
+pub const EXTENSIVE_INTENSIVE_EXEMPTIONS: &[IntensiveAggregationExemption] = &[];
+
+#[cfg(test)]
+mod tests {
+    use super::EXTENSIVE_INTENSIVE_EXEMPTIONS;
+
+    #[test]
+    fn every_exemption_row_carries_full_governance_metadata() {
+        for exemption in EXTENSIVE_INTENSIVE_EXEMPTIONS {
+            assert!(!exemption.field_name.is_empty());
+            assert!(!exemption.reason.is_empty());
+            assert!(!exemption.owner.is_empty());
+            assert!(!exemption.date.is_empty());
+        }
+    }
+}

--- a/rust/crates/babylon-bsl/src/lib.rs
+++ b/rust/crates/babylon-bsl/src/lib.rs
@@ -8,3 +8,11 @@ pub mod reader;
 pub use reader::{
     read, read_all, Atom, LexCode, ReadError, ReadErrorKind, SExpr, ScaledKind, ScaledLit,
 };
+
+pub mod exemptions;
+pub mod typecheck;
+pub mod types;
+
+pub use exemptions::{IntensiveAggregationExemption, EXTENSIVE_INTENSIVE_EXEMPTIONS};
+pub use typecheck::{typecheck_aggregation, TypeCode, TypeEnv, TypeError};
+pub use types::{BslType, FieldDecl, FieldKind};

--- a/rust/crates/babylon-bsl/src/typecheck.rs
+++ b/rust/crates/babylon-bsl/src/typecheck.rs
@@ -1,0 +1,341 @@
+//! The BSL typechecker's first slice: the §3.4 aggregation law
+//! (`bsl-language.rst` — "the extensive/intensive lexicon becomes real
+//! types"). The load-bearing rule the plan calls out: unweighted
+//! aggregation of an intensive-kinded field is a `TypeError` at load, not
+//! a runtime surprise — the intensive-aggregation-variance-error class,
+//! caught by the compiler.
+//!
+//! **Deviation from the Phase 1 plan's sketch, recorded:** the sketch
+//! rejected every unweighted op except `count` on an intensive field. The
+//! normative law is §3.4's five-row PER-OPERATOR table — `min`/`max` are
+//! kind-neutral and always legal, and `sum` of an intensive field is
+//! `E-TYPE-041` even WITH a weight (summing an intensive quantity is
+//! meaningless; no weight rescues it). This module implements the table.
+//!
+//! Scope (deliberately narrow, per the plan): the fold BODY here is a bare
+//! field reference, so its kind is always a declared `FieldKind`.
+//! Kind-NEUTRAL bodies (literals, `:const` bindings, arithmetic over them)
+//! arrive with the expression typechecker in later tasks, as does
+//! `E-TYPE-040` kind mixing.
+
+use crate::exemptions::IntensiveAggregationExemption;
+use crate::reader::{Atom, SExpr};
+use crate::types::{BslType, FieldDecl, FieldKind};
+use std::collections::HashMap;
+
+/// The §3.4 aggregation-law error codes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeCode {
+    /// `E-TYPE-041` — summing an intensive quantity is meaningless.
+    SumOfIntensive,
+    /// `E-TYPE-042` — unweighted `mean` of an intensive field.
+    UnweightedMeanOfIntensive,
+    /// `E-TYPE-043` — a `mean` weight that is not extensive-kinded.
+    NonExtensiveWeight,
+}
+
+impl TypeCode {
+    /// The spec's code string, e.g. `"E-TYPE-042"`.
+    #[must_use]
+    pub fn spec_code(self) -> &'static str {
+        match self {
+            Self::SumOfIntensive => "E-TYPE-041",
+            Self::UnweightedMeanOfIntensive => "E-TYPE-042",
+            Self::NonExtensiveWeight => "E-TYPE-043",
+        }
+    }
+}
+
+/// A typechecking failure: spec-coded where the spec codes it, structural
+/// otherwise (`code: None`) — no code is invented.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypeError {
+    /// The spec code, when §3.4 assigns one.
+    pub code: Option<TypeCode>,
+    /// Human-readable detail.
+    pub message: String,
+}
+
+/// The typechecker's environment: declared fields and the exemption ledger.
+#[derive(Debug, Clone)]
+pub struct TypeEnv {
+    /// Declared fields by BSL name (kebab-case symbols or qnames).
+    pub fields: HashMap<String, FieldDecl>,
+    /// The `EXTENSIVE_INTENSIVE_EXEMPTIONS` ledger in force — an exemption
+    /// suppresses `E-TYPE-041/042/043` for its named field only (§3.4).
+    pub exemptions: &'static [IntensiveAggregationExemption],
+}
+
+/// Typecheck one aggregation form: `(op field)` or
+/// `(mean field :weight weight-field)`, with `op` one of
+/// `sum | mean | min | max | count`, applying §3.4's per-operator table.
+///
+/// # Errors
+/// [`TypeError`] with the spec code for a §3.4 violation, or with
+/// `code: None` for a malformed form or an unknown field.
+pub fn typecheck_aggregation(expr: &SExpr, env: &TypeEnv) -> Result<BslType, TypeError> {
+    let (op, field_name, weight_name) = destructure_aggregation(expr)?;
+    let field = resolve_field(env, field_name)?;
+    let weight = match weight_name {
+        Some(name) => Some(resolve_field(env, name)?),
+        None => None,
+    };
+    let exempted = env.exemptions.iter().any(|e| e.field_name == field_name);
+    match op {
+        "sum" => {
+            if field.kind == FieldKind::Intensive && !exempted {
+                return Err(TypeError {
+                    code: Some(TypeCode::SumOfIntensive),
+                    message: format!(
+                        "sum of intensive field '{field_name}': summing an intensive \
+                         quantity is meaningless — no weight rescues it (§3.4)"
+                    ),
+                });
+            }
+            Ok(field.ty.clone())
+        }
+        "mean" => {
+            if field.kind == FieldKind::Intensive && !exempted {
+                match weight {
+                    None => {
+                        return Err(TypeError {
+                            code: Some(TypeCode::UnweightedMeanOfIntensive),
+                            message: format!(
+                                "unweighted mean of intensive field '{field_name}': add an \
+                                 explicit extensive :weight term (§3.4)"
+                            ),
+                        })
+                    }
+                    Some(w) if w.kind != FieldKind::Extensive => {
+                        return Err(TypeError {
+                            code: Some(TypeCode::NonExtensiveWeight),
+                            message: format!(
+                                "the :weight of a mean over intensive field '{field_name}' \
+                                 must be extensive-kinded (§3.4)"
+                            ),
+                        })
+                    }
+                    Some(_) => {}
+                }
+            }
+            Ok(field.ty.clone())
+        }
+        // §3.4 row 5: min/max are kind-neutral operations, legal on any kind.
+        "min" | "max" => Ok(field.ty.clone()),
+        // §3.4 row 6: count is always legal; result Int, extensive.
+        "count" => Ok(BslType::Int),
+        other => Err(TypeError {
+            code: None,
+            message: format!("unknown aggregation operator '{other}'"),
+        }),
+    }
+}
+
+/// Destructure `(op field)` / `(op field :weight weight-field)` into its
+/// three named parts, rejecting every other shape loudly.
+fn destructure_aggregation(expr: &SExpr) -> Result<(&str, &str, Option<&str>), TypeError> {
+    let malformed = || TypeError {
+        code: None,
+        message: "aggregation form must be (op field) or (op field :weight weight-field)".into(),
+    };
+    let SExpr::List(items) = expr else {
+        return Err(malformed());
+    };
+    let [op_expr, field_expr, rest @ ..] = items.as_slice() else {
+        return Err(malformed());
+    };
+    let SExpr::Atom(Atom::Symbol(op)) = op_expr else {
+        return Err(malformed());
+    };
+    let field_name = field_ref_name(field_expr).ok_or_else(malformed)?;
+    let weight_name = match rest {
+        [] => None,
+        [SExpr::Atom(Atom::Keyword(kw)), weight_expr] if kw == "weight" => {
+            Some(field_ref_name(weight_expr).ok_or_else(malformed)?)
+        }
+        _ => return Err(malformed()),
+    };
+    Ok((op, field_name, weight_name))
+}
+
+/// A field reference is a `symbol` or a `qname` (§1.4's own example:
+/// `social-class/wealth`).
+fn field_ref_name(expr: &SExpr) -> Option<&str> {
+    match expr {
+        SExpr::Atom(Atom::Symbol(name) | Atom::QName(name)) => Some(name),
+        _ => None,
+    }
+}
+
+fn resolve_field<'e>(env: &'e TypeEnv, name: &str) -> Result<&'e FieldDecl, TypeError> {
+    env.fields.get(name).ok_or_else(|| TypeError {
+        code: None,
+        message: format!("unknown field: '{name}'"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{typecheck_aggregation, TypeCode, TypeEnv};
+    use crate::exemptions::IntensiveAggregationExemption;
+    use crate::reader::read;
+    use crate::types::{BslType, FieldDecl, FieldKind};
+    use std::collections::HashMap;
+
+    fn env() -> TypeEnv {
+        let mut fields = HashMap::new();
+        fields.insert(
+            "wealth-share".to_string(),
+            FieldDecl {
+                ty: BslType::Coefficient,
+                kind: FieldKind::Intensive,
+            },
+        );
+        fields.insert(
+            "consciousness".to_string(),
+            FieldDecl {
+                ty: BslType::Intensity,
+                kind: FieldKind::Intensive,
+            },
+        );
+        fields.insert(
+            "population".to_string(),
+            FieldDecl {
+                ty: BslType::Int,
+                kind: FieldKind::Extensive,
+            },
+        );
+        fields.insert(
+            "wealth".to_string(),
+            FieldDecl {
+                ty: BslType::Currency,
+                kind: FieldKind::Extensive,
+            },
+        );
+        TypeEnv {
+            fields,
+            exemptions: &[],
+        }
+    }
+
+    fn check(source: &str, env: &TypeEnv) -> Result<BslType, super::TypeError> {
+        let (expr, _) = read(source).expect("test source should parse");
+        typecheck_aggregation(&expr, env)
+    }
+
+    fn code_of(source: &str, env: &TypeEnv) -> Option<TypeCode> {
+        check(source, env).expect_err("should be a type error").code
+    }
+
+    // ---- the five-row table (§3.4) ----
+
+    #[test]
+    fn unweighted_mean_of_an_intensive_field_is_e_type_042() {
+        // The recorded variance error, caught at load.
+        assert_eq!(
+            code_of("(mean wealth-share)", &env()),
+            Some(TypeCode::UnweightedMeanOfIntensive)
+        );
+    }
+
+    #[test]
+    fn mean_of_an_intensive_field_with_an_extensive_weight_is_legal() {
+        assert_eq!(
+            check("(mean wealth-share :weight population)", &env()),
+            Ok(BslType::Coefficient)
+        );
+    }
+
+    #[test]
+    fn a_weight_that_is_not_extensive_is_e_type_043() {
+        // consciousness is intensive — weighting by it is the same error
+        // one level up.
+        assert_eq!(
+            code_of("(mean wealth-share :weight consciousness)", &env()),
+            Some(TypeCode::NonExtensiveWeight)
+        );
+    }
+
+    #[test]
+    fn sum_of_an_intensive_field_is_e_type_041_even_with_a_weight() {
+        // §3.4: summing an intensive quantity is meaningless — no weight
+        // rescues it (deviation from the plan sketch, recorded above).
+        assert_eq!(
+            code_of("(sum wealth-share)", &env()),
+            Some(TypeCode::SumOfIntensive)
+        );
+        assert_eq!(
+            code_of("(sum wealth-share :weight population)", &env()),
+            Some(TypeCode::SumOfIntensive)
+        );
+    }
+
+    #[test]
+    fn sum_of_an_extensive_field_is_legal() {
+        assert_eq!(check("(sum wealth)", &env()), Ok(BslType::Currency));
+    }
+
+    #[test]
+    fn unweighted_mean_of_an_extensive_field_is_legal() {
+        assert_eq!(check("(mean wealth)", &env()), Ok(BslType::Currency));
+    }
+
+    #[test]
+    fn min_and_max_are_kind_neutral_and_always_legal() {
+        // The plan's sketch would have wrongly rejected these (§3.4 row 5).
+        assert_eq!(
+            check("(min wealth-share)", &env()),
+            Ok(BslType::Coefficient)
+        );
+        assert_eq!(check("(max consciousness)", &env()), Ok(BslType::Intensity));
+    }
+
+    #[test]
+    fn count_is_always_legal_and_returns_int() {
+        assert_eq!(check("(count wealth-share)", &env()), Ok(BslType::Int));
+    }
+
+    // ---- exemptions (§3.4: named-field suppression) ----
+
+    const TEST_EXEMPTION: &[IntensiveAggregationExemption] = &[IntensiveAggregationExemption {
+        field_name: "wealth-share",
+        reason: "test-only: verifies the suppression path",
+        owner: "test-suite",
+        date: "2026-07-30",
+    }];
+
+    #[test]
+    fn an_exemption_suppresses_the_law_for_its_named_field_only() {
+        let mut exempted = env();
+        exempted.exemptions = TEST_EXEMPTION;
+        assert!(check("(mean wealth-share)", &exempted).is_ok());
+        assert!(check("(sum wealth-share)", &exempted).is_ok());
+        // A different intensive field still rejects.
+        assert_eq!(
+            code_of("(mean consciousness)", &exempted),
+            Some(TypeCode::UnweightedMeanOfIntensive)
+        );
+    }
+
+    // ---- structural errors (no spec code) ----
+
+    #[test]
+    fn an_unknown_field_is_a_loud_uncoded_error() {
+        let err = check("(sum imperial-rent)", &env()).unwrap_err();
+        assert_eq!(err.code, None);
+        assert!(err.message.contains("imperial-rent"));
+    }
+
+    #[test]
+    fn an_unknown_operator_is_a_loud_uncoded_error() {
+        let err = check("(median wealth)", &env()).unwrap_err();
+        assert_eq!(err.code, None);
+    }
+
+    #[test]
+    fn a_malformed_form_is_a_loud_uncoded_error() {
+        assert!(check("wealth", &env()).is_err());
+        assert!(check("(mean)", &env()).is_err());
+        assert!(check("(mean wealth-share :weight)", &env()).is_err());
+    }
+}

--- a/rust/crates/babylon-bsl/src/types.rs
+++ b/rust/crates/babylon-bsl/src/types.rs
@@ -1,0 +1,50 @@
+//! The BSL type universe (spec §5 Types, `bsl-language.rst` §3): kernel
+//! scalars, closed enums, booleans, `Int`, and typed node/edge-set
+//! references. Intensivity is a per-field DECLARATION (`:kind
+//! intensive|extensive` on `deffield` forms, §3.4), not a property of the
+//! scalar type — `wealth` (Currency) is extensive while `consciousness`
+//! (Intensity) is intensive, and no type makes that decidable. `FieldKind`
+//! therefore travels alongside a field's `BslType`, and the typechecker
+//! (not the type) enforces the aggregation law.
+
+/// A BSL static type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BslType {
+    /// The `[0, 1]` probability scalar.
+    Probability,
+    /// The `[0, 1]` intensity scalar.
+    Intensity,
+    /// The `[0, 1]` coefficient scalar.
+    Coefficient,
+    /// Fixed-point i128 micro-unit currency.
+    Currency,
+    /// `int-lit`'s static type (§1.5); also `count`'s result type (§3.4).
+    Int,
+    /// `#t` / `#f`.
+    Bool,
+    /// A closed enum, by its registered type name (e.g. `"DoctrineTag"`).
+    Enum(&'static str),
+    /// A typed node-set reference, by `NodeType` name.
+    NodeSet(&'static str),
+    /// A typed edge-set reference, by `EdgeType` name.
+    EdgeSet(&'static str),
+}
+
+/// A field's declared intensivity kind (§3.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldKind {
+    /// Averages meaningfully only under an extensive weight.
+    Intensive,
+    /// Sums meaningfully over a population or region.
+    Extensive,
+}
+
+/// A model field's declared type + kind — the typechecker's environment
+/// entry for anything a fold can read.
+#[derive(Debug, Clone)]
+pub struct FieldDecl {
+    /// The field's scalar type.
+    pub ty: BslType,
+    /// The field's declared intensivity kind.
+    pub kind: FieldKind,
+}


### PR DESCRIPTION
## Summary

P27 Phase 1 Task 10, rebased onto dev after #425's merge. The intensive-aggregation-variance-error class, caught at load: `types.rs` (`BslType` incl. `Int`, `FieldKind`, `FieldDecl` — intensivity is a per-field DECLARATION, not a scalar-type property), `typecheck.rs` (`typecheck_aggregation`), `exemptions.rs` (`EXTENSIVE_INTENSIVE_EXEMPTIONS`, empty until Phase 2 content needs a row, governance metadata enforced by test).

**Deviation from the plan sketch, recorded in the module doc:** the sketch rejected every unweighted op except `count` on an intensive field. The normative law is `bsl-language.rst` §3.4's five-row PER-OPERATOR table, implemented as written:

- `sum` of intensive = **E-TYPE-041** even WITH a weight — nothing rescues it
- unweighted `mean` of intensive = **E-TYPE-042**; a non-extensive weight = **E-TYPE-043**
- `min`/`max` are kind-neutral and always legal (the sketch would have wrongly rejected them)
- `count` is always legal, result `Int`
- an exemption row suppresses 041/042/043 for its NAMED field only

`TypeError` carries the spec code where §3.4 assigns one and `code: None` for structural/unknown-field errors — no code invented.

## Gates

- 12 new tests, red phase first (all 12 failing on the stub) → 49 crate tests green
- `mise run rust:check` green (fmt, clippy pedantic `-D warnings`, test, doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)