### PR TITLE
test(bsl-corpus): conformance corpus transcription + composed load pipeline (P27 Phase 1 Task 17)

### DIFF
--- a/reports/p27-conformance-corpus-transcription.md
+++ b/reports/p27-conformance-corpus-transcription.md
@@ -1,0 +1,86 @@
+# P27 Conformance Corpus Transcription — Delta Ledger
+
+**Task 17 of the Phase 1 plan** (`docs/superpowers/plans/2026-07-29-program-27-phase-1-language-and-kernel.md`).
+Source corpora, read end-to-end before transcription (F1 discipline):
+
+- `tests/unit/domain/doctrine/test_mechanics.py` — 271 lines (the trap-DSL evaluator + doctrine mechanics)
+- `tests/unit/engine/test_event_evaluator.py` — 628 lines (the event-template evaluator)
+
+Rust side: `rust/crates/babylon-bsl/tests/conformance_corpus.rs` + `tests/conformance/*.bsl`
+fixtures, loaded through the composed pipeline (`babylon_bsl::rule_pipeline::load_rule`,
+built by this task — the first point where every load gate composes, in §4.6 class order).
+
+**The four M8 correction sites were re-verified against the live file before
+transcription — all four line numbers hold exactly** (`event_evaluator.py:103`,
+`:313`, `:405`, `:439`; no drift since spec-writing).
+
+**Phase-1 scope law applied throughout:** fold/query *execution* needs the Phase-2
+query evaluator, so aggregation vectors pin load-time verdicts here (parse,
+resolution, §3.4 typecheck, §3.7 bound) and their runtime values ride the Phase-2
+vector re-run. Everything expressible in the Task 14 expression core executes for
+real. Rows below say which.
+
+## The four III.11 corrections (spec §5 "Grammar-superset honesty", M8)
+
+| # | Python site | Old behavior | New behavior | Rust test |
+|---|-------------|--------------|--------------|-----------|
+| 1 | `event_evaluator.py:313` | unknown graph metric silently reads `0.0` | unregistered `:metric` is **E-LOAD-011** at content load — the rule never loads | `correction_1_unknown_metric_is_e_load_011_not_zero` (`unknown_metric.bsl`) |
+| 2 | `event_evaluator.py:439` | unknown aggregation falls through to `False` — the condition silently never fires | off-set fold operator is a loud typecheck rejection at load | `correction_2_unknown_aggregation_is_a_loud_load_error_not_false` |
+| 3 | `event_evaluator.py:405` | unknown comparison operator falls through to `False` | a token outside the closed operator set is not even an atom — **E-LEX-003** at read | `correction_3_unknown_comparison_operator_is_a_lex_error_not_false` |
+| 4 | `event_evaluator.py:103` | empty precondition set silently returns `True` | `(when)` is a loud rejection (E-PARSE-020); "always" is written by **omitting** the clause — explicit intent | `correction_4_empty_when_is_rejected_and_omission_is_the_legal_always` (`empty_when.bsl`, `unconditional.bsl`) |
+
+## Documented tightening beyond the four (the §3.4 law, not a correction row)
+
+Python's `sum_strength`/`avg_strength` edge metrics (`test_event_evaluator.py:307-323`)
+and unweighted `avg` over intensity fields silently commit the recorded
+intensive-aggregation variance error. Under §3.4 these are **E-TYPE-041/042** —
+pinned by `intensive_aggregation_is_rejected_where_python_allowed_it`. A weighted
+mean with an extensive `:weight` remains legal (`event_wealth_aggregates.bsl`).
+
+## Disposition — `test_mechanics.py` (271 lines)
+
+| Python test (file:lines) | Disposition | Rust side |
+|---|---|---|
+| `TestRealMvpConditions` ×4 (45–64) | **Executes** — the two MVP trap conditions as loaded rules, `<when>` evaluated against supplied envs | `real_mvp_conditions` (`doctrine_adventurism.bsl`, `doctrine_liquidationism.bsl`) |
+| `TestMissingTagIsZero` ×2 (67–75) | **Executes** — absent-reads-0 becomes a DECLARED `:optional :default 0`, carried on `DEFAULT_ALLOWLIST` (6 rows, §3.5 item 4) | `missing_tag_reads_the_declared_default` |
+| `TestMeasuredPracticeVocabulary` ×8 (97–144) | **Executes** — practice variables + `@coeff` → `:field`/`:const` bindings (the `@` sigil does not survive); unknown coeff/variable are **load** errors (E-LOAD-010), matching "fails loud" with an earlier failure time | `liquidation_absorbing_state`, `unknown_coefficient_and_variable_fail_loud_at_load` (`doctrine_liquidation_absorbing.bsl`) |
+| `TestFullGrammar` ×2 incl. 11 vectors (147–181) | **Executes** — all six comparisons, and/or/not, grouping; Python's infix precedence is STRUCTURAL in s-expressions, so the precedence test transcribes as explicit nesting | `full_condition_grammar` |
+| `TestMalformedRaises` ×1/7 params (184–202) | **Executes** — each malformed shape fails through its §4.6 class: empty→read error, dangling operator→E-PARSE-040 arity, missing comparison→E-LOAD-021, `UNKNOWN_TAG`→E-LEX-003 (SCREAMING_SNAKE is no atom class), free RHS symbol→E-LOAD-010, unterminated→read error | `malformed_conditions_fail_loud` |
+| `TestCanAcquire` ×6 (205–238), `TestAcquire` ×2 (241–246) | **Out of BSL scope** — doctrine-tree acquisition mechanics are domain code over loaded JSON data, not rule content; they port with `babylon-domain` (Phase 2), not as BSL | ledger row only |
+| `TestTheoreticalLabourAccrual` ×3 (249–258) | **Executes** — surplus×allocation with the negative floor and unit-interval clamp written as explicit `if` content (only SILENT clamping is banned, §3.3) | `theoretical_labor_accrual_vectors` |
+| `TestTagDecay` ×3 (261–271) | **Executes** — multiplicative decay as an expression; expected values computed by the SAME IEEE-754 formula, no approx literals | `tag_decay_vectors` |
+
+## Disposition — `test_event_evaluator.py` (628 lines)
+
+| Python test (file:lines) | Disposition | Rust side |
+|---|---|---|
+| `TestCompare` ×6 (124–151) | **Executes** — six-operator vectors incl. the binary64 equality pair | `compare_vectors` |
+| `TestGetNestedValue` ×6 (154–179) | **Transcribed as the honest-null law** — dotted paths are qname field paths; missing-key-returns-`None` does NOT transcribe: absence is a load decision (E-LOAD-010 or a declared default), never a skipped `None`; int-to-float coercion is §3.3 promotion | `nested_paths_are_qnames_and_absence_is_declared` |
+| `TestAggregateAndCompare` ×7 (182–214) | **Load-level** — any→`exists`, all→`forall`, count/sum/max/min/weighted-mean folds load, typecheck and bound; runtime values ride Phase 2 | `aggregation_fixtures_load_and_bound` (4 fixtures) |
+| `TestFilterNodes` ×4 (217–241) | **Partially transcribed** — type filtering is the query's `<enum-ref>`; role filtering is an `it`-predicate (Phase-2 execution); `id_pattern` REGEX is deliberately not expressible in BSL (no string operations, §2.8 Prohibited) — a permanent delta, not a gap | ledger row + query fixtures |
+| `TestEvaluateNodeCondition` ×4 (244–283) | **Load-level** — `exists`/`forall` fixtures with threshold predicates | `aggregation_fixtures_load_and_bound` (`event_node_condition.bsl`, `event_forall.bsl`) |
+| `TestEvaluateEdgeCondition` ×4 (286–323) | **Load-level** for count; sum/avg strength are the §3.4 tightening above | `event_edge_count.bsl`, `intensive_aggregation_is_rejected_…` |
+| `TestEvaluateGraphCondition` ×3 (326–351) | **Executes** — the six Python metrics are the registered `:metric` set; the conjunction evaluates in the expression core with metric values supplied | `metric_conditions_load_and_evaluate` (`event_metric_conditions.bsl`) |
+| `TestCalculateGraphMetric` ×3 (354–369) | Metric *computation* is kernel/engine work (Phase 2/3 — a registered metric's value arrives via the binding); the unknown-metric case is Correction 1 | `correction_1_…` |
+| `TestEvaluatePreconditions` ×3 (372–417) | **Executes** — "all"→`and`, "any"→`or` (§2.4 coverage table); the empty case is Correction 4 | `precondition_logic_vectors` |
+| `TestEvaluateTemplate` ×4 (420–590) | **Executes (resolution selection)** — Python's conditioned Resolutions become guards in ONE effect list, executed against a real substrate both ways (`bifurcation_routes_by_solidarity_density`); preconditions-unmet ≙ `<when>` false. **Cooldown_ticks does not transcribe to BSL** — it is scheduler state, engine-side (Phase 3 anchor registry), recorded here, not silently dropped | `event_bifurcation.bsl` |
+| `TestGetMatchingNodesForResolution` ×1 (593–628) | **Engine-side** — target selection (`${node_id}` interpolation) is the engine's per-node rule application (`self` iteration), not rule content; no string interpolation exists in payloads (§2.8) | ledger row only |
+
+## `DEFAULT_ALLOWLIST` population (Task 15's lint, §3.5 item 4)
+
+Six rows — one per transcribed absent-reads-as-0 binding: `mass-link`
+(adventurism); `class-analysis`, `militancy` (liquidationism); `solidarity-mass`,
+`co-optive-share`, `petty-bourgeois-drift` (the U11 absorbing state). Authority:
+spec §5's migration-corpus enumeration + the honest-null reading
+`test_mechanics.py:67-75` pins. The corpus lints clean
+(`missing_tag_reads_the_declared_default` asserts zero findings).
+
+## Built by this task
+
+- `babylon_bsl::rule_pipeline` — the composed load entry point (read → surface →
+  bindings → §3.4 fold typecheck → anchors → resolution → free variables → §3.7
+  bound), plus `bind_environment` (the §3.5 evaluation-side half: required-missing
+  is loud, `:optional` takes its declared default — no rule observes absence).
+- The fold-typecheck adapter resolves binding-name bodies through their `:field`
+  sources; compound fold bodies are rejected loudly as Phase-1-unverifiable
+  rather than passed unchecked (III.11).

--- a/rust/crates/babylon-bsl/src/default_lint.rs
+++ b/rust/crates/babylon-bsl/src/default_lint.rs
@@ -29,9 +29,61 @@ pub struct DefaultAllowlistEntry {
     pub date: &'static str,
 }
 
-/// The allowlist. Empty until Task 17 transcribes the trap DSL's pinned
-/// absent-reads-as-0 sites, one row each.
-pub const DEFAULT_ALLOWLIST: &[DefaultAllowlistEntry] = &[];
+/// The allowlist: the trap DSL's pinned absent-reads-as-0 sites, one row
+/// per transcribed binding (Task 17). Authority: spec §5 "The migration
+/// corpus enumerates the exact rules permitted to carry `:default 0`" +
+/// the honest-null reading `test_mechanics.py:67-75` pins ("absent = no
+/// accumulated strength, never a fabricated nonzero").
+pub const DEFAULT_ALLOWLIST: &[DefaultAllowlistEntry] = &[
+    DefaultAllowlistEntry {
+        rule_file: "tests/conformance/doctrine_adventurism.bsl",
+        binding_name: "mass-link",
+        reason: "trap DSL pinned site: an unaccrued doctrine tag reads 0 \
+                 (test_mechanics.py:48-52, 71-75)",
+        owner: "Director (spec \u{a7}5 migration-corpus enumeration)",
+        date: "2026-07-30",
+    },
+    DefaultAllowlistEntry {
+        rule_file: "tests/conformance/doctrine_liquidationism.bsl",
+        binding_name: "class-analysis",
+        reason: "trap DSL pinned site: an unaccrued doctrine tag reads 0 \
+                 (test_mechanics.py:54-64)",
+        owner: "Director (spec \u{a7}5 migration-corpus enumeration)",
+        date: "2026-07-30",
+    },
+    DefaultAllowlistEntry {
+        rule_file: "tests/conformance/doctrine_liquidationism.bsl",
+        binding_name: "militancy",
+        reason: "trap DSL pinned site: an unaccrued doctrine tag reads 0 \
+                 (test_mechanics.py:54-64, 71-75)",
+        owner: "Director (spec \u{a7}5 migration-corpus enumeration)",
+        date: "2026-07-30",
+    },
+    DefaultAllowlistEntry {
+        rule_file: "tests/conformance/doctrine_liquidation_absorbing.bsl",
+        binding_name: "solidarity-mass",
+        reason: "trap DSL pinned site: an unmeasured practice variable \
+                 reads 0 (test_mechanics.py:105-106, P25 U11/ADR137)",
+        owner: "Director (spec \u{a7}5 migration-corpus enumeration)",
+        date: "2026-07-30",
+    },
+    DefaultAllowlistEntry {
+        rule_file: "tests/conformance/doctrine_liquidation_absorbing.bsl",
+        binding_name: "co-optive-share",
+        reason: "trap DSL pinned site: an unmeasured practice variable \
+                 reads 0 (test_mechanics.py:101-103, P25 U11/ADR137)",
+        owner: "Director (spec \u{a7}5 migration-corpus enumeration)",
+        date: "2026-07-30",
+    },
+    DefaultAllowlistEntry {
+        rule_file: "tests/conformance/doctrine_liquidation_absorbing.bsl",
+        binding_name: "petty-bourgeois-drift",
+        reason: "trap DSL pinned site: an unmeasured practice variable \
+                 reads 0 (test_mechanics.py:114-122, P25 U11/ADR137)",
+        owner: "Director (spec \u{a7}5 migration-corpus enumeration)",
+        date: "2026-07-30",
+    },
+];
 
 /// Whether `(rule_file, binding_name)` carries Director sign-off for a
 /// `:default`.

--- a/rust/crates/babylon-bsl/src/lib.rs
+++ b/rust/crates/babylon-bsl/src/lib.rs
@@ -14,6 +14,7 @@ pub mod intrinsic_host;
 pub mod material_basis;
 pub mod mod_anchors;
 pub mod reader;
+pub mod rule_pipeline;
 pub mod structural_verbs;
 pub mod typecheck;
 pub mod types;
@@ -34,6 +35,7 @@ pub use mod_anchors::{check_anchor, AnchorDecl, AnchorError, AnchorPosition};
 pub use reader::{
     read, read_all, Atom, LexCode, ReadError, ReadErrorKind, SExpr, ScaledKind, ScaledLit,
 };
+pub use rule_pipeline::{bind_environment, load_rule, LoadContext, LoadError, LoadedRule};
 pub use structural_verbs::{CollectingSink, EffectExecutor, EventSink};
 pub use typecheck::{typecheck_aggregation, TypeCode, TypeEnv, TypeError};
 pub use types::{BslType, FieldDecl, FieldKind};

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -1,0 +1,313 @@
+//! The composed rule-loading pipeline — the single "load a rule" entry
+//! point Task 17 requires (no earlier task created it; each earlier task
+//! tests its own layer in isolation by design). Composition follows the
+//! §4.6 error-class ordering: lexical/syntactic (`E-LEX`/`E-PARSE`) →
+//! static/type (`E-TYPE`) → load/link (`E-LOAD`), so the FIRST failure a
+//! bad rule reports is the earliest-class one, matching "there is no
+//! partial load and no skip-the-bad-rule mode".
+//!
+//! Stages, in order: read (§1/§2) → rule surface (`:material-basis`
+//! `E-PARSE-011`, `:fuel` range `E-PARSE-012`) → binding declarations
+//! (`E-PARSE-013/022/030/031`) → fold aggregation typecheck (§3.4,
+//! `E-TYPE-041/042/043`) → anchor placement (`E-LOAD-002`) → binding
+//! resolution (`E-LOAD-010/011`) → free variables (`E-LOAD-010`) → static
+//! fuel bound + member-list ceilings (`E-LOAD-040/042`). The `:default`
+//! allowlist lint runs LAST and is carried as findings, not an error —
+//! §3.5 item 4 makes it a sign-off gate, not a load rejection.
+//!
+//! **Fold typecheck adapter (recorded gap):** the §3.4 checker (Task 10)
+//! takes the aggregation shape `(op field (:weight wfield)?)`; this
+//! pipeline adapts each real `(fold <op> <query> <body> (:weight <w>)?)`
+//! whose body (and weight) are FIELD REFERENCES. `count` needs no kind and
+//! always passes. A fold whose body is a compound expression needs §3.4's
+//! kind PROPAGATION rules, which no Phase-1 task implements — such a fold
+//! is rejected LOUDLY as unverifiable rather than passed unchecked (III.11:
+//! an unverified pass-through is the silent-degradation shape).
+
+use crate::bindings::{
+    check_free_variables, parse_bindings, resolve_bindings, BindingDecl, BindingError,
+    BindingVocabulary,
+};
+use crate::bound_checker::{check_rule, BoundError};
+use crate::default_lint::{lint_defaults, DefaultLintFinding};
+use crate::evaluator::Value;
+use crate::fuel::{CardinalityCeilings, IntrinsicCosts};
+use crate::material_basis::{check_rule_surface, SurfaceError};
+use crate::mod_anchors::{check_anchor, AnchorDecl, AnchorError};
+use crate::reader::{read, Atom, ReadError, SExpr};
+use crate::typecheck::{typecheck_aggregation, TypeEnv, TypeError};
+use std::collections::{HashMap, HashSet};
+
+/// Everything a rule loads against. Phase 1 takes each registry as an
+/// opaque input; their contents are Phase 2/3 content and engine data.
+pub struct LoadContext<'a> {
+    /// Declared fields / defines keys / registered metrics (§3.5).
+    pub vocabulary: &'a BindingVocabulary,
+    /// Declared field types and kinds (§3.4).
+    pub types: &'a TypeEnv,
+    /// Declared cardinality ceilings (§3.7).
+    pub ceilings: &'a CardinalityCeilings,
+    /// Declared intrinsic costs (§2.7).
+    pub intrinsics: &'a IntrinsicCosts,
+    /// Registered system names, for the anchor default (§2.3).
+    pub systems: &'a HashSet<String>,
+    /// The rule's source file, for the `:default` allowlist lint.
+    pub rule_file: &'a str,
+}
+
+/// A rule that survived every load-time gate.
+#[derive(Debug, Clone)]
+pub struct LoadedRule {
+    /// The parsed rule form.
+    pub rule: SExpr,
+    /// Its declared bindings.
+    pub bindings: Vec<BindingDecl>,
+    /// Its anchor declaration, or `None` for the anchor default.
+    pub anchor: Option<AnchorDecl>,
+    /// The §3.7 static bound `check_rule` computed and accepted.
+    pub static_bound: u64,
+    /// `:default` declarations with no allowlist row — sign-off findings,
+    /// never a rejection (§3.5 item 4).
+    pub default_findings: Vec<DefaultLintFinding>,
+}
+
+/// A load-time rejection, tagged by the stage that raised it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LoadError {
+    /// §1/§2 — the reader.
+    Read(ReadError),
+    /// §2.2 mandatory keywords.
+    Surface(SurfaceError),
+    /// §2.5/§3.5 binding declarations and resolution.
+    Binding(BindingError),
+    /// §3.4 aggregation law.
+    Type(TypeError),
+    /// §2.3 anchors.
+    Anchor(AnchorError),
+    /// §3.7 static bound and member-list ceilings.
+    Bound(BoundError),
+}
+
+impl LoadError {
+    /// The spec's error code, where the failing stage names one.
+    #[must_use]
+    pub fn spec_code(&self) -> Option<&'static str> {
+        match self {
+            Self::Read(e) => match &e.kind {
+                crate::reader::ReadErrorKind::Lex(code) => Some(code.spec_code()),
+                _ => None,
+            },
+            Self::Surface(e) => e.spec_code(),
+            Self::Binding(e) => e.spec_code(),
+            Self::Type(e) => e.code.map(crate::typecheck::TypeCode::spec_code),
+            Self::Anchor(e) => e.spec_code(),
+            Self::Bound(e) => e.spec_code(),
+        }
+    }
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read(e) => write!(f, "read: {}", e.message),
+            Self::Surface(e) => write!(f, "{e}"),
+            Self::Binding(e) => write!(f, "{e}"),
+            Self::Type(e) => write!(f, "{}", e.message),
+            Self::Anchor(e) => write!(f, "{e}"),
+            Self::Bound(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for LoadError {}
+
+/// Load one rule from source through every gate, in §4.6 class order.
+///
+/// # Errors
+///
+/// The first-failing stage's [`LoadError`]; a loaded content set has no
+/// partially-loaded rules.
+pub fn load_rule(source: &str, ctx: &LoadContext<'_>) -> Result<LoadedRule, LoadError> {
+    let (rule, _) = read(source).map_err(LoadError::Read)?;
+    check_rule_surface(&rule).map_err(LoadError::Surface)?;
+    let bindings = parse_bindings(&rule).map_err(LoadError::Binding)?;
+    typecheck_rule_folds(&rule, ctx.types, &bindings).map_err(LoadError::Type)?;
+    let anchor = check_anchor(&rule, ctx.systems).map_err(LoadError::Anchor)?;
+    resolve_bindings(&bindings, ctx.vocabulary).map_err(LoadError::Binding)?;
+    check_free_variables(&rule, &bindings).map_err(LoadError::Binding)?;
+    let static_bound = check_rule(&rule, ctx.ceilings, ctx.intrinsics).map_err(LoadError::Bound)?;
+    let default_findings = lint_defaults(ctx.rule_file, &bindings);
+    Ok(LoadedRule {
+        rule,
+        bindings,
+        anchor,
+        static_bound,
+        default_findings,
+    })
+}
+
+/// §3.5's evaluation-side half: build the evaluator environment from the
+/// declared bindings and the values the world supplied. A required binding
+/// with no supplied value is loud (`E-LOAD-010`-shaped — the loader should
+/// have proven it present); an `:optional` binding takes its declared
+/// default. No rule ever observes absence.
+///
+/// # Errors
+///
+/// [`BindingError::Unresolved`] for a missing required value.
+pub fn bind_environment<S: std::hash::BuildHasher>(
+    decls: &[BindingDecl],
+    supplied: &HashMap<String, Value, S>,
+) -> Result<HashMap<String, Value>, BindingError> {
+    let mut env = HashMap::with_capacity(decls.len());
+    for decl in decls {
+        if let Some(value) = supplied.get(&decl.name) {
+            env.insert(decl.name.clone(), value.clone());
+            continue;
+        }
+        match &decl.default {
+            Some(literal) => {
+                env.insert(decl.name.clone(), literal_value(literal));
+            }
+            None => {
+                return Err(BindingError::Unresolved {
+                    name: decl.name.clone(),
+                    what: "binding value (required, not supplied)",
+                })
+            }
+        }
+    }
+    Ok(env)
+}
+
+/// A `:default` literal's runtime value (§2.2: only literals).
+fn literal_value(atom: &Atom) -> Value {
+    match atom {
+        Atom::Int(n) => Value::Int(*n),
+        Atom::Currency(c) => Value::Currency(*c),
+        Atom::Scaled(s) => {
+            // Unit-interval literal, unscaled < 10⁹ — exact in f64.
+            #[allow(clippy::cast_precision_loss)]
+            let value = s.unscaled as f64 / 10f64.powi(i32::from(s.scale));
+            Value::Real(value)
+        }
+        Atom::Bool(b) => Value::Bool(*b),
+        // parse_bindings admits only the four literal atom classes above.
+        other => unreachable!("non-literal :default survived parse_bindings: {other:?}"),
+    }
+}
+
+/// Walk the rule's `<when>` and `<effects>` for `(fold …)` forms and run
+/// each through the §3.4 aggregation law via the adapter described in the
+/// module doc. A fold body written as a BINDING name resolves through the
+/// binding's `:field` source for kind purposes — the binding carries its
+/// declared kind (§3.4: "a `:field` binding carries its declared kind").
+fn typecheck_rule_folds(
+    rule: &SExpr,
+    types: &TypeEnv,
+    bindings: &[BindingDecl],
+) -> Result<(), TypeError> {
+    let SExpr::List(items) = rule else {
+        return Ok(()); // shape errors are earlier stages' business
+    };
+    for child in items {
+        if let SExpr::List(inner) = child {
+            if matches!(inner.first(), Some(SExpr::Atom(Atom::Symbol(h))) if h == "when" || h == "effects")
+            {
+                for body in &inner[1..] {
+                    walk_folds(body, types, bindings)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn walk_folds(expr: &SExpr, types: &TypeEnv, bindings: &[BindingDecl]) -> Result<(), TypeError> {
+    let SExpr::List(items) = expr else {
+        return Ok(());
+    };
+    if matches!(items.first(), Some(SExpr::Atom(Atom::Symbol(h))) if h == "fold") {
+        typecheck_one_fold(items, types, bindings)?;
+    }
+    for item in items {
+        walk_folds(item, types, bindings)?;
+    }
+    Ok(())
+}
+
+/// A fold-body field reference, resolved through the binding table when it
+/// is a binding name rather than a bare qname.
+fn field_ref_for(expr: &SExpr, bindings: &[BindingDecl]) -> Option<SExpr> {
+    match expr {
+        SExpr::Atom(Atom::QName(_)) => Some(expr.clone()),
+        SExpr::Atom(Atom::Symbol(name)) => {
+            let source_qname = bindings.iter().find_map(|decl| {
+                if decl.name == *name {
+                    if let crate::bindings::BindSource::Field(qname) = &decl.source {
+                        return Some(qname.clone());
+                    }
+                }
+                None
+            });
+            match source_qname {
+                Some(qname) => Some(SExpr::Atom(Atom::QName(qname))),
+                // Not a field binding — hand the symbol through so the §3.4
+                // checker rejects it loudly as an unknown field.
+                None => Some(expr.clone()),
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Adapt `(fold <op> <query> <body> (:weight <w>)?)` to the Task 10
+/// aggregation shape `(op body (:weight w)?)`. See the module doc for the
+/// count special case and the compound-body loud rejection.
+fn typecheck_one_fold(
+    items: &[SExpr],
+    types: &TypeEnv,
+    bindings: &[BindingDecl],
+) -> Result<(), TypeError> {
+    let (op, body, weight) = match items {
+        [_, op, _query, body] => (op, body, None),
+        [_, op, _query, body, SExpr::Atom(Atom::Keyword(kw)), w] if kw == "weight" => {
+            (op, body, Some(w))
+        }
+        _ => return Ok(()), // shape errors are the bound checker's business
+    };
+    let is_count = matches!(op, SExpr::Atom(Atom::Symbol(name)) if name == "count");
+    if is_count {
+        return Ok(()); // §3.4 row 6: count is always legal, no kind involved
+    }
+    let body_ref = field_ref_for(body, bindings);
+    let weight_ref = match weight {
+        None => None,
+        Some(w) => match field_ref_for(w, bindings) {
+            Some(resolved) => Some(resolved),
+            None => {
+                return Err(compound_fold_error());
+            }
+        },
+    };
+    let Some(body_ref) = body_ref else {
+        return Err(compound_fold_error());
+    };
+    let mut adapted: Vec<SExpr> = vec![(*op).clone(), body_ref];
+    if let Some(w) = weight_ref {
+        adapted.push(SExpr::Atom(Atom::Keyword("weight".to_owned())));
+        adapted.push(w);
+    }
+    typecheck_aggregation(&SExpr::List(adapted), types).map(|_| ())
+}
+
+fn compound_fold_error() -> TypeError {
+    TypeError {
+        code: None,
+        message: "fold body/weight kind-propagation over compound \
+                  expressions is not implemented in Phase 1 — rejected \
+                  loudly rather than passed unchecked (III.11); use a \
+                  field reference, or wait for the Phase-2 checker"
+            .to_owned(),
+    }
+}

--- a/rust/crates/babylon-bsl/tests/conformance/doctrine_adventurism.bsl
+++ b/rust/crates/babylon-bsl/tests/conformance/doctrine_adventurism.bsl
@@ -1,0 +1,13 @@
+; Transcribes test_mechanics.py:45-52 (TestRealMvpConditions, adventurism)
+; and 67-75 (TestMissingTagIsZero): "MASS_LINK <= 0" with absent-tag-reads-0.
+; The :optional :default 0 binding IS the trap DSL's pinned
+; absent-reads-as-0 site — honest-null: absent = no accumulated strength,
+; declared in content, carried on the DEFAULT_ALLOWLIST (§3.5 item 4).
+(rule doctrine/adventurism
+  :material-basis "isolation from the mass base severs the practice loop"
+  :fuel 16
+  (bindings
+    (binding mass-link :field organization/mass-link :optional :default 0))
+  (when (<= mass-link 0))
+  (effects
+    (emit EventType/DOCTRINE_TRAP (trap-id 1))))

--- a/rust/crates/babylon-bsl/tests/conformance/doctrine_liquidation_absorbing.bsl
+++ b/rust/crates/babylon-bsl/tests/conformance/doctrine_liquidation_absorbing.bsl
@@ -1,0 +1,18 @@
+; Transcribes test_mechanics.py:85-122 (the U11/ADR137 absorbing state):
+; practice variables + @coeff thresholds -> :field bindings + :const
+; bindings (the @ sigil does not survive, per the §2.2 keyword table).
+(rule doctrine/liquidation-absorbing
+  :material-basis "solidarity collapsed, co-optation dominant, base embourgeoised: the absorbing state"
+  :fuel 32
+  (bindings
+    (binding solidarity-mass :field organization/solidarity-mass :optional :default 0)
+    (binding co-optive-share :field organization/co-optive-share :optional :default 0)
+    (binding petty-bourgeois-drift :field organization/petty-bourgeois-drift :optional :default 0)
+    (binding solidarity-liquidation-floor :const doctrine/solidarity-liquidation-floor)
+    (binding co-optive-liquidation-threshold :const doctrine/co-optive-liquidation-threshold)
+    (binding petty-bourgeois-liquidation-threshold :const doctrine/petty-bourgeois-liquidation-threshold))
+  (when (and (<= solidarity-mass solidarity-liquidation-floor)
+             (>= co-optive-share co-optive-liquidation-threshold)
+             (>= petty-bourgeois-drift petty-bourgeois-liquidation-threshold)))
+  (effects
+    (emit EventType/DOCTRINE_TRAP (trap-id 3))))

--- a/rust/crates/babylon-bsl/tests/conformance/doctrine_liquidationism.bsl
+++ b/rust/crates/babylon-bsl/tests/conformance/doctrine_liquidationism.bsl
@@ -1,0 +1,10 @@
+; Transcribes test_mechanics.py:54-64: "CLASS_ANALYSIS <= 0 AND MILITANCY <= 0".
+(rule doctrine/liquidationism
+  :material-basis "theory and militancy both abandoned dissolves the organization into the movement it tailed"
+  :fuel 16
+  (bindings
+    (binding class-analysis :field organization/class-analysis :optional :default 0)
+    (binding militancy :field organization/militancy :optional :default 0))
+  (when (and (<= class-analysis 0) (<= militancy 0)))
+  (effects
+    (emit EventType/DOCTRINE_TRAP (trap-id 2))))

--- a/rust/crates/babylon-bsl/tests/conformance/empty_when.bsl
+++ b/rust/crates/babylon-bsl/tests/conformance/empty_when.bsl
@@ -1,0 +1,11 @@
+; CORRECTION 4 of 4 (event_evaluator.py:103): Python treats an empty
+; precondition set as True — silent permissiveness. BSL: (when) is
+; E-PARSE-020; "always" is written by OMITTING the clause or (when #t),
+; so the empty case can never be an accident (§2.3, §6.3).
+(rule event/empty-when
+  :material-basis "an event with no stated preconditions has no material trigger"
+  :fuel 16
+  (bindings)
+  (when)
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT (gate 0))))

--- a/rust/crates/babylon-bsl/tests/conformance/event_bifurcation.bsl
+++ b/rust/crates/babylon-bsl/tests/conformance/event_bifurcation.bsl
@@ -1,0 +1,15 @@
+; Transcribes test_event_evaluator.py:526-590 (resolution selection):
+; Python's two conditioned Resolutions become two guards in ONE effect
+; list — the routing is content, not engine machinery.
+(rule event/bifurcation
+  :material-basis "agitation routes to national identity or class consciousness by solidarity density"
+  :fuel 512
+  (bindings
+    (binding agitation :field social-class/agitation)
+    (binding solidarity-density :metric solidarity-density))
+  (when (>= agitation 0.5p))
+  (effects
+    (guard (< solidarity-density 0.1c)
+      (update-node self social-class/national-identity (add 0.15i)))
+    (guard (>= solidarity-density 0.1c)
+      (update-node self social-class/class-consciousness (add 0.15i)))))

--- a/rust/crates/babylon-bsl/tests/conformance/event_edge_count.bsl
+++ b/rust/crates/babylon-bsl/tests/conformance/event_edge_count.bsl
@@ -1,0 +1,10 @@
+; Transcribes test_event_evaluator.py:289-305 (EdgeCondition metric
+; "count"): count over the typed edge query; the empty query counts 0 and
+; the comparison decides — never a silent skip.
+(rule event/solidarity-web
+  :material-basis "the solidarity web's existence conditions rupture routing"
+  :fuel 128
+  (bindings)
+  (when (>= (fold count (edges EdgeType/SOLIDARITY) it) 1))
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT (web 1))))

--- a/rust/crates/babylon-bsl/tests/conformance/event_forall.bsl
+++ b/rust/crates/babylon-bsl/tests/conformance/event_forall.bsl
@@ -1,0 +1,10 @@
+; Transcribes test_event_evaluator.py:275-283 (aggregation "all"):
+; all -> forall (§2.4 coverage table).
+(rule event/agitation-everywhere
+  :material-basis "a threshold held by every fraction, not just the vanguard"
+  :fuel 512
+  (bindings
+    (binding agitation :field social-class/agitation))
+  (when (forall (nodes NodeType/SOCIAL_CLASS) (>= agitation 0.5p)))
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT (threshold 0.5p))))

--- a/rust/crates/babylon-bsl/tests/conformance/event_metric_conditions.bsl
+++ b/rust/crates/babylon-bsl/tests/conformance/event_metric_conditions.bsl
@@ -1,0 +1,15 @@
+; Transcribes test_event_evaluator.py:329-369 (GraphCondition +
+; calculate_graph_metric): the six named Python metrics become :metric
+; bindings against the registered metric set (§2.5).
+(rule event/conjuncture-metrics
+  :material-basis "graph-level density and aggregate positions gate the conjuncture"
+  :fuel 64
+  (bindings
+    (binding solidarity-density :metric solidarity-density)
+    (binding total-wealth :metric total-wealth)
+    (binding average-agitation :metric average-agitation))
+  (when (and (> solidarity-density 0c)
+             (>= total-wealth 550)
+             (>= average-agitation 0.3c)))
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT (gate 1))))

--- a/rust/crates/babylon-bsl/tests/conformance/event_node_condition.bsl
+++ b/rust/crates/babylon-bsl/tests/conformance/event_node_condition.bsl
@@ -1,0 +1,10 @@
+; Transcribes test_event_evaluator.py:247-273 (NodeCondition, aggregation
+; "any"): any -> exists over the node query (§2.4 coverage table).
+(rule event/agitation-anywhere
+  :material-basis "any class fraction past the agitation threshold marks the conjuncture"
+  :fuel 512
+  (bindings
+    (binding agitation :field social-class/agitation))
+  (when (exists (nodes NodeType/SOCIAL_CLASS) (>= agitation 0.6p)))
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT (threshold 0.6p))))

--- a/rust/crates/babylon-bsl/tests/conformance/event_wealth_aggregates.bsl
+++ b/rust/crates/babylon-bsl/tests/conformance/event_wealth_aggregates.bsl
@@ -1,0 +1,16 @@
+; Transcribes test_event_evaluator.py:200-214 + 337-343 (sum/max/min over
+; an EXTENSIVE field are legal, §3.4 rows 1 and 5) and 185-193 via the
+; weighted-mean row: mean of an intensive field with an extensive :weight.
+(rule event/wealth-aggregates
+  :material-basis "total and extremal wealth positions gate the conjuncture"
+  :fuel 1024
+  (bindings
+    (binding wealth :field social-class/wealth)
+    (binding agitation :field social-class/agitation)
+    (binding population :field social-class/population))
+  (when (and (>= (fold sum (nodes NodeType/SOCIAL_CLASS) wealth) 550)
+             (>= (fold max (nodes NodeType/SOCIAL_CLASS) wealth) 500)
+             (<= (fold min (nodes NodeType/SOCIAL_CLASS) wealth) 50)
+             (>= (fold mean (nodes NodeType/SOCIAL_CLASS) agitation :weight population) 0.3i)))
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT (gate 2))))

