### PR TITLE
docs(bsl): R9 step-2 spec chapters — the gap fill

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -463,10 +463,28 @@ Python grammars express:
      - ``(<cmp> (fold count|sum|mean|max|min …) <threshold>)``
    * - ``NodeFilter`` (node type / role / id pattern)
      - ``<node-pred>`` (§2.6)
-   * - ``EdgeCondition`` ``count``/``sum_strength``/``avg_strength``
-     - ``(fold count|sum|mean (edges …) …)``
+   * - ``EdgeCondition`` ``count``
+     - ``(fold count (edges EdgeType/SOLIDARITY) 1)``
+   * - ``EdgeCondition`` ``sum_strength`` / ``avg_strength``
+     - ``(fold sum|mean (edges EdgeType/SOLIDARITY)
+       (field-of it solidarity/strength))`` — the ``field-of`` accessor of
+       §2.10.
    * - ``GraphCondition`` six named metrics
      - ``:metric`` bindings, one per registered metric
+
+**A contradiction this table used to carry, now closed (R9 chapter C1).** The
+two ``EdgeCondition`` rows above were one row until the R9 gap analysis
+(``reports/bsl-gap-analysis-2026-08-10.md`` §2, Q1), and that row promised
+``sum_strength``/``avg_strength`` transcribe as a fold over ``edges`` — while
+§2.5 scoped ``:field`` to node types, §2.9's ``deffield`` had no edge case, and
+no §2.7 production could read anything off an ``EdgeRef``. The document
+committed to a capability its grammar could not express. §2.9 (edge- and
+hyperedge-qualified ``deffield``) and §2.10 (``field-of``) close it; the row is
+split above because ``count`` needs no attribute read and the other two do.
+The frozen Python site the row transcribes is
+``engine/event_evaluator.py:174-175``, which reads ``solidarity_strength`` and
+defaults it to ``0.0`` — the default is the §6.3 honest-null delta, not part of
+the form.
 
 2.5 Bindings
 ~~~~~~~~~~~~~~
@@ -492,6 +510,26 @@ legal inside a fold body over that type (``E-TYPE-010``). ``:const`` reads a
 coefficient from the defines environment. ``:metric`` reads a registered
 graph-level metric; an unregistered metric name is ``E-LOAD-011`` — never
 ``0.0`` (§6.3). ``:tick`` binds the current tick as ``Int``.
