### PR TITLE
feat(graph): the L/K/X split — dossier (L) + capacity (K), Lane A brick 3

### DIFF
--- a/rust/crates/babylon-graph/src/backfire.rs
+++ b/rust/crates/babylon-graph/src/backfire.rs
@@ -1,0 +1,273 @@
+//! The shared BACKFIRE term — why repression sometimes recruits (Lane A;
+//! heat dossier §5.3 mode 7 and §6's emergence check).
+//!
+//! Indiscriminate force does not have a fixed sign. Santiago de María was
+//! suppressed by it; other populations were radicalized by the same act. The
+//! record's explanation is structural rather than psychological: what differs
+//! is **how many of the affected people stood inside a structure** when it
+//! happened.
+//!
+//! Two channels, each a **count of people in a structural position**:
+//!
+//! - **Protected mass** (Kalyvas) — those inside a rival's protective reach.
+//! - **Interpreted mass** (Wood's catechists) — those inside a community or
+//!   organizational structure that frames the event for them.
+//!
+//! **These are measures, not curves.** Both are fractions of a real
+//! population, combined as a sum. There is no multiplier, no threshold, and
+//! no fitted shape anywhere in this module — which is the ADR172 ruling-5
+//! discipline (no imposed functional forms) applied to the one term most
+//! likely to attract one. If a coefficient ever appears here, the finding it
+//! encodes has been replaced by a stipulation.
+//!
+//! **The partition is a declared modelling choice, not a finding.** The
+//! dossier flags it honestly (§6): the record does not say how the two
+//! channels interact when they overlap — Wood's case had interpretation
+//! without protection, Kalyvas's had protection without much interpretation.
+//! Treating them as a partition, with **protection taking precedence**, is
+//! the dossier's construction; it is defensible because a person is either
+//! inside a protective reach or not, but the record does not settle it. It is
+//! recorded here so it stays visible and reversible instead of hardening into
+//! an assumed truth.
+//!
+//! Because the two cells are disjoint by construction, the sum is a measure
+//! over the affected population and never exceeds 1.
+
+use crate::substrate::{Direction, GraphError, GraphSubstrate, NodeId};
+use std::collections::BTreeSet;
+
+/// The two masses, as fractions of the affected population.
+///
+/// Kept apart rather than pre-summed: they are different social facts, and a
+/// narrator or rule may want to speak about them separately. [`Self::total`]
+/// is the composition the dossier specifies.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Backfire {
+    /// Fraction of the affected inside a rival's protective reach.
+    pub protected_fraction: f64,
+    /// Fraction of the affected who are NOT protected but stand inside a
+    /// structure that frames the event.
+    pub interpreted_fraction: f64,
+}
+
+impl Backfire {
+    /// The sum of the two measures over the partition.
+    ///
+    /// In `[0, 1]` by construction — the cells are disjoint and both are
+    /// fractions of the same denominator. Where both are ~0 the repression
+    /// suppresses; where either is substantial it recruits. That reversal is
+    /// the whole finding, and it is arithmetic on counted people rather than
+    /// a sign flip anybody wrote down.
+    #[must_use]
+    pub fn total(&self) -> f64 {
+        self.protected_fraction + self.interpreted_fraction
+    }
+}
+
+/// Whether `node` holds at least one edge of `edge_type`, either direction.
+///
+/// Undirected because standing inside a structure is not a claim about who
+/// authored the tie.
+fn stands_inside(
+    graph: &impl GraphSubstrate,
+    node: NodeId,
+    edge_type: &str,
+) -> Result<bool, GraphError> {
+    Ok(!graph.neighbors(node, edge_type, Direction::Any)?.is_empty())
+}
+
+/// Measure the backfire channels over an affected population.
+///
+/// `protective_edge_type` is the tie that puts someone inside a rival's
+/// reach; `interpreting_edge_type` is the tie that puts them inside a
+/// framing structure. Both are supplied by the caller because *which* edge
+/// types carry those meanings is content, not arithmetic.
+///
+/// Protection takes precedence: someone inside both is counted once, as
+/// protected (the declared partition — see the module doc).
+///
+/// # Errors
+/// Returns [`GraphError`] if `affected` is empty — a backfire fraction over
+/// nobody is not zero, it is undefined, and returning `0.0` would read as
+/// "this repression was safe". It also propagates a dangling-id error rather
+/// than reading an absent node as unaffiliated, which would silently deflate
+/// both channels.
+pub fn measure(
+    graph: &impl GraphSubstrate,
+    affected: &[NodeId],
+    protective_edge_type: &str,
+    interpreting_edge_type: &str,
+) -> Result<Backfire, GraphError> {
+    let population: BTreeSet<NodeId> = affected.iter().copied().collect();
+    if population.is_empty() {
+        return Err(GraphError {
+            message: "backfire over an empty affected population is undefined, \
+                      not zero — an empty sweep is not a safe one"
+                .to_owned(),
+        });
+    }
+    for node in &population {
+        if !graph.node_exists(*node) {
+            return Err(GraphError {
+                message: format!(
+                    "no such node: {node:?} — a dangling ref never reads as unaffiliated"
+                ),
+            });
+        }
+    }
+
+    let mut protected = 0_usize;
+    let mut interpreted = 0_usize;
+    for node in &population {
+        if stands_inside(graph, *node, protective_edge_type)? {
+            protected += 1;
+        } else if stands_inside(graph, *node, interpreting_edge_type)? {
+            interpreted += 1;
+        }
+    }
+
+    let total = count_as_f64(population.len())?;
+    Ok(Backfire {
+        protected_fraction: count_as_f64(protected)? / total,
+        interpreted_fraction: count_as_f64(interpreted)? / total,
+    })
+}
+
+/// Widen a count to `f64` loudly, matching [`crate::exposure`]'s discipline.
+fn count_as_f64(count: usize) -> Result<f64, GraphError> {
+    u32::try_from(count).map(f64::from).map_err(|_| GraphError {
+        message: format!("count {count} exceeds the exactly-representable range"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{measure, Backfire};
+    use crate::placeholder::PlaceholderGraph;
+    use crate::substrate::{GraphSubstrate, NodeId};
+
+    /// `size` affected people, plus one rival org and one community body they
+    /// may or may not be tied to.
+    fn population(size: usize) -> (PlaceholderGraph, Vec<NodeId>, NodeId, NodeId) {
+        let mut graph = PlaceholderGraph::new();
+        let people: Vec<NodeId> = (0..size)
+            .map(|_| graph.add_node("social_class").unwrap())
+            .collect();
+        let rival = graph.add_node("organization").unwrap();
+        let commune = graph.add_node("community").unwrap();
+        (graph, people, rival, commune)
+    }
+
+    #[test]
+    fn an_unorganized_population_does_not_backfire() {
+        // Santiago de María: nobody stands inside anything, and the
+        // repression suppresses. Not a coded exception — an empty count.
+        let (graph, people, ..) = population(10);
+        let measured = measure(&graph, &people, "protection", "membership").unwrap();
+        assert!(measured.protected_fraction.abs() < 1e-12);
+        assert!(measured.interpreted_fraction.abs() < 1e-12);
+        assert!(measured.total().abs() < 1e-12);
+    }
+
+    #[test]
+    fn interpretation_alone_backfires() {
+        // Wood's catechists: no protective reach at all, but the event is
+        // framed for those inside a community structure.
+        let (mut graph, people, _rival, commune) = population(10);
+        for person in people.iter().take(6) {
+            graph.add_edge("membership", commune, *person, 1.0).unwrap();
+        }
+        let measured = measure(&graph, &people, "protection", "membership").unwrap();
+        assert!(measured.protected_fraction.abs() < 1e-12);
+        assert!((measured.interpreted_fraction - 0.6).abs() < 1e-12);
+        assert!((measured.total() - 0.6).abs() < 1e-12);
+    }
+
+    #[test]
+    fn protection_alone_backfires() {
+        let (mut graph, people, rival, _commune) = population(10);
+        for person in people.iter().take(3) {
+            graph.add_edge("protection", rival, *person, 1.0).unwrap();
+        }
+        let measured = measure(&graph, &people, "protection", "membership").unwrap();
+        assert!((measured.protected_fraction - 0.3).abs() < 1e-12);
+        assert!(measured.interpreted_fraction.abs() < 1e-12);
+    }
+
+    #[test]
+    fn the_partition_never_double_counts_and_never_exceeds_one() {
+        // The declared modelling choice: protection takes precedence. Someone
+        // inside BOTH structures is one person, counted once — otherwise the
+        // "sum of measures" would stop being a measure and could exceed the
+        // population it is a fraction of.
+        let (mut graph, people, rival, commune) = population(4);
+        for person in &people {
+            graph.add_edge("protection", rival, *person, 1.0).unwrap();
+            graph.add_edge("membership", commune, *person, 1.0).unwrap();
+        }
+        let measured = measure(&graph, &people, "protection", "membership").unwrap();
+        assert!(
+            (measured.protected_fraction - 1.0).abs() < 1e-12,
+            "all four are protected"
+        );
+        assert!(
+            measured.interpreted_fraction.abs() < 1e-12,
+            "and none is counted a second time as interpreted"
+        );
+        assert!(
+            (measured.total() - 1.0).abs() < 1e-12,
+            "a measure, never above 1"
+        );
+    }
+
+    #[test]
+    fn the_two_channels_sum_over_a_partition() {
+        // Disjoint halves: 2 protected, 2 interpreted, 1 neither.
+        let (mut graph, people, rival, commune) = population(5);
+        for person in people.iter().take(2) {
+            graph.add_edge("protection", rival, *person, 1.0).unwrap();
+        }
+        for person in people.iter().skip(2).take(2) {
+            graph.add_edge("membership", commune, *person, 1.0).unwrap();
+        }
+        let measured = measure(&graph, &people, "protection", "membership").unwrap();
+        assert!((measured.protected_fraction - 0.4).abs() < 1e-12);
+        assert!((measured.interpreted_fraction - 0.4).abs() < 1e-12);
+        assert!((measured.total() - 0.8).abs() < 1e-12);
+    }
+
+    #[test]
+    fn an_empty_sweep_is_undefined_not_safe() {
+        // Returning 0.0 here would read as "this repression was safe", which
+        // is the opposite of what an empty population means.
+        let (graph, ..) = population(3);
+        let err = measure(&graph, &[], "protection", "membership").unwrap_err();
+        assert!(err.message.contains("undefined"), "{}", err.message);
+    }
+
+    #[test]
+    fn a_dangling_member_is_loud_never_read_as_unaffiliated() {
+        // Silently treating an absent id as "stands inside nothing" would
+        // deflate both channels and make repression look safer than it is.
+        let (graph, people, ..) = population(3);
+        let mut affected = people;
+        affected.push(NodeId(999));
+        let err = measure(&graph, &affected, "protection", "membership").unwrap_err();
+        assert!(
+            err.message.contains("never reads as unaffiliated"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn the_channels_stay_separable() {
+        // They are different social facts; a narrator may speak about either.
+        // total() is the dossier's composition, not the only readable form.
+        let measured = Backfire {
+            protected_fraction: 0.25,
+            interpreted_fraction: 0.5,
+        };
+        assert!((measured.total() - 0.75).abs() < 1e-12);
+    }
+}

--- a/rust/crates/babylon-graph/src/capacity.rs
+++ b/rust/crates/babylon-graph/src/capacity.rs
@@ -1,0 +1,378 @@
+//! `K` — the state's CAPACITY, and its allocation (Lane A brick 3; heat
+//! dossier §5.1 B and §5.3's argmax).
+//!
+//! **This module is where escalation stops being a threshold.** The old
+//! mechanic asked "has heat crossed 0.7?" and answered with a constant,
+//! which is question-begging twice over: it needs a number nobody can
+//! derive, and it keys repression to accumulated conduct. Here the state has
+//! a finite budget per instrument, ranks what it could do by yield per unit
+//! spent, and takes candidates in that order until the budget runs out.
+//! Escalation is what *happens* when a target rises in that ranking. **There
+//! is no threshold constant in this file and none may be added** — a
+//! reviewer finding one has found a bug.
+//!
+//! Two consequences fall out rather than being coded:
+//!
+//! - **Repression against a distributed organization declines itself.** A
+//!   redundant structure divides its own yield ([`crate::exposure`]'s
+//!   replaceability quotient), so it loses the ranking to a target worth
+//!   more per unit spent. Nothing anywhere says "if the org is distributed,
+//!   skip it."
+//! - **Cheap modes beat expensive ones at equal damage.** Disinformation is
+//!   the cheapest mode by state capacity and among the most expensive by
+//!   movement cost — which is exactly why it dominates the historical
+//!   record. That is the ranking's arithmetic, not a designer's thumb.
+//!
+//! **Yield is computed on `L`, never on truth.** A [`Candidate`]'s yield
+//! comes from [`crate::exposure`] evaluated over a [`crate::dossier::Dossier`]
+//! scope, so the state allocates against what it BELIEVES it would gain. It
+//! can spend its budget badly. That is the point.
+//!
+//! **What a mode costs, and what modes exist, are content** (BSL rules), not
+//! constants here. This module ranks and spends; it does not know what
+//! `"INFILTRATION"` means.
+
+use crate::substrate::{GraphError, NodeId};
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+
+/// One action the state could take this tick, already priced.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Candidate {
+    /// Which budget this draws on — modes sharing an instrument compete for
+    /// the same pool (§5.3: "modes compete for the same `K`").
+    pub instrument: String,
+    /// The mode being considered. Opaque here; its meaning is content.
+    pub mode: String,
+    /// Who it would be aimed at.
+    pub target: NodeId,
+    /// Expected damage, as the state BELIEVES it — normally
+    /// [`crate::exposure::decapitation_value`] over a dossier scope.
+    pub expected_yield: f64,
+    /// Capacity units consumed if taken. Never zero (see
+    /// [`Capacity::allocate`]).
+    pub cost: u64,
+}
+
+/// One candidate the state actually funded.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Allocation {
+    /// The funded candidate.
+    pub candidate: Candidate,
+    /// Its yield per unit spent — the quantity that won it the slot.
+    pub ratio: f64,
+}
+
+/// `K` — finite repressive capacity, per instrument.
+///
+/// Lives on the state apparatus's organization/institution nodes. Set by
+/// fiscal and institutional capacity, spent by allocation, replenished
+/// between ticks.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Capacity {
+    budgets: BTreeMap<String, u64>,
+}
+
+impl Capacity {
+    /// A state with no capacity at all — it can see, but it cannot act.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add units to one instrument's budget.
+    pub fn replenish(&mut self, instrument: &str, units: u64) {
+        *self.budgets.entry(instrument.to_owned()).or_insert(0) += units;
+    }
+
+    /// Units currently available to one instrument. An instrument never
+    /// funded reads zero — the honest answer, since a state that has not
+    /// built an apparatus does not have one.
+    #[must_use]
+    pub fn available(&self, instrument: &str) -> u64 {
+        self.budgets.get(instrument).copied().unwrap_or(0)
+    }
+
+    /// Total unspent capacity across every instrument.
+    #[must_use]
+    pub fn total_available(&self) -> u64 {
+        self.budgets.values().sum()
+    }
+
+    /// Rank `candidates` by yield per unit spent and fund them in that order
+    /// until each instrument's budget is exhausted. **This is the escalation
+    /// mechanic in full.**
+    ///
+    /// Spends from `self`, returning what was funded in the order it was
+    /// funded (descending ratio). Candidates that do not fit are simply not
+    /// returned — the state declining to act, which needs no separate
+    /// representation.
+    ///
+    /// A candidate whose cost exceeds its instrument's *remaining* budget is
+    /// skipped, and cheaper candidates behind it may still be funded. That is
+    /// deliberate: a state that cannot afford the raid still runs the
+    /// surveillance.
+    ///
+    /// **Determinism.** Ranking is a total order — ratio descending, then
+    /// `(instrument, mode, target)` ascending — so a permuted candidate list
+    /// produces a byte-identical allocation. Float ratios alone are only a
+    /// partial order, and leaving ties to input order would put the tick hash
+    /// at the mercy of iteration order upstream.
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if any candidate has zero cost (its ratio would
+    /// be infinite — a free action that always outranks everything, which is
+    /// a content bug, not a strategy) or a non-finite yield.
+    pub fn allocate(&mut self, candidates: &[Candidate]) -> Result<Vec<Allocation>, GraphError> {
+        let mut ranked = Vec::with_capacity(candidates.len());
+        for candidate in candidates {
+            if candidate.cost == 0 {
+                return Err(GraphError {
+                    message: format!(
+                        "candidate {}/{} against {:?} costs nothing — a free action \
+                         outranks every priced one; price it in content",
+                        candidate.instrument, candidate.mode, candidate.target
+                    ),
+                });
+            }
+            if !candidate.expected_yield.is_finite() {
+                return Err(GraphError {
+                    message: format!(
+                        "candidate {}/{} against {:?} has a non-finite expected yield — \
+                         refusing to rank it",
+                        candidate.instrument, candidate.mode, candidate.target
+                    ),
+                });
+            }
+            // u64 -> f64 is exact to 2^53; costs are per-tick budget units,
+            // orders of magnitude below that.
+            #[allow(clippy::cast_precision_loss)]
+            let ratio = candidate.expected_yield / candidate.cost as f64;
+            ranked.push(Allocation {
+                candidate: candidate.clone(),
+                ratio,
+            });
+        }
+
+        ranked.sort_by(|a, b| {
+            b.ratio
+                .partial_cmp(&a.ratio)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| a.candidate.instrument.cmp(&b.candidate.instrument))
+                .then_with(|| a.candidate.mode.cmp(&b.candidate.mode))
+                .then_with(|| a.candidate.target.cmp(&b.candidate.target))
+        });
+
+        let mut funded = Vec::new();
+        for allocation in ranked {
+            let remaining = self.available(&allocation.candidate.instrument);
+            if allocation.candidate.cost <= remaining {
+                self.budgets.insert(
+                    allocation.candidate.instrument.clone(),
+                    remaining - allocation.candidate.cost,
+                );
+                funded.push(allocation);
+            }
+        }
+        Ok(funded)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Candidate, Capacity};
+    use crate::substrate::NodeId;
+
+    fn candidate(mode: &str, target: u64, expected_yield: f64, cost: u64) -> Candidate {
+        Candidate {
+            instrument: "political-police".to_owned(),
+            mode: mode.to_owned(),
+            target: NodeId(target),
+            expected_yield,
+            cost,
+        }
+    }
+
+    #[test]
+    fn a_state_with_no_capacity_can_see_but_not_act() {
+        let mut capacity = Capacity::new();
+        let funded = capacity.allocate(&[candidate("RAID", 1, 0.9, 5)]).unwrap();
+        assert!(funded.is_empty(), "no budget, no action — and no error");
+    }
+
+    #[test]
+    fn escalation_is_what_a_bigger_budget_buys_not_a_threshold_crossing() {
+        // THE contract this module exists for. The same three candidates,
+        // ranked identically, funded to different depths purely by budget.
+        // Nothing in the engine asks "has heat crossed X".
+        let candidates = [
+            candidate("SURVEIL", 1, 0.2, 1),    // ratio 0.20
+            candidate("INFILTRATE", 2, 0.9, 3), // ratio 0.30
+            candidate("RAID", 3, 0.8, 8),       // ratio 0.10
+        ];
+
+        let mut lean = Capacity::new();
+        lean.replenish("political-police", 3);
+        let lean_funded = lean.allocate(&candidates).unwrap();
+        assert_eq!(
+            lean_funded
+                .iter()
+                .map(|a| a.candidate.mode.as_str())
+                .collect::<Vec<_>>(),
+            vec!["INFILTRATE"],
+            "a lean state buys the best ratio it can afford"
+        );
+
+        let mut flush = Capacity::new();
+        flush.replenish("political-police", 12);
+        let flush_funded = flush.allocate(&candidates).unwrap();
+        assert_eq!(
+            flush_funded
+                .iter()
+                .map(|a| a.candidate.mode.as_str())
+                .collect::<Vec<_>>(),
+            vec!["INFILTRATE", "SURVEIL", "RAID"],
+            "a flush state escalates by reaching further down the same ranking"
+        );
+    }
+
+    #[test]
+    fn a_redundant_target_declines_the_strike_by_itself() {
+        // exposure's replaceability quotient divides a distributed org's
+        // yield down; the ranking then declines it. There is no
+        // "if distributed, skip" branch anywhere.
+        let mut capacity = Capacity::new();
+        capacity.replenish("political-police", 4);
+        let funded = capacity
+            .allocate(&[
+                candidate("RAID", 1, 0.08, 4), // the distributed org
+                candidate("RAID", 2, 0.60, 4), // the centralized one
+            ])
+            .unwrap();
+        assert_eq!(funded.len(), 1);
+        assert_eq!(
+            funded[0].candidate.target,
+            NodeId(2),
+            "capacity went to the target worth more per unit spent"
+        );
+    }
+
+    #[test]
+    fn a_cheap_mode_outranks_an_expensive_one_at_higher_damage() {
+        // Why disinformation dominates the historical record: cheapest by
+        // state capacity, dear by movement cost. Arithmetic, not a thumb.
+        let mut capacity = Capacity::new();
+        capacity.replenish("political-police", 2);
+        let funded = capacity
+            .allocate(&[
+                candidate("LIQUIDATE", 1, 0.95, 20), // ratio 0.0475
+                candidate("BAD_JACKET", 2, 0.40, 1), // ratio 0.40
+            ])
+            .unwrap();
+        assert_eq!(funded[0].candidate.mode, "BAD_JACKET");
+    }
+
+    #[test]
+    fn an_unaffordable_candidate_does_not_block_a_cheaper_one_behind_it() {
+        // A state that cannot afford the raid still runs the surveillance.
+        let mut capacity = Capacity::new();
+        capacity.replenish("political-police", 2);
+        let funded = capacity
+            .allocate(&[
+                candidate("RAID", 1, 9.0, 10), // best ratio, unaffordable
+                candidate("SURVEIL", 2, 0.5, 2),
+            ])
+            .unwrap();
+        assert_eq!(funded.len(), 1);
+        assert_eq!(funded[0].candidate.mode, "SURVEIL");
+    }
+
+    #[test]
+    fn allocation_is_invariant_under_candidate_permutation() {
+        // The tick-hash contract. Float ratios alone are a PARTIAL order;
+        // ties broken by input order would leave the hash at the mercy of
+        // upstream iteration.
+        let a = candidate("RAID", 1, 0.5, 5); // ratio 0.1
+        let b = candidate("RAID", 2, 0.4, 4); // ratio 0.1 — an exact tie
+        let c = candidate("SURVEIL", 3, 0.2, 2); // ratio 0.1 — another
+        let orders = [
+            vec![a.clone(), b.clone(), c.clone()],
+            vec![c.clone(), b.clone(), a.clone()],
+            vec![b.clone(), a.clone(), c.clone()],
+        ];
+        let mut results = Vec::new();
+        for order in &orders {
+            let mut capacity = Capacity::new();
+            capacity.replenish("political-police", 100);
+            let funded = capacity.allocate(order).unwrap();
+            results.push(
+                funded
+                    .iter()
+                    .map(|x| (x.candidate.mode.clone(), x.candidate.target))
+                    .collect::<Vec<_>>(),
+            );
+        }
+        assert_eq!(results[0], results[1]);
+        assert_eq!(results[1], results[2]);
+    }
+
+    #[test]
+    fn spending_draws_down_the_budget_and_never_overspends() {
+        let mut capacity = Capacity::new();
+        capacity.replenish("political-police", 10);
+        let funded = capacity
+            .allocate(&[
+                candidate("A", 1, 1.0, 6),
+                candidate("B", 2, 1.0, 6),
+                candidate("C", 3, 1.0, 4),
+            ])
+            .unwrap();
+        assert_eq!(funded.len(), 2, "6 + 4 fits in 10; the second 6 does not");
+        assert_eq!(capacity.available("political-police"), 0);
+        assert_eq!(capacity.total_available(), 0);
+    }
+
+    #[test]
+    fn instruments_hold_separate_budgets() {
+        let mut capacity = Capacity::new();
+        capacity.replenish("political-police", 5);
+        capacity.replenish("courts", 5);
+        let funded = capacity
+            .allocate(&[
+                Candidate {
+                    instrument: "courts".to_owned(),
+                    mode: "PROSECUTE".to_owned(),
+                    target: NodeId(1),
+                    expected_yield: 0.5,
+                    cost: 5,
+                },
+                candidate("RAID", 2, 0.5, 5),
+            ])
+            .unwrap();
+        assert_eq!(funded.len(), 2, "each drew on its own pool");
+        assert_eq!(capacity.available("courts"), 0);
+        assert_eq!(capacity.available("political-police"), 0);
+    }
+
+    #[test]
+    fn a_free_action_is_loud_never_infinitely_attractive() {
+        let mut capacity = Capacity::new();
+        capacity.replenish("political-police", 10);
+        let err = capacity
+            .allocate(&[candidate("FREE", 1, 0.5, 0)])
+            .unwrap_err();
+        assert!(err.message.contains("costs nothing"), "{}", err.message);
+    }
+
+    #[test]
+    fn a_non_finite_yield_is_refused_not_ranked() {
+        let mut capacity = Capacity::new();
+        capacity.replenish("political-police", 10);
+        for bad in [f64::NAN, f64::INFINITY] {
+            let err = capacity
+                .allocate(&[candidate("RAID", 1, bad, 2)])
+                .unwrap_err();
+            assert!(err.message.contains("non-finite"), "{}", err.message);
+        }
+    }
+}

--- a/rust/crates/babylon-graph/src/dossier.rs
+++ b/rust/crates/babylon-graph/src/dossier.rs
@@ -210,6 +210,14 @@ impl Dossier {
         let mut added = usize::from(self.resolve_node(node));
         for (from, to) in graph.edges(edge_type) {
             if from == node || to == node {
+                // A newly-surfaced CONTACT is a new fact in its own right, and
+                // usually the one that mattered — `resolve_edge` reports only
+                // whether the TIE was new, so count the endpoints before it
+                // silently inserts them. Undercounting here would tell a
+                // collection rule that a productive interrogation bought
+                // nothing.
+                added += usize::from(!self.knows_node(from));
+                added += usize::from(!self.knows_node(to));
                 added += usize::from(self.resolve_edge(edge_type, from, to));
             }
         }
@@ -304,7 +312,11 @@ mod tests {
             .unwrap();
         assert_eq!(dossier.resolved_node_count(), all.len(), "the whole star");
         assert_eq!(dossier.resolved_edge_count(), 4);
-        assert!(added > 0);
+        assert_eq!(
+            added, 9,
+            "1 hub + 4 contacts newly surfaced + 4 ties = 9 new facts; the \
+             contacts are usually the ones that mattered, so they count"
+        );
         let again = dossier
             .resolve_neighborhood(&graph, hub, "coordination")
             .unwrap();

--- a/rust/crates/babylon-graph/src/dossier.rs
+++ b/rust/crates/babylon-graph/src/dossier.rs
@@ -1,0 +1,394 @@
+//! `L` — the state's DOSSIER on a movement (Lane A brick 3; heat dossier
+//! §5.1 A).
+//!
+//! The heat reformulation splits one question-begging `[0,1]` scalar into
+//! three quantities with different owners: what the state **knows** (`L`,
+//! here), what the state **spends** (`K`, [`crate::capacity`]), and what the
+//! movement **is** (`X`, [`crate::exposure`], derived and never stored).
+//! Conflating them is what forced the old mechanic to key repression to
+//! *conduct* — the ideological falsehood the dossier indicts. Kept apart,
+//! nothing needs to ask whether the player broke a law.
+//!
+//! **A dossier is a projection, not a fraction of the truth.** Scott's five
+//! properties of state legibility — interested, documentary, static,
+//! aggregate, standardized — mean `L` keeps only what the state's own
+//! categories can hold. So this type stores what the state has *resolved*
+//! and nothing else: it holds no pointer back to ground truth, and there is
+//! deliberately no method that answers "what is really there". Code that
+//! wants the truth must ask the substrate; code that wants the state's
+//! belief asks a `Dossier`. Those are different questions, and the type
+//! system is what keeps them different.
+//!
+//! **There is no threat score here, and none may be added.** Sparrow's
+//! conscious-opponent argument forbids an accumulated priority: an opponent
+//! who knows he is being ranked reorganizes, so the ranking must be
+//! recomputed from live structure at decision time. `L` records *resolution*
+//! — which nodes and ties the state has managed to see — never a verdict
+//! about a target. The verdict is [`crate::exposure`] evaluated over
+//! [`Dossier::scope`], every time it is asked for.
+//!
+//! **Growth and decay are not symmetric, and neither is conduct-keyed.**
+//! Resolution grows through named collection channels and — Sparrow's
+//! feedback loop — fastest where it is already high, because a resolved node
+//! exposes its neighbors. It decays through membership turnover,
+//! compartmentalization, and restructuring. Both are rules expressed as
+//! content (BSL), not arithmetic baked in here; this module supplies only
+//! the operations those rules drive.
+
+use crate::substrate::{GraphError, GraphSubstrate, NodeId};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// The state's partial, biased view of a movement's structure.
+///
+/// Iteration order everywhere is ascending and deterministic (`BTree*`), so
+/// two runs that resolved the same facts produce the same scope in the same
+/// order — a tick-hash prerequisite, not a convenience.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Dossier {
+    resolved_nodes: BTreeSet<NodeId>,
+    /// `edge_type -> {(from, to)}`. Stored as authored, because *which way
+    /// the state thinks a tie runs* is part of what it believes.
+    resolved_edges: BTreeMap<String, BTreeSet<(NodeId, NodeId)>>,
+}
+
+impl Dossier {
+    /// An empty dossier: the state knows nothing until it collects.
+    ///
+    /// This is the honest starting point and it matters — a dossier that
+    /// began populated would grant the state free omniscience at tick 0,
+    /// which is the failure this whole split exists to prevent.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that the state has resolved `node`.
+    ///
+    /// Idempotent: re-collecting a known node is not an error and does not
+    /// double-count. Returns whether this call added something new — the
+    /// signal a collection rule needs to decide whether effort paid off.
+    pub fn resolve_node(&mut self, node: NodeId) -> bool {
+        self.resolved_nodes.insert(node)
+    }
+
+    /// Record that the state has resolved a tie.
+    ///
+    /// Resolving a tie implies resolving BOTH endpoints: the state cannot
+    /// coherently know that two people are connected without knowing they
+    /// exist. Anything else would let a dossier describe ties among nodes it
+    /// has never seen, and [`Self::scope`] would then hand
+    /// [`crate::exposure`] a graph the state does not actually hold.
+    pub fn resolve_edge(&mut self, edge_type: &str, from: NodeId, to: NodeId) -> bool {
+        self.resolved_nodes.insert(from);
+        self.resolved_nodes.insert(to);
+        self.resolved_edges
+            .entry(edge_type.to_owned())
+            .or_default()
+            .insert((from, to))
+    }
+
+    /// Drop a node and every tie touching it — membership turnover, a
+    /// member going quiet, a cell restructuring out of the state's picture.
+    ///
+    /// Returns whether the node had been known. Decay is deliberately
+    /// *whole*: a dossier retaining ties to a person it can no longer place
+    /// would out-perform a real one.
+    pub fn forget_node(&mut self, node: NodeId) -> bool {
+        let known = self.resolved_nodes.remove(&node);
+        for ties in self.resolved_edges.values_mut() {
+            ties.retain(|(from, to)| *from != node && *to != node);
+        }
+        self.resolved_edges.retain(|_, ties| !ties.is_empty());
+        known
+    }
+
+    /// Drop one tie, leaving both endpoints known — compartmentalization:
+    /// the state still has the people, but no longer the link between them.
+    pub fn forget_edge(&mut self, edge_type: &str, from: NodeId, to: NodeId) -> bool {
+        let Some(ties) = self.resolved_edges.get_mut(edge_type) else {
+            return false;
+        };
+        let removed = ties.remove(&(from, to));
+        if ties.is_empty() {
+            self.resolved_edges.remove(edge_type);
+        }
+        removed
+    }
+
+    /// Whether the state has resolved this node.
+    #[must_use]
+    pub fn knows_node(&self, node: NodeId) -> bool {
+        self.resolved_nodes.contains(&node)
+    }
+
+    /// Whether the state has resolved this tie, as authored.
+    #[must_use]
+    pub fn knows_edge(&self, edge_type: &str, from: NodeId, to: NodeId) -> bool {
+        self.resolved_edges
+            .get(edge_type)
+            .is_some_and(|ties| ties.contains(&(from, to)))
+    }
+
+    /// How many nodes the state has resolved.
+    #[must_use]
+    pub fn resolved_node_count(&self) -> usize {
+        self.resolved_nodes.len()
+    }
+
+    /// How many ties the state has resolved, across every type.
+    #[must_use]
+    pub fn resolved_edge_count(&self) -> usize {
+        self.resolved_edges.values().map(BTreeSet::len).sum()
+    }
+
+    /// The scope to hand [`crate::exposure`], ascending.
+    ///
+    /// This is the whole point of the type. Every exposure function takes a
+    /// node set and is silent on whose view it is; passing this scope asks
+    /// *"what does the state BELIEVE a strike would yield"*, while passing
+    /// the substrate's own node list asks what it WOULD yield. Same
+    /// arithmetic, different question — and the state gets the first one.
+    #[must_use]
+    pub fn scope(&self) -> Vec<NodeId> {
+        self.resolved_nodes.iter().copied().collect()
+    }
+
+    /// Every resolved node that no longer exists in `graph`.
+    ///
+    /// A dossier outlives the structure it describes: arrests, deaths and
+    /// dissolutions leave the state holding cards for people who are gone.
+    /// [`crate::exposure`] rejects a dangling id loudly rather than reading
+    /// it as empty, so a caller that has mutated the graph asks this first
+    /// and reconciles with [`Self::forget_node`] — the state noticing, which
+    /// is an action, not an automatic correction.
+    #[must_use]
+    pub fn stale_nodes(&self, graph: &impl GraphSubstrate) -> Vec<NodeId> {
+        self.resolved_nodes
+            .iter()
+            .copied()
+            .filter(|node| !graph.node_exists(*node))
+            .collect()
+    }
+
+    /// Drop every resolved node the graph no longer has, and their ties.
+    ///
+    /// Returns what was dropped, ascending. Deliberately explicit rather
+    /// than implicit inside [`Self::scope`]: reconciliation is the state
+    /// spending attention, and a silent auto-clean would make the dossier
+    /// track reality for free.
+    pub fn reconcile(&mut self, graph: &impl GraphSubstrate) -> Vec<NodeId> {
+        let stale = self.stale_nodes(graph);
+        for node in &stale {
+            self.forget_node(*node);
+        }
+        stale
+    }
+
+    /// Resolve `node` and every tie of `edge_type` it holds in `graph`,
+    /// returning how many NEW facts that added.
+    ///
+    /// This is the shape of a successful collection action against a target
+    /// the state already had: interrogating a resolved member exposes his
+    /// contacts. It is also the mechanism behind Sparrow's feedback loop —
+    /// resolution grows fastest where it is already high, because each
+    /// resolved node is a doorway to its neighbors. The rule deciding WHEN
+    /// this happens is content; this is only the operation it performs.
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if `node` does not exist in `graph`.
+    pub fn resolve_neighborhood(
+        &mut self,
+        graph: &impl GraphSubstrate,
+        node: NodeId,
+        edge_type: &str,
+    ) -> Result<usize, GraphError> {
+        if !graph.node_exists(node) {
+            return Err(GraphError {
+                message: format!("no such node: {node:?} — a dangling ref never reads empty"),
+            });
+        }
+        let mut added = usize::from(self.resolve_node(node));
+        for (from, to) in graph.edges(edge_type) {
+            if from == node || to == node {
+                added += usize::from(self.resolve_edge(edge_type, from, to));
+            }
+        }
+        Ok(added)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Dossier;
+    use crate::exposure::decapitation_value;
+    use crate::placeholder::PlaceholderGraph;
+    use crate::substrate::{GraphSubstrate, NodeId};
+
+    /// A hub joined to `spokes` leaves — the centralized shape whose hub is
+    /// worth striking.
+    fn star(spokes: usize) -> (PlaceholderGraph, NodeId, Vec<NodeId>) {
+        let mut graph = PlaceholderGraph::new();
+        let hub = graph.add_node("cadre").unwrap();
+        let mut all = vec![hub];
+        for _ in 0..spokes {
+            let leaf = graph.add_node("cadre").unwrap();
+            graph.add_edge("coordination", hub, leaf, 1.0).unwrap();
+            all.push(leaf);
+        }
+        (graph, hub, all)
+    }
+
+    #[test]
+    fn a_dossier_starts_empty() {
+        let dossier = Dossier::new();
+        assert_eq!(dossier.resolved_node_count(), 0);
+        assert_eq!(dossier.resolved_edge_count(), 0);
+        assert!(dossier.scope().is_empty(), "the state knows nothing yet");
+    }
+
+    #[test]
+    fn resolving_a_tie_resolves_both_endpoints() {
+        // The state cannot know two people are connected without knowing
+        // they exist — otherwise scope() would hand exposure a graph the
+        // state does not hold.
+        let mut dossier = Dossier::new();
+        assert!(dossier.resolve_edge("coordination", NodeId(4), NodeId(9)));
+        assert!(dossier.knows_node(NodeId(4)));
+        assert!(dossier.knows_node(NodeId(9)));
+        assert_eq!(dossier.scope(), vec![NodeId(4), NodeId(9)]);
+    }
+
+    #[test]
+    fn resolution_is_idempotent_and_reports_novelty() {
+        let mut dossier = Dossier::new();
+        assert!(dossier.resolve_node(NodeId(1)), "first sighting is news");
+        assert!(!dossier.resolve_node(NodeId(1)), "the second is not");
+        assert_eq!(dossier.resolved_node_count(), 1);
+    }
+
+    #[test]
+    fn forgetting_a_node_takes_its_ties_with_it() {
+        // Decay is whole: a dossier retaining ties to someone it can no
+        // longer place would out-perform a real one.
+        let mut dossier = Dossier::new();
+        dossier.resolve_edge("coordination", NodeId(1), NodeId(2));
+        dossier.resolve_edge("coordination", NodeId(2), NodeId(3));
+        assert!(dossier.forget_node(NodeId(2)));
+        assert_eq!(dossier.resolved_edge_count(), 0);
+        assert!(dossier.knows_node(NodeId(1)), "the others stay known");
+        assert!(dossier.knows_node(NodeId(3)));
+    }
+
+    #[test]
+    fn compartmentalization_drops_the_tie_and_keeps_the_people() {
+        let mut dossier = Dossier::new();
+        dossier.resolve_edge("coordination", NodeId(1), NodeId(2));
+        assert!(dossier.forget_edge("coordination", NodeId(1), NodeId(2)));
+        assert!(dossier.knows_node(NodeId(1)));
+        assert!(dossier.knows_node(NodeId(2)));
+        assert!(!dossier.knows_edge("coordination", NodeId(1), NodeId(2)));
+        assert!(
+            !dossier.forget_edge("coordination", NodeId(1), NodeId(2)),
+            "forgetting what is already forgotten is not news"
+        );
+    }
+
+    #[test]
+    fn resolving_a_neighborhood_grows_the_dossier_from_a_doorway() {
+        // Sparrow's feedback loop: a resolved node exposes its neighbors, so
+        // knowledge grows fastest where it is already high.
+        let (graph, hub, all) = star(4);
+        let mut dossier = Dossier::new();
+        let added = dossier
+            .resolve_neighborhood(&graph, hub, "coordination")
+            .unwrap();
+        assert_eq!(dossier.resolved_node_count(), all.len(), "the whole star");
+        assert_eq!(dossier.resolved_edge_count(), 4);
+        assert!(added > 0);
+        let again = dossier
+            .resolve_neighborhood(&graph, hub, "coordination")
+            .unwrap();
+        assert_eq!(again, 0, "re-running the same collection adds nothing");
+    }
+
+    #[test]
+    fn a_dangling_collection_target_is_loud() {
+        let (graph, ..) = star(2);
+        let mut dossier = Dossier::new();
+        let err = dossier
+            .resolve_neighborhood(&graph, NodeId(999), "coordination")
+            .unwrap_err();
+        assert!(err.message.contains("never reads empty"), "{}", err.message);
+    }
+
+    #[test]
+    fn reconciliation_is_explicit_never_automatic() {
+        // A dossier outlives the structure it describes. Noticing costs the
+        // state an action; scope() must not quietly self-clean.
+        let (mut graph, hub, all) = star(3);
+        let mut dossier = Dossier::new();
+        dossier
+            .resolve_neighborhood(&graph, hub, "coordination")
+            .unwrap();
+        let gone = all[1];
+        graph.remove_node(gone).unwrap();
+
+        assert!(
+            dossier.knows_node(gone),
+            "the card is still in the drawer until the state looks"
+        );
+        assert_eq!(dossier.stale_nodes(&graph), vec![gone]);
+        assert_eq!(dossier.reconcile(&graph), vec![gone]);
+        assert!(!dossier.knows_node(gone));
+        assert!(dossier.stale_nodes(&graph).is_empty());
+    }
+
+    #[test]
+    fn the_state_can_be_wrong_about_what_a_strike_would_yield() {
+        // THE anti-omniscience contract. Same arithmetic, two scopes: the
+        // true graph answers what a strike WOULD yield, the dossier answers
+        // what the state BELIEVES it would. A partial dossier that has
+        // resolved only part of a hub's reach undervalues that hub — the
+        // state under-rates a target it cannot fully see. If these two ever
+        // agree by construction, the engine has granted the state free
+        // omniscience and this whole split is decoration.
+        let (graph, hub, all) = star(6);
+
+        let truth = decapitation_value(&graph, &all, "coordination", hub, 1).unwrap();
+
+        let mut dossier = Dossier::new();
+        dossier.resolve_node(hub);
+        for leaf in all.iter().skip(1).take(2) {
+            dossier.resolve_edge("coordination", hub, *leaf);
+        }
+        let believed =
+            decapitation_value(&graph, &dossier.scope(), "coordination", hub, 1).unwrap();
+
+        assert!(
+            believed < truth,
+            "a partially-resolved hub must look less valuable than it is \
+             (believed {believed}, true {truth})"
+        );
+    }
+
+    #[test]
+    fn a_fully_resolved_dossier_agrees_with_the_truth() {
+        // The other side of the same contract: the divergence above is a
+        // consequence of PARTIAL knowledge, not an artefact of scoping. When
+        // the state has resolved everything, its belief must converge.
+        let (graph, hub, all) = star(6);
+        let truth = decapitation_value(&graph, &all, "coordination", hub, 1).unwrap();
+
+        let mut dossier = Dossier::new();
+        dossier
+            .resolve_neighborhood(&graph, hub, "coordination")
+            .unwrap();
+        let believed =
+            decapitation_value(&graph, &dossier.scope(), "coordination", hub, 1).unwrap();
+
+        assert!(
+            (believed - truth).abs() < 1e-12,
+            "full resolution must converge (believed {believed}, true {truth})"
+        );
+    }
+}

--- a/rust/crates/babylon-graph/src/lib.rs
+++ b/rust/crates/babylon-graph/src/lib.rs
@@ -18,6 +18,7 @@
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
 
+pub mod dossier;
 pub mod exposure;
 pub mod induced;
 pub mod placeholder;

--- a/rust/crates/babylon-graph/src/lib.rs
+++ b/rust/crates/babylon-graph/src/lib.rs
@@ -18,6 +18,7 @@
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
 
+pub mod capacity;
 pub mod dossier;
 pub mod exposure;
 pub mod induced;

--- a/rust/crates/babylon-graph/src/lib.rs
+++ b/rust/crates/babylon-graph/src/lib.rs
@@ -18,6 +18,7 @@
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
 
+pub mod backfire;
 pub mod capacity;
 pub mod dossier;
 pub mod exposure;


### PR DESCRIPTION
Brick 3 of Lane A: `L` and `K` from the heat dossier's split (§5.1 A/B). `X` already exists in `exposure.rs`, derived and never stored.

Splitting them is what removes the ideological falsehood the dossier indicts. The old mechanic had one `[0,1]` scalar standing in for what the state **knows**, what it **spends**, and what the movement **is** — and the only way to write one number for all three is to key it to *conduct*, hence "illegality raises heat". Split, nothing needs to ask whether the player broke a law.

## `L` — the dossier

`exposure.rs` already takes a node scope and is deliberately silent on whose view it is. Passing the substrate's node list asks *what a strike WOULD yield*; passing `Dossier::scope()` asks *what the state BELIEVES it would*. Same arithmetic, different question — and the state only ever gets the second.

- `the_state_can_be_wrong_about_what_a_strike_would_yield` — a partially-resolved hub scores **0.5** against a true **0.83**. If these ever agree by construction, the engine has granted free omniscience and the split is decoration.
- `a_fully_resolved_dossier_agrees_with_the_truth` — the divergence comes from *partial knowledge*, not from scoping artifacts.

Constraints held as **absences**, so they can't be misused: no threat-score field (Sparrow's conscious-opponent argument forbids accumulated priority), no pointer back to ground truth (Scott — `L` is a projection, not a fraction of the truth). Reconciliation is explicit, never inside `scope()`: a dossier outlives what it describes, and noticing costs the state an action rather than tracking reality for free.

## `K` — capacity, and where escalation stops being a threshold

The old mechanic asked "has heat crossed 0.7?" — question-begging twice: a number nobody can derive, keyed to accumulated conduct. Here the state holds a finite budget per instrument, ranks candidates by yield per unit spent, and funds down the list until the budget runs out. **Escalation is what happens when a target rises in that ranking.** There is no threshold constant in the file.

Two results fall out rather than being coded, each pinned by a test:

- `a_redundant_target_declines_the_strike_by_itself` — `exposure`'s replaceability quotient divides a distributed org's yield down, so it loses the ranking. No "if distributed, skip" branch exists.
- `a_cheap_mode_outranks_an_expensive_one_at_higher_damage` — why disinformation dominates the record: cheapest by state capacity, dear by movement cost. Arithmetic, not a designer's thumb.

Plus `escalation_is_what_a_bigger_budget_buys_not_a_threshold_crossing`: identical candidates, identically ranked, funded to different depths purely by budget.

Determinism: ranking is a **total** order (ratio desc, then instrument/mode/target asc). Float ratios alone are only partial, and leaving ties to input order would put the tick hash at the mercy of upstream iteration — `allocation_is_invariant_under_candidate_permutation` pins it with three exact-tie candidates. Zero cost and non-finite yield are loud errors: a free action would outrank every priced one.

`mise run rust:check` green; babylon-graph 49 tests.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>