### PR TITLE
ci(data): bump the reference-data pin to ci-data-v8 (ADR169 follow-up)

### DIFF
--- a/.github/actions/fetch-reference-db/action.yml
+++ b/.github/actions/fetch-reference-db/action.yml
@@ -42,15 +42,26 @@ inputs:
     # all manifest-pinned — the manifest-driven step below fetches them
     # without any action-input bump. ingest_checkpoint left the governed
     # estate (loaders recreate on demand). tiger tarball unchanged from v3.
-    default: ci-data-v7
+    # v8 (2026-07-30, ADR169 follow-up executed): + fact_ricci_unequal_
+    # exchange_gvc FULL (51 rows) — created by P26 U5b (ADR165 D2/D3, commit
+    # 84e29ed8, 2026-07-28) EIGHT DAYS after the v7 cut, while
+    # _bootstrap_external_nodes reads it unconditionally at session init, so
+    # every CI job that hydrates a session died at TICK 0 with `no such
+    # table` — including qa:michigan-rollover-smoke, the tick-52 gate, which
+    # had therefore never once executed on its merits. Source DB rebuilt in
+    # the pinned dataBuild devshell (sqlite 3.53.1) and reproduced the
+    # registry product sha 5e1e60fc... exactly (76 tables, 59,828,266 rows);
+    # all 85 manifest-pinned dist artifacts sha-verified before upload.
+    # tiger tarball unchanged from v3.
+    default: ci-data-v8
   asset:
     description: Asset filename within the release
     required: false
-    default: reference-subset-20260720-v7.sqlite
+    default: reference-subset-20260730-v8.sqlite
   sha256:
     description: Expected sha256 of the asset (pin — bump with the tag)
     required: false
-    default: f193d44e1b11d4eee9675cbb129b72bd6cd3c05e50a90c3bdd136cb54d56b32f
+    default: c139c39859dd0975910a187737c4ef3cb520a1789689a958a2aeb1343a2e57e2
   tiger-asset:
     description: TIGER county-shapefile tarball within the release (the
       headless runner reads data/tiger/county/tl_2024_us_county.shp — proving


### PR DESCRIPTION
Executes the owner-gated ADR169 follow-up the Director approved this session. Unblocks three of the five failing nightly legs, which share this single cause.

**The defect.** `ci-data-v7` was cut 2026-07-20. P26 added `fact_ricci_unequal_exchange_gvc` on 2026-07-28 (commit 84e29ed8), and `_bootstrap_external_nodes` reads it unconditionally at session init — so every CI job that hydrates a session died at **tick 0** with `no such table`. That includes `qa:michigan-rollover-smoke`, the tick-52 year-rollover gate built specifically to close a 20-day blind spot, which has therefore **never once executed on its merits**. Whether the phi_hour crash is still live is, as of this writing, genuinely unknown.

**Provenance (the part that matters).** The source DB was rebuilt in the vendored flake's pinned `dataBuild` devshell (sqlite 3.53.1) and reproduced the manifest registry product sha `5e1e60fc…` **exactly** — 76 tables, 59,828,266 rows. Both local checkout copies of that DB were **off-pin** (`932f734f…`); cutting from either would have shipped an unverifiable artifact. The registry sha is the only trustworthy source, which is the whole point of ADR098.

All 85 manifest-pinned dist artifacts sha-verified before upload (zero mismatches, using the fetch action's own parser). TIGER tarball byte-identical to v3–v7, re-verified on download. v8 carries 89 assets, matching v7's count.

**Subset:** `reference-subset-20260730-v8.sqlite`, 14,192,298 rows, sha `c139c398…`, ricci table present at its full 51 rows via the existing `TablePolicy("full")` — no generator change needed.

Comment log updated with a dated v8 entry naming the table and the cause, matching the v2→v7 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)