+
+**[draft ruling — Phase 1 review, R9 chapter C1]** *A* ``:field`` *binding is
+node-scoped, and stays node-scoped.* An edge's or a hyperedge's declared field
+is read by the ``field-of`` accessor of §2.10, never by a ``:field`` binding.
+Two reasons, both taken from the rest of this document rather than invented
+here: a binding is declared once at rule scope and resolved *implicitly*
+against an enclosing body, which needs exactly one candidate body to be
+unambiguous — and the systems that read edge attributes read several edge types
+in one rule; and §2.10's accessor takes its owning type as a qname operand,
+which is D24's fix for the identical problem on ``members-of``. The R9 gap
+analysis §2 (Q1) sketched an edge-typed ``:field`` binding instead; this
+document's conventions override the sketch, and D29 records the divergence.
+
+**[draft ruling — Phase 1 review, R9 chapter C1]** *Implicit resolution
+requires a unique candidate.* A foreign-node-type ``:field`` binding
+referenced where **two or more** enclosing bodies range over that same node
+type is ``E-TYPE-013`` — the reference is ambiguous and the author must write
+``field-of`` against a named element (§2.6's ``:as``) instead. This is the
+narrow, loud form of the resolution rule §2.5 previously left to inference;
+single-body code is unaffected.
 
 Two symbols are **reserved and always in scope**, never declared and never
 shadowed (``E-PARSE-022``): ``self``, the node the rule is being evaluated
@@ -605,6 +643,7 @@ set, not a sequence.
                  | "(" <intrinsic-name> <expr>* ")"
                  | "(" "if" <cond> <expr> <expr> ")"
                  | <fold>
+                 | <accessor>                       ; §2.10
 
    <arith>     ::= "+" | "-" | "*" | "/"
    <literal>   ::= <int-lit> | <scaled-lit> | <bool-lit>
@@ -639,8 +678,19 @@ bound-checker are computable from content alone:
 A declaration whose signature disagrees with the kernel's registration is
 ``E-LOAD-020``; a call to an undeclared intrinsic is ``E-LOAD-021``. The
 *contents* of the intrinsic table are Program 27 Phase 2 work and are not fixed
-by this document — only the calling convention, the declaration form, and the
-"never a primitive" prohibition are normative here.
+by this document — only the calling convention, the declaration form, the
+reserved-name prohibition below, and the "never a primitive" prohibition are
+normative here. §3.10 records the cap the intrinsic table is held to and the
+rider slate proposed against it.
+
+**[draft ruling — Phase 1 review, R9 chapter C1]** *Form-head symbols are
+reserved against the intrinsic namespace.* An intrinsic call is
+``"(" <intrinsic-name> <expr>* ")"``, so an intrinsic whose name collided with
+a form head would make ``(field-of it x/y)`` ambiguous between an accessor and
+a call. Every head symbol listed as a form tag in §5.2 is therefore reserved:
+declaring an intrinsic with one of those names is ``E-LOAD-024``. The
+prohibition is checked at load against the §5.2 list, not against a separate
+registry, so adding a form tag automatically reserves it.
 
 **Folds** are the only iteration construct. There is no recursion, no
 ``while``, no ``loop``, no user-defined function, and no way to name a rule
@@ -772,6 +822,110 @@ the spec. A ``deffield`` whose type or kind disagrees with the kernel's model
 registration is ``E-LOAD-022`` — the two must agree, and the kernel is checked
 against content, not the reverse.
 
+**[draft ruling — Phase 1 review, R9 chapter C1]** *A field's owner may be a
+node type, an* ``EdgeType`` *or a* ``HyperedgeType``. The first segment of a
+``deffield``'s ``<qname>`` names the owning graph-element type; until this
+revision it could only name a node type, which is what left §2.4's
+``EdgeCondition`` row unwritable. A first segment naming no registered
+``NodeType``, ``EdgeType`` or ``HyperedgeType`` member is ``E-LOAD-023``.
+
+*The segment↔member correspondence, stated because it was only ever implied.*
+``social-class/wealth`` owns off ``NodeType/SOCIAL_CLASS`` by a rendering the
+document used from its first revision and never wrote down: **lowercase the
+enum member identifier and replace each** ``_`` **with** ``-``. The result must
+be a valid ``symbol`` per §1.4; a member whose rendering is not (a leading
+digit, say) is ``E-LOAD-033``. Because one namespace of renderings now spans
+three enum types, the registry must keep them **pairwise disjoint**: a
+``NodeType`` and an ``EdgeType`` (or either and a ``HyperedgeType``) rendering
+to the same symbol is ``E-LOAD-032``, checked at load over the whole closed
+vocabulary. Disjointness is a property of the vocabulary, so the check runs
+once per content set rather than per field.
+
+**[draft ruling — Phase 1 review, R9 chapter C1]** *Every* ``EdgeType``
+*carries one implicitly declared field,* ``<edge-type>/strength``, with
+``:type Coefficient`` and ``:kind extensive``. It needs no ``deffield`` — it is
+the field ``add-edge``'s ``:strength`` operand writes (§2.8), and before this
+revision the language could write it and never read it back. Re-declaring it
+explicitly is ``E-LOAD-001`` (a duplicate field declaration), so there is
+exactly one home for its type and kind.
+
+The ``Coefficient`` type is the frozen engine's: the ``sum_strength`` /
+``avg_strength`` metric of ``engine/event_evaluator.py:174-175`` reads
+``solidarity_strength``, declared ``Coefficient`` in
+``models/entities/relationship.py:116``. The ``extensive`` kind is the
+load-bearing half of the ruling and is chosen so §2.4's coverage row is
+honoured rather than half-honoured: under §3.4 an intensive fold body makes
+``sum`` an ``E-TYPE-041`` and ``mean`` legal only with a ``:weight``, so an
+intensive ``strength`` would have left ``sum_strength`` inexpressible after all.
+The extent being aggregated is the **edge population** — a total tie-weight
+over a set of edges is additive in exactly the way an intensity across classes
+or space is not, which is the distinction §3.4 exists to police. Authors
+wanting a genuinely intensive per-edge attribute (``tension``, a rate)
+``deffield`` it ``:kind intensive`` and carry the ``:weight`` obligation, and
+the recorded variance error stays caught.
+
+2.10 Element accessors
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Accessors are the expression forms that read *from a graph element the rule
+already holds a reference to*, as against ``:field``/``:const``/``:metric``
+bindings, which read from the rule's own environment. They are the R9
+chapter-C1/C2/C3/C9 additions and they all share one discipline, stated once
+here.
+
+.. code-block:: text
+
+   <accessor> ::= "(" "field-of" <expr> <qname> ")"
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 18 62
+
+   * - Form
+     - Result
+     - Reads
+   * - ``field-of``
+     - the field's declared type
+     - A declared field of the node, edge or hyperedge the ``<expr>``
+       denotes. The ``<qname>``'s first segment names the owning type
+       (§2.9).
+
+**The shared discipline.**
+
+1. *The qname carries the type annotation, the reference does not.* §3.1 gives
+   ``NodeRef``/``EdgeRef``/``HyperedgeRef`` no type variables, so a reference
+   does not carry which ``NodeType``/``EdgeType``/``HyperedgeType`` it belongs
+   to. The owning type therefore comes from the ``<qname>``, exactly as D24
+   makes the ``HyperedgeType`` a mandatory operand of ``members-of`` for the
+   same reason. A ``field-of`` whose referent is not of the qname's owning type
+   is ``E-EVAL-033`` at evaluation — **never** a default value and never an
+   absent read.
+2. *Absence is not a value.* A ``field-of`` against an element that carries no
+   value for a declared field is ``E-EVAL-033`` as well; there is no
+   ``:optional``/``:default`` on an accessor, because the opt-in to absence is
+   a property of a *binding* (§3.5) and an accessor names its element at the
+   point of use. §3.8 gives the re-modelling for genuinely optional axes.
+3. *Accessors are reads.* No accessor mutates. The verbs of §2.8 are the only
+   writes, and §2.8's ``update-edge`` (R9 chapter C2) is the write dual of
+   ``field-of`` over an ``EdgeRef``.
+4. *Kind and type propagate from the declaration.* A ``field-of`` expression
+   has the ``deffield``'s ``:type`` as its static type and its ``:kind`` as its
+   kind (§3.4), identically to a ``:field`` binding of the same field.
+
+**Worked shape.** The §2.4 coverage row, written out:
+
+.. code-block:: scheme
+
+   (fold mean (edges EdgeType/EXPLOITATION)
+         (field-of it exploitation/tension)
+         :weight (field-of it exploitation/value-flow))
+
+``it`` is an ``EdgeRef`` inside a fold over ``edges`` (§2.6's result table), so
+both accessors read the edge under the fold. The ``:weight`` is mandatory here
+because ``exploitation/tension`` would be declared ``:kind intensive`` — §3.4's
+rule is untouched by this chapter and applies to edge fields exactly as it
+applies to node fields.
+
 3. Static semantics
 ---------------------
 
@@ -816,9 +970,12 @@ degraded mode, and no rule that loads "partially".
    * - ``NodeRef`` / ``EdgeRef`` / ``HyperedgeRef``
      - one graph element
      - Produced by ``self``, ``add-node``, ``add-hyperedge``, and query
-       elements (``it``). A ``HyperedgeRef`` does **not** carry its
-       ``HyperedgeType`` statically — there are no type variables — which is
-       why §2.6's hyperedge queries take the type as an operand.
+       elements (``it``, and the ``:as`` names of §2.6). **No** reference
+       carries its ``NodeType``/``EdgeType``/``HyperedgeType`` statically —
+       there are no type variables — which is why §2.6's hyperedge queries
+       take the type as an operand and why §2.10's accessors take the owning
+       type in their ``<qname>``. Consumable by §2.10's accessors and by the
+       element-position operands of §2.8's verbs.
    * - ``NodeSet`` / ``EdgeSet`` / ``HyperedgeSet``
      - the result of a ``<query>``
      - Only consumable by ``fold``, ``exists``, ``forall``.
@@ -896,10 +1053,13 @@ extensive, ``consciousness`` (Intensity) is intensive, and there is no type at
 which that is decidable. Kind propagates through expressions:
 
 - a literal is **kind-neutral**;
-- a ``:field`` binding carries its declared kind; ``:const`` and ``:metric``
-  bindings are kind-neutral **[draft ruling — Phase 1 review]** (a coefficient
-  has no extent; a graph metric's kind, if it needs one, is declared on the
-  metric registration in a later revision);
+- a ``:field`` binding and a ``field-of`` accessor (§2.10) both carry the
+  ``deffield``'s declared kind, whether the owning type is a node type, an
+  ``EdgeType`` or a ``HyperedgeType`` — the kind rule does not care which, and
+  the implicit ``<edge-type>/strength`` field is ``extensive`` (§2.9);
+  ``:const`` and ``:metric`` bindings are kind-neutral
+  **[draft ruling — Phase 1 review]** (a coefficient has no extent; a graph
+  metric's kind is declared on the metric registration, §2.11);
 - ``+``/``-`` require both operands to have the same kind, or one to be
   kind-neutral; the result carries the non-neutral kind. Mixing intensive with
   extensive is ``E-TYPE-040``;
@@ -1026,6 +1186,7 @@ and are **pinned by conformance vector; revising them is a vector re-bless**
    cost(members list)           = Σ cost(members)        ; grouping, no base cost
    cost(guard)                  = 1 + cost(cond) + Σ cost(effect-items)
    cost(field path | enum-ref)  = 0                      ; static, like a literal
+   cost(field-of)               = 1 + cost(element expr) ; §2.10, R9 C1
    bound(rule)                  = cost(cond of <when>) + Σ cost(effect-items)
 
 **[draft ruling — Phase 1 review]** *Query operand charging* (implementation-
@@ -1293,7 +1454,7 @@ AST — a property implementations should exercise as a round-trip property test
 ``binding``, ``when``, ``effects``, ``and``, ``or``, ``not``, ``<``, ``<=``,
 ``>``, ``>=``, ``=``, ``!=``, ``+``, ``-``, ``*``, ``/``, ``if``, ``fold``,
 ``exists``, ``forall``, ``nodes``, ``edges``, ``neighbors``, ``hyperedges``,
-``members-of``, ``hyperedges-of``, ``guard``,
+``members-of``, ``hyperedges-of``, ``field-of``, ``guard``,
 ``update-node``, ``add-node``, ``remove-node``, ``add-edge``, ``remove-edge``,
 ``add-hyperedge``, ``remove-hyperedge``, ``members``,
 ``emit``, ``add``, ``sub``, ``set``, ``scale``, ``anchor``, ``deffield``,
@@ -1309,6 +1470,15 @@ this chapter changes. In particular the §5.6 worked example contains none of
 these forms, so **its 421 canonical bytes and both of its digests are unchanged
 by this revision** — a hyperedge-bearing example would need its own vector
 (§6.2), not a recomputation of that one.
+
+**The R9 tags obey the same rule, and the worked example survives them too.**
+Every form tag the R9 spec chapters add — listed in the paragraph above
+alongside the originals — is its own head symbol, needs no registry entry, no
+numeric id and no new atom kind; every keyword they add encodes as an ``opt``
+form. None of them appears in §5.6's example, and none of the R9 chapters makes
+a previously-optional child of ``rule`` mandatory, so **§5.6's 421 bytes and
+both digests remain correct as written**. That invariance is deliberate: it is
+the cheapest available proof that the chapters are additive.
 
 A keyword option is encoded as a two-child form:
 
@@ -1533,6 +1703,28 @@ At minimum, an implementation claiming conformance passes:
    missing ``:max-members`` on a ``HyperedgeType`` and one carrying it on a
    ``NodeType`` (both ``E-LOAD-042``); and a fold over ``members-of`` whose
    static bound equals the declared ``:max-members``.
+
+10. **Edge and hyperedge attributes** (chapter C1) — ``field-of`` over an
+    ``EdgeRef``, a ``HyperedgeRef`` and a ``NodeRef``; the §2.4 coverage row
+    written as a ``sum`` and as a weighted ``mean`` over
+    ``<edge-type>/strength``; ``sum`` over an intensive edge field rejected
+    ``E-TYPE-041`` and the same fold accepted with a ``:weight``; a
+    ``field-of`` whose referent is of another type (``E-EVAL-033``); a
+    ``deffield`` whose first segment names no registered type
+    (``E-LOAD-023``); a vocabulary with a ``NodeType``/``EdgeType`` rendering
+    collision (``E-LOAD-032``); a re-declaration of
+    ``<edge-type>/strength`` (``E-LOAD-001``); an ambiguous foreign-type
+    ``:field`` reference under two same-type bodies (``E-TYPE-013``); and an
+    ``intrinsic`` declared with a reserved form-head name
+    (``E-LOAD-024``).
+
+Families 10 and up are the R9 spec chapters' (the chapter letters cite
+``reports/bsl-gap-analysis-2026-08-10.md`` §7). Two obligations are stated
+once here rather than repeated in every family: each new form tag also owes a
+``:cas`` vector under family 6, and each new construct owes its exact
+``:fuel-used`` figure under family 5. Both make a chapter's landing a
+``rules_hash`` surface change and therefore a **vector re-bless ceremony**,
+which the teams should plan rather than discover.
 
 6.3 Transcription contract
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1764,6 +1956,43 @@ consequences are the ordinary kind of review item.
      - ``hyperedges-of`` uses the hyperedge type's ``:ceiling``; a per-node
        incidence-degree ceiling would be tighter and is deferred alongside
        D15's per-node degree ceiling for ``neighbors``.
+   * - D29
+     - §2.5, §2.10
+     - Edge and hyperedge fields are read by the ``field-of`` accessor, not by
+       an edge-typed ``:field`` binding. **Divergence recorded:** the R9 gap
+       analysis §2 (Q1) sketched the binding form; a binding resolves
+       implicitly against an enclosing body and the demanding systems read
+       several edge types per rule, so the annotated accessor — D24's fix for
+       ``members-of`` — wins.
+   * - D30
+     - §2.5
+     - A foreign-node-type ``:field`` reference under two or more enclosing
+       bodies of that type is ``E-TYPE-013``; the author names an element
+       (§2.6 ``:as``) and uses ``field-of``.
+   * - D31
+     - §2.9
+     - A ``deffield``'s first segment may name a ``NodeType``, ``EdgeType`` or
+       ``HyperedgeType`` member. The segment↔member rendering (lowercase,
+       ``_``→``-``) is stated normatively; renderings must be pairwise
+       disjoint across the three enum types (``E-LOAD-032``), must be valid
+       ``symbol``\ s (``E-LOAD-033``), and an unregistered first segment is
+       ``E-LOAD-023``.
+   * - D32
+     - §2.9
+     - ``<edge-type>/strength`` is implicitly declared on every ``EdgeType``:
+       ``Coefficient``, ``extensive``, re-declaration is ``E-LOAD-001``. The
+       ``extensive`` kind is what makes §2.4's ``sum_strength`` row honourable
+       under §3.4 without an exemption.
+   * - D33
+     - §2.7
+     - Every §5.2 form-head symbol is reserved against the intrinsic
+       namespace; declaring an intrinsic with one is ``E-LOAD-024``.
+   * - D34
+     - §2.10
+     - Accessors take their owning type in the ``<qname>``; a referent of
+       another type, or a field the element carries no value for, is
+       ``E-EVAL-033``. ``:optional``/``:default`` are binding options and
+       never apply to an accessor.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -326,6 +326,13 @@ A keyword in value position is ``E-PARSE-010``.
    * - ``:tick``
      - *flag*
      - Binding source: the current tick, as ``Int``.
+   * - ``:year`` / ``:tick-of-year``
+     - *flags*
+     - Binding sources: kernel-computed calendar reads, as ``Int`` (§2.5).
+   * - ``:tick-in-cycle``
+     - integer
+     - Binding source: the current tick's position in a cycle of the given
+       length, as ``Int``. The length must be ``> 0`` (``E-PARSE-014``).
    * - ``:kind``
      - ``intensive`` | ``extensive``
      - Per-field intensivity declaration, on ``deffield`` forms only (§3.4).
@@ -587,6 +594,9 @@ the form.
                  | ":const"  <qname>
                  | ":metric" <symbol>
                  | ":tick"
+                 | ":year"
+                 | ":tick-of-year"
+                 | ":tick-in-cycle" <int-lit>
                  | ":expr"   <expr>
 
    <bind-opt>  ::= ":optional" | ":default" <literal>
@@ -603,6 +613,21 @@ metric whose declared domain is ``:graph`` (§2.11); an unregistered metric name
 is ``E-LOAD-011`` — never ``0.0`` (§6.3) — and an element-indexed metric read
 through a ``:metric`` binding is ``E-LOAD-012``, since its value depends on an
 element a binding does not name. ``:tick`` binds the current tick as ``Int``.
+
+**[draft ruling — Phase 1 review, R9 chapter C13]** *Calendar reads are
+bindings, not arithmetic.* Four call sites in the frozen estate compute
+``tick % interval`` and ``base_year + tick // ticks_per_year``, and
+``<arith>`` provides neither integer modulo nor floor division. The two obvious
+repairs are an intrinsic rider for ``mod``/``floor-div`` or three more
+bind-srcs; this document takes the second. ``:year``, ``:tick-of-year`` and
+``:tick-in-cycle`` all bind ``Int``, all are computed by the kernel's clock,
+and all are **seams to a kernel service** rather than mathematics — which is
+the category R10 already sanctions without a rider, and a calendar is not a
+curve. The epoch and the ticks-per-year figure are the kernel's, pinned in
+:doc:`/reference/determinism-contract`; content does not choose them, which is
+also what stops a mod-by-anything operator from arriving through the back door.
+``:tick-in-cycle``'s length is a **literal**, not an expression, so the value
+is a static function of the tick and the content bytes.
 
 **[draft ruling — Phase 1 review, R9 chapter C1]** *A* ``:field`` *binding is
 node-scoped, and stays node-scoped.* An edge's or a hyperedge's declared field
@@ -866,10 +891,14 @@ left-fold convention — a cross-language float trap the design document names.
 ``if`` must have the same static type (``E-TYPE-020``).
 
 **Intrinsic calls** are ordinary forms whose head is a symbol declared in the
-intrinsic table. Transcendentals (``sigmoid``, ``exp``, ``log``, ``tanh``,
-``sqrt``, ``entropy``) and ``round-half-even`` are **never** language
+intrinsic table. Transcendentals and ``round-half-even`` are **never** language
 primitives — they exist only as named intrinsics with pinned deterministic
-implementations. BSL cannot define an intrinsic; ``intrinsic`` forms only
+implementations. The names this document has used to illustrate that
+(``sigmoid``, ``exp``, ``log``, ``tanh``, ``sqrt``, ``entropy``) are
+**illustrative of the class, not a table of intrinsics that exist** — a
+reading the R9 gap analysis found this document inviting. What is declarable is
+governed by §3.10, which holds the set at ``{exp, log}`` and rules ``sigmoid``
+prohibited outright. BSL cannot define an intrinsic; ``intrinsic`` forms only
 *declare* what the kernel provides, so that the typechecker and the fuel
 bound-checker are computable from content alone:
 
@@ -2019,6 +2048,148 @@ What hydration may do, stated once because three chapters now depend on it:
    dependency** for the systems that read those series, rather than a source of
    zeros at tick 1.
 
+3.10 The intrinsic cap, the rider slate, and RNG keys
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+§2.7 fixes the *calling convention* for intrinsics and says their contents are
+Phase-2 work. This section fixes what that leaves dangerous: how many
+intrinsics there may be, which authority says so, and why passing that test is
+not the same as being allowed.
+
+**The cap, and its authority chain, recorded exactly.** The Program 28
+roadmap's R10 row holds the intrinsic set at ``{exp, log}`` **at most**, citing
+ADR176 r21. r21's own text pins a *mechanism* — transcendentals cross via a
+pinned soft-float libm crate with golden vectors per intrinsic — and does not
+enumerate a membership; the ``{exp, log}`` enumeration is the roadmap's
+rendering of it. **R10 is operative** for R9 and R10 purposes and this document
+is written to it. The discrepancy is recorded rather than resolved, because
+resolving it is the Director's.
+
+Concretely, as of this revision: **``exp`` and ``log`` are the only declarable
+intrinsics.** ``round-half-even`` is *obliged* by §3.2 and §2.7 and sits
+outside the enumeration — see row 3 of the slate.
+
+**Cap-legality is not doctrine-legality, and this is the load-bearing
+sentence.** ``exp`` sits inside the cap. Three of the five ``exp`` call sites
+in the frozen estate stipulate a logistic sigmoid that ADR173 and the standing
+2026-07-29 no-imposed-functional-forms ruling retire: ``P(S|A)``, whose S-curve
+must **emerge** from within-class wealth dispersion rather than be asserted; a
+defection probability; a wage-pressure sigmoid. A verbatim transcription of
+those formulas would pass the cap check and violate the theory line. There are
+therefore **two gates**, and only one of them is mechanical:
+
+1. *Is the intrinsic declarable?* Mechanical, checked at load against the set
+   above (``E-LOAD-021`` for an undeclared call).
+2. *Does this use stipulate a functional form?* Not mechanical, and not
+   checkable by any typechecker. It belongs to Director review, and the
+   question it asks is always the same: **can this be re-derived as a measure
+   instead?**
+
+**[draft ruling — Phase 1 review, R9 chapter C13]** ``sigmoid`` *is a reserved
+prohibited intrinsic name.* Declaring an intrinsic named ``sigmoid`` is
+``E-LOAD-024`` — the same code §2.7 uses for a reserved form-head collision,
+and here for a stronger reason: declaring ``sigmoid`` would hand content the
+exact mechanism ADR172 ruling 5 forbids, pre-packaged and named. It is the one
+part of gate 2 that *can* be made mechanical, so it is.
+
+**The rider slate.** The table below records the R9 gap analysis §4 proposals
+**as proposals**. It is **not normative and declares nothing**; every row is a
+question for the Director, and the "Proposal" column is the analysis's
+recommendation, not this document's ruling.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 4 20 10 66
+
+   * - #
+     - Candidate
+     - In cap?
+     - Proposal (non-normative)
+   * - 1
+     - ``mod``, ``floor-div``
+     - No
+     - **No rider.** Superseded by the calendar bindings of §2.5 — a seam, not
+       mathematics.
+   * - 2
+     - ``floor`` / ``trunc``
+     - No
+     - **Rider proposed.** §3.1 declares no coercions and ``Int`` promotes to
+       ``Real`` one way only, so there is no demotion path at all today.
+   * - 3
+     - ``round-half-even``
+     - No
+     - **Housekeeping rider.** §3.2 and §2.7 already oblige the kernel to
+       expose it to rules; the enumeration omits it. Affirming it is not a
+       widening.
+   * - 4
+     - ``abs``
+     - No
+     - **No rider.** ``(if (>= a b) (- a b) (- b a))`` expresses it.
+   * - 5
+     - scalar ``min`` / ``max``
+     - No
+     - **No rider.** Nested ``if`` expresses them, and §3.3 already frames
+       silent clamping as forbidden quiet degradation — an explicit ``if``
+       makes the saturation legible. The ergonomic cost is real and recorded.
+   * - 6
+     - ``sqrt``
+     - No
+     - **Both presented.** Preferred: re-derive platform fit as a measure (the
+       share of a class's interest dimensions a platform satisfies), which
+       needs no norm. Fallback: a rider. A silent switch to squared magnitudes
+       changes the metric's scale and must never happen by default.
+   * - 7
+     - ``exp``
+     - **Yes**
+     - **No rider needed; a theory ruling is.** Three of five sites are
+       imposed sigmoids under ADR173. Ask the Director to dispose each:
+       re-derive as a measure, or except it explicitly as a bounded auxiliary.
+   * - 8
+     - ``tanh``
+     - No
+     - **Elimination presented first.** Squashing a log-ratio into ``[-1,1]``
+       is a stipulated bounded form; re-derive the scissors balance as a
+       measure. Rider only if the Director keeps the squash.
+   * - 9
+     - ``sigmoid``
+     - No
+     - **Never declarable** — ruled above, ``E-LOAD-024``.
+   * - 10
+     - ``entropy``
+     - No
+     - **No proposal.** Nothing in the thirty-four systems asks for it.
+   * - 11
+     - RNG draw
+     - n/a
+     - **Not a rider.** §2.8 already sanctions it as a kernel intrinsic; the
+       key convention is below.
+   * - 12
+     - bespoke ``renormalize``
+     - No
+     - **Recommend against**, per §3.8 item 7: it hides a mechanism in the
+       kernel for one call site.
+
+**[draft ruling — Phase 1 review, R9 chapter C13]** *The RNG carrier-key
+convention.* §2.8 sanctions RNG as a kernel intrinsic with per-(session, tick,
+salt) seeding and stops there; the rst never showed the convention, and five
+systems need draws. The signature stays Phase-2 work (§2.7), but the **key**
+is language-visible and is fixed here:
+
+- The carrier key is ``(session, tick, domain, stable_key)``.
+- ``session`` and ``tick`` are kernel-supplied and are **never operands** — a
+  rule cannot name them and therefore cannot replay a stream.
+- ``domain`` is a closed-vocabulary enum operand, so content cannot mint a new
+  stream; adding one is §3.6 amendment territory like any other member.
+- ``stable_key`` derives from the identities of the call's reference operands,
+  in operand order, using the same id bytes §2.6 orders by. It is therefore
+  stable across runs and independent of insertion history.
+- **A draw is a pure function of its key, not a position in a stream.** This is
+  the property that matters, and it is stronger than the obvious alternative
+  ("the kernel draws only when the guard consuming it passes"): because there
+  is no stream position, a guard that skips a draw cannot shift any other
+  draw, and §4.1's input-dependent short-circuiting can never perturb the RNG.
+  The determinism obligation holds unconditionally rather than by discipline.
+
 4. Dynamic semantics
 ----------------------
 
@@ -2078,12 +2249,13 @@ not, which is why the order is stated rather than left to the executor.
   correctly rounded round-to-nearest-even. These reproduce bit-exactly across
   conforming implementations.
 - Fixed-point operations are exact integer operations at the widths of §3.2.
-- **No transcendental is a language operation.** ``exp``, ``log``, ``sigmoid``,
-  ``tanh``, ``sqrt`` and ``entropy`` are named intrinsics whose implementations
-  are pinned by the kernel and validated by golden vectors with written
-  tolerance derivations. Whether those implementations are polynomial
-  approximations or a pinned deterministic libm is an **open Phase-1 Director
-  ruling** (design §13 item 2) and is deliberately not decided here.
+- **No transcendental is a language operation.** Any that exists is a named
+  intrinsic whose implementation is pinned by the kernel and validated by
+  golden vectors with a written tolerance derivation. Which ones may exist is
+  §3.10's, and it is a shorter list than the illustrative names above
+  suggest. Whether those implementations are polynomial approximations or a
+  pinned deterministic libm is an **open Phase-1 Director ruling** (design §13
+  item 2) and is deliberately not decided here.
 - No fused multiply-add. An implementation that contracts ``a*b+c`` into an FMA
   is non-conforming.
 - ``Int`` overflow is ``E-EVAL-011``.
@@ -2680,6 +2852,15 @@ At minimum, an implementation claiming conformance passes:
     ``<`` and one compared across kinds (both ``E-TYPE-019``); and the
     intersection idiom above, whose ``:fuel-used`` must show the quadratic
     cost the deferral is paying.
+22. **The intrinsic cap and calendar bindings** (chapter C13) — a call to an
+    intrinsic outside the declared set (``E-LOAD-021``); an ``intrinsic``
+    declaration named ``sigmoid`` (``E-LOAD-024``); ``:year``,
+    ``:tick-of-year`` and ``:tick-in-cycle`` at a known tick, with a boundary
+    case at each cycle wrap; ``:tick-in-cycle 0`` and a negative length (both
+    ``E-PARSE-014``); and — for the RNG — **two vectors with the same carrier
+    key whose draws must be equal**, and a pair of rules differing only in a
+    guard that skips a draw, whose other draws must be unchanged, pinning that
+    a draw is keyed rather than streamed.
 
 Families 10 and up are the R9 spec chapters' (the chapter letters cite
 ``reports/bsl-gap-analysis-2026-08-10.md`` §7). Two obligations are stated
@@ -3154,6 +3335,32 @@ consequences are the ordinary kind of review item.
        D54's naming, the intersection idiom becomes writable, and the
        deferral of a dedicated set-algebra operator stands on a form that can
        actually be written.
+   * - D68
+     - §2.5
+     - Calendar reads land as ``:year``/``:tick-of-year``/``:tick-in-cycle``
+       bindings rather than as ``mod``/``floor-div`` operators or an intrinsic
+       rider — a kernel seam, not mathematics, and the epoch stays the
+       kernel's so a mod-by-anything operator cannot arrive behind it.
+   * - D69
+     - §3.10
+     - The RNG carrier key is ``(session, tick, domain, stable_key)``, with
+       ``session``/``tick`` never operands and ``domain`` a closed-vocabulary
+       member. **A draw is a pure function of its key, not a stream
+       position**, so a skipped draw cannot shift any other and §4.1's
+       short-circuiting can never perturb the RNG.
+   * - D70
+     - §2.7, §3.10
+     - The cap's authority chain is recorded as it actually reads: R10 holds
+       ``{exp, log}`` citing ADR176 r21, whose own text pins the *mechanism*
+       rather than the membership. §2.7's transcendental list is illustrative
+       of the class, not a table of intrinsics that exist. The rider slate is
+       recorded as **proposals**; this document declares none of them.
+   * - D71
+     - §3.10
+     - ``sigmoid`` is a reserved **prohibited** intrinsic name
+       (``E-LOAD-024``). Cap-legality is not doctrine-legality: the two gates
+       are separate, gate 2 is Director review, and this is the one part of it
+       that can be made mechanical.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -1767,6 +1767,93 @@ exceeds a declared ceiling — including a hydrated hyperedge carrying more
 members than ``:max-members`` — is itself a III.11 load failure
 (``E-LOAD-041``). The runtime meter of §4.5 remains as the backstop.
 
+3.8 Deliberate absences and their re-modellings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Seven things the frozen estate reaches for do not exist in BSL and are not
+going to. Each is recorded here **with the re-modelling that replaces it**, so
+that a future port reads the absence as a decision rather than an oversight and
+does not re-propose the construct. None of these adds grammar; several delete a
+question.
+
+**1. Absence, and writing it back** (R9 gap analysis §2, Q17). There is no null
+literal, no ``unset`` update-op, and no ``bound?`` predicate — D13 removed the
+last of those on purpose. But two systems genuinely need to say "this node has
+no value on this axis": one writes ``None`` when a node loses an axis, and one
+skips permanently when a stock was never seeded.
+
+``:optional``/``:default`` is **not** the answer, and reading it as the answer
+changes behaviour silently: ``:default 0.0`` converts *never seeded* into
+*seeded with zero stock*, which is a different eligibility population and a
+different game. The landing is a **companion presence field**: a
+``deffield``-declared ``Bool`` alongside each genuinely optional axis, written
+by the same effects list that writes the value, under one ``guard`` so the pair
+moves together or not at all. Absence is then representable, hashable and
+inspectable — and "unset the axis" is an ordinary ``(set #f)`` on the presence
+field rather than a verb the language does not have. The EpistemicHorizon
+discipline (all three attributes or none) is already exactly this shape.
+
+**2. No sequence or map type** (Q13). Three systems keep ordered or list-valued
+state: a FIFO agenda, an order-significant acquisition list, a set of
+suppressed field names. A sequence type would drag ordering into CAS, into the
+kind rule and into the fuel model, and a map type would need a key ordering
+this document has deliberately confined to graph-element ids. Each case
+re-models with what §2 already has:
+
+- a FIFO agenda becomes its own bounded ``NodeType`` carrying a
+  ``queued-at-tick`` field, and "the next item" becomes ``select-min`` on that
+  field (§2.7);
+- an order-significant acquisition list becomes an edge type carrying
+  ``acquired-at-tick``, and "the most recent" becomes ``select-max``;
+- a set of suppressed field names becomes one ``Bool`` field per suppressible
+  field.
+
+All three land inside the closed vocabulary, inside the content hash, and
+inside the ceiling-bounded fuel model, which a list type would have left.
+
+**3. No same-tick event-history query** (Q16). ``emit`` is write-only and
+§2.6's query heads do not include an emission log; two systems ask "was a
+crisis emitted this tick?". The re-modelling is better than the feature: the
+**emitting** rule also stamps a field (a ``…-crisis-tick`` on a carrier or
+subject node), and the consuming rule reads it as an ordinary ``:field``. That
+makes the cross-system dependency visible in content, hashable, and
+inspectable — three properties an event-log query would not have, since a query
+over emissions would make the dependency invisible in every artifact except a
+runtime trace. It also means a crisis-gated system must be ported **together
+with its producer**, or the consuming rule reads a field nothing writes.
+
+**4. No string payloads on** ``emit`` (R9 gap analysis §3, B3). ``Str`` has no
+operations (§3.1) and ``<expr>`` has no string literal, so every
+``<payload-item>`` expression is a number, a bool or an enum-ref. Transcribed
+systems carrying ``predicate`` or ``description`` strings, or a field name as a
+string, convert them to enum-refs or drop them — the **rule id already
+identifies the rule**, and an event whose payload restates its own provenance
+in prose is carrying a log line, not state.
+
+**5. No ledger or receipt binding** (B6). §2.8 prohibits I/O outright, and
+three surveys independently reached for a "ledger-write binding" anyway. There
+is nothing to add: a receipt is a **kernel observation of an effect that
+already happened**. The rule emits; the kernel records. Making the rule write
+the receipt would put the same fact in the content hash twice and give a
+content author a way to record an effect that did not occur.
+
+**6. No cascade semantics in the verb table** (B7). What ``remove-node`` does
+to incident edges and memberships is an **engine-level observable**, specified
+outside this document (ADR185 R2: incident edges removed, memberships dropped,
+one write-log record per cascaded item). §2.8's verb table deliberately does
+not restate it, because two normative statements of one behaviour is one too
+many.
+
+**7. No bounded numeric iteration** (Q15). One system runs a five-iteration
+clamp-then-renormalise with an early-exit convergence check. A loop construct —
+even a bounded one — would break the *syntactic* totality argument §2.7 rests
+on, which is the property that makes the Power-of-10 Rule 2 claim static rather
+than analysed. With ``:expr`` (§2.5) the five iterations unroll into five named
+bindings, which is verbose and honest; failing that it is a legitimate Rust
+domain-crate binding. Declaring a bespoke ``renormalize`` intrinsic would be
+the worst of the three: it hides a mechanism inside the kernel, where neither
+the content diff nor the inspector can see it, for a single call site.
+
 4. Dynamic semantics
 ----------------------
 
@@ -2401,6 +2488,14 @@ At minimum, an implementation claiming conformance passes:
     feeding an unweighted ``mean`` (``E-TYPE-042``), proving the declared kind
     propagates; and a ``:cas`` vector for the ``metric`` form under both
     ``<domain>`` shapes.
+19. **Deliberate absences** (chapter C10) — a family of *rejecting* vectors, so
+    the absences of §3.8 are pinned as loudly as the presences: ``(bound? x)``
+    (``E-LOAD-021``, an undeclared intrinsic); a string literal in an ``emit``
+    payload (``E-LEX-0xx``/``E-PARSE-0xx``); an ``(unset …)`` update-op
+    (``E-PARSE-0xx``); and one *accepting* pair proving each re-modelling
+    works — a presence-field guard writing value and presence together, a
+    ``select-min`` over ``queued-at-tick`` returning the FIFO head, and a
+    producer-stamped tick field read by a consumer rule at a later anchor.
 
 Families 10 and up are the R9 spec chapters' (the chapter letters cite
 ``reports/bsl-gap-analysis-2026-08-10.md`` §7). Two obligations are stated
@@ -2813,6 +2908,30 @@ consequences are the ordinary kind of review item.
        tick hash only through the fields rules write from them; a Rust domain
        crate qualifies as a provider only inside the determinism contract's
        pinned toolchain and with golden vectors.
+   * - D58
+     - §3.8
+     - Optional axes take a **companion presence field** written under one
+       ``guard`` with their value. ``:optional``/``:default`` is explicitly
+       *not* the mechanism, because a default converts "never seeded" into
+       "seeded with zero" and changes the eligibility population.
+   * - D59
+     - §3.8
+     - No sequence or map type. FIFO agendas become a ``NodeType`` plus
+       ``select-min``; ordered acquisitions become an edge plus
+       ``select-max``; name sets become one ``Bool`` per name.
+   * - D60
+     - §3.8
+     - No same-tick event-history query. The emitting rule stamps a field and
+       the consumer reads it, which makes the dependency content rather than
+       trace — and makes a crisis-gated system unportable apart from its
+       producer.
+   * - D61
+     - §3.8
+     - Four standing "nothing to add" rulings recorded so they stop
+       returning: no string payloads on ``emit``; no ledger/receipt binding
+       (a receipt is a kernel observation); no cascade restatement in the verb
+       table (ADR185 R2 owns it); no bounded numeric iteration, and no
+       bespoke ``renormalize`` intrinsic in its place.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -29,6 +29,29 @@ query forms and edge verbs are **unchanged and coexist** with it: II.9's
 morphism layer stays strictly dyadic, and the two layers are separated by
 *type* inside one substrate (sub-ruling D-2 — one substrate, typed homes).
 
+**Third revision — the R9 gap-fill chapters (2026-08-10).** Twelve of the
+seventeen systems targeted at pure BSL rule packs carried at least one hard
+language blocker: they were BSL-shaped and unauthorable. Thirteen chapters
+(C1–C13), planned in ``reports/bsl-gap-analysis-2026-08-10.md`` §7, close them
+in place across §§1.6, 2.2–2.11, 3.1, 3.4, 3.6–3.10, 4.2, 4.5–4.7, 5.2, 5.3,
+5.5 and 6.2, adding rows **D29–D71** to the register below and vector families
+**10–22** to §6.2.
+
+The chapters were held to a stated reach: **query forms, bindings,
+iteration and selection structure, and graph-scope state are licensed**
+(Amendment AE clause (ii), which re-opens the formalism surface for BSL and for
+nothing else), while a new generator, constructor, adjunction, level lattice or
+severity rule is not — and neither is an addition to the intrinsic table beyond
+``{exp, log}``. Two items reached that boundary and are **escalated rather than
+specced**: per-membership hyperedge payload (§2.8's note — a change to the
+exposed hyperedge model Amendment AE clause (vi) ruled) and the minting of new
+scale-lattice rungs or adjunctions (§3.9's note). The rider slate in §3.10 is
+recorded as proposals and declares nothing. **This revision is additive**: no
+form changes meaning, and §5.6's canonical bytes and both its digests are
+unchanged — the one deliberate exception is ``neighbors``, which gains a
+mandatory operand (D51) against evidence that no conformance vector exercises
+it.
+
 **Standard this document is written to.** Constitution III.12(a) — the *rewrite
 test*: two independent implementations (the Rust ``babylon-bsl`` crate now,
 anything later) must be derivable from this document alone, without reading
@@ -2331,13 +2354,32 @@ two times at which an error can occur.
      - ``E-LOAD-0xx``
      - Content load — unresolved bindings, unknown vocabulary, fuel bound
        exceeded, ceiling violated at hydration, a missing or misplaced
-       ``:max-members``, a member list over that ceiling, anchor interleaved
-       into the Material Base partition, kernel/content disagreement.
+       ``:max-members`` or ``:invariant``, a member list over that ceiling,
+       anchor interleaved into the Material Base partition, kernel/content
+       disagreement; and, from the R9 chapters, an undeterminable or ambiguous
+       rule domain, a field owner that names no registered type, a
+       node/edge/hyperedge type-rendering collision, a metric read through the
+       wrong form for its declared domain, a structural verb naming an
+       ``:invariant`` type, a reserved or prohibited intrinsic name, and
+       ``the`` against a type whose ceiling is not 1.
    * - Evaluation
      - ``E-EVAL-0xx``
      - During a tick — checked-arithmetic failure, range violation at a store,
        non-finite result, empty aggregate, edge-mode violation, hyperedge type
-       mismatch, fuel exhaustion.
+       mismatch, fuel exhaustion; and, from the R9 chapters, an accessor whose
+       referent is of the wrong type or carries no value for the named field,
+       an ``edge-between`` that resolves to no edge, a ``the`` against an
+       unhydrated carrier, and a ``metric-of`` against the wrong element type
+       or a value the provider did not produce.
+
+**Every code the R9 chapters add continues an existing sequence and renumbers
+nothing.** The three families they extend most are ``E-LOAD-0xx`` (nine new
+codes, because most of what those chapters add is decidable from the content
+set alone), ``E-TYPE-0xx`` (five) and ``E-EVAL-0xx`` (five, all of them the
+"absence is never a value" discipline of §2.10 applied at a new referent).
+That the load class grew fastest is the intended shape: a chapter that made a
+new failure mode *runtime*-only would have moved the language in the wrong
+direction.
 
 **Load-time errors** report the offending file, line, column, form, and code,
 and reject the whole content set — there is no partial load and no "skip the

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -707,12 +707,16 @@ set, not a sequence.
                  | "(" "if" <cond> <expr> <expr> ")"
                  | <fold>
                  | <accessor>                       ; §2.10
+                 | <selection>
 
    <arith>     ::= "+" | "-" | "*" | "/"
    <literal>   ::= <int-lit> | <scaled-lit> | <bool-lit>
 
    <fold>      ::= "(" "fold" <fold-op> <query> <expr> ( ":weight" <expr> )? ")"
    <fold-op>   ::= "sum" | "mean" | "min" | "max" | "count"
+
+   <selection> ::= "(" "select-max" <query> <expr> ")"
+                 | "(" "select-min" <query> <expr> ")"
 
 Arithmetic is strictly binary; ``(+ a b c)`` is ``E-PARSE-040``. This keeps
 the reduction order explicit in the source rather than implied by a
@@ -755,17 +759,56 @@ declaring an intrinsic with one of those names is ``E-LOAD-024``. The
 prohibition is checked at load against the §5.2 list, not against a separate
 registry, so adding a form tag automatically reserves it.
 
-**Folds** are the only iteration construct. There is no recursion, no
-``while``, no ``loop``, no user-defined function, and no way to name a rule
-from inside a rule. Totality is therefore syntactic, and the static bound of
-§3.7 is computable.
+**Selection** returns the *element* that extremises a score, where a fold
+returns the extremised *value*. Eleven systems pick an element and then act on
+it — the winning claimant, the winning faction, the best platform, the FPTP
+winner, the top claims holder, the principal field (R9 gap analysis §2, Q4) —
+and until this chapter no expression form yielded a ``NodeRef`` other than
+``self`` and §2.8's effect-list-scoped minted names, so none of them was
+authorable.
+
+.. code-block:: scheme
+
+   (update-node (select-max (nodes NodeType/ORGANIZATION)
+                            (field-of it organization/claim-strength))
+                organization/holds-office (set #t))
+
+- The result type is the query's element type: ``NodeRef`` for ``nodes``,
+  ``neighbors`` and ``members-of``; ``EdgeRef`` for ``edges``;
+  ``HyperedgeRef`` for ``hyperedges`` and ``hyperedges-of``. ``it`` is bound in
+  the score expression exactly as it is in a fold body.
+- **The tiebreak is a property of the language, not of each rule.** Ties are
+  broken by §2.6's iteration order: the **first** element in ascending id byte
+  order wins, for ``select-max`` and ``select-min`` alike. Every frozen system
+  that picks an element carries its own tiebreak today, and several carry none;
+  hoisting it here means a transcribed rule cannot forget one.
+- An empty query is ``E-EVAL-021`` — the same code, for the same reason, as
+  ``min``/``max`` over an empty set (§4.4). There is no element to return and
+  there is no null.
+- The score expression must have a **comparable scalar** static type — ``Int``,
+  ``Currency``, ``Probability``, ``Intensity``, ``Coefficient`` or ``Real``.
+  ``Bool``, ``Enum<T>``, ``Str``, references and sets are ``E-TYPE-017``.
+- **Kind is unconstrained on the score** and the result is kind-neutral (a
+  reference has no extent). This is not a hole in §3.4: that law polices
+  *aggregation*, where an unweighted mean of an intensive quantity across
+  classes or space is the recorded variance error. Ranking elements by an
+  intensive field aggregates nothing — it orders — so the weighted-mean
+  obligation has nothing to attach to.
+
+**Folds and selection are the only expression-position iteration
+constructs**, and §2.8's ``for-each`` is the only one in effect position.
+There is no recursion, no ``while``, no ``loop``, no user-defined function, and
+no way to name a rule from inside a rule. Totality is therefore syntactic, and
+the static bound of §3.7 is computable.
 
 2.8 Effects — the typed structural verbs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: text
 
-   <effect-item> ::= <verb> | "(" "guard" <cond> <effect-item>+ ")"
+   <effect-item> ::= <verb>
+                   | "(" "guard"    <cond>  <effect-item>+ ")"
+                   | "(" "for-each" <query> <effect-item>+ ")"
 
    <verb> ::= "(" "update-node"  <expr> <qname> <update-op> ")"
             | "(" "update-edge"  <expr> <qname> <update-op> ")"
@@ -881,6 +924,55 @@ this revision. Both are Phase-1 review items; neither is a silent omission.
 
 ``emit``'s ``<enum-ref>`` is an ``EventType`` member; payload items are
 name/expression pairs. There is no string interpolation in a payload.
+
+**[draft ruling — Phase 1 review, R9 chapter C6]** ``for-each`` — *bounded
+iteration in effect position.* Nine systems apply a verb once per matching
+element (R9 gap analysis §2, Q5): an emit per contributing SOLIDARITY edge,
+a write to both endpoints of every value-bearing edge, a decay on every
+incident edge, a transition per territory, the two sibling nodes of a class
+split. None was expressible: ``<effect-item>+`` fixes arity at parse time,
+folds live in expression position only, and ``it`` outside a query context is
+``E-TYPE-012`` — so "for every matching element, apply a verb" had no form at
+all, and the surveys reached for one-summed-emit fallbacks that are content
+rulings in disguise.
+
+.. code-block:: scheme
+
+   (for-each (edges EdgeType/SOLIDARITY)
+     (update-edge it solidarity/strength (scale 0.95c))
+     (emit EventType/SOLIDARITY_DECAYED (strength (field-of it
+                                                            solidarity/strength))))
+
+- ``it`` is bound inside the body to the current element, with the query's
+  element type (§2.6's result table). Outside a ``for-each``, ``for-each``'s
+  body, or a query predicate or fold body, ``it`` remains ``E-TYPE-012``.
+- **The query is materialized against the rule's pre-state**, in §2.6's
+  iteration order, before any effect in the rule's list is applied. This is not
+  a convenience: §4.2's law that *a rule can never observe its own effects*
+  would otherwise be silently repealed by an iteration whose membership
+  depended on an earlier verb in the same list. Every expression anywhere in an
+  effects list — a verb's operands, a ``guard``'s condition, a ``for-each``'s
+  query — is evaluated against the pre-state, and the collected effects are
+  then applied.
+- **Application order is total.** The body runs once per element in iteration
+  order (outer), and the body's own items apply in source order (inner). Nested
+  ``for-each`` composes the same way. With §4.2's subject order this leaves no
+  unordered reduction anywhere in the language.
+- **An empty query applies nothing, and is not an error.** This is the one
+  place where an empty set is quiet, and the distinction is principled: §4.4's
+  ``mean``/``min``/``max`` must produce a *value* and have none to produce, so
+  they are ``E-EVAL-021``; an iteration is a *command*, and "do it to each of
+  no elements" is completely determined. The reading that would make it loud
+  would also make a correct rule fail on a legitimately empty graph.
+- **Totality holds.** The set is materialized before the body runs and its size
+  is bounded by the declared ceiling, so this is a bounded iteration and not a
+  loop; §3.7 charges it exactly as it charges ``exists``/``forall``.
+
+One consequence worth recording where the port train will look for it: with
+``for-each`` in hand, a bulk structural operation (re-parenting every claim of
+a collapsing sovereign, severing every exploitation edge) is **expressible in
+content**. A Rust bulk primitive for the same job therefore survives only as a
+*performance* escape, which needs measurement rather than assertion.
 
 **Effect ordering and application.** Effects are collected in source order and
 applied in source order at the point the rule fires. Structural verbs obey the
@@ -1387,6 +1479,12 @@ and are **pinned by conformance vector; revising them is a vector re-bless**
    cost(edge-between)           = 1 + Σ cost(operands)   ; §2.10, R9 C2
    cost(the)                    = 1                      ; §2.10, R9 C3
    cost(domain)                 = 0                      ; §2.3, R9 C4
+   cost(select-max | select-min)                         ; §2.7, R9 C5
+                                = 2 + cost(query)
+                                    + ceiling(query) × cost(score)
+   cost(for-each)                                        ; §2.8, R9 C6
+                                = 2 + cost(query)
+                                    + ceiling(query) × Σ cost(effect-items)
    bound(rule)                  = cost(cond of <when>) + Σ cost(effect-items)
 
 **[draft ruling — Phase 1 review, R9 chapters C1–C2]** *Accessors are keyed
@@ -1717,7 +1815,7 @@ AST — a property implementations should exercise as a round-trip property test
 ``>``, ``>=``, ``=``, ``!=``, ``+``, ``-``, ``*``, ``/``, ``if``, ``fold``,
 ``exists``, ``forall``, ``nodes``, ``edges``, ``neighbors``, ``hyperedges``,
 ``members-of``, ``hyperedges-of``, ``field-of``, ``edge-between``, ``the``,
-``domain``, ``guard``,
+``domain``, ``select-max``, ``select-min``, ``guard``, ``for-each``,
 ``update-node``, ``update-edge``,
 ``add-node``, ``remove-node``, ``add-edge``, ``remove-edge``,
 ``add-hyperedge``, ``remove-hyperedge``, ``members``,
@@ -2016,6 +2114,22 @@ At minimum, an implementation claiming conformance passes:
     (``E-TYPE-015``); ``:graph`` used outside a ``domain`` form
     (``E-PARSE-013``); and a ``:cas`` vector for each of the two ``domain``
     shapes.
+14. **Element selection** (chapter C5) — ``select-max`` and ``select-min`` over
+    each of the six query heads, proving the result's element type; a
+    **tie vector** whose two elements score equally, pinning that the lower id
+    wins for both operators; selection over an empty query
+    (``E-EVAL-021``); a ``Bool`` and an ``Enum<T>`` score (``E-TYPE-017``); a
+    selection whose result is the element operand of ``update-node`` and of
+    ``field-of``; and a selection over an intensive score, which must
+    **accept** (the kind rule polices aggregation, not ordering).
+15. **Effect-position iteration** (chapter C6) — ``for-each`` over ``edges``
+    applying ``update-edge`` and ``emit`` per element, with the expected
+    per-element results in iteration order; ``for-each`` whose query would
+    have changed had it seen an earlier verb's effect, proving pre-state
+    materialization; nested ``for-each`` and its static bound; ``for-each``
+    over an empty query, which applies nothing and **must not** error; and a
+    ``for-each`` whose ``:fuel`` is one short of its static bound
+    (``E-LOAD-040``).
 
 Families 10 and up are the R9 spec chapters' (the chapter letters cite
 ``reports/bsl-gap-analysis-2026-08-10.md`` §7). Two obligations are stated
@@ -2348,6 +2462,29 @@ consequences are the ordinary kind of review item.
        order and applies their effects in that order — previously
        unspecified, and load-bearing because the binary64 lane is not
        associative.
+   * - D45
+     - §2.7
+     - ``select-max``/``select-min`` return the extremising **element**; ties
+       break to the first element in §2.6 iteration order, making the
+       deterministic tiebreak a property of the language rather than of each
+       rule. An empty query is ``E-EVAL-021``.
+   * - D46
+     - §2.7
+     - The score expression must be a comparable scalar (``E-TYPE-017``); its
+       kind is unconstrained and the result is kind-neutral, because §3.4
+       polices aggregation and selection orders rather than aggregates.
+   * - D47
+     - §2.8
+     - ``for-each`` is bounded iteration in effect position, charged like
+       ``exists``/``forall``. ``it`` is bound in its body.
+   * - D48
+     - §2.8
+     - Every expression in an effects list — verb operands, ``guard``
+       conditions, ``for-each`` queries — is evaluated against the rule's
+       pre-state, which is what keeps §4.2's no-self-observation law true in
+       the presence of iteration. Application order is element order (outer)
+       then source order (inner), and an empty ``for-each`` query applies
+       nothing rather than erroring.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -337,6 +337,13 @@ A keyword in value position is ``E-PARSE-010``.
    * - ``:after`` / ``:before``
      - symbol
      - Ordering anchors (§2.8). A raw position float is not expressible.
+   * - ``:out`` / ``:in`` / ``:any``
+     - *flags*
+     - Traversal direction, on ``neighbors`` queries only (§2.6).
+   * - ``:graph``
+     - *flag*
+     - Graph domain, on ``domain`` forms only (§2.3). Illegal elsewhere
+       (``E-PARSE-013``).
    * - ``:params`` / ``:returns`` / ``:cost``
      - see §2.7
      - Intrinsic declaration fields.
@@ -348,6 +355,14 @@ A keyword in value position is ``E-PARSE-010``.
      - Declared **member-count** ceiling of one hyperedge type, on the
        ``manifest`` ``ceiling`` rows whose ``<enum-ref>`` is a
        ``HyperedgeType`` member (§3.7). Mandatory there, illegal elsewhere.
+
+**[draft ruling — Phase 1 review, R9 chapter C4]** The three ``neighbors``
+directions were used as bare flags by §2.6 from this document's first revision
+and were missing from this table — the same class of omission the operator-atom
+ruling of §1.4 records, and it is fixed the same way, by writing down what the
+grammar already required. ``:graph`` joins them as a flag keyword so that
+``(domain :graph)`` is a legal form rather than a keyword in value position
+(``E-PARSE-010``); it encodes as an ``opt`` under D20 like every other flag.
 
 The keyword set is **closed**. An unrecognized keyword is ``E-PARSE-013``; it
 is never ignored. Adding a keyword is a language revision and re-blesses the
@@ -386,12 +401,14 @@ content set are ``E-LOAD-001``.
    <rule>     ::= "(" "rule" <qname>
                       ":material-basis" <string>
                       ":fuel" <int-lit>
+                      <domain>?
                       <anchor>?
                       <bindings>
                       <when>?
                       <effects>
                   ")"
 
+   <domain>   ::= "(" "domain" ( <enum-ref> | ":graph" ) ")"
    <anchor>   ::= "(" "anchor" ( ":after" | ":before" ) <symbol> ")"
    <bindings> ::= "(" "bindings" <binding>* ")"
    <when>     ::= "(" "when" <cond> ")"
@@ -412,6 +429,52 @@ no registered system, and which carries no anchor, is ``E-LOAD-002``. Mods
 therefore cannot land a rule "nowhere", and cannot express a raw position
 float. Interleaving an anchor into the Material Base partition is
 ``E-LOAD-003`` (design §5, modding boundary).
+
+**[draft ruling — Phase 1 review, R9 chapter C4]** *The rule domain — what a
+rule fires over, and how many times.* §4.2 says a rule evaluates against "the
+subject node" and §5.6 lets the reader *infer* the subject's type from a
+binding's qname prefix; the document never stated the inference rule and said
+nothing at all about a rule whose only bindings are ``:const``, ``:metric`` and
+``:tick``. Six systems (R9 gap analysis §2, Q12) perform exactly one
+graph-level check per tick — ControlRatio's four-phase machine, Metabolism's
+overshoot check, FieldDerivative's principal-contradiction pick — and under a
+per-node reading those would fire once per node.
+
+``<domain>`` is **optional**, with the inference below as its default. It is
+optional rather than mandatory for the same reason ``<anchor>`` is (D5): the
+document already carries a default-inference convention for rule-level
+placement, mandating a new child would make every existing rule form
+non-conforming, and §5.6's pinned canonical bytes would need recomputation for
+no gain in expressiveness.
+
+*The inference, stated so it is computable at load.* Let ``U`` be the set of
+node types owning (§2.9):
+
+- every ``:field`` binding referenced at least once **outside every query
+  body**, and
+- every ``<qname>`` of an ``update-node`` verb whose element operand is the
+  symbol ``self``, and of every ``field-of`` whose element operand is ``self``.
+
+Then ``|U| = 1`` gives the domain; ``|U| = 0`` (nothing is self-scoped) and
+``|U| > 1`` (two node types are) are both ``E-LOAD-004``, and both are repaired
+by writing ``<domain>`` explicitly. **The surprise the gap analysis names is
+removed by construction**: a binding referenced only inside a fold body never
+enters ``U``, so adding one cannot change how many times a rule fires.
+
+*Explicit domains.* ``(domain NodeType/SOCIAL_CLASS)`` replaces the inference
+outright. A self-scoped reference owning off a different node type is then
+``E-TYPE-010`` — the existing code for a foreign node type read outside a fold
+body over that type, which is exactly what such a reference is.
+
+*The graph domain.* ``(domain :graph)`` fires the rule **exactly once per
+tick**, at its anchor position. ``self`` is not bound in a graph-domain rule:
+any reference to ``self``, and any ``:field`` binding referenced outside a
+query body, is ``E-TYPE-015``. Graph-domain rules read the graph through
+queries and through §2.10's accessors, which is what chapter C3's carrier
+ruling is for; they read nothing else the language did not already give them.
+``(domain :graph)`` is therefore a firing-multiplicity declaration and not a
+new capability — it removes an ``N``-fold repetition, it does not reach
+further.
 
 2.4 Conditions
 ~~~~~~~~~~~~~~~~
@@ -925,6 +988,7 @@ here.
 
    <accessor> ::= "(" "field-of"     <expr> <qname> ")"
                 | "(" "edge-between" <enum-ref> <expr> <expr> ")"
+                | "(" "the"          <enum-ref> ")"
 
 .. list-table::
    :header-rows: 1
@@ -942,6 +1006,11 @@ here.
      - ``EdgeRef``
      - The edge of the given ``EdgeType`` from the first node operand to the
        second. Absence is ``E-EVAL-034``.
+   * - ``the``
+     - ``NodeRef``
+     - The unique node of a ``NodeType`` whose manifest ``:ceiling`` is 1.
+       A ceiling other than 1 is ``E-LOAD-043``; a graph holding no such node
+       is ``E-EVAL-035``.
 
 **The shared discipline.**
 
@@ -995,6 +1064,24 @@ been given endpoint operands and left to skip quietly.
 
    (update-edge (edge-between EdgeType/SOLIDARITY self other)
                 solidarity/strength (scale 0.95c))
+
+**[draft ruling — Phase 1 review, R9 chapter C3]** ``the`` *reaches a singleton
+carrier without a degenerate fold.* Graph-scope state lives on carrier nodes
+(§3.6), and a rule whose domain is some other type has to name one. The
+alternative the language already had — ``(fold sum (nodes NodeType/POLITY)
+(field-of it polity/imperial-rent-pool))`` — reads as an aggregation, costs a
+ceiling factor it does not need, and is a fold whose result happens to be a
+single element only because the ceiling is 1. ``the`` says that directly and
+proves it statically: legality is conditioned on the manifest's ``:ceiling``
+being exactly 1 (``E-LOAD-043``), which is the same declared number §3.7
+already uses for the fuel bound, so the ruling adds no second registry. A
+graph that holds no such node at evaluation is ``E-EVAL-035`` — a carrier the
+scenario forgot to hydrate fails loudly rather than reading as zero.
+
+.. code-block:: scheme
+
+   (update-node (the NodeType/POLITY)
+                polity/imperial-rent-pool (sub drawn))
 
 3. Static semantics
 ---------------------
@@ -1210,6 +1297,46 @@ Modders author rules and coefficients
 over the closed vocabulary; fuel + the closed intrinsic set + no I/O is a
 sandbox with no escape to express.
 
+**[draft ruling — Phase 1 review, R9 chapter C3]** *Graph-scope state is
+ordinary node state on a declared carrier node type.* Twenty-two of the
+thirty-four frozen systems read or write state that belongs to the graph rather
+than to any node — the opposition registry, the market-scissors axis, the
+electoral registers, the national wealth vector, the imperial-rent pool, the
+phase latches — through ``graph.graph[...]``, ``set_graph_attr`` or
+``context.persistent_data`` (R9 gap analysis §2, Q6: the single most pervasive
+gap in the estate). None of it had a BSL home: ``<bind-src>`` closes at
+``:field``/``:const``/``:metric``/``:tick``, ``:metric`` is read-only by
+construction, and no §2.8 verb writes anything but a node, an edge, a hyperedge
+or an event.
+
+The ruling adds **no new grammar and no new storage class**. A value of
+graph scope is declared as an ordinary ``deffield`` owned by a **carrier node
+type** — a ``NodeType`` member whose manifest ``:ceiling`` is 1 — read with
+``(field-of (the NodeType/…) …)`` and written with ``(update-node (the
+NodeType/…) … )``. Everything the rest of this document says about node state
+then applies unchanged: the value is hashed as node state, iterated in the
+order of §2.6, bounded by the same ceilings, visible to the inspector and to
+the write log, and subject to §3.4's kind rule. Adding a carrier ``NodeType``
+member costs exactly one closed-vocabulary member and is therefore **amendment
+territory** under this section — which is the right weight for a decision this
+load-bearing, and is the ruling's price rather than a side effect of it.
+
+*The rejected route, recorded so it is not re-proposed.* The alternative was a
+``:global`` bind-src plus an ``update-global`` verb. It was rejected because it
+invents a second storage class whose determinism, iteration, hashing, kind and
+inspection obligations would every one of them have to be restated — a
+document's worth of duplicated law to avoid one enum member — and because
+state that is not node state is invisible to the two mechanisms the engine
+already built for exactly this scrutiny (the derivation inspector's write log,
+and the ceiling-bounded content hash). A closed verb set is a property worth
+more than the convenience of writing ``update-global``.
+
+*What the ruling does not do.* It does not make every register a singleton:
+per-sovereign and per-county registers are ordinary nodes of ordinary types,
+reached by ordinary queries. ``the`` and the carrier discipline are for the
+values that are genuinely one-per-graph. And it does not introduce a staging
+or double-buffering construct — see §4.7.
+
 3.7 The load-time fuel bound check
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1258,6 +1385,8 @@ and are **pinned by conformance vector; revising them is a vector re-bless**
    cost(field path | enum-ref)  = 0                      ; static, like a literal
    cost(field-of)               = 1 + cost(element expr) ; §2.10, R9 C1
    cost(edge-between)           = 1 + Σ cost(operands)   ; §2.10, R9 C2
+   cost(the)                    = 1                      ; §2.10, R9 C3
+   cost(domain)                 = 0                      ; §2.3, R9 C4
    bound(rule)                  = cost(cond of <when>) + Σ cost(effect-items)
 
 **[draft ruling — Phase 1 review, R9 chapters C1–C2]** *Accessors are keyed
@@ -1340,6 +1469,22 @@ system position observe the same pre-state.
 Rules at the same anchor position evaluate in **ascending rule-id byte order**
 **[draft ruling — Phase 1 review]**, and their effects apply in that same
 order. File order and load order are never observable.
+
+**[draft ruling — Phase 1 review, R9 chapter C4]** *Subject enumeration order,
+which this document had not specified.* A rule whose domain is a node type
+(§2.3) fires once per node of that type, in **ascending node-id byte order** —
+the same key §2.6 uses for queries. All firings of one rule observe the same
+pre-state (the law above is unchanged), and the effects they collect are
+applied in that subject order, and within one subject in source order. A
+``(domain :graph)`` rule fires once and takes its place among the rules at its
+anchor by rule id like any other.
+
+The order is not a formality. Accumulation into a shared target — every class
+adding its slice to a carrier node (§3.6) — reduces in exactly this order, and
+the binary64 lane of §3.3 is not associative, so an unspecified subject order
+would make the result implementation-dependent while every other clause of this
+chapter held. Currency's exact integer lane is immune; the bounded scalars are
+not, which is why the order is stated rather than left to the executor.
 
 4.3 Arithmetic
 ~~~~~~~~~~~~~~~~
@@ -1443,6 +1588,42 @@ rule id, the AST path to the offending node, the binding environment, and the
 fuel remaining. An implementation must not convert an evaluation error into a
 default value, a skipped effect, or a log line.
 
+4.7 Cross-system registers and one-tick handoffs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once graph-scope state is node state (§3.6), a whole class of construct stops
+being necessary, and this section exists to say so rather than to add anything.
+
+Several values in the frozen estate are **one-tick-lagged handoffs** between
+systems at different anchor positions — Sovereignty's output read by Metabolism,
+MarketScissors' correction read by WealthDistribution, Production's value read
+by ImperialRent. In the Python engine those live in ``persistent_data`` and the
+lag is a property of where the write and the read happen to sit.
+
+**[draft ruling — Phase 1 review, R9 chapter C3]** *There is no staging,
+double-buffering or "previous tick" construct, and none is needed.* A rule
+writes a carrier field at its anchor position; a rule at a later anchor
+position in the same tick reads the new value; a rule at an earlier position
+reads the value the previous tick left. Tick ordering already **is** the
+staging mechanism, and it is the one mechanism whose behaviour §4.2 has
+specified since this document's first revision. Adding a ``previous`` accessor
+or a staged-write verb would introduce a second notion of "when", and every rule
+in the estate would then have to be read twice to know which one it meant.
+
+Two obligations follow, and they are content obligations rather than language
+ones:
+
+1. **The lag is declared by the anchor, so the anchor is load-bearing.** A rule
+   pack that moves a read across the writing system's position silently
+   converts a one-tick lag into a same-tick read. The anchor is inside
+   ``rules_hash``, so the change is visible in the diff — but it is visible as
+   an anchor edit, not as a semantic one, and review should treat it as the
+   latter.
+2. **A carrier field read before anything has written it reads what hydration
+   seeded**, which is why §3.5's plain-binding rule matters here: a carrier
+   field is an ordinary declared field, so a rule reading one that the scenario
+   never seeded is ``E-LOAD-010`` at load, not a zero at tick 1.
+
 5. Canonical AST serialization
 --------------------------------
 
@@ -1535,7 +1716,8 @@ AST — a property implementations should exercise as a round-trip property test
 ``binding``, ``when``, ``effects``, ``and``, ``or``, ``not``, ``<``, ``<=``,
 ``>``, ``>=``, ``=``, ``!=``, ``+``, ``-``, ``*``, ``/``, ``if``, ``fold``,
 ``exists``, ``forall``, ``nodes``, ``edges``, ``neighbors``, ``hyperedges``,
-``members-of``, ``hyperedges-of``, ``field-of``, ``edge-between``, ``guard``,
+``members-of``, ``hyperedges-of``, ``field-of``, ``edge-between``, ``the``,
+``domain``, ``guard``,
 ``update-node``, ``update-edge``,
 ``add-node``, ``remove-node``, ``add-edge``, ``remove-edge``,
 ``add-hyperedge``, ``remove-hyperedge``, ``members``,
@@ -1586,6 +1768,15 @@ Within any form, children are emitted in three groups:
 Group 2's sort is what makes option order a formatting concern. Group 3's
 source order is load-bearing: order is structure (the effect application order
 of §2.8 is exactly this order).
+
+**[draft ruling — Phase 1 review, R9 chapter C4]** ``<domain>`` *encodes in
+its grammar position.* Like ``<anchor>``, ``<bindings>``, ``<when>`` and
+``<effects>``, a ``domain`` form is a child of ``rule`` emitted in the order
+the §2.3 grammar declares it — immediately before ``anchor``. It is optional
+and absent from §5.6's example, so that example's byte count and both its
+digests are unaffected. Its own children follow the general rule: an
+``<enum-ref>`` domain encodes as one ``atom enum`` child, and ``(domain
+:graph)`` as one ``opt`` form carrying the ``graph`` flag under D20.
 
 5.4 Determinism obligations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1808,6 +1999,23 @@ At minimum, an implementation claiming conformance passes:
     (``E-PARSE-041``) and one owning off the wrong type (``E-TYPE-014``); and
     an ``update-edge`` whose referent is of another edge type
     (``E-EVAL-033``).
+12. **Graph-scope carriers** (chapter C3) — ``the`` resolving against a
+    ``:ceiling 1`` manifest row; ``the`` against a row whose ceiling is not 1
+    (``E-LOAD-043``); ``the`` against a graph that hydrated no such node
+    (``E-EVAL-035``); a read and a write of one carrier field through
+    ``field-of``/``update-node``; and an **accumulation vector** — three
+    subject nodes each adding a bounded scalar to one carrier — whose expected
+    value pins the §4.2 subject order by being sensitive to it.
+13. **Rule domain** (chapter C4) — an inferred node domain (the §5.6 rule,
+    unchanged, is one); a rule with no self-scoped reference and no
+    ``<domain>`` (``E-LOAD-004``); a rule whose self-scoped references name two
+    node types (``E-LOAD-004``); an explicit ``(domain NodeType/…)`` overriding
+    a would-be ambiguity; a rule whose ``<domain>`` and self-scoped reference
+    disagree (``E-TYPE-010``); ``(domain :graph)`` firing exactly once against
+    a multi-node graph; ``self`` referenced in a graph-domain rule
+    (``E-TYPE-015``); ``:graph`` used outside a ``domain`` form
+    (``E-PARSE-013``); and a ``:cas`` vector for each of the two ``domain``
+    shapes.
 
 Families 10 and up are the R9 spec chapters' (the chapter letters cite
 ``reports/bsl-gap-analysis-2026-08-10.md`` §7). Two obligations are stated
@@ -2107,6 +2315,39 @@ consequences are the ordinary kind of review item.
      - Accessors are keyed lookups charged at 1 + operands and never
        multiplied by a ceiling, so only iteration constructs carry ceiling
        factors in the static bound.
+   * - D39
+     - §3.6
+     - Graph-scope state is ordinary node state on a carrier ``NodeType``
+       whose ceiling is 1 — no new grammar, no second storage class. Adding a
+       carrier type is amendment territory. The ``:global``/``update-global``
+       route is recorded as rejected.
+   * - D40
+     - §2.10
+     - ``the`` names the unique node of a ``:ceiling 1`` type; a ceiling other
+       than 1 is ``E-LOAD-043`` (static, off the manifest) and an unhydrated
+       carrier is ``E-EVAL-035``.
+   * - D41
+     - §4.7
+     - No staging, double-buffering or ``previous`` construct: tick ordering
+       is the handoff mechanism, and the anchor is where a one-tick lag is
+       declared.
+   * - D42
+     - §1.6
+     - ``:out``/``:in``/``:any`` are flag keywords the table had omitted;
+       ``:graph`` joins them, legal only in a ``domain`` form.
+   * - D43
+     - §2.3
+     - ``<domain>`` is optional with a stated inference (the unique node type
+       of the rule's self-scoped references); ``|U| ≠ 1`` is ``E-LOAD-004``.
+       ``(domain :graph)`` fires once per tick and unbinds ``self``
+       (``E-TYPE-015``). Explicit declarations override inference; a
+       disagreeing self-scoped reference is ``E-TYPE-010``.
+   * - D44
+     - §4.2
+     - A node-domain rule fires over its subjects in ascending node-id byte
+       order and applies their effects in that order — previously
+       unspecified, and load-bearing because the binary64 lane is not
+       associative.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -35,7 +35,12 @@ language blocker: they were BSL-shaped and unauthorable. Thirteen chapters
 (C1–C13), planned in ``reports/bsl-gap-analysis-2026-08-10.md`` §7, close them
 in place across §§1.6, 2.2–2.11, 3.1, 3.4, 3.6–3.10, 4.2, 4.5–4.7, 5.2, 5.3,
 5.5 and 6.2, adding rows **D29–D71** to the register below and vector families
-**10–22** to §6.2.
+**10–22** to §6.2. One planned item is **not** closed and is recorded as such:
+edge-endpoint accessors (gap item Q2), §3.8 item 8 and D78. A three-lens
+adversarial verification of the chapters (2026-08-10) added rows **D72–D78**,
+which repair what it found: query-result multiplicity, the edge-key uniqueness
+obligation at hydration, the enum-ref operand class rule, error-code hygiene,
+manifest completeness, and the fuel meter's scope under per-subject firing.
 
 The chapters were held to a stated reach: **query forms, bindings,
 iteration and selection structure, and graph-scope state are licensed**
@@ -300,7 +305,12 @@ reads as default" behavior anywhere in the language.
 A keyword is a colon-prefixed symbol. Keywords are never values: they may only
 appear in the option position of a form, always immediately followed by their
 operand (except for the flag keywords listed below, which take no operand).
-A keyword in value position is ``E-PARSE-010``.
+A keyword in value position is ``E-PARSE-010``. **[draft ruling — Phase 1
+review, R9 verification repair]** So is a **string literal** in expression
+position, for the same reason and under the same code: §1.5's strings are
+well-formed atoms admitted at ``:material-basis`` and at conformance-vector
+identifiers only, ``<expr>`` (§2.7) has no string form, and ``Str`` has no
+operations (§3.1). Both are atoms rejected by *position*, not by lexis.
 
 .. list-table::
    :header-rows: 1
@@ -508,8 +518,10 @@ removed by construction**: a binding referenced only inside a fold body never
 enters ``U``, so adding one cannot change how many times a rule fires.
 
 *Explicit domains.* ``(domain NodeType/SOCIAL_CLASS)`` replaces the inference
-outright. A self-scoped reference owning off a different node type is then
-``E-TYPE-010`` — the existing code for a foreign node type read outside a fold
+outright. Its operand is a ``NodeType`` member — an ``EdgeType`` or
+``HyperedgeType`` member there is ``E-TYPE-011`` under §2.6's enum-ref class
+rule — and a self-scoped reference owning off a different node type is
+``E-TYPE-010``, the existing code for a foreign node type read outside a fold
 body over that type, which is exactly what such a reference is.
 
 *The graph domain.* ``(domain :graph)`` fires the rule **exactly once per
@@ -545,7 +557,7 @@ correction as the empty precondition set).
 identity, with* ``=`` *and* ``!=`` *only.* Two ``NodeRef``\ s (or two
 ``EdgeRef``\ s, or two ``HyperedgeRef``\ s) may be compared for identity;
 comparing a reference with an ordering operator, or with a reference of a
-different kind, or with any non-reference, is ``E-TYPE-019``. This document
+different kind, or with any non-reference, is ``E-TYPE-017``. This document
 had left reference comparison undefined, which made the intersection idiom of
 §2.7 unwritable and would have left two implementations free to differ. There
 is no ordering on references *in the language* — §2.6's iteration order is the
@@ -743,13 +755,26 @@ construct, and nothing in it can read a value this rule wrote.
    <edge-pred>  ::= <cond>
    <hedge-pred> ::= <cond>
 
-The ``<enum-ref>`` operand of ``nodes`` must be a ``NodeType`` member, of
-``edges`` an ``EdgeType`` member, and of
-``hyperedges``/``members-of``/``hyperedges-of`` a ``HyperedgeType`` member
-(``E-TYPE-011``). ``neighbors`` takes two: an ``EdgeType`` for the relation
-traversed and a ``NodeType`` for the elements yielded (below). Predicates and
-bodies refer to the candidate element as ``it``, or by the ``:as`` name of
-the iterating form.
+**[draft ruling — Phase 1 review, R9 verification repair]** *Every*
+``<enum-ref>`` *operand position is typed, and* ``E-TYPE-011`` *is the code for
+all of them.* The rule is stated once here as a class rather than per form,
+because the R9 chapters added four such positions and a per-form restatement
+left each new one without a rejection:
+
+- ``NodeType`` — ``nodes``, ``neighbors``' **fourth** operand, ``the``
+  (§2.10) and ``(domain <enum-ref>)`` (§2.3);
+- ``EdgeType`` — ``edges``, ``neighbors``' **second** operand and
+  ``edge-between`` (§2.10);
+- ``HyperedgeType`` — ``hyperedges``, ``members-of`` and ``hyperedges-of``;
+- ``EventType`` — ``emit`` (§2.8).
+
+An operand naming a member of any other enum kind is ``E-TYPE-011``, checked
+statically. It is a *kind* check and nothing more: whether the named type and
+member exist at all is ``E-LOAD-030``/``E-LOAD-031`` (§1.5). ``neighbors``
+therefore takes two — an ``EdgeType`` for the relation traversed and a
+``NodeType`` for the elements yielded (below) — and swapping them is
+``E-TYPE-011`` at both positions. Predicates and bodies refer to the candidate
+element as ``it``, or by the ``:as`` name of the iterating form.
 
 Element and result types:
 
@@ -773,7 +798,8 @@ Element and result types:
      - ``NodeSet``
      - ``NodeRef``
      - Nodes **of the annotated** ``NodeType`` reachable from the operand
-       across that ``EdgeType`` in the given direction.
+       across that ``EdgeType`` in the given direction. Each such node appears
+       **once**, however many qualifying edges reach it (below).
    * - ``hyperedges``
      - ``HyperedgeSet``
      - ``HyperedgeRef``
@@ -817,11 +843,40 @@ graph-internal storage order. This is the language-level answer to the
 cross-language iteration-order trap; it makes fold results independent of
 insertion history and of the underlying graph library.
 
+That order is *total* only because each of the three keys identifies at most
+one element. For nodes and hyperedges the id is the identity. For edges the key
+is the ``(source-id, target-id, edge-type)`` triple, and it is a **key** rather
+than a sort field because both points at which an edge can enter the graph
+refuse a second one: an ``add-edge`` duplicating an existing edge is
+``E-EVAL-031`` (§2.8) and a hydration seeding the same triple twice is
+``E-LOAD-044`` (§3.9).
+
 **[draft ruling — Phase 1 review]** The same rule applies *inside* a
 hyperedge: ``members-of`` yields members in ascending node-id byte order, and a
 hyperedge's **declared** member order — the order ``add-hyperedge`` (§2.8) or a
 scenario hydration listed them in — is never observable. A member list is a
 set, not a sequence.
+
+**[draft ruling — Phase 1 review, R9 verification repair]** *A* ``NodeSet``
+*is a set, and* ``neighbors`` *yields each node exactly once.* A node reachable
+from the operand across two or more qualifying edges — two ``SOLIDARITY`` edges
+in opposite directions under ``:any``, an ``:out`` and an ``:in`` edge of one
+type — appears **once** in the result. This is the only reading compatible with
+the total order above: the order is ascending id byte order and a duplicated id
+has no defined position relative to its twin, so a multiset result would leave
+``(fold count (neighbors self EdgeType/SOLIDARITY :any NodeType/SOCIAL_CLASS))``
+reading 1 or 2 by implementation choice — two conforming implementations
+disagreeing on a tick hash, which is the failure this whole section exists to
+prevent. The alternative reading (a multiset, one element per traversed edge)
+is recorded as **rejected** for that reason (D72).
+
+The consequence is worth stating in the form an author meets it: **a fold over**
+``neighbors`` **counts and sums per node, never per edge.** A rule that means
+"once per contributing edge" — a per-edge emission, a total of tie strengths —
+folds over ``edges`` instead, or iterates one with ``for-each`` (§2.8), and
+reads the relation there; ``neighbors`` answers *which nodes*, not *how many
+ways*. ``members-of`` and ``hyperedges-of`` carry the same property for the same
+reason — which D25 above already said of a member list.
 
 **[draft ruling — Phase 1 review, R9 chapter C8]** ``neighbors`` *carries its
 result* ``NodeType`` *as a mandatory fourth operand.* §2.5 permits a foreign
@@ -840,12 +895,19 @@ node's edge may legitimately reach several node types while a hyperedge has one
 type.
 
 The operand is mandatory rather than optional, and that is a **breaking change
-to a form that already existed**. It is made rather than deferred because
-nothing in the estate pins the old shape: no conformance vector and no rule in
-``rust/crates/babylon-bsl/tests/conformance/`` exercises ``neighbors`` at all
-(verified 2026-08-10), so the cost of the correction is a grammar edit and no
-re-bless of an existing expectation. An optional operand would have left the
-untyped reading legal and the under-determination alive.
+to a form that already existed**. What the estate holds, stated exactly (all
+verified 2026-08-10): **no conformance vector and no content rule exercises**
+``neighbors`` — zero occurrences under ``rust/crates/babylon-bsl/tests/``
+(twelve ``.bsl`` vectors) and under ``rust/crates/babylon-tick/content/`` — so
+no blessed expectation moves and there is no vector re-bless to pay. The
+``babylon-bsl`` crate, however, **does** implement the pre-change form:
+``bound_checker.rs`` reads the ceiling operand of ``neighbors`` at index 2 and
+bounds it against the edge type alone, and a unit test pins that three-operand
+spelling together with the edge-type-only bound D52 revises. Those are updated
+when Phase 1 implements this chapter — the correction costs a grammar edit and
+a crate change, which is the cheapest of the three prices it could have carried
+and the reason to pay it now rather than defer. An optional operand would have
+left the untyped reading legal and the under-determination alive.
 
 ``ceiling(neighbors)`` is correspondingly tightened in §3.7.
 
@@ -908,6 +970,19 @@ to reach an *outer* element, and ``:as`` supplies it:
 Arithmetic is strictly binary; ``(+ a b c)`` is ``E-PARSE-040``. This keeps
 the reduction order explicit in the source rather than implied by a
 left-fold convention — a cross-language float trap the design document names.
+
+**[draft ruling — Phase 1 review, R9 verification repair]** *Arity and closed
+terminal sets each get a code, rather than an unnumbered prose prohibition.*
+Every form's operand count is fixed by its production, and a count that differs
+from it is ``E-PARSE-042``; ``E-PARSE-040`` remains the arithmetic-specific
+spelling of that class, and the three-operand ``neighbors`` of the pre-C8
+grammar (§2.6, D51) is the case this revision creates. A head symbol that is
+not a member of a closed terminal set — ``<fold-op>`` above, ``<cmp>`` (§2.4),
+``<update-op>`` (§2.8) or ``<arith>`` — is ``E-PARSE-015``, which is where two
+of §6.3's four silent-degradation corrections (unknown aggregation, unknown
+comparison operator) land. Both were previously written as prohibitions with no
+code, which left the conformance families that must pin them unable to name
+what they expect (§6.2 families 17 and 19).
 
 **Guards** are ``(if <cond> <a> <b>)`` in expression position and
 ``(guard <cond> <effect-item>+)`` in effect position (§2.8). Both branches of
@@ -978,7 +1053,7 @@ authorable.
   there is no null.
 - The score expression must have a **comparable scalar** static type — ``Int``,
   ``Currency``, ``Probability``, ``Intensity``, ``Coefficient`` or ``Real``.
-  ``Bool``, ``Enum<T>``, ``Str``, references and sets are ``E-TYPE-017``.
+  ``Bool``, ``Enum<T>``, ``Str``, references and sets are ``E-TYPE-016``.
 - **Kind is unconstrained on the score** and the result is kind-neutral (a
   reference has no extent). This is not a hole in §3.4: that law polices
   *aggregation*, where an unweighted mean of an intensive quantity across
@@ -1044,7 +1119,9 @@ the static bound of §3.7 is computable.
 
 The four ``<update-op>`` forms are exactly today's four-operation effect enum
 — ``add`` = ``increase``, ``sub`` = ``decrease``, ``set`` = ``set``,
-``scale`` = ``multiply``. Of the **nine** structural verbs, **five** are the
+``scale`` = ``multiply``. The set is closed: a fifth head there — the
+``(unset …)`` the frozen estate reaches for (§3.8) — is ``E-PARSE-015``.
+Of the **nine** structural verbs, **five** are the
 addition the design document's §6.4 audit found necessary (20 of 39 system
 modules mutate graph structure); **two** — ``add-hyperedge`` and
 ``remove-hyperedge`` — are what the Amendment D ruling adds, since if a
@@ -1125,16 +1202,18 @@ alone. It also keeps the ruling legible in the grammar itself — **a clique
 expansion is not expressible**, because no verb takes a member set and emits
 edges.
 
-**[draft ruling — Phase 1 review]** *Membership changes are whole-hyperedge
-replacement.* There is no ``add-member``/``remove-member`` verb and no
-``update-hyperedge``: a rule that changes a formation's roster emits
-``(remove-hyperedge h)`` and then ``(add-hyperedge …)`` in one effect list,
-applied in source order (below). This keeps the member-count check at a single
-point (§3.7) and makes a partially-mutated hyperedge unrepresentable. The cost
-is stated rather than hidden: **per-membership payload** (the
-role/strength/visibility fields today's Python ``CommunityMembership`` carries)
-and **mutation of a hyperedge's own declared fields** are not expressible in
-this revision. Both are Phase-1 review items; neither is a silent omission.
+**[draft ruling — Phase 1 review;** *field-mutation half superseded by the C12
+ruling below* **]** *Membership changes are whole-hyperedge replacement.* There
+is no ``add-member``/``remove-member`` verb: a rule that changes a formation's
+roster emits ``(remove-hyperedge h)`` and then ``(add-hyperedge …)`` in one
+effect list, applied in source order (below). This keeps the member-count check
+at a single point (§3.7) and makes a partially-mutated hyperedge
+unrepresentable. The cost was stated rather than hidden: **per-membership
+payload** (the role/strength/visibility fields today's Python
+``CommunityMembership`` carries) and **mutation of a hyperedge's own declared
+fields** were both inexpressible in the revision that made this ruling. The
+second of those is retired immediately below (D65); the first stands, and D66
+escalates it. Neither was a silent omission.
 
 **[draft ruling — Phase 1 review, R9 chapter C12]** *D26's second half is
 closed:* ``update-hyperedge`` *writes a hyperedge's own declared fields.* The
@@ -1172,7 +1251,8 @@ range and I.15 disciplines apply as they do to the other two update verbs.
    scoring depends *entirely* on per-membership payload cannot be authored in
    BSL until this is ruled, and that is a **port blocker**, not a review item.
 
-``emit``'s ``<enum-ref>`` is an ``EventType`` member; payload items are
+``emit``'s ``<enum-ref>`` is an ``EventType`` member — a member of another
+enum kind there is ``E-TYPE-011`` under §2.6's class rule; payload items are
 name/expression pairs. There is no string interpolation in a payload.
 
 **[draft ruling — Phase 1 review, R9 chapter C6]** ``for-each`` — *bounded
@@ -1266,6 +1346,20 @@ A ``ceiling`` row's ``<enum-ref>`` is a ``NodeType``, ``EdgeType`` or
 on a ``NodeType`` or ``EdgeType`` row and illegal on a ``HyperedgeType`` row
 (§3.9). Any of those mismatches is ``E-LOAD-042``. The semantics of the two
 numbers are §3.7's; the flag's are §3.9's.
+
+**[draft ruling — Phase 1 review, R9 verification repair]** *The manifest must
+be complete for the types the content set actually uses.* The grammar demands
+``<ceiling>+`` — one row or more — and nothing until now said which rows were
+owed. A content set that queries a type, names it in a structural verb, or
+reaches it through ``the`` (§2.10), and whose manifest carries no row for that
+type, is ``E-LOAD-045``. The omission is not survivable by defaulting:
+``ceiling(query)`` (§3.7) is not computable without the row, so ``bound(rule)``
+has nothing to compare against ``:fuel``; ``the``'s ``E-LOAD-043`` tests for a
+ceiling "other than 1" and a *missing* row is neither 1 nor other than 1; and
+``:invariant`` (§3.9) is a flag on a row that does not exist, so its
+``E-LOAD-013`` check silently never fires. The obligation is scoped to the
+vocabulary the content set mentions, not to the whole registry — a scenario
+owes no row for a type nothing touches.
 
 **[draft ruling — Phase 1 review]** The design document says intensivity is "a
 per-field declaration (``:kind intensive|extensive``) on model fields" without
@@ -1382,6 +1476,10 @@ here.
 4. *Kind and type propagate from the declaration.* A ``field-of`` expression
    has the ``deffield``'s ``:type`` as its static type and its ``:kind`` as its
    kind (§3.4), identically to a ``:field`` binding of the same field.
+5. *The enum-ref operand is kind-checked like any other.* ``edge-between``'s
+   operand is an ``EdgeType`` member and ``the``'s is a ``NodeType`` member;
+   either naming a member of another enum kind is ``E-TYPE-011`` under §2.6's
+   class rule, statically and at load.
 
 **Worked shape.** The §2.4 coverage row, written out:
 
@@ -1400,12 +1498,14 @@ applies to node fields.
 **[draft ruling — Phase 1 review, R9 chapter C2]** ``edge-between`` *is
 well-defined because the triple is a key.* §2.6 fixes the edge iteration order
 at ascending ``(source-id, target-id, edge-type)`` lexicographic byte order —
-which is a *total* order only if no two edges share that triple, and §2.8
-already makes "adding an edge that already exists" ``E-EVAL-031`` and a
-ceiling-violating hydration ``E-LOAD-041``. Parallel edges of one type between
-one ordered pair are therefore not representable, and "the edge between a and
-b of type T" denotes at most one element. When it denotes none, that is
-``E-EVAL-034`` — the accessor never yields an absent reference and never
+which is a *total* order only if no two edges share that triple, and the two
+points at which an edge enters the graph both refuse a second one: §2.8 makes
+"adding an edge that already exists" ``E-EVAL-031``, and §3.9's hydration
+contract makes a scenario seeding one triple twice ``E-LOAD-044``. Parallel
+edges of one type between one ordered pair are therefore not representable
+(a ceiling-violating hydration is separately ``E-LOAD-041``), and "the edge
+between a and b of type T" denotes at most one element. When it denotes none,
+that is ``E-EVAL-034`` — the accessor never yields an absent reference and never
 degrades to a no-op write, which is what would happen if ``update-edge`` had
 been given endpoint operands and left to skip quietly.
 
@@ -1572,10 +1672,14 @@ degraded mode, and no rule that loads "partially".
        type in their ``<qname>``. Consumable by §2.10's accessors and by the
        element-position operands of §2.8's verbs, and comparable for
        **identity** with ``=``/``!=`` against a reference of the same kind
-       (``E-TYPE-019`` otherwise, §2.4). There is no ordering on references.
+       (``E-TYPE-017`` otherwise, §2.4). There is no ordering on references.
    * - ``NodeSet`` / ``EdgeSet`` / ``HyperedgeSet``
      - the result of a ``<query>``
-     - Only consumable by ``fold``, ``exists``, ``forall``.
+     - Only consumable by ``fold``, ``exists``, ``forall`` (and §2.7's
+       selections, which take a ``<query>`` in the same position). A set holds
+       each element **once**: a query result is duplicate-free whatever
+       multiplicity of edges or memberships produced it, so a ``count`` over
+       ``neighbors`` counts nodes and not traversals (§2.6).
    * - ``Str``
      - UTF-8, NFC
      - Only ``:material-basis`` and vector ids. No operations.
@@ -1866,10 +1970,12 @@ the row as ``1 + Σ cost(children)``: identical for the predicate queries
 (enum-refs and direction keywords cost 0), and additionally charging the
 operand where one exists.
 
-``ceiling(query)`` is the manifest ceiling of the queried type; for
-``neighbors`` it is **[draft ruling — Phase 1 review, revised by R9 chapter
-C8]** the *lesser* of the queried edge type's ceiling and the annotated result
-node type's ceiling — neither bound can be exceeded, so the smaller is the
+``ceiling(query)`` is the manifest ceiling of the queried type — which is why
+§2.9 makes a queried type carrying no manifest row ``E-LOAD-045`` rather than a
+defaulted or skipped bound; for ``neighbors`` it is **[draft ruling — Phase 1
+review, revised by R9 chapter C8]** the *lesser* of the queried edge type's
+ceiling and the annotated result node type's ceiling — neither bound can be
+exceeded, so the smaller is the
 honest one, and the annotation C8 makes mandatory is what makes the second
 number available. (A per-node degree ceiling would be tighter still and remains
 the Phase-1 review item D15 recorded.) For the three hyperedge queries
@@ -1904,7 +2010,8 @@ Seven things the frozen estate reaches for do not exist in BSL and are not
 going to. Each is recorded here **with the re-modelling that replaces it**, so
 that a future port reads the absence as a decision rather than an oversight and
 does not re-propose the construct. None of these adds grammar; several delete a
-question.
+question. An eighth item follows them under its own heading: it is *not* a
+settled absence, and saying so is the point of recording it here.
 
 **1. Absence, and writing it back** (R9 gap analysis §2, Q17). There is no null
 literal, no ``unset`` update-op, and no ``bound?`` predicate — D13 removed the
@@ -1953,7 +2060,8 @@ runtime trace. It also means a crisis-gated system must be ported **together
 with its producer**, or the consuming rule reads a field nothing writes.
 
 **4. No string payloads on** ``emit`` (R9 gap analysis §3, B3). ``Str`` has no
-operations (§3.1) and ``<expr>`` has no string literal, so every
+operations (§3.1) and ``<expr>`` has no string literal — one in a payload is
+``E-PARSE-010``, an atom rejected by position (§1.6) — so every
 ``<payload-item>`` expression is a number, a bool or an enum-ref. Transcribed
 systems carrying ``predicate`` or ``description`` strings, or a field name as a
 string, convert them to enum-refs or drop them — the **rule id already
@@ -1983,6 +2091,36 @@ bindings, which is verbose and honest; failing that it is a legitimate Rust
 domain-crate binding. Declaring a bespoke ``renormalize`` intrinsic would be
 the worst of the three: it hides a mechanism inside the kernel, where neither
 the content diff nor the inspector can see it, for a single call site.
+
+**8. No edge-endpoint accessors — an open item, not a settled absence**
+(R9 gap analysis §2, Q2; recorded on verification, 2026-08-10). No form yields
+an ``EdgeRef``'s source or target node. Twelve systems reach for one, the R9
+chapter plan (report §7) assigned Q2 to no chapter, and it is written down here
+because the alternative is that it reads as an oversight — which, unlike the
+seven above, is closer to the truth: this is the one item of the gap analysis
+this revision neither closes nor deliberately refuses.
+
+What is expressible today reaches only the case where one endpoint is already
+in hand. A rule holding ``self`` walks to its counterparties and resolves each
+edge by key:
+
+.. code-block:: scheme
+
+   (fold sum (neighbors self EdgeType/SOLIDARITY :in NodeType/SOCIAL_CLASS)
+         (field-of (edge-between EdgeType/SOLIDARITY it self)
+                   solidarity/strength))
+
+That is correct and priced — §3.7 charges the extra keyed lookup per
+neighbour — and it does **not** reach the general case: an ``EdgeRef`` taken
+from a fold or a ``for-each`` over ``edges`` has *both* endpoints unknown,
+which is what most of the twelve call sites need. Two landings are available,
+and choosing between them is a chapter rather than a sentence: a
+``source-of``/``target-of`` pair in §2.10 — reads of the triple §2.6 already
+treats as the edge's key, minting no new kind of object — or leaving those
+systems on the ``self``-anchored idiom and accepting that edge-iterating rules
+cannot name their endpoints. Until it is chosen, a system that iterates edges
+it did not start from is **not authorable in BSL**, and that is a port blocker
+of the same standing as D66's (D78).
 
 3.9 Invariant substrate, hydrated data, and the scale lattice
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2070,6 +2208,16 @@ What hydration may do, stated once because three chapters now depend on it:
    clause that makes "the reference-series hydration contract" a **blocking
    dependency** for the systems that read those series, rather than a source of
    zeros at tick 1.
+5. **[draft ruling — Phase 1 review, R9 verification repair]** It may not seed
+   two dyadic edges sharing one ``(source-id, target-id, edge-type)`` triple; a
+   scenario that does is ``E-LOAD-044``. §2.8 already refuses the duplicate at
+   the verb (``E-EVAL-031``), and hydration is the only other way an edge
+   enters the graph, so this is the clause that makes the triple a **key**
+   rather than a sort field. Without it §2.6's edge iteration order is not a
+   total order — a duplicated triple has no defined position relative to its
+   twin — and §2.10's ``edge-between`` has no rule for resolving *two*, having
+   one only for none (``E-EVAL-034``). Node ids and hyperedge ids need no such
+   clause: they are identities, and seeding one twice is not expressible.
 
 3.10 The intrinsic cap, the rider slate, and RNG keys
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2315,6 +2463,20 @@ inline costs strictly more than the same algebra named once.
 Reaching or passing zero is ``E-EVAL-040``, which aborts the tick (§4.6) — it
 never truncates a fold or returns a partial result.
 
+**[draft ruling — Phase 1 review, R9 verification repair]** *The meter is per
+firing.* A node-domain rule fires once per subject (§4.2), and **each firing
+starts a fresh meter at the declared** ``:fuel``: the budget is a property of
+one evaluation, never of a rule's whole pass over its subjects. That is the
+only reading consistent with ``bound(rule)`` (§3.7), which carries no
+subject-count factor, and the only one under which a rule's legality at load
+does not depend on how many nodes the scenario it is later hydrated against
+happens to hold. Chapter C4's subject enumeration made the multiplicity
+explicit and therefore made this sentence necessary. It follows that a
+conformance vector's ``:fuel-used`` (§6.1) is also per firing; a vector whose
+rule fires over several subjects — §6.2 family 12's accumulation vector — states
+the figure for the **first** subject in §4.2's order, which is well defined
+because that order is.
+
 The cost table is **pinned by conformance vector; any revision is a vector
 re-bless** (design §5 Totality). This is what makes fuel a stable, hashable
 property of content rather than an implementation detail.
@@ -2360,8 +2522,9 @@ two times at which an error can occur.
        rule domain, a field owner that names no registered type, a
        node/edge/hyperedge type-rendering collision, a metric read through the
        wrong form for its declared domain, a structural verb naming an
-       ``:invariant`` type, a reserved or prohibited intrinsic name, and
-       ``the`` against a type whose ceiling is not 1.
+       ``:invariant`` type, a reserved or prohibited intrinsic name, ``the``
+       against a type whose ceiling is not 1, a hydration seeding one edge key
+       twice, and a manifest with no row for a type the content set uses.
    * - Evaluation
      - ``E-EVAL-0xx``
      - During a tick — checked-arithmetic failure, range violation at a store,
@@ -2372,14 +2535,24 @@ two times at which an error can occur.
        unhydrated carrier, and a ``metric-of`` against the wrong element type
        or a value the provider did not produce.
 
-**Every code the R9 chapters add continues an existing sequence and renumbers
-nothing.** The three families they extend most are ``E-LOAD-0xx`` (nine new
-codes, because most of what those chapters add is decidable from the content
-set alone), ``E-TYPE-0xx`` (five) and ``E-EVAL-0xx`` (five, all of them the
-"absence is never a value" discipline of §2.10 applied at a new referent).
-That the load class grew fastest is the intended shape: a chapter that made a
-new failure mode *runtime*-only would have moved the language in the wrong
-direction.
+**Every code the R9 chapters add continues an existing sequence, and no code
+that existed before this revision is renumbered.** The new codes are
+``E-LOAD-0xx`` (eleven, because most of what those chapters add is decidable
+from the content set alone), ``E-PARSE-0xx`` (six), ``E-TYPE-0xx`` (five) and
+``E-EVAL-0xx`` (five, all of them the "absence is never a value" discipline of
+§2.10 applied at a new referent). That the load class grew fastest is the
+intended shape: a chapter that made a new failure mode *runtime*-only would
+have moved the language in the wrong direction.
+
+Sequence continuation is meant literally, and is checkable by inspection: every
+decade block of every family is **contiguous**, with no reserved and no
+skipped number — ``E-LOAD`` 001–004, 010–013, 020–025, 030–033, 040–045;
+``E-PARSE`` 010–015, 020–022, 030–033, 040–042; ``E-TYPE`` 010–017, 020, 030,
+040–043; ``E-EVAL`` 010–014, 020–021, 030–037, 040; ``E-LEX`` 001–003,
+010–011, 020–026. The R9 chapters allocated per chapter and left two holes in
+the ``E-TYPE`` sequence; they were closed by renumbering the two offending
+**new** codes before any implementation pinned them, which is a liberty
+available exactly once and only to codes this revision minted.
 
 **Load-time errors** report the offending file, line, column, form, and code,
 and reject the whole content set — there is no partial load and no "skip the
@@ -2763,10 +2936,13 @@ At minimum, an implementation claiming conformance passes:
 3. **Currency operators** — every row of §3.2, including half-even ties in both
    directions, the ``i256`` intermediate width for ``Currency ÷ Currency``, and
    both overflow ends.
-4. **Kind rule** — the five rows of §3.4's table, accepting and rejecting.
+4. **Kind rule** — the six rows of §3.4's table, accepting and rejecting.
 5. **Fuel** — the static bound for a fold at a declared ceiling; a rule
    rejected at load for exceeding its budget; a rule exhausting fuel at
-   evaluation; per-vector ``:fuel-used``.
+   evaluation; a query against a type the manifest declares no row for
+   (``E-LOAD-045``); a node-domain rule fired over three subjects whose
+   ``:fuel-used`` is one firing's and not three (§4.5); and per-vector
+   ``:fuel-used``.
 6. **CAS** — one ``:cas`` vector per form tag and per atom kind, plus the §5.6
    worked example verbatim.
 7. **Transcription** — §6.3.
@@ -2800,16 +2976,21 @@ At minimum, an implementation claiming conformance passes:
     (``E-EVAL-020``) and an I.15-illegal mode transition (``E-EVAL-030``);
     ``edge-between`` resolving, and failing to resolve (``E-EVAL-034``);
     ``add-edge`` carrying ``<field-init>``\ s, one of them naming ``strength``
-    (``E-PARSE-041``) and one owning off the wrong type (``E-TYPE-014``); and
-    an ``update-edge`` whose referent is of another edge type
-    (``E-EVAL-033``).
+    (``E-PARSE-041``) and one owning off the wrong type (``E-TYPE-014``); an
+    ``update-edge`` whose referent is of another edge type (``E-EVAL-033``);
+    an ``edge-between`` whose enum-ref names a ``NodeType`` (``E-TYPE-011``);
+    and a hydration seeding two edges of one type between one ordered pair
+    (``E-LOAD-044``).
 12. **Graph-scope carriers** (chapter C3) — ``the`` resolving against a
     ``:ceiling 1`` manifest row; ``the`` against a row whose ceiling is not 1
     (``E-LOAD-043``); ``the`` against a graph that hydrated no such node
     (``E-EVAL-035``); a read and a write of one carrier field through
-    ``field-of``/``update-node``; and an **accumulation vector** — three
-    subject nodes each adding a bounded scalar to one carrier — whose expected
-    value pins the §4.2 subject order by being sensitive to it.
+    ``field-of``/``update-node``; ``the`` against an ``EdgeType`` member
+    (``E-TYPE-011``); a manifest carrying no row for the carrier type
+    (``E-LOAD-045``); and an **accumulation vector** — three subject nodes each
+    adding a bounded scalar to one carrier — whose expected value pins the §4.2
+    subject order by being sensitive to it, and whose ``:fuel-used`` is the
+    first subject's firing (§4.5).
 13. **Rule domain** (chapter C4) — an inferred node domain (the §5.6 rule,
     unchanged, is one); a rule with no self-scoped reference and no
     ``<domain>`` (``E-LOAD-004``); a rule whose self-scoped references name two
@@ -2818,13 +2999,13 @@ At minimum, an implementation claiming conformance passes:
     disagree (``E-TYPE-010``); ``(domain :graph)`` firing exactly once against
     a multi-node graph; ``self`` referenced in a graph-domain rule
     (``E-TYPE-015``); ``:graph`` used outside a ``domain`` form
-    (``E-PARSE-013``); and a ``:cas`` vector for each of the two ``domain``
-    shapes.
+    (``E-PARSE-013``); a ``(domain EdgeType/…)`` (``E-TYPE-011``); and a
+    ``:cas`` vector for each of the two ``domain`` shapes.
 14. **Element selection** (chapter C5) — ``select-max`` and ``select-min`` over
     each of the six query heads, proving the result's element type; a
     **tie vector** whose two elements score equally, pinning that the lower id
     wins for both operators; selection over an empty query
-    (``E-EVAL-021``); a ``Bool`` and an ``Enum<T>`` score (``E-TYPE-017``); a
+    (``E-EVAL-021``); a ``Bool`` and an ``Enum<T>`` score (``E-TYPE-016``); a
     selection whose result is the element operand of ``update-node`` and of
     ``field-of``; and a selection over an intensive score, which must
     **accept** (the kind rule polices aggregation, not ordering).
@@ -2849,7 +3030,10 @@ At minimum, an implementation claiming conformance passes:
     ``neighbors`` vectors this document has ever required: a fold over
     ``neighbors`` reading the annotated type's field (which must typecheck), a
     graph whose traversal reaches two node types proving the operand *filters*,
-    a three-operand ``neighbors`` (``E-PARSE-0xx`` — arity), and a static bound
+    a three-operand ``neighbors`` (``E-PARSE-042``, arity), the two operands
+    swapped (``E-TYPE-011`` at both positions), a **multiplicity vector** — a
+    graph where two qualifying edges reach one node, whose ``fold count`` over
+    ``neighbors`` must be ``1`` — and a static bound
     equal to the **lesser** of the two ceilings; and for ``:as``, a two-hop
     nested fold naming the outer element, ``it`` inside the inner body
     resolving to the *inner* element, a ``:as`` name referenced outside its
@@ -2870,8 +3054,9 @@ At minimum, an implementation claiming conformance passes:
 19. **Deliberate absences** (chapter C10) — a family of *rejecting* vectors, so
     the absences of §3.8 are pinned as loudly as the presences: ``(bound? x)``
     (``E-LOAD-021``, an undeclared intrinsic); a string literal in an ``emit``
-    payload (``E-LEX-0xx``/``E-PARSE-0xx``); an ``(unset …)`` update-op
-    (``E-PARSE-0xx``); and one *accepting* pair proving each re-modelling
+    payload (``E-PARSE-010`` — the string lexes, the position rejects it); an
+    ``(unset …)`` update-op (``E-PARSE-015``); and one *accepting* pair
+    proving each re-modelling
     works — a presence-field guard writing value and presence together, a
     ``select-min`` over ``queued-at-tick`` returning the FIFO head, and a
     producer-stamped tick field read by a consumer rule at a later anchor.
@@ -2891,7 +3076,7 @@ At minimum, an implementation claiming conformance passes:
     owns off another hyperedge type (``E-EVAL-033``); a roster change proving
     membership is still whole-object replacement; ``=`` and ``!=`` on two
     references of the same kind, both outcomes; a reference compared with
-    ``<`` and one compared across kinds (both ``E-TYPE-019``); and the
+    ``<`` and one compared across kinds (both ``E-TYPE-017``); and the
     intersection idiom above, whose ``:fuel-used`` must show the quadratic
     cost the deferral is paying.
 22. **The intrinsic cap and calendar bindings** (chapter C13) — a call to an
@@ -2975,10 +3160,10 @@ Their BSL dispositions:
      - ``E-LOAD-011`` at load
      - §2.5 (``:metric`` resolution against the closed registry)
    * - unknown aggregation → ``False``
-     - ``E-PARSE-0xx`` at parse
+     - ``E-PARSE-015`` at parse
      - §2.7 (``<fold-op>`` is a closed five-member terminal set)
    * - unknown comparison operator → ``False``
-     - ``E-PARSE-0xx`` at parse
+     - ``E-PARSE-015`` at parse
      - §2.4 (``<cmp>`` is a closed six-member terminal set)
    * - empty precondition set → ``True``
      - ``E-PARSE-020`` at parse
@@ -3072,7 +3257,10 @@ consequences are the ordinary kind of review item.
    * - D12
      - §3.4
      - ``:const``/``:metric`` bindings are kind-neutral; ``extensive ×
-       extensive`` is a type error.
+       extensive`` is a type error. **The** ``:metric`` **clause is superseded
+       by D55**: a ``:metric`` binding and a ``metric-of`` accessor carry the
+       kind their §2.11 registration declares. The ``:const`` clause and the
+       ``extensive × extensive`` rule stand.
    * - D13
      - §3.5
      - ``:optional`` requires ``:default``; there is no ``bound?`` predicate.
@@ -3129,8 +3317,10 @@ consequences are the ordinary kind of review item.
      - §2.8
      - Two typed verbs (``add-hyperedge``/``remove-hyperedge``) rather than an
        overloaded ``add-edge``; membership change is whole-hyperedge
-       replacement, so per-membership payload and hyperedge-field mutation are
-       **not expressible in this revision** and are review items.
+       replacement, so per-membership payload and hyperedge-field mutation
+       were both inexpressible when this row was written. **The
+       hyperedge-field half is superseded by D65** (``update-hyperedge``); the
+       per-membership half stands and is escalated by D66.
    * - D27
      - §2.9, §3.7
      - A hyperedge manifest row declares two numbers — ``:ceiling`` and
@@ -3243,7 +3433,7 @@ consequences are the ordinary kind of review item.
        rule. An empty query is ``E-EVAL-021``.
    * - D46
      - §2.7
-     - The score expression must be a comparable scalar (``E-TYPE-017``); its
+     - The score expression must be a comparable scalar (``E-TYPE-016``); its
        kind is unconstrained and the result is kind-neutral, because §3.4
        polices aggregation and selection orders rather than aggregates.
    * - D47
@@ -3273,8 +3463,11 @@ consequences are the ordinary kind of review item.
      - §2.6
      - ``neighbors`` takes a mandatory result-``NodeType`` operand — D24's fix
        applied to D24's problem. It **filters** (a node may reach several
-       types) where D24's operand **asserts**. Breaking, and made anyway
-       because no conformance vector exercises ``neighbors``.
+       types) where D24's operand **asserts**. Breaking, and made anyway: no
+       conformance vector and no content rule exercises ``neighbors``, so
+       nothing is re-blessed, while the ``babylon-bsl`` bound checker *does*
+       carry the three-operand form and its edge-type-only bound and is
+       updated when Phase 1 implements the chapter.
    * - D52
      - §3.7
      - ``ceiling(neighbors)`` is the lesser of the edge-type and
@@ -3373,7 +3566,7 @@ consequences are the ordinary kind of review item.
    * - D67
      - §2.4, §3.1, §2.7
      - References compare by identity with ``=``/``!=`` only
-       (``E-TYPE-019``); there is no ordering on references. With that and
+       (``E-TYPE-017``); there is no ordering on references. With that and
        D54's naming, the intersection idiom becomes writable, and the
        deferral of a dedicated set-algebra operator stands on a form that can
        actually be written.
@@ -3381,8 +3574,11 @@ consequences are the ordinary kind of review item.
      - §2.5
      - Calendar reads land as ``:year``/``:tick-of-year``/``:tick-in-cycle``
        bindings rather than as ``mod``/``floor-div`` operators or an intrinsic
-       rider — a kernel seam, not mathematics, and the epoch stays the
-       kernel's so a mod-by-anything operator cannot arrive behind it.
+       rider — a kernel seam, not mathematics. The reach is bounded rather than
+       nil, and §2.5 states the bound precisely: ``:tick-in-cycle`` makes
+       ``tick mod k`` available for a **literal** ``k`` only, on the tick only,
+       with the epoch staying the kernel's — so what cannot arrive behind it is
+       a general mod operator over arbitrary expressions.
    * - D69
      - §3.10
      - The RNG carrier key is ``(session, tick, domain, stable_key)``, with
@@ -3403,6 +3599,68 @@ consequences are the ordinary kind of review item.
        (``E-LOAD-024``). Cap-legality is not doctrine-legality: the two gates
        are separate, gate 2 is Director review, and this is the one part of it
        that can be made mechanical.
+   * - D72
+     - §2.6, §3.1
+     - A query result is a **set**: ``neighbors`` yields a node reachable by
+       several qualifying edges exactly once, and a fold over it counts and
+       sums per node rather than per edge. **Alternative rejected:** the
+       multiset reading (one element per traversed edge), because a duplicated
+       id has no defined position in §2.6's ascending-id order, so two
+       conforming implementations could differ on a ``count`` and therefore on
+       a tick hash. Per-edge work folds over ``edges`` or iterates it with
+       ``for-each``.
+   * - D73
+     - §2.6, §2.10, §3.9
+     - A hydration seeding two edges with one ``(source-id, target-id,
+       edge-type)`` triple is ``E-LOAD-044``. This is what makes the triple a
+       key rather than a sort field, and it is the clause §2.6's total order
+       and ``edge-between``'s well-definedness were both resting on without
+       citing: the pre-existing citations covered the verb (``E-EVAL-031``)
+       and the ceiling (``E-LOAD-041``) but not hydration.
+   * - D74
+     - §2.3, §2.6, §2.8, §2.10
+     - ``E-TYPE-011`` is stated once as a class rule covering **every**
+       ``<enum-ref>`` operand position — ``NodeType`` for ``nodes``,
+       ``neighbors``' fourth operand, ``the`` and ``(domain <enum-ref>)``;
+       ``EdgeType`` for ``edges``, ``neighbors``' second operand and
+       ``edge-between``; ``HyperedgeType`` for the three hyperedge queries;
+       ``EventType`` for ``emit``. The R9 chapters added four positions and
+       the per-form phrasing had left each of them without a rejection.
+   * - D75
+     - §1.6, §2.7, §4.6
+     - Error-code hygiene, ruled once. Arity gets ``E-PARSE-042`` (with
+       ``E-PARSE-040`` as its arithmetic-specific spelling); an unrecognized
+       member of a closed terminal set gets ``E-PARSE-015``; a string literal
+       in expression position is ``E-PARSE-010``, the existing
+       atom-in-the-wrong-position code. The three ``E-PARSE-0xx`` placeholders
+       in §6.2/§6.3 are retired, and the two ``E-TYPE`` holes the chapters left
+       are closed by renumbering the offending **new** codes — a liberty that
+       exists only before an implementation pins them and is spent here.
+   * - D76
+     - §2.9, §3.7
+     - A manifest owes a ``ceiling`` row for every type the content set
+       queries, mutates or reaches with ``the``; an omission is
+       ``E-LOAD-045``. Without the row ``ceiling(query)`` is not computable,
+       ``E-LOAD-043``'s "other than 1" test cannot fire on a missing row, and
+       ``:invariant``'s check silently never runs.
+   * - D77
+     - §4.5, §6.1
+     - The fuel meter is **per firing**: each subject of a node-domain rule
+       starts a fresh meter at the declared ``:fuel``, which is the only
+       reading consistent with ``bound(rule)`` carrying no subject-count
+       factor and with load-time legality being independent of graph size. A
+       vector's ``:fuel-used`` is one firing's, reported for the first subject
+       in §4.2's order.
+   * - D78
+     - §3.8
+     - **Not ruled here.** Edge-endpoint accessors (gap item Q2) are recorded
+       as an *open* item rather than a deliberate absence: the chapter plan
+       assigned Q2 to no chapter, the ``self``-anchored
+       ``neighbors``/``edge-between`` idiom covers only one endpoint-known
+       case, and a rule iterating ``edges`` cannot name endpoints at all. The
+       two landings — a ``source-of``/``target-of`` pair in §2.10, or leaving
+       the systems on the idiom — are named and neither is specced; recorded
+       as a **port blocker** alongside D66.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -332,6 +332,10 @@ A keyword in value position is ``E-PARSE-010``.
    * - ``:type``
      - type name
      - Scalar type, on ``deffield``/``intrinsic`` forms.
+   * - ``:as``
+     - symbol
+     - Names the current element of an iterating form, so a nested body can
+       still reach it (§2.6).
    * - ``:weight``
      - expression
      - The mandatory explicit weight term of a weighted aggregation (§3.4).
@@ -490,8 +494,8 @@ further.
               | "(" "or"  <cond>+ ")"
               | "(" "not" <cond> ")"
               | "(" <cmp> <expr> <expr> ")"
-              | "(" "exists" <query> <cond>? ")"
-              | "(" "forall" <query> <cond> ")"
+              | "(" "exists" <query> <elem-name>? <cond>? ")"
+              | "(" "forall" <query> <elem-name>? <cond> ")"
 
    <cmp>    ::= "<" | "<=" | ">" | ">=" | "=" | "!="
 
@@ -659,20 +663,24 @@ construct, and nothing in it can read a value this rule wrote.
 
    <query>      ::= "(" "nodes" <enum-ref> <node-pred>? ")"
                   | "(" "edges" <enum-ref> <edge-pred>? ")"
-                  | "(" "neighbors" <expr> <enum-ref> <direction> ")"
+                  | "(" "neighbors" <expr> <enum-ref> <direction> <enum-ref> ")"
                   | "(" "hyperedges" <enum-ref> <hedge-pred>? ")"
                   | "(" "members-of" <expr> <enum-ref> ")"
                   | "(" "hyperedges-of" <expr> <enum-ref> ")"
 
+   <elem-name>  ::= ":as" <symbol>
    <direction>  ::= ":out" | ":in" | ":any"
    <node-pred>  ::= <cond>
    <edge-pred>  ::= <cond>
    <hedge-pred> ::= <cond>
 
 The ``<enum-ref>`` operand of ``nodes`` must be a ``NodeType`` member, of
-``edges``/``neighbors`` an ``EdgeType`` member, and of
+``edges`` an ``EdgeType`` member, and of
 ``hyperedges``/``members-of``/``hyperedges-of`` a ``HyperedgeType`` member
-(``E-TYPE-011``). Predicates refer to the candidate element as ``it``.
+(``E-TYPE-011``). ``neighbors`` takes two: an ``EdgeType`` for the relation
+traversed and a ``NodeType`` for the elements yielded (below). Predicates and
+bodies refer to the candidate element as ``it``, or by the ``:as`` name of
+the iterating form.
 
 Element and result types:
 
@@ -695,7 +703,8 @@ Element and result types:
    * - ``neighbors``
      - ``NodeSet``
      - ``NodeRef``
-     - Nodes reachable from the operand across that ``EdgeType``.
+     - Nodes **of the annotated** ``NodeType`` reachable from the operand
+       across that ``EdgeType`` in the given direction.
    * - ``hyperedges``
      - ``HyperedgeSet``
      - ``HyperedgeRef``
@@ -745,6 +754,65 @@ hyperedge's **declared** member order — the order ``add-hyperedge`` (§2.8) or
 scenario hydration listed them in — is never observable. A member list is a
 set, not a sequence.
 
+**[draft ruling — Phase 1 review, R9 chapter C8]** ``neighbors`` *carries its
+result* ``NodeType`` *as a mandatory fourth operand.* §2.5 permits a foreign
+node type's ``:field`` "only inside a fold body over that type", and a fold
+over ``nodes`` carries that annotation in the query's operand. ``neighbors``
+did not: it yielded an untyped ``NodeSet``, so this document never said whether
+``(fold mean (neighbors self EdgeType/TENANCY :in) social-class/consciousness
+:weight …)`` typechecks — and six systems need exactly that read. This is
+**D24's problem verbatim**, and it takes D24's fix: the type becomes an
+operand, because §3.1 gives references no static type and an annotation is the
+only thing that can supply one. With it, a fold body over ``neighbors``
+legalises the annotated type's fields exactly as a fold over ``nodes`` does,
+and a neighbour that is not of the annotated type is simply **not in the set** —
+this operand *filters*, where ``members-of``'s D24 operand *asserts*, because a
+node's edge may legitimately reach several node types while a hyperedge has one
+type.
+
+The operand is mandatory rather than optional, and that is a **breaking change
+to a form that already existed**. It is made rather than deferred because
+nothing in the estate pins the old shape: no conformance vector and no rule in
+``rust/crates/babylon-bsl/tests/conformance/`` exercises ``neighbors`` at all
+(verified 2026-08-10), so the cost of the correction is a grammar edit and no
+re-bless of an existing expectation. An optional operand would have left the
+untyped reading legal and the under-determination alive.
+
+``ceiling(neighbors)`` is correspondingly tightened in §3.7.
+
+**[draft ruling — Phase 1 review, R9 chapter C8]** ``:as`` — *naming the
+element, and what* ``it`` *actually means.* Two passages of this document
+disagreed: §2.5 declares ``it`` "reserved and always in scope, never declared
+and never shadowed (``E-PARSE-022``)", while §3.7's cost model discusses "a
+fold over members nested inside a fold over hyperedges", which needs two live
+elements at once. Four systems need a two-hop rule and none could be authored
+with confidence.
+
+The resolution is a reading, not a repeal. **``it`` always denotes the element
+of the innermost enclosing iterating form.** That is rebinding by construction
+— ``it`` is never *declared*, so there is no declaration for an inner form to
+shadow, and ``E-PARSE-022``'s prohibition (content may not declare or shadow
+``it``) is untouched and still means what it said. What was missing was a way
+to reach an *outer* element, and ``:as`` supplies it:
+
+.. code-block:: scheme
+
+   (fold sum (hyperedges HyperedgeType/ECONOMIC_SECTOR) :as sector
+         (fold sum (members-of sector HyperedgeType/ECONOMIC_SECTOR)
+               (field-of it social-class/wealth)))
+
+- A ``:as`` name is in scope for the whole body of its form, **including
+  nested bodies**, and has the query's element type.
+- Names share the rule's binding namespace: colliding with a binding or another
+  ``:as`` name is ``E-PARSE-030``, and naming ``self`` or ``it`` is
+  ``E-PARSE-022``.
+- A ``:as`` name referenced outside its body is ``E-TYPE-012``, the same code
+  and the same reason as ``it`` outside a query context.
+- Naming is optional everywhere. Single-level rules keep reading ``it``, and
+  **no existing form changes meaning** — which is the property that made
+  naming the safer of the two candidate resolutions, against rebinding rules
+  that would have had to carve an exception into ``E-PARSE-022``.
+
 2.7 Expressions, intrinsics, folds, guards
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -761,11 +829,12 @@ set, not a sequence.
    <arith>     ::= "+" | "-" | "*" | "/"
    <literal>   ::= <int-lit> | <scaled-lit> | <bool-lit>
 
-   <fold>      ::= "(" "fold" <fold-op> <query> <expr> ( ":weight" <expr> )? ")"
+   <fold>      ::= "(" "fold" <fold-op> <query> <elem-name>?
+                       <expr> ( ":weight" <expr> )? ")"
    <fold-op>   ::= "sum" | "mean" | "min" | "max" | "count"
 
-   <selection> ::= "(" "select-max" <query> <expr> ")"
-                 | "(" "select-min" <query> <expr> ")"
+   <selection> ::= "(" "select-max" <query> <elem-name>? <expr> ")"
+                 | "(" "select-min" <query> <elem-name>? <expr> ")"
 
 Arithmetic is strictly binary; ``(+ a b c)`` is ``E-PARSE-040``. This keeps
 the reduction order explicit in the source rather than implied by a
@@ -857,7 +926,7 @@ the static bound of §3.7 is computable.
 
    <effect-item> ::= <verb>
                    | "(" "guard"    <cond>  <effect-item>+ ")"
-                   | "(" "for-each" <query> <effect-item>+ ")"
+                   | "(" "for-each" <query> <elem-name>? <effect-item>+ ")"
 
    <verb> ::= "(" "update-node"  <expr> <qname> <update-op> ")"
             | "(" "update-edge"  <expr> <qname> <update-op> ")"
@@ -1535,6 +1604,8 @@ and are **pinned by conformance vector; revising them is a vector re-bless**
                                 = 2 + cost(query)
                                     + ceiling(query) × Σ cost(effect-items)
    cost(:expr binding)          = cost(expr)             ; §2.5, R9 C7
+   cost(:as name)               = 0                      ; §2.6, R9 C8
+                                                         ; a reference costs 1
    bound(rule)                  = Σ cost(:expr bindings)
                                     + cost(cond of <when>)
                                     + Σ cost(effect-items)
@@ -1560,9 +1631,12 @@ the row as ``1 + Σ cost(children)``: identical for the predicate queries
 operand where one exists.
 
 ``ceiling(query)`` is the manifest ceiling of the queried type; for
-``neighbors`` it is the ceiling of the queried edge type
-**[draft ruling — Phase 1 review]** (a per-node degree ceiling would be
-tighter and is a Phase-1 review item). For the three hyperedge queries
+``neighbors`` it is **[draft ruling — Phase 1 review, revised by R9 chapter
+C8]** the *lesser* of the queried edge type's ceiling and the annotated result
+node type's ceiling — neither bound can be exceeded, so the smaller is the
+honest one, and the annotation C8 makes mandatory is what makes the second
+number available. (A per-node degree ceiling would be tighter still and remains
+the Phase-1 review item D15 recorded.) For the three hyperedge queries
 **[draft ruling — Phase 1 review]**: ``hyperedges`` uses the hyperedge type's
 ``:ceiling``; ``members-of`` uses that type's ``:max-members``; and
 ``hyperedges-of`` uses the type's ``:ceiling`` — a per-node *incidence-degree*
@@ -2198,6 +2272,16 @@ At minimum, an implementation claiming conformance passes:
     node type's ``:field`` referenced from a ``:expr`` (``E-TYPE-010``); and a
     ``:expr`` whose kind is intensive feeding an unweighted ``mean``
     (``E-TYPE-042``), proving kind propagates through the binding.
+17. **Typed neighbours and element naming** (chapter C8) — the first
+    ``neighbors`` vectors this document has ever required: a fold over
+    ``neighbors`` reading the annotated type's field (which must typecheck), a
+    graph whose traversal reaches two node types proving the operand *filters*,
+    a three-operand ``neighbors`` (``E-PARSE-0xx`` — arity), and a static bound
+    equal to the **lesser** of the two ceilings; and for ``:as``, a two-hop
+    nested fold naming the outer element, ``it`` inside the inner body
+    resolving to the *inner* element, a ``:as`` name referenced outside its
+    body (``E-TYPE-012``), ``:as it`` and ``:as self`` (``E-PARSE-022``), and a
+    ``:as`` colliding with a binding name (``E-PARSE-030``).
 
 Families 10 and up are the R9 spec chapters' (the chapter letters cite
 ``reports/bsl-gap-analysis-2026-08-10.md`` §7). Two obligations are stated
