### PR TITLE
feat(bsl): Vitality as the first Material Base rule pack (P28 §7c6)

### DIFF
--- a/docs/superpowers/plans/2026-08-10-vitality-bsl-rule-pack.md
+++ b/docs/superpowers/plans/2026-08-10-vitality-bsl-rule-pack.md
@@ -92,10 +92,21 @@ The pack is one rule file,
 | emits | `ENTITY_DEATH` under the same guard |
 | **not** written | `attrition-rate`, the `population` decrement, `POPULATION_ATTRITION` — see §6 |
 
-The rule spells `max(0, …)` as an explicit `(if (> … 0) … 0)`: §3.10's rider
-slate row 5 declines a scalar `min`/`max` precisely so a saturation stays
-legible in the source, and §3.3 frames a silent clamp as forbidden quiet
-degradation.
+The rule spells `max(0, wealth − cost)` out rather than reaching for a scalar
+`min`/`max`: §3.10's rider slate row 5 declines that operator precisely so a
+saturation stays legible in the source, and §3.3 frames a silent clamp as
+forbidden quiet degradation.
+
+**The landed spelling is `paid = (if (> wealth cost) cost wealth)` followed by
+`drained = (- wealth paid)`** — what the class actually hands over, subsistence
+or everything it has, whichever is less. The obvious alternative,
+`(if (> (- wealth cost) 0) (- wealth cost) 0)`, is **not legal BSL**: §1.5
+admits no bare non-integer literal, so its zero branch is an `Int` sitting
+under a `Real` branch — two static types under one `if`, in a language that
+declares no coercions (§3.1). Subtracting the payment keeps one type
+throughout and lands on exactly `0.0` when a class loses everything. A reader
+following an earlier draft of this section would have written the illegal
+form; this paragraph is the correction.
 
 Because Phase 2 does not land, `is_extinct` becomes unreachable in the ported
 subset (the guard already excludes `population <= 0`, and only an attrition
@@ -154,7 +165,7 @@ Vectors come from the frozen Python `VitalitySystem` run in isolation against a
 fixture that mirrors the `.bscn` scenario node for node, single process, one
 `step()` call, with the real `ServiceContainer` defines. The repository carries
 the script at
-`rust/crates/babylon-tick/content/scenarios/vitality-conformance.py`, so anyone
+`rust/crates/babylon-tick/content/scenarios/vitality_conformance.py`, so anyone
 can re-run the provenance, and the Rust test pins the values it prints.
 
 **The fixture makes the un-ported phase contribute nothing.** Every subject
@@ -164,6 +175,19 @@ clears the threshold (the rate is exactly `0.0`) or because
 `POPULATION_ATTRITION`, so the ported subset's post-tick state should match the
 *full* Python system **exactly**, not approximately. Any divergence is a real
 defect rather than an artefact of the missing phase.
+
+**That precondition is gate-enforced, not merely documented.** Asserting it
+only inside the Python script would leave it unchecked, because nothing runs
+that script — no mise task, no CI leg, no `pytest` collection — so a `.bscn` edit
+nudging one subject into killing range would void every vector while the gates
+stayed green, which is absence reading as success (III.11). The Rust test suite
+recomputes the envelope from the committed scenario seeds, in the gate that
+already runs, and a mutation check confirms the guard reds on a drifted seed. The rate formula it
+uses lives **inside a test, marked a fixture guard rather than content**: no
+rule reads it, nothing declares it, it writes nothing. A guard bounding the
+fixture takes no position on what the blocked phase should eventually compute.
+A guard inside the *rule* would, which is why §6.2 leaves the mechanic empty
+and nothing in the shipped content mentions a threshold.
 
 **Tolerance policy: none.** Every operation on both sides is an IEEE-754 basic
 operation (`+ − × ÷` and comparison) on binary64, correctly rounded and
@@ -321,7 +345,7 @@ population figure.
 2. Defines environment (`defconst` plus `:const` serving) and unit tests. →
    *verify:* `cargo test -p babylon-bsl` green; an unknown coefficient fails
    loudly at load and a missing one fails loudly at bind.
-3. `vitality.bscn` and `vitality.bsl` content. → *verify:* the rule passes
+3. `vitality-conformance.bscn` and `vitality.bsl` content. → *verify:* the rule passes
    every load gate (`load_rule`); the tick runs.
 4. Conformance script and Python run. → *verify:* single-process
    `uv run python …` prints post-tick state per subject.

--- a/docs/superpowers/plans/2026-08-10-vitality-bsl-rule-pack.md
+++ b/docs/superpowers/plans/2026-08-10-vitality-bsl-rule-pack.md
@@ -1,0 +1,331 @@
+# Vitality as the first Material Base rule pack (Program 28 §7 criterion 6)
+
+**Status:** implementation plan. Written against `origin/dev` at `2c28c446`
+(PR #480 merged: R9 chapters C1–C13 plus `rust/crates/babylon-bsl`).
+
+**Scope:** port `VitalitySystem` (Material Base position 1.0) from the frozen
+Python engine to a BSL rule pack the Rust engine runs, conformance-vectored
+from the live frozen surface.
+
+**Verdict up front:** the system ports **in part**. Phases 1 and 3 (The Drain,
+The Reaper) land as one BSL rule. Phase 2 (Grinding Attrition) **does not
+land**, for two independent reasons — one mechanical (a missing language
+construct), one doctrinal (a stipulated functional form that ADR175 puts
+behind a Director derivation review). This port improvises around neither.
+§6 records both precisely.
+
+---
+
+## 1. What the Python system does (the structure/ordering contract)
+
+`src/babylon/engine/systems/vitality.py`, 256 lines, `partition = MATERIAL_BASE`,
+`position = 1.0`, `creates_value = False`. One pass over
+`graph.query_nodes(node_type=NodeType.SOCIAL_CLASS)`, in graph order. Per node:
+
+| Step | Reads | Writes / emits |
+|---|---|---|
+| skip | `active` (default `True`), `population` (default `1`) | `continue` when inactive or `population <= 0` |
+| **Phase 1 — The Drain** | `wealth` (default `0.0`), `subsistence_multiplier` (default `1.0`), define `economy.base_subsistence` | `wealth = max(0.0, wealth − (base_subsistence × population) × multiplier)` |
+| **Phase 2 — Grinding Attrition** | re-reads the node; `wealth`, `population`, `inequality`, `s_bio`, `s_class` (all `required=True`), define `vitality.attrition_base_factor` | `population −= deaths`; emits `POPULATION_ATTRITION` when `deaths > 0` |
+| **Phase 3 — The Reaper** | re-reads the node; `population`, `wealth` (post-drain), `s_bio`, `s_class` (off the **pre-phase** dict, `.get(…, 0.0)`), define `economy.death_threshold` | `active = False`, `population = 0`; emits `ENTITY_DEATH` |
+
+Phase 2's rate comes from `formulas/vitality.py::calculate_mortality_rate`:
+
+```
+coverage_ratio = wealth_per_capita / subsistence_needs      # needs = s_bio + s_class
+threshold      = 1.0 + inequality
+if coverage_ratio >= threshold: return 0.0
+deficit        = threshold - coverage_ratio
+rate           = deficit * (attrition_base_factor + inequality)
+return max(0.0, min(1.0, rate))                             # the clamp
+deaths         = int(population * rate)                     # truncation toward zero
+```
+
+Phase 3's predicates:
+
+```
+consumption_needs  = s_bio + s_class
+is_extinct         = current_population <= 0
+is_starving        = current_population == 1 and wealth < consumption_needs
+is_zombie_trapped  = wealth < death_threshold and current_population == 1
+cause              = "extinction" | "wealth_threshold" | "starvation"   (that precedence)
+```
+
+**Ordering facts that belong to the contract:** the three phases run
+sequentially *within one subject* (Phase 2 re-reads the node, so it sees Phase
+1's wealth; Phase 3 re-reads, so it sees Phase 2's population); subjects stay
+independent — nothing in the system reads another node, an edge, or a
+graph-level measure. Vitality is **entirely self-scoped**, which is what makes
+a one-rule port possible at all.
+
+Defines the system reads: `economy.base_subsistence = 0.0005`,
+`economy.death_threshold = 0.001`, `vitality.attrition_base_factor = 0.5`
+(`src/babylon/data/defines.yaml:88,89,177`).
+
+## 2. Rule decomposition
+
+**One rule, not three.** §4.2 of `bsl-language.rst` states that rules within one
+system position **observe the same pre-state**; a rule can never observe another
+rule's effects at the same position. A three-rule decomposition would then have
+to re-derive the post-drain wealth in each of the two downstream rules — the
+"restate the same algebra in four places and eventually restate it differently
+in one" hazard that R9 chapter C7 (`:expr` bindings) exists to remove. The R9
+gap analysis reaches the same conclusion independently: *"Vitality (three
+phases collapse into one rule and must re-derive the post-drain value
+algebraically)"* (`reports/bsl-gap-analysis-2026-08-10.md:419`; survey row 1.0
+says the same).
+
+The pack is one rule file,
+`rust/crates/babylon-tick/content/rules/vitality.bsl`:
+
+```
+(rule vitality/subsistence-and-death …)
+```
+
+| | |
+|---|---|
+| subject | `social-class`, which `tick.rs` derives from the `:field` `namespace` |
+| guard | `(and (= active 1) (> population 0))` — the Python `continue`s |
+| reads | `active`, `population`, `wealth`, `subsistence-multiplier`, `s-bio`, `s-class` as `:field`; `economy/base-subsistence`, `economy/death-threshold` as `:const` |
+| intermediates | `cost`, `drained`, `consumption-needs` as `:expr` (C7) |
+| writes | `wealth` always; `active` plus `population` under a `(guard …)` |
+| emits | `ENTITY_DEATH` under the same guard |
+| **not** written | `attrition-rate`, the `population` decrement, `POPULATION_ATTRITION` — see §6 |
+
+The rule spells `max(0, …)` as an explicit `(if (> … 0) … 0)`: §3.10's rider
+slate row 5 declines a scalar `min`/`max` precisely so a saturation stays
+legible in the source, and §3.3 frames a silent clamp as forbidden quiet
+degradation.
+
+Because Phase 2 does not land, `is_extinct` becomes unreachable in the ported
+subset (the guard already excludes `population <= 0`, and only an attrition
+decrement could drive a live population to zero mid-tick). The Reaper's two
+remaining causes both require `population == 1`, and both set the same two
+fields, so they collapse into **one** guarded block.
+
+### Content that becomes scenario/manifest data
+
+- The six node fields become `deffield` declarations in the scenario. All six
+  take integer literals, which is the only lane slice 1's scenario loader
+  stores (`scenario.rs::attribute_value`); nothing in the ported subset needs a
+  fractional seed, so this port leaves the loader alone.
+- `active` travels as an `int` 0/1 field. BSL has `Bool` (§3.1) but `deffield`
+  has no `bool` type and `GraphSubstrate` attributes are `f64`; 0/1 is the
+  honest rendering available today, and this plan records it rather than
+  leaving a later reader to discover it.
+- The two defines become `(defconst …)` rows in the scenario — see §3.
+
+## 3. Engine machinery the port needs
+
+Two changes, both inside the slice-1 driver scaffolding, neither touching BSL
+grammar, the `<bind-src>` set, or the error codes.
+
+**(a) A defines environment, so a rule can read `:const`.** `tick.rs`'s
+`check_sources_servable` refuses `:const` by name today: *"slice 1 has no
+defines environment; the coefficient registry is Phase-2 content"*. Vitality
+reads two coefficients, and writing `0.0005` into a rule would break the
+project's single-source-of-truth rule for coefficients (a define supplies the
+scale; a rule supplies the shape). The minimal honest fix:
+
+- `scenario.rs` gains `(defconst <qname> <literal>)`, exactly parallel to the
+  `deffield` registry-in-miniature it already carries, producing a
+  `HashMap<String, Value>`;
+- `run_tick` takes that map and serves `BindSource::Const`, refusing loudly
+  (and naming the qualified name) when a rule reads a coefficient the
+  environment does not hold;
+- `run_once` feeds the scenario's declared coefficients into both
+  `BindingVocabulary::consts` (so `E-LOAD-010` still gates an unknown name at
+  load) and the tick.
+
+This is the same declared temporary as `deffield`: the Phase-2 successor is the
+real `GameDefines`/`defines.yaml`-backed registry, and the scenario file cites
+the `defines.yaml` line each value came from.
+
+**(b) Nothing else.** This port builds no rule-pack sequencer. A pack is a set
+of rules at one position observing one pre-state; with a single rule there is no
+order to declare, so an ordering mechanism now would be machinery with no
+caller — and the anchor-to-total-order resolver belongs explicitly to
+`babylon-engine` Phase-3 work (`mod_anchors.rs` module doc). This port leaves
+`run_once`'s signature and `TickReport` alone.
+
+## 4. Conformance-vector strategy
+
+Vectors come from the frozen Python `VitalitySystem` run in isolation against a
+fixture that mirrors the `.bscn` scenario node for node, single process, one
+`step()` call, with the real `ServiceContainer` defines. The repository carries
+the script at
+`rust/crates/babylon-tick/content/scenarios/vitality-conformance.py`, so anyone
+can re-run the provenance, and the Rust test pins the values it prints.
+
+**The fixture makes the un-ported phase contribute nothing.** Every subject
+satisfies `int(population × attrition_rate) == 0` — either because coverage
+clears the threshold (the rate is exactly `0.0`) or because
+`population × rate < 1`. Python performs no population decrement and emits no
+`POPULATION_ATTRITION`, so the ported subset's post-tick state should match the
+*full* Python system **exactly**, not approximately. Any divergence is a real
+defect rather than an artefact of the missing phase.
+
+**Tolerance policy: none.** Every operation on both sides is an IEEE-754 basic
+operation (`+ − × ÷` and comparison) on binary64, correctly rounded and
+reproducible across implementations (§4.3; `bsl-language.rst:1842`). No
+transcendental, no libm, no ambiguity about accumulation order — BSL's
+`<arith>` is strictly binary (`E-PARSE-040`), so the source states the
+association explicitly, and the transcription matches Python's
+`(base × population) × multiplier` exactly. Scaled literals reach `Value::Real`
+as `unscaled / 10^scale`, a correctly-rounded division that lands on the same
+double as the matching Python decimal literal. The test asserts
+exact `f64` equality. A tolerance here would hide precisely the transcription
+error it would appear to absorb.
+
+A second Python run, on a fixture where `deaths > 0`, goes into the PR body as
+the **blocked vector** — the numbers the §6.1 rider would have to reproduce.
+Nothing asserts it, because no code claims to produce it.
+
+**Determinism:** the Vitality pair repeats the existing
+`run_once_is_deterministic` shape — two loads, two ticks, one identical
+post-state hash.
+
+## 5. §5.4 defects this port repairs
+
+Per ADR183 and `ai/bsl-architecture-standard.md` §5.4: the frozen engine is the
+contract source for **structure and ordering**, not a correctness oracle.
+
+**D-1 — Two absence policies for the same fields in the same tick.**
+`_calculate_deaths` reads `wealth`/`population`/`inequality`/`s_bio`/`s_class`
+with `required=True` (`vitality.py:227-231`, whose comment names the
+silently-masked-missing-field gotcha it repairs). Phase 3, twelve lines later,
+reads `s_bio` and `s_class` off the **pre-phase** dict with
+`attrs.get("s_bio", 0.0)` (`:154-155`), and the skip block reads `active`,
+`population`, `wealth` and `subsistence_multiplier` with `.get` defaults
+(`:106,109,116,118`). A `social_class` missing `s_bio` raises in Phase 2 and
+quietly reads `0.0` in Phase 3 — where `consumption_needs = 0` makes a starving
+class un-starvable. **Repair:** every field a BSL rule reads is a required
+`:field` binding, and a never-written field raises the substrate's loud error
+(III.11 — absence is not zero). *Behavioural difference from the frozen
+engine:* a node missing any of the six fields now aborts the tick instead of
+proceeding on a default. That is the intended direction.
+
+**D-2 — `if base_subsistence > 0` is a dead branch.** `vitality.py:117` guards
+the whole drain on a define whose value is `0.0005`. Nothing a tick can observe
+sets it to zero. **Repair:** the transcription drops the branch; the drain runs
+unconditionally and the define supplies its scale. Recorded rather than
+quietly dropped: a mod setting `base_subsistence: 0.0` gets a zero-scale drain,
+whose observable outcome equals the skipped write, because the effect is
+`set drained` and `drained == wealth` at that value.
+
+**D-3 — `calculate_mortality_rate` cannot see `defines.yaml`.**
+`formulas/vitality.py:13` binds `_DEFINES = GameDefines()` at import — the
+**schema defaults**, not `GameDefines.load_default()`, which is the loader that
+reads `src/babylon/data/defines.yaml`. `attrition_base_factor` then bakes into
+a default argument that Python evaluates once at import, and `VitalitySystem`
+never passes the parameter explicitly. Anyone editing
+`defines.yaml: vitality.attrition_base_factor` changes nothing. This is a live
+modding-contract defect in the frozen engine, found by reading it for this
+port. **Repair:** not applicable to the ported subset, since §6.2 declines the
+formula — but this plan records the defect, and the port's `:const` binding is
+the structural answer: a coefficient reaches a rule only through the defines
+environment, so no import-time capture can go stale.
+
+**D-4 — `cause` is a string in an event payload.** §2.8 admits no string in a
+payload, and §1.5 admits string literals only at `:material-basis` and vector
+ids (`E-PARSE-010`). The discriminant would need a registered closed enum,
+which is a vocabulary addition, and so spec-first work. **Repair:** the
+`ENTITY_DEATH` payload carries `entity-id`, `wealth`, `consumption-needs`,
+`s-bio`, `s-class` and drops `cause`. This plan names the gap instead of
+omitting it silently; with `is_extinct` unreachable in the ported subset a
+reader can recover the discriminant from the payload anyway
+(`wealth < death_threshold` means `wealth_threshold`, else `starvation`).
+
+**Not a defect, recorded so a later reader does not "fix" it:**
+`max(0.0, wealth − cost)` destroys the part a class cannot pay rather than
+carrying a debt. That is a modelling choice of the frozen engine and part of
+the structure contract, so the rule transcribes it as written, spelled as an
+explicit `if`.
+
+## 6. What does NOT land, and exactly why
+
+### 6.1 Mechanical: BSL has no `Real → Int` demotion
+
+`deaths = int(population * attrition_rate)` (`vitality.py:253`) needs a floor.
+`bsl-language.rst` §3.1 declares **no coercions**, and §3.3 promotes `Int` to
+`Real` **one way only**, so the language holds no demotion path at all.
+§3.10's rider slate row 2 (`floor` / `trunc`, "In cap? **No**") records this as
+a *proposed* rider — a question for the Director, explicitly non-normative and
+declaring nothing. The intrinsic cap holds at `{exp, log}` at most (R10 citing
+ADR176 r21), so `floor` sits outside it and no one may declare it.
+
+Consequences, stated exactly: nothing computes `deaths`; nothing writes the
+population decrement; `POPULATION_ATTRITION` has no trigger. **What it would
+take:** a Director ruling on rider-slate row 2, then §3.1/§3.2 gaining the
+demotion with its rounding mode pinned, an `E-` code for a non-finite or
+out-of-`i64` demotion, a §3.7 cost row, and CAS coverage. That is spec work
+rather than implementation work, and this port does not improvise it.
+
+### 6.2 Doctrinal: the mortality curve is a stipulated functional form
+
+Even with a floor, nobody should transcribe the rate verbatim.
+
+```
+rate = (1.0 + inequality − coverage_ratio) × (attrition_base_factor + inequality)
+```
+
+is a piecewise-linear form with a **tuned knob** — `attrition_base_factor = 0.5`,
+described in its own schema as *"Base multiplier in grinding attrition"*
+(`config/defines/survival.py:88-92`), a feel-tier define with no written
+`Aleksandrov` chain. Standard S-7 and the Director ruling of 2026-07-29
+(ADR172 ruling 5): *no functional form may be imposed on a mechanic; curve
+shapes must emerge from the algebraic operations.*
+
+The construct is not even a new one. Vitality's own module header says what
+it approximates: *"One agent = one demographic block. High inequality within a
+block means you need MORE coverage to prevent deaths"* — that is **the mass of
+the within-class wealth distribution that fails to clear subsistence** — which
+is exactly ADR173's ruled formulation for `P(S|A)`
+(`ai/bsl-architecture-standard.md` §3.2 fact 2): the measure of class members
+whose wealth clears subsistence, with the curve read off the distribution
+rather than stipulated. Grinding Attrition repeats that same construct, wearing a linear proxy with a steepness knob where the distribution
+integral belongs.
+
+ADR175 governs every non-survival site: the Python reference freezes as-is,
+each site receives an **emergent re-derivation from material operations at its
+Rust/BSL port**, and the Director reviews each derivation per family before it
+lands (§3.2 fact 3; S-7's evidence column: *"each non-survival family
+additionally requires its ADR175 per-family derivation review before
+landing"*). Mortality has had no such review.
+
+**This port transcribes no formula and invents no replacement.**
+Writing the stipulated form into BSL would enshrine exactly what ADR172 ruling
+5 retires; writing a *substitute* measure would be an ideological call nobody has reviewed, which Constitution IX.5 reserves to the Director. This is an
+escalation, not a workaround.
+
+**What it would take:** an ADR175 derivation review for the vitality/mortality
+family, answering the question §3.2 asks of every site — *can this be
+re-derived as a measure instead?* — plus (open, and shared with `P(S|A)`) the
+canonical within-class wealth distribution, which audit Q3 records as
+undecided. §6.1's rider is then still needed to turn a measure into whole
+people.
+
+### 6.3 Consequence for the delivered pack
+
+On a world where the frozen engine's attrition would kill, the rule pack
+under-kills. That is why §4 picks a fixture where the frozen engine kills
+nobody — the delivered rule holds conformance exactly on the ground it claims,
+and claims no ground it cannot hold. Nothing wires it into an always-on path:
+`run_once` still takes its rule as an argument, and tests exercise the Vitality
+pair. Nothing in the tree runs Vitality over an arbitrary world and reports a
+population figure.
+
+## 7. Steps and verification
+
+1. Plan committed. → *verify:* file exists, `git log --oneline -1` moved.
+2. Defines environment (`defconst` plus `:const` serving) and unit tests. →
+   *verify:* `cargo test -p babylon-bsl` green; an unknown coefficient fails
+   loudly at load and a missing one fails loudly at bind.
+3. `vitality.bscn` and `vitality.bsl` content. → *verify:* the rule passes
+   every load gate (`load_rule`); the tick runs.
+4. Conformance script and Python run. → *verify:* single-process
+   `uv run python …` prints post-tick state per subject.
+5. Rust conformance test pinning those exact values, plus a determinism test. →
+   *verify:* `cargo test -p babylon-tick` green, exact `f64` equality.
+6. Gates. → *verify:* `mise run rust:check` green; `cargo clippy -p babylon-bsl
+   -- -W clippy::pedantic` clean.

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -50,6 +50,7 @@
 //!   unwritten field errors on read (III.11), and seeding zeros here would
 //!   defeat that at the one place it is easiest to defeat.
 
+use crate::evaluator::Value;
 use crate::reader::{read_all, Atom, ReadError, SExpr};
 use crate::types::{BslType, FieldDecl, FieldKind};
 use babylon_graph::substrate::{GraphError, GraphSubstrate, NodeId};
@@ -137,6 +138,17 @@ pub struct LoadedScenario {
     /// Deriving it from usage instead would mean guessing a kind, and
     /// intensivity is exactly what §3.4 refuses to guess.
     pub fields: HashMap<String, FieldDecl>,
+    /// The DEFINES ENVIRONMENT a `:const` binding reads (§2.5, §4.2),
+    /// keyed by qualified name.
+    ///
+    /// The same registry-in-miniature argument as `fields`, one level up: a
+    /// coefficient's *value* is content, and until Phase 2's registry reads
+    /// `GameDefines`/`defines.yaml` there is nowhere else it can honestly
+    /// come from. Writing the number into the rule instead would put a
+    /// magnitude in the shape's file, which is the one thing the project's
+    /// coefficient discipline forbids — so the scenario declares it and
+    /// cites the `defines.yaml` line it was taken from.
+    pub consts: HashMap<String, Value>,
 }
 
 /// Read `source` and populate `graph` with it.
@@ -176,6 +188,7 @@ pub fn load_scenario(
     // Local name -> minted id. Load-time only; it does not outlive this call.
     let mut named: HashMap<String, NodeId> = HashMap::new();
     let mut fields: HashMap<String, FieldDecl> = HashMap::new();
+    let mut consts: HashMap<String, Value> = HashMap::new();
     let mut node_types: HashMap<String, u64> = HashMap::new();
     let mut node_count = 0_usize;
     let mut edge_count = 0_usize;
@@ -196,6 +209,9 @@ pub fn load_scenario(
             Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "deffield" => {
                 load_deffield(parts, &mut fields)?;
             }
+            Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "defconst" => {
+                load_defconst(parts, &mut consts)?;
+            }
             Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "node" => {
                 let minted = load_node(parts, graph, &mut named, &fields)?;
                 *node_types.entry(minted).or_insert(0) += 1;
@@ -207,7 +223,8 @@ pub fn load_scenario(
             }
             _ => {
                 return Err(err(
-                    "a scenario body form must begin with `deffield`, `node` or `edge`",
+                    "a scenario body form must begin with `deffield`, `defconst`, \
+                     `node` or `edge`",
                 ))
             }
         }
@@ -219,7 +236,59 @@ pub fn load_scenario(
         edge_count,
         node_types,
         fields,
+        consts,
     })
+}
+
+/// `(defconst <qname> <literal>)`
+///
+/// The defines environment in miniature (§2.5's `:const`, §4.2's
+/// "the defines environment (coefficients)"). Slice 1 has no
+/// `GameDefines`/`defines.yaml` reader, and §2.5 gives `:const` no other
+/// source, so the alternative to declaring the value here is writing it
+/// into the rule — putting a magnitude in the file that owns the shape.
+///
+/// Only the four literal atom classes §2.2 admits at `:default` are legal
+/// here, for the same reason: a coefficient is a number, not an expression,
+/// and an expression would need an evaluation environment that does not
+/// exist at scenario-load time.
+fn load_defconst(
+    parts: &[SExpr],
+    consts: &mut HashMap<String, Value>,
+) -> Result<(), ScenarioError> {
+    let [_, SExpr::Atom(Atom::QName(qname)), SExpr::Atom(literal)] = parts else {
+        return Err(err(
+            "expected (defconst <qname> <literal>) — one qualified name, one literal",
+        ));
+    };
+    let value = match literal {
+        Atom::Int(value) => Value::Int(*value),
+        Atom::Scaled(scaled) => {
+            // `unscaled / 10^scale`, the canonical minimal-scale form, and
+            // the SAME arithmetic `tick.rs::atom_to_value` performs on a
+            // `:default` literal — one conversion, so a coefficient reads
+            // identically wherever it enters.
+            #[allow(clippy::cast_precision_loss)]
+            let numerator = scaled.unscaled as f64;
+            Value::Real(numerator / 10_f64.powi(i32::from(scaled.scale)))
+        }
+        Atom::Bool(value) => Value::Bool(*value),
+        Atom::Currency(value) => Value::Currency(*value),
+        other => {
+            return Err(err(format!(
+                "defconst `{qname}`: expected a literal (int, scaled, currency or \
+                 boolean), found {other:?}"
+            )))
+        }
+    };
+    if consts.insert(qname.clone(), value).is_some() {
+        return Err(err(format!(
+            "duplicate defconst `{qname}` — a coefficient has one value, and \
+             silently rebinding it would make the rule reading it depend on \
+             declaration order"
+        )));
+    }
+    Ok(())
 }
 
 /// `(deffield <qname> <type-symbol> <kind-symbol>)`
@@ -574,6 +643,64 @@ mod tests {
         let mut graph = MemoryGraph::new();
         let err = load_scenario(source, &mut graph).unwrap_err();
         assert!(err.message.contains("declared"), "{}", err.message);
+    }
+
+    #[test]
+    fn a_defconst_becomes_the_defines_environment() {
+        // §2.5's `:const` reads the defines environment, and slice 1 has no
+        // GameDefines reader — so the scenario declares it, exactly as it
+        // declares fields.
+        let source = r"
+(scenario ft/coefficients
+  (defconst economy/base-subsistence 0.0005c)
+  (defconst economy/tick-budget 12))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph).unwrap();
+        assert_eq!(loaded.consts.len(), 2);
+        // 5 / 10^4, the canonical minimal-scale form — the same conversion
+        // the tick applies to a `:default` literal.
+        assert_eq!(
+            loaded.consts["economy/base-subsistence"],
+            crate::evaluator::Value::Real(5.0 / 10_f64.powi(4))
+        );
+        assert_eq!(
+            loaded.consts["economy/tick-budget"],
+            crate::evaluator::Value::Int(12)
+        );
+    }
+
+    #[test]
+    fn a_duplicate_defconst_is_loud_never_last_one_wins() {
+        // A coefficient has one value. Silently rebinding it would make the
+        // rule reading it depend on declaration order.
+        let source = r"
+(scenario ft/twice
+  (defconst economy/base-subsistence 0.0005c)
+  (defconst economy/base-subsistence 0.5c))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(
+            err.message.contains("duplicate defconst"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn a_defconst_taking_an_expression_is_refused() {
+        // A coefficient is a number. An expression would need an evaluation
+        // environment that does not exist at scenario-load time, and
+        // accepting the form while ignoring the operand is the silent-drop
+        // shape.
+        let source = r"
+(scenario ft/computed
+  (defconst economy/base-subsistence (* 2 3)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(err.message.contains("<literal>"), "{}", err.message);
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -266,18 +266,34 @@ fn load_defconst(
         Atom::Scaled(scaled) => {
             // `unscaled / 10^scale`, the canonical minimal-scale form, and
             // the SAME arithmetic `tick.rs::atom_to_value` performs on a
-            // `:default` literal — one conversion, so a coefficient reads
-            // identically wherever it enters.
+            // `:default` literal — so a scaled coefficient reads identically
+            // whichever door it enters by.
             #[allow(clippy::cast_precision_loss)]
             let numerator = scaled.unscaled as f64;
             Value::Real(numerator / 10_f64.powi(i32::from(scaled.scale)))
         }
         Atom::Bool(value) => Value::Bool(*value),
-        Atom::Currency(value) => Value::Currency(*value),
+        // Refused, not carried. `tick.rs::atom_to_value` refuses a Currency
+        // `:default` and `attribute_value` above refuses a Currency
+        // attribute, both because slice 1 has no typed storage for i128
+        // micro-units. Accepting one HERE would make the same literal legal
+        // through one door and rejected through the others — the entry point
+        // deciding the type system, which is the drift the sibling refusals
+        // exist to prevent. Currency coefficients arrive with typed attribute
+        // storage (a declared Phase-2 trait revision), not before.
+        Atom::Currency(_) => {
+            return Err(err(format!(
+                "defconst `{qname}`: a Currency coefficient needs typed \
+                 attribute storage (a declared Phase-2 trait revision) — the \
+                 `:default` and node-attribute paths refuse one for the same \
+                 reason, and admitting it here alone would make the literal's \
+                 legality depend on which form it was written in"
+            )))
+        }
         other => {
             return Err(err(format!(
-                "defconst `{qname}`: expected a literal (int, scaled, currency or \
-                 boolean), found {other:?}"
+                "defconst `{qname}`: expected an int, scaled or boolean \
+                 literal, found {other:?}"
             )))
         }
     };
@@ -667,6 +683,25 @@ mod tests {
         assert_eq!(
             loaded.consts["economy/tick-budget"],
             crate::evaluator::Value::Int(12)
+        );
+    }
+
+    #[test]
+    fn a_currency_defconst_is_refused_exactly_as_a_currency_default_is() {
+        // One literal, one legality. `tick.rs::atom_to_value` refuses a
+        // Currency `:default` and `attribute_value` refuses a Currency
+        // attribute; a defconst that accepted one would make the form the
+        // literal was written in decide whether it typechecks.
+        let source = r"
+(scenario ft/money-coefficient
+  (defconst economy/floor-wage 15$))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(
+            err.message.contains("typed attribute storage"),
+            "{}",
+            err.message
         );
     }
 

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -248,10 +248,13 @@ pub fn load_scenario(
 /// source, so the alternative to declaring the value here is writing it
 /// into the rule — putting a magnitude in the file that owns the shape.
 ///
-/// Only the four literal atom classes §2.2 admits at `:default` are legal
-/// here, for the same reason: a coefficient is a number, not an expression,
-/// and an expression would need an evaluation environment that does not
-/// exist at scenario-load time.
+/// Of the four literal atom classes §2.2 admits at `:default`, three are
+/// legal here — `Int`, `Scaled`, and `Bool` (defines carry toggles as well
+/// as magnitudes); `Currency` is refused exactly as `:default` refuses it
+/// (no i128 storage in slice 1). The literal-only rule holds for the same
+/// reason `:default`'s does: a define is a value, not an expression, and
+/// an expression would need an evaluation environment that does not exist
+/// at scenario-load time.
 fn load_defconst(
     parts: &[SExpr],
     consts: &mut HashMap<String, Value>,

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -97,6 +97,14 @@ pub struct TickOutcome {
     pub fired: usize,
 }
 
+/// The defines environment §4.2 names — coefficients by qualified name, the
+/// values a `:const` binding reads (§2.5).
+///
+/// Its *contents* are content: `GameDefines`/`defines.yaml` in Phase 2, the
+/// scenario's `(defconst …)` rows until then. Its *shape* belongs here
+/// because the tick is where a coefficient meets a rule.
+pub type DefinesEnv = HashMap<String, Value>;
+
 /// `social-class` → `SOCIAL_CLASS`: the field namespace as a `NodeType`
 /// member.
 ///
@@ -172,12 +180,36 @@ fn bind_subject(
     subject: NodeId,
     bindings: &[BindingDecl],
     graph: &dyn GraphSubstrate,
+    defines: &DefinesEnv,
     tick: i64,
 ) -> Result<HashMap<String, Value>, TickError> {
     let mut env = HashMap::from([("self".to_owned(), Value::NodeRef(subject))]);
     for binding in bindings {
         let qname = match &binding.source {
             BindSource::Field(qname) => qname,
+            // §2.5/§4.2: a coefficient out of the defines environment. The
+            // value is the same for every subject, so this is a lookup
+            // rather than a read — but it happens HERE, per subject, so that
+            // one code path owns "what a binding resolves to".
+            BindSource::Const(qname) => {
+                let Some(value) = defines.get(qname) else {
+                    // Unreachable when the vocabulary and the environment
+                    // come from one scenario, which is what the message
+                    // says: `resolve_bindings` already rejected an unknown
+                    // qname with E-LOAD-010, and `check_sources_servable`
+                    // already refused an unsupplied one at entry. Arriving
+                    // here is a driver wiring bug, never content's fault.
+                    return Err(err(format!(
+                        "binding `{}`: :const {qname} resolved at load but the \
+                         defines environment holds no value for it — the \
+                         binding vocabulary and the defines environment have \
+                         drifted apart",
+                        binding.name
+                    )));
+                };
+                env.insert(binding.name.clone(), value.clone());
+                continue;
+            }
             // §2.5: the current tick, as `Int`. The driver knows its own
             // tick number, so this is served rather than refused.
             BindSource::Tick => {
@@ -195,8 +227,7 @@ fn bind_subject(
             BindSource::Expr(_) => continue,
             // Refused at entry by `check_sources_servable`; reaching here
             // would mean that check and this match had drifted apart.
-            BindSource::Const(_) | BindSource::Metric(_) | BindSource::Year
-            | BindSource::TickOfYear => {
+            BindSource::Metric(_) | BindSource::Year | BindSource::TickOfYear => {
                 return Err(err(format!(
                     "binding `{}`: unservable source reached the subject loop —                      check_sources_servable and bind_subject have drifted",
                     binding.name
@@ -252,11 +283,15 @@ fn atom_to_value(atom: &Atom) -> Option<Value> {
 ///   and D68's cycle length is a literal, so both are exact.
 /// - `:expr` — self-contained: it needs only the bound environment, the
 ///   evaluator and the fuel meter, all of which the per-subject path has.
+/// - `:const` — **when, and only when, the driver supplied the coefficient.**
+///   §4.2 puts the defines environment in a rule's environment alongside the
+///   graph and the tick, and the driver now passes one in. Until the Phase-2
+///   `GameDefines`/`defines.yaml` registry exists, its contents are the
+///   scenario's `(defconst …)` rows. A rule reading a coefficient the
+///   environment does not hold is refused BY NAME below, never defaulted.
 ///
 /// What it cannot, and why each is a *seam* rather than a bug:
 ///
-/// - `:const` — the defines environment is Phase-2 content
-///   (`GameDefines`/`defines.yaml`); slice 1 has no coefficient registry.
 /// - `:metric` — §2.11 metrics come from a registered kernel provider, and
 ///   slice 1 registers none.
 /// - `:year` / `:tick-of-year` — §2.5 pins the epoch and the ticks-per-year
@@ -264,12 +299,17 @@ fn atom_to_value(atom: &Atom) -> Option<Value> {
 ///   pins neither. Serving them would mean inventing a calendar, which is
 ///   exactly the guess III.11 forbids. `:tick`/`:tick-in-cycle` need no
 ///   epoch, which is why they are served and these are not.
-fn check_sources_servable(bindings: &[BindingDecl]) -> Result<(), TickError> {
+fn check_sources_servable(bindings: &[BindingDecl], defines: &DefinesEnv) -> Result<(), TickError> {
     for binding in bindings {
         let reason = match &binding.source {
-            BindSource::Const(qname) => Some(format!(
-                ":const {qname} — slice 1 has no defines environment; the \
-                 coefficient registry is Phase-2 content (GameDefines/defines.yaml)"
+            // Servable exactly when the driver supplied the coefficient.
+            // Checked AT ENTRY, by name, for the same reason as every other
+            // row: a rule that dies mid-guard on an unbound variable names
+            // neither the source nor the reason.
+            BindSource::Const(qname) if !defines.contains_key(qname) => Some(format!(
+                ":const {qname} — the driver supplied no such coefficient. The \
+                 defines environment is the scenario's (defconst …) rows until \
+                 the Phase-2 GameDefines/defines.yaml registry lands"
             )),
             BindSource::Metric(name) => Some(format!(
                 ":metric {name} — slice 1 registers no metric provider; §2.11 \
@@ -286,7 +326,10 @@ fn check_sources_servable(bindings: &[BindingDecl]) -> Result<(), TickError> {
                  as for :year)"
                     .to_owned(),
             ),
-            BindSource::Field(_)
+            // Every servable source, including a `:const` the driver DID
+            // supply — the guard arm above owns the unsupplied case.
+            BindSource::Const(_)
+            | BindSource::Field(_)
             | BindSource::Tick
             | BindSource::TickInCycle(_)
             | BindSource::Expr(_) => None,
@@ -305,9 +348,10 @@ fn check_sources_servable(bindings: &[BindingDecl]) -> Result<(), TickError> {
 ///
 /// # Errors
 ///
-/// [`TickError`] if the subject type cannot be derived, a required field was
-/// never written, the guard does not evaluate to a `Bool`, or evaluation or
-/// an effect fails.
+/// [`TickError`] if the subject type cannot be derived, a rule reads a
+/// coefficient `defines` does not hold, a required field was never written,
+/// the guard does not evaluate to a `Bool`, or evaluation or an effect
+/// fails.
 #[allow(clippy::too_many_arguments)]
 pub fn run_tick(
     loaded: &LoadedRule,
@@ -316,16 +360,17 @@ pub fn run_tick(
     graph: &mut dyn GraphSubstrate,
     sink: &mut dyn EventSink,
     costs: &crate::fuel::IntrinsicCosts,
+    defines: &DefinesEnv,
     tick: i64,
 ) -> Result<TickOutcome, TickError> {
-    check_sources_servable(&loaded.bindings)?;
+    check_sources_servable(&loaded.bindings, defines)?;
     let subject_type = subject_type_of(&loaded.bindings)?;
     let (guard, effects) = guard_and_effects(&loaded.rule)?;
     let subjects = graph.nodes(&subject_type);
     let mut fired = 0_usize;
 
     for subject in &subjects {
-        let mut values = bind_subject(*subject, &loaded.bindings, &*graph, tick)?;
+        let mut values = bind_subject(*subject, &loaded.bindings, &*graph, defines, tick)?;
         // Per-subject budget, from the rule's DECLARED `:fuel` — not from
         // `static_bound`, which is the load-time proof that the rule fits
         // rather than the allowance it runs under. Metering on the computed
@@ -381,14 +426,73 @@ pub fn run_tick(
 
 #[cfg(test)]
 mod tests {
-    use super::subject_type_of;
+    use super::{check_sources_servable, subject_type_of, DefinesEnv};
     use crate::bindings::{BindSource, BindingDecl};
+    use crate::evaluator::Value;
     fn field(name: &str, qname: &str) -> BindingDecl {
         BindingDecl {
             name: name.to_owned(),
             source: BindSource::Field(qname.to_owned()),
             optional: false,
             default: None,
+        }
+    }
+
+    fn constant(name: &str, qname: &str) -> BindingDecl {
+        BindingDecl {
+            name: name.to_owned(),
+            source: BindSource::Const(qname.to_owned()),
+            optional: false,
+            default: None,
+        }
+    }
+
+    #[test]
+    fn a_const_the_driver_supplied_is_servable() {
+        let env = DefinesEnv::from([("economy/base-subsistence".to_owned(), Value::Real(0.0005))]);
+        assert!(check_sources_servable(
+            &[constant("base-subsistence", "economy/base-subsistence")],
+            &env
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn a_const_the_driver_did_not_supply_is_refused_by_name_at_entry() {
+        // Refused AT ENTRY rather than at the read: a rule that dies
+        // mid-guard on an unbound variable names neither the source nor the
+        // reason, and a defaulted coefficient would be silent degradation.
+        let err = check_sources_servable(
+            &[constant("floor-wage", "economy/floor-wage")],
+            &DefinesEnv::new(),
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("economy/floor-wage"),
+            "{}",
+            err.message
+        );
+        assert!(
+            err.message.contains("supplied no such coefficient"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn the_calendar_sources_needing_an_epoch_stay_refused() {
+        // A defines environment does not buy `:year` — §2.5 puts the epoch
+        // and the ticks-per-year figure in the kernel's clock, and this
+        // driver pins neither. Guards the const change against widening the
+        // refusal set by accident.
+        for source in [BindSource::Year, BindSource::TickOfYear] {
+            let decl = BindingDecl {
+                name: "when".to_owned(),
+                source,
+                optional: false,
+                default: None,
+            };
+            assert!(check_sources_servable(&[decl], &DefinesEnv::new()).is_err());
         }
     }
 

--- a/rust/crates/babylon-bsl/tests/fundamental_theorem_tick.rs
+++ b/rust/crates/babylon-bsl/tests/fundamental_theorem_tick.rs
@@ -33,7 +33,7 @@ use babylon_bsl::intrinsic_host::EmptyIntrinsicHost;
 use babylon_bsl::rule_pipeline::{load_rule, LoadContext};
 use babylon_bsl::scenario::load_scenario;
 use babylon_bsl::structural_verbs::CollectingSink;
-use babylon_bsl::tick::run_tick;
+use babylon_bsl::tick::{run_tick, DefinesEnv};
 use babylon_bsl::typecheck::TypeEnv;
 use babylon_bsl::types::{BslType, FieldDecl, FieldKind};
 use babylon_bsl::BindingVocabulary;
@@ -141,6 +141,7 @@ fn run_one_tick() -> (MemoryGraph, usize, usize) {
         &mut graph,
         &mut sink,
         &r.intrinsics,
+        &DefinesEnv::new(),
         1,
     )
     .expect("the tick must run");
@@ -249,6 +250,7 @@ fn a_changed_scenario_changes_the_hash() {
         &mut richer,
         &mut sink,
         &r.intrinsics,
+        &DefinesEnv::new(),
         1,
     )
     .unwrap();
@@ -356,6 +358,7 @@ fn run_expr_tick(rule: &str) -> Result<(MemoryGraph, usize), String> {
         &mut graph,
         &mut sink,
         &r.intrinsics,
+        &DefinesEnv::new(),
         1,
     )
     .map_err(|e| format!("tick: {e}"))?;

--- a/rust/crates/babylon-tick/content/rules/vitality.bsl
+++ b/rust/crates/babylon-tick/content/rules/vitality.bsl
@@ -1,0 +1,91 @@
+; VitalitySystem (Material Base @1.0) — The Drain and The Reaper.
+;
+; Living costs wealth. A class burns subsistence every tick in proportion to
+; its numbers and to the standard of living its position requires, and a
+; block that can no longer cover its own reproduction stops existing.
+;
+; ONE rule, not three. §4.2: rules within one system position observe the
+; same pre-state, so a three-rule decomposition would have to restate the
+; drain algebra in each downstream rule. The `:expr` bindings of R9 chapter
+; C7 name the intermediates once instead.
+;
+; WHAT THIS RULE DELIBERATELY DOES NOT DO — Grinding Attrition, the frozen
+; system's Phase 2. Two independent blockers, both recorded in
+; docs/superpowers/plans/2026-08-10-vitality-bsl-rule-pack.md §6:
+;
+;   1. `deaths = floor(population × rate)` needs a Real→Int demotion. §3.1
+;      declares no coercions and §3.3 promotes one way only, so the language
+;      has no demotion path at all. §3.10's rider slate row 2 records
+;      `floor`/`trunc` as a PROPOSAL, outside the {exp, log} intrinsic cap.
+;   2. The rate itself — deficit × (attrition_base_factor + inequality),
+;      clamped — is a stipulated functional form with a tuned knob, and it
+;      is the same construct as ADR173's P(S|A): the mass of the
+;      within-class wealth distribution that fails to clear subsistence.
+;      ADR175 puts its emergent re-derivation behind a per-family Director
+;      review, which has not happened.
+;
+; So a world where the frozen engine's attrition would kill is a world this
+; rule under-kills. The conformance scenario shipped beside it is chosen so
+; the frozen engine kills nobody, and nothing wires this rule into an
+; always-on path.
+(rule vitality/subsistence-and-death
+  :material-basis "a class reproduces itself out of its own wealth every tick, at a cost set by its numbers and by the standard of living its position in production requires; a block that cannot meet that cost ceases to exist as a class"
+  :fuel 512
+  (bindings
+    (binding active :field social-class/active)
+    (binding population :field social-class/population)
+    (binding wealth :field social-class/wealth)
+    (binding subsistence-multiplier :field social-class/subsistence-multiplier)
+    (binding s-bio :field social-class/s-bio)
+    (binding s-class :field social-class/s-class)
+    (binding base-subsistence :const economy/base-subsistence)
+    (binding death-threshold :const economy/death-threshold)
+    ; The frozen engine's association order, transcribed exactly:
+    ; (base_subsistence * population) * multiplier. `<arith>` is strictly
+    ; binary (E-PARSE-040), so the source states it rather than implying it,
+    ; and binary64 reproduces the same double.
+    (binding cost :expr (* (* base-subsistence population) subsistence-multiplier))
+    ; The frozen engine writes max(0.0, wealth - cost): it destroys the part
+    ; a class cannot pay rather than carrying a debt. That is a modelling
+    ; choice of the reference and part of the structure contract, so this
+    ; transcribes it — stated positively, as what the class actually hands
+    ; over: subsistence, or everything it has, whichever is less.
+    ;
+    ; Written this way and not as `(if (> (- wealth cost) 0) … 0)` for two
+    ; reasons. §3.10's rider slate row 5 declines a scalar min/max precisely
+    ; so a saturation stays legible in the source rather than hiding in an
+    ; operator — and §1.5 admits NO bare non-integer literal, so the zero
+    ; branch of that form would be an `Int` where the other branch is a
+    ; `Real`: two static types under one `if`, in a language that declares
+    ; no coercions (§3.1). Subtracting what was paid keeps one type
+    ; throughout and lands on exactly 0.0 when a class is wiped out.
+    (binding paid :expr (if (> wealth cost) cost wealth))
+    (binding drained :expr (- wealth paid))
+    (binding consumption-needs :expr (+ s-bio s-class)))
+  ; The two `continue`s at the top of the frozen loop.
+  (when (and (= active 1) (> population 0)))
+  (effects
+    (update-node self social-class/wealth (set drained))
+    ; The Reaper. `is_extinct` (population <= 0 after attrition) cannot fire
+    ; here — the guard above already excludes it and no attrition decrement
+    ; runs — so the two surviving causes remain, both of which require a
+    ; block of one and both of which set the same two fields:
+    ;   wealth_threshold: drained < death_threshold  (the zombie failsafe)
+    ;   starvation:       drained < s_bio + s_class
+    (guard (and (= population 1)
+                (or (< drained death-threshold)
+                    (< drained consumption-needs)))
+      (update-node self social-class/active (set 0))
+      (update-node self social-class/population (set 0))
+      ; The frozen payload's `cause` string does not travel: §2.8 admits no
+      ; string in a payload and §1.5 admits string literals at
+      ; :material-basis and vector ids only (E-PARSE-010). A discriminant
+      ; would need a registered closed enum, which is a vocabulary addition
+      ; and therefore spec-first. It stays recoverable from the payload:
+      ; drained < death_threshold means wealth_threshold, else starvation.
+      (emit EventType/ENTITY_DEATH
+        (entity-id self)
+        (wealth drained)
+        (consumption-needs consumption-needs)
+        (s-bio s-bio)
+        (s-class s-class)))))

--- a/rust/crates/babylon-tick/content/scenarios/vitality-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/vitality-conformance.bscn
@@ -1,0 +1,107 @@
+; The conformance world for vitality/subsistence-and-death.
+;
+; Six social classes, each one a case the rule has to tell apart: a fed core
+; class, an elite whose standard of living costs five times as much per head,
+; a block of one that survives, a block of one that starves, a block of one
+; the zombie failsafe removes, and a class already dissolved.
+;
+; THE FIXTURE IS CHOSEN SO THE UN-PORTED PHASE CONTRIBUTES NOTHING. Every
+; subject satisfies int(population × attrition_rate) == 0 under the frozen
+; engine's Grinding Attrition — either coverage clears the threshold and the
+; rate is exactly 0.0, or population × rate < 1. The frozen engine therefore
+; performs no population decrement and emits no POPULATION_ATTRITION here, so
+; the post-tick state below is expected to match the FULL Python system
+; exactly rather than approximately. Any divergence is a real defect.
+;
+; The mirror of this file is content/scenarios/vitality_conformance.py, which
+; builds the same six classes against the frozen VitalitySystem and prints
+; the post-tick values the Rust test pins.
+(scenario vitality/conformance
+  ; 0/1 rather than #t/#f: BSL has Bool (§3.1) but `deffield` has no bool
+  ; type and GraphSubstrate attributes are f64. Recorded, not hidden.
+  (deffield social-class/active int extensive)
+  (deffield social-class/population int extensive)
+  (deffield social-class/wealth int extensive)
+  ; Per-head quantities: an unweighted mean of one across classes is the
+  ; variance error §3.4 exists to reject, so they are declared intensive.
+  (deffield social-class/subsistence-multiplier int intensive)
+  (deffield social-class/s-bio int intensive)
+  (deffield social-class/s-class int intensive)
+  ; Declared and seeded, read by NO rule in this pack. It is here because
+  ; the frozen engine's Phase 2 requires it and this world mirrors that
+  ; fixture node for node; the rule that would read it does not exist, for
+  ; the two reasons the .bsl header records.
+  (deffield social-class/inequality int intensive)
+
+  ; The defines environment (§2.5's `:const`, §4.2's "the defines
+  ; environment (coefficients)"). Values transcribed from the canonical
+  ; single source of truth, src/babylon/data/defines.yaml:
+  ;   line 88  economy.base_subsistence: 0.0005
+  ;   line 89  economy.death_threshold:  0.001
+  ; The Phase-2 successor reads that file directly; until then a rule still
+  ; reads a coefficient rather than carrying a magnitude of its own.
+  (defconst economy/base-subsistence 0.0005c)
+  (defconst economy/death-threshold 0.001c)
+
+  ; Fed: cost 0.05 against wealth 1000, coverage far above threshold.
+  (node core NodeType/SOCIAL_CLASS
+    (social-class/active 1)
+    (social-class/population 100)
+    (social-class/wealth 1000)
+    (social-class/subsistence-multiplier 1)
+    (social-class/s-bio 1)
+    (social-class/s-class 1)
+    (social-class/inequality 0))
+
+  ; The Drain scaled by a standard of living: five times the per-head cost.
+  ; The elite burns faster per head than the core class it lives off.
+  (node bourgeoisie NodeType/SOCIAL_CLASS
+    (social-class/active 1)
+    (social-class/population 4)
+    (social-class/wealth 500)
+    (social-class/subsistence-multiplier 5)
+    (social-class/s-bio 2)
+    (social-class/s-class 8)
+    (social-class/inequality 0))
+
+  ; A block of one that SURVIVES. Without this subject, `population == 1`
+  ; and "dies this tick" would be indistinguishable in every vector.
+  (node hermit NodeType/SOCIAL_CLASS
+    (social-class/active 1)
+    (social-class/population 1)
+    (social-class/wealth 100)
+    (social-class/subsistence-multiplier 1)
+    (social-class/s-bio 1)
+    (social-class/s-class 1)
+    (social-class/inequality 0))
+
+  ; Starvation: one member, post-drain wealth 0.9995 against needs of 2.
+  (node last-worker NodeType/SOCIAL_CLASS
+    (social-class/active 1)
+    (social-class/population 1)
+    (social-class/wealth 1)
+    (social-class/subsistence-multiplier 1)
+    (social-class/s-bio 1)
+    (social-class/s-class 1)
+    (social-class/inequality 0))
+
+  ; The zombie failsafe: one member, no wealth at all, so the drain floors
+  ; at zero and post-drain wealth falls below death_threshold.
+  (node remnant NodeType/SOCIAL_CLASS
+    (social-class/active 1)
+    (social-class/population 1)
+    (social-class/wealth 0)
+    (social-class/subsistence-multiplier 1)
+    (social-class/s-bio 3)
+    (social-class/s-class 1)
+    (social-class/inequality 0))
+
+  ; Already dissolved: the guard must skip it entirely, wealth untouched.
+  (node dissolved NodeType/SOCIAL_CLASS
+    (social-class/active 0)
+    (social-class/population 5)
+    (social-class/wealth 10)
+    (social-class/subsistence-multiplier 1)
+    (social-class/s-bio 1)
+    (social-class/s-class 1)
+    (social-class/inequality 0)))

--- a/rust/crates/babylon-tick/content/scenarios/vitality_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/vitality_conformance.py
@@ -1,0 +1,191 @@
+"""Conformance vectors for ``vitality/subsistence-and-death``, from the frozen engine.
+
+This script is the PROVENANCE of every number pinned in
+``rust/crates/babylon-tick/tests/vitality_conformance.rs``. It builds the six
+social classes of ``vitality-conformance.bscn`` node for node, runs the frozen
+``VitalitySystem`` once against them, and prints the post-tick state plus every
+event the tick emitted.
+
+Run it from the repository root, single process::
+
+    PYTHONPATH="$PWD/src" uv run python \\
+        rust/crates/babylon-tick/content/scenarios/vitality_conformance.py
+
+The frozen system is the contract source for STRUCTURE and ORDERING, not a
+correctness oracle (ADR183). The fixture is chosen so that Grinding Attrition —
+the phase the BSL pack does not port, see the ``.bsl`` header — kills nobody
+here: every subject satisfies ``int(population * attrition_rate) == 0``. The
+script asserts that, so a fixture edit that quietly made the un-ported phase
+matter fails loudly instead of drifting the vectors.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from babylon.engine.context import TickContext
+from babylon.engine.services import ServiceContainer
+from babylon.engine.systems.vitality import VitalitySystem
+from babylon.formulas import calculate_mortality_rate
+from babylon.models.enums import NodeType
+from babylon.topology.graph import BabylonGraph
+
+#: The six classes, in the declaration order of ``vitality-conformance.bscn``.
+#: Every value here is an integer, which is the only lane slice 1's scenario
+#: loader stores, so the two fixtures agree literally rather than by rounding.
+SUBJECTS: list[tuple[str, dict[str, Any]]] = [
+    (
+        "core",
+        {
+            "active": True,
+            "population": 100,
+            "wealth": 1000,
+            "subsistence_multiplier": 1,
+            "s_bio": 1,
+            "s_class": 1,
+            "inequality": 0,
+        },
+    ),
+    (
+        "bourgeoisie",
+        {
+            "active": True,
+            "population": 4,
+            "wealth": 500,
+            "subsistence_multiplier": 5,
+            "s_bio": 2,
+            "s_class": 8,
+            "inequality": 0,
+        },
+    ),
+    (
+        "hermit",
+        {
+            "active": True,
+            "population": 1,
+            "wealth": 100,
+            "subsistence_multiplier": 1,
+            "s_bio": 1,
+            "s_class": 1,
+            "inequality": 0,
+        },
+    ),
+    (
+        "last-worker",
+        {
+            "active": True,
+            "population": 1,
+            "wealth": 1,
+            "subsistence_multiplier": 1,
+            "s_bio": 1,
+            "s_class": 1,
+            "inequality": 0,
+        },
+    ),
+    (
+        "remnant",
+        {
+            "active": True,
+            "population": 1,
+            "wealth": 0,
+            "subsistence_multiplier": 1,
+            "s_bio": 3,
+            "s_class": 1,
+            "inequality": 0,
+        },
+    ),
+    (
+        "dissolved",
+        {
+            "active": False,
+            "population": 5,
+            "wealth": 10,
+            "subsistence_multiplier": 1,
+            "s_bio": 1,
+            "s_class": 1,
+            "inequality": 0,
+        },
+    ),
+]
+
+
+def build_graph() -> BabylonGraph:
+    """Build the six-class world, in scenario declaration order."""
+    graph = BabylonGraph()
+    for node_id, attrs in SUBJECTS:
+        graph.add_node(node_id, NodeType.SOCIAL_CLASS, **attrs)
+    return graph
+
+
+def check_attrition_is_inert(services: ServiceContainer) -> None:
+    """Assert the un-ported phase kills nobody in this fixture.
+
+    Recomputes Grinding Attrition exactly as ``VitalitySystem`` would, on the
+    POST-drain wealth, and refuses to emit vectors if any subject would lose a
+    member. That is what lets the Rust test claim an exact match against the
+    FULL frozen system rather than against a subset of it.
+    """
+    base = services.defines.economy.base_subsistence
+    for node_id, attrs in SUBJECTS:
+        if not attrs["active"] or attrs["population"] <= 0:
+            continue
+        population = attrs["population"]
+        cost = (base * population) * attrs["subsistence_multiplier"]
+        drained = max(0.0, attrs["wealth"] - cost)
+        needs = attrs["s_bio"] + attrs["s_class"]
+        rate = calculate_mortality_rate(
+            wealth_per_capita=drained / population,
+            subsistence_needs=needs,
+            inequality=attrs["inequality"],
+        )
+        deaths = int(population * rate)
+        if deaths:
+            raise SystemExit(
+                f"fixture drift: {node_id} loses {deaths} member(s) to Grinding "
+                f"Attrition (rate {rate!r}). The BSL pack does not port that "
+                f"phase, so a fixture where it fires cannot carry an exact "
+                f"conformance vector."
+            )
+        print(f"  {node_id:<12} attrition_rate={rate!r} deaths={deaths}")
+
+
+def main() -> None:
+    """Run one tick of the frozen VitalitySystem and print the vectors."""
+    services = ServiceContainer.create()
+    try:
+        print("defines (src/babylon/data/defines.yaml):")
+        print(f"  economy.base_subsistence = {services.defines.economy.base_subsistence!r}")
+        print(f"  economy.death_threshold  = {services.defines.economy.death_threshold!r}")
+        print()
+
+        print("Grinding Attrition (the un-ported phase), verified inert here:")
+        check_attrition_is_inert(services)
+        print()
+
+        graph = build_graph()
+        VitalitySystem().step(graph, services, TickContext(tick=1))
+        events = services.event_bus.get_history()
+
+        print("post-tick state:")
+        for node_id, _ in SUBJECTS:
+            node = graph.get_node(node_id)
+            if node is None:
+                raise SystemExit(f"node {node_id} vanished during the tick")
+            a = node.attributes
+            print(
+                f"  {node_id:<12} active={a['active']!r:<6} "
+                f"population={a['population']!r:<4} wealth={a['wealth']!r}"
+            )
+        print()
+
+        print("events:")
+        for event in events:
+            print(f"  {event.type} {event.payload!r}")
+        if not events:
+            print("  (none)")
+    finally:
+        services.database.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -38,7 +38,31 @@ pub fn hex(bytes: &[u8; 32]) -> String {
 /// sharing this code path, not a lookalike reimplementation.
 pub fn run_once(scenario_src: &str, rule_src: &str) -> Result<TickReport, String> {
     let mut graph = MemoryGraph::new();
-    let scenario = load_scenario(scenario_src, &mut graph).map_err(|e| e.to_string())?;
+    let mut sink = CollectingSink::default();
+    run_once_into(scenario_src, rule_src, &mut graph, &mut sink)
+}
+
+/// `run_once`, with the world and the event sink supplied by the caller so
+/// they survive the call.
+///
+/// `run_once` returns hashes, which prove that state MOVED and that it moves
+/// the same way twice — but a conformance vector has to name the values a
+/// named class ended the tick holding, and an emitted event has to be
+/// inspectable at all. Threading the two outputs through a parameter keeps
+/// **one** implementation of the flow: `run_once`'s signature and
+/// [`TickReport`] are the seam `babylon-client` consumes and neither moves.
+///
+/// # Errors
+///
+/// A description of the first failing stage — scenario load, rule load,
+/// state hash, or the tick itself.
+pub fn run_once_into(
+    scenario_src: &str,
+    rule_src: &str,
+    graph: &mut MemoryGraph,
+    sink: &mut CollectingSink,
+) -> Result<TickReport, String> {
+    let scenario = load_scenario(scenario_src, graph).map_err(|e| e.to_string())?;
 
     let before = graph
         .state_hash()
@@ -54,7 +78,12 @@ pub fn run_once(scenario_src: &str, rule_src: &str) -> Result<TickReport, String
     };
     let vocabulary = BindingVocabulary {
         fields: scenario.fields.keys().cloned().collect(),
-        consts: HashSet::new(),
+        // The scenario's `(defconst …)` rows ARE the defines environment for
+        // slice 1, exactly as its `deffield` rows are the field registry.
+        // Taking the vocabulary and the values from ONE declaration is what
+        // keeps `E-LOAD-010` (unknown coefficient, at load) and the tick's
+        // lookup from ever disagreeing.
+        consts: scenario.consts.keys().cloned().collect(),
         metrics: HashSet::new(),
     };
     // One ceiling per node type the scenario ACTUALLY minted, keyed as the
@@ -98,14 +127,14 @@ pub fn run_once(scenario_src: &str, rule_src: &str) -> Result<TickReport, String
     };
     let loaded = load_rule(rule_src, &ctx).map_err(|e| format!("rule rejected: {e}"))?;
 
-    let mut sink = CollectingSink::default();
     let outcome = run_tick(
         &loaded,
         &types,
         &EmptyIntrinsicHost,
-        &mut graph,
-        &mut sink,
+        graph,
+        sink,
         &intrinsics,
+        &scenario.consts,
         // `run_once` is one tick, and it is tick 1 — the same number the
         // CLI has always printed. §2.5's `:tick`/`:tick-in-cycle` bindings
         // read it; `:year`/`:tick-of-year` need an epoch slice 1 does not

--- a/rust/crates/babylon-tick/tests/vitality_conformance.rs
+++ b/rust/crates/babylon-tick/tests/vitality_conformance.rs
@@ -67,6 +67,7 @@
 //! would hide exactly the transcription error it would appear to absorb.
 
 use babylon_bsl::evaluator::Value;
+use babylon_bsl::scenario::load_scenario;
 use babylon_bsl::structural_verbs::CollectingSink;
 use babylon_graph::memory::MemoryGraph;
 use babylon_graph::substrate::{GraphSubstrate, NodeId};
@@ -253,4 +254,89 @@ fn a_rule_reading_an_undeclared_coefficient_is_refused_at_load() {
         err.contains("economy/base-subsistance"),
         "the rejection must name the coefficient: {err}"
     );
+}
+
+/// **FIXTURE GUARD — NOT CONTENT.**
+///
+/// The whole conformance claim above rests on one precondition: that the
+/// phase this rule pack does *not* port — Grinding Attrition — kills nobody
+/// in this fixture, so the pinned post-tick state is the FULL frozen
+/// system's rather than a subset's. Until this test existed, that
+/// precondition was asserted only inside `vitality_conformance.py`, and
+/// **nothing runs that script**: no mise task, no CI leg, no pytest
+/// collection. A `.bscn` edit nudging one subject into killing range would
+/// void every vector in this file while every gate stayed green — absence
+/// of a check reading as success, which III.11 exists to forbid.
+///
+/// So the envelope is recomputed here, in the gate that already runs.
+///
+/// **What the formula below is, and is not.** It transcribes
+/// `formulas/vitality.py::calculate_mortality_rate` and `vitality.py:253`'s
+/// truncation, INSIDE A TEST, purely to bound the fixture. It is **not**
+/// mechanics and does not ship: no rule reads it, no content declares it,
+/// and it writes nothing. That distinction is the point — §6.2 of the plan
+/// declines to transcribe this form as a MECHANIC because it is a
+/// stipulated functional form with a tuned knob, and ADR175 puts its
+/// emergent re-derivation behind a per-family Director review. A fixture
+/// guard asserting "this world stays outside the blocked phase's reach"
+/// takes no position on what that phase should eventually compute; a
+/// runtime guard inside the rule would, which is why there is none.
+///
+/// Mutation-verified: seeding `last-worker` with `population 4` (which puts
+/// `int(4 × 0.250125) == 1` inside killing range) reds this test with the
+/// subject named, and restoring the seed greens it again.
+#[test]
+fn the_fixture_keeps_the_un_ported_phase_inert() {
+    /// `vitality.attrition_base_factor`, `src/babylon/data/defines.yaml:177`.
+    ///
+    /// A literal here rather than a `(defconst …)` row because no rule in
+    /// this pack reads it: putting it in the scenario would ship a
+    /// coefficient for a mechanic that does not exist. It belongs to the
+    /// guard, so it lives with the guard.
+    const ATTRITION_BASE_FACTOR: f64 = 0.5;
+
+    let mut seeds = MemoryGraph::new();
+    let scenario = load_scenario(SCENARIO, &mut seeds).expect("the scenario must load");
+    let Some(Value::Real(base_subsistence)) = scenario.consts.get("economy/base-subsistence")
+    else {
+        panic!("the scenario must declare economy/base-subsistence as a scaled literal");
+    };
+
+    for (name, id, ..) in EXPECTED {
+        let seed = |field: &str| {
+            seeds
+                .node_attribute(NodeId(id), field)
+                .unwrap_or_else(|e| panic!("{name}: {}", e.message))
+        };
+        let population = seed("social-class/population");
+        // The frozen loop's two `continue`s: an inactive or empty class
+        // never reaches Phase 2 at all.
+        if seed("social-class/active") == 0.0 || population <= 0.0 {
+            continue;
+        }
+        let cost = (base_subsistence * population) * seed("social-class/subsistence-multiplier");
+        let wealth = seed("social-class/wealth");
+        let drained = if wealth > cost { wealth - cost } else { 0.0 };
+        let needs = seed("social-class/s-bio") + seed("social-class/s-class");
+        let inequality = seed("social-class/inequality");
+
+        let coverage = (drained / population) / needs;
+        let threshold = 1.0 + inequality;
+        let rate = if coverage >= threshold {
+            0.0
+        } else {
+            ((threshold - coverage) * (ATTRITION_BASE_FACTOR + inequality)).clamp(0.0, 1.0)
+        };
+        // `int(population * rate)` — truncation toward zero, as Python's
+        // `int()` does on a non-negative float.
+        let deaths = (population * rate).trunc();
+
+        assert_eq!(
+            deaths, 0.0,
+            "{name} loses {deaths} member(s) to Grinding Attrition (rate {rate}). \
+             The pack does not port that phase, so a fixture where it fires \
+             cannot carry an exact conformance vector — either move the seed \
+             back inside the envelope or stop claiming an exact match."
+        );
+    }
 }

--- a/rust/crates/babylon-tick/tests/vitality_conformance.rs
+++ b/rust/crates/babylon-tick/tests/vitality_conformance.rs
@@ -1,0 +1,256 @@
+//! Conformance vectors for `vitality/subsistence-and-death`, taken from the
+//! frozen Python engine's live behaviour.
+//!
+//! # Provenance
+//!
+//! Every expected value below was printed by the frozen `VitalitySystem`
+//! running one `step()` over a fixture that mirrors
+//! `content/scenarios/vitality-conformance.bscn` node for node. The command,
+//! from the repository root:
+//!
+//! ```text
+//! PYTHONPATH="$PWD/src" uv run python \
+//!     rust/crates/babylon-tick/content/scenarios/vitality_conformance.py
+//! ```
+//!
+//! Its output on 2026-08-10, verbatim:
+//!
+//! ```text
+//! defines (src/babylon/data/defines.yaml):
+//!   economy.base_subsistence = 0.0005
+//!   economy.death_threshold  = 0.001
+//!
+//! Grinding Attrition (the un-ported phase), verified inert here:
+//!   core         attrition_rate=0.0 deaths=0
+//!   bourgeoisie  attrition_rate=0.0 deaths=0
+//!   hermit       attrition_rate=0.0 deaths=0
+//!   last-worker  attrition_rate=0.250125 deaths=0
+//!   remnant      attrition_rate=0.5 deaths=0
+//!
+//! post-tick state:
+//!   core         active=True   population=100  wealth=999.95
+//!   bourgeoisie  active=True   population=4    wealth=499.99
+//!   hermit       active=True   population=1    wealth=99.9995
+//!   last-worker  active=False  population=0    wealth=0.9995
+//!   remnant      active=False  population=0    wealth=0.0
+//!   dissolved    active=False  population=5    wealth=10
+//!
+//! events:
+//!   entity_death {'entity_id': 'last-worker', 'wealth': 0.9995,
+//!                 'consumption_needs': 2, 's_bio': 1, 's_class': 1,
+//!                 'cause': 'starvation'}
+//!   entity_death {'entity_id': 'remnant', 'wealth': 0.0,
+//!                 'consumption_needs': 4, 's_bio': 3, 's_class': 1,
+//!                 'cause': 'wealth_threshold'}
+//! ```
+//!
+//! Two of those lines carry weight beyond their numbers. The attrition block
+//! is the script's own assertion that the phase this rule pack does **not**
+//! port kills nobody in this fixture — which is what lets the state below be
+//! compared against the FULL frozen system rather than against a subset of
+//! it. And `cause` is the one payload key that does not cross: §2.8 admits no
+//! string in a payload (`E-PARSE-010`), so the discriminant would need a
+//! registered closed enum. It stays recoverable — `wealth < 0.001` means
+//! `wealth_threshold`, else `starvation`.
+//!
+//! # Why exact equality and no tolerance
+//!
+//! Both sides run IEEE-754 basic operations on binary64 — `+ − × ÷` and
+//! comparison, correctly rounded, reproducing bit-exactly across
+//! implementations (`bsl-language.rst` §4.3). No transcendental, no libm, no
+//! ambiguity about accumulation order: `<arith>` is strictly binary
+//! (`E-PARSE-040`), so the rule states the association Python's
+//! `(base × population) × multiplier` uses rather than implying it. The
+//! decimals below are Python `repr` output, i.e. the shortest round-tripping
+//! decimal for each double, and Rust parses a float literal correctly
+//! rounded — so `999.95_f64` IS the double Python printed. A tolerance here
+//! would hide exactly the transcription error it would appear to absorb.
+
+use babylon_bsl::evaluator::Value;
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::memory::MemoryGraph;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::{run_once, run_once_into};
+
+const SCENARIO: &str = include_str!("../content/scenarios/vitality-conformance.bscn");
+const RULE: &str = include_str!("../content/rules/vitality.bsl");
+
+/// One subject's post-tick vector: `(scenario name, node id, active,
+/// population, wealth)`.
+///
+/// Node ids follow scenario declaration order (`scenario.rs`: "declaration
+/// order is the id order"), so the names here are the `.bscn`'s and the
+/// `.py`'s, in the one order both files use.
+const EXPECTED: [(&str, u64, f64, f64, f64); 6] = [
+    ("core", 0, 1.0, 100.0, 999.95),
+    ("bourgeoisie", 1, 1.0, 4.0, 499.99),
+    ("hermit", 2, 1.0, 1.0, 99.9995),
+    ("last-worker", 3, 0.0, 0.0, 0.9995),
+    ("remnant", 4, 0.0, 0.0, 0.0),
+    ("dissolved", 5, 0.0, 5.0, 10.0),
+];
+
+fn run() -> (MemoryGraph, CollectingSink) {
+    let mut graph = MemoryGraph::new();
+    let mut sink = CollectingSink::default();
+    run_once_into(SCENARIO, RULE, &mut graph, &mut sink).expect("the Vitality pack must run");
+    (graph, sink)
+}
+
+fn attribute(graph: &MemoryGraph, id: u64, field: &str) -> f64 {
+    graph
+        .node_attribute(NodeId(id), field)
+        .unwrap_or_else(|e| panic!("node {id} field {field}: {}", e.message))
+}
+
+/// The Drain and The Reaper, against the frozen engine's own numbers.
+#[test]
+fn post_tick_state_matches_the_frozen_engine_exactly() {
+    let (graph, _) = run();
+    for (name, id, active, population, wealth) in EXPECTED {
+        assert_eq!(
+            attribute(&graph, id, "social-class/active"),
+            active,
+            "{name}: active"
+        );
+        assert_eq!(
+            attribute(&graph, id, "social-class/population"),
+            population,
+            "{name}: population"
+        );
+        assert_eq!(
+            attribute(&graph, id, "social-class/wealth"),
+            wealth,
+            "{name}: wealth"
+        );
+    }
+}
+
+/// The elite's per-head burn is five times the core class's, and both come
+/// out of the same `:const` coefficient.
+///
+/// Asserted separately from the table because it is the whole *point* of the
+/// Drain — "elites with higher subsistence multipliers burn faster when cut
+/// off from imperial rent flows" (the frozen module's own words) — and a
+/// table row proves it only to a reader who does the division.
+#[test]
+fn the_drain_scales_with_population_and_standard_of_living() {
+    let (graph, _) = run();
+    // FORWARD arithmetic, in the rule's own association order. Recovering
+    // the cost by subtracting the post-tick wealth from the seed instead
+    // would lose most of its significant digits to cancellation and then
+    // fail an exact comparison for a reason that has nothing to do with the
+    // port — the numbers below are exact in binary64, the difference is not.
+    let core_cost = (0.0005_f64 * 100.0) * 1.0;
+    let elite_cost = (0.0005_f64 * 4.0) * 5.0;
+    assert_eq!(
+        attribute(&graph, 0, "social-class/wealth"),
+        1000.0 - core_cost
+    );
+    assert_eq!(
+        attribute(&graph, 1, "social-class/wealth"),
+        500.0 - elite_cost
+    );
+    assert_eq!(
+        core_cost / 100.0,
+        0.0005,
+        "core burns base_subsistence/head"
+    );
+    assert_eq!(
+        elite_cost / 4.0,
+        0.0025,
+        "the elite burns five times as much per head"
+    );
+}
+
+/// A block of one that can still cover its own reproduction survives the
+/// tick. Without this the death guard would look like "population == 1".
+#[test]
+fn a_solvent_block_of_one_survives() {
+    let (graph, _) = run();
+    assert_eq!(attribute(&graph, 2, "social-class/active"), 1.0);
+    assert_eq!(attribute(&graph, 2, "social-class/population"), 1.0);
+}
+
+/// An inactive class is skipped whole: the guard runs before any effect, so
+/// even the unconditional wealth write does not touch it.
+#[test]
+fn a_dissolved_class_is_untouched() {
+    let (graph, _) = run();
+    assert_eq!(
+        attribute(&graph, 5, "social-class/wealth"),
+        10.0,
+        "the drain must not run on an inactive class"
+    );
+}
+
+/// The Reaper's two deaths, with the payload the frozen engine emitted —
+/// minus `cause`, which §2.8 gives no way to carry.
+#[test]
+fn the_reaper_emits_one_entity_death_per_dissolution() {
+    let (_, sink) = run();
+    assert_eq!(
+        sink.events.len(),
+        2,
+        "exactly the two blocks the frozen engine killed"
+    );
+    for (event_type, _) in &sink.events {
+        assert_eq!(event_type, "ENTITY_DEATH");
+    }
+
+    let expected: [(u64, f64, f64, f64, f64); 2] = [
+        // last-worker: starvation — 0.9995 against needs of 2.
+        (3, 0.9995, 2.0, 1.0, 1.0),
+        // remnant: the zombie failsafe — 0.0, below death_threshold.
+        (4, 0.0, 4.0, 3.0, 1.0),
+    ];
+    for (i, (id, wealth, needs, s_bio, s_class)) in expected.into_iter().enumerate() {
+        let payload = &sink.events[i].1;
+        let expected_payload = vec![
+            ("entity-id".to_owned(), Value::NodeRef(NodeId(id))),
+            ("wealth".to_owned(), Value::Real(wealth)),
+            ("consumption-needs".to_owned(), Value::Real(needs)),
+            ("s-bio".to_owned(), Value::Real(s_bio)),
+            ("s-class".to_owned(), Value::Real(s_class)),
+        ];
+        assert_eq!(payload, &expected_payload, "payload of death {i}");
+    }
+}
+
+/// Byte-determinism: the same content twice is the same post-state hash, and
+/// the tick moved state at all.
+#[test]
+fn the_vitality_tick_is_deterministic() {
+    let a = run_once(SCENARIO, RULE).expect("first run");
+    let b = run_once(SCENARIO, RULE).expect("second run");
+    assert_eq!(a.after, b.after, "two runs, one post-state");
+    assert_ne!(a.before, a.after, "the pack must move state");
+    assert_eq!(a.fired, 5, "five of six subjects pass the guard");
+}
+
+/// A rule naming a coefficient the scenario never declared fails at LOAD,
+/// with the coefficient named.
+///
+/// The defines environment and the binding vocabulary come from one place —
+/// the scenario's `(defconst …)` rows — so `E-LOAD-010` catches a mistyped
+/// coefficient before any subject runs, exactly as it catches a mistyped
+/// field. A defaulted coefficient would be the quiet degradation §6.3
+/// forbids, and one discovered at the read would report an unbound variable
+/// instead of a missing define.
+#[test]
+fn a_rule_reading_an_undeclared_coefficient_is_refused_at_load() {
+    let rule = "(rule vitality/typo \
+                :material-basis \"subsistence is paid out of wealth\" :fuel 32 \
+                (bindings \
+                  (binding wealth :field social-class/wealth) \
+                  (binding base :const economy/base-subsistance)) \
+                (when (> wealth base)) \
+                (effects (update-node self social-class/wealth (set base))))";
+    let Err(err) = run_once(SCENARIO, rule) else {
+        panic!("a mistyped coefficient must not load");
+    };
+    assert!(
+        err.contains("economy/base-subsistance"),
+        "the rejection must name the coefficient: {err}"
+    );
+}


### PR DESCRIPTION
Ports `VitalitySystem` (Material Base position 1.0) from the frozen Python engine to a BSL rule the Rust engine runs, conformance-vectored from the frozen engine's live behaviour.

**It ports in part, and the part that does not land is the point of the PR.** Phases 1 and 3 land exactly. Phase 2 (Grinding Attrition) is blocked twice over — once mechanically, once doctrinally — and this PR escalates rather than improvising.

Plan: `docs/superpowers/plans/2026-08-10-vitality-bsl-rule-pack.md`. **F-3:** the plan has been corrected where it drifted from what landed — the two filenames, and §2's claim that the rule spells `max(0,…)` as `(if (> … 0) … 0)`. That form is **illegal BSL**: §1.5 admits no bare non-integer literal, so its zero branch is an `Int` under a `Real` branch with no coercion to bridge them (§3.1). The plan now carries the landed `paid`/`drained` spelling with that explanation, because a reader following the old text would have written a rule that cannot load.

## What landed

**`vitality/subsistence-and-death`** — ONE rule, not three. §4.2 says rules within one system position observe the same pre-state, so a three-rule decomposition would restate the drain algebra in each downstream rule; R9 chapter C7's `:expr` bindings name the intermediates once instead. The R9 gap analysis reads it the same way (`reports/bsl-gap-analysis-2026-08-10.md:419`).

- The Drain: `cost = (base_subsistence × population) × multiplier`, in the frozen engine's association order, transcribed literally because `<arith>` is strictly binary (`E-PARSE-040`).
- The Reaper: `population == 1` and post-drain wealth below either `death_threshold` (the zombie failsafe) or `s_bio + s_class` (starvation) → `active = 0`, `population = 0`, `ENTITY_DEATH`.

**A defines environment, so `:const` is servable.** `check_sources_servable` refused every `:const` binding by name ("slice 1 has no defines environment"), which blocked *any* ported system that reads a coefficient. `scenario.rs` gains `(defconst <qname> <literal>)` — the same registry-in-miniature argument as `deffield`, one level up — and `run_tick` takes a `DefinesEnv`. Engine machinery only: **no new BSL form, no new `<bind-src>`, no new error code**. `:const` and its `E-LOAD-010` gate already existed. The warrant for "no new BSL form" is **D91**'s scope split (`bsl-language.rst:4443`, merged in #482): a scenario file is reader-parsed fixture surface with exactly the standing of a `vector` form — never encoded under §5, never hashed into a content digest — and the spec carries no `.bscn` grammar at all, so `defconst` extends a fixture format the language does not define rather than the language. `:year`/`:tick-of-year` stay refused; a defines environment does not buy an epoch. **F-2:** `defconst` accepted `Atom::Currency` while `tick.rs::atom_to_value` (the `:default` path) and `scenario.rs::attribute_value` (the attribute path) both refuse one — the same literal legal through one door and rejected through the others, i.e. the entry point deciding the type system. It now refuses loudly with the sibling refusals' own reason (no typed storage for i128 micro-units; Currency arrives with the declared Phase-2 trait revision), pinned by `a_currency_defconst_is_refused_exactly_as_a_currency_default_is`, and the "one conversion" comment is narrowed to the scaled lane it actually covers. `run_once`'s signature and `TickReport` — the `babylon-client` seam — are untouched; `run_once_into` is a new sibling that hands back the world and the sink.

## Conformance-vector provenance

Exact command, single process, from the repository root:

```
PYTHONPATH="$PWD/src" uv run python \
    rust/crates/babylon-tick/content/scenarios/vitality_conformance.py
```

Output on 2026-08-10, verbatim (the script is committed; the Rust test's module doc carries the same block):

```
defines (src/babylon/data/defines.yaml):
  economy.base_subsistence = 0.0005
  economy.death_threshold  = 0.001

Grinding Attrition (the un-ported phase), verified inert here:
  core         attrition_rate=0.0 deaths=0
  bourgeoisie  attrition_rate=0.0 deaths=0
  hermit       attrition_rate=0.0 deaths=0
  last-worker  attrition_rate=0.250125 deaths=0
  remnant      attrition_rate=0.5 deaths=0

post-tick state:
  core         active=True   population=100  wealth=999.95
  bourgeoisie  active=True   population=4    wealth=499.99
  hermit       active=True   population=1    wealth=99.9995
  last-worker  active=False  population=0    wealth=0.9995
  remnant      active=False  population=0    wealth=0.0
  dissolved    active=False  population=5    wealth=10

events:
  entity_death {'entity_id': 'last-worker', 'wealth': 0.9995, 'consumption_needs': 2, 's_bio': 1, 's_class': 1, 'cause': 'starvation'}
  entity_death {'entity_id': 'remnant', 'wealth': 0.0, 'consumption_needs': 4, 's_bio': 3, 's_class': 1, 'cause': 'wealth_threshold'}
```

**The fixture makes the missing phase non-load-bearing, and that is now gate-enforced (F-1, option b).** Every subject satisfies `int(population × attrition_rate) == 0`. Asserting that only inside the Python script left it unchecked — nothing runs that script: no mise task, no CI leg, no `pytest` collection — so a `.bscn` edit nudging one subject into killing range would have voided every vector above while the gates stayed green. `the_fixture_keeps_the_un_ported_phase_inert` now recomputes the envelope from the committed scenario seeds inside `mise run rust:check`.

The rate formula that guard uses is marked **FIXTURE GUARD — NOT CONTENT** in those words: it lives in a test, no rule reads it, nothing declares it, it writes nothing. Bounding the *fixture* takes no position on what the blocked phase should eventually compute; a guard inside the *rule* would, which is why the conservative runtime predicate (`population > 1 ∧ coverage < 1.0 + inequality`) is **deliberately absent** — it would transcribe part of the blocked threshold boundary into shipped mechanics, the exact territory §6.2 keeps clear pending the Director's mortality-family ruling.

**Mutation-verified:** seeding `last-worker` with `population 4` (`int(4 × 0.250125) == 1`) reds the guard naming the subject and the rate — `last-worker loses 1 member(s) to Grinding Attrition (rate 0.437625)` — and restoring the seed greens it.

**Tolerance policy: none, asserted at exact `f64` equality.** Both sides run IEEE-754 basic operations on binary64 only (`+ − × ÷`, comparison), correctly rounded and reproducible across implementations (`bsl-language.rst` §4.3). No transcendental, no libm, no accumulation-order ambiguity. The decimals are Python `repr` output — the shortest round-tripping decimal per double — and Rust parses float literals correctly rounded, so `999.95_f64` *is* the double Python printed. A tolerance here would hide exactly the transcription error it appears to absorb.

### The blocked vector (asserted nowhere)

What the frozen engine does when attrition fires — the numbers the §3.10 rider would have to reproduce. 1000 members, wealth 1500, `s_bio = s_class = 1`, `inequality = 0.4`:

```
post-tick: {'active': True, 'population': 415, 'wealth': 1499.5}
population_attrition {'entity_id': 'mass', 'deaths': 585, 'remaining_population': 415, 'attrition_rate': 0.5852249999999999}
```

No code in this PR claims to produce it, so nothing asserts it.

## §5.4 repair records (ADR183: structure/ordering contract, not a correctness oracle)

**D-1 — two absence policies for the same fields in one tick.** `_calculate_deaths` reads `wealth`/`population`/`inequality`/`s_bio`/`s_class` with `required=True` (`vitality.py:227-231`, with a comment naming the gotcha it repairs). Twelve lines later Phase 3 reads `s_bio`/`s_class` off the pre-phase dict with `attrs.get("s_bio", 0.0)` (`:154-155`), and the skip block uses `.get` defaults (`:106,109,116,118`). A class missing `s_bio` raises in Phase 2 and silently reads `0.0` in Phase 3 — where `consumption_needs = 0` makes a starving class un-starvable. **Repaired:** every field is a required `:field` binding; absence is the substrate's loud error (III.11). *Behavioural difference:* a node missing any of the six fields now aborts the tick instead of proceeding on a default.

**D-2 — `if base_subsistence > 0` is a dead branch** (`vitality.py:117`, guarding on a define whose value is `0.0005`). Not transcribed; the drain is unconditional and the define supplies its scale. A mod setting it to `0.0` gets the same observable outcome, since the effect is `set drained` and `drained == wealth` there.

**D-3 — `calculate_mortality_rate` cannot see `defines.yaml`.** `formulas/vitality.py:13` binds `_DEFINES = GameDefines()` at import — the **schema defaults**, not `GameDefines.load_default()` — and bakes `attrition_base_factor` into a default argument the system never overrides. Editing `defines.yaml: vitality.attrition_base_factor` changes nothing. A modding-contract defect in the frozen engine, found by reading it for this port. **It is LATENT today**, which my earlier phrasing did not say: `defines.yaml:177` and the schema default are both `0.5`, so no value diverges until somebody edits the YAML — the contract is broken, the numbers are not. **Plausible root cause (verifier-found):** `src/babylon/config/defines/_assembler.py:398-399` still documents `load_default` as *"The repository ships without the YAML, so the dataclass defaults are the canonical values today"* — **stale**; `src/babylon/data/defines.yaml` exists and CLAUDE.md names it the canonical player-editable source of truth. A reader trusting that docstring would conclude `GameDefines()` and `load_default()` are interchangeable, which is exactly the mistake `formulas/vitality.py:13` makes. Both are informational here — neither is repaired in this PR (Python is out of its scope, and the docstring is its own unit). Not repaired here (the formula is not transcribed, below), but the `:const` binding is the structural answer: a coefficient reaches a rule only through the defines environment, so no import-time capture can go stale.

**D-4 — `cause` is a string in an event payload.** §2.8 admits no string in a payload and §1.5 admits string literals at `:material-basis` and vector ids only (`E-PARSE-010`); a discriminant needs a registered closed enum, which is spec-first. The `ENTITY_DEATH` payload carries `entity-id`, `wealth`, `consumption-needs`, `s-bio`, `s-class`. Recoverable: `wealth < death_threshold` means `wealth_threshold`, else `starvation`.

**Not a defect, recorded so nobody "fixes" it:** `max(0.0, wealth − cost)` destroys the part a class cannot pay rather than carrying a debt. That is the reference's modelling choice and part of the structure contract; the rule transcribes it, stated positively as `paid = min(cost, wealth)` so both `if` branches carry one static type (§1.5 admits no bare non-integer literal, so an `Int` zero branch under a `Real` branch would be two types under one `if` in a language declaring no coercions).

## What I deliberately did NOT do

**Grinding Attrition — ESCALATED, not worked around. Two independent blockers:**

1. **Mechanical.** `deaths = int(population * attrition_rate)` (`vitality.py:253`) needs a floor. §3.1 declares **no coercions** and §3.3 promotes `Int → Real` **one way only**, so the language holds no `Real → Int` demotion path at all. §3.10's rider slate row 2 (`floor`/`trunc`, "In cap? **No**") records this as a *proposal*, explicitly non-normative; the cap is `{exp, log}` at most (R10 citing ADR176 r21). *What it would take:* a Director ruling on row 2, then §3.1/§3.2 gaining the demotion with its rounding mode pinned, an `E-` code, a §3.7 cost row, CAS coverage.

2. **Doctrinal, and the one I would most like a Director eye on.** `rate = (1.0 + inequality − coverage_ratio) × (attrition_base_factor + inequality)`, clamped, is a stipulated piecewise-linear form with a tuned knob — `attrition_base_factor = 0.5`, described in its own schema as *"Base multiplier in grinding attrition"* (`config/defines/survival.py:88-92`), a feel-tier define with no written Aleksandrov chain. Standard S-7 / ADR172 ruling 5 forbid imposing a functional form on a mechanic. And Vitality's own module header says what it approximates: *"One agent = one demographic block. High inequality within a block means you need MORE coverage to prevent deaths"* — i.e. **the mass of the within-class wealth distribution that fails to clear subsistence**, which is exactly ADR173's ruled formulation for `P(S|A)` (`ai/bsl-architecture-standard.md` §3.2 fact 2). Grinding Attrition repeats that construct with a linear proxy where the distribution integral belongs. ADR175 puts every non-survival site's emergent re-derivation behind a **per-family Director review**, and mortality has had none. Transcribing the form would enshrine what ADR172 ruling 5 retires; substituting a measure would be an ideological call Constitution IX.5 reserves to the Director.

**Also not done, each for a stated reason:**

- **No rule-pack sequencer.** A pack is rules at one position observing one pre-state; with a single rule there is no order to declare, and the anchor→total-order resolver is `babylon-engine` Phase-3 work (`mod_anchors.rs` module doc). Building it now would be machinery with no caller.
- **No scenario-loader widening.** Every fixture value is an integer, so the `int`-declared-fields-only restriction was never hit and stays as it was.
- **No always-on wiring.** `run_once` still takes its rule as an argument; tests exercise the Vitality pair. Nothing in the tree runs Vitality over an arbitrary world and reports a population figure — which matters, because on a world where attrition would kill, this rule under-kills.
- **No Python touched** beyond adding the conformance script under `rust/crates/babylon-tick/content/scenarios/`.

## Gates

- `mise run rust:check` — **green** (format + clippy `-D warnings` + test + doc, `--locked`). `babylon-bsl` carries `#![warn(clippy::pedantic)]`, so pedantic is enforced by that gate and clean.
- New tests: **8** in `babylon-tick` (conformance table, drain scaling, solvent block of one, dissolved class untouched, the two `ENTITY_DEATH` payloads, byte-determinism, undeclared-coefficient load rejection, fixture-inertness guard) + **7** in `babylon-bsl` (`defconst` load, duplicate, non-literal, Currency refused, `:const` servable/refused-by-name, calendar sources still refused). Workspace: 236 + 121 + 83 + 48 + 19 + 9 + 8 + 1 + 1 + 1, all passing.
- `ruff check` / `ruff format --check` / `mypy` clean on the conformance script; `vale` clean on the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
