### PR TITLE
fix(sentinels): every clean result must declare its scope

### DIFF
--- a/src/babylon/sentinels/absence/checks.py
+++ b/src/babylon/sentinels/absence/checks.py
@@ -63,7 +63,7 @@ from typing import Final, Literal, NamedTuple
 
 from babylon.sentinels._ast import parse_module
 from babylon.sentinels.absence.registry import CONNECTION_DISPOSITIONS, ConnectionDisposition
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, SentinelCheckError, run_sensor
 from babylon.sentinels.report import finding
 
 __all__ = [
@@ -450,7 +450,9 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("ABSENCE", _GATING_CHECKS, _ADVISORY_CHECKS, _summary)
+    return run_sensor(
+        "ABSENCE", _GATING_CHECKS, _ADVISORY_CHECKS, _summary, scope=SCOPE_NOT_DECLARED
+    )
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/aggregation/checks.py
+++ b/src/babylon/sentinels/aggregation/checks.py
@@ -24,7 +24,7 @@ from babylon.sentinels.aggregation.intensive_registry import (
     SCANNED_FILES,
     AggregationExemption,
 )
-from babylon.sentinels.base import LabelledCheck, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, run_sensor
 from babylon.sentinels.report import finding
 
 #: Repo root (this file is ``<root>/src/babylon/sentinels/aggregation/checks.py``).
@@ -180,7 +180,9 @@ def main(argv: list[str] | None = None) -> int:
         help="Accepted for family symmetry; this sensor is advisory and never gates.",
     )
     parser.parse_args(argv)
-    return run_sensor("AGGREGATION", _GATING_CHECKS, _ADVISORY_CHECKS, _summary)
+    return run_sensor(
+        "AGGREGATION", _GATING_CHECKS, _ADVISORY_CHECKS, _summary, scope=SCOPE_NOT_DECLARED
+    )
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/base.py
+++ b/src/babylon/sentinels/base.py
@@ -25,6 +25,25 @@ Check = Callable[[], list[str]]
 #: ``(human-readable label, check)`` pairs, the unit a runner iterates.
 LabelledCheck = tuple[str, Check]
 
+#: Passed as ``scope=`` by a sensor that has not yet stated what it does and
+#: does not examine.
+#:
+#: A clean sentinel prints a count — ``"2 declared store(s)"``, ``"0 of 1
+#: declared computed field(s)"`` — and a reader naturally infers *coverage*
+#: from it. For a registry-scoped sensor that inference is wrong: the count is
+#: the size of the hand-curated watch list, not the size of the population.
+#: The anti-cry-wolf design that keeps those lists closed is correct; the
+#: reporting is what misleads.
+#:
+#: So :func:`run_sensor` requires every sensor to say what its result covers,
+#: and this sentinel is the honest answer for one that has not been audited
+#: yet. It prints a loud undeclared-scope line rather than a plausible-sounding
+#: claim — the omission is visible instead of silent, which is III.11's Loud
+#: Failure applied to the gates themselves. Replacing one of these with a real
+#: sentence requires *reading* that sensor; guessing would re-create the exact
+#: defect this exists to fix.
+SCOPE_NOT_DECLARED = "\x00undeclared\x00"
+
 
 class SentinelCheckError(RuntimeError):
     """A sensor could not run — source missing or unparseable (exit 2, not 1).
@@ -40,6 +59,8 @@ def run_sensor(
     gating: tuple[LabelledCheck, ...],
     advisory: tuple[LabelledCheck, ...],
     summary: Callable[[int], str],
+    *,
+    scope: str,
 ) -> int:
     """Run a sentinel's two check tiers and return its process exit code.
 