@@ -2564,6 +2648,30 @@ consequences are the ordinary kind of review item.
        ``bound(rule)`` gains ``Σ cost(:expr bindings)``. A computed binding
        cannot observe the rule's own effects — it is an abbreviation, not a
        sequencing construct.
+   * - D51
+     - §2.6
+     - ``neighbors`` takes a mandatory result-``NodeType`` operand — D24's fix
+       applied to D24's problem. It **filters** (a node may reach several
+       types) where D24's operand **asserts**. Breaking, and made anyway
+       because no conformance vector exercises ``neighbors``.
+   * - D52
+     - §3.7
+     - ``ceiling(neighbors)`` is the lesser of the edge-type and
+       result-node-type ceilings, revising D15's edge-type-only reading; the
+       per-node degree ceiling stays deferred.
+   * - D53
+     - §2.5, §2.6
+     - ``it`` denotes the element of the **innermost** enclosing iterating
+       form. This is rebinding by construction, not shadowing of a
+       declaration, so ``E-PARSE-022`` is untouched — the §2.5/§3.7 tension is
+       resolved by reading rather than by repeal.
+   * - D54
+     - §2.6
+     - ``:as`` optionally names an iterating form's element, in scope through
+       nested bodies, sharing the rule's binding namespace
+       (``E-PARSE-030``/``E-PARSE-022``) and ``E-TYPE-012`` outside its body.
+       Naming was chosen over rebinding rules because it changes the meaning
+       of no existing form.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -355,6 +355,9 @@ A keyword in value position is ``E-PARSE-010``.
    * - ``:params`` / ``:returns`` / ``:cost``
      - see §2.7
      - Intrinsic declaration fields.