--- a/rust/crates/babylon-bsl/tests/conformance/unconditional.bsl
+++ b/rust/crates/babylon-bsl/tests/conformance/unconditional.bsl
@@ -1,0 +1,8 @@
+; The legal spelling of "always" (§2.3): omit <when> entirely — explicit
+; intent, not an accident of an empty list.
+(rule event/unconditional
+  :material-basis "a standing levy applies every tick by declared intent"
+  :fuel 16
+  (bindings)
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT (standing 1))))

--- a/rust/crates/babylon-bsl/tests/conformance/unknown_metric.bsl
+++ b/rust/crates/babylon-bsl/tests/conformance/unknown_metric.bsl
@@ -1,0 +1,11 @@
+; CORRECTION 1 of 4 (event_evaluator.py:313): Python returns 0.0 for an
+; unknown graph metric — silent degradation. BSL: an unregistered :metric
+; is E-LOAD-011 at content load, never 0.0 (§2.5, §6.3).
+(rule event/phantom-metric
+  :material-basis "a metric that does not exist grounds nothing"
+  :fuel 16
+  (bindings
+    (binding phantom :metric no-such-metric))
+  (when (>= phantom 1))
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT (gate 0))))

--- a/rust/crates/babylon-bsl/tests/conformance_corpus.rs
+++ b/rust/crates/babylon-bsl/tests/conformance_corpus.rs
@@ -1,0 +1,739 @@
+//! The transcribed conformance corpus (spec §5, §8.1): the 271-line
+//! doctrine trap-DSL corpus (`tests/unit/domain/doctrine/test_mechanics.py`)
+//! and the 628-line event-evaluator corpus
+//! (`tests/unit/engine/test_event_evaluator.py`), ported with the
+//! documented 4-point M8 delta at exactly the sites spec §5
+//! "Grammar-superset honesty" names — each correction test cites the
+//! Python line it replaces and the old vs. new behavior. The full
+//! per-function disposition table is
+//! `reports/p27-conformance-corpus-transcription.md`.
+//!
+//! Phase-1 scope note (recorded in the ledger, not silent): fold/query
+//! EXECUTION needs the Phase-2 query evaluator, so aggregation vectors pin
+//! load-time verdicts (parse, resolve, §3.4 typecheck, §3.7 bound) here
+//! and their runtime values ride the Phase-2 vector re-run. Everything
+//! expressible in the Task 14 expression core executes for real.
+#![allow(clippy::doc_markdown)] // doc comments cite Python test names and file paths verbatim
+
+use babylon_bsl::evaluator::{evaluate, EvalEnv, Value};
+use babylon_bsl::fuel::{CardinalityCeilings, IntrinsicCosts};
+use babylon_bsl::intrinsic_host::EmptyIntrinsicHost;
+use babylon_bsl::reader::read;
+use babylon_bsl::rule_pipeline::{bind_environment, load_rule, LoadContext, LoadError, LoadedRule};
+use babylon_bsl::structural_verbs::{CollectingSink, EffectExecutor};
+use babylon_bsl::typecheck::TypeEnv;
+use babylon_bsl::types::{BslType, FieldDecl, FieldKind};
+use babylon_bsl::BindingVocabulary;
+use babylon_graph::placeholder::PlaceholderGraph;
+use babylon_graph::substrate::GraphSubstrate;
+use std::collections::{HashMap, HashSet};
+
+// ---------------------------------------------------------------- context
+
+fn field(ty: BslType, kind: FieldKind) -> FieldDecl {
+    FieldDecl { ty, kind }
+}
+
+fn types() -> TypeEnv {
+    TypeEnv {
+        fields: HashMap::from([
+            // Doctrine tag totals: accumulated counts, extensive.
+            (
+                "organization/mass-link".to_owned(),
+                field(BslType::Int, FieldKind::Extensive),
+            ),
+            (
+                "organization/class-analysis".to_owned(),
+                field(BslType::Int, FieldKind::Extensive),
+            ),
+            (
+                "organization/militancy".to_owned(),
+                field(BslType::Int, FieldKind::Extensive),
+            ),
+            // Measured-practice variables: unit-interval shares, intensive.
+            (
+                "organization/solidarity-mass".to_owned(),
+                field(BslType::Coefficient, FieldKind::Intensive),
+            ),
+            (
+                "organization/co-optive-share".to_owned(),
+                field(BslType::Coefficient, FieldKind::Intensive),
+            ),
+            (
+                "organization/petty-bourgeois-drift".to_owned(),
+                field(BslType::Coefficient, FieldKind::Intensive),
+            ),
+            // Event-evaluator estate.
+            (
+                "social-class/agitation".to_owned(),
+                field(BslType::Intensity, FieldKind::Intensive),
+            ),
+            (
+                "social-class/national-identity".to_owned(),
+                field(BslType::Intensity, FieldKind::Intensive),
+            ),
+            (
+                "social-class/class-consciousness".to_owned(),
+                field(BslType::Intensity, FieldKind::Intensive),
+            ),
+            (
+                "social-class/wealth".to_owned(),
+                field(BslType::Currency, FieldKind::Extensive),
+            ),
+            (
+                "social-class/population".to_owned(),
+                field(BslType::Int, FieldKind::Extensive),
+            ),
+            (
+                "solidarity/strength".to_owned(),
+                field(BslType::Intensity, FieldKind::Intensive),
+            ),
+        ]),
+        exemptions: &[],
+    }
+}
+
+fn vocabulary() -> BindingVocabulary {
+    let types = types();
+    BindingVocabulary {
+        fields: types.fields.keys().cloned().collect(),
+        consts: HashSet::from([
+            "doctrine/solidarity-liquidation-floor".to_owned(),
+            "doctrine/co-optive-liquidation-threshold".to_owned(),
+            "doctrine/petty-bourgeois-liquidation-threshold".to_owned(),
+        ]),
+        metrics: HashSet::from([
+            // The six Python metrics (event_evaluator.py:301-310), as the
+            // registered metric set.
+            "solidarity-density".to_owned(),
+            "exploitation-density".to_owned(),
+            "average-agitation".to_owned(),
+            "average-consciousness".to_owned(),
+            "total-wealth".to_owned(),
+            "gini-coefficient".to_owned(),
+        ]),
+    }
+}
+
+fn ceilings() -> CardinalityCeilings {
+    CardinalityCeilings::new(
+        HashMap::from([
+            ("NodeType/SOCIAL_CLASS".to_owned(), 100),
+            ("EdgeType/SOLIDARITY".to_owned(), 40),
+        ]),
+        HashMap::new(),
+    )
+}
+
+struct Registries {
+    vocabulary: BindingVocabulary,
+    types: TypeEnv,
+    ceilings: CardinalityCeilings,
+    intrinsics: IntrinsicCosts,
+    systems: HashSet<String>,
+}
+
+fn registries() -> Registries {
+    Registries {
+        vocabulary: vocabulary(),
+        types: types(),
+        ceilings: ceilings(),
+        intrinsics: IntrinsicCosts::default(),
+        systems: HashSet::from(["doctrine".to_owned(), "event".to_owned()]),
+    }
+}
+
+fn load(source: &str, rule_file: &str) -> Result<LoadedRule, LoadError> {
+    let r = registries();
+    let ctx = LoadContext {
+        vocabulary: &r.vocabulary,
+        types: &r.types,
+        ceilings: &r.ceilings,
+        intrinsics: &r.intrinsics,
+        systems: &r.systems,
+        rule_file,
+    };
+    load_rule(source, &ctx)
+}
+
+/// Load a fixture and evaluate its `<when>` condition against supplied
+/// binding values — the trap-DSL calling convention
+/// (`evaluate_trap_condition(expr, env, coeffs)`) reconstructed from the
+/// composed pipeline.
+fn eval_when(rule: &LoadedRule, supplied: &HashMap<String, Value>) -> bool {
+    let env_map = bind_environment(&rule.bindings, supplied).expect("environment must bind");
+    let costs = IntrinsicCosts::default();
+    let env = EvalEnv {
+        bindings: env_map,
+        intrinsic_costs: &costs,
+    };
+    let babylon_bsl::SExpr::List(items) = &rule.rule else {
+        unreachable!()
+    };
+    let cond = items
+        .iter()
+        .find_map(|child| match child {
+            babylon_bsl::SExpr::List(inner)
+                if matches!(inner.first(), Some(babylon_bsl::SExpr::Atom(babylon_bsl::Atom::Symbol(h))) if h == "when") =>
+            {
+                inner.get(1)
+            }
+            _ => None,
+        })
+        .expect("fixture has a when clause");
+    let mut fuel = 10_000;
+    match evaluate(cond, &env, &EmptyIntrinsicHost, &mut fuel).expect("condition must evaluate") {
+        Value::Bool(b) => b,
+        other => panic!("a <cond> must be Bool, got {other:?}"),
+    }
+}
+
+fn int(n: i64) -> Value {
+    Value::Int(n)
+}
+fn real(r: f64) -> Value {
+    Value::Real(r)
+}
+
+// ================================================================ doctrine
+// tests/unit/domain/doctrine/test_mechanics.py (271 lines)
+
+const ADVENTURISM: &str = include_str!("conformance/doctrine_adventurism.bsl");
+const LIQUIDATIONISM: &str = include_str!("conformance/doctrine_liquidationism.bsl");
+const ABSORBING: &str = include_str!("conformance/doctrine_liquidation_absorbing.bsl");
+
+/// test_mechanics.py:45-64 (TestRealMvpConditions) — the two shipped MVP
+/// trap conditions, behavior preserved exactly.
+#[test]
+fn real_mvp_conditions() {
+    let adventurism = load(ADVENTURISM, "tests/conformance/doctrine_adventurism.bsl").unwrap();
+    assert!(eval_when(&adventurism, &owned(vec![("mass-link", int(0))])));
+    assert!(!eval_when(
+        &adventurism,
+        &owned(vec![("mass-link", int(3))])
+    ));
+
+    let liquidationism = load(
+        LIQUIDATIONISM,
+        "tests/conformance/doctrine_liquidationism.bsl",
+    )
+    .unwrap();
+    assert!(eval_when(
+        &liquidationism,
+        &owned(vec![("class-analysis", int(0)), ("militancy", int(0))])
+    ));
+    assert!(!eval_when(
+        &liquidationism,
+        &owned(vec![("class-analysis", int(0)), ("militancy", int(5))])
+    ));
+}
+
+/// test_mechanics.py:67-75 (TestMissingTagIsZero) — absent = no
+/// accumulated strength. In BSL the honest-null site is DECLARED:
+/// `:optional :default 0`, carried on the DEFAULT_ALLOWLIST.
+#[test]
+fn missing_tag_reads_the_declared_default() {
+    let adventurism = load(ADVENTURISM, "tests/conformance/doctrine_adventurism.bsl").unwrap();
+    // No value supplied at all: the declared default 0 applies -> fires.
+    assert!(eval_when(&adventurism, &HashMap::new()));
+    // The allowlist covers every :default this corpus declares — zero
+    // sign-off findings.
+    assert!(adventurism.default_findings.is_empty());
+    let absorbing = load(
+        ABSORBING,
+        "tests/conformance/doctrine_liquidation_absorbing.bsl",
+    )
+    .unwrap();
+    assert!(absorbing.default_findings.is_empty());
+}
+
+/// test_mechanics.py:85-134 (TestMeasuredPracticeVocabulary) — the U11
+/// absorbing state over practice variables + coefficient thresholds.
+#[test]
+fn liquidation_absorbing_state() {
+    let absorbing = load(
+        ABSORBING,
+        "tests/conformance/doctrine_liquidation_absorbing.bsl",
+    )
+    .unwrap();
+    let coeffs = [
+        ("solidarity-liquidation-floor", real(0.05)),
+        ("co-optive-liquidation-threshold", real(0.6)),
+        ("petty-bourgeois-liquidation-threshold", real(0.6)),
+    ];
+    // test_mechanics.py:114-117 — collapsed solidarity, high co-optation,
+    // embourgeoised base: liquidated.
+    let mut fires: Vec<(&str, Value)> = coeffs.to_vec();
+    fires.extend([
+        ("solidarity-mass", real(0.0)),
+        ("co-optive-share", real(0.8)),
+        ("petty-bourgeois-drift", real(0.7)),
+    ]);
+    assert!(eval_when(&absorbing, &owned(fires)));
+    // test_mechanics.py:119-122 — a live SOLIDARITY mass base defeats the
+    // absorbing state, whatever else.
+    let mut dormant: Vec<(&str, Value)> = coeffs.to_vec();
+    dormant.extend([
+        ("solidarity-mass", real(0.5)),
+        ("co-optive-share", real(0.8)),
+        ("petty-bourgeois-drift", real(0.7)),
+    ]);
+    assert!(!eval_when(&absorbing, &owned(dormant)));
+}
+
+/// test_mechanics.py:124-138 — an unknown `@coeff` / unknown variable
+/// fails LOUD. In BSL both are load-time resolution failures, not
+/// evaluation-time surprises.
+#[test]
+fn unknown_coefficient_and_variable_fail_loud_at_load() {
+    // Unknown coefficient: a :const outside the defines vocabulary.
+    let unknown_coeff = ABSORBING.replace(
+        ":const doctrine/solidarity-liquidation-floor",
+        ":const doctrine/no-such-threshold",
+    );
+    let err = load(&unknown_coeff, "x.bsl").unwrap_err();
+    assert_eq!(err.spec_code(), Some("E-LOAD-010"), "{err}");
+
+    // Unknown variable: a free symbol no binding declares.
+    let unknown_var = ADVENTURISM.replace("(<= mass-link 0)", "(<= not-a-variable 0)");
+    let err = load(&unknown_var, "x.bsl").unwrap_err();
+    assert_eq!(err.spec_code(), Some("E-LOAD-010"), "{err}");
+}
+
+/// test_mechanics.py:147-181 (TestFullGrammar) — all six comparisons,
+/// AND/OR/NOT and grouping. Python's infix precedence ("AND binds tighter
+/// than OR") is STRUCTURAL in BSL — s-expressions have no precedence to
+/// get wrong, so the precedence test transcribes as explicit nesting.
+#[test]
+fn full_condition_grammar() {
+    type Vector<'a> = (&'a str, &'a [(&'a str, Value)], bool);
+    let vectors: &[Vector<'_>] = &[
+        ("(>= ca 3)", &[("ca", Value::Int(3))], true),
+        ("(> ca 3)", &[("ca", Value::Int(3))], false),
+        ("(< ml 2)", &[("ml", Value::Int(1))], true),
+        ("(= mi 4)", &[("mi", Value::Int(4))], true),
+        ("(!= mi 4)", &[("mi", Value::Int(4))], false),
+        (
+            "(or (<= ml 0) (<= mi 0))",
+            &[("ml", Value::Int(5)), ("mi", Value::Int(0))],
+            true,
+        ),
+        (
+            "(or (<= ml 0) (<= mi 0))",
+            &[("ml", Value::Int(5)), ("mi", Value::Int(5))],
+            false,
+        ),
+        ("(not (<= ml 0))", &[("ml", Value::Int(3))], true),
+        ("(not (<= ml 0))", &[("ml", Value::Int(0))], false),
+        (
+            "(and (or (<= ca 0) (<= mi 0)) (<= ml 0))",
+            &[
+                ("ca", Value::Int(0)),
+                ("mi", Value::Int(5)),
+                ("ml", Value::Int(0)),
+            ],
+            true,
+        ),
+        (
+            "(and (or (<= ca 0) (<= mi 0)) (<= ml 0))",
+            &[
+                ("ca", Value::Int(5)),
+                ("mi", Value::Int(5)),
+                ("ml", Value::Int(0)),
+            ],
+            false,
+        ),
+        // test_mechanics.py:177-181 — "A OR (B AND C)", nesting explicit.
+        (
+            "(or (<= ca 0) (and (<= ml 0) (<= mi 0)))",
+            &[
+                ("ca", Value::Int(0)),
+                ("ml", Value::Int(0)),
+                ("mi", Value::Int(5)),
+            ],
+            true,
+        ),
+    ];
+    for (source, env_pairs, expected) in vectors {
+        assert_eq!(eval_cond(source, env_pairs), *expected, "vector: {source}");
+    }
+}
+
+/// test_mechanics.py:184-202 (TestMalformedRaises) — every malformed
+/// condition fails LOUDLY, each through the §4.6 class its defect belongs
+/// to; a trap that silently never fires is a correctness hole.
+#[test]
+fn malformed_conditions_fail_loud() {
+    // "" — nothing to read.
+    assert!(read("").is_err());
+    // "MASS_LINK <=" — dangling operator: strictly binary arity.
+    let err = eval_cond_err("(<= ml)", &[("ml", Value::Int(0))]);
+    assert!(err.message.contains("E-PARSE-040"), "{err}");
+    // "MASS_LINK 0" — missing comparison: the head is an undeclared call.
+    let err = eval_cond_err("(ml 0)", &[("ml", Value::Int(0))]);
+    assert!(err.message.contains("E-LOAD-021"), "{err}");
+    // "UNKNOWN_TAG <= 0" — SCREAMING_SNAKE is no BSL atom class at all.
+    assert!(read("(<= UNKNOWN_TAG 0)").is_err());
+    // "MASS_LINK <= zero" — a non-literal RHS is a free variable: load error.
+    let with_free = ADVENTURISM.replace("(<= mass-link 0)", "(<= mass-link zero)");
+    assert_eq!(
+        load(&with_free, "x.bsl").unwrap_err().spec_code(),
+        Some("E-LOAD-010")
+    );
+    // "MASS_LINK <= 0 AND" / "(MASS_LINK <= 0" — unterminated forms.
+    assert!(read("(and (<= ml 0)").is_err());
+}
+
+/// test_mechanics.py:249-258 (TestTheoreticalLabourAccrual) — surplus ×
+/// allocation with the negative floor and the unit-interval clamp WRITTEN
+/// AS CONTENT (an explicit `if` is honest math; only SILENT clamping is
+/// banned, §3.3).
+#[test]
+fn theoretical_labor_accrual_vectors() {
+    let accrual = "(if (< surplus 0) \
+                     0 \
+                     (* surplus (if (> alloc 1.0c) 1.0c (if (< alloc 0c) 0c alloc))))";
+    let cases: &[(f64, f64, f64)] = &[
+        (1000.0, 0.2, 200.0),
+        (-500.0, 0.2, 0.0),
+        (100.0, 1.5, 100.0),
+        (100.0, -0.5, 0.0),
+    ];
+    for (surplus, alloc, expected) in cases {
+        let value = eval_value(
+            accrual,
+            &[("surplus", real(*surplus)), ("alloc", real(*alloc))],
+        );
+        match value {
+            Value::Real(r) => assert!(
+                (r - expected).abs() < 1e-9,
+                "accrue({surplus}, {alloc}) = {r}, expected {expected}"
+            ),
+            Value::Int(n) => {
+                // The zero arms return the Int literal 0.
+                #[allow(clippy::cast_precision_loss)]
+                let as_real = n as f64;
+                assert!((as_real - expected).abs() < 1e-9);
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+}
+
+/// test_mechanics.py:261-271 (TestTagDecay) — multiplicative decay as an
+/// expression: identical IEEE-754 arithmetic on both sides, so the
+/// expected value is computed by the SAME formula, not an approx literal.
+#[test]
+fn tag_decay_vectors() {
+    let decay = "(* total (- 1 rate))";
+    for (total, rate) in [(100.0_f64, 0.0055_f64), (50.0, 0.0055), (7.0, 0.0)] {
+        let value = eval_value(decay, &[("total", real(total)), ("rate", real(rate))]);
+        assert_eq!(
+            value,
+            Value::Real(total * (1.0 - rate)),
+            "decay({total}, {rate})"
+        );
+    }
+}
+
+// ============================================================== event corpus
+// tests/unit/engine/test_event_evaluator.py (628 lines)
+
+const BIFURCATION: &str = include_str!("conformance/event_bifurcation.bsl");
+const NODE_CONDITION: &str = include_str!("conformance/event_node_condition.bsl");
+const FORALL: &str = include_str!("conformance/event_forall.bsl");
+const EDGE_COUNT: &str = include_str!("conformance/event_edge_count.bsl");
+const WEALTH_AGGREGATES: &str = include_str!("conformance/event_wealth_aggregates.bsl");
+const METRIC_CONDITIONS: &str = include_str!("conformance/event_metric_conditions.bsl");
+const UNKNOWN_METRIC: &str = include_str!("conformance/unknown_metric.bsl");
+const EMPTY_WHEN: &str = include_str!("conformance/empty_when.bsl");
+const UNCONDITIONAL: &str = include_str!("conformance/unconditional.bsl");
+
+/// test_event_evaluator.py:124-151 (TestCompare) — the six comparison
+/// operators, exact vectors.
+#[test]
+fn compare_vectors() {
+    let vectors: &[(&str, bool)] = &[
+        ("(>= 5 5)", true),
+        ("(>= 6 5)", true),
+        ("(>= 4 5)", false),
+        ("(<= 5 5)", true),
+        ("(<= 4 5)", true),
+        ("(<= 6 5)", false),
+        ("(> 6 5)", true),
+        ("(> 5 5)", false),
+        ("(< 4 5)", true),
+        ("(< 5 5)", false),
+        ("(= 5 5)", true),
+        ("(!= 5 5)", false),
+    ];
+    for (source, expected) in vectors {
+        assert_eq!(eval_cond(source, &[]), *expected, "vector: {source}");
+    }
+    // 5.1 == 5.0 / != — the binary64 lane.
+    assert!(!eval_cond("(= x 5)", &[("x", real(5.1))]));
+    assert!(eval_cond("(!= x 5)", &[("x", real(5.1))]));
+}
+
+/// test_event_evaluator.py:154-179 (TestGetNestedValue) — dotted paths
+/// become qname field paths; the missing-key-returns-None behavior does
+/// NOT transcribe: absence is a load decision (`E-LOAD-010` or a declared
+/// `:optional :default`), never a silently skipped None (§3.5).
+#[test]
+fn nested_paths_are_qnames_and_absence_is_declared() {
+    // A declared field resolves...
+    assert!(load(NODE_CONDITION, "x.bsl").is_ok());
+    // ...an undeclared one is E-LOAD-010 at load, never a skipped None.
+    let missing = NODE_CONDITION.replace("social-class/agitation", "social-class/missing");
+    assert_eq!(
+        load(&missing, "x.bsl").unwrap_err().spec_code(),
+        Some("E-LOAD-010")
+    );
+    // A required binding with no supplied value is loud at bind time.
+    let loaded = load(NODE_CONDITION, "x.bsl").unwrap();
+    assert!(bind_environment(&loaded.bindings, &HashMap::new()).is_err());
+}
+
+/// test_event_evaluator.py:182-214 + 244-323 — aggregations become folds:
+/// any -> exists, all -> forall, count/sum/max/min/weighted-mean load and
+/// bound against declared ceilings. Runtime fold values ride the Phase-2
+/// query evaluator (ledger row); the load verdicts pin here.
+#[test]
+fn aggregation_fixtures_load_and_bound() {
+    for (fixture, name) in [
+        (NODE_CONDITION, "exists/any"),
+        (FORALL, "forall/all"),
+        (EDGE_COUNT, "count"),
+        (WEALTH_AGGREGATES, "sum/max/min/weighted-mean"),
+    ] {
+        let loaded = load(fixture, "x.bsl").unwrap_or_else(|e| panic!("{name}: {e}"));
+        assert!(loaded.static_bound > 0, "{name} has a real bound");
+    }
+}
+
+/// §3.4 catches what Python's aggregate_and_compare silently permitted:
+/// summing / unweighted-averaging an INTENSIVE field is the recorded
+/// variance error. Python's `sum_strength`/`avg_strength`
+/// (test_event_evaluator.py:307-323) and unweighted `avg` over agitation
+/// are E-TYPE-041/042 here — a documented tightening, not a correction
+/// row (the four M8 corrections are separate).
+#[test]
+fn intensive_aggregation_is_rejected_where_python_allowed_it() {
+    let sum_strength = EDGE_COUNT.replace(
+        "(fold count (edges EdgeType/SOLIDARITY) it)",
+        "(fold sum (edges EdgeType/SOLIDARITY) solidarity/strength)",
+    );
+    assert_eq!(
+        load(&sum_strength, "x.bsl").unwrap_err().spec_code(),
+        Some("E-TYPE-041")
+    );
+    let avg_strength = EDGE_COUNT.replace(
+        "(fold count (edges EdgeType/SOLIDARITY) it)",
+        "(fold mean (edges EdgeType/SOLIDARITY) solidarity/strength)",
+    );
+    assert_eq!(
+        load(&avg_strength, "x.bsl").unwrap_err().spec_code(),
+        Some("E-TYPE-042")
+    );
+}
+
+/// test_event_evaluator.py:326-369 (graph conditions + metrics) — the six
+/// Python metrics are the registered :metric set; conditions over them
+/// load, and their conjunction evaluates in the expression core.
+#[test]
+fn metric_conditions_load_and_evaluate() {
+    let loaded = load(METRIC_CONDITIONS, "x.bsl").unwrap();
+    // solidarity_graph analogue: density 2/6, wealth 550, agitation 0.4.
+    let fires = [
+        ("solidarity-density", real(2.0 / 6.0)),
+        ("total-wealth", real(550.0)),
+        ("average-agitation", real(0.4)),
+    ];
+    assert!(eval_when(&loaded, &owned(fires.to_vec())));
+    // simple_graph analogue for density: no solidarity edges -> 0.0.
+    let dormant = [
+        ("solidarity-density", real(0.0)),
+        ("total-wealth", real(550.0)),
+        ("average-agitation", real(0.4)),
+    ];
+    assert!(!eval_when(&loaded, &owned(dormant.to_vec())));
+}
+
+/// test_event_evaluator.py:372-417 (PreconditionSet logic) — "all" is
+/// `and`, "any" is `or`; both short-circuit per §4.1.
+#[test]
+fn precondition_logic_vectors() {
+    let all = "(and (>= agitation 0.6p) (>= wealth 1000))";
+    assert!(!eval_cond(
+        all,
+        &[("agitation", real(0.7)), ("wealth", real(550.0))]
+    ));
+    let any = "(or (>= agitation 0.6p) (>= wealth 1000))";
+    assert!(eval_cond(
+        any,
+        &[("agitation", real(0.7)), ("wealth", real(550.0))]
+    ));
+}
+
+/// test_event_evaluator.py:526-590 (resolution selection) — the
+/// bifurcation rule EXECUTES: guards route the same effect list two ways
+/// by solidarity density, against a real substrate.
+#[test]
+fn bifurcation_routes_by_solidarity_density() {
+    let loaded = load(BIFURCATION, "x.bsl").unwrap();
+    for (density, touched_field) in [
+        (0.05, "social-class/national-identity"),
+        (2.0 / 6.0, "social-class/class-consciousness"),
+    ] {
+        let mut graph = PlaceholderGraph::new();
+        let self_id = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph
+            .update_node(self_id, "social-class/national-identity", 0.2)
+            .unwrap();
+        graph
+            .update_node(self_id, "social-class/class-consciousness", 0.4)
+            .unwrap();
+        let before = graph.node_attribute(self_id, touched_field).unwrap();
+
+        let supplied = owned(vec![
+            ("agitation", real(0.8)),
+            ("solidarity-density", real(density)),
+            ("self", Value::NodeRef(self_id)),
+        ]);
+        let mut env_map = bind_environment(&loaded.bindings, &supplied).unwrap();
+        env_map.insert("self".to_owned(), Value::NodeRef(self_id));
+        let costs = IntrinsicCosts::default();
+        let env = EvalEnv {
+            bindings: env_map,
+            intrinsic_costs: &costs,
+        };
+        let babylon_bsl::SExpr::List(items) = &loaded.rule else {
+            unreachable!()
+        };
+        let effects = items
+            .iter()
+            .find_map(|child| match child {
+                babylon_bsl::SExpr::List(inner)
+                    if matches!(inner.first(), Some(babylon_bsl::SExpr::Atom(babylon_bsl::Atom::Symbol(h))) if h == "effects") =>
+                {
+                    Some(&inner[1..])
+                }
+                _ => None,
+            })
+            .unwrap();
+        let registries = registries();
+        let mut executor = EffectExecutor::new(&registries.types);
+        let mut sink = CollectingSink::default();
+        let mut fuel = 512;
+        executor
+            .execute_effects(
+                effects,
+                &env,
+                &EmptyIntrinsicHost,
+                &mut graph,
+                &mut sink,
+                &mut fuel,
+            )
+            .unwrap();
+        let after = graph.node_attribute(self_id, touched_field).unwrap();
+        assert!(
+            (after - (before + 0.15)).abs() < 1e-12,
+            "density {density} must route +0.15 to {touched_field}"
+        );
+    }
+}
+
+// ------------------------------------------------- the four M8 corrections
+
+/// CORRECTION 1 of 4 — event_evaluator.py:313: `calculator() if
+/// calculator else 0.0`. Old: an unknown graph metric silently reads 0.0.
+/// New: an unregistered :metric is E-LOAD-011 at content load (§2.5) —
+/// the rule never loads, nothing reads a phantom zero.
+#[test]
+fn correction_1_unknown_metric_is_e_load_011_not_zero() {
+    let err = load(UNKNOWN_METRIC, "x.bsl").unwrap_err();
+    assert_eq!(err.spec_code(), Some("E-LOAD-011"), "{err}");
+}
+
+/// CORRECTION 2 of 4 — event_evaluator.py:439: the aggregation dispatch
+/// falls through to `return False`. Old: an unknown aggregation silently
+/// never fires. New: an off-set fold operator is a loud typecheck
+/// rejection at content load.
+#[test]
+fn correction_2_unknown_aggregation_is_a_loud_load_error_not_false() {
+    let median = EDGE_COUNT.replace(
+        "(fold count (edges EdgeType/SOLIDARITY) it)",
+        "(fold median (edges EdgeType/SOLIDARITY) solidarity/strength)",
+    );
+    let err = load(&median, "x.bsl").unwrap_err();
+    assert!(
+        err.to_string().contains("unknown aggregation operator"),
+        "{err}"
+    );
+}
+
+/// CORRECTION 3 of 4 — event_evaluator.py:405: the comparison dispatch
+/// falls through to `return False`. Old: an unknown operator silently
+/// never fires. New: a token outside the closed operator set is not even
+/// an atom — E-LEX-003 at read time.
+#[test]
+fn correction_3_unknown_comparison_operator_is_a_lex_error_not_false() {
+    let err = read("(~= agitation 0.5p)").unwrap_err();
+    assert!(matches!(
+        err.kind,
+        babylon_bsl::ReadErrorKind::Lex(babylon_bsl::LexCode::UnclassifiableToken)
+    ));
+}
+
+/// CORRECTION 4 of 4 — event_evaluator.py:103: `if not results: return
+/// True`. Old: an empty precondition set silently always passes. New:
+/// `(when)` is a loud load rejection (E-PARSE-020); "always" is written by
+/// omitting the clause — explicit intent, never an accident.
+#[test]
+fn correction_4_empty_when_is_rejected_and_omission_is_the_legal_always() {
+    let err = load(EMPTY_WHEN, "x.bsl").unwrap_err();
+    assert!(err.to_string().contains("E-PARSE-020"), "{err}");
+    let unconditional = load(UNCONDITIONAL, "x.bsl").unwrap();
+    assert_eq!(
+        unconditional.static_bound, 3,
+        "an omitted <when> contributes 0; the emit costs 3"
+    );
+}
+
+// ---------------------------------------------------------------- helpers
+
+fn owned(pairs: Vec<(&str, Value)>) -> HashMap<String, Value> {
+    pairs
+        .into_iter()
+        .map(|(name, value)| (name.to_owned(), value))
+        .collect()
+}
+
+fn eval_value(source: &str, env_pairs: &[(&str, Value)]) -> Value {
+    let costs = IntrinsicCosts::default();
+    let env = EvalEnv {
+        bindings: owned(env_pairs.to_vec()),
+        intrinsic_costs: &costs,
+    };
+    let (expr, _) = read(source).expect("vector source must parse");
+    let mut fuel = 10_000;
+    evaluate(&expr, &env, &EmptyIntrinsicHost, &mut fuel).expect("vector must evaluate")
+}
+
+fn eval_cond(source: &str, env_pairs: &[(&str, Value)]) -> bool {
+    match eval_value(source, env_pairs) {
+        Value::Bool(b) => b,
+        other => panic!("a <cond> must be Bool, got {other:?}"),
+    }
+}
+
+fn eval_cond_err(source: &str, env_pairs: &[(&str, Value)]) -> babylon_bsl::EvalError {
+    let costs = IntrinsicCosts::default();
+    let env = EvalEnv {
+        bindings: owned(env_pairs.to_vec()),
+        intrinsic_costs: &costs,
+    };
+    let (expr, _) = read(source).expect("vector source must parse");
+    let mut fuel = 10_000;
+    evaluate(&expr, &env, &EmptyIntrinsicHost, &mut fuel).expect_err("vector must fail")
+}


### PR DESCRIPTION
## Summary

P27 Phase 1 **Task 17** — the freeze-tag-parity milestone: the 271-line doctrine trap-DSL corpus and the 628-line event-evaluator corpus transcribed to BSL fixtures + a Rust conformance harness, **both Python files read end-to-end first** (F1 discipline), with the documented **4-point M8 delta** as explicit correction tests. All four Python sites re-verified live before transcription — `event_evaluator.py:103/313/405/439`, zero drift from the spec's citations.

| # | Old (Python) | New (BSL) |
|---|---|---|
| 1 | unknown metric silently reads `0.0` (`:313`) | **E-LOAD-011** at load |
| 2 | unknown aggregation → `False` (`:439`) | loud typecheck rejection |
| 3 | unknown comparison → `False` (`:405`) | **E-LEX-003** — not even an atom |
| 4 | empty precondition set → `True` (`:103`) | loud rejection; "always" = the **omitted** `<when>` |

## The composed pipeline (built here, as the plan required)

`rule_pipeline::load_rule` — the first point where every load gate composes, in §4.6 class order: read → surface → bindings → §3.4 fold typecheck → anchors → resolution → free variables → §3.7 bound. Plus `bind_environment`, §3.5's evaluation half: required-missing is loud, `:optional` takes its declared default — **no rule observes absence**.

## What executes vs what pins

Trap-DSL conditions (both MVP traps + the U11 absorbing state), grammar vectors, the malformed-fails-loud table, accrual/decay arithmetic, compare vectors, precondition logic, and **bifurcation resolution routing** (guards against a real substrate, both directions) all **execute**. Fold aggregations pin parse/typecheck/bound verdicts; runtime values ride the Phase-2 query evaluator — a ledger-recorded scope law, not a silent gap. Full per-function disposition: `reports/p27-conformance-corpus-transcription.md`.

**§3.4 tightening beyond the four**: Python's `sum_strength`/`avg_strength` silently commit the intensive-aggregation variance error — E-TYPE-041/042 here, pinned. `id_pattern` regex (no string ops in BSL, by design) and `cooldown_ticks` (scheduler state, Phase 3) are recorded deltas.

**`DEFAULT_ALLOWLIST` populated**: six rows, one per transcribed absent-reads-as-0 trap-DSL binding, reason/owner/date each; the corpus lints clean.

19 conformance tests + 12 fixtures; 135 unit + 19 conformance green; `mise run rust:check` clean.

Part of #368. Remaining on the ladder: Task 18 (the Phase-1 exit gate — its ruling precondition already satisfied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)