### PR TITLE
docs(protocol): ADR181 + Copilot harvest merge-precondition + instructions rewrite (CI train A)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,322 +1,65 @@
-# Copilot Instructions
-
-**Babylon** - Geopolitical simulation engine modeling class struggle through MLM-TW (Marxist-Leninist-Maoist Third Worldist) theory.
-
-> **Primary Reference:** [`CLAUDE.md`](CLAUDE.md) contains comprehensive development standards, architectural decisions, and coding patterns. Read it first.
-
-## Quick Start
-
-```bash
-uv sync --extra server               # Install dependencies
-mise run ci                         # Fast CI gate: lint + format + typecheck + test:unit
-mise run test:all                   # All non-AI tests (~1500 tests)
-mise run docs-live                  # Live documentation server
-```
-
-## Essential Knowledge
-
-### Architecture: The Embedded Trinity
-
-Three-layer local system (no external servers):
-
-1. **The Ledger** (SQLite/Pydantic) - Persistent material state in [src/babylon/data/](src/babylon/data/)
-
-   - 17 JSON entity collections validated against JSON Schema Draft 2020-12
-   - `defines.yaml` - Single source of truth for all tunable coefficients
-   - Hydration pattern: Load at startup → mutate in RAM → persist on save (NO DB I/O during tick)
-
-1. **The Topology** (NetworkX/GraphProtocol) - Hot computational graph in [src/babylon/models/world_state.py](src/babylon/models/world_state.py)
-
-   - `to_graph()` / `from_graph()` - Convert Pydantic ↔ DiGraph
-   - Node types: `SocialClass` (entities), `Territory` (spatial)
-   - Edge types: EXPLOITATION, SOLIDARITY, WAGES, TRIBUTE, REPRESSION, TENANCY
-   - Future: Interface-first design enables swapping NetworkX for DuckDB+DuckPGQ without changing System code
-
-1. **The Archive** (ChromaDB) - Semantic history for AI narrative in [src/babylon/rag/](src/babylon/rag/)
-
-   - AI observes state changes, **never controls mechanics**
-   - Non-deterministic narrative only, deterministic formulas separate
-
-**Key Insight:** State is pure data. Engine is pure transformation. They never mix.
-
-### Development Workflow (Critical!)
-
-**COMMIT EARLY, COMMIT OFTEN** - After each logical unit of work:
-
-```bash
-# Anti-pattern: Accumulating multiple changes before committing
-# ❌ BAD: Fix Genesis bug + Fix Zombie bug → try to commit separately → FAILS
-#         Pre-commit hooks test only staged files; if Bug B tests need Bug A code, you're forced into giant commits
-
-# ✅ GOOD: Fix Genesis bug → commit immediately → Fix Zombie bug → commit immediately
-git add src/babylon/scenarios.py tests/unit/test_scenario_initialization.py
-git commit -m "fix(genesis): resolve initialization order"  # Conventional commit format
-```
-
-**Why:** Pre-commit hooks run tests on staged files only. Accumulating work creates dependency chains that force large, unreviewable commits.
-
-### Core Principles
-
-- **Test-Driven Development (TDD):** Red-Green-Refactor cycle mandatory. Use `@pytest.mark.red_phase` for TDD RED phase.
-- **Pydantic First:** All game objects as `pydantic.BaseModel`, no raw dicts. Use constrained types (`Probability`, `Currency`, `Intensity`).
-- **Strict Typing:** MyPy strict mode enforced. Explicit return types on all functions.
-- **Data-Driven Design:** Game logic in `defines.yaml` and JSON data files, not hardcoded conditionals.
-- **Test Constants:** Use `tests/constants.py` for domain defaults (e.g., `TC.Wealth.WORKER_BASELINE`). Keep type boundaries inline (e.g., `0.0`, `1.0` for Probability).
-
-## Task Runner (mise)
-
-All development tasks use `mise` with namespace-driven organization:
-
-```bash
-mise tasks                          # List all available tasks
-
-# CI & Quality (fast gate)
-mise run check                      # lint + format + typecheck + test:unit (use before commits)
-mise run lint                       # Ruff linter with auto-fix
-mise run format                     # Ruff formatter
-mise run typecheck                  # MyPy strict mode
-
-# Testing (test:* namespace)
-mise run test:unit                  # Unit tests only (fast, ~500 tests)
-mise run test:int                   # Integration tests (mechanics & systems)
-mise run test:all                   # All non-AI tests (~1500 tests)
-mise run test:cov                   # Tests with coverage report
-mise run test:doctest               # Doctest examples in formulas
-
-# Simulation (sim:* namespace)
-mise run sim:run                    # Main simulation entry point
-mise run sim:trace                  # Time-series CSV + JSON output
-mise run sim:sweep                  # Parameter sweep analysis
-mise run sim:profile                # cProfile performance analysis
-
-# QA (qa:* namespace)
-mise run qa:verify                  # Formula correctness verification
-mise run qa:schemas                 # JSON schema validation
-mise run qa:security                # Dependency security audit
-
-# Documentation (docs:* namespace)
-mise run docs:build                 # Build Sphinx documentation
-mise run docs:live                  # Live-reload documentation server
-mise run docs:strict                # Build with warnings as errors (CI mode)
-```
-
-**Direct pytest** (for specific tests):
-
-```bash
-uv run pytest tests/unit/test_foo.py::test_specific    # Single test
-uv run pytest -k "test_name_pattern"                   # Pattern matching
-uv run pytest -m "math"                                # Run specific markers
-```
-
-## Pytest Markers
-
-Tests are categorized by performance and I/O characteristics:
-
-- `@pytest.mark.math` - Deterministic formulas (fast, pure functions)
-- `@pytest.mark.ledger` - Economic/political state manipulation
-- `@pytest.mark.topology` - Graph/network operations (NetworkX)
-- `@pytest.mark.integration` - Database/ChromaDB (I/O bound)
-- `@pytest.mark.ai` - AI/RAG evaluation (slow, non-deterministic)
-- `@pytest.mark.red_phase` - TDD RED phase (intentionally failing until GREEN)
-
-**Filter examples:**
-
-```bash
-uv run pytest -m "math"                    # Only fast math tests
-uv run pytest -m "not ai"                  # Exclude slow AI tests (default)
-uv run pytest -m "math or ledger"          # Multiple markers
-```
-
-## Engine Architecture
-
-Modular systems with dependency injection:
-
-```
-step(WorldState, SimulationConfig) -> WorldState
-     |
-     v
-SimulationEngine.run_tick(graph, services, context)
-     |
-     +-- 1. ImperialRentSystem   - Wealth extraction via imperial rent
-     +-- 2. SolidaritySystem     - Consciousness transmission
-     +-- 3. ConsciousnessSystem  - Ideology drift & bifurcation
-     +-- 4. SurvivalSystem       - P(S|A), P(S|R) calculations
-     +-- 5. StruggleSystem       - Agency Layer (George Floyd Dynamic)
-     +-- 6. ContradictionSystem  - Tension/rupture dynamics
-     +-- 7. TerritorySystem      - Heat, eviction, carceral geography
-```
-
-**Key Components:**
-
-- `src/babylon/engine/simulation_engine.py` - Orchestrates Systems
-- `src/babylon/engine/services.py` - ServiceContainer (DI container)
-- `src/babylon/engine/event_bus.py` - Publish/subscribe events (12 EventTypes)
-- `src/babylon/engine/formula_registry.py` - 17 hot-swappable formulas
-- `src/babylon/config/defines.py` - GameDefines (all tunable coefficients)
-- `src/babylon/formulas/formulas.py` - Mathematical formulas (17 total)
-
-**Observer System:**
-
-- `SimulationObserver` - Protocol for state change notifications
-- `SessionRecorder` - Black box recording for debugging/replay
-- `TopologyMonitor` - Phase transition detection via percolation theory
-
-## Type System & Imports
-
-All game entities use Pydantic models with constrained types:
-
-```python
-# Constrained numeric types (ALWAYS use these, never raw floats)
-from babylon.models import Probability, Currency, Intensity, Ideology, Coefficient
-
-# Enums
-from babylon.models import SocialRole, EdgeType, IntensityLevel, ResolutionType
-
-# Core entities
-from babylon.models import SocialClass, Territory, Relationship, WorldState, SimulationConfig
-
-# Test constants
-from tests.constants import TestConstants
-TC = TestConstants  # Shorthand alias
-
-# Example usage
-worker = SocialClass(
-    id="C001",
-    name="Worker",
-    wealth=Currency(TC.Wealth.WORKER_BASELINE),
-    ideology=Ideology(TC.Ideology.AWAKENING),
-    consciousness=Probability(0.7),
-)
-```
-
-## Docstring Standards (Critical for CI)
-
-**All public classes/functions MUST have Sphinx-compatible RST docstrings.** CI fails on malformed docstrings (`-W` flag).
-
-```python
-def calculate_imperial_rent(wages: Currency, value: Currency) -> Currency:
-    """Calculate imperial rent extracted via unequal exchange.
-
-    The fundamental theorem of MLM-TW: when wages exceed value produced,
-    the difference represents imperial rent transferred from periphery.
-
-    Args:
-        wages: Currency amount paid to workers in core.
-        value: Currency amount of value actually produced.
-
-    Returns:
-        Imperial rent (Phi) extracted from periphery workers.
-
-    Raises:
-        ValueError: If wages or value are negative.
-
-    Example:
-        >>> calculate_imperial_rent(wages=Currency(100.0), value=Currency(80.0))
-        Currency(20.0)
-
-    See Also:
-        :func:`calculate_exploitation_rate`: Related exploitation metric.
-        :class:`ImperialRentSystem`: System that applies this formula.
-    """
-```
-
-**RST Rules:**
-
-- Use `::` for code blocks (not markdown triple backticks)
-- Use `Args:` / `Returns:` / `Raises:` sections
-- Use `:func:`function_name\`\` for cross-references to functions
-- Use `:class:`ClassName\`\` for cross-references to classes
-- Examples should pass `pytest --doctest-modules`
-- Blank line required before and after code blocks
-
-## Verification Checklist
-
-Before submitting any PR:
-
-```bash
-mise run check                      # Fast CI gate (lint + format + typecheck + test:unit)
-mise run test:all                   # All non-AI tests
-uv run pytest --doctest-modules src/babylon/formulas/formulas/  # If you modified formulas
-```
-
-## Key Files Reference
-
-| File/Directory                                                     | Purpose                                           |
-| ------------------------------------------------------------------ | ------------------------------------------------- |
-| [`CLAUDE.md`](CLAUDE.md)                                           | Comprehensive development guidelines (READ FIRST) |
-| [`ai-docs/`](ai-docs/)                                             | Machine-readable YAML specs for all systems       |
-| [`ai-docs/formulas-spec.yaml`](ai-docs/formulas-spec.yaml)         | All mathematical formulas                         |
-| [`ai-docs/architecture.yaml`](ai-docs/architecture.yaml)           | System architecture deep-dive                     |
-| [`ai-docs/pydantic-patterns.yaml`](ai-docs/pydantic-patterns.yaml) | Pydantic V2 patterns & reference                  |
-| [`ai-docs/anti-patterns.yaml`](ai-docs/anti-patterns.yaml)         | What NOT to do                                    |
-| [`tests/constants.py`](tests/constants.py)                         | Test constants and patterns                       |
-| [`src/babylon/data/defines.yaml`](src/babylon/data/defines.yaml)   | All tunable game coefficients                     |
-| [`pyproject.toml`](pyproject.toml)                                 | Project configuration                             |
-
-## AI Agent Pitfalls (Critical!)
-
-**NEVER:**
-
-- ❌ Delete tests to make them pass - Fix the code, not the tests
-- ❌ Hallucinate APIs - Only use imports from codebase or `pyproject.toml`
-- ❌ Ignore edge cases - Check boundaries, empty inputs, error states
-- ❌ Add dependencies without verification - Check PyPI first (`uv pip show <package>`)
-- ❌ Use raw dicts - All game objects must be Pydantic models
-- ❌ Let AI control mechanics - AI observes only, formulas are deterministic
-- ❌ Use `test_` prefix in production code - Pytest auto-collects these (use `check_`, `verify_`, `validate_`)
-
-**Self-Review Questions:**
-
-1. *"What tests validating this change don't exist yet?"* - Add them
-1. *"What edge cases might this miss?"* - Handle them
-1. *"Does this align with existing patterns in CLAUDE.md?"* - Follow them
-1. *"Am I deleting or modifying tests just to make CI pass?"* - Don't
-
-## Good Issue Patterns for AI Agents
-
-These types of issues work well with coding agents:
-
-- ✅ **Add unit tests for module X** - Well-scoped, clear success criteria
-- ✅ **Fix lint/type errors in file Y** - Deterministic, verifiable
-- ✅ **Add docstrings to module Z** - Follows existing patterns
-- ✅ **Refactor function to use Pydantic model** - Clear transformation
-- ✅ **Implement formula from ai-docs/formulas-spec.yaml** - Spec-driven
-
-## Branch & Git Workflow
-
-This project uses the **Benevolent Dictator** model:
-
-```
-main ────► stable releases (BD merges only)
-  │              ▲
-  ▼              │
-dev ─────► integration (PRs welcome here)
-  │    ▲
-  ▼    │
-feature/*, fix/*, docs/*, refactor/*
-```
-
-- **Contributors:** Branch from `dev`, PR to `dev`
-- **BD only:** Merges `dev` → `main` for releases
-- **Never:** Commit directly to `main` or `dev`
-
-**Conventional commits:**
-
-```bash
-git commit -m "feat(solidarity): add consciousness transmission"
-git commit -m "fix(genesis): resolve initialization order"
-git commit -m "docs(formulas): add LaTeX for survival calculus"
-git commit -m "refactor(ledger): extract GameDefines loading"
-```
-
-## Mathematical Core (Theory)
-
-**Fundamental Theorem:** Revolution in Core impossible if W_c > V_c (wages > value produced). The difference is Imperial Rent (Phi).
-
-**Survival Calculus:**
-
-- P(S|A) = Sigmoid(Wealth - Subsistence) - survival by acquiescence
-- P(S|R) = Organization / Repression - survival by revolution
-- Rupture occurs when P(S|R) > P(S|A)
-
-**See:** [`ai-docs/formulas-spec.yaml`](ai-docs/formulas-spec.yaml) for full mathematical specifications.
+# Copilot Review Instructions — Babylon
+
+**Primary reference:** [`CLAUDE.md`](../CLAUDE.md) (architecture, standards, the
+Constitution pointer). These instructions tune your REVIEW: flag what our
+deterministic gates cannot see. Rewritten 2026-07-30 under ADR181 — review
+directives only, no architecture prose.
+
+## What to flag (our invariants, in priority order)
+
+1. **Determinism is law** (Constitution III.7): every tick produces a
+   deterministic hash. Flag any float path that can emit `-0.0`, `NaN`, or
+   `inf`; any reduction whose order is not fixed; any iteration over an
+   unordered container that reaches an observable output; any wall-clock or
+   `time.sleep`-based logic in tests.
+2. **No imposed functional forms** (ADR172 ruling 5): a sigmoid / logistic /
+   tanh / softmax STIPULATED inside a mechanic is a constitutional violation —
+   S-curves must EMERGE from `P(revolution)`/`P(acquiescence)` and within-class
+   dispersion. Flag any new stipulated curve in `src/babylon/` mechanics or
+   `rust/` engine code, including via coefficient tables that encode one.
+3. **Frozen Pydantic + `model_copy`**: `model_copy(update=...)` SKIPS
+   validation (the phi_hour scar). Flag every `model_copy(update=...)` that
+   writes a constrained scalar (`ge=`, `le=`, `Probability`, `Currency`,
+   `Intensity`, `Coefficient`).
+4. **Native hyperedge law** (Amendment D): `babylon-graph`'s exposed model has
+   first-class hyperedges; Levi/incidence encodings are internal storage ONLY.
+   Flag any API that expands a member list into pairwise edges or leaks an
+   incidence representation.
+5. **Cross-language transcription fidelity** (your best skill): Rust code in
+   `rust/crates/` ports frozen Python reference semantics (`babylon.kernel`)
+   and the normative `docs/reference/bsl-language.rst` (§-numbers,
+   `E-LEX`/`E-PARSE`/`E-TYPE`/`E-LOAD`/`E-EVAL` codes). Flag any divergence
+   between a doc comment's claim and the code, any operation the §3.2 Currency
+   operator table does not license, and any error path that silently defaults
+   instead of failing loud (Constitution III.11).
+6. **Vocabulary honesty**: node/edge types and attributes in fixtures must be
+   ones production actually stamps (`NodeType.*`, declared model fields —
+   never invented strings or phantom attributes). Flag fixture-only vocabulary.
+7. **The Python engine is FROZEN** (tag `p27-python-freeze`, Amendment AE):
+   flag any PR adding engine capability in `src/babylon/engine/`,
+   `src/babylon/domain/`, or `src/babylon/formulas/` — new capability lands
+   Rust-side; Python changes are reference repairs or contract authoring only.
+8. **Determinism-adjacent config**: flag `gh pr merge --auto` anywhere, venv
+   cache keys gaining `restore-keys` (deliberate exact-match — a fallback
+   resurrects a stale `babylon-tui` wheel), and scheduled workflows that do
+   not exist on the default branch.
+
+## What NOT to comment on
+
+- Formatting, line length, import order — ruff/rustfmt own these; your one
+  hallucination on record was a line-length claim.
+- Naming preferences, doc phrasing style, unused dev-dependencies.
+- Suggestions to add flexibility/configurability not asked for.
+- The `web/` and `src/frontend/` trees (legacy per Amendment V, non-gating).
+
+## House facts (so you don't re-derive them wrong)
+
+- Graph substrate: **rustworkx** via `babylon.topology.BabylonGraph` (Python)
+  and the `GraphSubstrate` trait (Rust). NetworkX was removed (Amendment L).
+- Archive/RAG: **pgvector in Postgres** (ChromaDB retired, spec-037).
+- Coefficients live in `GameDefines`/`defines.yaml` — a hardcoded coefficient
+  in logic is a defect worth flagging.
+- Governance: a human Director holds the ideological line; agents self-merge
+  on green under `CLAUDE.md`'s merge protocol, which now REQUIRES harvesting
+  your review — write comments an agent can act on: one defect, its
+  consequence, the file:line.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,17 @@ files, so intertwined units force ugly giant commits. Use `mise run commit -- "t
 (hook-safe: pre-runs hooks, re-stages fixes, verifies HEAD moved). End commit messages with the
 `Co-Authored-By` trailer. Full workflow: `CONTRIBUTORS.md`.
 
+**Merge protocol (ADR181, ratified 2026-07-30):** before self-merging a PR, (1) verify every CI
+check completed and `headRefOid` == the green run's `headSha`; (2) **harvest the Copilot review** —
+wait for it (median ~230s, lands before CI green) and for EACH inline comment either push a fix or
+post a reply stating why not; zero unaddressed comments is a merge precondition (evidence: 83%
+substantive signal, 4 real conformance defects found the first time it was harvested — audit
+`reports/ci-copilot-codeql-synergy-2026-07-30.md`); (3) merge with `gh pr merge N --merge` — NEVER
+`--auto` (#392: it ignores failing non-required checks), never `--delete-branch` on stacked PRs
+(#193: closes-not-merges the child). Copilot stays advisory machinery, never a required check — its
+verdict is stochastic and does not belong on the merge path (WND-2); the OBLIGATION to read it is
+what's binding.
+
 ## Definition of done
 
 - `mise run check` — lint + format + typecheck + `test:unit` — green.

--- a/ai/decisions/ADR181_ci_synergy_rulings.yaml
+++ b/ai/decisions/ADR181_ci_synergy_rulings.yaml
@@ -1,0 +1,110 @@
+ADR181_ci_synergy_rulings:
+  status: "accepted"
+  date: "2026-07-30"
+  title: >
+    Director rulings, live session 2026-07-30 (fourth batch — the CI
+    synergy train): every recommendation of the Director-commissioned
+    CI/Copilot/CodeQL audit (reports/ci-copilot-codeql-synergy-2026-07-30.md,
+    PR #437) APPROVED via the interactive question flow, plus the two
+    estate calls the audit surfaced (OpenWiki landing, XDG paths). The CI
+    train executes BEFORE Lane A opens.
+  context: |
+    The Director asked mid-session "see how we can more efficiently use
+    copilot and codeql and all that stuff to synergize with the way we
+    work here". A six-agent audit (5 evidence lanes + Opus synthesis)
+    produced the report; the main loop independently verified every
+    defect claim before delivery (report §5) and fixed the four confirmed
+    Rust conformance defects immediately (PR #438). The Director then
+    ruled ALL recommendations through the interactive question UI
+    ("i want the pop up questions"), two batches, eight questions.
+    Evidence anchors: Copilot review 83% substantive / 0% acted-on
+    (37 comments, 18 PRs); CodeQL 418 min/day on the frozen Python
+    estate, zero Rust coverage; Rust Gate not required on dev; nightly
+    76/76 failed ever; 22% of post-merge dev runs cancelled; eight
+    process scar classes living as prose.
+  decision: |
+    COPILOT (question 1):
+    (R1) HARVEST PROTOCOL ADOPTED: before self-merging, an agent waits
+        for the Copilot review and, for each inline comment, pushes a fix
+        or posts a reply stating why not — zero unaddressed comments is a
+        merge precondition. Protocol law in CLAUDE.md, NOT a GitHub
+        required check (WND-2: no stochastic verdict on the merge path).
+    (R1b) copilot-instructions.md REWRITTEN around repo invariants
+        (determinism/-0.0/NaN, no imposed sigmoids, model_copy skips
+        validation, native-hyperedge law, cross-language transcription,
+        vocabulary classes, "never comment on formatting"), replacing the
+        323 stale lines (NetworkX/ChromaDB/ai-docs era).
+    MERGE MECHANISM (question 2 — all three):
+    (R2a) dev ruleset 18807584 gains three required contexts: Rust Gate,
+        Baseline Ceremony Gate, Postgres Integration Tier (each finishes
+        inside the unit-test job; zero added latency; Rust could
+        previously merge red).
+    (R2b) gh pr merge --auto DELETED from dependabot-automerge.yml (the
+        literal #392 mechanism) — replaced with wait-then-verify-merge.
+    (R2c) post-merge dev CI runs are never cancelled (cancel-in-progress
+        false for push:dev) — 22% were dying mid-flight, leaving 1 in 5
+        merged states unvalidated.
+    NIGHTLY (question 3):
+    (R3) FULL SPLIT + TRIAGE: per-leg workflows so one red leg cannot
+        mask the estate; qa:michigan-rollover-smoke extracted to its own
+        visible lane; the five failing legs triaged (read-only
+        investigation dispatched same session).
+    CODEQL / RUST SUPPLY CHAIN (question 4 — all four):
+    (R5a) CodeQL gains the rust matrix leg (public-preview extractor,
+        build-mode none, informational — WND-4 stands: never required).
+    (R5b) CodeQL pull_request trigger DROPPED (push dev/main + weekly
+        cron remain); concurrency block added.
+    (R5c) the 11 standing legacy web/ alerts are dismissed/path-ignored
+        citing Amendment V, so the alert floor is ZERO and any new alert
+        on src/ or rust/ is actionable news.
+    (R6) dependabot cargo ecosystem block (weekly, grouped) + cargo-deny
+        in the Rust Gate with a [sources] allowlist for the hypergraph-rs
+        git dependency.
+    HYGIENE (question 5 — all four):
+    (R4) pre-push full-tree sentinel leg (kills the staged-files blind
+        spot, the #1 recurring scar class).
+    (R7) main.yml loses its pull_request trigger — PRs to main run ci.yml
+        only (the stronger twin; removes the weaker-copy race on the
+        required path).
+    (R8) babylon-tui wheel built once per PR head and shared as an
+        artifact; restore-keys added to the CARGO caches only (the venv
+        cache exact-match key is deliberate — WND-3 stands).
+    (R9) three process sentinels: semgrep wall-clock-test ban;
+        workflow-hygiene rules (scheduled workflows must exist on the
+        default branch; doc-referenced workflows must be tracked);
+        worktree environment contract incl. uv.lock-unmodified.
+    (R10) mise run pr:merge wrapper mechanizes the four merge-discipline
+        prose rules (no --auto, headRefOid==headSha, non-required-check
+        red refusal, stacked-PR delete-branch guard) PLUS the R1 harvest
+        precondition; CLAUDE.md names it the only sanctioned merge path.
+    ESTATE CALLS (questions 6-7):
+    (R11) OPENWIKI: the agent LANDS the Director's untracked
+        openwiki-update.yml + openwiki/ tree (from the main checkout's
+        working tree, read fully before committing) — resolving the
+        CLAUDE.md verifiability violation the audit flagged.
+    (R12) XDG HONORED: logs AND archives resolve $XDG_DATA_HOME (falling
+        back to ~/.local/share) — an amendment to the 2026-07-28 logging
+        directive's literal path, applied to the Python periphery and the
+        Rust client logging together, never half-and-half.
+    SEQUENCING (question 8):
+    (R13) THE CI TRAIN EXECUTES FIRST — before Lane A (heat) opens.
+        Order: protocol (A) -> merge mechanism (B) -> CodeQL/cargo (D) ->
+        hygiene (E) -> nightly (C) -> OpenWiki (F) -> XDG (G).
+  consequences: |
+    - The merge protocol section of CLAUDE.md changes (R1, R10) — agents
+      MUST harvest Copilot before merging from this ADR forward.
+    - The dev ruleset change (R2a) is a SETTINGS mutation executed via
+      gh api, recorded here as its audit trail.
+    - WND-1..8 of the report remain binding negative space: Copilot and
+      CodeQL stay non-required; no merge queue; no test-impact selection;
+      no venv-cache restore-keys; no ci.yml/main.yml workflow_call
+      refactor.
+    - The michigan-rollover gate becomes a visible, standalone signal for
+      the first time since its creation.
+    - The audit report (PR #437) + the fix PR (#438) + this ADR are the
+      train's evidence spine; the train issue tracks execution.
+  verification: |
+    Popup answers recorded verbatim in the session (two AskUserQuestion
+    batches, 2026-07-30): Q1 "Yes — R1 + R1b"; Q2 all three options; Q3
+    "Full split + triage"; Q4 all four options; Q5 all four options; Q6
+    "I land them (agent)"; Q7 "Honor XDG"; Q8 "CI train first".

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -815,3 +815,8 @@ decisions:
     status: accepted
     date: '2026-07-30'
     file: ADR180_gate_clearing_rulings_batch.yaml
+  ADR181_ci_synergy_rulings:
+    title: 'Director rulings live session 2026-07-30 (fourth batch — the CI synergy train): ALL audit recommendations APPROVED via the interactive question flow — Copilot harvest protocol becomes merge-precondition law in CLAUDE.md + copilot-instructions rewritten around repo invariants (R1/R1b); dev ruleset gains Rust Gate + Baseline Ceremony Gate + PG Integration Tier as required contexts, --auto deleted from dependabot-automerge, post-merge dev runs never cancelled (R2); nightly FULL SPLIT + triage with the michigan-rollover gate extracted to its own visible lane (R3); CodeQL gains the rust leg, loses the PR trigger, the legacy web/ alert floor zeroed per Amendment V, cargo supply chain via dependabot block + cargo-deny with hypergraph-rs sources allowlist (R5/R6); pre-push full-tree sentinels, main.yml PR-trigger dedup, wheel artifact + cargo restore-keys, three process sentinels, and the mise pr:merge wrapper as the only sanctioned merge path (R4/R7-R10); the agent LANDS the Director''s untracked OpenWiki estate; XDG honored for logs+archives together; THE CI TRAIN EXECUTES BEFORE LANE A'
+    status: accepted
+    date: '2026-07-30'
+    file: ADR181_ci_synergy_rulings.yaml


### PR DESCRIPTION
## Summary

Train A of the ruled CI synergy train (ADR181 — all R1–R10 approved by the Director via the interactive question flow, 2026-07-30):

- **`ai/decisions/ADR181_ci_synergy_rulings.yaml`** + index entry — the full ruling record (R1–R13 incl. the OpenWiki and XDG estate calls and the CI-train-first sequencing), with the verbatim popup answer set as verification.
- **`CLAUDE.md`** — the merge protocol now requires the **Copilot harvest**: fix-or-reply to every inline comment before self-merge; `--auto` and stacked `--delete-branch` prohibitions codified in the same block. Copilot remains advisory (WND-2) — never a required check.
- **`.github/copilot-instructions.md`** — full rewrite: 323 stale lines (NetworkX/ChromaDB era, ~8 factual errors) → ~65 lines of review directives keyed to the repo's real invariants, plus an explicit do-not-comment list targeting the recorded noise/hallucination classes.

Remaining trains follow as separate PRs: B (merge mechanism), D (CodeQL/cargo), E (hygiene), C (nightly split), F (OpenWiki), G (XDG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)