+   * - ``:provider``
+     - symbol
+     - The kernel service a ``metric`` declaration binds to (§2.11).
    * - ``:ceiling``
      - integer
      - Declared cardinality ceiling, on ``manifest`` forms (§3.7).
@@ -394,6 +397,7 @@ classes from §1 appear as ``<symbol>``, ``<qname>``, ``<keyword>``,
 
    <file>        ::= <top-form>*
    <top-form>    ::= <rule> | <deffield> | <intrinsic-decl> | <manifest>
+                   | <metric-decl>
 
 A content set is the union of all files under the declared content roots. File
 boundaries and file names carry **no semantics**: the same forms split across
@@ -580,8 +584,10 @@ opt-in to absence is content, not a test list.
 name's first segment names a different node type, in which case it is only
 legal inside a fold body over that type (``E-TYPE-010``). ``:const`` reads a
 coefficient from the defines environment. ``:metric`` reads a registered
-graph-level metric; an unregistered metric name is ``E-LOAD-011`` — never
-``0.0`` (§6.3). ``:tick`` binds the current tick as ``Int``.
+metric whose declared domain is ``:graph`` (§2.11); an unregistered metric name
+is ``E-LOAD-011`` — never ``0.0`` (§6.3) — and an element-indexed metric read
+through a ``:metric`` binding is ``E-LOAD-012``, since its value depends on an
+element a binding does not name. ``:tick`` binds the current tick as ``Int``.
 
 **[draft ruling — Phase 1 review, R9 chapter C1]** *A* ``:field`` *binding is
 node-scoped, and stays node-scoped.* An edge's or a hyperedge's declared field
