### PR TITLE
fix(severity): complete the PR #395 TERMINAL_APPROACH sweep + sentinel the enum-keyed duplicate-dict class

### DIFF
--- a/src/babylon/models/event_severity.py
+++ b/src/babylon/models/event_severity.py
@@ -455,8 +455,9 @@ SEVERITY_TAXONOMY: Final[tuple[EventKindRow, ...]] = (
         kind=EventKind.CROSSING,
         terminal_proximity=TerminalProximity.INTRA_LEVEL,
     ),
-    # DRIFT (warning -> critical): a node is captured by a fascist faction — completed hostile
-    # transition, same axis as RED_BROWN_COUP below.
+    # DRIFT (critical -> warning): one recruit is an increment along the
+    # FASCIST_CONSOLIDATION axis, not the completed capture — the derivative tier
+    # PR #395 introduced. RED_BROWN_COUP below is the lock; this is approach to it.
     EventKindRow(
         event_type=EventType.FASCIST_RECRUITMENT,
         kind=EventKind.CROSSING,
@@ -1128,12 +1129,6 @@ _DRIFT_RATIONALES: Final[dict[EventType, str]] = {
         "milestone marker on a continuous decline, not itself a terminal lock; demotes from "
         "warning to informational."
     ),
-    EventType.FASCIST_RECRUITMENT: (
-        "CROSSING (guard: fascist alignment > recruitment threshold) classified "
-        "TERMINAL_ADJACENT: a node is captured by a fascist faction — a completed hostile "
-        "transition on the same axis as RED_BROWN_COUP (already critical); promotes from "
-        "warning to critical."
-    ),
     EventType.ORGANIZATIONAL_FRACTURE: (
         "CROSSING (a single member's defection) classified INTRA_LEVEL: an individual, "
         "reversible defection that only completes the hostile capture (RED_BROWN_COUP, "
@@ -1143,18 +1138,6 @@ _DRIFT_RATIONALES: Final[dict[EventType, str]] = {
         "CROSSING (hazard-crossing family, congress purge succeeded) classified INTRA_LEVEL: "
         "the org's positive resolution out of DOCTRINE_TRAP_SPRUNG's critical condition; "
         "demotes from warning to informational."
-    ),
-    EventType.DOCTRINE_PURGE_FAILED: (
-        "CROSSING (hazard-crossing family, congress purge attempt failed) classified "
-        "TERMINAL_ADJACENT: the org remains in DOCTRINE_TRAP_SPRUNG's critical trapped "
-        "condition after a failed escape attempt; promotes from warning to critical so the "
-        "persisting crisis is not under-signaled."
-    ),
-    EventType.MARKET_CORRECTION: (
-        "CROSSING (census: 'crossing, snap') classified TERMINAL_ADJACENT: a fictitious/real "
-        "divergence exceeding profit-rate serviceability is a completed crisis-axis 'snap', "
-        "materially on par with ECONOMIC_CRISIS/SUPERWAGE_CRISIS (both already critical); "
-        "promotes from warning to critical."
     ),
     EventType.ENTITY_DEATH: (
         "CROSSING (guard: wealth < consumption_needs) classified INTRA_LEVEL: an individual, "
@@ -1174,12 +1157,6 @@ _DRIFT_RATIONALES: Final[dict[EventType, str]] = {
         "CROSSING (guard: |score| crosses threshold) classified TERMINAL_ADJACENT: this IS "
         "the George-Jackson bifurcation-axis crossing feeding POWER_VACUUM's branch "
         "resolution — an endgame-axis lock; promotes from warning to critical."
-    ),
-    EventType.CO_OPTIVE_BREAKDOWN: (
-        "CROSSING (arc, EdgeTransition) classified TERMINAL_ADJACENT: a co-optation failure "
-        "WITH bifurcation is structurally the same bifurcation-axis event as "
-        "POWER_VACUUM/REVOLUTIONARY_OFFENSIVE/FASCIST_REVANCHISM (all already critical); "
-        "promotes from warning to critical."
     ),
     EventType.LEVEL_TRANSITION: (
         "CROSSING (arc, Lawverian Aufhebung) classified TERMINAL_ADJACENT: sublating the "

--- a/tests/integration/test_event_serialization.py
+++ b/tests/integration/test_event_serialization.py
@@ -64,9 +64,6 @@ class TestSeveritySchema:
             # BIFURCATION_THRESHOLD's tier — detecting this pattern means the
             # RED_OGV terminal-endgame track is live.
             "red_settler_trap_detected",
-            # DRIFT (warning -> critical): a completed hostile capture, same
-            # axis as red_brown_coup.
-            "fascist_recruitment",
             # DRIFT (warning -> critical): PATTERN inheriting
             # ENDGAME_REACHED's tier — directly endgame-axis content.
             "pattern_shift",
@@ -74,10 +71,15 @@ class TestSeveritySchema:
             assert _classify_event(event_type) == "critical", event_type
 
     def test_warning_events_classified_as_warning(self) -> None:
-        # Only ACT-kind verb resolutions stay at warning under the pure rule
-        # (a CROSSING is binary critical-or-informational — there is no
-        # warning tier for one).
-        for event_type in ("state_repression",):
+        # ACT-kind verb resolutions, plus CROSSINGs keyed TERMINAL_APPROACH —
+        # the derivative tier PR #395 added, which is precisely a warning-tier
+        # value for a CROSSING (movement toward a terminal, not the lock).
+        for event_type in (
+            "state_repression",
+            # one recruit is an increment toward consolidation, not the
+            # completed capture — TERMINAL_APPROACH, not TERMINAL_ADJACENT.
+            "fascist_recruitment",
+        ):
             assert _classify_event(event_type) == "warning", event_type
 
     def test_informational_events_classified_as_informational(self) -> None:

--- a/tests/unit/test_duplicate_dict_keys.py
+++ b/tests/unit/test_duplicate_dict_keys.py
@@ -27,7 +27,11 @@ from pathlib import Path
 
 import pytest
 
-SRC = Path("src/babylon")
+#: Resolved from ``__file__``, not the cwd — matching the sentinel-suite
+#: precedent (tests/unit/sentinels/test_ast_helpers.py:38 et al.) so a
+#: pytest run from a subdirectory cannot silently sweep nothing.
+_REPO_ROOT: Path = Path(__file__).resolve().parents[2]
+SRC = _REPO_ROOT / "src" / "babylon"
 
 
 def _dotted_name(node: ast.expr) -> str | None:
@@ -85,7 +89,7 @@ class TestNoDuplicateAttributeKeys:
     def test_src_tree_is_clean(self) -> None:
         violations: list[str] = []
         for path in sorted(SRC.rglob("*.py")):
-            tree = ast.parse(path.read_text(), filename=str(path))
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
             violations.extend(duplicate_attribute_keys(tree, str(path)))
         assert not violations, "\n".join(violations)
 

--- a/tests/unit/test_duplicate_dict_keys.py
+++ b/tests/unit/test_duplicate_dict_keys.py
@@ -1,0 +1,115 @@
+"""Duplicate dict keys that ruff cannot see (sentinel for a live error class).
+
+Discovered 2026-07-30 in ``src/babylon/models/event_severity.py``: PR #395
+reclassified ``FASCIST_RECRUITMENT`` from TERMINAL_ADJACENT to
+TERMINAL_APPROACH and added a new ``_DRIFT_RATIONALES`` entry, but left the
+old entry in place. Python's dict literal silently keeps the LAST value, so
+the live rationale became the stale, contradictory text — no error, no
+warning, no test failure.
+
+**Why the linter missed it.** Ruff/pyflakes flag repeated *literal* keys
+(``F601``) and repeated *variable* keys (``F602``). They do NOT flag repeated
+**attribute** keys — and every taxonomy mapping in this codebase is keyed by
+an enum member (``EventType.X``, ``NodeType.Y``), which is an attribute
+expression. Verified empirically: a dict with ``{E.A: 1, E.B: 2, E.A: 3}``
+passes ``ruff check --select F`` clean, while the same dict with string keys
+raises F601. So the single most common mapping shape in this repo had zero
+duplicate-key protection.
+
+This closes that gap: an AST sweep for repeated dotted-name keys inside one
+dict literal, across ``src/``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SRC = Path("src/babylon")
+
+
+def _dotted_name(node: ast.expr) -> str | None:
+    """Render an attribute chain (``EventType.FASCIST_RECRUITMENT``) as text.
+
+    :param node: The dict-key expression to render.
+    :returns: The dotted source name, or ``None`` when the key is not a plain
+        attribute chain (a literal, a call, a subscript — someone else's
+        problem, or ruff's).
+    """
+    parts: list[str] = []
+    current: ast.expr = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name) or not parts:
+        return None
+    parts.append(current.id)
+    return ".".join(reversed(parts))
+
+
+def duplicate_attribute_keys(tree: ast.AST, filename: str) -> list[str]:
+    """One message per dict literal that repeats an attribute key.
+
+    :param tree: Parsed module AST.
+    :param filename: Display name for the messages.
+    :returns: Human-readable violations; empty when the module is clean.
+    """
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        seen: dict[str, int] = {}
+        for key in node.keys:
+            # `**spread` entries carry a None key — nothing to compare.
+            if key is None:
+                continue
+            name = _dotted_name(key)
+            if name is None:
+                continue
+            if name in seen:
+                violations.append(
+                    f"{filename}:{key.lineno}: duplicate dict key {name} "
+                    f"(first at line {seen[name]}) — the later value silently wins"
+                )
+            else:
+                seen[name] = key.lineno
+    return violations
+
+
+@pytest.mark.skipif(not SRC.is_dir(), reason="src/babylon not present")
+class TestNoDuplicateAttributeKeys:
+    """No dict literal in src/ repeats an enum-member key."""
+
+    def test_src_tree_is_clean(self) -> None:
+        violations: list[str] = []
+        for path in sorted(SRC.rglob("*.py")):
+            tree = ast.parse(path.read_text(), filename=str(path))
+            violations.extend(duplicate_attribute_keys(tree, str(path)))
+        assert not violations, "\n".join(violations)
+
+    def test_checker_catches_the_event_severity_shape(self) -> None:
+        # Mutation validation: the exact historical bug, reduced.
+        tree = ast.parse(
+            "RATIONALES = {\n"
+            "    EventType.FASCIST_DRIFT: 'a',\n"
+            "    EventType.FASCIST_RECRUITMENT: 'correct',\n"
+            "    EventType.ORGANIZATIONAL_FRACTURE: 'b',\n"
+            "    EventType.FASCIST_RECRUITMENT: 'stale, and this one WINS',\n"
+            "}\n"
+        )
+        assert duplicate_attribute_keys(tree, "event_severity.py") == [
+            "event_severity.py:5: duplicate dict key EventType.FASCIST_RECRUITMENT "
+            "(first at line 3) — the later value silently wins"
+        ]
+
+    def test_distinct_members_and_spreads_are_not_flagged(self) -> None:
+        tree = ast.parse("X = {EventType.A: 1, EventType.B: 2, **other, NodeType.A: 3}\n")
+        assert duplicate_attribute_keys(tree, "x.py") == []
+
+    def test_ruff_already_covers_literal_keys_so_we_do_not(self) -> None:
+        # Literal duplicates are F601's job; this checker deliberately
+        # ignores them rather than double-reporting.
+        tree = ast.parse("X = {'a': 1, 'a': 2}\n")
+        assert duplicate_attribute_keys(tree, "x.py") == []


### PR DESCRIPTION
Two of the five failing nightly legs (Non-Unit Tests, Python 3.13) share ONE root cause: PR #395 reclassified events to TERMINAL_APPROACH but left `tests/integration/test_event_serialization.py` and four `_DRIFT_RATIONALES` entries behind. That shard has no PR-time gate on dev, so nothing could catch it.

- `test_event_serialization.py`: `fascist_recruitment` moved critical -> warning, matching the unit suite that PR #395 did update
- deleted 4 stale duplicate `_DRIFT_RATIONALES` entries (FASCIST_RECRUITMENT, DOCTRINE_PURGE_FAILED, MARKET_CORRECTION, CO_OPTIVE_BREAKDOWN) — in every case the stale TERMINAL_ADJACENT text was silently WINNING via dict last-value-wins, contradicting the live taxonomy
- fixed the stale block comment above the FASCIST_RECRUITMENT taxonomy row

**New sentinel** (`tests/unit/test_duplicate_dict_keys.py`) for the error class: ruff flags duplicate *literal* keys (F601) and *variable* keys (F602) but is **blind to attribute keys** like `EventType.X` — verified empirically both ways. Every taxonomy mapping here is enum-keyed, so the most common dict shape in the repo had zero duplicate-key protection. The sentinel found 3 instances beyond the 1 the triage identified, on its first run.

76 scoped tests green; check:quick green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)