### PR TITLE
feat(bsl): typed structural verb algebra + modding anchors (P27 Phase 1 Task 16)

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -685,6 +685,16 @@ names its member nodes. The grammar's ``<expr>+`` makes a **zero-member
 hyperedge unexpressible**; the upper end is the declared ``:max-members``
 ceiling of §3.7, checked statically.
 
+**[draft ruling — Phase 1 review]** *Id operands are effect-list-scoped
+names* (implementation-discovered, 2026-07-30, Phase 1 Task 16). The id
+operand above is written as ``<expr>``, but no expression form yields a
+*fresh* identity and §2.5 gives rules no way to declare one. The executor
+therefore reads it as a **symbol introducing an effect-list-scoped name**
+for the minted object: later effect items in the same list may reference it
+(roster replacement needs exactly this), the substrate mints the actual
+identity, and the no-shadowing discipline of ``E-PARSE-022`` extends to
+these names. A non-symbol id operand is a loud error pending the review.
+
 **[draft ruling — Phase 1 review]** *Two verbs, not an overloaded* ``add-edge``.
 Membership is minted by its own typed verb rather than by an ``add-edge``
 variant carrying a member set. Three reasons, each following the rest of this

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -108,6 +108,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 name = "babylon-bsl"
 version = "0.1.0"
 dependencies = [
+ "babylon-graph",
  "babylon-kernel",
  "pretty_assertions",
  "sha2",

--- a/rust/crates/babylon-bsl/Cargo.toml
+++ b/rust/crates/babylon-bsl/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
+babylon-graph = { path = "../babylon-graph" }
 babylon-kernel = { path = "../babylon-kernel" }
 
 [dev-dependencies]

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -63,6 +63,13 @@ pub enum Value {
         /// The member identifier.
         member: String,
     },
+    /// `NodeRef` (§3.1) — produced by `self`, `add-node`, and node-query
+    /// elements. No arithmetic, no ordering; refs are identities.
+    NodeRef(babylon_graph::substrate::NodeId),
+    /// `HyperedgeRef` (§3.1) — produced by `add-hyperedge` and hyperedge-
+    /// query elements. Does NOT carry its `HyperedgeType` statically, which
+    /// is why §2.6's hyperedge queries take the type as an operand.
+    HyperedgeRef(babylon_graph::substrate::HyperedgeId),
 }
 
 /// The spec's evaluation error codes (§4.6 / §3.2), one variant per code
@@ -80,6 +87,14 @@ pub enum EvalCode {
     CoefficientOutOfRange,
     /// `E-EVAL-014` — a binary64 operation producing a non-finite result.
     NonFinite,
+    /// `E-EVAL-020` — a store whose resulting value falls outside the
+    /// target field's declared range (§3.3: the range check happens once,
+    /// at the store boundary — a loud failure, never a clamp).
+    StoreRangeViolation,
+    /// `E-EVAL-031` — the §2.8 existence discipline: removing what does
+    /// not exist, adding what exists, an unknown or duplicated hyperedge
+    /// member. Absence is never treated as success.
+    ExistenceDiscipline,
     /// `E-EVAL-040` — the fuel meter reached or passed zero.
     FuelExhausted,
 }
@@ -94,6 +109,8 @@ impl EvalCode {
             Self::DivisionByZero => "E-EVAL-012",
             Self::CoefficientOutOfRange => "E-EVAL-013",
             Self::NonFinite => "E-EVAL-014",
+            Self::StoreRangeViolation => "E-EVAL-020",
+            Self::ExistenceDiscipline => "E-EVAL-031",
             Self::FuelExhausted => "E-EVAL-040",
         }
     }
@@ -179,8 +196,10 @@ pub fn evaluate(
 }
 
 /// §4.5: subtract `amount`, erroring when the meter would reach or pass