@@ -1199,6 +1205,7 @@ here.
    <accessor> ::= "(" "field-of"     <expr> <qname> ")"
                 | "(" "edge-between" <enum-ref> <expr> <expr> ")"
                 | "(" "the"          <enum-ref> ")"
+                | "(" "metric-of"    <expr> <symbol> ")"
 
 .. list-table::
    :header-rows: 1
@@ -1221,6 +1228,10 @@ here.
      - The unique node of a ``NodeType`` whose manifest ``:ceiling`` is 1.
        A ceiling other than 1 is ``E-LOAD-043``; a graph holding no such node
        is ``E-EVAL-035``.
+   * - ``metric-of``
+     - the metric's declared type
+     - A registered **element-indexed** metric, evaluated at the element the
+       ``<expr>`` denotes (§2.11).
 
 **The shared discipline.**
 
@@ -1292,6 +1303,95 @@ scenario forgot to hydrate fails loudly rather than reading as zero.
 
    (update-node (the NodeType/POLITY)
                 polity/imperial-rent-pool (sub drawn))
+
+2.11 Metric registration
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+§2.5 said ``:metric`` "reads a registered graph-level metric" and stopped
+there. It never said who may register one, what determinism obligations a
+registration carries, whether a Rust domain crate's per-tick output qualifies,
+or whether a metric may be **indexed by element**. The last question is the one
+that blocks work: every topological score the OODA seam needs — degree and
+betweenness centrality, articulation-point cutsets, isolation — is per-node,
+and a graph-scope scalar cannot carry any of them to content.
+
+.. code-block:: text
+
+   <metric-decl> ::= "(" "metric" <symbol>
+                         ":type" <type-name>
+                         ":kind" ( "intensive" | "extensive" )
+                         <domain>
+                         ":provider" <symbol>
+                     ")"
+
+``<domain>`` is §2.3's production, reused unchanged: ``(domain :graph)``
+declares a graph-scope metric read by a ``:metric`` binding, and ``(domain
+NodeType/ORGANIZATION)`` declares an element-indexed metric read by
+``metric-of``.
+
+.. code-block:: scheme
+
+   (metric betweenness-centrality
+     :type Coefficient :kind intensive
+     (domain NodeType/ORGANIZATION)
+     :provider topology-scores)
+
+   (binding centrality :expr (metric-of self betweenness-centrality))
+
+**[draft ruling — Phase 1 review, R9 chapter C9]** *A* ``metric`` *form
+declares, it does not define* — exactly as ``intrinsic`` does, and for exactly
+the reason D9 gives for ``deffield``: the typechecker and the fuel-bound
+checker must be computable from **content alone** for this document to satisfy
+III.12(a), and a metric whose type, kind and domain lived only in a Rust
+registration would make a second implementation underivable from the spec. The
+kernel provides the value; the declaration is checked against the kernel's
+registration and a disagreement is ``E-LOAD-025``. An unregistered metric name
+remains ``E-LOAD-011`` — never ``0.0``, which is one of §6.3's four corrected
+silent degradations.
+
+**Reading a metric through the wrong form for its declared domain is
+``E-LOAD-012``** — a graph metric via ``metric-of``, or an element-indexed
+metric via a ``:metric`` binding. Both are static: the declaration and the
+reading form are both content. At evaluation, a ``metric-of`` whose referent is
+not of the declared domain type is ``E-EVAL-036``, and a metric the provider
+produced no value for is ``E-EVAL-037`` — the same discipline as §2.10's
+accessors, and for the same reason: absence is never a zero.
+
+**Determinism obligations a registration carries.** These are the substance of
+the contract, and they are obligations on the *provider*, enforced by review
+and by the determinism contract's golden vectors rather than by the
+typechecker:
+
+1. A metric is a **pure function of the graph pre-state at the anchor position
+   at which it is read**. Not of wall clock, not of RNG, not of I/O, and not of
+   any rule's effects within the position.
+2. Its value is **stable across every read at one position**. Whether a
+   provider recomputes between positions is its own business; what it may not
+   do is return two values to two rules at one position.
+3. Its arithmetic obeys §4.3 — IEEE-754 basic operations, correctly rounded,
+   no FMA contraction, no transcendental that is not a pinned intrinsic. A
+   provider that cannot meet that bit-exactly must either declare an ``Int``
+   ordinal (which is exact) or carry golden vectors with a **written tolerance
+   derivation** in :doc:`/reference/determinism-contract`.
+4. **A Rust domain crate's per-tick output qualifies as a provider** only if
+   the crate is inside that document's pinned-toolchain set and carries those
+   vectors. This is the answer to the question three surveys asked
+   independently: the seam is legitimate, and it is not free.
+
+**What enters which hash.** A metric's *name, type, kind and domain* are
+content: they are ``metric`` forms, hashed into their own digest exactly as
+``deffield``/``intrinsic``/``manifest`` are (§5.5). A metric's *value* is
+runtime and appears in **no** content hash — it enters the tick hash only
+through the fields rules write from it. An implementation that hashed metric
+values directly would be hashing the provider's schedule rather than the
+game's state.
+
+**Fuel.** The provider's computation is **not** metered against the reading
+rule: a rule cannot bound a betweenness computation, and pretending otherwise
+would put a number in ``:fuel`` that means nothing. The *read* costs
+``1 + cost(operand)`` (§3.7), the same as any other accessor. The kernel's own
+budget for provider work lives in the determinism contract, which is where the
+cost honestly went — this document declines to hide it in a rule's meter.
 
 3. Static semantics
 ---------------------
