### PR TITLE
refactor(graph): retire hyperedge_exists, make hyperedges_of fallible

### DIFF
--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -869,6 +869,7 @@ mod tests {
             )
             .unwrap();
         let grown = fixture.graph.hyperedges_of(fixture.self_id, "CELL");
+        let grown = grown.unwrap();
         assert_eq!(grown.len(), 1);
         assert_eq!(
             fixture.graph.members_of(grown[0]).unwrap().len(),

--- a/rust/crates/babylon-graph/src/placeholder.rs
+++ b/rust/crates/babylon-graph/src/placeholder.rs
@@ -220,7 +220,19 @@ impl GraphSubstrate for PlaceholderGraph {
             })
     }
 
-    fn hyperedges_of(&self, node: NodeId, hyperedge_type: &str) -> Vec<HyperedgeId> {
+    fn hyperedges_of(
+        &self,
+        node: NodeId,
+        hyperedge_type: &str,
+    ) -> Result<Vec<HyperedgeId>, GraphError> {
+        if !self.nodes.contains_key(&node) {
+            return Err(GraphError {
+                message: format!(
+                    "no such node: {node:?} — belonging to nothing and not existing \
+                     are different facts"
+                ),
+            });
+        }
         let mut found: Vec<HyperedgeId> = self
             .hyperedges
             .iter()
@@ -228,11 +240,7 @@ impl GraphSubstrate for PlaceholderGraph {
             .map(|(id, _)| *id)
             .collect();
         found.sort_unstable();
-        found
-    }
-
-    fn hyperedge_exists(&self, id: HyperedgeId) -> bool {
-        self.hyperedges.contains_key(&id)
+        Ok(found)
     }
 }
 
@@ -240,6 +248,40 @@ impl GraphSubstrate for PlaceholderGraph {
 mod tests {
     use super::{GraphSubstrate, NodeId, PlaceholderGraph};
     use crate::substrate::Direction;
+
+    #[test]
+    fn belonging_to_nothing_and_not_existing_are_different_facts() {
+        // The honest-null discipline at the hyperedge half. An unknown TYPE
+        // is an empty range (type validity is BSL's E-TYPE-011, not the
+        // substrate's); an unknown NODE is loud.
+        //
+        // Why the asymmetry is load-bearing rather than pedantic: a target
+        // that belongs to no protective structure is the CHEAPEST one an
+        // adversary can reach. If a missing node read as "belongs to
+        // nothing", every data hole would present as a defenceless target.
+        // Pine Ridge (FIPS 46102) has zero census rows at every vintage, so
+        // that is a real shape in the data, not a hypothetical.
+        let mut graph = PlaceholderGraph::new();
+        let lone = graph.add_node("social_class").unwrap();
+
+        assert_eq!(
+            graph.hyperedges_of(lone, "community").unwrap(),
+            vec![],
+            "a real node in no community of that type is an empty range"
+        );
+        assert_eq!(
+            graph.hyperedges_of(lone, "no_such_type").unwrap(),
+            vec![],
+            "an unknown TYPE is empty, not an error — E-TYPE-011 is BSL's job"
+        );
+
+        let err = graph.hyperedges_of(NodeId(999), "community").unwrap_err();
+        assert!(
+            err.message.contains("different facts"),
+            "an absent NODE must be loud: {}",
+            err.message
+        );
+    }
 
     #[test]
     fn add_then_update_then_read_back() {
@@ -413,7 +455,10 @@ mod tests {
         let sector = graph
             .add_hyperedge("economic_sector", &[first, second])
             .unwrap();
-        assert_eq!(graph.hyperedges_of(first, "economic_sector"), vec![sector]);
+        assert_eq!(
+            graph.hyperedges_of(first, "economic_sector").unwrap(),
+            vec![sector]
+        );
         // the dyadic half is untouched by minting a hyperedge
         assert_eq!(graph.edge_count(), 0);
         assert_eq!(graph.hyperedges.len(), 1);

--- a/rust/crates/babylon-graph/src/substrate.rs
+++ b/rust/crates/babylon-graph/src/substrate.rs
@@ -192,8 +192,24 @@ pub trait GraphSubstrate {
 
     /// The hyperedges of the given type a node belongs to, in ascending
     /// [`HyperedgeId`] order.
-    fn hyperedges_of(&self, node: NodeId, hyperedge_type: &str) -> Vec<HyperedgeId>;
-
-    /// Whether `id` names a live hyperedge.
-    fn hyperedge_exists(&self, id: HyperedgeId) -> bool;
+    ///
+    /// An unknown *type* is an empty range, matching [`Self::nodes`]: type
+    /// validity is BSL's static check (`E-TYPE-011`), not the substrate's.
+    /// An unknown *node* is an error, matching [`Self::neighbors`].
+    ///
+    /// The two halves are not symmetric on purpose. "This node belongs to no
+    /// community" and "there is no such node" are different facts, and the
+    /// first is load-bearing here: a county with no census rows must not
+    /// read as a node that belongs to nothing, because a target belonging to
+    /// no protective structure is the CHEAPEST one an adversary can reach
+    /// ([`crate::backfire`]). Pine Ridge (FIPS 46102) is empty at every
+    /// census vintage, so this is a live data shape, not a hypothetical.
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if `node` does not exist.
+    fn hyperedges_of(
+        &self,
+        node: NodeId,
+        hyperedge_type: &str,
+    ) -> Result<Vec<HyperedgeId>, GraphError>;
 }


### PR DESCRIPTION
Two trait changes that are **free right now and expensive later**: `PlaceholderGraph` is the only implementor, so the cost is one impl. Once hypergraph-rs backs `GraphSubstrate` (the next Phase 2 task), every signature change costs two. That window closes with the storage swap.

**`hyperedge_exists` — deleted.** Zero callers, zero tests; `rg` found exactly two hits and both were definitions.

**`hyperedges_of` — now fallible.** The trait's own doc already flagged this: `neighbors` says *"contrast `hyperedges_of`, whose infallible signature predates this ruling and is flagged for Phase-2 review."* This is that review.

The two halves are deliberately asymmetric, matching existing precedent in the same trait:
- unknown **type** → empty range, matching `nodes()` (type validity is BSL's static `E-TYPE-011`, not the substrate's)
- unknown **node** → loud error, matching `neighbors()`

**Why the asymmetry is load-bearing rather than pedantic.** "Belongs to no community" and "there is no such node" are different facts, and collapsing them is dangerous in one specific direction: a target belonging to no protective structure is the *cheapest* one an adversary can reach (`backfire.rs`). If a missing node read as "belongs to nothing", every hole in the data would present as a defenceless target. Pine Ridge (FIPS 46102) has zero census rows at every vintage — that's a real shape in the reference data, not a hypothetical.

Pinned by `belonging_to_nothing_and_not_existing_are_different_facts`, which asserts all three cases.

Call-site census confirmed the adjudication: **zero production callers**, three in test modules (one in `placeholder.rs`, two in `structural_verbs.rs`).

`mise run rust:check` EXIT=0; 68 graph tests, 148 bsl.