-/// zero — it stays strictly positive.
-fn charge(fuel: &mut u64, amount: u64) -> Result<(), EvalError> {
+/// zero — it stays strictly positive. `pub(crate)` so the effect executor
+/// (`structural_verbs`, Task 16) charges through the SAME meter — one §4.5
+/// accounting, not two.
+pub(crate) fn charge(fuel: &mut u64, amount: u64) -> Result<(), EvalError> {
     if amount >= *fuel {
         return Err(EvalError::coded(
             EvalCode::FuelExhausted,

--- a/rust/crates/babylon-bsl/src/lib.rs
+++ b/rust/crates/babylon-bsl/src/lib.rs
@@ -12,7 +12,9 @@ pub mod exemptions;
 pub mod fuel;
 pub mod intrinsic_host;
 pub mod material_basis;
+pub mod mod_anchors;
 pub mod reader;
+pub mod structural_verbs;
 pub mod typecheck;
 pub mod types;
 
@@ -28,8 +30,10 @@ pub use exemptions::{IntensiveAggregationExemption, EXTENSIVE_INTENSIVE_EXEMPTIO
 pub use fuel::{CardinalityCeilings, IntrinsicCosts};
 pub use intrinsic_host::{EmptyIntrinsicHost, IntrinsicHost};
 pub use material_basis::{check_rule_surface, SurfaceError, MAX_FUEL};
+pub use mod_anchors::{check_anchor, AnchorDecl, AnchorError, AnchorPosition};
 pub use reader::{
     read, read_all, Atom, LexCode, ReadError, ReadErrorKind, SExpr, ScaledKind, ScaledLit,
 };
+pub use structural_verbs::{CollectingSink, EffectExecutor, EventSink};
 pub use typecheck::{typecheck_aggregation, TypeCode, TypeEnv, TypeError};
 pub use types::{BslType, FieldDecl, FieldKind};

--- a/rust/crates/babylon-bsl/src/mod_anchors.rs
+++ b/rust/crates/babylon-bsl/src/mod_anchors.rs
@@ -1,0 +1,233 @@
+//! Modding ordering anchors (`bsl-language.rst` §2.3): a rule declares
+//! `(anchor :after <system>)` / `(anchor :before <system>)`, or omits the
+//! anchor and belongs to the system named by its rule id's first segment —
+//! a rule can never land "nowhere", and a raw position float is not
+//! expressible (§2.2 `:after`/`:before`).
+//!
+//! Scope (Phase 1 Task 16, per the plan): this module validates the
+//! DECLARATION — shape, and the E-LOAD-002 no-system case. Resolving
+//! anchors into a total order belongs to `babylon-engine`'s anchor-based
+//! registry (Phase 3), and the Material Base interleave check
+//! (`E-LOAD-003`) belongs there with it, because the partition boundaries
+//! are engine registry data this crate does not hold — deferred with a
+//! name, not silently.
+
+use crate::reader::{Atom, SExpr};
+use std::collections::HashSet;
+
+/// Which side of the named system the rule lands on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnchorPosition {
+    /// `:before <system>`.
+    Before,
+    /// `:after <system>`.
+    After,
+}
+
+/// A validated anchor declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnchorDecl {
+    /// Before or after.
+    pub position: AnchorPosition,
+    /// The registered system the anchor names.
+    pub system: String,
+}
+
+/// An anchor rejection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnchorError {
+    /// `E-LOAD-002` — a rule with no `<anchor>` whose first id segment
+    /// names no registered system: mods cannot land a rule "nowhere".
+    NoSystemForRule {
+        /// The rule id whose first segment resolved nothing.
+        rule_id: String,
+    },
+    /// `E-PARSE-013` — an anchor keyword outside `:after`/`:before`.
+    UnknownKeyword {
+        /// The offending keyword (without colon).
+        keyword: String,
+    },
+    /// A shape off the §2.3 `<anchor>` production.
+    Malformed {
+        /// What was expected, and what was found.
+        message: String,
+    },
+}
+
+impl AnchorError {
+    /// The spec's error code, where the reference names one.
+    #[must_use]
+    pub fn spec_code(&self) -> Option<&'static str> {
+        match self {
+            Self::NoSystemForRule { .. } => Some("E-LOAD-002"),
+            Self::UnknownKeyword { .. } => Some("E-PARSE-013"),
+            Self::Malformed { .. } => None,
+        }
+    }
+}
+
+impl std::fmt::Display for AnchorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoSystemForRule { rule_id } => write!(
+                f,
+                "E-LOAD-002: rule {rule_id} carries no anchor and its first \
+                 id segment names no registered system — a rule cannot land \
+                 nowhere (§2.3)"
+            ),
+            Self::UnknownKeyword { keyword } => write!(
+                f,
+                "E-PARSE-013: anchor keyword :{keyword} — the set is \
+                 :after | :before (§2.3)"
+            ),
+            Self::Malformed { message } => write!(f, "malformed anchor: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for AnchorError {}
+
+fn malformed(message: impl Into<String>) -> AnchorError {
+    AnchorError::Malformed {
+        message: message.into(),
+    }
+}
+
+/// Validate a rule's anchor situation against the registered system set:
+/// returns the declared anchor if present and well-shaped, or `None` for
+/// the anchor-default case (first id segment names a registered system).
+///
+/// # Errors
+///
+/// [`AnchorError::NoSystemForRule`] (`E-LOAD-002`) when neither an anchor
+/// nor a system-named id segment places the rule;
+/// [`AnchorError::UnknownKeyword`] / [`AnchorError::Malformed`] for shapes
+/// off the §2.3 production.
+pub fn check_anchor<S: std::hash::BuildHasher>(
+    rule: &SExpr,
+    registered_systems: &HashSet<String, S>,
+) -> Result<Option<AnchorDecl>, AnchorError> {
+    let SExpr::List(items) = rule else {
+        return Err(malformed(format!(
+            "expected a (rule …) form, found {rule:?}"
+        )));
+    };
+    let anchor_form = items.iter().find_map(|child| match child {
+        SExpr::List(inner)
+            if matches!(inner.first(), Some(SExpr::Atom(Atom::Symbol(h))) if h == "anchor") =>
+        {
+            Some(inner.as_slice())
+        }
+        _ => None,
+    });
+    if let Some(anchor_items) = anchor_form {
+        let [_, SExpr::Atom(Atom::Keyword(kw)), SExpr::Atom(Atom::Symbol(system))] = anchor_items
+        else {
+            return Err(malformed(format!(
+                "(anchor (:after | :before) <symbol>) — unrecognized shape {anchor_items:?}"
+            )));
+        };
+        let position = match kw.as_str() {
+            "after" => AnchorPosition::After,
+            "before" => AnchorPosition::Before,
+            other => {
+                return Err(AnchorError::UnknownKeyword {
+                    keyword: other.to_owned(),
+                })
+            }
+        };
+        return Ok(Some(AnchorDecl {
+            position,
+            system: system.clone(),
+        }));
+    }
+    // Anchor default (§2.3 draft ruling): the rule belongs to the system
+    // named by its id's first segment.
+    let rule_id = match items.get(1) {
+        Some(SExpr::Atom(Atom::QName(q))) => q.clone(),
+        other => {
+            return Err(malformed(format!(
+                "rule id must be a qname, found {other:?}"
+            )))
+        }
+    };
+    let first_segment = rule_id.split('/').next().unwrap_or_default();
+    if registered_systems.contains(first_segment) {
+        Ok(None)
+    } else {
+        Err(AnchorError::NoSystemForRule { rule_id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reader::read;
+
+    fn systems() -> HashSet<String> {
+        HashSet::from(["survival".to_owned(), "consciousness".to_owned()])
+    }
+
+    fn rule(source: &str) -> SExpr {
+        read(source).expect("test rule must parse").0
+    }
+
+    #[test]
+    fn a_declared_anchor_parses_both_positions() {
+        for (kw, position) in [
+            ("after", AnchorPosition::After),
+            ("before", AnchorPosition::Before),
+        ] {
+            let r = rule(&format!(
+                "(rule mods/extra :material-basis \"wage relation\" :fuel 8 \
+                 (anchor :{kw} survival) (bindings) \
+                 (effects (update-node self social-class/agitation (add 0.05i))))"
+            ));
+            assert_eq!(
+                check_anchor(&r, &systems()),
+                Ok(Some(AnchorDecl {
+                    position,
+                    system: "survival".to_owned(),
+                }))
+            );
+        }
+    }
+
+    #[test]
+    fn the_anchor_default_places_a_system_named_rule() {
+        let r = rule(
+            "(rule survival/hunger :material-basis \"wage relation\" :fuel 8 \
+             (bindings) \
+             (effects (update-node self social-class/agitation (add 0.05i))))",
+        );
+        assert_eq!(check_anchor(&r, &systems()), Ok(None));
+    }
+
+    #[test]
+    fn a_rule_landing_nowhere_is_e_load_002() {
+        let r = rule(
+            "(rule nowhere/hunger :material-basis \"wage relation\" :fuel 8 \
+             (bindings) \
+             (effects (update-node self social-class/agitation (add 0.05i))))",
+        );
+        let err = check_anchor(&r, &systems()).unwrap_err();
+        assert_eq!(
+            err,
+            AnchorError::NoSystemForRule {
+                rule_id: "nowhere/hunger".to_owned()
+            }
+        );
+        assert_eq!(err.spec_code(), Some("E-LOAD-002"));
+    }
+
+    #[test]
+    fn an_off_set_anchor_keyword_is_e_parse_013() {
+        let r = rule(
+            "(rule mods/extra :material-basis \"wage relation\" :fuel 8 \
+             (anchor :during survival) (bindings) \
+             (effects (update-node self social-class/agitation (add 0.05i))))",
+        );
+        let err = check_anchor(&r, &systems()).unwrap_err();
+        assert_eq!(err.spec_code(), Some("E-PARSE-013"));
+    }
+}

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -1,0 +1,825 @@
+//! The typed structural verb algebra (`bsl-language.rst` §2.8): the seven
+//! graph verbs plus `emit`, executed against any
+//! [`babylon_graph::substrate::GraphSubstrate`] — in Phase 1 that means
+//! `PlaceholderGraph`; the production store swaps in at the Phase 1/2
+//! boundary. This is the crate-DAG edge Task 11 planned: `babylon-bsl` now
+//! depends on `babylon-graph`.
+//!
+//! **No clique expansion exists in this module** and none may be added: a
+//! member list is handed to `GraphSubstrate::add_hyperedge` whole — that is
+//! Anti-Pattern VIII.9 enforced where the verbs live. There is deliberately
+//! no `add-member`/`remove-member`/`update-hyperedge`: membership change is
+//! whole-hyperedge replacement, `remove-hyperedge` then `add-hyperedge` in
+//! one effect list (§2.8 draft ruling).
+//!
+//! **Id operands are effect-list-scoped names** (draft ruling recorded in
+//! §2.8, implementation-discovered): `add-node`/`add-hyperedge`'s id
+//! operand is read as a symbol naming the minted object for the rest of the
+//! effect list — the substrate mints the actual identity; roster
+//! replacement referencing the new hyperedge needs exactly this.
+//!
+//! Discipline held here, not invented here:
+//! - Effects apply in **source order** (§2.8); `guard` evaluates only the
+//!   taken branch (§4.1) and charges accordingly.
+//! - Substrate failures surface as `E-EVAL-031` — removing what does not
+//!   exist, adding what exists, unknown/duplicate members: absence is never
+//!   success, and nothing is silently deduplicated.
+//! - The **store boundary** runs §3.3's one range check: a written value
+//!   outside the target field's declared `[0,1]` domain is `E-EVAL-020`, a
+//!   loud failure, never a clamp.
+//! - Fuel: verbs charge their §3.7 base cost (3), update-ops theirs (1),
+//!   operand expressions charge through the Task 14 evaluator — one §4.5
+//!   meter end to end.
+//! - I.15's edge-mode transition law and typed attribute storage (Currency
+//!   i128 exactness — the trait's `f64` attributes cannot hold it, so a
+//!   Currency-typed write is a LOUD error, not a lossy cast) are declared
+//!   Phase-2 gaps, named here rather than silently absorbed.
+
+use crate::evaluator::{charge, evaluate, EvalCode, EvalEnv, EvalError, Value};
+use crate::fuel::cost;
+use crate::intrinsic_host::IntrinsicHost;
+use crate::reader::{Atom, SExpr};
+use crate::typecheck::TypeEnv;
+use crate::types::BslType;
+use babylon_graph::substrate::{GraphError, GraphSubstrate, HyperedgeId, NodeId};
+use std::collections::HashMap;
+
+/// Where `emit` lands (§2.8): an event sink the engine wires to the kernel
+/// event bus (Phase 3). Payload values are already evaluated.
+pub trait EventSink {
+    /// Record one emitted event.
+    fn emit(&mut self, event_type: &str, payload: Vec<(String, Value)>);
+}
+
+/// A sink that simply collects, for tests and the conformance corpus.
+#[derive(Debug, Default)]
+pub struct CollectingSink {
+    /// Every event emitted, in source order.
+    pub events: Vec<(String, Vec<(String, Value)>)>,
+}
+
+impl EventSink for CollectingSink {
+    fn emit(&mut self, event_type: &str, payload: Vec<(String, Value)>) {
+        self.events.push((event_type.to_owned(), payload));
+    }
+}
+
+fn plain(message: impl Into<String>) -> EvalError {
+    EvalError::plain(message)
+}
+
+fn from_graph(e: GraphError) -> EvalError {
+    // Every GraphSubstrate failure is the §2.8 existence discipline:
+    // absence is never success, presence is never overwritten, a member
+    // list is a set (E-EVAL-031).
+    EvalError::coded(EvalCode::ExistenceDiscipline, e.message)
+}
+
+/// Executes one rule's effect list against a substrate, carrying the
+/// effect-list-scoped names `add-node`/`add-hyperedge` introduce.
+pub struct EffectExecutor<'a> {
+    types: &'a TypeEnv,
+    declared_nodes: HashMap<String, NodeId>,
+    declared_hyperedges: HashMap<String, HyperedgeId>,
+}
+
+impl<'a> EffectExecutor<'a> {
+    /// A fresh executor for one effect list. `types` supplies the declared
+    /// field types the §3.3 store-boundary range check needs.
+    #[must_use]
+    pub fn new(types: &'a TypeEnv) -> Self {
+        Self {
+            types,
+            declared_nodes: HashMap::new(),
+            declared_hyperedges: HashMap::new(),
+        }
+    }
+
+    /// Execute the items of an `(effects …)` form in source order (§2.8).
+    ///
+    /// # Errors
+    ///
+    /// Any [`EvalError`] an operand expression raises, `E-EVAL-031` from
+    /// the substrate's existence discipline, `E-EVAL-020` from the store
+    /// boundary, `E-EVAL-040` from the shared fuel meter, and loud uncoded
+    /// errors for shapes off the §2.8 grammar.
+    #[allow(clippy::too_many_arguments)]
+    pub fn execute_effects(
+        &mut self,
+        effect_items: &[SExpr],
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        graph: &mut dyn GraphSubstrate,
+        sink: &mut dyn EventSink,
+        fuel: &mut u64,
+    ) -> Result<(), EvalError> {
+        for item in effect_items {
+            self.execute_item(item, env, host, graph, sink, fuel)?;
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn execute_item(
+        &mut self,
+        item: &SExpr,
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        graph: &mut dyn GraphSubstrate,
+        sink: &mut dyn EventSink,
+        fuel: &mut u64,
+    ) -> Result<(), EvalError> {
+        let SExpr::List(items) = item else {
+            return Err(plain(format!(
+                "an effect item must be a form, found {item:?}"
+            )));
+        };
+        let Some(SExpr::Atom(Atom::Symbol(head))) = items.first() else {
+            return Err(plain(format!(
+                "an effect item must be a verb or guard form, found {:?}",
+                items.first()
+            )));
+        };
+        match head.as_str() {
+            "guard" => {
+                // cost(guard) base, then only the taken branch (§4.1).
+                charge(fuel, cost::GUARD_BASE)?;
+                let [_, cond, nested @ ..] = items.as_slice() else {
+                    return Err(plain("(guard <cond> <effect-item>+) — missing condition"));
+                };
+                if nested.is_empty() {
+                    return Err(plain("(guard …) requires at least one effect item"));
+                }
+                let taken = matches!(evaluate(cond, env, host, fuel)?, Value::Bool(true));
+                if taken {
+                    for nested_item in nested {
+                        self.execute_item(nested_item, env, host, graph, sink, fuel)?;
+                    }
+                }
+                Ok(())
+            }
+            "update-node" => self.update_node(items, env, host, graph, fuel),
+            "add-node" => self.add_node(items, env, host, graph, fuel),
+            "remove-node" => {
+                charge(fuel, cost::STRUCTURAL_VERB_BASE)?;
+                let [_, node] = items.as_slice() else {
+                    return Err(plain("(remove-node <expr>) takes exactly one operand"));
+                };
+                let id = self.resolve_node(node, env, host, fuel)?;
+                graph.remove_node(id).map_err(from_graph)
+            }
+            "add-edge" => self.add_edge(items, env, host, graph, fuel),
+            "remove-edge" => self.remove_edge(items, env, host, graph, fuel),
+            "add-hyperedge" => self.add_hyperedge(items, env, host, graph, fuel),
+            "remove-hyperedge" => {
+                charge(fuel, cost::STRUCTURAL_VERB_BASE)?;
+                let [_, h] = items.as_slice() else {
+                    return Err(plain("(remove-hyperedge <expr>) takes exactly one operand"));
+                };
+                let id = self.resolve_hyperedge(h, env, host, fuel)?;
+                graph.remove_hyperedge(id).map_err(from_graph)
+            }
+            "emit" => Self::emit(items, env, host, sink, fuel),
+            other => Err(plain(format!(
+                "unknown effect head ({other} …) — the §2.8 verb set is closed"
+            ))),
+        }
+    }
+
+    /// `(update-node <expr> <qname> <update-op>)` — read-modify-write under
+    /// the §3.3 store-boundary range check.
+    fn update_node(
+        &mut self,
+        items: &[SExpr],
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        graph: &mut dyn GraphSubstrate,
+        fuel: &mut u64,
+    ) -> Result<(), EvalError> {
+        charge(fuel, cost::STRUCTURAL_VERB_BASE)?;
+        let [_, node, SExpr::Atom(Atom::QName(field)), op_form] = items else {
+            return Err(plain(
+                "(update-node <expr> <qname> <update-op>) — unrecognized shape",
+            ));
+        };
+        let id = self.resolve_node(node, env, host, fuel)?;
+        let SExpr::List(op_items) = op_form else {
+            return Err(plain(
+                "update-op must be a form: (add|sub|set|scale <expr>)",
+            ));
+        };
+        let [SExpr::Atom(Atom::Symbol(op)), operand] = op_items.as_slice() else {
+            return Err(plain("update-op must be (add|sub|set|scale <expr>)"));
+        };
+        charge(fuel, cost::UPDATE_OP_BASE)?;
+        let operand_value = Self::numeric_write_value(operand, env, host, fuel, field)?;
+        let new_value = match op.as_str() {
+            "set" => operand_value,
+            "add" | "sub" | "scale" => {
+                let current = graph.node_attribute(id, field).map_err(from_graph)?;
+                let combined = match op.as_str() {
+                    "add" => current + operand_value,
+                    "sub" => current - operand_value,
+                    _ => current * operand_value,
+                };
+                if !combined.is_finite() {
+                    return Err(EvalError::coded(
+                        EvalCode::NonFinite,
+                        format!("({op} …) on {field} produced a non-finite value"),
+                    ));
+                }
+                combined
+            }
+            other => {
+                return Err(plain(format!(
+                    "unknown update-op ({other} …) — the set is add|sub|set|scale (§2.8)"
+                )))
+            }
+        };
+        self.store_range_check(field, new_value)?;
+        graph.update_node(id, field, new_value).map_err(from_graph)
+    }
+
+    /// `(add-node <enum-ref> <expr> <field-init>*)`.
+    fn add_node(
+        &mut self,
+        items: &[SExpr],
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        graph: &mut dyn GraphSubstrate,
+        fuel: &mut u64,
+    ) -> Result<(), EvalError> {
+        charge(fuel, cost::STRUCTURAL_VERB_BASE)?;
+        let [_, type_ref, id_expr, field_inits @ ..] = items else {
+            return Err(plain(
+                "(add-node <enum-ref> <expr> <field-init>*) — too few operands",
+            ));
+        };
+        let node_type = Self::enum_member(type_ref)?;
+        let name = self.fresh_declared_name(id_expr, env)?;
+        let id = graph.add_node(node_type).map_err(from_graph)?;
+        self.declared_nodes.insert(name, id);
+        for init in field_inits {
+            let SExpr::List(pair) = init else {
+                return Err(plain(format!(
+                    "a field-init must be (<qname> <expr>), found {init:?}"
+                )));
+            };
+            let [SExpr::Atom(Atom::QName(field)), value_expr] = pair.as_slice() else {
+                return Err(plain(format!(
+                    "a field-init must be (<qname> <expr>), found {pair:?}"
+                )));
+            };
+            let value = Self::numeric_write_value(value_expr, env, host, fuel, field)?;
+            self.store_range_check(field, value)?;
+            graph.update_node(id, field, value).map_err(from_graph)?;
+        }
+        Ok(())
+    }
+
+    /// `(add-edge <enum-ref> <expr> <expr> :strength <expr>)`.
+    fn add_edge(
+        &mut self,
+        items: &[SExpr],
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        graph: &mut dyn GraphSubstrate,
+        fuel: &mut u64,
+    ) -> Result<(), EvalError> {
+        charge(fuel, cost::STRUCTURAL_VERB_BASE)?;
+        let [_, type_ref, from, to, SExpr::Atom(Atom::Keyword(kw)), strength_expr] = items else {
+            return Err(plain(
+                "(add-edge <enum-ref> <expr> <expr> :strength <expr>) — unrecognized shape",
+            ));
+        };
+        if kw != "strength" {
+            return Err(plain(format!("add-edge requires :strength, found :{kw}")));
+        }
+        let edge_type = Self::enum_member(type_ref)?;
+        let from_id = self.resolve_node(from, env, host, fuel)?;
+        let to_id = self.resolve_node(to, env, host, fuel)?;
+        let strength = match evaluate(strength_expr, env, host, fuel)? {
+            Value::Real(r) => r,
+            other => {
+                return Err(plain(format!(
+                    ":strength must evaluate in the binary64 lane, got {other:?}"
+                )))
+            }
+        };
+        graph
+            .add_edge(edge_type, from_id, to_id, strength)
+            .map_err(from_graph)
+    }
+
+    /// `(remove-edge <enum-ref> <expr> <expr>)`.
+    fn remove_edge(
+        &mut self,
+        items: &[SExpr],
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        graph: &mut dyn GraphSubstrate,
+        fuel: &mut u64,
+    ) -> Result<(), EvalError> {
+        charge(fuel, cost::STRUCTURAL_VERB_BASE)?;
+        let [_, type_ref, from, to] = items else {
+            return Err(plain(
+                "(remove-edge <enum-ref> <expr> <expr>) — unrecognized shape",
+            ));
+        };
+        let edge_type = Self::enum_member(type_ref)?;
+        let from_id = self.resolve_node(from, env, host, fuel)?;
+        let to_id = self.resolve_node(to, env, host, fuel)?;
+        graph
+            .remove_edge(edge_type, from_id, to_id)
+            .map_err(from_graph)
+    }
+
+    /// `(add-hyperedge <enum-ref> <expr> <members> <field-init>*)` — the
+    /// member list crosses WHOLE; no path here expands it (VIII.9).
+    fn add_hyperedge(
+        &mut self,
+        items: &[SExpr],
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        graph: &mut dyn GraphSubstrate,
+        fuel: &mut u64,
+    ) -> Result<(), EvalError> {
+        charge(fuel, cost::STRUCTURAL_VERB_BASE)?;
+        let [_, type_ref, id_expr, members_form, field_inits @ ..] = items else {
+            return Err(plain(
+                "(add-hyperedge <enum-ref> <expr> <members> <field-init>*) — too few operands",
+            ));
+        };
+        if !field_inits.is_empty() {
+            // §2.8's ruling already names the adjacent gap (per-membership
+            // payload, hyperedge field mutation); initial hyperedge fields
+            // have no trait storage either — loud, not dropped.
+            return Err(plain(
+                "hyperedge <field-init> has no substrate storage in Phase 1 — \
+                 a declared Phase-2 gap (§2.8 draft ruling), never silently dropped",
+            ));
+        }
+        let hyperedge_type = Self::enum_member(type_ref)?;
+        let name = self.fresh_declared_name(id_expr, env)?;
+        let SExpr::List(member_items) = members_form else {
+            return Err(plain("expected a (members <expr>+) form"));
+        };
+        let [SExpr::Atom(Atom::Symbol(head)), member_exprs @ ..] = member_items.as_slice() else {
+            return Err(plain("expected a (members <expr>+) form"));
+        };
+        if head != "members" || member_exprs.is_empty() {
+            // The grammar's <expr>+ makes a zero-member hyperedge
+            // unexpressible; meeting one here is a shape error.
+            return Err(plain("(members <expr>+) requires at least one member"));
+        }
+        let mut members = Vec::with_capacity(member_exprs.len());
+        for member in member_exprs {
+            members.push(self.resolve_node(member, env, host, fuel)?);
+        }
+        let id = graph
+            .add_hyperedge(hyperedge_type, &members)
+            .map_err(from_graph)?;
+        self.declared_hyperedges.insert(name, id);
+        Ok(())
+    }
+
+    /// `(emit <enum-ref> <payload-item>*)` — payload names are labels;
+    /// there is no string interpolation in a payload (§2.8).
+    fn emit(
+        items: &[SExpr],
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        sink: &mut dyn EventSink,
+        fuel: &mut u64,
+    ) -> Result<(), EvalError> {
+        charge(fuel, cost::STRUCTURAL_VERB_BASE)?;
+        let [_, type_ref, payload_items @ ..] = items else {
+            return Err(plain(
+                "(emit <enum-ref> <payload-item>*) — missing event type",
+            ));
+        };
+        let event_type = Self::enum_member(type_ref)?;
+        let mut payload = Vec::with_capacity(payload_items.len());
+        for item in payload_items {
+            let SExpr::List(pair) = item else {
+                return Err(plain(format!(
+                    "a payload item must be (<symbol> <expr>), found {item:?}"
+                )));
+            };
+            let [SExpr::Atom(Atom::Symbol(name)), value_expr] = pair.as_slice() else {
+                return Err(plain(format!(
+                    "a payload item must be (<symbol> <expr>), found {pair:?}"
+                )));
+            };
+            payload.push((name.clone(), evaluate(value_expr, env, host, fuel)?));
+        }
+        sink.emit(event_type, payload);
+        Ok(())
+    }
+
+    /// An enum-ref operand's member name — the substrate's type string.
+    fn enum_member(expr: &SExpr) -> Result<&str, EvalError> {
+        match expr {
+            SExpr::Atom(Atom::EnumRef { member, .. }) => Ok(member),
+            other => Err(plain(format!(
+                "expected an enum-ref where the grammar requires one, found {other:?}"
+            ))),
+        }
+    }
+
+    /// The id operand of `add-node`/`add-hyperedge`: a symbol introducing a
+    /// fresh effect-list-scoped name (the §2.8 draft ruling this task
+    /// records). Shadowing a binding, a reserved symbol, or an earlier
+    /// declared id is loud.
+    fn fresh_declared_name(&self, id_expr: &SExpr, env: &EvalEnv<'_>) -> Result<String, EvalError> {
+        let SExpr::Atom(Atom::Symbol(name)) = id_expr else {
+            return Err(plain(format!(
+                "an add-node/add-hyperedge id operand must be a symbol naming \
+                 the minted object for this effect list (§2.8 draft ruling), \
+                 found {id_expr:?}"
+            )));
+        };
+        let taken = crate::bindings::RESERVED_NAMES.contains(&name.as_str())
+            || env.bindings.contains_key(name)
+            || self.declared_nodes.contains_key(name)
+            || self.declared_hyperedges.contains_key(name);
+        if taken {
+            return Err(plain(format!(
+                "declared id {name} shadows an existing name — E-PARSE-022's \
+                 no-shadowing discipline applies to effect-scoped ids too"
+            )));
+        }
+        Ok(name.clone())
+    }
+
+    /// Resolve a node-ref operand: an effect-scoped declared id, or any
+    /// expression evaluating to a `NodeRef` (`self`, a bound ref).
+    fn resolve_node(
+        &self,
+        expr: &SExpr,
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        fuel: &mut u64,
+    ) -> Result<NodeId, EvalError> {
+        if let SExpr::Atom(Atom::Symbol(name)) = expr {
+            if let Some(id) = self.declared_nodes.get(name) {
+                charge(fuel, cost::VARIABLE_REF)?;
+                return Ok(*id);
+            }
+        }
+        match evaluate(expr, env, host, fuel)? {
+            Value::NodeRef(id) => Ok(id),
+            other => Err(plain(format!(
+                "expected a NodeRef operand, got {other:?} (§3.1)"
+            ))),
+        }
+    }
+
+    /// Resolve a hyperedge-ref operand, symmetrically.
+    fn resolve_hyperedge(
+        &self,
+        expr: &SExpr,
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        fuel: &mut u64,
+    ) -> Result<HyperedgeId, EvalError> {
+        if let SExpr::Atom(Atom::Symbol(name)) = expr {
+            if let Some(id) = self.declared_hyperedges.get(name) {
+                charge(fuel, cost::VARIABLE_REF)?;
+                return Ok(*id);
+            }
+        }
+        match evaluate(expr, env, host, fuel)? {
+            Value::HyperedgeRef(id) => Ok(id),
+            other => Err(plain(format!(
+                "expected a HyperedgeRef operand, got {other:?} (§3.1)"
+            ))),
+        }
+    }
+
+    /// Evaluate a value that will be WRITTEN to `field`, in the binary64
+    /// lane the trait's attribute storage carries. A Currency-typed value
+    /// is a loud declared Phase-2 gap (i128 exactness does not survive an
+    /// f64 attribute), never a lossy cast.
+    fn numeric_write_value(
+        expr: &SExpr,
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        fuel: &mut u64,
+        field: &str,
+    ) -> Result<f64, EvalError> {
+        match evaluate(expr, env, host, fuel)? {
+            Value::Real(r) => Ok(r),
+            // i64 -> f64 is deterministic; exactness beyond 2^53 belongs to
+            // the typed-attribute-storage gap named in the module doc.
+            #[allow(clippy::cast_precision_loss)]
+            Value::Int(n) => Ok(n as f64),
+            Value::Currency(_) => Err(plain(format!(
+                "writing a Currency value to {field} needs typed attribute \
+                 storage (Phase 2 gap, module doc) — refusing the lossy f64 cast"
+            ))),
+            other => Err(plain(format!(
+                "cannot store {other:?} as a numeric node attribute"
+            ))),
+        }
+    }
+
+    /// §3.3's one range check, at the store boundary: a value outside the
+    /// target field's declared domain is `E-EVAL-020` — never a clamp. A
+    /// field absent from the registry is loud (closed vocabulary, §3.6).
+    fn store_range_check(&self, field: &str, value: f64) -> Result<(), EvalError> {
+        let Some(decl) = self.types.fields.get(field) else {
+            return Err(plain(format!(
+                "unknown field {field} — the vocabulary is closed (§3.6); the \
+                 loader should have rejected this content"
+            )));
+        };
+        let unit_interval = matches!(
+            decl.ty,
+            BslType::Probability | BslType::Intensity | BslType::Coefficient
+        );
+        if unit_interval && !(0.0..=1.0).contains(&value) {
+            return Err(EvalError::coded(
+                EvalCode::StoreRangeViolation,
+                format!(
+                    "storing {value} to {field} ({:?}) leaves its declared \
+                     [0,1] domain — a loud failure, never a clamp (§3.3)",
+                    decl.ty
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fuel::IntrinsicCosts;
+    use crate::intrinsic_host::EmptyIntrinsicHost;
+    use crate::reader::read;
+    use crate::types::{FieldDecl, FieldKind};
+    use babylon_graph::placeholder::PlaceholderGraph;
+
+    fn types() -> TypeEnv {
+        TypeEnv {
+            fields: HashMap::from([
+                (
+                    "social-class/agitation".to_owned(),
+                    FieldDecl {
+                        ty: BslType::Intensity,
+                        kind: FieldKind::Intensive,
+                    },
+                ),
+                (
+                    "social-class/head-count".to_owned(),
+                    FieldDecl {
+                        ty: BslType::Int,
+                        kind: FieldKind::Extensive,
+                    },
+                ),
+            ]),
+            exemptions: &[],
+        }
+    }
+
+    struct Fixture {
+        graph: PlaceholderGraph,
+        self_id: NodeId,
+        costs: IntrinsicCosts,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let mut graph = PlaceholderGraph::new();
+            let self_id = graph.add_node("SOCIAL_CLASS").unwrap();
+            graph
+                .update_node(self_id, "social-class/agitation", 0.10)
+                .unwrap();
+            Self {
+                graph,
+                self_id,
+                costs: IntrinsicCosts::default(),
+            }
+        }
+
+        /// Execute an `(effects …)` source against the fixture, returning
+        /// the collected event stream.
+        #[allow(clippy::type_complexity)]
+        fn run(
+            &mut self,
+            effects_source: &str,
+            fuel: &mut u64,
+        ) -> Result<Vec<(String, Vec<(String, Value)>)>, EvalError> {
+            let (form, _) = read(effects_source).expect("effects source must parse");
+            let SExpr::List(items) = form else {
+                unreachable!()
+            };
+            let env = EvalEnv {
+                bindings: HashMap::from([("self".to_owned(), Value::NodeRef(self.self_id))]),
+                intrinsic_costs: &self.costs,
+            };
+            let types = types();
+            let mut executor = EffectExecutor::new(&types);
+            let mut sink = CollectingSink::default();
+            executor.execute_effects(
+                &items[1..],
+                &env,
+                &EmptyIntrinsicHost,
+                &mut self.graph,
+                &mut sink,
+                fuel,
+            )?;
+            Ok(sink.events)
+        }
+    }
+
+    #[test]
+    fn the_demo_rule_effect_executes_with_pinned_fuel() {
+        // The §5.6 effect against agitation = 0.10: update-node charges its
+        // static per-node sum exactly — verb(3) + self(1) + qname(0) +
+        // update-op(1) + literal(0) = 5.
+        let mut fixture = Fixture::new();
+        let mut fuel = 64;
+        fixture
+            .run(
+                "(effects (update-node self social-class/agitation (add 0.05i)))",
+                &mut fuel,
+            )
+            .unwrap();
+        let stored = fixture
+            .graph
+            .node_attribute(fixture.self_id, "social-class/agitation")
+            .unwrap();
+        assert!((stored - 0.15).abs() < 1e-12);
+        assert_eq!(fuel, 59, "5 consumed — a conformance-vector quantity");
+    }
+
+    #[test]
+    fn the_store_boundary_rejects_out_of_range_never_clamps() {
+        let mut fixture = Fixture::new();
+        let mut fuel = 64;
+        let err = fixture
+            .run(
+                "(effects (update-node self social-class/agitation (add 0.95i)))",
+                &mut fuel,
+            )
+            .unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::StoreRangeViolation));
+        assert_eq!(err.code.unwrap().spec_code(), "E-EVAL-020");
+        // The failed write left the attribute untouched.
+        let stored = fixture
+            .graph
+            .node_attribute(fixture.self_id, "social-class/agitation")
+            .unwrap();
+        assert!((stored - 0.10).abs() < 1e-12);
+    }
+
+    #[test]
+    fn add_node_introduces_a_name_later_effects_can_use() {
+        let mut fixture = Fixture::new();
+        let mut fuel = 128;
+        fixture
+            .run(
+                "(effects \
+                   (add-node NodeType/SOCIAL_CLASS recruit (social-class/agitation 0.2i)) \
+                   (add-edge EdgeType/SOLIDARITY recruit self :strength 0.5c))",
+                &mut fuel,
+            )
+            .unwrap();
+        assert_eq!(fixture.graph.edge_count(), 1);
+    }
+
+    #[test]
+    fn roster_replacement_is_remove_then_add_in_one_list() {
+        // §2.8 draft ruling: no add-member verb exists; changing a roster
+        // is remove-hyperedge + add-hyperedge in one effect list.
+        let mut fixture = Fixture::new();
+        let mut fuel = 256;
+        fixture
+            .run(
+                "(effects \
+                   (add-node NodeType/SOCIAL_CLASS comrade) \
+                   (add-hyperedge HyperedgeType/CELL nucleus (members self)) \
+                   (remove-hyperedge nucleus) \
+                   (add-hyperedge HyperedgeType/CELL grown (members self comrade)))",
+                &mut fuel,
+            )
+            .unwrap();
+        let grown = fixture.graph.hyperedges_of(fixture.self_id, "CELL");
+        assert_eq!(grown.len(), 1);
+        assert_eq!(
+            fixture.graph.members_of(grown[0]).unwrap().len(),
+            2,
+            "the replacement roster, whole — never pairwise edges"
+        );
+    }
+
+    #[test]
+    fn substrate_discipline_surfaces_as_e_eval_031() {
+        let mut fixture = Fixture::new();
+        let mut fuel = 128;
+        // Duplicate member: the substrate refuses, nothing deduplicates.
+        let err = fixture
+            .run(
+                "(effects (add-hyperedge HyperedgeType/CELL c (members self self)))",
+                &mut fuel,
+            )
+            .unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::ExistenceDiscipline));
+        assert_eq!(err.code.unwrap().spec_code(), "E-EVAL-031");
+        // Removing an edge that does not exist: absence is never success.
+        let mut fuel2 = 128;
+        let err2 = fixture
+            .run(
+                "(effects (remove-edge EdgeType/SOLIDARITY self self))",
+                &mut fuel2,
+            )
+            .unwrap_err();
+        assert_eq!(err2.code, Some(EvalCode::ExistenceDiscipline));
+    }
+
+    #[test]
+    fn a_false_guard_skips_and_does_not_charge_its_effects() {
+        let mut fixture = Fixture::new();
+        let mut fuel = 64;
+        fixture
+            .run(
+                "(effects (guard (< 1 0) \
+                   (update-node self social-class/agitation (add 0.05i))))",
+                &mut fuel,
+            )
+            .unwrap();
+        // guard(1) + cmp(1) + two literals(0) = 2; the verb never charged.
+        assert_eq!(fuel, 62);
+        let stored = fixture
+            .graph
+            .node_attribute(fixture.self_id, "social-class/agitation")
+            .unwrap();
+        assert!((stored - 0.10).abs() < 1e-12, "untaken effects never apply");
+    }
+
+    #[test]
+    fn emit_collects_the_evaluated_payload() {
+        let mut fixture = Fixture::new();
+        let mut fuel = 64;
+        let events = fixture
+            .run(
+                "(effects (emit EventType/RUPTURE (severity 0.9c) (tick 52)))",
+                &mut fuel,
+            )
+            .unwrap();
+        assert_eq!(
+            events,
+            vec![(
+                "RUPTURE".to_owned(),
+                vec![
+                    ("severity".to_owned(), Value::Real(0.9)),
+                    ("tick".to_owned(), Value::Int(52)),
+                ]
+            )]
+        );
+    }
+
+    #[test]
+    fn currency_writes_are_a_loud_declared_gap_never_a_lossy_cast() {
+        let mut fixture = Fixture::new();
+        let mut fuel = 64;
+        let err = fixture
+            .run(
+                "(effects (update-node self social-class/head-count (set 100$)))",
+                &mut fuel,
+            )
+            .unwrap_err();
+        assert!(err.message.contains("Phase 2 gap"), "{err}");
+    }
+
+    #[test]
+    fn a_declared_id_may_not_shadow_bindings_or_reserved_names() {
+        let mut fixture = Fixture::new();
+        for id in ["self", "it"] {
+            let mut fuel = 64;
+            let err = fixture
+                .run(
+                    &format!("(effects (add-node NodeType/SOCIAL_CLASS {id}))"),
+                    &mut fuel,
+                )
+                .unwrap_err();
+            assert!(err.message.contains("shadows"), "{id}: {err}");
+        }
+    }
+
+    #[test]
+    fn hyperedge_field_inits_are_a_loud_phase_2_gap() {
+        let mut fixture = Fixture::new();
+        let mut fuel = 128;
+        let err = fixture
+            .run(
+                "(effects (add-hyperedge HyperedgeType/CELL c (members self) \
+                   (social-class/agitation 0.5i)))",
+                &mut fuel,
+            )
+            .unwrap_err();
+        assert!(err.message.contains("Phase-2 gap"), "{err}");
+    }
+}

--- a/rust/crates/babylon-graph/src/placeholder.rs
+++ b/rust/crates/babylon-graph/src/placeholder.rs
@@ -5,7 +5,9 @@
 //! before the concrete Phase-2 storage lands. It DOES honor the Amendment D
 //! shape the trait fixes (hyperedges are their own objects with their own id
 //! space, members are a sorted set, no pairwise expansion anywhere), because
-//! that shape is ruled, not provisional. Deleting this module and swapping in
+//! that shape is ruled, not provisional — and it honors the §2.8 existence
+//! discipline (duplicate add and absent remove are loud errors), because the
+//! verb layer's tests pin exactly that. Deleting this module and swapping in
 //! the production storage is expected, low-risk churn — nothing outside this
 //! crate and its direct test dependents should assume its internals.
 use crate::substrate::{GraphError, GraphSubstrate, HyperedgeId, NodeId};
@@ -15,12 +17,15 @@ use std::collections::HashMap;
 /// foundation.
 #[derive(Debug, Default)]
 pub struct PlaceholderGraph {
-    nodes: HashMap<NodeId, &'static str>,
-    attributes: HashMap<(NodeId, &'static str), f64>,
+    nodes: HashMap<NodeId, String>,
+    attributes: HashMap<(NodeId, String), f64>,
+    /// `(edge_type, from, to)` -> strength. Real storage, so the §2.8
+    /// duplicate-add / absent-remove discipline is checkable.
+    edges: HashMap<(String, NodeId, NodeId), f64>,
     /// Hyperedge id -> (type, sorted member list). Stored as ONE record per
     /// hyperedge — the toy analogue of a first-class object. A production
     /// store may instead keep incidence edges (Levi); callers cannot tell.
-    hyperedges: HashMap<HyperedgeId, (&'static str, Vec<NodeId>)>,
+    hyperedges: HashMap<HyperedgeId, (String, Vec<NodeId>)>,
     next_id: u64,
     next_hyperedge_id: u64,
 }
@@ -31,13 +36,19 @@ impl PlaceholderGraph {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Test-visible edge count (the dyadic half only).
+    #[must_use]
+    pub fn edge_count(&self) -> usize {
+        self.edges.len()
+    }
 }
 
 impl GraphSubstrate for PlaceholderGraph {
-    fn add_node(&mut self, node_type: &'static str) -> Result<NodeId, GraphError> {
+    fn add_node(&mut self, node_type: &str) -> Result<NodeId, GraphError> {
         let id = NodeId(self.next_id);
         self.next_id += 1;
-        self.nodes.insert(id, node_type);
+        self.nodes.insert(id, node_type.to_owned());
         Ok(id)
     }
 
@@ -52,40 +63,60 @@ impl GraphSubstrate for PlaceholderGraph {
 
     fn add_edge(
         &mut self,
-        _edge_type: &'static str,
+        edge_type: &str,
         from: NodeId,
         to: NodeId,
+        strength: f64,
     ) -> Result<(), GraphError> {
         if !self.node_exists(from) || !self.node_exists(to) {
             return Err(GraphError {
                 message: "edge endpoint does not exist".into(),
             });
         }
-        Ok(()) // placeholder: no edge storage at all, deliberately (see module doc)
-    }
-
-    fn remove_edge(
-        &mut self,
-        _edge_type: &'static str,
-        _from: NodeId,
-        _to: NodeId,
-    ) -> Result<(), GraphError> {
+        let key = (edge_type.to_owned(), from, to);
+        if self.edges.contains_key(&key) {
+            return Err(GraphError {
+                message: format!("edge already exists: {key:?}"),
+            });
+        }
+        self.edges.insert(key, strength);
         Ok(())
     }
 
-    fn update_node(
-        &mut self,
-        id: NodeId,
-        attribute: &'static str,
-        value: f64,
-    ) -> Result<(), GraphError> {
+    fn remove_edge(&mut self, edge_type: &str, from: NodeId, to: NodeId) -> Result<(), GraphError> {
+        let key = (edge_type.to_owned(), from, to);
+        self.edges
+            .remove(&key)
+            .map(|_| ())
+            .ok_or_else(|| GraphError {
+                message: format!("no such edge: {key:?} — absence is never success"),
+            })
+    }
+
+    fn update_node(&mut self, id: NodeId, attribute: &str, value: f64) -> Result<(), GraphError> {
         if !self.node_exists(id) {
             return Err(GraphError {
                 message: format!("no such node: {id:?}"),
             });
         }
-        self.attributes.insert((id, attribute), value);
+        self.attributes.insert((id, attribute.to_owned()), value);
         Ok(())
+    }
+
+    fn node_attribute(&self, id: NodeId, attribute: &str) -> Result<f64, GraphError> {
+        if !self.node_exists(id) {
+            return Err(GraphError {
+                message: format!("no such node: {id:?}"),
+            });
+        }
+        self.attributes
+            .get(&(id, attribute.to_owned()))
+            .copied()
+            .ok_or_else(|| GraphError {
+                message: format!(
+                    "attribute {attribute} was never written on {id:?} — never a default 0.0"
+                ),
+            })
     }
 
     fn node_exists(&self, id: NodeId) -> bool {
@@ -94,7 +125,7 @@ impl GraphSubstrate for PlaceholderGraph {
 
     fn add_hyperedge(
         &mut self,
-        hyperedge_type: &'static str,
+        hyperedge_type: &str,
         members: &[NodeId],
     ) -> Result<HyperedgeId, GraphError> {
         if members.is_empty() {
@@ -116,7 +147,8 @@ impl GraphSubstrate for PlaceholderGraph {
         }
         let id = HyperedgeId(self.next_hyperedge_id);
         self.next_hyperedge_id += 1;
-        self.hyperedges.insert(id, (hyperedge_type, sorted));
+        self.hyperedges
+            .insert(id, (hyperedge_type.to_owned(), sorted));
         Ok(id)
     }
 
@@ -138,11 +170,11 @@ impl GraphSubstrate for PlaceholderGraph {
             })
     }
 
-    fn hyperedges_of(&self, node: NodeId, hyperedge_type: &'static str) -> Vec<HyperedgeId> {
+    fn hyperedges_of(&self, node: NodeId, hyperedge_type: &str) -> Vec<HyperedgeId> {
         let mut found: Vec<HyperedgeId> = self
             .hyperedges
             .iter()
-            .filter(|(_, (ty, members))| *ty == hyperedge_type && members.contains(&node))
+            .filter(|(_, (ty, members))| ty == hyperedge_type && members.contains(&node))
             .map(|(id, _)| *id)
             .collect();
         found.sort_unstable();
@@ -163,14 +195,36 @@ mod tests {
         let mut graph = PlaceholderGraph::new();
         let node = graph.add_node("social_class").unwrap();
         graph.update_node(node, "wealth", 42.0).unwrap();
-        assert_eq!(graph.attributes.get(&(node, "wealth")), Some(&42.0));
+        assert_eq!(graph.node_attribute(node, "wealth"), Ok(42.0));
+    }
+
+    #[test]
+    fn an_unwritten_attribute_reads_loud_never_zero() {
+        let mut graph = PlaceholderGraph::new();
+        let node = graph.add_node("social_class").unwrap();
+        assert!(graph.node_attribute(node, "wealth").is_err());
     }
 
     #[test]
     fn edge_to_nonexistent_node_is_a_loud_error() {
         let mut graph = PlaceholderGraph::new();
         let node = graph.add_node("territory").unwrap();
-        assert!(graph.add_edge("adjacency", node, NodeId(9999)).is_err());
+        assert!(graph
+            .add_edge("adjacency", node, NodeId(9999), 1.0)
+            .is_err());
+    }
+
+    #[test]
+    fn duplicate_edge_add_and_absent_edge_remove_are_loud() {
+        // §2.8: absence is never success, and adding what exists is an
+        // error, not an overwrite.
+        let mut graph = PlaceholderGraph::new();
+        let a = graph.add_node("social_class").unwrap();
+        let b = graph.add_node("social_class").unwrap();
+        graph.add_edge("solidarity", a, b, 0.5).unwrap();
+        assert!(graph.add_edge("solidarity", a, b, 0.9).is_err());
+        graph.remove_edge("solidarity", a, b).unwrap();
+        assert!(graph.remove_edge("solidarity", a, b).is_err());
     }
 
     #[test]
@@ -209,6 +263,7 @@ mod tests {
             .unwrap();
         assert_eq!(graph.hyperedges_of(first, "economic_sector"), vec![sector]);
         // the dyadic half is untouched by minting a hyperedge
+        assert_eq!(graph.edge_count(), 0);
         assert_eq!(graph.hyperedges.len(), 1);
     }
 }

--- a/rust/crates/babylon-graph/src/substrate.rs
+++ b/rust/crates/babylon-graph/src/substrate.rs
@@ -15,6 +15,17 @@
 //! permitted and unobservable. What IS exposed, because the ruling fixes it:
 //! a hyperedge has an identity and a member list, and there is no method
 //! anywhere that expands a member list into pairwise edges (VIII.9).
+//!
+//! **Task 16 revisions (recorded, not silent):** type/attribute names are
+//! `&str` (the drafted `&'static str` forced every runtime-string caller
+//! through `Box::leak` — the exact smell the Phase-1 plan's own TODO said
+//! not to ship); `add_edge` carries the `:strength` operand §2.8's grammar
+//! makes mandatory; and `node_attribute` exists because §2.8's four
+//! update-ops (`add`/`sub`/`scale` read-modify-write) are unimplementable
+//! without a read point. Attribute values are `f64` — the binary64 lane
+//! only; typed attribute storage (Currency's i128 exactness) is a declared
+//! Phase-2 gap, not a silent coercion (`babylon-bsl`'s executor rejects
+//! Currency-typed writes loudly).
 
 /// Opaque node identity — a newtype so no caller depends on it being an
 /// integer index vs. a UUID vs. anything else the concrete shape picks.
@@ -38,10 +49,14 @@ pub struct GraphError {
 }
 
 /// The typed structural-verb surface a `GraphSubstrate` implementation
-/// provides. `node_type`/`edge_type`/`hyperedge_type` are `&'static str` here
-/// (the closed `NodeType`/`EdgeType`/`HyperedgeType` enums are a
-/// `babylon-domain` concern, Phase 2/3; this trait is domain-agnostic on
-/// purpose so it compiles before those enums port).
+/// provides. `node_type`/`edge_type`/`hyperedge_type` are plain `&str` (the
+/// closed `NodeType`/`EdgeType`/`HyperedgeType` enums are a `babylon-domain`
+/// concern, Phase 2/3; this trait is domain-agnostic on purpose so it
+/// compiles before those enums port).
+///
+/// **Absence is never success** (§2.8): removing what does not exist and
+/// adding what already exists are errors on every method below — a
+/// substrate that silently no-ops either is non-conforming.
 pub trait GraphSubstrate {
     // ---- dyadic half (II.9 morphism layer) ----
 
@@ -50,7 +65,7 @@ pub trait GraphSubstrate {
     /// # Errors
     /// Returns [`GraphError`] if the implementation cannot allocate the node
     /// (for example, an exhausted identity space).
-    fn add_node(&mut self, node_type: &'static str) -> Result<NodeId, GraphError>;
+    fn add_node(&mut self, node_type: &str) -> Result<NodeId, GraphError>;
 
     /// Remove a node.
     ///
@@ -58,28 +73,26 @@ pub trait GraphSubstrate {
     /// Returns [`GraphError`] if `id` names no node in this substrate.
     fn remove_node(&mut self, id: NodeId) -> Result<(), GraphError>;
 
-    /// Mint one typed dyadic edge.
+    /// Mint one typed dyadic edge with its mandatory `:strength` (§2.8).
     ///
     /// # Errors
-    /// Returns [`GraphError`] if either endpoint does not exist.
+    /// Returns [`GraphError`] if either endpoint does not exist, or if the
+    /// `(edge_type, from, to)` edge already exists (`E-EVAL-031` — never a
+    /// silent overwrite).
     fn add_edge(
         &mut self,
-        edge_type: &'static str,
+        edge_type: &str,
         from: NodeId,
         to: NodeId,
+        strength: f64,
     ) -> Result<(), GraphError>;
 
     /// Remove one typed dyadic edge.
     ///
     /// # Errors
-    /// Returns [`GraphError`] if the implementation cannot service the
-    /// removal (for example, an unknown endpoint under a stricter store).
-    fn remove_edge(
-        &mut self,
-        edge_type: &'static str,
-        from: NodeId,
-        to: NodeId,
-    ) -> Result<(), GraphError>;
+    /// Returns [`GraphError`] if the edge does not exist — absence is never
+    /// treated as success (`E-EVAL-031`).
+    fn remove_edge(&mut self, edge_type: &str, from: NodeId, to: NodeId) -> Result<(), GraphError>;
 
     /// Update a single attribute on a node under the I.15 edge-mode state
     /// machine's constraints — this trait method does NOT itself enforce
@@ -88,12 +101,16 @@ pub trait GraphSubstrate {
     ///
     /// # Errors
     /// Returns [`GraphError`] if `id` names no node in this substrate.
-    fn update_node(
-        &mut self,
-        id: NodeId,
-        attribute: &'static str,
-        value: f64,
-    ) -> Result<(), GraphError>;
+    fn update_node(&mut self, id: NodeId, attribute: &str, value: f64) -> Result<(), GraphError>;
+
+    /// Read a single attribute — the read half §2.8's `add`/`sub`/`scale`
+    /// update-ops need for their read-modify-write.
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if `id` names no node, or the attribute has
+    /// never been written — never a default `0.0` (the honest-null
+    /// discipline, §3.5).
+    fn node_attribute(&self, id: NodeId, attribute: &str) -> Result<f64, GraphError>;
 
     /// Whether `id` names a live node.
     fn node_exists(&self, id: NodeId) -> bool;
@@ -110,7 +127,7 @@ pub trait GraphSubstrate {
     /// names a node that does not exist.
     fn add_hyperedge(
         &mut self,
-        hyperedge_type: &'static str,
+        hyperedge_type: &str,
         members: &[NodeId],
     ) -> Result<HyperedgeId, GraphError>;
 
@@ -130,7 +147,7 @@ pub trait GraphSubstrate {
 
     /// The hyperedges of the given type a node belongs to, in ascending
     /// [`HyperedgeId`] order.
-    fn hyperedges_of(&self, node: NodeId, hyperedge_type: &'static str) -> Vec<HyperedgeId>;
+    fn hyperedges_of(&self, node: NodeId, hyperedge_type: &str) -> Vec<HyperedgeId>;
 
     /// Whether `id` names a live hyperedge.
     fn hyperedge_exists(&self, id: HyperedgeId) -> bool;


### PR DESCRIPTION
## Summary

P27 Phase 1 **Task 16**: the §2.8 effect layer executed against `GraphSubstrate` — the crate-DAG edge Task 11 planned (`babylon-bsl` → `babylon-graph`).

- **`structural_verbs.rs`** — all seven graph verbs plus `emit`, applied in source order; `guard` evaluates (and charges) only the taken branch; the member list crosses to `add_hyperedge` **whole** — no clique expansion exists in the module (VIII.9 enforced where the verbs live); roster change is remove-then-add replacement in one effect list, pinned by test. Substrate discipline surfaces as **E-EVAL-031** (absence is never success, nothing deduplicates); the §3.3 store boundary runs its one range check — **E-EVAL-020, never a clamp**, with a failed write leaving the attribute untouched. One §4.5 fuel meter end to end: the §5.6 effect consumes exactly 5. `Value` gains the §3.1 `NodeRef`/`HyperedgeRef` variants.
- **`mod_anchors.rs`** — `(anchor :after|:before <system>)` declaration validation plus the anchor default (**E-LOAD-002** — a rule cannot land nowhere). Order *resolution* and E-LOAD-003 stay with `babylon-engine`'s registry (Phase 3), deferred by name.

## Trait completions in babylon-graph (recorded, not silent)

Type/attribute names become `&str` — the drafted `&'static str` forced `Box::leak`, the exact smell the plan's own TODO said not to ship. `add_edge` carries the `:strength` operand §2.8's grammar makes mandatory. `node_attribute` exists because `add`/`sub`/`scale` are read-modify-write, and an unwritten attribute reads **loud, never 0.0**. The placeholder gains real edge storage so duplicate-add / absent-remove are checkable. Declared Phase-2 gaps, all loud errors: Currency-typed attribute writes (i128 exactness does not survive `f64`), hyperedge field-inits, the I.15 edge-mode law.

## Normative note recorded (draft ruling, implementation-discovered)

§2.8 gains the id-operand ruling: `add-node`/`add-hyperedge` id operands are **effect-list-scoped names** for the minted object — no expression form yields a fresh identity, and roster replacement referencing the new hyperedge needs exactly this — with E-PARSE-022's no-shadowing discipline extended to them.

15 new tests; 135 babylon-bsl + 7 babylon-graph tests green; `mise run rust:check` clean.

Part of #368 (P27 Phase 1 kernel ladder). Next: Task 17 (conformance corpus transcription).

🤖 Generated with [Claude Code](https://claude.com/claude-code)