@@ -1424,9 +1524,12 @@ which that is decidable. Kind propagates through expressions:
   ``deffield``'s declared kind, whether the owning type is a node type, an
   ``EdgeType`` or a ``HyperedgeType`` — the kind rule does not care which, and
   the implicit ``<edge-type>/strength`` field is ``extensive`` (§2.9);
-  ``:const`` and ``:metric`` bindings are kind-neutral
-  **[draft ruling — Phase 1 review]** (a coefficient has no extent; a graph
-  metric's kind is declared on the metric registration, §2.11);
+  a ``:const`` binding is kind-neutral **[draft ruling — Phase 1 review]** (a
+  coefficient has no extent); a ``:metric`` binding and a ``metric-of``
+  accessor carry the **declared** ``:kind`` of their §2.11 registration
+  **[draft ruling — Phase 1 review, R9 chapter C9]**, which supersedes the
+  metric half of D12 — the earlier revision made them kind-neutral only
+  because there was nowhere to declare a kind, and §2.11 is that place;
 - ``+``/``-`` require both operands to have the same kind, or one to be
   kind-neutral; the result carries the non-neutral kind. Mixing intensive with
   extensive is ``E-TYPE-040``;
@@ -1596,6 +1699,9 @@ and are **pinned by conformance vector; revising them is a vector re-bless**
    cost(field-of)               = 1 + cost(element expr) ; §2.10, R9 C1
    cost(edge-between)           = 1 + Σ cost(operands)   ; §2.10, R9 C2
    cost(the)                    = 1                      ; §2.10, R9 C3
+   cost(metric-of)              = 1 + cost(element expr) ; §2.10, R9 C9
+                                                         ; provider work is
+                                                         ; not rule-metered
    cost(domain)                 = 0                      ; §2.3, R9 C4
    cost(select-max | select-min)                         ; §2.7, R9 C5
                                 = 2 + cost(query)
@@ -1948,7 +2054,8 @@ AST — a property implementations should exercise as a round-trip property test
 ``>``, ``>=``, ``=``, ``!=``, ``+``, ``-``, ``*``, ``/``, ``if``, ``fold``,
 ``exists``, ``forall``, ``nodes``, ``edges``, ``neighbors``, ``hyperedges``,
 ``members-of``, ``hyperedges-of``, ``field-of``, ``edge-between``, ``the``,
-``domain``, ``select-max``, ``select-min``, ``guard``, ``for-each``,
+``domain``, ``select-max``, ``select-min``, ``metric``, ``metric-of``,
+``guard``, ``for-each``,
 ``update-node``, ``update-edge``,
 ``add-node``, ``remove-node``, ``add-edge``, ``remove-edge``,
 ``add-hyperedge``, ``remove-hyperedge``, ``members``,
@@ -2034,8 +2141,8 @@ digests are unaffected. Its own children follow the general rule: an
 
 where ``r_1 … r_N`` are all ``rule`` forms in the content set sorted by rule id
 in ascending ASCII byte order, and ``N`` is their count. ``deffield``,
-``intrinsic`` and ``manifest`` forms are hashed the same way into their own
-digests, which ``ContentDigest`` combines
+``intrinsic``, ``manifest`` and ``metric`` forms are hashed the same way into
+their own digests, which ``ContentDigest`` combines
 (:doc:`/reference/determinism-contract`). The digest is rendered as **64
 lowercase hex characters** — never truncated. (Truncation to 16 hex is exactly
 the defect the ``defines_hash`` triad carried; see the determinism contract's
@@ -2282,6 +2389,18 @@ At minimum, an implementation claiming conformance passes:
     resolving to the *inner* element, a ``:as`` name referenced outside its
     body (``E-TYPE-012``), ``:as it`` and ``:as self`` (``E-PARSE-022``), and a
     ``:as`` colliding with a binding name (``E-PARSE-030``).
+18. **Metric registration** (chapter C9) — a graph-domain ``metric`` read by a
+    ``:metric`` binding and an element-indexed one read by ``metric-of``; each
+    read through the other's form (``E-LOAD-012``); a declaration disagreeing
+    with the kernel's registration (``E-LOAD-025``); an unregistered name
+    (``E-LOAD-011``, the §6.3 correction, re-proved for both forms); a
+    ``metric-of`` against a referent of another type (``E-EVAL-036``) and one
+    the provider produced no value for (``E-EVAL-037``); a **stability
+    vector** — two rules at one anchor position reading one metric, whose
+    expected values must be equal; a metric declared ``:kind intensive``
+    feeding an unweighted ``mean`` (``E-TYPE-042``), proving the declared kind
+    propagates; and a ``:cas`` vector for the ``metric`` form under both
+    ``<domain>`` shapes.
 
 Families 10 and up are the R9 spec chapters' (the chapter letters cite
 ``reports/bsl-gap-analysis-2026-08-10.md`` §7). Two obligations are stated
@@ -2672,6 +2791,28 @@ consequences are the ordinary kind of review item.
        (``E-PARSE-030``/``E-PARSE-022``) and ``E-TYPE-012`` outside its body.
        Naming was chosen over rebinding rules because it changes the meaning
        of no existing form.
+   * - D55
+     - §2.11
+     - A ``metric`` form declares what the kernel provides — type, kind,
+       domain, provider — so the typechecker and fuel checker stay derivable
+       from content (D9's rationale). Kernel disagreement is ``E-LOAD-025``.
+       Supersedes D12's clause making ``:metric`` bindings kind-neutral: they
+       now carry the declared kind.
+   * - D56
+     - §2.10, §2.11
+     - Element-indexed metrics are read by the ``metric-of`` **accessor**, not
+       by a ``:metric-of`` bind-src. **Divergence recorded:** the R9 gap
+       analysis §3 (B4) sketched the bind-src; a bind-src encodes as a
+       two-child ``opt`` under D20 and this one needs two operands, so it
+       would have been the only bind-src of its shape. Wrong-form reads are
+       ``E-LOAD-012``; runtime failures are ``E-EVAL-036``/``E-EVAL-037``.
+   * - D57
+     - §2.11
+     - Provider work is **not** metered against the reading rule (the read
+       costs 1 + operand); metric *values* enter no content hash and reach the
+       tick hash only through the fields rules write from them; a Rust domain
+       crate qualifies as a provider only inside the determinism contract's
+       pinned toolchain and with golden vectors.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -705,9 +705,11 @@ from inside a rule. Totality is therefore syntactic, and the static bound of
    <effect-item> ::= <verb> | "(" "guard" <cond> <effect-item>+ ")"
 
    <verb> ::= "(" "update-node"  <expr> <qname> <update-op> ")"
+            | "(" "update-edge"  <expr> <qname> <update-op> ")"
             | "(" "add-node"     <enum-ref> <expr> <field-init>* ")"
             | "(" "remove-node"  <expr> ")"
-            | "(" "add-edge"     <enum-ref> <expr> <expr> ":strength" <expr> ")"
+            | "(" "add-edge"     <enum-ref> <expr> <expr> ":strength" <expr>
+                                 <field-init>* ")"
             | "(" "remove-edge"  <enum-ref> <expr> <expr> ")"
             | "(" "add-hyperedge"    <enum-ref> <expr> <members> <field-init>* ")"
             | "(" "remove-hyperedge" <expr> ")"
@@ -723,11 +725,57 @@ from inside a rule. Totality is therefore syntactic, and the static bound of
 
 The four ``<update-op>`` forms are exactly today's four-operation effect enum
 — ``add`` = ``increase``, ``sub`` = ``decrease``, ``set`` = ``set``,
-``scale`` = ``multiply``. Of the seven structural verbs, **five** are the
+``scale`` = ``multiply``. Of the **eight** structural verbs, **five** are the
 addition the design document's §6.4 audit found necessary (20 of 39 system
-modules mutate graph structure) and **two** — ``add-hyperedge`` and
-``remove-hyperedge`` — are what the Amendment D ruling adds: if a hyperedge is
-a first-class object, minting and retiring one is a first-class verb.
+modules mutate graph structure); **two** — ``add-hyperedge`` and
+``remove-hyperedge`` — are what the Amendment D ruling adds, since if a
+hyperedge is a first-class object, minting and retiring one is a first-class
+verb; and **one** — ``update-edge`` — is what R9 chapter C2 adds, below.
+
+**[draft ruling — Phase 1 review, R9 chapter C2]** ``update-edge``, *and why
+the dyadic layer differs from D26.* Eight systems overwrite a standing edge's
+attributes (R9 gap analysis §2, Q3): ``value_flow`` on four edge types,
+SOLIDARITY decay, MEMBERSHIP accrual, ``field_gradients``, the EdgeTransition
+mode fields. Before this chapter nothing in the verb set could, and the
+question that had to be answered first is whether D26's refusal to mutate a
+hyperedge in place carries over. **It does not.** D26's stated rationale is
+that a partially-mutated *member list* must be unrepresentable, so membership
+changes go through whole-object replacement and the member-count check stays at
+a single point. A dyadic edge has no member list; there is no partial state for
+in-place mutation to leave behind, and the ``:max-members`` check it protects
+does not exist on the dyadic layer. The rationale is therefore specific to the
+construct it was written about, and re-using it here would be an argument from
+symmetry rather than from the reason. (C12 revisits the *other* half of D26 —
+mutation of a hyperedge's own declared fields — on exactly this reasoning.)
+
+**[draft ruling — Phase 1 review, R9 chapter C2]** ``update-edge`` *takes an*
+``EdgeRef``, *not a type-and-endpoints triple.* It mirrors ``update-node``
+operand for operand — element, field qname, update-op — because the effect
+positions that will supply it are ``it`` inside a ``for-each`` over ``edges``
+(§2.8, chapter C6) and the result of ``select-max`` (§2.7, chapter C5), both of
+which yield refs. Giving the verb a second arity taking ``<enum-ref> <expr>
+<expr>`` would have made it the grammar's only overloaded head — the exact
+objection D26 raises against an overloaded ``add-edge``. Rules that hold the
+endpoints instead of the ref reach the edge through §2.10's ``edge-between``
+accessor, which is one form used in expression position rather than a second
+shape of a verb. The R9 gap analysis §2 (Q3) sketched the triple form; D36
+records the divergence.
+
+A ``<qname>`` whose owning type (§2.9) is not the element type the verb's
+``<enum-ref>`` names is ``E-TYPE-014`` — a **static** check on ``add-node``,
+``add-edge`` and ``add-hyperedge``, whose element type is an operand. On
+``update-node``/``update-edge`` the element is a reference, which §3.1 gives no
+static type, so the same disagreement surfaces at evaluation as ``E-EVAL-033``
+(§2.10). A ``<field-init>`` on ``add-edge`` naming the implicit
+``<edge-type>/strength`` field is ``E-PARSE-041``: the ``:strength`` operand is
+that field's only writer at mint time, and two writers for one field in one
+form is an authoring bug rather than a precedence question.
+
+``update-edge`` inherits the structural-verb discipline unchanged: it obeys the
+I.15 edge-mode state machine, so a write that would take an edge to a mode the
+machine does not admit from its current one is ``E-EVAL-030``, and a store
+outside the target field's declared range is ``E-EVAL-020`` (§3.3) — never a
+clamp, never a silent no-op.
 
 ``add-hyperedge``'s ``<enum-ref>`` is a ``HyperedgeType`` member, its ``<expr>``
 is the new hyperedge's id (as ``add-node``'s is a node id), and ``<members>``
