### PR TITLE
fix(rust): rust-majors bump + the two defects it surfaced

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
  "babylon-graph",
  "babylon-kernel",
  "pretty_assertions",
- "sha2",
+ "sha2 0.11.0",
  "unicode-normalization",
 ]
 
@@ -129,9 +129,9 @@ version = "0.1.0"
 dependencies = [
  "bnum",
  "pretty_assertions",
- "rand_chacha",
- "rand_core 0.6.4",
- "sha2",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -265,10 +265,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bnum"
-version = "0.13.0"
+name = "block-buffer"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bnum"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1b08cb4ecbb540b940016b0a0f35b7e48ab0cc372ab88150c351de4cc469959"
 
 [[package]]
 name = "bumpalo"
@@ -387,6 +396,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +512,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,8 +611,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -913,6 +948,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hypergraph-rs"
@@ -1860,7 +1904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -1892,6 +1936,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2347,7 +2401,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2627,7 +2692,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -3041,7 +3106,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,21 @@ members = [
 ]
 resolver = "2"
 
+# Release must fail as loudly as dev. Cargo's implicit release default is
+# `overflow-checks = false`, which turns every arithmetic overflow into a
+# silent wrap — the exact shape Constitution III.11 (Loud Failure) forbids,
+# and in a hash-producing engine a wrapped intermediate is a wrong tick that
+# still validates. A real instance shipped here: `round_half_even_div`'s
+# `denominator.abs()` returned -1 instead of 0 in release while panicking in
+# dev (fixed at the site with `unsigned_abs`; this table closes the class).
+#
+# `debug-assertions` stays at the release default (off): those are for
+# invariants we choose to check, whereas overflow is never intended.
+# Determinism is unaffected either way — an overflow panic is not a
+# divergent number, it is the absence of one.
+[profile.release]
+overflow-checks = true
+
 [workspace.package]
 version = "0.1.0"
 edition = "2021"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,5 +13,9 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.85"
+# 1.87 is bnum 0.14's MSRV, not a preference — declaring 1.85 while
+# depending on a crate that needs 1.87 would be a false claim about who
+# can build this workspace. The toolchain pin (rust-toolchain.toml) is
+# 1.91.1, so this is the floor we support, not the one we use.
+rust-version = "1.87"
 license = "AGPL-3.0-or-later"   # in-tree = babylon's own license, not the sibling BSD

--- a/rust/crates/babylon-bsl/Cargo.toml
+++ b/rust/crates/babylon-bsl/Cargo.toml
@@ -18,4 +18,4 @@ pretty_assertions = "1"
 version = "0.1"
 
 [dependencies.sha2]
-version = "0.10"
+version = "0.11"

--- a/rust/crates/babylon-graph/src/state_hash.rs
+++ b/rust/crates/babylon-graph/src/state_hash.rs
@@ -213,6 +213,7 @@ impl StateEncoder {
 mod tests {
     use super::StateEncoder;
     use crate::substrate::{HyperedgeId, NodeId};
+    use std::fmt::Write as _;
 
     fn encoder_with_one_attribute(value: f64) -> [u8; 32] {
         let mut enc = StateEncoder::new();
@@ -223,6 +224,97 @@ mod tests {
         enc.write_edges(&[]).unwrap();
         enc.write_hyperedges(&[]).unwrap();
         enc.finish()
+    }
+
+    /// **The golden byte vector — the actual cross-language contract.**
+    ///
+    /// Every other test in this module is RELATIONAL: same-in/same-out,
+    /// changed-in/changed-out, distinct-shapes-differ. All of them would
+    /// still pass if this encoder wrote little-endian integers, or moved
+    /// the length prefix after the string, or swapped `from`/`to`. They
+    /// pin that the encoding is a *function*; they do not pin *which*
+    /// function, and the module docs above claim a normative layout that
+    /// another language must reproduce from the description alone.
+    ///
+    /// So this test writes one entry into every section and asserts the
+    /// exact bytes, annotated field by field. A reimplementation in any
+    /// language can be checked against this array without running Rust —
+    /// which is the whole point of calling the layout normative.
+    #[test]
+    fn the_canonical_encoding_is_pinned_byte_for_byte() {
+        let mut enc = StateEncoder::new();
+        enc.write_nodes(&[(NodeId(1), "c".to_owned())]).unwrap();
+        enc.write_attributes(&[(NodeId(1), "w".to_owned(), 1.0)])
+            .unwrap();
+        enc.write_edges(&[("E".to_owned(), NodeId(1), NodeId(2), 0.5)])
+            .unwrap();
+        enc.write_hyperedges(&[(HyperedgeId(7), "H".to_owned(), vec![NodeId(1), NodeId(2)])])
+            .unwrap();
+
+        #[rustfmt::skip]
+        let expected: &[u8] = &[
+            // ── section 0x01: nodes ──────────────────────────────────
+            0x01,                                            // tag
+            0x00, 0x00, 0x00, 0x01,                          // u32 count = 1
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,  // u64 id = 1
+            0x00, 0x00, 0x00, 0x01, b'c',                    // str "c"
+            // ── section 0x02: attributes ─────────────────────────────
+            0x02,                                            // tag
+            0x00, 0x00, 0x00, 0x01,                          // u32 count = 1
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,  // u64 id = 1
+            0x00, 0x00, 0x00, 0x01, b'w',                    // str "w"
+            0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // f64 1.0 bits
+            // ── section 0x03: edges ──────────────────────────────────
+            0x03,                                            // tag
+            0x00, 0x00, 0x00, 0x01,                          // u32 count = 1
+            0x00, 0x00, 0x00, 0x01, b'E',                    // str "E" FIRST
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,  // u64 from = 1
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,  // u64 to   = 2
+            0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // f64 0.5 bits
+            // ── section 0x04: hyperedges ─────────────────────────────
+            0x04,                                            // tag
+            0x00, 0x00, 0x00, 0x01,                          // u32 count = 1
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07,  // u64 id = 7
+            0x00, 0x00, 0x00, 0x01, b'H',                    // str "H"
+            0x00, 0x00, 0x00, 0x02,                          // u32 members = 2
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,  // u64 member 1
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,  // u64 member 2
+        ];
+
+        assert_eq!(
+            enc.as_bytes(),
+            expected,
+            "the canonical encoding moved — if this was deliberate it is a \
+             CONTRACT CHANGE that invalidates every stored state hash and \
+             every other implementation, not a test to re-bless casually"
+        );
+    }
+
+    /// The digest over that exact vector, pinned so a change of hash
+    /// FUNCTION is caught too — the byte test above cannot see that.
+    /// Generated once from this implementation, byte-pinned thereafter.
+    #[test]
+    fn the_golden_vector_hashes_to_its_pinned_digest() {
+        let mut enc = StateEncoder::new();
+        enc.write_nodes(&[(NodeId(1), "c".to_owned())]).unwrap();
+        enc.write_attributes(&[(NodeId(1), "w".to_owned(), 1.0)])
+            .unwrap();
+        enc.write_edges(&[("E".to_owned(), NodeId(1), NodeId(2), 0.5)])
+            .unwrap();
+        enc.write_hyperedges(&[(HyperedgeId(7), "H".to_owned(), vec![NodeId(1), NodeId(2)])])
+            .unwrap();
+
+        // `fold` + `write!` rather than `map(format!).collect()`: the latter
+        // allocates a String per byte and clippy::pedantic refuses it.
+        let hex = enc.finish().iter().fold(String::new(), |mut acc, b| {
+            let _ = write!(acc, "{b:02x}");
+            acc
+        });
+        assert_eq!(
+            hex, "5e0041a4948bc52530bdcc3a19e61f94aee5523027e2ed1aee5310109fa1c0d8",
+            "SHA-256 over the golden vector moved: either the encoding changed \
+             (see the byte test) or the digest function did"
+        );
     }
 
     #[test]

--- a/rust/crates/babylon-kernel/Cargo.toml
+++ b/rust/crates/babylon-kernel/Cargo.toml
@@ -8,10 +8,10 @@ license.workspace = true
 publish = false
 
 [dependencies]
-bnum = "0.13"
-rand_chacha = "0.3"
-rand_core = "0.6"
-sha2 = "0.10"
+bnum = "0.14"
+rand_chacha = "0.10"
+rand_core = "0.10"
+sha2 = "0.11"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/rust/crates/babylon-kernel/src/currency.rs
+++ b/rust/crates/babylon-kernel/src/currency.rs
@@ -113,8 +113,8 @@ impl Currency {
     /// invoking this projection), not recoverable conditions.
     #[must_use]
     pub fn div_currency(self, other: Self) -> Coefficient {
-        let numerator = I256::from(self.0) * I256::from(MICRO);
-        let ratio = round_half_even_div_i256(numerator, I256::from(other.0));
+        let numerator = widen(self.0) * widen(MICRO);
+        let ratio = round_half_even_div_i256(numerator, widen(other.0));
         let as_i128: i128 = ratio
             .try_into()
             .expect("i256 intermediate must fit i128 for a [0,1] ratio");
@@ -163,20 +163,32 @@ pub fn round_half_even_div(numerator: i128, denominator: i128) -> i128 {
     }
 }
 
+/// `i128 → I256`, the one widening this module needs.
+///
+/// bnum 0.14 replaced `From<primitive>` with `TryFrom<primitive>` and
+/// removed the `ZERO`/`ONE` consts, so every widening is now fallible at
+/// the type level. It is not fallible in fact: `I256` holds 256 bits and
+/// `i128` holds 128, so **every** `i128` is representable and the `Err`
+/// arm is unreachable by width. Centralised here so that invariant is
+/// stated once rather than restated at five call sites.
+fn widen(value: i128) -> I256 {
+    I256::try_from(value).expect("every i128 fits i256 by construction — 128 bits into 256")
+}
+
 /// The same half-even division at i256 width, for `div_currency`'s
 /// intermediate — kept private: the public intrinsic surface is the i128
 /// form above.
 fn round_half_even_div_i256(numerator: I256, denominator: I256) -> I256 {
     let q = numerator / denominator;
     let r = numerator % denominator;
-    let two = I256::from(2_i128);
+    let two = widen(2);
     let twice_r = r * two; // i256 headroom: cannot overflow for i128-derived inputs
     let step = numerator.signum() * denominator.signum();
     match twice_r.abs().cmp(&denominator.abs()) {
         std::cmp::Ordering::Less => q,
         std::cmp::Ordering::Greater => q + step,
         std::cmp::Ordering::Equal => {
-            if q % two == I256::ZERO {
+            if q % two == widen(0) {
                 q
             } else {
                 q + step

--- a/rust/crates/babylon-kernel/src/currency.rs
+++ b/rust/crates/babylon-kernel/src/currency.rs
@@ -150,7 +150,12 @@ pub fn round_half_even_div(numerator: i128, denominator: i128) -> i128 {
     let twice_r = r
         .checked_mul(2)
         .expect("round_half_even_div: 2*remainder overflow");
-    match twice_r.abs().cmp(&denominator.abs()) {
+    // `unsigned_abs`, never `abs`: `i128::MIN.abs()` overflows (i128 holds
+    // −2¹²⁷ but not +2¹²⁷), which panics in dev and — with release's
+    // `overflow-checks = false` — WRAPS back to a negative i128, inverting
+    // this comparison for every input. `unsigned_abs` returns u128, where
+    // every magnitude is representable, so the compare is total.
+    match twice_r.unsigned_abs().cmp(&denominator.unsigned_abs()) {
         std::cmp::Ordering::Less => q,
         std::cmp::Ordering::Greater => q + numerator.signum() * denominator.signum(),
         std::cmp::Ordering::Equal => {
@@ -201,6 +206,25 @@ fn round_half_even_div_i256(numerator: I256, denominator: I256) -> I256 {
 mod tests {
     use super::{round_half_even_div, Currency, CurrencyOverflow};
     use crate::scalars::Coefficient;
+
+    #[test]
+    fn half_even_div_survives_the_most_negative_denominator() {
+        // `i128::MIN.abs()` overflows: i128 holds -2^127 but not +2^127.
+        // In dev that panics; in release — where this workspace declares no
+        // [profile.release] and so inherits `overflow-checks = false` — it
+        // WRAPS back to i128::MIN, a negative value. The comparison at the
+        // heart of the rounding rule then reads "|2r| > |d|" for every
+        // input and the intrinsic silently returns the wrong quotient.
+        //
+        // 1 / i128::MIN is ≈ -5.9e-39, which half-even-rounds to 0. The
+        // wrapped path returns -1. Wrong money, quietly, in release only —
+        // the III.11 failure mode exactly.
+        assert_eq!(round_half_even_div(1, i128::MIN), 0);
+        assert_eq!(round_half_even_div(-1, i128::MIN), 0);
+        // The symmetric hazard on the numerator side: |2r| can itself reach
+        // i128::MIN's magnitude for a large enough divisor.
+        assert_eq!(round_half_even_div(i128::MIN, i128::MIN), 1);
+    }
 
     #[test]
     fn add_overflow_is_loud_not_wrapping() {

--- a/rust/crates/babylon-kernel/src/rng.rs
+++ b/rust/crates/babylon-kernel/src/rng.rs
@@ -33,7 +33,7 @@
 //! ensemble-envelope comparison, not byte replay.
 use crate::clock::SessionId;
 use rand_chacha::ChaCha8Rng;
-use rand_core::{RngCore, SeedableRng};
+use rand_core::{Rng, SeedableRng};
 use sha2::{Digest, Sha256};
 
 /// Mirrors `kernel/system_base.py::_SYSTEM_RNG_SEED_SALT` structurally


### PR DESCRIPTION
Three commits. Supersedes #442 (dependabot's group bump, Rust Gate red with 9 errors).

## 1. `cabb3b8c` — the bump

| crate | bump | breaking change |
|---|---|---|
| `bnum` | 0.13 → 0.14 | `From<primitive>` → `TryFrom<primitive>`; `ZERO`/`ONE` consts removed |
| `rand_core` | 0.6 → 0.10 | `RngCore` trait renamed to `Rng` |
| `rand_chacha` | 0.3 → 0.10 | follows rand_core |
| `sha2` | 0.10 → 0.11 | no source change needed |

These are the four crates that *define* determinism here, so the bump is only safe if the numbers didn't move. Three pinned conformance vectors say they didn't:

- `rng::tests::conformance_vector_first_four_u64s` — ChaCha8 stream byte-identical across rand_chacha 0.3 → 0.10
- `content_digest::tests::matches_the_python_canonical_defines_hash` — sha2 0.10 → 0.11 same SHA-256
- `grid::tests::matches_the_python_quantize_conformance_vector` — bnum 0.13 → 0.14 same fixed-point

`rust-version` 1.85 → **1.87**: not a preference, bnum 0.14's MSRV. Declaring 1.85 while depending on a crate needing 1.87 is a false claim about who can build this workspace.

## 2. `061d261c` — a live Loud-Failure breach in money math

Found by the Rust estate audit (`reports/rust-estate-audit-2026-07-31.md`), reproduced before believing it.

`round_half_even_div` — the §6.2 normative rounding intrinsic, re-exported for BSL content to call — used `denominator.abs()`. `i128::MIN.abs()` overflows:

| build | `round_half_even_div(1, i128::MIN)` |
|---|---|
| debug | `panicked: attempt to negate with overflow` |
| **release** | **returns `-1`; the answer is `0`** |

The workspace declared no `[profile]` table at all, so release inherited Cargo's implicit `overflow-checks = false` — silent wrapping in a hash-producing engine, exactly what III.11 forbids.

Fixed both halves: `unsigned_abs()` at the site (u128, every magnitude representable, comparison total), and `[profile.release] overflow-checks = true` to close the class. Regression test fails in **both** profiles without the fix.

## 3. `3585ad89` — the state-hash contract was self-referential

Also from the audit. `state_hash.rs` documents a normative cross-language byte layout, but its 6 tests were all *relational* (same→same, changed→different). Every one would still pass if the encoder wrote little-endian, or moved the length prefix after the string, or swapped `from`/`to`. They pinned that the encoding is a function, not *which* function.

Added a golden byte vector — one entry in every section, asserted byte-for-byte with field-by-field annotation — plus the SHA-256 over it (which the byte test alone cannot catch a change of hash function). A reimplementation in any language can now be checked against the array without running Rust, which is what "normative" has to mean.

The hand-derived expected bytes matched the implementation on the first run, independently confirming the module docs describe what the code does.