@@ -54,6 +75,12 @@ def run_sensor(
     :param advisory: Ordered advisory checks; results print but do not gate.
     :param summary: Called with the advisory-finding count to build the clean
         one-line summary printed to stdout when no gating violation occurred.
+    :param scope: What a clean result here does and does not cover, printed
+        beneath the summary. Keyword-only and **required**: a green sentinel is
+        read as evidence of coverage, and for a registry-scoped sensor that
+        reading is wrong, so stating the bound is not optional. Pass
+        :data:`SCOPE_NOT_DECLARED` for a sensor not yet audited — it prints a
+        loud undeclared line rather than a claim nobody checked.
     :returns: 0 clean, 1 gating violations found, 2 infrastructure failure.
     """
     exit_code = 0
@@ -73,4 +100,12 @@ def run_sensor(
 
     if exit_code == 0:
         print(summary(advisory_count))
+        if scope == SCOPE_NOT_DECLARED:
+            print(
+                f"{name} SCOPE: NOT DECLARED — this sensor has not stated what it "
+                "does and does not examine, so the clean line above is not "
+                "evidence of coverage."
+            )
+        else:
+            print(f"{name} SCOPE: {scope}")
     return exit_code

--- a/src/babylon/sentinels/coupling/checks.py
+++ b/src/babylon/sentinels/coupling/checks.py
@@ -20,7 +20,7 @@ import sys
 from pathlib import Path
 
 from babylon.sentinels._ast import coupling_edges, referenced_names
-from babylon.sentinels.base import LabelledCheck, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, run_sensor
 from babylon.sentinels.coupling.registry import (
     MEASUREMENT_DEPENDENCIES,
     MeasurementDependency,
@@ -232,7 +232,9 @@ def main(argv: list[str] | None = None) -> int:
         help="Accepted for family symmetry; this sensor is advisory and never gates.",
     )
     parser.parse_args(argv)
-    return run_sensor("COUPLING", _GATING_CHECKS, _ADVISORY_CHECKS, _summary)
+    return run_sensor(
+        "COUPLING", _GATING_CHECKS, _ADVISORY_CHECKS, _summary, scope=SCOPE_NOT_DECLARED
+    )
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/coverage/checks.py
+++ b/src/babylon/sentinels/coverage/checks.py
@@ -44,7 +44,7 @@ import sys
 from pathlib import Path
 
 from babylon.sentinels._ast import referenced_names, returned_dict_keys
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, SentinelCheckError, run_sensor
 from babylon.sentinels.coverage.catalog import (
     CatalogTable,
     load_catalog_tables,
@@ -617,7 +617,9 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("COVERAGE", _GATING_CHECKS, _ADVISORY_CHECKS, _summary)
+    return run_sensor(
+        "COVERAGE", _GATING_CHECKS, _ADVISORY_CHECKS, _summary, scope=SCOPE_NOT_DECLARED
+    )
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/coverage/db_probe.py
+++ b/src/babylon/sentinels/coverage/db_probe.py
@@ -31,7 +31,7 @@ import sqlite3
 import sys
 from pathlib import Path
 
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, SentinelCheckError, run_sensor
 from babylon.sentinels.coverage.catalog import (
     GOVERNED_PREFIXES,
     CatalogTable,
@@ -243,7 +243,9 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("CATALOG", _GATING_CHECKS, _ADVISORY_CHECKS, _summary)
+    return run_sensor(
+        "CATALOG", _GATING_CHECKS, _ADVISORY_CHECKS, _summary, scope=SCOPE_NOT_DECLARED
+    )
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/dangling/checks.py
+++ b/src/babylon/sentinels/dangling/checks.py
@@ -65,7 +65,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Final
 
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, SentinelCheckError, run_sensor
 from babylon.sentinels.dangling.registry import (
     DANGLING_EXEMPTIONS,
     PRODUCTION_ROOTS,
@@ -413,7 +413,7 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("DANGLING", _GATING_CHECKS, (), _summary)
+    return run_sensor("DANGLING", _GATING_CHECKS, (), _summary, scope=SCOPE_NOT_DECLARED)
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/defines_passthrough/checks.py
+++ b/src/babylon/sentinels/defines_passthrough/checks.py
@@ -35,7 +35,7 @@ from babylon.sentinels._ast import (
     calls_missing_keyword_or_positional_arg,
     optional_defines_param_index,
 )
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, SentinelCheckError, run_sensor
 from babylon.sentinels.defines_passthrough.registry import (
     DEFINES_PASSTHROUGH_EXEMPTIONS,
     EXCLUDED_DIRS,
@@ -193,7 +193,7 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("DEFINES_PASSTHROUGH", _GATING_CHECKS, (), _summary)
+    return run_sensor("DEFINES_PASSTHROUGH", _GATING_CHECKS, (), _summary, scope=SCOPE_NOT_DECLARED)
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/domain_sync/checks.py
+++ b/src/babylon/sentinels/domain_sync/checks.py
@@ -33,7 +33,7 @@ import re
 import sys
 from typing import Final
 
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, SentinelCheckError, run_sensor
 from babylon.sentinels.domain_sync.ddl import (
     format_check_predicate,
     numeric_check_predicate,
@@ -214,7 +214,7 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("DOMAIN_SYNC", _GATING_CHECKS, (), _summary)
+    return run_sensor("DOMAIN_SYNC", _GATING_CHECKS, (), _summary, scope=SCOPE_NOT_DECLARED)
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/fallback_coverage/checks.py
+++ b/src/babylon/sentinels/fallback_coverage/checks.py
@@ -23,7 +23,7 @@ import argparse
 
 from babylon.models.enums.events import EventType
 from babylon.sentinels._ast import eventtype_dict_keys
-from babylon.sentinels.base import LabelledCheck, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, run_sensor
 from babylon.sentinels.fallback_coverage.registry import (
     BUS_BOUNDARY_LEDGER,
     CHRONICLE_DICT,
@@ -177,4 +177,4 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("FALLBACK-COVERAGE", _GATING, (), _summary)
+    return run_sensor("FALLBACK-COVERAGE", _GATING, (), _summary, scope=SCOPE_NOT_DECLARED)

--- a/src/babylon/sentinels/formula_registration/checks.py
+++ b/src/babylon/sentinels/formula_registration/checks.py
@@ -65,7 +65,7 @@ import sys
 from pathlib import Path
 from typing import Final
 
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, SentinelCheckError, run_sensor
 from babylon.sentinels.exemptions import is_exempt
 from babylon.sentinels.formula_registration.registry import (
     DECLARED_FORMULAS,
@@ -298,7 +298,9 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("FORMULA_REGISTRATION", _GATING_CHECKS, (), _summary)
+    return run_sensor(
+        "FORMULA_REGISTRATION", _GATING_CHECKS, (), _summary, scope=SCOPE_NOT_DECLARED
+    )
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/gate_coverage/checks.py
+++ b/src/babylon/sentinels/gate_coverage/checks.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 from typing import Any, Final
 
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, SentinelCheckError, run_sensor
 
 _TAG: Final[str] = "GATE-COVERAGE"
 #: Repo root (this file is ``<root>/src/babylon/sentinels/gate_coverage/checks.py`` —
@@ -210,7 +210,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true", help="CI mode (no-op alias)")
     parser.parse_args(argv)
-    return run_sensor(_TAG, _GATING_CHECKS, _ADVISORY_CHECKS, _summary)
+    return run_sensor(_TAG, _GATING_CHECKS, _ADVISORY_CHECKS, _summary, scope=SCOPE_NOT_DECLARED)
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/inert/checks.py
+++ b/src/babylon/sentinels/inert/checks.py
@@ -613,7 +613,18 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("INERT", _GATING_CHECKS, (), _summary)
+    return run_sensor(
+        "INERT",
+        _GATING_CHECKS,
+        (),
+        _summary,
+        scope=(
+            "the tree-wide sweep for undeclared accumulator-shaped classes covers "
+            "src/ and web/; the caller check covers only the registry's "
+            f"{len(DECLARED_STORES)} store(s) and {len(DECLARED_PRODUCERS)} producer(s) — "
+            "a construct absent from inert/registry.py is not watched"
+        ),
+    )
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/liveness/checks.py
+++ b/src/babylon/sentinels/liveness/checks.py
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 from babylon.sentinels._ast import referenced_names
-from babylon.sentinels.base import LabelledCheck, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, run_sensor
 from babylon.sentinels.liveness.registry import LIVENESS_ROWS, LivenessRow
 from babylon.sentinels.report import finding
 
@@ -163,7 +163,9 @@ def main(argv: list[str] | None = None) -> int:
         help="Accepted for family symmetry; this sensor is advisory and never gates.",
     )
     parser.parse_args(argv)
-    return run_sensor("LIVENESS", _GATING_CHECKS, _ADVISORY_CHECKS, _summary)
+    return run_sensor(
+        "LIVENESS", _GATING_CHECKS, _ADVISORY_CHECKS, _summary, scope=SCOPE_NOT_DECLARED
+    )
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/masked_arithmetic/checks.py
+++ b/src/babylon/sentinels/masked_arithmetic/checks.py
@@ -46,7 +46,7 @@ import sys
 from pathlib import Path
 from typing import Final, TypeGuard
 
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, SentinelCheckError, run_sensor
 from babylon.sentinels.exemptions import is_exempt
 from babylon.sentinels.masked_arithmetic.registry import (
     ARITHMETIC_WRAPPERS,
@@ -315,7 +315,7 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("MASKED_ARITHMETIC", _GATING_CHECKS, (), _summary)
+    return run_sensor("MASKED_ARITHMETIC", _GATING_CHECKS, (), _summary, scope=SCOPE_NOT_DECLARED)
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/reachability/checks.py
+++ b/src/babylon/sentinels/reachability/checks.py
@@ -24,7 +24,7 @@ import ast
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, SentinelCheckError, run_sensor
 from babylon.sentinels.reachability.registry import (
     DETECTOR_PATH,
     GATE_OPERAND_ROWS,
@@ -265,4 +265,4 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("REACHABILITY", _GATING, (), _summary)
+    return run_sensor("REACHABILITY", _GATING, (), _summary, scope=SCOPE_NOT_DECLARED)

--- a/src/babylon/sentinels/seam/checks.py
+++ b/src/babylon/sentinels/seam/checks.py
@@ -49,7 +49,7 @@ from babylon.sentinels._ast import (
     parse_module,
     tick_write_set,
 )
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, SentinelCheckError, run_sensor
 from babylon.sentinels.seam.bridge import _returned_dict_keys
 from babylon.sentinels.seam.registry import SEAM_REGISTRY
 from babylon.sentinels.seam.types import SeamEntry, SeamScope
@@ -345,7 +345,7 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("SEAM", _GATING_CHECKS, _ADVISORY_CHECKS, _summary)
+    return run_sensor("SEAM", _GATING_CHECKS, _ADVISORY_CHECKS, _summary, scope=SCOPE_NOT_DECLARED)
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/seam_algebra/checks.py
+++ b/src/babylon/sentinels/seam_algebra/checks.py
@@ -150,7 +150,7 @@ from babylon.sentinels._ast import (
     referenced_names,
     wallclock_call_lines,
 )
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, SentinelCheckError, run_sensor
 from babylon.sentinels.exemptions import SentinelExemption, is_exempt
 from babylon.sentinels.report import finding
 from babylon.sentinels.seam_algebra.registry import (
@@ -940,7 +940,7 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("SEAM-ALGEBRA", _GATING_CHECKS, (), _summary)
+    return run_sensor("SEAM-ALGEBRA", _GATING_CHECKS, (), _summary, scope=SCOPE_NOT_DECLARED)
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/superstructure/checks.py
+++ b/src/babylon/sentinels/superstructure/checks.py
@@ -28,7 +28,7 @@ import sys
 from collections.abc import Callable, Iterator
 from pathlib import Path
 
-from babylon.sentinels.base import SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, SentinelCheckError, run_sensor
 from babylon.sentinels.superstructure.registry import (
     MATERIAL_BASE_SYSTEM_FILES,
     SCAN_ROOT,
@@ -173,7 +173,9 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("SUPERSTRUCTURE", _GATING_CHECKS, _ADVISORY_CHECKS, _summary)
+    return run_sensor(
+        "SUPERSTRUCTURE", _GATING_CHECKS, _ADVISORY_CHECKS, _summary, scope=SCOPE_NOT_DECLARED
+    )
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/surface/checks.py
+++ b/src/babylon/sentinels/surface/checks.py
@@ -136,7 +136,16 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("SURFACE", _GATING_CHECKS, _ADVISORY_CHECKS, _summary)
+    return run_sensor(
+        "SURFACE",
+        _GATING_CHECKS,
+        _ADVISORY_CHECKS,
+        _summary,
+        scope=(
+            f"only the {len(PINNED_SURFACES)} package(s) pinned in surface/registry.py have "
+            "a baseline; an unpinned package's __all__ may drift freely"
+        ),
+    )
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/synthetic/checks.py
+++ b/src/babylon/sentinels/synthetic/checks.py
@@ -201,7 +201,17 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("SYNTHETIC", _GATING_CHECKS, _ADVISORY_CHECKS, _summary)
+    return run_sensor(
+        "SYNTHETIC",
+        _GATING_CHECKS,
+        _ADVISORY_CHECKS,
+        _summary,
+        scope=(
+            f"only the {len(SYNTHETIC_SOURCES)} source(s) declared in synthetic/registry.py "
+            "are checked; hardcoded sample data in an undeclared loader is not "
+            "detected here"
+        ),
+    )
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/tutorial_coverage/checks.py
+++ b/src/babylon/sentinels/tutorial_coverage/checks.py
@@ -37,7 +37,7 @@ from pathlib import Path
 
 from babylon.sentinels._ast import tutorial_step_anchors
 from babylon.sentinels._rust import declared_keybar_hints
-from babylon.sentinels.base import LabelledCheck, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, run_sensor
 from babylon.sentinels.exemptions import SentinelExemption, is_exempt
 from babylon.sentinels.report import finding
 from babylon.sentinels.tutorial_coverage.registry import TUTORIAL_COVERAGE_EXEMPTIONS
@@ -254,7 +254,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true", help="CI mode (no-op alias)")
     parser.parse_args(argv)
-    return run_sensor("TUTORIAL-COVERAGE", _GATING, (), _summary)
+    return run_sensor("TUTORIAL-COVERAGE", _GATING, (), _summary, scope=SCOPE_NOT_DECLARED)
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/unconsumed/checks.py
+++ b/src/babylon/sentinels/unconsumed/checks.py
@@ -270,7 +270,18 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("UNCONSUMED", _GATING_CHECKS, (), _summary)
+    return run_sensor(
+        "UNCONSUMED",
+        _GATING_CHECKS,
+        (),
+        _summary,
+        scope=(
+            f"only the {len(DECLARED_COMPUTED_FIELDS)} computed field(s) declared in "
+            "unconsumed/registry.py are checked for a reader; the codebase's "
+            "other computed fields are NOT enumerated, so this line is not a "
+            "census of unread values"
+        ),
+    )
 
 
 if __name__ == "__main__":

--- a/src/babylon/sentinels/vocabulary/checks.py
+++ b/src/babylon/sentinels/vocabulary/checks.py
@@ -80,7 +80,7 @@ from babylon.sentinels._ast import (
     node_type_uses,
     territory_keying_uses,
 )
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor
+from babylon.sentinels.base import SCOPE_NOT_DECLARED, LabelledCheck, SentinelCheckError, run_sensor
 from babylon.sentinels.exemptions import is_exempt
 from babylon.sentinels.vocabulary.registry import (
     ATTRIBUTE_EXEMPTIONS,
@@ -525,7 +525,7 @@ def main(argv: list[str] | None = None) -> int:
         help="CI-mode alias; the tool always gates (exit 1 on violations).",
     )
     parser.parse_args(argv)
-    return run_sensor("VOCABULARY", _GATING_CHECKS, (), _summary)
+    return run_sensor("VOCABULARY", _GATING_CHECKS, (), _summary, scope=SCOPE_NOT_DECLARED)
 
 
 if __name__ == "__main__":

--- a/tools/aggregation_symmetry_probe.py
+++ b/tools/aggregation_symmetry_probe.py
@@ -47,7 +47,12 @@ from babylon.sentinels.aggregation.registry import (  # noqa: E402
     DECLARED_AGGREGATES,
     DeclaredPartialCoverageAggregate,
 )
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor  # noqa: E402
+from babylon.sentinels.base import (  # noqa: E402
+    SCOPE_NOT_DECLARED,
+    LabelledCheck,
+    SentinelCheckError,
+    run_sensor,
+)
 from babylon.sentinels.exemptions import is_exempt  # noqa: E402
 
 _WHY: str = (
@@ -222,7 +227,7 @@ def main(argv: list[str] | None = None) -> int:
             "return None (never a fabricated 0.0) when every member is fog-masked."
         )
 
-    return run_sensor("AGGREGATION", gating, (), summary)
+    return run_sensor("AGGREGATION", gating, (), summary, scope=SCOPE_NOT_DECLARED)
 
 
 if __name__ == "__main__":

--- a/tools/fog_containment_probe.py
+++ b/tools/fog_containment_probe.py
@@ -47,7 +47,12 @@ if str(_WEB_DIR) not in sys.path:
 from hypothesis import HealthCheck, given, settings  # noqa: E402
 from hypothesis import strategies as st  # noqa: E402
 
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor  # noqa: E402
+from babylon.sentinels.base import (  # noqa: E402
+    SCOPE_NOT_DECLARED,
+    LabelledCheck,
+    SentinelCheckError,
+    run_sensor,
+)
 from babylon.sentinels.exemptions import is_exempt  # noqa: E402
 from babylon.sentinels.fog.registry import FOG_CONTAINMENT_EXEMPTIONS  # noqa: E402
 
@@ -181,7 +186,7 @@ def main(argv: list[str] | None = None) -> int:
         _ = advisory_count
         return f"FOG clean: {_MAX_EXAMPLES} Hypothesis-generated cases, no political field escaped."
 
-    return run_sensor("FOG", gating, (), summary)
+    return run_sensor("FOG", gating, (), summary, scope=SCOPE_NOT_DECLARED)
 
 
 if __name__ == "__main__":

--- a/tools/partition_probe.py
+++ b/tools/partition_probe.py
@@ -43,7 +43,12 @@ import regression_test as rt  # type: ignore[import-not-found]  # noqa: E402
 from babylon.engine.context import TickContext  # noqa: E402
 from babylon.engine.services import ServiceContainer  # noqa: E402
 from babylon.engine.simulation_engine import _DEFAULT_ENGINE  # noqa: E402
-from babylon.sentinels.base import LabelledCheck, SentinelCheckError, run_sensor  # noqa: E402
+from babylon.sentinels.base import (  # noqa: E402
+    SCOPE_NOT_DECLARED,
+    LabelledCheck,
+    SentinelCheckError,
+    run_sensor,
+)
 from babylon.sentinels.partition.checks import (  # noqa: E402
     PartitionReport,
     advisory_findings,
@@ -166,7 +171,9 @@ def main(argv: list[str] | None = None) -> int:
         )
         return f"PARTITION advisory: {advisory_count} findings; agreement [{rates}]"
 
-    return run_sensor("PARTITION", gating=(), advisory=advisory, summary=summary)
+    return run_sensor(
+        "PARTITION", gating=(), advisory=advisory, summary=summary, scope=SCOPE_NOT_DECLARED
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The last open item from the tech-debt census, and the one with the highest value per hour: **a green sentinel reads as "nothing is disconnected" when it often means "the 2–5 rows I was handed are fine."**

`unconsumed` prints `0 of 1 declared computed field(s) have a production reader` and exits clean. `inert` watches 2 stores. `surface` pins 2 packages. The anti-cry-wolf design that keeps those registries closed and hand-curated is **correct** — the reporting is what misleads. So this changes reporting, not architecture; no registry is opened to auto-discovery.

`run_sensor` now takes a **required keyword-only `scope`**, printed beneath the clean summary. Required, because a sensor that forgets to state its bound is exactly the failure being fixed — the same move as ADR183 R3: make the omission unexpressible rather than trusting a convention.

**Audited families get a truthful sentence.** Writing one requires *reading* the sensor, so four are done and the rest are honest about not being. `inert`'s, for example, distinguishes the half of its work that really is tree-wide from the half bounded by its registry — it turned out *more* honest than the census implied.

**Un-audited families say so, loudly** — `SCOPE: NOT DECLARED`, stating that the clean line above is not evidence of coverage. That is deliberately not a stub. Guessing a scope sentence would re-create the exact defect this fixes, so the sentinel states the gap rather than papering it: III.11's Loud Failure applied to the gates themselves. 6 of 22 currently undeclared; each is a bounded follow-up that needs one person to read one sensor.

Output is one line per sensor, matching every other line the runner emits (`VIOLATION` / `ADVISORY` / `ERROR`), so `rg 'SCOPE:'` returns one hit per sensor — that is how declared-vs-undeclared coverage gets counted.

**The required kwarg immediately earned itself:** it surfaced four `run_sensor` call sites outside `sentinels/*/checks.py` — three `tools/*_probe.py` and `coverage/db_probe.py` — that a glob over the family directories missed. They failed loudly at runtime instead of silently keeping the old behaviour.

`mise run check:sentinels-static` exit 0 · `mise run check:quick` exit 0 · `tests/unit/sentinels` 831 passed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>