@@ -875,7 +923,8 @@ here.
 
 .. code-block:: text
 
-   <accessor> ::= "(" "field-of" <expr> <qname> ")"
+   <accessor> ::= "(" "field-of"     <expr> <qname> ")"
+                | "(" "edge-between" <enum-ref> <expr> <expr> ")"
 
 .. list-table::
    :header-rows: 1
@@ -889,6 +938,10 @@ here.
      - A declared field of the node, edge or hyperedge the ``<expr>``
        denotes. The ``<qname>``'s first segment names the owning type
        (§2.9).
+   * - ``edge-between``
+     - ``EdgeRef``
+     - The edge of the given ``EdgeType`` from the first node operand to the
+       second. Absence is ``E-EVAL-034``.
 
 **The shared discipline.**
 
@@ -925,6 +978,23 @@ both accessors read the edge under the fold. The ``:weight`` is mandatory here
 because ``exploitation/tension`` would be declared ``:kind intensive`` — §3.4's
 rule is untouched by this chapter and applies to edge fields exactly as it
 applies to node fields.
+
+**[draft ruling — Phase 1 review, R9 chapter C2]** ``edge-between`` *is
+well-defined because the triple is a key.* §2.6 fixes the edge iteration order
+at ascending ``(source-id, target-id, edge-type)`` lexicographic byte order —
+which is a *total* order only if no two edges share that triple, and §2.8
+already makes "adding an edge that already exists" ``E-EVAL-031`` and a
+ceiling-violating hydration ``E-LOAD-041``. Parallel edges of one type between
+one ordered pair are therefore not representable, and "the edge between a and
+b of type T" denotes at most one element. When it denotes none, that is
+``E-EVAL-034`` — the accessor never yields an absent reference and never
+degrades to a no-op write, which is what would happen if ``update-edge`` had
+been given endpoint operands and left to skip quietly.
+
+.. code-block:: scheme
+
+   (update-edge (edge-between EdgeType/SOLIDARITY self other)
+                solidarity/strength (scale 0.95c))
 
 3. Static semantics
 ---------------------
@@ -1187,7 +1257,18 @@ and are **pinned by conformance vector; revising them is a vector re-bless**
    cost(guard)                  = 1 + cost(cond) + Σ cost(effect-items)
    cost(field path | enum-ref)  = 0                      ; static, like a literal
    cost(field-of)               = 1 + cost(element expr) ; §2.10, R9 C1
+   cost(edge-between)           = 1 + Σ cost(operands)   ; §2.10, R9 C2
    bound(rule)                  = cost(cond of <when>) + Σ cost(effect-items)
+
+**[draft ruling — Phase 1 review, R9 chapters C1–C2]** *Accessors are keyed
+lookups, not iterations.* Every §2.10 accessor charges a variable-reference
+base of 1 plus its operands and is **never multiplied by a ceiling**, because
+none of them ranges over a set: ``field-of`` reads one element's one field, and
+``edge-between`` resolves one ``(source, target, type)`` key. The static bound
+of a rule using them is therefore the same shape as before — the accessors add
+constants, and only the iteration constructs (``fold``, ``exists``/``forall``,
+and the chapter-C5/C6 forms) carry ceiling factors. That is what keeps the
+Power-of-10 Rule 2 claim static as the accessor set grows.
 
 **[draft ruling — Phase 1 review]** *Query operand charging* (implementation-
 discovered, 2026-07-30, Phase 1 Task 13). The ``cost(query)`` row names only
@@ -1454,8 +1535,9 @@ AST — a property implementations should exercise as a round-trip property test
 ``binding``, ``when``, ``effects``, ``and``, ``or``, ``not``, ``<``, ``<=``,
 ``>``, ``>=``, ``=``, ``!=``, ``+``, ``-``, ``*``, ``/``, ``if``, ``fold``,
 ``exists``, ``forall``, ``nodes``, ``edges``, ``neighbors``, ``hyperedges``,
-``members-of``, ``hyperedges-of``, ``field-of``, ``guard``,
-``update-node``, ``add-node``, ``remove-node``, ``add-edge``, ``remove-edge``,
+``members-of``, ``hyperedges-of``, ``field-of``, ``edge-between``, ``guard``,
+``update-node``, ``update-edge``,
+``add-node``, ``remove-node``, ``add-edge``, ``remove-edge``,
 ``add-hyperedge``, ``remove-hyperedge``, ``members``,
 ``emit``, ``add``, ``sub``, ``set``, ``scale``, ``anchor``, ``deffield``,
 ``intrinsic``, ``manifest``, ``ceiling``), plus the synthetic tag ``opt`` for a
@@ -1717,6 +1799,15 @@ At minimum, an implementation claiming conformance passes:
     ``:field`` reference under two same-type bodies (``E-TYPE-013``); and an
     ``intrinsic`` declared with a reserved form-head name
     (``E-LOAD-024``).
+11. **Edge mutation** (chapter C2) — ``update-edge`` under each of the four
+    ``<update-op>`` forms, against ``<edge-type>/strength`` and against a
+    ``deffield``-declared edge field; the same write reaching a range boundary
+    (``E-EVAL-020``) and an I.15-illegal mode transition (``E-EVAL-030``);
+    ``edge-between`` resolving, and failing to resolve (``E-EVAL-034``);
+    ``add-edge`` carrying ``<field-init>``\ s, one of them naming ``strength``
+    (``E-PARSE-041``) and one owning off the wrong type (``E-TYPE-014``); and
+    an ``update-edge`` whose referent is of another edge type
+    (``E-EVAL-033``).
 
 Families 10 and up are the R9 spec chapters' (the chapter letters cite
 ``reports/bsl-gap-analysis-2026-08-10.md`` §7). Two obligations are stated
@@ -1993,6 +2084,29 @@ consequences are the ordinary kind of review item.
        another type, or a field the element carries no value for, is
        ``E-EVAL-033``. ``:optional``/``:default`` are binding options and
        never apply to an accessor.
+   * - D35
+     - §2.8
+     - ``update-edge`` exists. D26's whole-object discipline is specific to the
+       member list it protects and does **not** carry to the dyadic layer,
+       which has no partial state to leave behind.
+   * - D36
+     - §2.8, §2.10
+     - ``update-edge`` takes an ``EdgeRef`` and has one shape, not two;
+       endpoint-holding rules reach the edge through ``edge-between``, whose
+       well-definedness follows from §2.6's ``(source, target, type)`` order
+       key. Absence is ``E-EVAL-034``. **Divergence recorded:** the R9 gap
+       analysis §2 (Q3) sketched a type-and-endpoints verb.
+   * - D37
+     - §2.8
+     - ``add-edge`` carries ``<field-init>*``; a ``<field-init>`` naming the
+       implicit ``strength`` field is ``E-PARSE-041``, and one whose owning
+       type is not the verb's ``<enum-ref>`` type is ``E-TYPE-014``
+       (statically on the minting verbs, ``E-EVAL-033`` on the updating ones).
+   * - D38
+     - §3.7
+     - Accessors are keyed lookups charged at 1 + operands and never
+       multiplied by a ceiling, so only iteration constructs carry ceiling
+       factors in the static bound.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -311,6 +311,10 @@ A keyword in value position is ``E-PARSE-010``.
    * - ``:metric``
      - symbol
      - Binding source: read a named graph-level metric (§2.5).
+   * - ``:expr``
+     - expression
+     - Binding source: a computed value, a pure function of the bindings
+       declared before it (§2.5).
    * - ``:optional``
      - *flag*
      - Marks a binding permitted to be absent at evaluation. Requires
@@ -560,6 +564,7 @@ the form.
                  | ":const"  <qname>
                  | ":metric" <symbol>
                  | ":tick"
+                 | ":expr"   <expr>
 
    <bind-opt>  ::= ":optional" | ":default" <literal>
 
@@ -602,6 +607,50 @@ ranges over). ``it`` outside a query context is ``E-TYPE-012``.
 
 Binding names are otherwise rule-scoped; a duplicate name in one rule is
 ``E-PARSE-030``.
+
+**[draft ruling — Phase 1 review, R9 chapter C7]** ``:expr`` — *a rule may name
+an intermediate value.* Every other ``<bind-src>`` names an **external**
+source, so before this chapter a rule could not name anything it computed
+itself, and every non-trivial rule repeated its sub-expressions verbatim. That
+costs three things at once: fuel (a repeated fold is charged at its ceiling
+every time it is written), correctness (a transcription that must restate the
+same algebra in four places will eventually restate it differently in one), and
+reviewability — and the third is the one that matters most here, because the
+standing no-imposed-functional-forms line can only be enforced against algebra
+a reviewer can read.
+
+.. code-block:: scheme
+
+   (bindings
+     (binding wealth      :field social-class/wealth)
+     (binding subsistence :const vitality/subsistence-cost)
+     (binding drained     :expr (- wealth subsistence)))
+
+- *Type and kind* come from the expression, computed bottom-up like any other
+  (§3.1, §3.4). There is no annotation and no inference beyond that.
+- *Resolution is in declaration order.* A ``:expr`` may reference bindings
+  declared **before** it and no others; a forward reference or a self-reference
+  is ``E-PARSE-032``. Order therefore matters inside ``<bindings>``, which is
+  the one place in this document where a list's order carries meaning and is
+  not a formatting concern — §5.3's group 3 already emits it in source order,
+  so CAS needs no change.
+- *No cycles are expressible*, by construction: the forward-reference ban makes
+  the dependency graph a DAG in source order, so nothing needs a cycle
+  analysis.
+- *A* ``:expr`` *is evaluated at rule scope*, so ``it`` is ``E-TYPE-012``
+  inside one, and referencing a foreign-node-type ``:field`` binding — legal
+  only inside a fold body over that type — is ``E-TYPE-010``. A ``:expr``
+  **may** contain a fold, a selection or an accessor of its own; that is the
+  fuel win, since the ceiling factor is then paid once.
+- ``:optional`` *and* ``:default`` *are illegal on a* ``:expr`` (``E-PARSE-033``).
+  A computed value is never absent: its operands were resolved at load or the
+  rule did not load, and §3.5's whole point is that absence is opted into at
+  the external source rather than inherited by everything downstream.
+
+Critically, ``:expr`` does **not** weaken §4.2's law that a rule never observes
+its own effects. A computed binding is a pure function of pre-state bindings,
+evaluated before any effect applies — it is an abbreviation, not a sequencing
+construct, and nothing in it can read a value this rule wrote.
 
 2.6 Queries
 ~~~~~~~~~~~~~
@@ -1485,7 +1534,10 @@ and are **pinned by conformance vector; revising them is a vector re-bless**
    cost(for-each)                                        ; §2.8, R9 C6
                                 = 2 + cost(query)
                                     + ceiling(query) × Σ cost(effect-items)
-   bound(rule)                  = cost(cond of <when>) + Σ cost(effect-items)
+   cost(:expr binding)          = cost(expr)             ; §2.5, R9 C7
+   bound(rule)                  = Σ cost(:expr bindings)
+                                    + cost(cond of <when>)
+                                    + Σ cost(effect-items)
 
 **[draft ruling — Phase 1 review, R9 chapters C1–C2]** *Accessors are keyed
 lookups, not iterations.* Every §2.10 accessor charges a variable-reference
@@ -1560,8 +1612,10 @@ pair (§6.1).
 
 A rule evaluates against: the graph (read-only during condition evaluation),
 the defines environment (coefficients), the current tick, the subject node, and
-the fuel meter. Effects are applied only after the whole condition has been
-evaluated. **A rule can never observe its own effects**, and rules within one
+the fuel meter. Bindings resolve first, in declaration order — the external
+sources by lookup, the ``:expr`` bindings (§2.5) by evaluation against the
+bindings already resolved. Effects are applied only after the whole condition
+has been evaluated. **A rule can never observe its own effects**, and rules within one
 system position observe the same pre-state.
 
 Rules at the same anchor position evaluate in **ascending rule-id byte order**
@@ -1625,9 +1679,14 @@ Each AST node charges its **base** cost when it is evaluated — the same base
 numbers §3.7 uses to compute the static bound, without the ceiling
 multiplication (the multiplication is the static worst case; at runtime each
 actual iteration charges the body's cost once). The meter starts at the rule's
-declared ``:fuel`` and decrements. Reaching or passing zero is ``E-EVAL-040``,
-which aborts the tick (§4.6) — it never truncates a fold or returns a partial
-result.
+declared ``:fuel`` and decrements. A ``:expr`` binding charges its expression
+**once**, when the binding resolves; each later *reference* to it charges a
+variable-reference 1 like a reference to any other binding. That asymmetry is
+the whole of the fuel win C7 buys, and it is why the same algebra written twice
+inline costs strictly more than the same algebra named once.
+
+Reaching or passing zero is ``E-EVAL-040``, which aborts the tick (§4.6) — it
+never truncates a fold or returns a partial result.
 
 The cost table is **pinned by conformance vector; any revision is a vector
 re-bless** (design §5 Totality). This is what makes fuel a stable, hashable
@@ -2130,6 +2189,15 @@ At minimum, an implementation claiming conformance passes:
     over an empty query, which applies nothing and **must not** error; and a
     ``for-each`` whose ``:fuel`` is one short of its static bound
     (``E-LOAD-040``).
+16. **Computed bindings** (chapter C7) — a ``:expr`` over earlier bindings,
+    with ``:fuel-used`` proving the expression is charged once and each
+    reference 1; the same rule written with the algebra inlined twice, whose
+    ``:fuel-used`` must be strictly larger; a forward reference and a
+    self-reference (``E-PARSE-032``); ``:optional`` on a ``:expr``
+    (``E-PARSE-033``); ``it`` inside a ``:expr`` (``E-TYPE-012``); a foreign
+    node type's ``:field`` referenced from a ``:expr`` (``E-TYPE-010``); and a
+    ``:expr`` whose kind is intensive feeding an unweighted ``mean``
+    (``E-TYPE-042``), proving kind propagates through the binding.
 
 Families 10 and up are the R9 spec chapters' (the chapter letters cite
 ``reports/bsl-gap-analysis-2026-08-10.md`` §7). Two obligations are stated
@@ -2485,6 +2553,17 @@ consequences are the ordinary kind of review item.
        the presence of iteration. Application order is element order (outer)
        then source order (inner), and an empty ``for-each`` query applies
        nothing rather than erroring.
+   * - D49
+     - §2.5
+     - ``:expr`` computed bindings, resolved in declaration order; forward and
+       self references are ``E-PARSE-032``, so no cycle analysis is needed.
+       ``:optional``/``:default`` on a ``:expr`` is ``E-PARSE-033``.
+   * - D50
+     - §3.7, §4.5
+     - A ``:expr`` is charged once at binding time and 1 per reference, and
+       ``bound(rule)`` gains ``Σ cost(:expr bindings)``. A computed binding
+       cannot observe the rule's own effects — it is an abbreviation, not a
+       sequencing construct.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -511,6 +511,17 @@ further.
 ``(or)`` are ``E-PARSE-021`` (there is no implicit identity element — the same
 correction as the empty precondition set).
 
+**[draft ruling — Phase 1 review, R9 chapter C12]** *References compare by
+identity, with* ``=`` *and* ``!=`` *only.* Two ``NodeRef``\ s (or two
+``EdgeRef``\ s, or two ``HyperedgeRef``\ s) may be compared for identity;
+comparing a reference with an ordering operator, or with a reference of a
+different kind, or with any non-reference, is ``E-TYPE-019``. This document
+had left reference comparison undefined, which made the intersection idiom of
+§2.7 unwritable and would have left two implementations free to differ. There
+is no ordering on references *in the language* — §2.6's iteration order is the
+executor's, and exposing it as a comparison would invite content to depend on
+id assignment.
+
 ``exists``/``forall`` bind no variable of their own; the query's element is
 referred to inside the body as ``it`` **[draft ruling — Phase 1 review]** —
 a reserved binding name that may not be declared or shadowed
@@ -923,6 +934,27 @@ authorable.
   intensive field aggregates nothing — it orders — so the weighted-mean
   obligation has nothing to attach to.
 
+**[draft ruling — Phase 1 review, R9 chapter C12]** *No set-algebra operator,
+and the deferral is now honest.* One system needs a set intersection (shared
+memberships between two nodes). This document adds no ``intersect``,
+``union`` or ``difference``: a dedicated operator would need a result type
+that is a ``NodeSet`` **not** produced by a ``<query>``, which §3.1's "only
+consumable by ``fold``, ``exists``, ``forall``" line and §3.7's
+``ceiling(query)`` both assume away. Intersection is expressible today, at
+quadratic fuel cost, with C8's naming and C12's reference identity:
+
+.. code-block:: scheme
+
+   (fold count (hyperedges-of a HyperedgeType/COMMUNITY) :as ha
+         (if (exists (hyperedges-of b HyperedgeType/COMMUNITY) (= it ha))
+             1 0))
+
+The earlier judgement to defer rested on a form that could not actually be
+written — ``it`` meant the inner element in both positions and references had
+no comparison. Both holes are closed above, so the deferral now stands on its
+own: **revisit when a second system asks**, and pay the quadratic cost
+visibly in ``:fuel`` until then, where a reviewer can see it.
+
 **Folds and selection are the only expression-position iteration
 constructs**, and §2.8's ``for-each`` is the only one in effect position.
 There is no recursion, no ``while``, no ``loop``, no user-defined function, and
