### PR TITLE
ci(p27): frozen-engine gate + freeze-tag reference — Phase 0 Task 17

### DIFF
--- a/.github/workflows/frozen-engine.yml
+++ b/.github/workflows/frozen-engine.yml
@@ -1,0 +1,50 @@
+name: frozen-engine
+
+# Program 27 Phase 0 Task 17: the frozen-engine gate. Checks out the
+# `p27-python-freeze` executable pin (Amendment AE: the Python engine is
+# reference-only past that tag) and proves it still RUNS byte-identically —
+# the canon-scenario byte-gate plus the golden-vault byte-gate, mirroring
+# ci.yml's qa-regression job step-for-step. A red run here is a RED GATE
+# (spec §4): the frozen reference has rotted and cutover comparisons are
+# unsound until it is repaired. Repairs to the frozen engine require
+# Director sign-off + contract re-extraction — never a silent re-tag.
+#
+# The scenarios are synthetic in-memory factories (no Postgres, no LFS, no
+# reference DB, no gdal) — proven byte-identical on hosted runners by the
+# Phase-0 probe. See docs/reference/freeze-tag.md.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Monday 06:00 UTC — keeps the pin proven through cutover
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frozen-engine
+  cancel-in-progress: false
+
+jobs:
+  frozen-canon:
+    name: Frozen canon byte-gate (p27-python-freeze pin)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: p27-python-freeze
+
+      - name: Materialize hypergraph-rs metadata stub (sibling repo, no remote)
+        run: sh tools/ci_hypergraph_stub.sh
+
+      - uses: ./.github/actions/bootstrap-python
+
+      - name: qa:regression (canon scenarios vs the frozen baselines)
+        run: mise run qa:regression
+
+      - name: qa:vault-regression (golden-vault byte-gate, in-process scenario)
+        run: mise run qa:vault-regression-ci
+
+      - name: Gate-coverage truth probe (declared evidence verified at gate cadence)
+        run: mise run check:gate-coverage-truth

--- a/docs/reference/freeze-tag.md
+++ b/docs/reference/freeze-tag.md
@@ -1,0 +1,60 @@
+# The `p27-python-freeze` tag — the frozen Python engine's executable pin
+
+**Authority:** Amendment AE (Constitution v3.0.0, ADR172) — "the Python engine
+freezes at the `p27-python-freeze` executable pin, reference-only after."
+Chartered as Program 27 Phase 0 Task 17
+(`docs/superpowers/plans/2026-07-29-program-27-phase-0-contracts-and-evidence.md`);
+Phase 0 is complete at this document's merge plus the first green
+`frozen-engine` run.
+
+## What the tag pins
+
+An annotated tag on `dev` at the last commit of the frozen reference era —
+after the Director-merged phi_hour boundary clamp (PR #370, the final
+authorized Python-engine fix) and the Phase 1 exit checklist (PR #435). The
+tag message records the exact pin set:
+
+| Pin | Value at the tag | Where it lives |
+|---|---|---|
+| Source tree | the tagged commit | git |
+| Nix toolchain | `flake.lock` blob `94ed2d750efa` | in-tree, flake-owned sqlite 3.53.1 |
+| Python deps | `uv.lock` blob `d35423513fb1` | in-tree, frozen-sync only |
+| Reference DB | product sha256 `5e1e60fc8097…` | `data-artifacts.yaml` (the registry is canonical — ADR098; `mise run data:build-db` reproduces it sha-identically on the pinned toolchain) |
+| Migration head | `0044_hash_rename_adr179_t2.sql` | `src/babylon/persistence/migrations/` |
+
+## What "frozen" means (spec §4)
+
+The Python engine is **reference-only** past this tag:
+
+- New capability lands Rust-side (Amendment AE; the Rust-first inversion).
+- Python engine changes after the tag are **repairs to the reference or
+  contract authoring only**, require Director sign-off, and trigger contract
+  re-extraction for any family whose vectors they touch.
+- The frozen reference keeps its known honest divergences BY DESIGN — e.g.
+  the imposed survival logistic (ADR173: the Rust/BSL engine derives the
+  S-curve emergently; survival conformance vectors encode the EMERGENT
+  formulation, not Python replay) and the phi_hour clamp as a
+  frozen-reference noise floor (ADR175 ruling 13: signed Φ with attribution
+  is the Rust-side law).
+
+## How to run the frozen engine
+
+```bash
+git checkout p27-python-freeze
+sh tools/ci_hypergraph_stub.sh   # only where ../hypergraph-rs is absent (CI)
+uv sync --frozen
+mise run qa:regression           # canon scenarios, byte-identical
+mise run qa:vault-regression-ci  # golden-vault byte-gate
+```
+
+## The `frozen-engine` CI job
+
+`.github/workflows/frozen-engine.yml` runs weekly (Monday 06:00 UTC) and on
+dispatch (`gh workflow run frozen-engine`). It checks out the tag and runs
+the same byte-gates as `ci.yml`'s qa-regression job, step-for-step.
+
+**A red `frozen-engine` run is a red gate** (spec §4): the frozen reference
+has rotted — a runner-image drift, a dependency yank, or an accidental
+force-move of the tag — and every cutover comparison is unsound until it is
+repaired. STOP and diagnose; repairing the frozen engine requires Director
+sign-off, and the tag is never silently re-cut.


### PR DESCRIPTION
## Summary

Phase 0 Task 17's two artifacts. The `p27-python-freeze` executable pin is **already cut and pushed** (annotated tag on dev tip `bb6df6cf` — after the Director-merged phi_hour clamp #370 and the Phase 1 exit checklist #435).

- **`.github/workflows/frozen-engine.yml`** — weekly (Mon 06:00 UTC) + dispatchable job checking out the tag and running `ci.yml`'s qa-regression legs step-for-step (hypergraph stub → bootstrap-python → `qa:regression` → `qa:vault-regression-ci` → gate-coverage truth probe). A red run is a **red gate**: the frozen reference rotted and cutover comparisons are unsound.
- **`docs/reference/freeze-tag.md`** — what the tag pins (source, `flake.lock 94ed2d750efa`, `uv.lock d35423513fb1`, reference-DB registry sha `5e1e60fc8097` per ADR098, migration head `0044`), what frozen means (reference-only; Director-signed repairs; the DESIGNED divergences per ADR173/ADR175), how to run it, what red means.

## Preconditions (verified at the cut)

- `mise run check` — 14,209 unit tests green
- `tests/unit/engine/laws/` — 83 green (the Task 11 coverage floor)
- `qa:regression` — all scenarios + the two-process determinism leg
- `qa:vault-regression-ci` — byte-identical to golden
- `gh pr list --label director-gate --state open` — empty

**Phase 0 is complete when this merges and the first `frozen-engine` dispatch runs green** (plan Task 17 Step 4). Train #343 closes with that evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)