### PR TITLE
feat(graph): Lane A bricks 1+2 — §2.6 query surface + org↔org co-projection inducement

### DIFF
--- a/rust/crates/babylon-graph/src/induced.rs
+++ b/rust/crates/babylon-graph/src/induced.rs
@@ -1,0 +1,116 @@
+//! Induced co-projection adjacency (Lane A brick 2; heat dossier §5.2).
+//!
+//! Two organizations that organize the same class or hold presence in the
+//! same territory share an exposure — Serge's penetrability argument and
+//! Kalyvas's "chances that were largely geographical" in one construction.
+//! The state's targeting practice (Sparrow) needs an org↔org adjacency, and
+//! no production writer creates org↔org SOLIDARITY edges; the materially
+//! correct adjacency is *induced* from existing base edges
+//! (`org --MEMBERSHIP--> social_class`, `org --PRESENCE--> territory`)
+//! without minting any new edge type.
+//!
+//! This is pure composition over the §2.6 query surface — no new
+//! mathematics (ADR172: BSL/engine constructs mint none). The shared-base
+//! *count* is returned because it is a measure the caller may consume
+//! (co-exposure mass), never a chosen curve; ignoring it recovers the plain
+//! adjacency.
+
+use crate::substrate::{Direction, GraphError, GraphSubstrate, NodeId};
+
+/// The peers of `node` under the co-projection through `base_edge_type`:
+/// every other node that shares at least one out-neighbor with `node`
+/// across that edge type, in ascending [`NodeId`] order, each with the
+/// count of shared bases.
+///
+/// # Errors
+/// Returns [`GraphError`] if `node` does not exist (the same dangling-ref
+/// loudness as [`GraphSubstrate::neighbors`]).
+pub fn co_projected_peers(
+    graph: &impl GraphSubstrate,
+    node: NodeId,
+    base_edge_type: &str,
+) -> Result<Vec<(NodeId, usize)>, GraphError> {
+    let bases = graph.neighbors(node, base_edge_type, Direction::Out)?;
+    let mut counts: Vec<(NodeId, usize)> = Vec::new();
+    for base in bases {
+        for peer in graph.neighbors(base, base_edge_type, Direction::In)? {
+            if peer == node {
+                continue;
+            }
+            match counts.binary_search_by_key(&peer, |(id, _)| *id) {
+                Ok(found) => counts[found].1 += 1,
+                Err(insert_at) => counts.insert(insert_at, (peer, 1)),
+            }
+        }
+    }
+    Ok(counts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::co_projected_peers;
+    use crate::placeholder::PlaceholderGraph;
+    use crate::substrate::{GraphSubstrate, NodeId};
+
+    #[test]
+    fn shared_class_base_induces_adjacency_with_multiplicity() {
+        // dossier §5.2: org_a and org_b organize the same two classes
+        // (count 2); org_c shares one territory-shaped base under a
+        // DIFFERENT edge type and must be invisible to this projection.
+        let mut graph = PlaceholderGraph::new();
+        let org_a = graph.add_node("organization").unwrap();
+        let org_b = graph.add_node("organization").unwrap();
+        let org_c = graph.add_node("organization").unwrap();
+        let class_x = graph.add_node("social_class").unwrap();
+        let class_y = graph.add_node("social_class").unwrap();
+        let territory = graph.add_node("territory").unwrap();
+        graph.add_edge("membership", org_a, class_x, 1.0).unwrap();
+        graph.add_edge("membership", org_a, class_y, 1.0).unwrap();
+        graph.add_edge("membership", org_b, class_x, 1.0).unwrap();
+        graph.add_edge("membership", org_b, class_y, 1.0).unwrap();
+        graph.add_edge("presence", org_a, territory, 1.0).unwrap();
+        graph.add_edge("presence", org_c, territory, 1.0).unwrap();
+
+        assert_eq!(
+            co_projected_peers(&graph, org_a, "membership").unwrap(),
+            vec![(org_b, 2)]
+        );
+        assert_eq!(
+            co_projected_peers(&graph, org_a, "presence").unwrap(),
+            vec![(org_c, 1)]
+        );
+        // org_b holds no presence edges: an empty projection, not an error.
+        assert_eq!(
+            co_projected_peers(&graph, org_b, "presence").unwrap(),
+            vec![]
+        );
+    }
+
+    #[test]
+    fn peers_come_back_in_ascending_id_order() {
+        let mut graph = PlaceholderGraph::new();
+        // peer `b` shares MORE bases than peer `a` but has the higher id —
+        // the result must order by id, never by count.
+        let subject = graph.add_node("organization").unwrap();
+        let a = graph.add_node("organization").unwrap();
+        let b = graph.add_node("organization").unwrap();
+        let class_x = graph.add_node("social_class").unwrap();
+        let class_y = graph.add_node("social_class").unwrap();
+        graph.add_edge("membership", subject, class_x, 1.0).unwrap();
+        graph.add_edge("membership", subject, class_y, 1.0).unwrap();
+        graph.add_edge("membership", a, class_x, 1.0).unwrap();
+        graph.add_edge("membership", b, class_x, 1.0).unwrap();
+        graph.add_edge("membership", b, class_y, 1.0).unwrap();
+
+        assert_eq!(
+            co_projected_peers(&graph, subject, "membership").unwrap(),
+            vec![(a, 1), (b, 2)]
+        );
+    }
+
+    #[test]
+    fn a_dangling_ref_is_a_loud_error() {
+        let graph = PlaceholderGraph::new();
+        assert!(co_projected_peers(&graph, NodeId(404), "membership").is_err());
+    }
+}

--- a/rust/crates/babylon-graph/src/induced.rs
+++ b/rust/crates/babylon-graph/src/induced.rs
@@ -16,6 +16,7 @@
 //! adjacency.
 
 use crate::substrate::{Direction, GraphError, GraphSubstrate, NodeId};
+use std::collections::BTreeMap;
 
 /// The peers of `node` under the co-projection through `base_edge_type`:
 /// every other node that shares at least one out-neighbor with `node`
@@ -31,19 +32,16 @@ pub fn co_projected_peers(
     base_edge_type: &str,
 ) -> Result<Vec<(NodeId, usize)>, GraphError> {
     let bases = graph.neighbors(node, base_edge_type, Direction::Out)?;
-    let mut counts: Vec<(NodeId, usize)> = Vec::new();
+    // BTreeMap: O(log p) increments and ascending-NodeId iteration for free.
+    let mut counts: BTreeMap<NodeId, usize> = BTreeMap::new();
     for base in bases {
         for peer in graph.neighbors(base, base_edge_type, Direction::In)? {
-            if peer == node {
-                continue;
-            }
-            match counts.binary_search_by_key(&peer, |(id, _)| *id) {
-                Ok(found) => counts[found].1 += 1,
-                Err(insert_at) => counts.insert(insert_at, (peer, 1)),
+            if peer != node {
+                *counts.entry(peer).or_insert(0) += 1;
             }
         }
     }
-    Ok(counts)
+    Ok(counts.into_iter().collect())
 }
 
 #[cfg(test)]

--- a/rust/crates/babylon-graph/src/lib.rs
+++ b/rust/crates/babylon-graph/src/lib.rs
@@ -18,5 +18,6 @@
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
 
+pub mod induced;
 pub mod placeholder;
 pub mod substrate;

--- a/rust/crates/babylon-graph/src/placeholder.rs
+++ b/rust/crates/babylon-graph/src/placeholder.rs
@@ -10,7 +10,7 @@
 //! verb layer's tests pin exactly that. Deleting this module and swapping in
 //! the production storage is expected, low-risk churn — nothing outside this
 //! crate and its direct test dependents should assume its internals.
-use crate::substrate::{GraphError, GraphSubstrate, HyperedgeId, NodeId};
+use crate::substrate::{Direction, GraphError, GraphSubstrate, HyperedgeId, NodeId};
 use std::collections::HashMap;
 
 /// A toy substrate. See the module documentation: compile-target, not a
@@ -123,6 +123,56 @@ impl GraphSubstrate for PlaceholderGraph {
         self.nodes.contains_key(&id)
     }
 
+    fn nodes(&self, node_type: &str) -> Vec<NodeId> {
+        let mut found: Vec<NodeId> = self
+            .nodes
+            .iter()
+            .filter(|(_, ty)| *ty == node_type)
+            .map(|(id, _)| *id)
+            .collect();
+        found.sort_unstable();
+        found
+    }
+
+    fn edges(&self, edge_type: &str) -> Vec<(NodeId, NodeId)> {
+        let mut found: Vec<(NodeId, NodeId)> = self
+            .edges
+            .keys()
+            .filter(|(ty, _, _)| ty == edge_type)
+            .map(|(_, from, to)| (*from, *to))
+            .collect();
+        found.sort_unstable();
+        found
+    }
+
+    fn neighbors(
+        &self,
+        node: NodeId,
+        edge_type: &str,
+        direction: Direction,
+    ) -> Result<Vec<NodeId>, GraphError> {
+        if !self.node_exists(node) {
+            return Err(GraphError {
+                message: format!("no such node: {node:?} — a dangling ref never reads empty"),
+            });
+        }
+        let mut found: Vec<NodeId> = self
+            .edges
+            .keys()
+            .filter(|(ty, _, _)| ty == edge_type)
+            .filter_map(|(_, from, to)| match direction {
+                Direction::Out => (*from == node).then_some(*to),
+                Direction::In => (*to == node).then_some(*from),
+                Direction::Any if *from == node => Some(*to),
+                Direction::Any if *to == node => Some(*from),
+                Direction::Any => None,
+            })
+            .collect();
+        found.sort_unstable();
+        found.dedup();
+        Ok(found)
+    }
+
     fn add_hyperedge(
         &mut self,
         hyperedge_type: &str,
@@ -189,6 +239,7 @@ impl GraphSubstrate for PlaceholderGraph {
 #[cfg(test)]
 mod tests {
     use super::{GraphSubstrate, NodeId, PlaceholderGraph};
+    use crate::substrate::Direction;
 
     #[test]
     fn add_then_update_then_read_back() {
@@ -250,6 +301,107 @@ mod tests {
         assert!(graph
             .add_hyperedge("economic_sector", &[member, member])
             .is_err());
+    }
+
+    #[test]
+    fn nodes_query_ranges_over_one_type_in_ascending_id_order() {
+        // §2.6 `(nodes <enum-ref>)` + the iteration-order ruling: ascending
+        // node-id order, never storage order.
+        let mut graph = PlaceholderGraph::new();
+        let class_a = graph.add_node("social_class").unwrap();
+        let territory = graph.add_node("territory").unwrap();
+        let class_b = graph.add_node("social_class").unwrap();
+        assert_eq!(graph.nodes("social_class"), vec![class_a, class_b]);
+        assert_eq!(graph.nodes("territory"), vec![territory]);
+        assert_eq!(graph.nodes("organization"), Vec::<NodeId>::new());
+    }
+
+    #[test]
+    fn edges_query_ranges_over_one_type_in_source_target_order() {
+        // §2.6 `(edges <enum-ref>)`: ascending (source-id, target-id) order.
+        let mut graph = PlaceholderGraph::new();
+        let a = graph.add_node("social_class").unwrap();
+        let b = graph.add_node("social_class").unwrap();
+        let c = graph.add_node("social_class").unwrap();
+        graph.add_edge("solidarity", b, a, 0.4).unwrap();
+        graph.add_edge("solidarity", a, c, 0.6).unwrap();
+        graph.add_edge("wages", c, a, 0.9).unwrap();
+        assert_eq!(graph.edges("solidarity"), vec![(a, c), (b, a)]);
+        assert_eq!(graph.edges("wages"), vec![(c, a)]);
+        assert_eq!(graph.edges("tribute"), Vec::<(NodeId, NodeId)>::new());
+    }
+
+    #[test]
+    fn neighbors_query_honors_direction_and_dedups_as_a_set() {
+        // §2.6 `(neighbors <expr> <enum-ref> <direction>)`: :out follows
+        // source->target, :in the reverse, :any their union — a NodeSet,
+        // so a node reachable both ways appears once.
+        let mut graph = PlaceholderGraph::new();
+        let org = graph.add_node("organization").unwrap();
+        let class_a = graph.add_node("social_class").unwrap();
+        let class_b = graph.add_node("social_class").unwrap();
+        graph.add_edge("membership", org, class_a, 1.0).unwrap();
+        graph.add_edge("membership", org, class_b, 1.0).unwrap();
+        graph.add_edge("membership", class_b, org, 0.2).unwrap();
+        assert_eq!(
+            graph.neighbors(org, "membership", Direction::Out).unwrap(),
+            vec![class_a, class_b]
+        );
+        assert_eq!(
+            graph.neighbors(org, "membership", Direction::In).unwrap(),
+            vec![class_b]
+        );
+        assert_eq!(
+            graph.neighbors(org, "membership", Direction::Any).unwrap(),
+            vec![class_a, class_b]
+        );
+        // other edge types are invisible to this query
+        assert_eq!(
+            graph.neighbors(org, "solidarity", Direction::Any).unwrap(),
+            Vec::<NodeId>::new()
+        );
+    }
+
+    #[test]
+    fn neighbors_of_a_nonexistent_node_is_a_loud_error() {
+        // A dangling NodeRef must never read as an empty neighborhood.
+        let graph = PlaceholderGraph::new();
+        assert!(graph
+            .neighbors(NodeId(9999), "membership", Direction::Any)
+            .is_err());
+    }
+
+    #[test]
+    fn co_projection_composes_from_neighbors_alone() {
+        // The dossier §5.2 org<->org inducement (shared class base via
+        // MEMBERSHIP) expressed as pure composition over the query surface —
+        // the shape the heat system's targeting reads. Two orgs organizing
+        // the same class are induced-adjacent; a third org organizing a
+        // different class is not.
+        let mut graph = PlaceholderGraph::new();
+        let org_a = graph.add_node("organization").unwrap();
+        let org_b = graph.add_node("organization").unwrap();
+        let org_c = graph.add_node("organization").unwrap();
+        let shared_class = graph.add_node("social_class").unwrap();
+        let other_class = graph.add_node("social_class").unwrap();
+        graph
+            .add_edge("membership", org_a, shared_class, 1.0)
+            .unwrap();
+        graph
+            .add_edge("membership", org_b, shared_class, 1.0)
+            .unwrap();
+        graph
+            .add_edge("membership", org_c, other_class, 1.0)
+            .unwrap();
+
+        let induced: Vec<NodeId> = graph
+            .neighbors(org_a, "membership", Direction::Out)
+            .unwrap()
+            .into_iter()
+            .flat_map(|base| graph.neighbors(base, "membership", Direction::In).unwrap())
+            .filter(|peer| *peer != org_a)
+            .collect();
+        assert_eq!(induced, vec![org_b]);
     }
 
     #[test]

--- a/rust/crates/babylon-graph/src/substrate.rs
+++ b/rust/crates/babylon-graph/src/substrate.rs
@@ -48,6 +48,18 @@ pub struct GraphError {
     pub message: String,
 }
 
+/// §2.6 `<direction>` for the `neighbors` query: `:out` follows
+/// source→target, `:in` the reverse, `:any` their union.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    /// `:out` — nodes this node points at across the edge type.
+    Out,
+    /// `:in` — nodes pointing at this node across the edge type.
+    In,
+    /// `:any` — the set union of both directions.
+    Any,
+}
+
 /// The typed structural-verb surface a `GraphSubstrate` implementation
 /// provides. `node_type`/`edge_type`/`hyperedge_type` are plain `&str` (the
 /// closed `NodeType`/`EdgeType`/`HyperedgeType` enums are a `babylon-domain`
@@ -114,6 +126,39 @@ pub trait GraphSubstrate {
 
     /// Whether `id` names a live node.
     fn node_exists(&self, id: NodeId) -> bool;
+
+    // ---- §2.6 query surface (dyadic half) ----
+    //
+    // Iteration order is part of the CONTRACT (§2.6 iteration-order ruling):
+    // ascending id order / ascending (source-id, target-id) order — never
+    // graph-internal storage order. Predicates (`<node-pred>` etc.) are the
+    // evaluator's concern; the substrate provides the unfiltered range.
+
+    /// `(nodes <enum-ref>)` — every node of the given type, ascending
+    /// [`NodeId`] order. An unknown type is an empty range, not an error:
+    /// type validity is BSL's static check (`E-TYPE-011`), not the
+    /// substrate's.
+    fn nodes(&self, node_type: &str) -> Vec<NodeId>;
+
+    /// `(edges <enum-ref>)` — every dyadic edge of the given type as
+    /// `(source, target)`, ascending `(source-id, target-id)` order.
+    fn edges(&self, edge_type: &str) -> Vec<(NodeId, NodeId)>;
+
+    /// `(neighbors <expr> <enum-ref> <direction>)` — the `NodeSet` reachable
+    /// from `node` across `edge_type` in `direction`, ascending [`NodeId`]
+    /// order, deduplicated (a set, so `:any` never yields a node twice).
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if `node` does not exist — a dangling
+    /// `NodeRef` must never read as an empty neighborhood (the honest-null
+    /// discipline; contrast `hyperedges_of`, whose infallible signature
+    /// predates this ruling and is flagged for Phase-2 review).
+    fn neighbors(
+        &self,
+        node: NodeId,
+        edge_type: &str,
+        direction: Direction,
+    ) -> Result<Vec<NodeId>, GraphError>;
 
     // ---- hyperedge half (Amendment D: first-class membership) ----
 


### PR DESCRIPTION
Heat system lane (ADR180 R3-R7; dossier §5.2). Brick 1: the BSL §2.6 query surface (nodes/edges/neighbors + Direction) on GraphSubstrate with the contractual ascending-id iteration order — the trait previously exposed no enumeration. Brick 2: `co_projected_peers` — the org↔org adjacency induced from shared MEMBERSHIP/PRESENCE bases, the dossier's highest-leverage item (makes the Sparrow targeting estate expressible with no new edge type and no new math). TDD; 15/15 crate tests; full rust:check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)