@@ -946,6 +978,7 @@ the static bound of §3.7 is computable.
                                  <field-init>* ")"
             | "(" "remove-edge"  <enum-ref> <expr> <expr> ")"
             | "(" "add-hyperedge"    <enum-ref> <expr> <members> <field-init>* ")"
+            | "(" "update-hyperedge" <expr> <qname> <update-op> ")"
             | "(" "remove-hyperedge" <expr> ")"
             | "(" "emit"         <enum-ref> <payload-item>* ")"
 
@@ -959,12 +992,13 @@ the static bound of §3.7 is computable.
 
 The four ``<update-op>`` forms are exactly today's four-operation effect enum
 — ``add`` = ``increase``, ``sub`` = ``decrease``, ``set`` = ``set``,
-``scale`` = ``multiply``. Of the **eight** structural verbs, **five** are the
+``scale`` = ``multiply``. Of the **nine** structural verbs, **five** are the
 addition the design document's §6.4 audit found necessary (20 of 39 system
 modules mutate graph structure); **two** — ``add-hyperedge`` and
 ``remove-hyperedge`` — are what the Amendment D ruling adds, since if a
 hyperedge is a first-class object, minting and retiring one is a first-class
-verb; and **one** — ``update-edge`` — is what R9 chapter C2 adds, below.
+verb; and **two** — ``update-edge`` and ``update-hyperedge`` — are what R9
+chapters C2 and C12 add, below.
 
 **[draft ruling — Phase 1 review, R9 chapter C2]** ``update-edge``, *and why
 the dyadic layer differs from D26.* Eight systems overwrite a standing edge's
@@ -1049,6 +1083,42 @@ is stated rather than hidden: **per-membership payload** (the
 role/strength/visibility fields today's Python ``CommunityMembership`` carries)
 and **mutation of a hyperedge's own declared fields** are not expressible in
 this revision. Both are Phase-1 review items; neither is a silent omission.
+
+**[draft ruling — Phase 1 review, R9 chapter C12]** *D26's second half is
+closed:* ``update-hyperedge`` *writes a hyperedge's own declared fields.* The
+verb mirrors ``update-node`` and ``update-edge`` operand for operand, and it is
+added on exactly the reasoning C2 sets out above: D26's rationale is that a
+partially-mutated **member list** must be unrepresentable, and writing a
+declared field of a hyperedge leaves no member list partially anything. The
+member list stays whole-object replacement (``remove-hyperedge`` then
+``add-hyperedge`` in one effect list), so the ``:max-members`` check stays at
+its single point and D26's actual guarantee is untouched. What is retired is
+only the *incidental* consequence that a formation's own state was frozen for
+the life of the object.
+
+A ``<qname>`` whose owning type is not the referent's ``HyperedgeType`` is
+``E-EVAL-033`` (§2.10), since a ``HyperedgeRef`` carries no static type; the
+range and I.15 disciplines apply as they do to the other two update verbs.
+
+.. note::
+
+   **Per-membership payload is amendment territory, and this document does not
+   spec it.** D26's *first* half — the role/strength/visibility a membership
+   carries — is not a missing verb but a **missing kind of object**. Amendment
+   D as ratified (Amendment AE clause (vi), sub-rulings D-1…D-7) exposes a
+   hyperedge as an object with an identity, declared fields, and a member
+   *list*; attributes belonging to the pair *(member, hyperedge)* would add a
+   third element kind to that exposed model, with its own iteration order,
+   ceiling axis, hashing rules and verbs. The two obvious landings both carry
+   costs the Director should weigh rather than an author assume: attributed
+   memberships as a first-class incidence object, or a per-(member,
+   hyperedge) dyadic edge carrying the payload — and the second re-exposes
+   precisely the incidence encoding sub-ruling D-1 confined to internal
+   storage.
+
+   The consequence is concrete and should be planned for: a system whose
+   scoring depends *entirely* on per-membership payload cannot be authored in
+   BSL until this is ruled, and that is a **port blocker**, not a review item.
 
 ``emit``'s ``<enum-ref>`` is an ``EventType`` member; payload items are
 name/expression pairs. There is no string interpolation in a payload.
@@ -1448,7 +1518,9 @@ degraded mode, and no rule that loads "partially".
        there are no type variables — which is why §2.6's hyperedge queries
        take the type as an operand and why §2.10's accessors take the owning
        type in their ``<qname>``. Consumable by §2.10's accessors and by the
-       element-position operands of §2.8's verbs.
+       element-position operands of §2.8's verbs, and comparable for
+       **identity** with ``=``/``!=`` against a reference of the same kind
+       (``E-TYPE-019`` otherwise, §2.4). There is no ordering on references.
    * - ``NodeSet`` / ``EdgeSet`` / ``HyperedgeSet``
      - the result of a ``<query>``
      - Only consumable by ``fold``, ``exists``, ``forall``.
@@ -2238,7 +2310,7 @@ AST — a property implementations should exercise as a round-trip property test
 ``guard``, ``for-each``,
 ``update-node``, ``update-edge``,
 ``add-node``, ``remove-node``, ``add-edge``, ``remove-edge``,
-``add-hyperedge``, ``remove-hyperedge``, ``members``,
+``add-hyperedge``, ``update-hyperedge``, ``remove-hyperedge``, ``members``,
 ``emit``, ``add``, ``sub``, ``set``, ``scale``, ``anchor``, ``deffield``,
 ``intrinsic``, ``manifest``, ``ceiling``), plus the synthetic tag ``opt`` for a
 keyword option.
@@ -2600,6 +2672,14 @@ At minimum, an implementation claiming conformance passes:
     keyed reference series as declared fields against a rule reading them
     with a plain ``:field``, plus the same rule against a hydration that
     omits the series (``E-LOAD-010``).
+21. **Hyperedge fields and reference identity** (chapter C12) —
+    ``update-hyperedge`` under each ``<update-op>``, and one whose ``<qname>``
+    owns off another hyperedge type (``E-EVAL-033``); a roster change proving
+    membership is still whole-object replacement; ``=`` and ``!=`` on two
+    references of the same kind, both outcomes; a reference compared with
+    ``<`` and one compared across kinds (both ``E-TYPE-019``); and the
+    intersection idiom above, whose ``:fuel-used`` must show the quadratic
+    cost the deferral is paying.
 
 Families 10 and up are the R9 spec chapters' (the chapter letters cite
 ``reports/bsl-gap-analysis-2026-08-10.md`` §7). Two obligations are stated
@@ -3055,6 +3135,25 @@ consequences are the ordinary kind of review item.
        declared node fields at hydration and read with an ordinary ``:field``
        (ADR174's boundary), which makes the hydration contract a blocking
        dependency rather than a source of zeros.
+   * - D65
+     - §2.8
+     - ``update-hyperedge`` closes the second half of D26 on C2's reasoning:
+       writing a declared field leaves no member list partially anything.
+       Membership change stays whole-object replacement, so D26's actual
+       guarantee is untouched.
+   * - D66
+     - §2.8
+     - **Not ruled here.** Per-membership payload — D26's first half — is a
+       missing *kind of object*, not a missing verb, and changing the exposed
+       hyperedge model is Amendment-AE-(vi) territory. Recorded as a **port
+       blocker** with its two candidate landings named and neither specced.
+   * - D67
+     - §2.4, §3.1, §2.7
+     - References compare by identity with ``=``/``!=`` only
+       (``E-TYPE-019``); there is no ordering on references. With that and
+       D54's naming, the intersection idiom becomes writable, and the
+       deferral of a dedicated set-algebra operator stands on a form that can
+       actually be written.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -366,6 +366,10 @@ A keyword in value position is ``E-PARSE-010``.
      - Declared **member-count** ceiling of one hyperedge type, on the
        ``manifest`` ``ceiling`` rows whose ``<enum-ref>`` is a
        ``HyperedgeType`` member (§3.7). Mandatory there, illegal elsewhere.
+   * - ``:invariant``
+     - *flag*
+     - Marks a ``NodeType`` or ``EdgeType`` ``ceiling`` row as invariant
+       substrate that no structural verb may add to or remove from (§3.9).
 
 **[draft ruling — Phase 1 review, R9 chapter C4]** The three ``neighbors``
 directions were used as bare flags by §2.6 from this document's first revision
@@ -1132,12 +1136,14 @@ the combinatorial object Anti-Pattern VIII.9 bans has no BSL representation
 
    <manifest> ::= "(" "manifest" <symbol> <ceiling>+ ")"
    <ceiling>  ::= "(" "ceiling" <enum-ref> ":ceiling" <int-lit>
-                      ( ":max-members" <int-lit> )? ")"
+                      ( ":max-members" <int-lit> )? ":invariant"? ")"
 
 A ``ceiling`` row's ``<enum-ref>`` is a ``NodeType``, ``EdgeType`` or
 ``HyperedgeType`` member. ``:max-members`` is **mandatory** on a
-``HyperedgeType`` row and **illegal** on the other two; either mismatch is
-``E-LOAD-042``. The semantics of both numbers are §3.7's.
+``HyperedgeType`` row and **illegal** on the other two; ``:invariant`` is legal
+on a ``NodeType`` or ``EdgeType`` row and illegal on a ``HyperedgeType`` row
+(§3.9). Any of those mismatches is ``E-LOAD-042``. The semantics of the two
+numbers are §3.7's; the flag's are §3.9's.
 
 **[draft ruling — Phase 1 review]** The design document says intensivity is "a
 per-field declaration (``:kind intensive|extensive``) on model fields" without
@@ -1854,6 +1860,93 @@ domain-crate binding. Declaring a bespoke ``renormalize`` intrinsic would be
 the worst of the three: it hides a mechanism inside the kernel, where neither
 the content diff nor the inspector can see it, for a single call site.
 
+3.9 Invariant substrate, hydrated data, and the scale lattice
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Five systems aggregate up a scale lattice — county to commuting zone to state
+to nation, hex link to county pair to national, per-county sums then a reverse
+join — and one asks whether the language needs a grouping operator. It does
+not, and this section says why, what it needs instead, and where the boundary
+of this document's authority to say so lies.
+
+**No** ``group-by``, **and no keyed collection.** A fold that grouped elements
+by a runtime attribute value would have to return a *map*, which §3.1
+deliberately lacks and §3.8 declines to add: a map drags a key ordering into
+CAS, into the kind rule and into the fuel model. Everything the lattice needs
+is instead expressible as **graph content**, because a scale level is a thing
+in the world and membership in it is a relation:
+
+.. code-block:: scheme
+
+   (fold sum (neighbors self EdgeType/IN_SCALE :in NodeType/TERRITORY)
+         (field-of it territory/wage-bill))
+
+Aggregation up one rung is then an ordinary one-hop fold, and distribution down
+one rung is an ordinary ``for-each`` over the same query. This costs
+closed-vocabulary members and a hydration contract; it costs no grammar.
+
+.. note::
+
+   **The boundary of this section.** What is specified here is how an
+   **existing** lattice is *expressed* in BSL. Minting a new scale level,
+   declaring a new ``allocate``/``aggregate`` pair, or altering the
+   conservation obligation between rungs is **not** a language question and is
+   not within this document's reach: it is Director/amendment territory under
+   Amendment AE (ii), which re-opens the formalism surface for BSL and for
+   nothing else. A content set that adds a rung is proposing a level lattice,
+   not writing a rule pack, and should be reviewed as such.
+
+**[draft ruling — Phase 1 review, R9 chapter C11]** *Invariant substrate is
+declared, and structural verbs cannot touch it.* The spatial substrate is
+immutable (Constitution: political claims are overlays), and the Director's
+2026-07-30 spatial-adjacency ruling puts the invariant relations in static
+lookup tables rather than per-tick state. A ``manifest`` ``ceiling`` row may
+therefore carry the flag ``:invariant``:
+
+.. code-block:: text
+
+   <ceiling>  ::= "(" "ceiling" <enum-ref> ":ceiling" <int-lit>
+                      ( ":max-members" <int-lit> )? ":invariant"? ")"
+
+``:invariant`` is legal on a ``NodeType`` or ``EdgeType`` row and illegal on a
+``HyperedgeType`` row (``E-LOAD-042``, with the ``:max-members`` mismatches it
+already covers). Its meaning is narrow and static: **an** ``add-node``,
+``remove-node``, ``add-edge`` **or** ``remove-edge`` **naming an invariant type
+is** ``E-LOAD-013``, checked at load off the verb's ``<enum-ref>`` operand.
+Field writes are unaffected — a territory's stock changes every tick while the
+territory's *existence* and its rung in the lattice do not, and it is exactly
+that distinction the flag encodes. The check is worth having in the language
+rather than in a sentinel because it is decidable from the content set alone
+and because "a rule rewired the substrate" is the failure it prevents.
+
+**[draft ruling — Phase 1 review, R9 chapter C11]** *The hydration contract,
+and why there is no* ``:reference`` *bind-src.* Five systems read external
+keyed reference data — roughly fourteen ``(fips, year)``-keyed series, a
+tensor registry, a county crosswalk — through host calls, and a naive port
+would invent a bind-src to match. It must not. ADR174 already draws the
+boundary: data sources are Python-glue concerns, and values enter as declared
+BSL bindings. The consistent landing is that the **data-build pipeline
+materialises keyed series as declared node fields at hydration**, so a rule
+reads them with an ordinary ``:field``. That keeps §2.8's no-I/O prohibition
+intact, keeps the values inside the content hash rather than beside it, and
+needs no language change at all.
+
+What hydration may do, stated once because three chapters now depend on it:
+
+1. It creates elements of declared types and writes declared fields, and
+   nothing else. An undeclared field or type at hydration is the same
+   ``E-LOAD-0xx`` class as it would be in content — hydration is not a
+   back door into the closed vocabulary (§3.6).
+2. It is bounded by the declared ceilings, including ``:max-members``; an
+   over-ceiling hydration is ``E-LOAD-041`` (§3.7), unchanged.
+3. It is the **only** writer of ``:invariant`` structure, which is what makes
+   the ``E-LOAD-013`` check above meaningful rather than merely restrictive.
+4. A field a rule declares a plain ``:field`` binding against must be seeded by
+   hydration or the rule does not load (``E-LOAD-010``, §3.5). This is the
+   clause that makes "the reference-series hydration contract" a **blocking
+   dependency** for the systems that read those series, rather than a source of
+   zeros at tick 1.
+
 4. Dynamic semantics
 ----------------------
 
@@ -2496,6 +2589,17 @@ At minimum, an implementation claiming conformance passes:
     works — a presence-field guard writing value and presence together, a
     ``select-min`` over ``queued-at-tick`` returning the FIFO head, and a
     producer-stamped tick field read by a consumer rule at a later anchor.
+20. **Invariant substrate and the lattice** (chapter C11) — a one-hop
+    aggregation fold over an ``IN_SCALE`` relation and the ``for-each``
+    distribution that mirrors it; ``add-edge`` and ``remove-edge`` naming an
+    ``:invariant`` edge type, and ``add-node``/``remove-node`` naming an
+    ``:invariant`` node type (all ``E-LOAD-013``); an ``update-node`` field
+    write on an invariant type, which must **accept**, proving the flag
+    constrains structure and not state; ``:invariant`` on a
+    ``HyperedgeType`` row (``E-LOAD-042``); and a hydration that seeds a
+    keyed reference series as declared fields against a rule reading them
+    with a plain ``:field``, plus the same rule against a hydration that
+    omits the series (``E-LOAD-010``).
 
 Families 10 and up are the R9 spec chapters' (the chapter letters cite
 ``reports/bsl-gap-analysis-2026-08-10.md`` §7). Two obligations are stated
@@ -2932,6 +3036,25 @@ consequences are the ordinary kind of review item.
        (a receipt is a kernel observation); no cascade restatement in the verb
        table (ADR185 R2 owns it); no bounded numeric iteration, and no
        bespoke ``renormalize`` intrinsic in its place.
+   * - D62
+     - §3.9
+     - No ``group-by`` and no keyed collection. A scale lattice is graph
+       content — carrier types plus a typed membership relation — so
+       aggregation is a one-hop fold and distribution a ``for-each``.
+       **Minting a rung or an adjunction is amendment territory and outside
+       this document**; only the expression of an existing lattice is
+       specified here.
+   * - D63
+     - §2.9, §3.9
+     - ``:invariant`` on a ``NodeType``/``EdgeType`` ``ceiling`` row makes
+       ``add-*``/``remove-*`` naming that type ``E-LOAD-013``, statically.
+       Field writes are unaffected: the flag constrains structure, not state.
+   * - D64
+     - §3.9
+     - No ``:reference`` bind-src. Keyed reference series are materialised as
+       declared node fields at hydration and read with an ordinary ``:field``
+       (ADR174's boundary), which makes the hydration contract a blocking
+       dependency rather than a source of zeros.
 
 See Also
 ----------


### PR DESCRIPTION
R9 step 2 of the Program 28 roadmap: the normative spec chapters that fill the
language gaps blocking **12 of the 17 BSL_RULES systems**. Work order:
`reports/bsl-gap-analysis-2026-08-10.md` §7. One file changed —
`docs/reference/bsl-language.rst`, the one normative home. No code.

Register grows **D29 → D71**; §6.2 gains vector families **10 → 22**. The
revision is **additive**: no form changes meaning, and §5.6's 421 canonical
bytes and both its digests are unchanged. The single deliberate exception is
`neighbors`, which gains a mandatory operand — made rather than deferred
because no conformance vector in `rust/crates/babylon-bsl/tests/conformance/`
exercises it (verified).

## The chapters

| # | Chapter | rst | Gaps closed | New codes | D-rows | Vectors |
|---|---|---|---|---|---|---|
| C1 | Edge and hyperedge attributes | §2.4, §2.5, §2.7, §2.9, **§2.10 new**, §3.1, §3.4, §3.7 | Q1 (16 systems) | `E-TYPE-013`, `E-LOAD-023/024/032/033`, `E-EVAL-033` | D29–D34 | 10 |
| C2 | Edge mutation | §2.8, §2.10, §3.7 | Q3 (8) | `E-PARSE-041`, `E-TYPE-014`, `E-EVAL-034` | D35–D38 | 11 |
| C3 | Graph-scope state | §3.6, §2.10, **§4.7 new** | Q6 (22) | `E-LOAD-043`, `E-EVAL-035` | D39–D41 | 12 |
| C4 | Rule domain | §1.6, §2.3, §4.2, §5.3 | Q12 (6) | `E-LOAD-004`, `E-TYPE-015` | D42–D44 | 13 |
| C5 | Element selection | §2.7, §3.7 | Q4 (11) | `E-TYPE-017` | D45–D46 | 14 |
| C6 | Effect-position iteration | §2.8, §3.7 | Q5 (9) | — (reuses `E-TYPE-012`, `E-LOAD-040`) | D47–D48 | 15 |
| C7 | Computed bindings | §1.6, §2.5, §3.7, §4.2, §4.5 | Q14 | `E-PARSE-032/033` | D49–D50 | 16 |
| C8 | Typed `neighbors`, element naming | §1.6, §2.4, §2.6, §2.7, §2.8, §3.7 | Q8, Q9 (10) | — (reuses `E-PARSE-022/030`, `E-TYPE-012`) | D51–D54 | 17 |
| C9 | Metric registration | §2.2, §2.5, **§2.11 new**, §2.10, §3.4, §3.7, §5.5 | B4 (5 + OODA) | `E-LOAD-012/025`, `E-EVAL-036/037` | D55–D57 | 18 |
| C10 | Deliberate absences | **§3.8 new** | Q13, Q15, Q16, Q17, B3, B6, B7 | — (rejecting vectors only) | D58–D61 | 19 |
| C11 | Invariant substrate, hydration, scale lattice | §1.6, §2.9, **§3.9 new** | Q7, Q18, B5 (5) | `E-LOAD-013` | D62–D64 | 20 |
| C12 | Hyperedge fields, reference identity, set algebra | §2.4, §2.7, §2.8, §3.1 | Q10, Q11 | `E-TYPE-019` | D65–D67 | 21 |
| C13 | Intrinsic cap, rider slate, RNG keys | §1.6, §2.5, §2.7, **§3.10 new**, §4.3 | B1, B2 | `E-PARSE-014` | D68–D71 | 22 |

Plus a closing consistency pass: §4.6's taxonomy rows enumerate the new failure
modes, and the header records the revision, its reach and its limits.

## What the chapters actually settled

- **§2.4 carried a contradiction, not a wish.** Its coverage table promised
  `sum_strength`/`avg_strength` transcribe as a fold over `(edges …)` while no
  §2.7 production could read anything off an `EdgeRef`. C1 closes it, and rules
  `<edge-type>/strength` **extensive** on purpose — an intensive `strength`
  would have left `sum_strength` inexpressible after all under §3.4.
- **Graph-scope state costs one enum member, not a storage class.** C3 lands
  the singleton-carrier route and records `:global`/`update-global` as
  rejected: a second storage class would need its determinism, iteration,
  hashing, kind and inspection obligations all restated.
- **Two determinism holes closed that nobody had listed as gaps.** §4.2 never
  said in what order a rule fires across its subject nodes (D44 — load-bearing,
  because binary64 accumulation into a carrier is not associative), and
  references had no defined comparison (D67 — which had quietly made the set
  intersection idiom unwritable).
- **`it` versus nested folds is resolved by reading, not repeal** (D53): `it`
  denotes the innermost enclosing form's element, which is rebinding by
  construction — `it` is never *declared*, so `E-PARSE-022` still means exactly
  what it said.
- **Cap-legality is not doctrine-legality** (§3.10). `exp` is in the cap and
  three of its five sites stipulate a sigmoid ADR173 retires. `sigmoid` is made
  a reserved **prohibited** intrinsic name (`E-LOAD-024`) — the one part of the
  theory gate that can be made mechanical.
- **RNG draws are keyed, not streamed** (D69). Stronger than "the kernel draws
  only when the guard passes": with no stream position, §4.1's short-circuiting
  cannot perturb the RNG unconditionally rather than by discipline.

## Where the rst overrode the gap report's sketch

Recorded in-line as D-rows, per the Phase-1 standing lesson:

- **D29** — edge fields read by the `field-of` accessor, **not** by an
  edge-typed `:field` binding: a binding resolves *implicitly* against an
  enclosing body and the demanding systems read several edge types per rule.
- **D36** — `update-edge` takes an `EdgeRef` and has one shape, not a
  type-and-endpoints triple; a second arity would be the grammar's only
  overloaded head, the exact objection D26 raises against an overloaded
  `add-edge`. Endpoint-holding rules use `edge-between`.
- **D56** — element-indexed metrics use a `metric-of` **accessor**, not a
  `:metric-of` bind-src: a bind-src encodes as a two-child `opt` under D20 and
  this one needs two operands.
- **D43** — `<domain>` is **optional with a stated inference**, not mandatory,
  following D5's precedent for `<anchor>` — which is also what keeps §5.6's
  pinned bytes correct.

## Skipped as amendment territory (committed `.. note::` stubs)

1. **Per-membership hyperedge payload** (§2.8 note, D66) — D26's first half is
   a missing *kind of object*, not a missing verb; attributes on the
   `(member, hyperedge)` pair change the exposed model **Amendment AE clause
   (vi)** ruled. Both candidate landings are named, neither specced. Recorded
   as a **port blocker**, not a review item — Community's threat score depends
   on it entirely. `update-hyperedge` closes the *other* half of D26 on C2's
   reasoning.
2. **Minting scale-lattice rungs or adjunctions** (§3.9 note, D62) — outside
   this document under Amendment AE clause (ii). C11 specs only how an
   **existing** lattice is expressed.
3. **The intrinsic rider slate** (§3.10) — the 12 rows are recorded explicitly
   as Director-gated proposals; the table is non-normative and declares
   nothing. No intrinsic beyond `{exp, log}` is specced.

## Not merged

Per Amendment AD the Director holds merge authority. The chapters change
`rules_hash`'s form-tag surface, so landing them is a **vector re-bless
ceremony** — stated in-line in §6.2 so the teams plan it rather than discover
it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
