### PR TITLE
test(integration): political_form joins the grundrisse canon + nightly root causes (ADR181 train C part 1)

### DIFF
--- a/tests/integration/test_grundrisse_cycle.py
+++ b/tests/integration/test_grundrisse_cycle.py
@@ -121,6 +121,10 @@ class TestGrundrisseArc:
             system.step(graph, services, TickContext(tick=tick))
 
             states = graph.graph["opposition_states"]
+            # political_form joined the canon with P25 (ADR136: it competes
+            # for principal through the electoral machinery) — 11 oppositions
+            # since; the arc's invariant is the SINGLE principal, not the
+            # count.
             assert set(states) == {
                 "capital_labor",
                 "wage",
@@ -132,6 +136,7 @@ class TestGrundrisseArc:
                 "debt_spiral",
                 "credit",
                 "financial",
+                "political_form",
             }
             assert sum(1 for s in states.values() if s["is_principal"]) == 1
             assert all(s["tick"] == tick for s in states.values())

--- a/tests/integration/test_grundrisse_cycle.py
+++ b/tests/integration/test_grundrisse_cycle.py
@@ -110,7 +110,7 @@ _GRUNDRISSE_DELTAS: tuple[tuple[float, float], ...] = (
 class TestGrundrisseArc:
     """The 10-tick circuit: all oppositions present, capital_labor leads."""
 
-    def test_ten_tick_cycle_keeps_ten_oppositions_and_one_principal(self) -> None:
+    def test_ten_tick_cycle_keeps_the_opposition_canon_and_one_principal(self) -> None:
         graph = _build_circuit_graph()
         services = ServiceContainer.create()
         system = ContradictionSystem()


### PR DESCRIPTION
## Summary

Train C part 1 — the nightly triage's two root causes, fixed:

1. **The one in-tree defect**: `test_grundrisse_cycle.py`'s hardcoded 10-opposition set predates P25's `political_form` (ADR136). Added; the arc's real invariants (single principal, `capital_labor` holds it) unchanged. Scoped run: 10/10 green.
2. **The out-of-tree fix, recorded here**: the `ci-data-v7` release asset `fact_bilateral_trade_annual.parquet` was re-cut this session — the 540-row parquet **reproduced bit-for-bit** from the reference DB via the canonical `export_table_parquet` path (sha `3c018a5d…` == manifest pin) and uploaded `--clobber`. This was the flagged owner-gated P26 follow-up, discharged under ADR181 R3 + the standing release delegation. It unblocks 4 of the 5 failing nightly legs — and lets `qa:michigan-rollover-smoke` execute in CI **for the first time since its creation**.

After merge: nightly gets a `workflow_dispatch` to prove the legs green; the per-leg split lands as train C part 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)