### PR TITLE
docs(bsl): consolidated EBNF grammar (§7/D92) + tree-sitter-bsl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,11 @@ deploy/ansible/.ansible/
 
 # Generated environment snapshot — embeds plaintext env-var values (secrets); never commit
 snapshot_report.html
+
+# tree-sitter-bsl: the parser is a BUILD PRODUCT of grammar.js (itself derived
+# from docs/reference/bsl.ebnf). Regenerate with `mise run bsl:grammar-test`;
+# committing generated C would make the grammar's real source ambiguous.
+/tools/tree-sitter-bsl/src/
+/tools/tree-sitter-bsl/bindings/
+/tools/tree-sitter-bsl/build/
+/tools/tree-sitter-bsl/*.wasm

--- a/.mise.toml
+++ b/.mise.toml
@@ -1653,6 +1653,21 @@ description = "Refresh rust/Cargo.lock after workspace-member or dependency chan
 dir = "rust"
 run = "cargo build --workspace"
 
+[tasks."bsl:grammar-test"]
+description = "Regenerate the derived tree-sitter-bsl parser from grammar.js and run its corpus tests (tools/tree-sitter-bsl). The grammar is DERIVED from docs/reference/bsl.ebnf and is normative for nothing — docs/reference/bsl-language.rst is. Generated parser sources are git-ignored build products, so this task is how a fresh clone gets one."
+dir = "tools/tree-sitter-bsl"
+run = """
+set -e
+command -v tree-sitter >/dev/null 2>&1 || {
+  echo "tree-sitter CLI not found on PATH."
+  echo "Install it with: cargo install tree-sitter-cli"
+  echo "(node comes from the repo flake: mise run nix -- node --version)"
+  exit 1
+}
+tree-sitter generate
+tree-sitter test
+"""
+
 [tasks."test:optimization"]
 description = "Ungated behavioral-contract tests for the optimization package (in_memory backend, no Postgres required) — NOT wired into mise run check"
 run = "uv run pytest tests/unit/engine/optimization -q"

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -85,6 +85,16 @@ revision is additive on the same terms as the third: no form changes meaning,
 §5.6's canonical bytes and both its digests are unchanged, and the intrinsic
 table is untouched.
 
+**Fifth revision — the consolidated grammar (2026-08-10).** §7 collects every
+production of §§1, 2 and 6.1 into ``docs/reference/bsl.ebnf`` and includes it
+here, adding row **D92** and a *rigor index* (§7.1) that says where each
+artifact of the language's rigor lives. The collection **declares nothing**:
+it states one EBNF dialect, records in comments the context conditions a
+context-free grammar cannot carry, and where the sections are silent or
+disagree with themselves it flags the gap at the production instead of
+choosing. No form is added, retired or changed; §5.6's bytes and both its
+digests are again unchanged.
+
 **Standard this document is written to.** Constitution III.12(a) — the *rewrite
 test*: two independent implementations (the Rust ``babylon-bsl`` crate now,
 anything later) must be derivable from this document alone, without reading
@@ -3817,6 +3827,112 @@ code path it tests is invalid), transcription review with an idiom-mismatch
 checklist (F3), and spec-completeness (F4 — every construct §2 defines has at
 least one vector).
 
+7. Consolidated grammar
+-------------------------
+
+Every production of §§1, 2 and 6.1, collected into one file and included here.
+**The grammar collects; it does not amend.** On any divergence between a
+§1/§2/§6 production and this appendix, the **section text wins**, and the
+divergence is a defect in the appendix to be repaired there. Nothing in this
+section adds a form, retires one, or changes what one means — an inclusion is
+not a second home, which is the property that keeps this document the *one*
+normative home its Program-27 charter makes it (D92).
+
+Two things the file carries that the sections do not, both notation rather
+than language. It states a **single EBNF dialect** — W3C EBNF, the XML 1.0 §6
+notation whose operator set §1.4 and §2.1 already use — and applies it
+uniformly, so that a reader is never left inferring which dialect a `?` came
+from. And it collects, in comments, the **context conditions an EBNF cannot
+express**: maximal munch within a token run, the closed keyword set, the
+reserved element names ``self`` and ``it``, and the whole of §3's static
+semantics. A derivation read from the file without them accepts programs this
+language rejects, and the file says so at the top rather than leaving the gap
+to be discovered.
+
+Where the sections are silent or disagree with themselves, the file **records
+the gap at the production** rather than choosing quietly: ``<type-name>``
+carries no §1.4 atom class and §3.1 spells the type names capitalized, which
+§1.4 cannot lex; and §6.1's ``:graph`` / ``:fuel-used`` / ``:cas`` are written
+with the ``?`` binding to the *value*, which makes the keywords themselves
+mandatory against §6.1's own prose. Both are transcribed as the sections write
+them, annotated with the reading the Rust reference implementation took, and
+left to the Phase-1 review — a grammar appendix is exactly the wrong place to
+settle a question of what the language *is*.
+
+.. literalinclude:: bsl.ebnf
+   :language: bnf
+   :caption: ``docs/reference/bsl.ebnf`` — the consolidated grammar
+
+7.1 The rigor index
+~~~~~~~~~~~~~~~~~~~~~
+
+Where each artifact of this language's rigor lives. **Pointers only**: every
+row's content belongs to the place it names, and this table restates none of
+it.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 30 46
+
+   * - Artifact
+     - Home
+     - What it fixes
+   * - Consolidated grammar
+     - §7 / ``docs/reference/bsl.ebnf``
+     - Every production of §§1, 2 and 6.1 in one stated dialect. Normative
+       by inclusion; the section text wins on divergence.
+   * - Lexis and syntax
+     - §1, §2
+     - The productions themselves, with the rulings that shaped each.
+   * - Static semantics
+     - §3
+     - Types (§3.1), the currency lane (§3.2–§3.3), the intensivity kind
+       rule (§3.4), binding resolution (§3.5), the closed vocabulary
+       (§3.6), deliberate absences (§3.8), the invariant substrate and
+       scale lattice (§3.9), the intrinsic cap (§3.10).
+   * - Dynamic semantics
+     - §4
+     - Evaluation order (§4.1), the environment and subject order (§4.2),
+       arithmetic (§4.3), query evaluation (§4.4), cross-system handoffs
+       (§4.7).
+   * - Cost model
+     - §3.7 (static bound), §4.5 (runtime meter)
+     - ``cost(n)`` per AST node and ``bound(rule)``; pinned by conformance
+       vector, so a revision is a re-bless ceremony.
+   * - Error-code register
+     - §4.6
+     - The five families (``E-LEX`` / ``E-PARSE`` / ``E-TYPE`` /
+       ``E-LOAD`` / ``E-EVAL``), when each fires, and the contiguity rule
+       every decade block is checkable against.
+   * - Canonical encoding
+     - §5, worked example §5.6
+     - The CAS byte layout, canonical child order, and ``rules_hash``.
+   * - Conformance vectors
+     - §6.1 (format), §6.2 (24 required families), §6.3 (transcription)
+     - What an implementation must pass to claim conformance, and the four
+       silent degradations deliberately broken.
+   * - Decision register
+     - *Draft-Ruling Register*, below
+     - Every point the design document under-determined, D1–D92, each a
+       Phase-1 review item.
+   * - Reference implementation
+     - ``rust/crates/babylon-bsl``
+     - The executable reading: ``reader.rs`` (§1), ``grammar.rs`` (§2's
+       static shape rules), ``canonical_ast.rs`` (§5), ``bound_checker.rs``
+       (§3.7), ``rule_pipeline.rs`` (the §4.6 class ordering). It is *an*
+       implementation, not the spec — III.12(a) requires this document to
+       be derivable without reading it.
+   * - Editor tooling
+     - ``tools/tree-sitter-bsl``
+     - A tree-sitter grammar **derived** from ``bsl.ebnf`` and normative
+       for nothing, with a corpus drawn from real in-tree content. It
+       parses; it does not check §3.
+   * - Determinism contract
+     - :doc:`/reference/determinism-contract`
+     - What ``rules_hash`` is combined with and compared against: the
+       tick-hash field set, ``ContentDigest`` composition, and the
+       float-tolerance regimes.
+
 Draft-Ruling Register
 -----------------------
 
@@ -4453,6 +4569,33 @@ consequences are the ordinary kind of review item.
        form if one ever reached the canonical encoder, so the encoder now
        has license to treat that as a caller error. Re-spelling the vector
        keywords was rejected as churn in a fixture format §5 never touches.
+   * - D92
+     - §7, §1.4, §2.1, §6.1
+     - **The grammar is consolidated as an INCLUDED ASSET, not a second
+       home.** ``docs/reference/bsl.ebnf`` collects every production of §§1,
+       2 and 6.1 and is part of this document by ``literalinclude`` (§7); it
+       **collects and does not amend**, so on any divergence the §1/§2/§6
+       text wins and the appendix is the defect. The dialect is **W3C EBNF**
+       (the XML 1.0 §6 notation), chosen because §1.4 and §2.1 already write
+       their productions in its operator set — collecting them is
+       transcription, where ISO 14977 would have meant translating a
+       normative text into comma-concatenation and ``{ }`` repetition:
+       transcription risk bought for nothing. Two notation-level deviations
+       are stated in the file and are spellings rather than changes —
+       nonterminals lose §2's angle brackets, and §1.4's ``"0" … "9"``
+       ranges become W3C character classes. **Two gaps are recorded at their
+       productions rather than resolved**: ``<type-name>`` has no §1.4 atom
+       class and §3.1's capitalized spelling is unlexable, so the file
+       collects the reference implementation's lowercase-``symbol`` reading
+       and flags it; and §6.1's ``:graph`` / ``:fuel-used`` / ``:cas`` are
+       written with ``?`` binding to the value, which makes the keywords
+       themselves mandatory against §6.1's own prose. Both belong to the
+       Phase-1 review, not to an appendix. A derived, non-normative
+       tree-sitter grammar lives at ``tools/tree-sitter-bsl``; a sync guard
+       (``tests/unit/reference/test_bsl_grammar_sync.py``) requires every
+       §5.2 form tag and every ``::=`` production of §§1/2/6.1 to appear in
+       the appendix, so the collection cannot silently fall behind the
+       sections it collects.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -87,13 +87,15 @@ table is untouched.
 
 **Fifth revision — the consolidated grammar (2026-08-10).** §7 collects every
 production of §§1, 2 and 6.1 into ``docs/reference/bsl.ebnf`` and includes it
-here, adding row **D92** and a *rigor index* (§7.1) that says where each
-artifact of the language's rigor lives. The collection **declares nothing**:
-it states one EBNF dialect, records in comments the context conditions a
-context-free grammar cannot carry, and where the sections are silent or
-disagree with themselves it flags the gap at the production instead of
-choosing. No form is added, retired or changed; §5.6's bytes and both its
-digests are again unchanged.
+here, adding rows **D92** and **D93** and a *rigor index* (§7.1) that says
+where each artifact of the language's rigor lives. The collection **adds no
+form and changes no meaning**: it states one EBNF dialect, records in comments
+the context conditions a context-free grammar cannot carry, and where the
+sections are silent or disagree with themselves it **collects the reference
+implementation's reading and flags it** — nine of its productions come from
+prose rather than from a code block, so the appendix does choose where it must,
+and says which choice it made and what cuts against it. §5.6's bytes and both
+its digests are again unchanged.
 
 **Standard this document is written to.** Constitution III.12(a) — the *rewrite
 test*: two independent implementations (the Rust ``babylon-bsl`` crate now,
@@ -3831,33 +3833,61 @@ least one vector).
 -------------------------
 
 Every production of §§1, 2 and 6.1, collected into one file and included here.
-**The grammar collects; it does not amend.** On any divergence between a
-§1/§2/§6 production and this appendix, the **section text wins**, and the
+**The grammar collects; it does not amend.** On any divergence between the
+§1/§2/§6 **text** and this appendix, the **section text wins**, and the
 divergence is a defect in the appendix to be repaired there. Nothing in this
 section adds a form, retires one, or changes what one means — an inclusion is
 not a second home, which is the property that keeps this document the *one*
 normative home its Program-27 charter makes it (D92).
 
-Two things the file carries that the sections do not, both notation rather
-than language. It states a **single EBNF dialect** — W3C EBNF, the XML 1.0 §6
-notation whose operator set §1.4 and §2.1 already use — and applies it
-uniformly, so that a reader is never left inferring which dialect a `?` came
-from. And it collects, in comments, the **context conditions an EBNF cannot
-express**: maximal munch within a token run, the closed keyword set, the
-reserved element names ``self`` and ``it``, and the whole of §3's static
-semantics. A derivation read from the file without them accepts programs this
-language rejects, and the file says so at the top rather than leaving the gap
+*Text, not merely production.* The trigger is deliberately the section **text**
+rather than a section production, because nine of the appendix's productions
+have no code block behind them at all — the sections state them in **prose**,
+and a grammar needs a right-hand side. They are ``Char`` (§1.1),
+``whitespace``, ``comment`` and ``delimiter`` (§1.2, §1.4), ``operator``
+(§1.4's draft ruling), ``escape`` (§1.5), ``intrinsic-name`` (§2.7),
+``type-name`` (§2.9/§2.11 use it, §3.1 names the types) and ``vector-file``
+(§6.1). Under a production-only trigger those nine would adjudicate
+themselves — the appendix legislating in exactly the places where no section
+production exists to check it against, which is the reverse of what this
+section is for.
+
+Three things the file carries that the sections do not. It states a **single
+EBNF dialect** — W3C EBNF, the XML 1.0 §6 notation whose operator set §1.4 and
+§2.1 already use — and applies it uniformly, so that a reader is never left
+inferring which dialect a ``?`` came from. It supplies the nine prose-sourced
+right-hand sides above, each carrying its citation. And it collects, in
+comments, the **context conditions an EBNF cannot express**: maximal munch
+within a token run, the string literal's exemption from it, the closed keyword
+set, the reserved element names ``self`` and ``it``, and the whole of §3's
+static semantics. Read without them the file **both** accepts programs this
+language rejects and rejects programs it accepts — the token-run rule applied
+naively to a ``string`` would cut every non-trivial ``:material-basis``
+apart — and the file says so at the top rather than leaving either direction
 to be discovered.
 
-Where the sections are silent or disagree with themselves, the file **records
-the gap at the production** rather than choosing quietly: ``<type-name>``
-carries no §1.4 atom class and §3.1 spells the type names capitalized, which
-§1.4 cannot lex; and §6.1's ``:graph`` / ``:fuel-used`` / ``:cas`` are written
-with the ``?`` binding to the *value*, which makes the keywords themselves
-mandatory against §6.1's own prose. Both are transcribed as the sections write
-them, annotated with the reading the Rust reference implementation took, and
-left to the Phase-1 review — a grammar appendix is exactly the wrong place to
-settle a question of what the language *is*.
+Where the sections are silent or disagree with themselves, the file **collects
+the reference implementation's reading and flags it**. That wording is exact,
+and an earlier "records the gap instead of choosing" was not: a production must
+have a right-hand side, so writing one *is* choosing, and the honest record
+names the reading taken and what cuts against it. Two places:
+
+- ``<type-name>`` carries no §1.4 atom class, while §3.1 spells the type names
+  capitalized and **§2.11's own worked example writes** ``:type Coefficient``.
+  No capitalized spelling is lexable under §1.4, so the appendix collects the
+  reference implementation's lowercase-``symbol`` reading — and records the
+  worked example that contradicts it. The repair is the Phase-1 review's and
+  runs either way: §1.4 gains an atom class for capitalized type names, or
+  §3.1's table and §2.11's example are re-spelled lowercase.
+- §6.1's ``:graph`` / ``:fuel-used`` / ``:cas`` are written with the ``?``
+  binding to the *value*, which makes the keywords themselves mandatory
+  against §6.1's own prose. Here the section production exists, so the
+  appendix transcribes it verbatim and names the divergence in place.
+
+*What the appendix does not reach.* The ``.bscn`` scenario-file dialect is
+outside its scope — no section specifies it, and D91's fixture/content split
+is why — so the shape conflict that follows is **recorded as D93, not resolved
+here**.
 
 .. literalinclude:: bsl.ebnf
    :language: bnf
@@ -4570,12 +4600,18 @@ consequences are the ordinary kind of review item.
        has license to treat that as a caller error. Re-spelling the vector
        keywords was rejected as churn in a fixture format §5 never touches.
    * - D92
-     - §7, §1.4, §2.1, §6.1
+     - §7, §1.1, §1.2, §1.4, §2.1, §2.11, §6.1
      - **The grammar is consolidated as an INCLUDED ASSET, not a second
        home.** ``docs/reference/bsl.ebnf`` collects every production of §§1,
        2 and 6.1 and is part of this document by ``literalinclude`` (§7); it
        **collects and does not amend**, so on any divergence the §1/§2/§6
-       text wins and the appendix is the defect. The dialect is **W3C EBNF**
+       text wins and the appendix is the defect. The precedence trigger is
+       the section **text**, not merely a section production: **nine**
+       productions are collected from PROSE rather than from a code block
+       (``Char``, ``whitespace``, ``comment``, ``delimiter``, ``operator``,
+       ``escape``, ``intrinsic-name``, ``type-name``, ``vector-file``), and
+       a production-only trigger would leave exactly those nine adjudicating
+       themselves. The dialect is **W3C EBNF**
        (the XML 1.0 §6 notation), chosen because §1.4 and §2.1 already write
        their productions in its operator set — collecting them is
        transcription, where ISO 14977 would have meant translating a
@@ -4583,19 +4619,45 @@ consequences are the ordinary kind of review item.
        transcription risk bought for nothing. Two notation-level deviations
        are stated in the file and are spellings rather than changes —
        nonterminals lose §2's angle brackets, and §1.4's ``"0" … "9"``
-       ranges become W3C character classes. **Two gaps are recorded at their
-       productions rather than resolved**: ``<type-name>`` has no §1.4 atom
-       class and §3.1's capitalized spelling is unlexable, so the file
-       collects the reference implementation's lowercase-``symbol`` reading
-       and flags it; and §6.1's ``:graph`` / ``:fuel-used`` / ``:cas`` are
-       written with ``?`` binding to the value, which makes the keywords
-       themselves mandatory against §6.1's own prose. Both belong to the
+       ranges become W3C character classes. **Two under-determined points
+       are collected with the reference implementation's reading and
+       flagged** — not "recorded instead of chosen", since a production
+       needs a right-hand side and writing one is a choice: ``<type-name>``
+       has no §1.4 atom class and no capitalized spelling is lexable, so the
+       lowercase-``symbol`` reading is taken and **§2.11's own worked
+       example** (``:type Coefficient``) is recorded as cutting against it;
+       and §6.1's ``:graph`` / ``:fuel-used`` / ``:cas`` are written with
+       ``?`` binding to the value, which makes the keywords themselves
+       mandatory against §6.1's own prose, so the production is transcribed
+       verbatim with the divergence named. Both repairs belong to the
        Phase-1 review, not to an appendix. A derived, non-normative
        tree-sitter grammar lives at ``tools/tree-sitter-bsl``; a sync guard
        (``tests/unit/reference/test_bsl_grammar_sync.py``) requires every
        §5.2 form tag and every ``::=`` production of §§1/2/6.1 to appear in
        the appendix, so the collection cannot silently fall behind the
        sections it collects.
+   * - D93
+     - §7, §2.9, §6.1
+     - **The** ``.bscn`` **scenario dialect is out of the appendix's scope,
+       and its** ``deffield`` **is a DIFFERENT form sharing a name with
+       §2.9's.** The Rust reference implementation's scenario loader
+       (``rust/crates/babylon-bsl/src/scenario.rs``) reads
+       ``(scenario …)`` files containing ``(node …)``, ``(edge …)`` and
+       ``(deffield <qname> <type-symbol> <kind-symbol>)`` — the last one
+       **positional**, where §2.9's ``deffield`` takes ``:type`` and
+       ``:kind`` keyword options. No section of this document specifies any
+       of those forms. The scope ruling follows D91's fixture/content split
+       rather than inventing a second one: a scenario file is a **fixture**
+       that hydrates a world (§3.9's hydration contract governs what it may
+       do), not canonical content: §5 never encodes it and §7's appendix
+       never collects it. **This row records the shape conflict;
+       it does not resolve it.** Two repairs are available and both are the
+       Director's: rename the scenario form so one name does not denote two
+       shapes, or give the scenario format a chapter of its own here. Until
+       one is chosen, the conflict is written down in a normative place
+       rather than living only in ``tools/tree-sitter-bsl``, which this
+       document declares normative for nothing. Recorded on adversarial
+       verification of PR #485.
 
 See Also
 ----------

--- a/docs/reference/bsl.ebnf
+++ b/docs/reference/bsl.ebnf
@@ -5,9 +5,16 @@
    Every production of the Babylon Scripting Language, collected from the
    scattered code blocks of `docs/reference/bsl-language.rst` §§1, 2 and
    6.1. This file is part of that document by inclusion (§7): it COLLECTS,
-   it does not AMEND. On any divergence between a §1/§2/§6 production and
-   the text collected here, the SECTION text wins and the divergence is a
+   it does not AMEND. On any divergence between the §1/§2/§6 TEXT and the
+   text collected here, the SECTION text wins and the divergence is a
    defect to be repaired here.
+
+   The trigger is the section TEXT and not merely a section PRODUCTION,
+   deliberately: nine productions below are collected from prose rather
+   than from a code block (listed under DEVIATIONS, item 3), and a
+   production-only trigger would leave exactly those nine adjudicating
+   themselves — the appendix legislating in the one place it has no
+   section production to be checked against.
 
    NOTATION — W3C EBNF, the notation of the XML 1.0 (5th ed.) §6
    production grammar. Chosen over ISO 14977 for one reason: §1.4 and §2.1
@@ -31,24 +38,50 @@
      [^abc]             negated character class
      #xNN               character by code point
      A - B              set subtraction
-     /* … */            comment
+     slash-star …       comment. Written out in words rather than shown,
+     star-slash         because the first star-slash closes a comment: a
+                        comment containing the literal sequence would end
+                        early, and a reader stripping comments with the
+                        obvious regex would then read prose as grammar.
 
-   TWO NOTATION-LEVEL DEVIATIONS FROM THE SECTION TEXT, both spellings of
-   the same set rather than changes to it:
+   DEVIATIONS FROM THE SECTION TEXT. The first two are spellings of the
+   same set rather than changes to it; the third is a real addition and is
+   listed exhaustively because it is where this file carries the most
+   weight:
 
    1. §2 writes nonterminals as `<name>`; W3C EBNF writes them bare. The
       angle brackets are dropped, nothing else.
    2. §1.4 writes character ranges as `"0" … "9"`; this file writes the
       W3C character class `[0-9]`. Same set, one dialect.
+   3. NINE productions below have no §1/§2/§6 code block behind them: the
+      sections state them in PROSE, and a grammar needs a right-hand side.
+      They are `Char` (§1.1), `whitespace`, `comment` and `delimiter`
+      (§1.2, §1.4), `operator` (§1.4's draft ruling), `escape` (§1.5),
+      `intrinsic-name` (§2.7), `type-name` (§2.9/§2.11 use it, §3.1 names
+      the types) and `vector-file` (§6.1). Each is transcribed from the
+      prose that governs it and carries its citation; `type-name` is the
+      one whose prose does not determine a single answer, and its
+      production records both the reading taken and the section text that
+      cuts against it.
 
    WHAT AN EBNF CANNOT CARRY, and where it lives instead. These are
-   context conditions on a derivation, not productions, and reading this
-   file without them will accept programs the language rejects:
+   context conditions on a derivation, not productions. Read without them
+   this file BOTH accepts programs the language rejects (nothing here
+   enforces §3) and rejects programs it accepts (the token-run and comment
+   rules below are not context-free and would otherwise cut string
+   literals apart):
 
      - tokenization is maximal munch within a token run (§1.4): a run is
        read to the next delimiter and classified WHOLE, so `1000.5$x` is
        one unclassifiable run (E-LEX-003), never `1000.5$` then `x`;
      - a token ends at whitespace, "(", ")", ";" or end of input (§1.4);
+     - THE STRING LITERAL IS THE EXCEPTION TO BOTH RULES ABOVE, and it is
+       load-bearing: a `string` lexes as ONE token from its opening quote
+       to its closing quote (§1.4, §1.5), so the run-terminators do not
+       apply inside it. A space, a "(", a ")" or a ";" between the quotes
+       is ordinary string content — `"a; b (c)"` is one atom, not four
+       tokens and not a comment. Every `:material-basis` in the estate
+       depends on this;
      - whitespace and comments separate tokens and are otherwise
        insignificant (§1.2); comments are whitespace;
      - `operator` is valid ONLY in form-head position (§1.4);
@@ -77,14 +110,30 @@ whitespace  ::= #x20 | #x9 | #xA | #xD                        /* §1.2 */
                    separators are NOT whitespace. */
 
 comment     ::= ";" ( Char - #xA )*                           /* §1.2 */
-                /* Runs to the next LF or to end of input. There are no
-                   block comments and no reader macros (D2). */
+                /* §1.2 in full: "A comment begins with `;` OUTSIDE A
+                   STRING LITERAL and extends to the next LF or to end of
+                   file." The carve-out is not decoration and cannot be
+                   expressed in the production: a `;` between the quotes
+                   of a `string` is string content, so this production
+                   applies only where a token is not already open. There
+                   are no block comments and no reader macros (D2). */
 
 delimiter   ::= whitespace | "(" | ")" | ";"                  /* §1.4 */
+                /* Ends a token RUN. It does not end a `string`, which
+                   runs quote to quote — see the string-literal bullet in
+                   the header. */
 
-Char        ::= /* any Unicode scalar value; a source file is UTF-8
-                   (§1.1). Invalid UTF-8, or a BOM anywhere but offset 0,
-                   is E-LEX-001. */
+Char        ::= [#x0-#xD7FF] | [#xE000-#x10FFFF]              /* §1.1 */
+                /* Any Unicode SCALAR value — §1.1's own words — which is
+                   every code point except the surrogate range
+                   #xD800-#xDFFF, since a surrogate is not a scalar value
+                   and cannot be encoded in UTF-8. A source file is UTF-8;
+                   invalid UTF-8, or a BOM anywhere but offset 0, is
+                   E-LEX-001 (§1.1). Stated as a real right-hand side
+                   because a production whose RHS is only a comment is not
+                   a production in this dialect at all: a literal reading
+                   would collapse `string-char` to escapes and `comment`
+                   to a bare ";". */
 
 /* --- 1.4 Atoms ------------------------------------------------------ */
 
@@ -169,22 +218,38 @@ literal     ::= int-lit | scaled-lit | bool-lit               /* §2.7 */
                    has no string form (§1.6, §3.8 item 4). */
 
 type-name   ::= symbol                                        /* §3.1 */
-                /* RECORDED GAP, not a ruling (see §7's rigor index and
-                   the PR that landed this file). §2.9 / §2.11 / §2.7
-                   write <type-name> as a grammar nonterminal and never
-                   assign it a §1.4 atom class, while §3.1's table spells
-                   the type names capitalized (`Currency`, `Int`, …) — and
-                   a bare capitalized run matches NO §1.4 atom class (an
-                   enum-ref needs its `/`, and `symbol` is lowercase-only),
-                   so the document's own spelling is unlexable as written.
-                   The reference implementation reads <type-name> as a
-                   lowercase `symbol` (`int`, `bool`, `currency`,
-                   `probability`, `intensity`, `coefficient`) and records
+                /* RECORDED GAP. This production COLLECTS THE REFERENCE
+                   IMPLEMENTATION'S READING AND FLAGS IT — it does not
+                   merely flag a gap, because a production must have a
+                   right-hand side and writing one is a choice. Say so
+                   plainly: of the nine prose-sourced productions, this is
+                   the only one whose prose does not determine the answer.
+
+                   §2.9 / §2.11 / §2.7 write <type-name> as a grammar
+                   nonterminal and never assign it a §1.4 atom class,
+                   while §3.1's table spells the type names capitalized
+                   (`Currency`, `Int`, …) — and a bare capitalized run
+                   matches NO §1.4 atom class (an enum-ref needs its `/`,
+                   `symbol` is lowercase-only), so that spelling is
+                   unlexable as written.
+
+                   THE SECTION TEXT THAT CUTS AGAINST THIS READING,
+                   recorded rather than buried: §2.11's own worked example
+                   writes `:type Coefficient` — capitalized — so the
+                   lowercase reading contradicts a worked example, not
+                   merely a table. The other side is that no capitalized
+                   reading is lexable at all under §1.4, and the reference
+                   implementation accepts `int` / `bool` / `currency` /
+                   `probability` / `intensity` / `coefficient`, recording
                    the same gap at
                    rust/crates/babylon-bsl/src/declarations.rs::parse_type_name.
-                   This file collects that reading because it is the only
-                   one §1.4 admits; the choice is the Phase-1 review's,
-                   and nothing else in the language depends on it. */
+
+                   Both facts belong to the Phase-1 review, which owns the
+                   repair: either §1.4 gains an atom class for capitalized
+                   type names, or §3.1's table and §2.11's example are
+                   re-spelled lowercase. Until then the §7 precedence rule
+                   governs — the section text wins, and this production is
+                   the defect it names. */
 
 
 /* =====================================================================

--- a/docs/reference/bsl.ebnf
+++ b/docs/reference/bsl.ebnf
@@ -1,0 +1,598 @@
+/* =====================================================================
+   BSL — the consolidated grammar
+   =====================================================================
+
+   Every production of the Babylon Scripting Language, collected from the
+   scattered code blocks of `docs/reference/bsl-language.rst` §§1, 2 and
+   6.1. This file is part of that document by inclusion (§7): it COLLECTS,
+   it does not AMEND. On any divergence between a §1/§2/§6 production and
+   the text collected here, the SECTION text wins and the divergence is a
+   defect to be repaired here.
+
+   NOTATION — W3C EBNF, the notation of the XML 1.0 (5th ed.) §6
+   production grammar. Chosen over ISO 14977 for one reason: §1.4 and §2.1
+   already write their productions in `::=` / `|` / `?` / `*` / `+` /
+   quoted-terminal form, which IS W3C EBNF's operator set, so collecting
+   them is transcription rather than translation. ISO 14977 would have
+   demanded rewriting every production of a normative text into comma-
+   concatenation, `{ }` repetition and `;` termination — transcription
+   risk paid for nothing, against a document whose whole standard is that
+   two implementations be derivable from it (Constitution III.12(a)).
+
+   The dialect subset used here:
+
+     name ::= expr      a production
+     A | B              alternation
+     A?  A*  A+         zero-or-one, zero-or-more, one-or-more
+     ( … )              grouping
+     "lit"  'lit'       terminal (either quote; single quotes where the
+                        terminal contains a double quote)
+     [a-z]              character class
+     [^abc]             negated character class
+     #xNN               character by code point
+     A - B              set subtraction
+     /* … */            comment
+
+   TWO NOTATION-LEVEL DEVIATIONS FROM THE SECTION TEXT, both spellings of
+   the same set rather than changes to it:
+
+   1. §2 writes nonterminals as `<name>`; W3C EBNF writes them bare. The
+      angle brackets are dropped, nothing else.
+   2. §1.4 writes character ranges as `"0" … "9"`; this file writes the
+      W3C character class `[0-9]`. Same set, one dialect.
+
+   WHAT AN EBNF CANNOT CARRY, and where it lives instead. These are
+   context conditions on a derivation, not productions, and reading this
+   file without them will accept programs the language rejects:
+
+     - tokenization is maximal munch within a token run (§1.4): a run is
+       read to the next delimiter and classified WHOLE, so `1000.5$x` is
+       one unclassifiable run (E-LEX-003), never `1000.5$` then `x`;
+     - a token ends at whitespace, "(", ")", ";" or end of input (§1.4);
+     - whitespace and comments separate tokens and are otherwise
+       insignificant (§1.2); comments are whitespace;
+     - `operator` is valid ONLY in form-head position (§1.4);
+     - a keyword is never a value: it appears in option position followed
+       immediately by its operand, or alone if §1.6's table marks it a
+       flag. A keyword in value position is E-PARSE-010, and so is a
+       `string` in expression position (§1.6, D75);
+     - the keyword set is CLOSED (§1.6): an unrecognized keyword is
+       E-PARSE-013, never ignored;
+     - `self` and `it` are reserved symbols, never declared and never
+       shadowed (§2.5, E-PARSE-022);
+     - all typing, kind (§3.4), scope, cardinality, fuel-bound (§3.7) and
+       vocabulary (§3.6) checks are static semantics, not syntax.
+
+   ===================================================================== */
+
+
+/* =====================================================================
+   1. LEXICAL GRAMMAR  (bsl-language.rst §1)
+   ===================================================================== */
+
+/* --- 1.2 Whitespace and comments ------------------------------------ */
+
+whitespace  ::= #x20 | #x9 | #xA | #xD                        /* §1.2 */
+                /* Exactly these four. #xC and the Unicode space
+                   separators are NOT whitespace. */
+
+comment     ::= ";" ( Char - #xA )*                           /* §1.2 */
+                /* Runs to the next LF or to end of input. There are no
+                   block comments and no reader macros (D2). */
+
+delimiter   ::= whitespace | "(" | ")" | ";"                  /* §1.4 */
+
+Char        ::= /* any Unicode scalar value; a source file is UTF-8
+                   (§1.1). Invalid UTF-8, or a BOM anywhere but offset 0,
+                   is E-LEX-001. */
+
+/* --- 1.4 Atoms ------------------------------------------------------ */
+
+DIGIT       ::= [0-9]                                         /* §1.4 */
+LOWER       ::= [a-z]                                         /* §1.4 */
+UPPER       ::= [A-Z]                                         /* §1.4 */
+
+symbol      ::= LOWER ( LOWER | DIGIT | "-" )*                /* §1.4 */
+                /* Max length 64 (E-LEX-010). */
+
+qname       ::= symbol ( "/" symbol )+                        /* §1.4 */
+                /* Max 4 segments, 128 bytes total (E-LEX-011). */
+
+keyword     ::= ":" symbol                                    /* §1.4, §1.6 */
+
+enum-ref    ::= enum-type "/" enum-member                     /* §1.4 */
+enum-type   ::= UPPER ( UPPER | LOWER | DIGIT )*              /* §1.4 */
+enum-member ::= UPPER ( UPPER | DIGIT | "_" )*                /* §1.4 */
+                /* The member is the enum member IDENTIFIER, never its
+                   serialized value: NodeType/SOCIAL_CLASS, never
+                   NodeType/social_class. Registry membership is checked
+                   at load (E-LOAD-030 / E-LOAD-031, §1.5). */
+
+bool-lit    ::= "#t" | "#f"                                   /* §1.4 */
+                /* The only two boolean tokens; `true` / `false` are
+                   ordinary symbols. */
+
+operator    ::= "<" | "<=" | ">" | ">=" | "="                 /* §1.4 */
+              | "!=" | "+" | "-" | "*" | "/"
+                /* The tenth atom class, added by the §1.4 draft ruling
+                   (implementation-discovered 2026-07-30): §2 quotes these
+                   as terminals and §5.2 lists them as form tags, so the
+                   atom-class table had to carry them. Lexed by exact
+                   match against this closed set; valid only in form-head
+                   position; CAS encodes them as form tags, never as
+                   atoms. `-5` still lexes as an integer literal. */
+
+/* --- 1.5 Literals --------------------------------------------------- */
+
+digits      ::= DIGIT ( "_"? DIGIT )*                         /* §1.4 */
+                /* Underscores are digit-group separators, removed before
+                   interpretation; leading, trailing or doubled
+                   underscores are E-LEX-003. Leading zeros are
+                   insignificant. */
+
+int-lit     ::= "-"? digits                                   /* §1.4, §1.5 */
+                /* Must fit i64 (E-LEX-020). Static type Int. */
+
+scaled-lit  ::= "-"? digits ( "." digits )? suffix            /* §1.4, §1.5 */
+                /* A leading digit is mandatory: `.5c` is E-LEX-003.
+                   Canonicalized to minimal scale; Currency further to
+                   integer micro-units, so `0.50c` ≡ `0.5c` and `1000.5$`
+                   ≡ `1000.500$` (D4). */
+
+suffix      ::= "$" | "p" | "i" | "c"                         /* §1.4, §1.5 */
+                /* The kind suffix is MANDATORY on every non-integer
+                   literal — a bare `0.5` is E-LEX-021, which is the
+                   lexical enforcement of the house prohibition on bare
+                   floats (D3). $ = Currency [0,∞), scale ≤ 6;
+                   p/i/c = Probability/Intensity/Coefficient [0,1],
+                   scale ≤ 9. */
+
+string      ::= '"' string-char* '"'                          /* §1.4, §1.5 */
+                /* NFC-checked at load (E-LEX-002, D1); max 1024 bytes
+                   after escape processing (E-LEX-026). Strings appear
+                   only at `:material-basis` and in conformance-vector
+                   identifiers; `Str` has no operations (§3.1). */
+
+string-char ::= ( Char - ( '"' | "\" | #xA ) )                /* §1.4, §1.5 */
+              | escape
+
+escape      ::= "\" ( '"' | "\" | "n" | "t" )                 /* §1.5 */
+                /* The only four escapes. Any other backslash sequence,
+                   and a raw LF inside a string, are E-LEX-025. §1.4
+                   spells this class as the four resulting values
+                   (`"\\" | '\"' | "\n" | "\t"`); the same set, written
+                   as the source sequences that produce it. */
+
+literal     ::= int-lit | scaled-lit | bool-lit               /* §2.7 */
+                /* NOTE the asymmetry, and it is deliberate: `string` is a
+                   well-formed atom but NOT a `literal`, because <expr>
+                   has no string form (§1.6, §3.8 item 4). */
+
+type-name   ::= symbol                                        /* §3.1 */
+                /* RECORDED GAP, not a ruling (see §7's rigor index and
+                   the PR that landed this file). §2.9 / §2.11 / §2.7
+                   write <type-name> as a grammar nonterminal and never
+                   assign it a §1.4 atom class, while §3.1's table spells
+                   the type names capitalized (`Currency`, `Int`, …) — and
+                   a bare capitalized run matches NO §1.4 atom class (an
+                   enum-ref needs its `/`, and `symbol` is lowercase-only),
+                   so the document's own spelling is unlexable as written.
+                   The reference implementation reads <type-name> as a
+                   lowercase `symbol` (`int`, `bool`, `currency`,
+                   `probability`, `intensity`, `coefficient`) and records
+                   the same gap at
+                   rust/crates/babylon-bsl/src/declarations.rs::parse_type_name.
+                   This file collects that reading because it is the only
+                   one §1.4 admits; the choice is the Phase-1 review's,
+                   and nothing else in the language depends on it. */
+
+
+/* =====================================================================
+   2. SYNTACTIC GRAMMAR — CONTENT FORMS  (bsl-language.rst §2)
+
+   Every non-atomic construct is a parenthesised FORM whose first element
+   is a symbol (or an `operator`) naming the form. `(` and `)` are the
+   only structural delimiters: no brackets, no quote syntax, no dotted
+   pairs, no vectors (§1.3).
+   ===================================================================== */
+
+/* --- 2.2 Content files ---------------------------------------------- */
+
+file        ::= top-form*                                     /* §2.2 */
+
+top-form    ::= rule | deffield | intrinsic-decl              /* §2.2 */
+              | manifest | metric-decl
+                /* File boundaries and file names carry NO semantics: the
+                   same forms split across different files produce the
+                   same rules_hash (§5.5). Duplicate rule ids, field,
+                   intrinsic, rung or adjunction names across the content
+                   set are E-LOAD-001. */
+
+/* --- 2.3 Rules ------------------------------------------------------ */
+
+rule        ::= "(" "rule" qname                              /* §2.3 */
+                    ":material-basis" string
+                    ":fuel" int-lit
+                    domain?
+                    anchor?
+                    bindings
+                    when?
+                    effects
+                ")"
+                /* The two keyword options may appear in EITHER source
+                   order (§2.3); the canonical serialization sorts them
+                   (§5.3), so the fixed order above is this grammar's
+                   spelling, not a constraint. `:material-basis` must be
+                   present and non-empty (E-PARSE-011); `:fuel` must be
+                   > 0 and ≤ 1_000_000 (E-PARSE-012).
+                   An omitted <when> is unconditional. An EMPTY condition
+                   is NOT expressible: `(when)` is E-PARSE-020, and a rule
+                   meaning "always" writes `(when #t)` or omits the
+                   clause — one of §6.3's four III.11 corrections. */
+
+domain      ::= "(" "domain" ( enum-ref | ":graph" ) ")"      /* §2.3, D43 */
+                /* Optional, with §2.3's stated inference as its default.
+                   The enum-ref is a NodeType member (E-TYPE-011
+                   otherwise). `(domain :graph)` fires the rule exactly
+                   once per tick and leaves `self` unbound (E-TYPE-015).
+                   `:graph` is a FLAG keyword, legal only here
+                   (E-PARSE-013 elsewhere, D42). */
+
+anchor      ::= "(" "anchor" ( ":after" | ":before" ) symbol ")"   /* §2.3 */
+                /* Optional: an anchorless rule takes the position of the
+                   system named by its rule id's first segment (D5). A raw
+                   position float is not expressible. */
+
+bindings    ::= "(" "bindings" binding* ")"                   /* §2.3 */
+when        ::= "(" "when" cond ")"                           /* §2.3 */
+effects     ::= "(" "effects" effect-item+ ")"                /* §2.3 */
+
+/* --- 2.4 Conditions ------------------------------------------------- */
+
+cond        ::= bool-lit                                      /* §2.4 */
+              | "(" "and" cond+ ")"
+              | "(" "or"  cond+ ")"
+              | "(" "not" cond ")"
+              | "(" cmp expr expr ")"
+              | "(" "exists" query elem-name? cond? ")"
+              | "(" "forall" query elem-name? cond ")"
+                /* `and` / `or` are variadic with at least one operand:
+                   `(and)` and `(or)` are E-PARSE-021 — there is no
+                   implicit identity element. `exists` / `forall` bind no
+                   variable of their own; the element is `it` (D6).
+                   `(exists <query>)` with no body means "the query is
+                   non-empty". References compare with `=` / `!=` only,
+                   against a reference of the same kind (E-TYPE-017, D67).
+                   A head symbol outside a closed terminal set is
+                   E-PARSE-015; an operand count differing from a
+                   production is E-PARSE-042 (D75). */
+
+cmp         ::= "<" | "<=" | ">" | ">=" | "=" | "!="          /* §2.4 */
+
+/* --- 2.5 Bindings --------------------------------------------------- */
+
+binding     ::= "(" "binding" symbol bind-src bind-opt* ")"   /* §2.5 */
+                /* Binding names are rule-scoped; a duplicate in one rule
+                   is E-PARSE-030, and naming `self` or `it` is
+                   E-PARSE-022. */
+
+bind-src    ::= ":field"  qname                               /* §2.5 */
+              | ":const"  qname
+              | ":metric" symbol
+              | ":tick"
+              | ":year"
+              | ":tick-of-year"
+              | ":tick-in-cycle" int-lit
+              | ":expr"   expr
+                /* `:field` is NODE-scoped and stays node-scoped (D29): an
+                   edge's or hyperedge's field is read by `field-of`
+                   (§2.10). `:tick` / `:year` / `:tick-of-year` are flag
+                   keywords; `:tick-in-cycle`'s length is a LITERAL and
+                   must be > 0 (E-PARSE-014, D68). A `:expr` may reference
+                   only bindings declared BEFORE it — a forward or self
+                   reference is E-PARSE-032, which makes the dependency
+                   graph a DAG in source order (D49). */
+
+bind-opt    ::= ":optional" | ":default" literal              /* §2.5 */
+                /* `:optional` requires `:default` (bare is E-PARSE-031,
+                   D13); `:default` takes a literal, never an expression;
+                   both are illegal on a `:expr` (E-PARSE-033). */
+
+/* --- 2.6 Queries ---------------------------------------------------- */
+
+query       ::= "(" "nodes" enum-ref node-pred? ")"           /* §2.6 */
+              | "(" "edges" enum-ref edge-pred? ")"
+              | "(" "neighbors" expr enum-ref direction enum-ref ")"
+              | "(" "hyperedges" enum-ref hedge-pred? ")"
+              | "(" "members-of" expr enum-ref ")"
+              | "(" "hyperedges-of" expr enum-ref ")"
+                /* `neighbors` takes FOUR operands: the element, the
+                   EdgeType traversed, the direction, and the result
+                   NodeType — mandatory since D51, and the operand
+                   FILTERS (a node's edges may reach several types) where
+                   `members-of`'s ASSERTS (D24). Every enum-ref operand
+                   position is kind-checked, E-TYPE-011 for all of them
+                   (D74). A query result is a SET: each element appears
+                   once however many edges reach it (D72), iterated in
+                   ascending id byte order (D7, D25). */
+
+elem-name   ::= ":as" symbol                                  /* §2.6, D54 */
+                /* Names an iterating form's element so a nested body can
+                   still reach it; `it` always denotes the INNERMOST
+                   enclosing iterating form's element (D53). */
+
+direction   ::= ":out" | ":in" | ":any"                       /* §2.6, D42 */
+                /* Flag keywords, legal only on `neighbors`. */
+
+node-pred   ::= cond                                          /* §2.6 */
+edge-pred   ::= cond                                          /* §2.6 */
+hedge-pred  ::= cond                                          /* §2.6 */
+
+/* --- 2.7 Expressions, intrinsics, folds, selections ----------------- */
+
+expr        ::= literal | symbol | enum-ref                   /* §2.7 */
+              | "(" arith expr expr ")"
+              | "(" intrinsic-name expr* ")"
+              | "(" "if" cond expr expr ")"
+              | fold
+              | accessor                                      /* §2.10 */
+              | selection
+                /* Arithmetic is strictly binary: `(+ a b c)` is
+                   E-PARSE-040 (D8), keeping the reduction order explicit
+                   in the source. Both branches of `if` must have the same
+                   static type (E-TYPE-020) and the same kind (§3.4). */
+
+arith       ::= "+" | "-" | "*" | "/"                         /* §2.7 */
+
+fold        ::= "(" "fold" fold-op query elem-name?           /* §2.7 */
+                    expr ( ":weight" expr )? ")"
+                /* An intensive body makes `sum` E-TYPE-041 and requires
+                   an extensive `:weight` on `mean` (E-TYPE-042 /
+                   E-TYPE-043, §3.4). */
+
+fold-op     ::= "sum" | "mean" | "min" | "max" | "count"      /* §2.7 */
+                /* Closed five-member set; anything else is E-PARSE-015 —
+                   the "unknown aggregation → False" correction (§6.3). */
+
+selection   ::= "(" "select-max" query elem-name? expr ")"    /* §2.7, D45 */
+              | "(" "select-min" query elem-name? expr ")"
+                /* Returns the extremising ELEMENT where a fold returns
+                   the extremised VALUE. Ties break to the first element
+                   in §2.6's iteration order — a property of the language,
+                   not of each rule. An empty query is E-EVAL-021; a score
+                   that is not a comparable scalar is E-TYPE-016. */
+
+intrinsic-name ::= symbol                                     /* §2.7 */
+                /* A symbol declared in the intrinsic table. BSL cannot
+                   DEFINE an intrinsic; transcendentals and
+                   `round-half-even` are never language primitives. Every
+                   §5.2 form-head symbol is reserved against this
+                   namespace (E-LOAD-024, D33), `sigmoid` is prohibited
+                   outright (D71), and §3.10 holds the declarable set at
+                   {exp, log}. A call to an undeclared intrinsic is
+                   E-LOAD-021. */
+
+intrinsic-decl ::= "(" "intrinsic" symbol                     /* §2.7 */
+                       ":params" "(" type-name* ")"
+                       ":returns" type-name
+                       ":cost" int-lit
+                   ")"
+                /* Declares what the kernel provides, so the typechecker
+                   and the fuel bound checker are computable from content
+                   alone. A signature disagreeing with the kernel's
+                   registration is E-LOAD-020. */
+
+/* --- 2.8 Effects — the typed structural verbs ----------------------- */
+
+effect-item ::= verb                                          /* §2.8 */
+              | "(" "guard"    cond  effect-item+ ")"
+              | "(" "for-each" query elem-name? effect-item+ ")"
+                /* `for-each` is bounded iteration in effect position
+                   (D47): the query is materialized against the rule's
+                   PRE-state before any effect applies (D48), the body
+                   runs once per element in iteration order, and an empty
+                   query applies nothing rather than erroring. */
+
+verb        ::= "(" "update-node"  expr qname update-op ")"   /* §2.8 */
+              | "(" "update-edge"  expr qname update-op ")"
+              | "(" "add-node"     enum-ref expr field-init* ")"
+              | "(" "remove-node"  expr ")"
+              | "(" "add-edge"     enum-ref expr expr ":strength" expr
+                                   field-init* ")"
+              | "(" "remove-edge"  enum-ref expr expr ")"
+              | "(" "add-hyperedge"    enum-ref expr members field-init* ")"
+              | "(" "update-hyperedge" expr qname update-op ")"
+              | "(" "remove-hyperedge" expr ")"
+              | "(" "update-membership" expr expr qname update-op ")"
+              | "(" "emit"         enum-ref payload-item* ")"
+                /* Ten structural verbs plus `emit`. The id operand of
+                   `add-node` / `add-hyperedge` is written <expr>, but no
+                   expression form yields a FRESH identity: the executor
+                   reads it as a SYMBOL introducing an effect-list-scoped
+                   name for the minted object (§2.8's draft ruling,
+                   implementation-discovered 2026-07-30). A <field-init>
+                   naming the implicit <edge-type>/strength on `add-edge`
+                   is E-PARSE-041 (D37); one owning off another type is
+                   E-TYPE-014 statically on the minting verbs and
+                   E-EVAL-033 at evaluation on the updating ones.
+                   `update-membership` takes TWO element operands — the
+                   hyperedge then the member — because BSL mints no
+                   membership reference kind (D80, D82). There is no
+                   add-member / remove-member verb and no clique
+                   expansion: a member list crosses whole (D26, VIII.9). */
+
+update-op   ::= "(" "add"   expr ")"                          /* §2.8 */
+              | "(" "sub"   expr ")"
+              | "(" "set"   expr ")"
+              | "(" "scale" expr ")"
+                /* Exactly today's four-operation effect enum. The set is
+                   closed: a fifth head — the `(unset …)` the frozen
+                   estate reaches for — is E-PARSE-015 (§3.8 item 1). */
+
+members     ::= "(" "members" member-item+ ")"                /* §2.8 */
+                /* `+` makes a zero-member hyperedge unexpressible; the
+                   upper end is the declared `:max-members` (§3.7),
+                   checked STATICALLY because the list length is fixed in
+                   the source text (E-LOAD-042). */
+
+member-item ::= expr                                          /* §2.8 */
+              | "(" "member" enum-ref expr field-init* ")"
+                /* A bare item where the hyperedge type declares no
+                   membership payload; the annotated form where it does,
+                   whose field-inits are EXACTLY that pair's declared
+                   payload fields — no more and no fewer (E-LOAD-047,
+                   D83). The enum-ref is the member's NodeType and it
+                   ASSERTS: a member not of that type is E-EVAL-033. */
+
+field-init  ::= "(" qname expr ")"                            /* §2.8 */
+payload-item ::= "(" symbol expr ")"                          /* §2.8 */
+                /* No string interpolation and no string payloads: a
+                   string literal here is E-PARSE-010 (§3.8 item 4). */
+
+/* --- 2.9 Field and manifest declarations ---------------------------- */
+
+deffield    ::= "(" "deffield" qname                          /* §2.9 */
+                    ":type" type-name
+                    ":kind" ( "intensive" | "extensive" )
+                    ( ":member" enum-ref )?
+                ")"
+                /* The qname's first segment names the OWNING element
+                   type — a NodeType, EdgeType or HyperedgeType member
+                   (D31), rendered by lowercasing the member identifier
+                   and replacing `_` with `-`; an unregistered segment is
+                   E-LOAD-023. `:member` is what makes a deffield a
+                   MEMBERSHIP-payload declaration (D79): its operand is a
+                   NodeType member and its qname's first segment must
+                   render a HyperedgeType (E-LOAD-048 otherwise).
+                   Every EdgeType additionally carries one IMPLICITLY
+                   declared field, <edge-type>/strength, `:type
+                   Coefficient` `:kind extensive` — re-declaring it is
+                   E-LOAD-001 (D32). Kernel disagreement is E-LOAD-022. */
+
+manifest    ::= "(" "manifest" symbol ceiling+ rung* adjunction* ")"   /* §2.9 */
+                /* A manifest owes a `ceiling` row for every type the
+                   content set queries, mutates, reaches with `the`, or
+                   names in a `rung`; an omission is E-LOAD-045 (D76). */
+
+ceiling     ::= "(" "ceiling" enum-ref ":ceiling" int-lit     /* §2.9, §3.9 */
+                    ( ":max-members" int-lit )? ":invariant"? ")"
+                /* `:max-members` is MANDATORY on a HyperedgeType row and
+                   illegal on the other two; `:invariant` is legal on a
+                   NodeType or EdgeType row and illegal on a HyperedgeType
+                   row — any mismatch is E-LOAD-042 (D27). `:invariant`
+                   makes add-node / remove-node / add-edge / remove-edge
+                   naming that type E-LOAD-013, statically; field writes
+                   are unaffected (D63). */
+
+rung        ::= "(" "rung" symbol enum-ref enum-ref           /* §2.9, §3.9 */
+                    ":via" enum-ref ":substrate"? ")"
+                /* One step of a scale lattice. The positional operands
+                   are NodeType members, FINER FIRST and coarser second,
+                   and `:via` is the EdgeType carrying the relation,
+                   directed finer → coarser (D86). `:substrate` obliges
+                   all three types to carry `:invariant` (E-LOAD-049,
+                   D87). */
+
+adjunction  ::= "(" "adjunction" symbol qname qname           /* §2.9, §3.9 */
+                    ":rung" symbol ( ":weighted-by" qname )? ")"
+                /* One INSTANCE of the allocate ⊣ aggregate schema along a
+                   declared rung; the two qnames are the fields at the
+                   rung's finer and coarser ends IN THE RUNG'S ORDER. An
+                   intensive field pair with no `:weighted-by` is
+                   E-LOAD-050 and a non-extensive weight is E-TYPE-043
+                   (D88); any other misfit at the declared rung is the
+                   single code E-LOAD-051 (D89). The grammar gives an
+                   adjunction NO clause in which to state a conservation
+                   law — that is how "instances, not kinds" is enforced by
+                   construction. */
+
+/* --- 2.10 Element accessors ----------------------------------------- */
+
+accessor    ::= "(" "field-of"     expr qname ")"             /* §2.10 */
+              | "(" "edge-between" enum-ref expr expr ")"
+              | "(" "the"          enum-ref ")"
+              | "(" "metric-of"    expr symbol ")"
+              | "(" "membership-field-of" expr expr qname ")"
+                /* Accessors read from an element the rule already holds a
+                   reference to. The QNAME carries the type annotation
+                   because a reference carries none (§3.1); a referent of
+                   another type, or a field it carries no value for, is
+                   E-EVAL-033 — never a default and never an absent read
+                   (D34). No accessor mutates (§2.10 discipline 3).
+                   `the` is legal only against a NodeType whose manifest
+                   ceiling is exactly 1 (E-LOAD-043, D40).
+                   `membership-field-of` keys the pair hyperedge-then-
+                   member, one order shared with `members-of` and
+                   `update-membership` (D81). */
+
+/* --- 2.11 Metric registration --------------------------------------- */
+
+metric-decl ::= "(" "metric" symbol                           /* §2.11 */
+                    ":type" type-name
+                    ":kind" ( "intensive" | "extensive" )
+                    domain
+                    ":provider" symbol
+                ")"
+                /* Reuses §2.3's <domain> unchanged: `(domain :graph)`
+                   declares a graph-scope metric read by a `:metric`
+                   binding, `(domain NodeType/…)` an element-indexed one
+                   read by `metric-of`. A metric form DECLARES what the
+                   kernel provides (D55); kernel disagreement is
+                   E-LOAD-025, an unregistered name E-LOAD-011, and
+                   reading one through the wrong form for its declared
+                   domain is E-LOAD-012. */
+
+
+/* =====================================================================
+   3. VECTOR-FILE FORMAT — FIXTURES, NOT CONTENT  (§6.1, D91)
+
+   Conformance vectors are written in BSL's surface syntax and read by
+   §1's reader, but no `vector` form is canonical CONTENT: §5 encodes the
+   content forms of §2, and a `vector` form is never encoded under §5 nor
+   hashed into any content digest. "Hashable" in §6.1 means file
+   identity — the byte hash of the vector file itself.
+
+   The consequence this section exists to keep visible (D91): §1.6's
+   closed flag/valued keyword dichotomy governs CONTENT forms only.
+   Within a `vector` form, `:graph`, `:fuel-used` and `:cas` are
+   vector-format keywords carrying OPTIONAL VALUES — a shape the content
+   dichotomy has no room for — and the collision with `:graph`'s content
+   classification as a flag is a scope boundary, not an amendment to it.
+   An implementation's canonical encoder never sees a `vector` form;
+   handing it one is a caller error, not a defined encoding.
+   ===================================================================== */
+
+vector-file ::= vector*                                       /* §6.1 */
+                /* Vector files live under a declared conformance root and
+                   are sorted by vector id for execution. */
+
+vector      ::= "(" "vector" string                           /* §6.1 */
+                    ":rule"   rule
+                    ":env"    "(" env-entry* ")"
+                    ":graph"  graph-lit?
+                    outcome
+                    ":fuel-used" int-lit?
+                    ":cas"    string?
+                ")"
+                /* TRANSCRIBED VERBATIM, including an ambiguity this file
+                   does not resolve: the `?` here binds to the VALUE, so
+                   as written the keywords `:graph`, `:fuel-used` and
+                   `:cas` are themselves mandatory. §6.1's own prose says
+                   otherwise for two of them — `:fuel-used` is "mandatory
+                   on every non-error vector" (so absent on error vectors)
+                   and `:cas` is "optional" outright. The grammar collects;
+                   it does not amend, so the divergence is recorded here
+                   and belongs to the §6.1 text to repair. */
+
+env-entry   ::= "(" symbol literal ")"                        /* §6.1 */
+
+outcome     ::= ":expect" literal | ":expect-error" symbol    /* §6.1 */
+                /* `:expect` compares EXACTLY — bit-exact for binary64,
+                   integer-exact for fixed point; conformance is not
+                   tolerance-bounded. `:expect-error` requires the named
+                   code at its class's declared time (load vs
+                   evaluation). */
+
+graph-lit   ::= "(" "graph" node-lit* edge-lit* ")"           /* §6.1 */
+node-lit    ::= "(" "node" symbol enum-ref field-init* ")"    /* §6.1 */
+edge-lit    ::= "(" "edge" enum-ref symbol symbol expr ")"    /* §6.1 */

--- a/docs/reference/bsl.ebnf
+++ b/docs/reference/bsl.ebnf
@@ -13,8 +13,8 @@
    deliberately: nine productions below are collected from prose rather
    than from a code block (listed under DEVIATIONS, item 3), and a
    production-only trigger would leave exactly those nine adjudicating
-   themselves — the appendix legislating in the one place it has no
-   section production to be checked against.
+   themselves — the appendix legislating in precisely the places where no
+   section production exists to check it against.
 
    NOTATION — W3C EBNF, the notation of the XML 1.0 (5th ed.) §6
    production grammar. Chosen over ISO 14977 for one reason: §1.4 and §2.1

--- a/tests/unit/reference/test_bsl_grammar_sync.py
+++ b/tests/unit/reference/test_bsl_grammar_sync.py
@@ -58,6 +58,31 @@ CAS_ENCODING_PRODUCTIONS = frozenset({"atom", "form", "opt"})
 #: carries it and the surface grammar cannot.
 SYNTHETIC_FORM_TAGS = frozenset({"opt"})
 
+#: The NINE productions the appendix collects from the rst's PROSE rather than
+#: from one of its code blocks. §7 and D92 list exactly these, so the set is a
+#: contract between the document and this guard, not a convenience: a tenth
+#: entry here without a matching edit there is drift in the thing §7 discloses.
+#:
+#: An earlier spelling of this set also carried ``literal``, ``payload-item``
+#: and ``string-char`` — all three of which ARE backed by rst code blocks
+#: (§2.7, §2.8, §1.4). The annotations were simply wrong, and wrong in the
+#: direction that weakens the guard: an exemption for a production that needs
+#: none silently excuses it if the rst ever drops it. Removed (adversarial
+#: verification, PR #485).
+PROSE_SOURCED = frozenset(
+    {
+        "Char",  # §1.1, "a sequence of Unicode scalar values"
+        "whitespace",  # §1.2, "exactly U+0020, U+0009, U+000A and U+000D"
+        "comment",  # §1.2, "begins with ; outside a string literal"
+        "delimiter",  # §1.4, "a token ends at whitespace, (, ), ; or EOF"
+        "operator",  # §1.4's draft ruling — the tenth atom class
+        "escape",  # §1.5's four escapes, spelled as source sequences
+        "intrinsic-name",  # §2.7, "a symbol declared in the intrinsic table"
+        "type-name",  # §2.9/§2.11 use it; §3.1 names the types (the gap)
+        "vector-file",  # §6.1, "a vector file is a sequence of vector forms"
+    }
+)
+
 
 def _read(path: Path) -> str:
     assert path.exists(), f"{path} is missing"
@@ -69,13 +94,48 @@ def _ebnf_text() -> str:
 
 
 def _ebnf_code() -> str:
-    """The appendix with its ``/* … */`` comments stripped.
+    """The appendix with its comments stripped: the grammar and nothing else.
 
     Comment prose carries apostrophes and quoted phrases, and a naive scan for
     quoted terminals over the raw file pairs quotes ACROSS them — which found
     zero terminals while looking like it worked. Strip first, then scan.
+
+    The strip is non-greedy and therefore implements the dialect's own rule
+    exactly: the FIRST comment terminator closes the comment. That makes it
+    correct and fragile in the same stroke — a comment containing the literal
+    terminator ends early and the prose after it is read as grammar, which is
+    what the appendix's own dialect table used to do (it showed the comment
+    syntax by example) and why that table now spells the delimiters in words.
+    ``TestTheCommentStripIsSound`` holds the invariant that makes this safe.
     """
     return re.sub(r"/\*.*?\*/", " ", _ebnf_text(), flags=re.DOTALL)
+
+
+def _referenced_nonterminals() -> set[str]:
+    """Every bare name appearing on a right-hand side in the appendix.
+
+    Quoted terminals, character classes, ``#xNN`` code points and the
+    production's own left-hand side are excluded; what remains is what a
+    reader must be able to look up.
+    """
+    referenced: set[str] = set()
+    for body in re.split(r"^(?=[A-Za-z][A-Za-z0-9-]*\s*::=)", _ebnf_code(), flags=re.MULTILINE):
+        head = re.match(r"^([A-Za-z][A-Za-z0-9-]*)\s*::=(.*)$", body, re.DOTALL)
+        if not head:
+            continue
+        rhs = head.group(2)
+        # SINGLE quotes first, and the order is load-bearing: the appendix
+        # uses single quotes exactly where a terminal CONTAINS a double quote
+        # (`'"'` in `string` and `string-char`). Stripping double-quoted runs
+        # first mis-pairs on that quote and then swallows the delimiters of
+        # every terminal after it — which made `escape`'s "n" and "t" read as
+        # undefined nonterminals when this row was first written.
+        rhs = re.sub(r"'[^'\n]*'", " ", rhs)  # single-quoted terminals
+        rhs = re.sub(r'"[^"\n]*"', " ", rhs)  # double-quoted terminals
+        rhs = re.sub(r"\[[^\]\n]*\]", " ", rhs)  # character classes
+        rhs = re.sub(r"#x[0-9A-Fa-f]+", " ", rhs)  # code points
+        referenced |= set(re.findall(r"\b([A-Za-z][A-Za-z0-9-]*)\b", rhs))
+    return referenced
 
 
 def _ebnf_productions() -> set[str]:
@@ -162,24 +222,70 @@ class TestTheAppendixCollectsTheSections:
         helpers §1 states in prose rather than in a code block are exempt and
         listed by name.
         """
-        prose_only = {
-            "whitespace",  # §1.2, stated in prose
-            "comment",  # §1.2, stated in prose
-            "delimiter",  # §1.4, stated in prose
-            "Char",  # §1.1, "a Unicode scalar value" — prose, not a block
-            "escape",  # §1.5's four escapes, spelled as source sequences
-            "operator",  # §1.4's tenth atom class (its draft ruling)
-            "literal",  # §2.7's <literal>, also used by §6.1
-            "type-name",  # §2.9/§2.11/§2.7 use it; §3.1 names the types
-            "vector-file",  # §6.1's "a sequence of vector forms", in prose
-            "intrinsic-name",  # §2.7's intrinsic-call head
-            "payload-item",  # §2.8 (matched by the rst scan, kept explicit)
-            "string-char",  # §1.4
-        }
-        extra = _ebnf_productions() - _rst_productions() - prose_only
+        extra = _ebnf_productions() - _rst_productions() - PROSE_SOURCED
         assert not extra, (
             f"bsl.ebnf defines productions the rst does not: {sorted(extra)}. "
             "The appendix collects; it does not amend (D92)."
+        )
+
+
+class TestTheAppendixIsSelfContained:
+    """The grammar closes over itself: nothing referenced is undefined.
+
+    This is the property a reader deriving an implementation actually needs —
+    §7's whole claim is that the appendix can be read as a grammar, and a
+    dangling name breaks that no matter how faithfully every other production
+    was transcribed. It is also the row that catches a production whose
+    right-hand side went missing: an RHS that is only a comment vanishes when
+    comments are stripped, and its name then defines nothing while everything
+    referencing it dangles (adversarial verification, PR #485, found exactly
+    that on ``Char``).
+    """
+
+    def test_every_referenced_nonterminal_is_defined(self) -> None:
+        undefined = _referenced_nonterminals() - _ebnf_productions()
+        assert not undefined, (
+            f"bsl.ebnf references nonterminals it never defines: {sorted(undefined)}. "
+            "A grammar that does not close over itself cannot be derived from, "
+            "which is §7's entire claim (D92)."
+        )
+
+    def test_every_production_has_a_non_empty_right_hand_side(self) -> None:
+        """The same defect from the other side, named for the reader.
+
+        ``name ::=`` followed by nothing is not a production in the declared
+        W3C dialect; a literal reading collapses whatever referenced it.
+        """
+        empty = [
+            name
+            for name, rhs in re.findall(
+                r"^([A-Za-z][A-Za-z0-9-]*)\s*::=([^\n]*(?:\n[ \t]+[^\n]*)*)",
+                _ebnf_code(),
+                re.MULTILINE,
+            )
+            if not rhs.strip()
+        ]
+        assert not empty, f"productions with an empty right-hand side: {empty}"
+
+
+class TestTheCommentStripIsSound:
+    """The comment strip implements the dialect, and the file respects it.
+
+    ``_ebnf_code`` strips to the FIRST comment terminator, which is the
+    dialect's own rule. The consequence is that a comment containing the
+    literal terminator ends early and its remaining prose is read as grammar —
+    which the appendix's dialect table used to do, by showing the comment
+    syntax with a live example, leaking 26 lines of header prose into "code"
+    (harmless then, latent forever). The table now spells the delimiters in
+    words, and this row keeps it that way.
+    """
+
+    def test_stripping_leaves_no_comment_markers(self) -> None:
+        code = _ebnf_code()
+        strays = [line.strip() for line in code.splitlines() if "/*" in line or "*/" in line]
+        assert not strays, (
+            "comment markers survived the strip, so a comment ended early and "
+            f"prose is being read as grammar: {strays[:3]}"
         )
 
 
@@ -231,6 +337,25 @@ class TestTheInclusionIsWired:
 
     def test_the_appendix_names_its_dialect(self) -> None:
         assert "W3C EBNF" in _ebnf_text()
+
+    def test_section_seven_discloses_every_prose_sourced_production(self) -> None:
+        """§7 must name the productions that have no section production.
+
+        The precedence rule is "the section TEXT wins", and it is only
+        checkable by a reader who knows WHICH productions have no code block
+        behind them — those are the ones where the appendix necessarily chose.
+        §7 lists them, D92 repeats the count, and this row keeps the list from
+        drifting away from the set the guard exempts (adversarial
+        verification, PR #485).
+        """
+        body = _read(RST)
+        start = body.index("7. Consolidated grammar")
+        section = body[start : body.index("7.1 The rigor index", start)]
+        undisclosed = {name for name in PROSE_SOURCED if f"``{name}``" not in section}
+        assert not undisclosed, (
+            f"§7 does not disclose these prose-sourced productions: {sorted(undisclosed)}"
+        )
+        assert f"**{len(PROSE_SOURCED)}**" in section or "nine" in section.lower()
 
 
 class TestTheDerivedGrammarsCorpusCoversEveryForm:

--- a/tests/unit/reference/test_bsl_grammar_sync.py
+++ b/tests/unit/reference/test_bsl_grammar_sync.py
@@ -1,0 +1,247 @@
+"""Sync guard for the consolidated BSL grammar (``docs/reference/bsl.ebnf``, §7/D92).
+
+``docs/reference/bsl-language.rst`` is the ONE normative home for BSL. §7
+collects its scattered productions into ``bsl.ebnf`` and includes that file
+back into the document, so the appendix is normative **by inclusion** — which
+buys the rigor of a single consolidated grammar only for as long as the
+collection actually tracks the sections it collects. Left unguarded, the
+failure mode is silent and certain: a chapter adds a form, the section text
+carries it, the appendix does not, and two implementations derived from "the
+document" disagree about what the language is. That is a III.12(a) failure,
+not a formatting drift.
+
+The guard is therefore three containments, each in the safe direction:
+
+1. every ``<name> ::=`` production the rst's §§1/2/6.1 code blocks define
+   appears in ``bsl.ebnf``;
+2. every form tag §5.2 enumerates appears in ``bsl.ebnf`` as a quoted
+   terminal — §5.2 is the CAS-side list of head symbols, so a form with a
+   tag and no production is exactly the drift above, caught from the other
+   side;
+3. every form head the **Rust reference implementation** knows
+   (``RESERVED_FORM_TAGS`` in ``babylon-bsl``'s ``declarations.rs``, which is
+   that crate's rendering of the same §5.2 list) appears in ``bsl.ebnf``.
+
+Direction matters. The guard never demands the reverse containment — that
+every production or tag in the appendix be known to Rust — because the rst
+leads the implementation by design: the Amendment AG forms (``member``,
+``membership-field-of``, ``update-membership``, ``rung``, ``adjunction``)
+are specified and not yet implemented, and a guard that failed on that would
+be demanding the spec wait for the code.
+
+No test here parses BSL or checks a program: this is a documents-agree test.
+The language's own conformance lives in the crate's vectors (§6.2).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+EBNF = REPO_ROOT / "docs" / "reference" / "bsl.ebnf"
+RST = REPO_ROOT / "docs" / "reference" / "bsl-language.rst"
+DECLARATIONS_RS = REPO_ROOT / "rust" / "crates" / "babylon-bsl" / "src" / "declarations.rs"
+
+#: Productions of the rst that are deliberately NOT in the appendix. §5.2's
+#: ``atom`` / ``form`` / ``opt`` are the canonical-serialization BYTE layout —
+#: a schema over octets (``0x01``, ``u8 len(kind)``, …), not a production over
+#: the token stream — and collecting them into a surface grammar would be a
+#: category error. They are named here rather than filtered by a pattern so
+#: that a NEW §5 production cannot slip through the same hole unnoticed.
+CAS_ENCODING_PRODUCTIONS = frozenset({"atom", "form", "opt"})
+
+#: The synthetic CAS tag for a keyword option (§5.2). It is a tag with no
+#: surface syntax — no BSL source ever spells ``(opt …)`` — so §5.2's list
+#: carries it and the surface grammar cannot.
+SYNTHETIC_FORM_TAGS = frozenset({"opt"})
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"{path} is missing"
+    return path.read_text(encoding="utf-8")
+
+
+def _ebnf_text() -> str:
+    return _read(EBNF)
+
+
+def _ebnf_code() -> str:
+    """The appendix with its ``/* … */`` comments stripped.
+
+    Comment prose carries apostrophes and quoted phrases, and a naive scan for
+    quoted terminals over the raw file pairs quotes ACROSS them — which found
+    zero terminals while looking like it worked. Strip first, then scan.
+    """
+    return re.sub(r"/\*.*?\*/", " ", _ebnf_text(), flags=re.DOTALL)
+
+
+def _ebnf_productions() -> set[str]:
+    """Left-hand sides defined in the appendix."""
+    return set(re.findall(r"^([A-Za-z][A-Za-z0-9-]*)\s*::=", _ebnf_code(), re.MULTILINE))
+
+
+def _rst_productions() -> set[str]:
+    """Left-hand sides the rst's own code blocks define.
+
+    The rst writes nonterminals two ways — bare in §1.4's lexical block
+    (``symbol      ::= …``) and angle-bracketed everywhere else
+    (``<rule>     ::= …``) — and at least one row omits the space before
+    ``::=`` (``<payload-item>::=``). All three spellings are matched.
+    """
+    pattern = re.compile(r"^\s+<?([a-z][a-z0-9-]*)>?\s*::=", re.MULTILINE)
+    return set(pattern.findall(_read(RST)))
+
+
+def _rst_form_tags() -> set[str]:
+    """The form tags §5.2 enumerates, from its own paragraph.
+
+    §5.2 writes them as a parenthesised list of double-backquoted symbols
+    followed by "plus the synthetic tag ``opt``"; the operator tags (``<``,
+    ``+``, …) are in the same list and are dropped here because they are not
+    spellable as symbols.
+    """
+    body = _read(RST)
+    start = body.index("**Form tags** are the form's head symbol verbatim")
+    end = body.index("A keyword option is encoded as a two-child form", start)
+    section = body[start:end]
+    return {
+        tag
+        for tag in re.findall(r"``([a-z][a-z0-9-]*)``", section)
+        if tag not in SYNTHETIC_FORM_TAGS
+    }
+
+
+def _rust_reserved_form_tags() -> set[str]:
+    """``RESERVED_FORM_TAGS`` from the Rust crate — its §5.2 rendering."""
+    body = _read(DECLARATIONS_RS)
+    match = re.search(r"pub const RESERVED_FORM_TAGS: \[&str; \d+\] = \[(.*?)\];", body, re.DOTALL)
+    assert match, "RESERVED_FORM_TAGS not found in declarations.rs"
+    return set(re.findall(r'"([a-z][a-z0-9-]*)"', match.group(1))) - SYNTHETIC_FORM_TAGS
+
+
+def _quoted_terminals() -> set[str]:
+    """Every quoted terminal in the appendix, both quote styles."""
+    code = _ebnf_code()
+    return set(re.findall(r'"([^"\n]+)"', code)) | set(re.findall(r"'([^'\n]+)'", code))
+
+
+class TestTheAppendixCollectsTheSections:
+    """§7's claim — "every production of §§1, 2 and 6.1" — held to."""
+
+    def test_every_rst_production_appears_in_the_appendix(self) -> None:
+        missing = _rst_productions() - _ebnf_productions() - CAS_ENCODING_PRODUCTIONS
+        assert not missing, (
+            "productions defined in bsl-language.rst but absent from bsl.ebnf: "
+            f"{sorted(missing)}. §7 says the appendix collects EVERY production of "
+            "§§1, 2 and 6.1 — add them there (the section text wins, D92)."
+        )
+
+    def test_the_cas_encoding_productions_are_still_the_only_exclusion(self) -> None:
+        """The exclusion list is an allowlist, so it must stay exact.
+
+        If §5 ever loses one of these, the exclusion silently widens; this row
+        fails first and names the drift.
+        """
+        assert _rst_productions() >= CAS_ENCODING_PRODUCTIONS
+
+    def test_the_appendix_defines_nothing_the_rst_does_not(self) -> None:
+        """The other containment, where it IS safe to demand.
+
+        A production in the appendix with no counterpart in the sections would
+        be the appendix legislating — exactly what D92 forbids. The lexical
+        helpers §1 states in prose rather than in a code block are exempt and
+        listed by name.
+        """
+        prose_only = {
+            "whitespace",  # §1.2, stated in prose
+            "comment",  # §1.2, stated in prose
+            "delimiter",  # §1.4, stated in prose
+            "Char",  # §1.1, "a Unicode scalar value"
+            "DIGIT",  # §1.4's character terminals
+            "LOWER",
+            "UPPER",
+            "escape",  # §1.5's four escapes, spelled as source sequences
+            "operator",  # §1.4's tenth atom class (its draft ruling)
+            "literal",  # §2.7's <literal>, also used by §6.1
+            "type-name",  # §2.9/§2.11/§2.7 use it; §3.1 names the types
+            "vector-file",  # §6.1's "a sequence of vector forms", in prose
+            "intrinsic-name",  # §2.7's intrinsic-call head
+            "payload-item",  # §2.8 (matched by the rst scan, kept explicit)
+            "string-char",  # §1.4
+        }
+        extra = _ebnf_productions() - _rst_productions() - prose_only
+        assert not extra, (
+            f"bsl.ebnf defines productions the rst does not: {sorted(extra)}. "
+            "The appendix collects; it does not amend (D92)."
+        )
+
+
+class TestEveryFormTagHasAProduction:
+    """A tag with no production is a form the appendix forgot."""
+
+    def test_every_rst_form_tag_is_a_terminal_in_the_appendix(self) -> None:
+        missing = _rst_form_tags() - _quoted_terminals()
+        assert not missing, (
+            "form tags §5.2 enumerates but bsl.ebnf never quotes: "
+            f"{sorted(missing)}. Every form the canonical serialization can "
+            "encode must have a production to be derived from."
+        )
+
+    def test_every_rust_form_head_is_a_terminal_in_the_appendix(self) -> None:
+        missing = _rust_reserved_form_tags() - _quoted_terminals()
+        assert not missing, (
+            "form heads the Rust reference implementation knows "
+            f"(RESERVED_FORM_TAGS) but bsl.ebnf never quotes: {sorted(missing)}."
+        )
+
+    def test_the_rust_tag_list_stays_a_subset_of_the_rst_list(self) -> None:
+        """Rust may lag the spec; it may never lead it.
+
+        A tag the crate knows and §5.2 does not is an implementation that
+        invented a form — the direction the Constitution forbids.
+        """
+        invented = _rust_reserved_form_tags() - _rst_form_tags()
+        assert not invented, f"babylon-bsl knows form heads §5.2 does not list: {sorted(invented)}"
+
+
+class TestTheInclusionIsWired:
+    """§7 is only normative if the document actually includes the file."""
+
+    def test_the_rst_literalincludes_the_appendix(self) -> None:
+        body = _read(RST)
+        assert ".. literalinclude:: bsl.ebnf" in body
+
+    def test_section_seven_exists_and_states_the_precedence_rule(self) -> None:
+        body = _read(RST)
+        assert "7. Consolidated grammar" in body
+        assert "collects; it does not amend" in body
+
+    def test_the_register_carries_d92(self) -> None:
+        body = _read(RST)
+        assert re.search(r"^\s+\* - D92$", body, re.MULTILINE), (
+            "the consolidated grammar is a decision and owes a register row"
+        )
+
+    def test_the_appendix_names_its_dialect(self) -> None:
+        assert "W3C EBNF" in _ebnf_text()
+
+
+class TestTheRecordedGapsStayRecorded:
+    """Two under-determined points are flagged in place rather than settled.
+
+    A future edit that quietly deletes the flag would convert an honest gap
+    into a silent ruling — the one thing an appendix must never do.
+    """
+
+    @pytest.mark.parametrize(
+        "needle",
+        [
+            "RECORDED GAP",  # <type-name> has no §1.4 atom class
+            "TRANSCRIBED VERBATIM",  # §6.1's optional-valued vector keywords
+        ],
+    )
+    def test_the_gap_is_still_flagged(self, needle: str) -> None:
+        assert needle in _ebnf_text()

--- a/tests/unit/reference/test_bsl_grammar_sync.py
+++ b/tests/unit/reference/test_bsl_grammar_sync.py
@@ -229,6 +229,47 @@ class TestTheInclusionIsWired:
         assert "W3C EBNF" in _ebnf_text()
 
 
+class TestTheDerivedGrammarsCorpusCoversEveryForm:
+    """Every §5.2 form tag is exercised by a tree-sitter corpus case.
+
+    This row exists because the failure it catches actually happened. A corpus
+    case whose source is not terminated by a ``---`` separator is folded into
+    the PREVIOUS case's expected tree by ``tree-sitter test --update``, which
+    then rewrites the file without it: five cases vanished silently, and
+    ``tree-sitter test`` went on reporting 100%% because the cases it no longer
+    knew about could not fail. A green suite that quietly shrank is exactly the
+    shape III.11 rejects, and coverage measured against the SPEC's tag list —
+    rather than against whatever the corpus currently happens to contain — is
+    what makes the shrinkage visible.
+
+    The corpus is derived tooling and normative for nothing; what is asserted
+    here is only that it exercises what the language has.
+    """
+
+    @staticmethod
+    def _corpus_sources() -> str:
+        """The source halves of every corpus case, expectations excluded."""
+        corpus_dir = REPO_ROOT / "tools" / "tree-sitter-bsl" / "test" / "corpus"
+        sources: list[str] = []
+        for path in sorted(corpus_dir.glob("*.txt")):
+            for block in _read(path).split("=" * 50):
+                if "\n---\n" in block:
+                    sources.append(block.split("\n---\n")[0])
+        return "\n".join(sources)
+
+    def test_the_corpus_has_cases_at_all(self) -> None:
+        assert self._corpus_sources().strip(), "no corpus case survived parsing"
+
+    def test_every_form_tag_appears_in_a_corpus_source(self) -> None:
+        used = set(re.findall(r"\(([a-z][a-z0-9-]*)[\s)]", self._corpus_sources()))
+        missing = _rst_form_tags() - used
+        assert not missing, (
+            f"form tags no tree-sitter corpus case exercises: {sorted(missing)}. "
+            "A dropped case is invisible to `tree-sitter test`, which cannot fail "
+            "a case it no longer has — check for a source with no `---` separator."
+        )
+
+
 class TestTheRecordedGapsStayRecorded:
     """Two under-determined points are flagged in place rather than settled.
 

--- a/tests/unit/reference/test_bsl_grammar_sync.py
+++ b/tests/unit/reference/test_bsl_grammar_sync.py
@@ -90,8 +90,15 @@ def _rst_productions() -> set[str]:
     (``symbol      ::= …``) and angle-bracketed everywhere else
     (``<rule>     ::= …``) — and at least one row omits the space before
     ``::=`` (``<payload-item>::=``). All three spellings are matched.
+
+    **Case matters, and an earlier spelling of this scan got it wrong**
+    (Copilot review, PR #485): §1.4's character terminals are UPPERCASE
+    (``DIGIT``, ``LOWER``, ``UPPER``), so a lowercase-only pattern silently
+    excused exactly the three productions the whole lexical layer rests on —
+    they fell through to the prose-only exemption below and were guarded by
+    nothing.
     """
-    pattern = re.compile(r"^\s+<?([a-z][a-z0-9-]*)>?\s*::=", re.MULTILINE)
+    pattern = re.compile(r"^\s+<?([A-Za-z][A-Za-z0-9-]*)>?\s*::=", re.MULTILINE)
     return set(pattern.findall(_read(RST)))
 
 
@@ -159,10 +166,7 @@ class TestTheAppendixCollectsTheSections:
             "whitespace",  # §1.2, stated in prose
             "comment",  # §1.2, stated in prose
             "delimiter",  # §1.4, stated in prose
-            "Char",  # §1.1, "a Unicode scalar value"
-            "DIGIT",  # §1.4's character terminals
-            "LOWER",
-            "UPPER",
+            "Char",  # §1.1, "a Unicode scalar value" — prose, not a block
             "escape",  # §1.5's four escapes, spelled as source sequences
             "operator",  # §1.4's tenth atom class (its draft ruling)
             "literal",  # §2.7's <literal>, also used by §6.1

--- a/tools/tree-sitter-bsl/README.md
+++ b/tools/tree-sitter-bsl/README.md
@@ -88,10 +88,25 @@ Against the in-tree estate, as of this grammar's landing:
    specified (§6.1, collected in `bsl.ebnf` §3) — but no in-tree file uses
    one yet, so structuring them here would be a grammar with no corpus to
    hold it honest. It is a follow-up, not an omission.
-3. **Reserved words in value position.** Every §5.2 form-head symbol is a
-   keyword token here. Value positions accept them through the `symbol` rule
-   (a binding named `set` is legal BSL — D33 reserves those names against the
-   *intrinsic* namespace only), but they cannot head a `generic_form`.
+3. **Reserved words.** Every §5.2 form-head symbol is a keyword token here.
+   Value positions accept them through the `symbol` rule (a binding named
+   `set` is legal BSL — D33 reserves those names against the *intrinsic*
+   namespace only).
+
+   Whether one may **head** a `generic_form` depends on position, and the two
+   cases differ:
+
+   - where the content grammar admits the matching form, the keyword wins and
+     the structured rule applies. A **top-level** `(deffield <qname> <type>
+     <kind>)` — the `.bscn` positional shape — is therefore an error, because
+     §2.9's `deffield` takes `:type` and `:kind`;
+   - where the content grammar admits no form at all — inside a
+     `generic_form` body — the head lexes as a plain symbol and the fallback
+     takes it. That same positional `deffield` nested in `(scenario …)`
+     parses clean, which is why the real `.bscn` file parses end to end.
+
+   So limitation 1's divergence stays *visible* without making the scenario
+   file unopenable.
 4. **`type_name` is a lowercase symbol**, per the gap `bsl.ebnf` records:
    §3.1 spells the type names capitalized, and a bare capitalized run matches
    no §1.4 atom class. The reference implementation reads them lowercase and

--- a/tools/tree-sitter-bsl/README.md
+++ b/tools/tree-sitter-bsl/README.md
@@ -1,0 +1,111 @@
+# tree-sitter-bsl
+
+A [tree-sitter](https://tree-sitter.github.io/) grammar for **BSL**, the
+Babylon Scripting Language.
+
+## Derivation status: DERIVED, NON-NORMATIVE
+
+`docs/reference/bsl-language.rst` is the **one normative home** for BSL. Its
+§7 collects every production into `docs/reference/bsl.ebnf`, which is part of
+that document by inclusion. **`grammar.js` is derived from `bsl.ebnf`**, and
+it declares nothing:
+
+- on any divergence between this grammar and the rst, **the rst wins** and
+  this grammar is the defect;
+- this is a **parser for tooling**, not a validator. Every static check of
+  §3 — types, the intensivity kind rule, scope, ceilings, the load-time fuel
+  bound, the closed vocabulary — lives in the reference implementation at
+  `rust/crates/babylon-bsl`. A file this grammar parses may still be rejected
+  at content load by any of them, loudly (III.11);
+- adding a form here does not add it to the language. The route for that is
+  the rst, its decision register, and — where the change reaches the
+  formalism surface — an amendment.
+
+## Layout
+
+| Path                     | What it is                                              |
+| ------------------------ | ------------------------------------------------------- |
+| `grammar.js`             | The grammar. The only hand-written source here.         |
+| `queries/highlights.scm` | Highlight captures (standard nvim-treesitter names).    |
+| `test/corpus/*.txt`      | Corpus tests, sourced from real in-tree content.        |
+| `tree-sitter.json`       | CLI metadata: scope, file types (`.bsl`, `.bscn`).      |
+| `src/`                   | **Generated**, git-ignored. Never edit; regenerate.     |
+
+## Regenerate and test
+
+```bash
+mise run bsl:grammar-test        # generate + run the corpus (the sanctioned path)
+```
+
+or, directly, from this directory:
+
+```bash
+tree-sitter generate             # writes src/parser.c and friends
+tree-sitter test                 # runs test/corpus
+tree-sitter parse <file.bsl>     # print a parse tree; exits non-zero on error
+```
+
+The CLI ships with the repo's Rust toolchain (`cargo install tree-sitter-cli`,
+already present at `~/.cargo/bin/tree-sitter` on the dev box); node is
+available via the repo flake (`mise run nix -- node --version`). The generated
+parser is **not committed** — it is a build product of `grammar.js`, and
+committing it would make the grammar's real source ambiguous.
+
+Verified with tree-sitter CLI 0.25.10, node v26.5.1.
+
+## What the corpus covers
+
+Every form in §2, plus the atom classes of §1.4–§1.5, taken from **real
+content** rather than invented examples: the twelve conformance vectors under
+`rust/crates/babylon-bsl/tests/conformance/`, the content rule under
+`rust/crates/babylon-tick/content/rules/`, the scenario under
+`.../content/scenarios/`, and the worked examples the rst itself carries
+(§2.5, §2.6, §2.8, §2.9, §2.10, §2.11, §2.12, §3.9, §5.6).
+
+Against the in-tree estate, as of this grammar's landing:
+
+- 11 of the 12 conformance `.bsl` vectors and the one content rule parse
+  clean;
+- `empty_when.bsl` **does not parse**, and must not: `(when)` is
+  `E-PARSE-020`, a rejecting vector by design. The parser reports a missing
+  `#t`, which is the language's own advice for spelling "always";
+- `two-classes.bscn` parses entirely through the `generic_form` fallback —
+  see the next section.
+
+## Known limitations, each deliberate
+
+1. **The `.bscn` scenario format has no normative home.** The rst specifies
+   content forms (§2) and the §6.1 vector fixture format, and says nothing
+   about `(scenario …)`, `(node …)` or `(edge …)` — yet
+   `rust/crates/babylon-bsl/src/scenario.rs` reads exactly those. They parse
+   here as `generic_form`, the fallback for a form whose head the content
+   grammar does not name. That is honest tooling support, not a
+   specification: nothing about the scenario dialect is derivable from
+   `bsl.ebnf`. Note in particular that its `deffield` is **positional** —
+   `(deffield <qname> <type> <kind>)` — where §2.9's takes `:type` and
+   `:kind` keywords; the two forms share a name and not a shape.
+2. **§6.1 `vector` forms** likewise land in `generic_form`. They *are*
+   specified (§6.1, collected in `bsl.ebnf` §3) — but no in-tree file uses
+   one yet, so structuring them here would be a grammar with no corpus to
+   hold it honest. It is a follow-up, not an omission.
+3. **Reserved words in value position.** Every §5.2 form-head symbol is a
+   keyword token here. Value positions accept them through the `symbol` rule
+   (a binding named `set` is legal BSL — D33 reserves those names against the
+   *intrinsic* namespace only), but they cannot head a `generic_form`.
+4. **`type_name` is a lowercase symbol**, per the gap `bsl.ebnf` records:
+   §3.1 spells the type names capitalized, and a bare capitalized run matches
+   no §1.4 atom class. The reference implementation reads them lowercase and
+   records the same gap.
+5. **No `word` token.** The usual keyword-extraction optimization is declined
+   because with it the parser silently repairs a missing `symbol` operand
+   into a zero-width node that `tree-sitter parse` does not flag — a tool
+   that quietly fixes its input is the silent-degradation shape this project
+   rejects.
+
+## Editor wiring
+
+Not packaged yet — no npm publish, no nvim-treesitter registration, no VS Code
+extension. `tree-sitter.json` carries the scope (`source.bsl`) and file types
+a host needs, and `queries/highlights.scm` is written to the standard capture
+set, so wiring it into a local `nvim-treesitter` install is a
+`parser_config` entry plus a `tree-sitter generate`. Packaging is a follow-up.

--- a/tools/tree-sitter-bsl/README.md
+++ b/tools/tree-sitter-bsl/README.md
@@ -55,12 +55,21 @@ Verified with tree-sitter CLI 0.25.10, node v26.5.1.
 
 ## What the corpus covers
 
-Every form in §2, plus the atom classes of §1.4–§1.5, taken from **real
-content** rather than invented examples: the twelve conformance vectors under
+Every form in §2, plus the atom classes of §1.4–§1.5, **sourced from** real
+content rather than invented examples: the conformance vectors under
 `rust/crates/babylon-bsl/tests/conformance/`, the content rule under
 `rust/crates/babylon-tick/content/rules/`, the scenario under
 `.../content/scenarios/`, and the worked examples the rst itself carries
 (§2.5, §2.6, §2.8, §2.9, §2.10, §2.11, §2.12, §3.9, §5.6).
+
+**Sourced from is not identical to, and every case title says which.** Cases
+are marked `VERBATIM`, `ABRIDGED` (a `:material-basis` string or a binding
+list shortened for readability) or — for the scenario case — `TRIMMED and
+AUGMENTED`: that one adds an `(edge …)` form taken from `scenario.rs`'s
+module doc, because nothing in the tree exercises the scenario dialect's edge
+form. The corpus is a **grammar witness, never a byte-regression** against
+those files. For the latter, parse the files themselves
+(`tree-sitter parse <file>`) — which is how the table below was produced.
 
 Against the in-tree estate, as of this grammar's landing:
 
@@ -74,9 +83,11 @@ Against the in-tree estate, as of this grammar's landing:
 
 ## Known limitations, each deliberate
 
-1. **The `.bscn` scenario format has no normative home.** The rst specifies
-   content forms (§2) and the §6.1 vector fixture format, and says nothing
-   about `(scenario …)`, `(node …)` or `(edge …)` — yet
+1. **The `.bscn` scenario format has no normative home** — now recorded as
+   **register row D93** in `bsl-language.rst`, which is where the conflict
+   belongs; this file is normative for nothing and cannot carry it. The rst
+   specifies content forms (§2) and the §6.1 vector fixture format, and says
+   nothing about `(scenario …)`, `(node …)` or `(edge …)` — yet
    `rust/crates/babylon-bsl/src/scenario.rs` reads exactly those. They parse
    here as `generic_form`, the fallback for a form whose head the content
    grammar does not name. That is honest tooling support, not a

--- a/tools/tree-sitter-bsl/grammar.js
+++ b/tools/tree-sitter-bsl/grammar.js
@@ -1,0 +1,456 @@
+/**
+ * @file tree-sitter grammar for BSL (the Babylon Scripting Language)
+ *
+ * DERIVED ARTIFACT — NOT NORMATIVE.
+ *
+ * This grammar is derived from `docs/reference/bsl.ebnf`, which is part of
+ * the ONE normative home for BSL, `docs/reference/bsl-language.rst`, by
+ * inclusion (§7). Nothing here declares anything about the language: on any
+ * divergence the rst wins, this file is the defect, and the repair is here.
+ * It exists for tooling — syntax highlighting, structural editing, code
+ * navigation — and for nothing else. It is not a validator: every static
+ * check of §3 (types, kinds, scope, ceilings, the fuel bound, the closed
+ * vocabulary) lives in the reference implementation at
+ * `rust/crates/babylon-bsl`, and a file this grammar parses may still be
+ * rejected at load by any of them.
+ *
+ * Production names track `bsl.ebnf`'s (hyphens become underscores, as
+ * tree-sitter rule names must be identifiers).
+ *
+ * THREE DELIBERATE DEPARTURES, each recorded rather than hidden:
+ *
+ * 1. `generic_form` — a fallback for any form whose head is a plain symbol
+ *    the content grammar does not name. It exists because the tree carries
+ *    two s-expression dialects the rst does NOT specify: the `.bscn`
+ *    scenario-file format read by `babylon-bsl`'s `scenario.rs`, and §6.1's
+ *    `vector` fixture format (which no in-tree file yet uses). Parsing them
+ *    as generic forms keeps the editor working without minting a second
+ *    source of truth for either.
+ * 2. Reserved words. Every §5.2 form-head symbol is a keyword token here. A
+ *    binding, `:as` name or payload key spelled exactly like one is legal
+ *    BSL (D33 reserves them against the INTRINSIC namespace only) and is
+ *    accepted in value positions via the `symbol` rule — but it cannot head
+ *    a `generic_form`. The `.bscn` `deffield` shape hits this on purpose;
+ *    see README.md's known limitations.
+ * 3. `type_name` is a lowercase `symbol`, per bsl.ebnf's recorded gap.
+ *
+ * NO `word` TOKEN, deliberately. Declaring `word: $._plain_symbol` turns the
+ * reserved words into extracted keywords and is the usual optimization — but
+ * with it, a missing `symbol` operand is repaired by the parser into a
+ * zero-width node that `tree-sitter parse` does not flag: `(remove-node)`
+ * parsed clean. A tool that silently repairs its input is the
+ * silent-degradation shape this project rejects (III.11), so the
+ * optimization is declined and the error is loud.
+ *
+ * @license AGPL-3.0-or-later
+ */
+
+/* Every §5.2 form-head symbol that is a valid `symbol` (the operator tags
+ * cannot be spelled as symbols). Kept as one list so that a value position
+ * can accept them all and `generic_form` can reject them all. */
+const RESERVED_WORDS = [
+  'add', 'add-edge', 'add-hyperedge', 'add-node', 'adjunction', 'anchor',
+  'and', 'binding', 'bindings', 'ceiling', 'deffield', 'domain',
+  'edge-between', 'edges', 'effects', 'emit', 'exists', 'field-of', 'fold',
+  'for-each', 'forall', 'guard', 'hyperedges', 'hyperedges-of', 'if',
+  'intrinsic', 'manifest', 'member', 'members', 'members-of',
+  'membership-field-of', 'metric', 'metric-of', 'neighbors', 'nodes', 'not',
+  'or', 'remove-edge', 'remove-hyperedge', 'remove-node', 'rule', 'rung',
+  'scale', 'select-max', 'select-min', 'set', 'sub', 'the', 'update-edge',
+  'update-hyperedge', 'update-membership', 'update-node', 'when',
+];
+
+/* §2.7 `<fold-op>`, §2.4 `<cmp>`, §2.7 `<arith>` — closed terminal sets. */
+const FOLD_OPS = ['sum', 'mean', 'min', 'max', 'count'];
+const CMP = ['<', '<=', '>', '>=', '=', '!='];
+const ARITH = ['+', '-', '*', '/'];
+
+module.exports = grammar({
+  name: 'bsl',
+
+  /* §1.2: whitespace is exactly these four characters, and a comment is
+   * whitespace. */
+  extras: ($) => [/[ \t\r\n]/, $.comment],
+
+  rules: {
+    /* --- §2.2 content files ------------------------------------------ */
+
+    source_file: ($) => repeat($._top_form),
+
+    _top_form: ($) =>
+      choice(
+        $.rule,
+        $.deffield,
+        $.intrinsic_decl,
+        $.manifest,
+        $.metric_decl,
+        $.generic_form,
+      ),
+
+    /* --- §2.3 rules --------------------------------------------------- */
+
+    rule: ($) =>
+      seq(
+        '(',
+        'rule',
+        field('id', $.qname),
+        repeat(choice($.material_basis, $.fuel)),
+        optional($.domain),
+        optional($.anchor),
+        $.bindings,
+        optional($.when),
+        $.effects,
+        ')',
+      ),
+
+    /* §2.3: the two keyword options may appear in either source order, so
+     * they are collected rather than sequenced. Presence is a load check
+     * (E-PARSE-011 / E-PARSE-012), not a syntactic one. */
+    material_basis: ($) => seq(':material-basis', $.string),
+    fuel: ($) => seq(':fuel', $.int_lit),
+
+    domain: ($) => seq('(', 'domain', choice($.enum_ref, $.graph_flag), ')'),
+    graph_flag: (_$) => ':graph',
+
+    anchor: ($) => seq('(', 'anchor', choice(':after', ':before'), $.symbol, ')'),
+
+    bindings: ($) => seq('(', 'bindings', repeat($.binding), ')'),
+    when: ($) => seq('(', 'when', $._cond, ')'),
+    effects: ($) => seq('(', 'effects', repeat1($._effect_item), ')'),
+
+    /* --- §2.4 conditions ---------------------------------------------- */
+
+    _cond: ($) =>
+      choice(
+        $.bool_lit,
+        $.and_cond,
+        $.or_cond,
+        $.not_cond,
+        $.comparison,
+        $.exists,
+        $.forall,
+      ),
+
+    and_cond: ($) => seq('(', 'and', repeat1($._cond), ')'),
+    or_cond: ($) => seq('(', 'or', repeat1($._cond), ')'),
+    not_cond: ($) => seq('(', 'not', $._cond, ')'),
+    comparison: ($) => seq('(', $.cmp, $._expr, $._expr, ')'),
+    cmp: (_$) => choice(...CMP),
+
+    exists: ($) =>
+      seq('(', 'exists', $._query, optional($.elem_name), optional($._cond), ')'),
+    forall: ($) =>
+      seq('(', 'forall', $._query, optional($.elem_name), $._cond, ')'),
+
+    /* --- §2.5 bindings ------------------------------------------------ */
+
+    binding: ($) => seq('(', 'binding', $.symbol, $.bind_src, repeat($.bind_opt), ')'),
+
+    bind_src: ($) =>
+      choice(
+        seq(':field', $.qname),
+        seq(':const', $.qname),
+        seq(':metric', $.symbol),
+        ':tick',
+        ':year',
+        ':tick-of-year',
+        seq(':tick-in-cycle', $.int_lit),
+        seq(':expr', $._expr),
+      ),
+
+    bind_opt: ($) => choice(':optional', seq(':default', $.literal)),
+
+    /* --- §2.6 queries -------------------------------------------------- */
+
+    _query: ($) =>
+      choice($.nodes, $.edges, $.neighbors, $.hyperedges, $.members_of, $.hyperedges_of),
+
+    nodes: ($) => seq('(', 'nodes', $.enum_ref, optional($._cond), ')'),
+    edges: ($) => seq('(', 'edges', $.enum_ref, optional($._cond), ')'),
+    hyperedges: ($) => seq('(', 'hyperedges', $.enum_ref, optional($._cond), ')'),
+
+    /* D51: four operands — element, EdgeType traversed, direction, result
+     * NodeType. The fourth is mandatory and it FILTERS. */
+    neighbors: ($) =>
+      seq('(', 'neighbors', $._expr, $.enum_ref, $.direction, $.enum_ref, ')'),
+
+    members_of: ($) => seq('(', 'members-of', $._expr, $.enum_ref, ')'),
+    hyperedges_of: ($) => seq('(', 'hyperedges-of', $._expr, $.enum_ref, ')'),
+
+    direction: (_$) => choice(':out', ':in', ':any'),
+    elem_name: ($) => seq(':as', $.symbol),
+
+    /* --- §2.7 expressions ---------------------------------------------- */
+
+    _expr: ($) =>
+      choice(
+        $.literal,
+        $.symbol,
+        $.enum_ref,
+        $.arith_expr,
+        $.if_expr,
+        $.fold,
+        $._accessor,
+        $.selection,
+        $.intrinsic_call,
+      ),
+
+    arith_expr: ($) => seq('(', $.arith, $._expr, $._expr, ')'),
+    arith: (_$) => choice(...ARITH),
+
+    if_expr: ($) => seq('(', 'if', $._cond, $._expr, $._expr, ')'),
+
+    fold: ($) =>
+      seq(
+        '(',
+        'fold',
+        $.fold_op,
+        $._query,
+        optional($.elem_name),
+        $._expr,
+        optional($.weight),
+        ')',
+      ),
+    fold_op: (_$) => choice(...FOLD_OPS),
+    weight: ($) => seq(':weight', $._expr),
+
+    selection: ($) =>
+      seq(
+        '(',
+        choice('select-max', 'select-min'),
+        $._query,
+        optional($.elem_name),
+        $._expr,
+        ')',
+      ),
+
+    /* §2.7: an intrinsic call is an ordinary form whose head is a symbol
+     * declared in the intrinsic table. D33 reserves every §5.2 form tag
+     * against that namespace, which is exactly why the head here is a plain
+     * symbol and never a reserved word. */
+    intrinsic_call: ($) =>
+      seq('(', alias($._plain_symbol, $.symbol), repeat($._expr), ')'),
+
+    /* --- §2.10 element accessors ---------------------------------------- */
+
+    _accessor: ($) =>
+      choice($.field_of, $.edge_between, $.the, $.metric_of, $.membership_field_of),
+
+    field_of: ($) => seq('(', 'field-of', $._expr, $.qname, ')'),
+    edge_between: ($) => seq('(', 'edge-between', $.enum_ref, $._expr, $._expr, ')'),
+    the: ($) => seq('(', 'the', $.enum_ref, ')'),
+    metric_of: ($) => seq('(', 'metric-of', $._expr, $.symbol, ')'),
+    membership_field_of: ($) =>
+      seq('(', 'membership-field-of', $._expr, $._expr, $.qname, ')'),
+
+    /* --- §2.8 effects --------------------------------------------------- */
+
+    _effect_item: ($) => choice($._verb, $.guard, $.for_each),
+
+    guard: ($) => seq('(', 'guard', $._cond, repeat1($._effect_item), ')'),
+    for_each: ($) =>
+      seq('(', 'for-each', $._query, optional($.elem_name), repeat1($._effect_item), ')'),
+
+    _verb: ($) =>
+      choice(
+        $.update_node,
+        $.update_edge,
+        $.add_node,
+        $.remove_node,
+        $.add_edge,
+        $.remove_edge,
+        $.add_hyperedge,
+        $.update_hyperedge,
+        $.remove_hyperedge,
+        $.update_membership,
+        $.emit,
+      ),
+
+    update_node: ($) => seq('(', 'update-node', $._expr, $.qname, $.update_op, ')'),
+    update_edge: ($) => seq('(', 'update-edge', $._expr, $.qname, $.update_op, ')'),
+    update_hyperedge: ($) =>
+      seq('(', 'update-hyperedge', $._expr, $.qname, $.update_op, ')'),
+    update_membership: ($) =>
+      seq('(', 'update-membership', $._expr, $._expr, $.qname, $.update_op, ')'),
+
+    add_node: ($) => seq('(', 'add-node', $.enum_ref, $._expr, repeat($.field_init), ')'),
+    remove_node: ($) => seq('(', 'remove-node', $._expr, ')'),
+
+    add_edge: ($) =>
+      seq(
+        '(',
+        'add-edge',
+        $.enum_ref,
+        $._expr,
+        $._expr,
+        $.strength,
+        repeat($.field_init),
+        ')',
+      ),
+    strength: ($) => seq(':strength', $._expr),
+    remove_edge: ($) => seq('(', 'remove-edge', $.enum_ref, $._expr, $._expr, ')'),
+
+    add_hyperedge: ($) =>
+      seq('(', 'add-hyperedge', $.enum_ref, $._expr, $.members, repeat($.field_init), ')'),
+    remove_hyperedge: ($) => seq('(', 'remove-hyperedge', $._expr, ')'),
+
+    emit: ($) => seq('(', 'emit', $.enum_ref, repeat($.payload_item), ')'),
+
+    update_op: ($) => seq('(', choice('add', 'sub', 'set', 'scale'), $._expr, ')'),
+
+    members: ($) => seq('(', 'members', repeat1($._member_item), ')'),
+    _member_item: ($) => choice($._expr, $.member),
+    member: ($) => seq('(', 'member', $.enum_ref, $._expr, repeat($.field_init), ')'),
+
+    field_init: ($) => seq('(', $.qname, $._expr, ')'),
+    payload_item: ($) => seq('(', $.symbol, $._expr, ')'),
+
+    /* --- §2.9 / §2.11 declarations --------------------------------------- */
+
+    deffield: ($) =>
+      seq(
+        '(',
+        'deffield',
+        $.qname,
+        ':type',
+        $.type_name,
+        ':kind',
+        $.field_kind,
+        optional(seq(':member', $.enum_ref)),
+        ')',
+      ),
+    field_kind: (_$) => choice('intensive', 'extensive'),
+    type_name: ($) => $.symbol,
+
+    intrinsic_decl: ($) =>
+      seq(
+        '(',
+        'intrinsic',
+        $.symbol,
+        ':params',
+        seq('(', repeat($.type_name), ')'),
+        ':returns',
+        $.type_name,
+        ':cost',
+        $.int_lit,
+        ')',
+      ),
+
+    manifest: ($) =>
+      seq(
+        '(',
+        'manifest',
+        $.symbol,
+        repeat1($.ceiling),
+        repeat($.rung),
+        repeat($.adjunction),
+        ')',
+      ),
+
+    ceiling: ($) =>
+      seq(
+        '(',
+        'ceiling',
+        $.enum_ref,
+        ':ceiling',
+        $.int_lit,
+        optional(seq(':max-members', $.int_lit)),
+        optional(':invariant'),
+        ')',
+      ),
+
+    rung: ($) =>
+      seq(
+        '(',
+        'rung',
+        $.symbol,
+        $.enum_ref,
+        $.enum_ref,
+        ':via',
+        $.enum_ref,
+        optional(':substrate'),
+        ')',
+      ),
+
+    adjunction: ($) =>
+      seq(
+        '(',
+        'adjunction',
+        $.symbol,
+        $.qname,
+        $.qname,
+        ':rung',
+        $.symbol,
+        optional(seq(':weighted-by', $.qname)),
+        ')',
+      ),
+
+    metric_decl: ($) =>
+      seq(
+        '(',
+        'metric',
+        $.symbol,
+        ':type',
+        $.type_name,
+        ':kind',
+        $.field_kind,
+        $.domain,
+        ':provider',
+        $.symbol,
+        ')',
+      ),
+
+    /* --- the fallback (see the file header, departure 1) ----------------- */
+
+    generic_form: ($) =>
+      seq(
+        '(',
+        choice(alias($._plain_symbol, $.symbol), $.qname),
+        repeat($._generic_item),
+        ')',
+      ),
+
+    _generic_item: ($) =>
+      choice(
+        $.literal,
+        $.string,
+        $.symbol,
+        $.qname,
+        $.enum_ref,
+        $.keyword,
+        $.rule,
+        $.generic_form,
+      ),
+
+    /* --- §1.4 / §1.5 atoms ------------------------------------------------ */
+
+    literal: ($) => choice($.int_lit, $.scaled_lit, $.bool_lit),
+
+    /* A symbol in VALUE position may be spelled like a §5.2 form tag: D33
+     * reserves those names against the intrinsic namespace only. */
+    symbol: ($) => choice($._plain_symbol, ...RESERVED_WORDS),
+    _plain_symbol: (_$) => /[a-z][a-z0-9-]*/,
+
+    qname: (_$) => token(/[a-z][a-z0-9-]*(\/[a-z][a-z0-9-]*)+/),
+
+    enum_ref: (_$) => token(/[A-Z][A-Za-z0-9]*\/[A-Z][A-Z0-9_]*/),
+
+    bool_lit: (_$) => choice('#t', '#f'),
+
+    int_lit: (_$) => token(/-?[0-9](_?[0-9])*/),
+
+    /* §1.5: the kind suffix is mandatory; a bare `0.5` is E-LEX-021 and is
+     * therefore not a token of this grammar at all. */
+    scaled_lit: (_$) => token(/-?[0-9](_?[0-9])*(\.[0-9](_?[0-9])*)?[$pic]/),
+
+    /* §1.5: the only four escapes; strings are single-line. */
+    string: (_$) => token(/"([^"\\\n]|\\["\\nt])*"/),
+
+    /* Any colon-prefixed symbol, for the fallback dialects only — the
+     * content grammar spells each of its keywords literally (§1.6's set is
+     * closed, and an unrecognized keyword is E-PARSE-013, never ignored). */
+    keyword: (_$) => token(/:[a-z][a-z0-9-]*/),
+
+    comment: (_$) => token(seq(';', /[^\n]*/)),
+  },
+});

--- a/tools/tree-sitter-bsl/grammar.js
+++ b/tools/tree-sitter-bsl/grammar.js
@@ -29,9 +29,20 @@
  * 2. Reserved words. Every §5.2 form-head symbol is a keyword token here. A
  *    binding, `:as` name or payload key spelled exactly like one is legal
  *    BSL (D33 reserves them against the INTRINSIC namespace only) and is
- *    accepted in value positions via the `symbol` rule — but it cannot head
- *    a `generic_form`. The `.bscn` `deffield` shape hits this on purpose;
- *    see README.md's known limitations.
+ *    accepted in value positions via the `symbol` rule.
+ *
+ *    Whether a reserved word may HEAD a `generic_form` is decided by
+ *    tree-sitter's context-aware lexing, and the answer differs by position
+ *    — stated exactly, because an earlier draft of this comment got it
+ *    wrong (Copilot review, PR #485). Where the content grammar admits the
+ *    matching form, the keyword token wins and the structured rule applies:
+ *    a top-level `(deffield <qname> <type> <kind>)` — the `.bscn` positional
+ *    shape — is therefore an ERROR, since §2.9's `deffield` wants `:type`
+ *    and `:kind`. Where the content grammar admits no form at all, as
+ *    inside a `generic_form` body, the head lexes as a plain symbol and the
+ *    fallback takes it: the same positional `deffield` nested in
+ *    `(scenario …)` parses clean. That is why the real `.bscn` file parses
+ *    and a bare scenario `deffield` would not. See README.md.
  * 3. `type_name` is a lowercase `symbol`, per bsl.ebnf's recorded gap.
  *
  * NO `word` TOKEN, deliberately. Declaring `word: $._plain_symbol` turns the

--- a/tools/tree-sitter-bsl/package.json
+++ b/tools/tree-sitter-bsl/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "tree-sitter-bsl",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Tree-sitter grammar for BSL (the Babylon Scripting Language) — DERIVED from docs/reference/bsl.ebnf; docs/reference/bsl-language.rst is normative",
+  "license": "AGPL-3.0-or-later",
+  "main": "bindings/node",
+  "keywords": ["parser", "tree-sitter", "bsl", "babylon"],
+  "scripts": {
+    "generate": "tree-sitter generate",
+    "test": "tree-sitter generate && tree-sitter test"
+  },
+  "tree-sitter": [
+    {
+      "scope": "source.bsl",
+      "file-types": ["bsl", "bscn"],
+      "highlights": "queries/highlights.scm"
+    }
+  ]
+}

--- a/tools/tree-sitter-bsl/queries/highlights.scm
+++ b/tools/tree-sitter-bsl/queries/highlights.scm
@@ -1,0 +1,183 @@
+;; Syntax highlighting for BSL — DERIVED, NON-NORMATIVE.
+;;
+;; docs/reference/bsl-language.rst is the one normative home; this file
+;; colours what ../grammar.js parses and declares nothing about the
+;; language. Capture names follow the tree-sitter/nvim-treesitter standard
+;; set so the queries drop into any host that speaks it.
+;;
+;; The colouring intent, stated once: a reader should be able to see the
+;; three things BSL makes load-bearing — WHICH FORM this is (the head), WHAT
+;; IT READS (qnames, enum-refs, metric and binding names), and WHICH
+;; QUANTITY KIND a literal carries (§1.5's four suffixes are the lexical
+;; enforcement of the no-bare-floats rule, so they are highlighted as a
+;; class of their own rather than as generic numbers).
+
+;; ── Form heads ──────────────────────────────────────────────────────────
+;; §2.2's top-level declaration forms: the content set's own structure.
+[
+  "rule"
+  "deffield"
+  "intrinsic"
+  "manifest"
+  "metric"
+] @keyword
+
+;; §2.3 rule children and §2.9's manifest children.
+[
+  "bindings"
+  "binding"
+  "when"
+  "effects"
+  "domain"
+  "anchor"
+  "ceiling"
+  "rung"
+  "adjunction"
+] @keyword
+
+;; §2.4 / §2.7 control and aggregation forms.
+[
+  "and"
+  "or"
+  "not"
+  "if"
+  "exists"
+  "forall"
+  "fold"
+  "select-max"
+  "select-min"
+  "guard"
+  "for-each"
+] @keyword.control
+
+;; §2.6 query heads — every one of them ranges over the graph.
+[
+  "nodes"
+  "edges"
+  "neighbors"
+  "hyperedges"
+  "members-of"
+  "hyperedges-of"
+] @function.builtin
+
+;; §2.10 accessors — reads from an element already in hand.
+[
+  "field-of"
+  "edge-between"
+  "the"
+  "metric-of"
+  "membership-field-of"
+] @function.builtin
+
+;; §2.8 structural verbs — the ONLY writes in the language.
+[
+  "update-node"
+  "update-edge"
+  "update-hyperedge"
+  "update-membership"
+  "add-node"
+  "remove-node"
+  "add-edge"
+  "remove-edge"
+  "add-hyperedge"
+  "remove-hyperedge"
+  "emit"
+  "members"
+  "member"
+] @function.method
+
+;; §2.8's four update operations, §2.7's closed fold-op set, §2.9's kinds.
+[
+  "add"
+  "sub"
+  "set"
+  "scale"
+] @operator
+(fold_op) @function.builtin
+(field_kind) @type.builtin
+
+;; §2.4 comparisons and §2.7 arithmetic.
+(cmp) @operator
+(arith) @operator
+
+;; ── Keywords (the `:name` option markers, §1.6's closed set) ────────────
+[
+  ":material-basis"
+  ":fuel"
+  ":field"
+  ":const"
+  ":metric"
+  ":expr"
+  ":optional"
+  ":default"
+  ":tick"
+  ":year"
+  ":tick-of-year"
+  ":tick-in-cycle"
+  ":kind"
+  ":type"
+  ":member"
+  ":as"
+  ":weight"
+  ":strength"
+  ":after"
+  ":before"
+  ":params"
+  ":returns"
+  ":cost"
+  ":provider"
+  ":ceiling"
+  ":max-members"
+  ":invariant"
+  ":via"
+  ":substrate"
+  ":rung"
+  ":weighted-by"
+] @attribute
+(direction) @attribute
+(graph_flag) @attribute
+(keyword) @attribute
+
+;; ── Names ───────────────────────────────────────────────────────────────
+;; A qname is a rule id or a field reference — always a name in the closed
+;; vocabulary (§3.6), never a free identifier.
+(qname) @variable.member
+
+;; An enum-ref names a member of a closed enum; the type half and the member
+;; half are one token by §1.4, so the whole reference is one capture.
+(enum_ref) @constant
+
+(type_name (symbol) @type)
+
+;; The generic case first: later patterns override earlier ones in the
+;; hosts that consume these queries, so the specific captures below win.
+(symbol) @variable
+
+;; The reserved element references (§2.5): `self` is the rule's subject and
+;; `it` the innermost enclosing iterating form's element (D53). Neither is
+;; ever declared, which is why they are `variable.builtin` and not
+;; `variable`.
+((symbol) @variable.builtin
+  (#any-of? @variable.builtin "self" "it"))
+
+(binding (symbol) @variable.parameter)
+(elem_name (symbol) @variable.parameter)
+(intrinsic_call (symbol) @function.builtin)
+(payload_item (symbol) @property)
+
+;; ── Literals ────────────────────────────────────────────────────────────
+;; §1.5: a non-integer literal MUST carry a kind suffix ($ / p / i / c), so
+;; a scaled literal is a different thing from a plain integer and reads as
+;; one.
+(scaled_lit) @number.float
+(int_lit) @number
+(bool_lit) @constant.builtin
+(string) @string
+
+;; ── Punctuation and trivia ──────────────────────────────────────────────
+[
+  "("
+  ")"
+] @punctuation.bracket
+
+(comment) @comment @spell

--- a/tools/tree-sitter-bsl/test/corpus/declarations.txt
+++ b/tools/tree-sitter-bsl/test/corpus/declarations.txt
@@ -81,3 +81,58 @@ Intrinsic declaration (§2.7; the declarable set is {exp, log}, §3.10)
     (type_name
       (symbol))
     (int_lit)))
+
+==================================================
+Manifest with a substrate rung and two adjunctions (§3.9 worked example)
+==================================================
+
+; illustrative; the delineation counts are a scenario's, not the document's
+(manifest usa-2026
+  (ceiling NodeType/TERRITORY       :ceiling 3143 :invariant)
+  (ceiling NodeType/COMMUTING_ZONE  :ceiling 741  :invariant)
+  (ceiling EdgeType/IN_SCALE        :ceiling 3143 :invariant)
+  (ceiling HyperedgeType/COMMUNITY  :ceiling 500 :max-members 40)
+  (rung county-cz NodeType/TERRITORY NodeType/COMMUTING_ZONE
+        :via EdgeType/IN_SCALE :substrate)
+  (adjunction wage-bill
+              territory/wage-bill commuting-zone/wage-bill
+              :rung county-cz)
+  (adjunction unemployment
+              territory/unemployment-rate commuting-zone/unemployment-rate
+              :rung county-cz :weighted-by territory/labor-force))
+
+---
+
+(source_file
+  (comment)
+  (manifest
+    (symbol)
+    (ceiling
+      (enum_ref)
+      (int_lit))
+    (ceiling
+      (enum_ref)
+      (int_lit))
+    (ceiling
+      (enum_ref)
+      (int_lit))
+    (ceiling
+      (enum_ref)
+      (int_lit)
+      (int_lit))
+    (rung
+      (symbol)
+      (enum_ref)
+      (enum_ref)
+      (enum_ref))
+    (adjunction
+      (symbol)
+      (qname)
+      (qname)
+      (symbol))
+    (adjunction
+      (symbol)
+      (qname)
+      (qname)
+      (symbol)
+      (qname))))

--- a/tools/tree-sitter-bsl/test/corpus/declarations.txt
+++ b/tools/tree-sitter-bsl/test/corpus/declarations.txt
@@ -1,0 +1,83 @@
+==================================================
+Membership payload deffields (bsl-language.rst §2.9 worked example)
+==================================================
+
+(deffield community/strength   :type coefficient :kind extensive
+          :member NodeType/SOCIAL_CLASS)
+(deffield community/visibility :type probability :kind intensive
+          :member NodeType/SOCIAL_CLASS)
+
+---
+
+(source_file
+  (deffield
+    (qname)
+    (type_name
+      (symbol))
+    (field_kind)
+    (enum_ref))
+  (deffield
+    (qname)
+    (type_name
+      (symbol))
+    (field_kind)
+    (enum_ref)))
+
+==================================================
+Element-indexed metric declaration (bsl-language.rst §2.11 worked example)
+==================================================
+
+(metric betweenness-centrality
+  :type coefficient :kind intensive
+  (domain NodeType/ORGANIZATION)
+  :provider topology-scores)
+
+---
+
+(source_file
+  (metric_decl
+    (symbol)
+    (type_name
+      (symbol))
+    (field_kind)
+    (domain
+      (enum_ref))
+    (symbol)))
+
+==================================================
+Graph-scope metric declaration (§2.11, the <domain> :graph shape)
+==================================================
+
+(metric solidarity-density
+  :type coefficient :kind intensive
+  (domain :graph)
+  :provider topology-scores)
+
+---
+
+(source_file
+  (metric_decl
+    (symbol)
+    (type_name
+      (symbol))
+    (field_kind)
+    (domain
+      (graph_flag))
+    (symbol)))
+
+==================================================
+Intrinsic declaration (§2.7; the declarable set is {exp, log}, §3.10)
+==================================================
+
+(intrinsic exp :params (real) :returns real :cost 20)
+
+---
+
+(source_file
+  (intrinsic_decl
+    (symbol)
+    (type_name
+      (symbol))
+    (type_name
+      (symbol))
+    (int_lit)))

--- a/tools/tree-sitter-bsl/test/corpus/effects.txt
+++ b/tools/tree-sitter-bsl/test/corpus/effects.txt
@@ -222,3 +222,51 @@ The remaining structural verbs, and the four update-ops (§2.8)
             (scaled_lit))))
       (remove_hyperedge
         (symbol)))))
+
+==================================================
+A graph-domain rule with an explicit anchor (§2.3, D43)
+==================================================
+
+(rule control-ratio/phase
+  :material-basis "the control ratio is a property of the formation, not a class"
+  :fuel 256
+  (domain :graph)
+  (anchor :after metabolism)
+  (bindings
+    (binding ratio :metric control-ratio))
+  (when (> ratio 0.5c))
+  (effects
+    (update-node (the NodeType/POLITY) polity/phase (set 2))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (domain
+      (graph_flag))
+    (anchor
+      (symbol))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (symbol))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (literal
+          (scaled_lit))))
+    (effects
+      (update_node
+        (the
+          (enum_ref))
+        (qname)
+        (update_op
+          (literal
+            (int_lit)))))))

--- a/tools/tree-sitter-bsl/test/corpus/effects.txt
+++ b/tools/tree-sitter-bsl/test/corpus/effects.txt
@@ -1,0 +1,224 @@
+==================================================
+for-each in effect position (§2.8 worked example, D47)
+==================================================
+
+(rule solidarity/decay
+  :material-basis "unmaintained ties decay at the rate practice does not renew"
+  :fuel 4096
+  (bindings)
+  (effects
+    (for-each (edges EdgeType/SOLIDARITY)
+      (update-edge it solidarity/strength (scale 0.95c))
+      (emit EventType/SOLIDARITY_DECAYED (strength (field-of it
+                                                             solidarity/strength))))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings)
+    (effects
+      (for_each
+        (edges
+          (enum_ref))
+        (update_edge
+          (symbol)
+          (qname)
+          (update_op
+            (literal
+              (scaled_lit))))
+        (emit
+          (enum_ref)
+          (payload_item
+            (symbol)
+            (field_of
+              (symbol)
+              (qname))))))))
+
+==================================================
+update-edge through edge-between (§2.10 worked example)
+==================================================
+
+(rule solidarity/pairwise-decay
+  :material-basis "a named tie decays where its practice lapsed"
+  :fuel 128
+  (bindings
+    (binding other :field social-class/counterparty))
+  (effects
+    (update-edge (edge-between EdgeType/SOLIDARITY self other)
+                 solidarity/strength (scale 0.95c))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname))))
+    (effects
+      (update_edge
+        (edge_between
+          (enum_ref)
+          (symbol)
+          (symbol))
+        (qname)
+        (update_op
+          (literal
+            (scaled_lit)))))))
+
+==================================================
+Attributed membership: mint with payload, then write it (§2.8, Amendment AG (i))
+==================================================
+
+(rule community/formation
+  :material-basis "a community forms and its memberships carry their weight"
+  :fuel 2048
+  (bindings)
+  (effects
+    (add-hyperedge HyperedgeType/COMMUNITY h
+      (members (member NodeType/SOCIAL_CLASS c1 (community/strength 0.4c)
+                                                (community/visibility 0.5p))
+               (member NodeType/SOCIAL_CLASS c2 (community/strength 0.7c)
+                                                (community/visibility 0.2p))))
+    (for-each (members-of c HyperedgeType/COMMUNITY)
+      (update-membership c it community/visibility (scale 0.9c)))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings)
+    (effects
+      (add_hyperedge
+        (enum_ref)
+        (symbol)
+        (members
+          (member
+            (enum_ref)
+            (symbol)
+            (field_init
+              (qname)
+              (literal
+                (scaled_lit)))
+            (field_init
+              (qname)
+              (literal
+                (scaled_lit))))
+          (member
+            (enum_ref)
+            (symbol)
+            (field_init
+              (qname)
+              (literal
+                (scaled_lit)))
+            (field_init
+              (qname)
+              (literal
+                (scaled_lit))))))
+      (for_each
+        (members_of
+          (symbol)
+          (enum_ref))
+        (update_membership
+          (symbol)
+          (symbol)
+          (qname)
+          (update_op
+            (literal
+              (scaled_lit))))))))
+
+==================================================
+The remaining structural verbs, and the four update-ops (§2.8)
+==================================================
+
+(rule sovereignty/collapse
+  :material-basis "a sovereign that cannot reproduce its claims sheds them"
+  :fuel 4096
+  (bindings
+    (binding pressure :field sovereign/pressure))
+  (when (> pressure 0.9i))
+  (effects
+    (add-node NodeType/SOCIAL_CLASS n1 (social-class/wealth 5$))
+    (remove-node n1)
+    (add-edge EdgeType/SOLIDARITY a b :strength 0.5c (solidarity/tension 0.1i))
+    (remove-edge EdgeType/SOLIDARITY a b)
+    (update-hyperedge h community/size (add 1))
+    (update-node self sovereign/pressure (sub 0.1i))
+    (remove-hyperedge h)))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (literal
+          (scaled_lit))))
+    (effects
+      (add_node
+        (enum_ref)
+        (symbol)
+        (field_init
+          (qname)
+          (literal
+            (scaled_lit))))
+      (remove_node
+        (symbol))
+      (add_edge
+        (enum_ref)
+        (symbol)
+        (symbol)
+        (strength
+          (literal
+            (scaled_lit)))
+        (field_init
+          (qname)
+          (literal
+            (scaled_lit))))
+      (remove_edge
+        (enum_ref)
+        (symbol)
+        (symbol))
+      (update_hyperedge
+        (symbol)
+        (qname)
+        (update_op
+          (literal
+            (int_lit))))
+      (update_node
+        (symbol)
+        (qname)
+        (update_op
+          (literal
+            (scaled_lit))))
+      (remove_hyperedge
+        (symbol)))))

--- a/tools/tree-sitter-bsl/test/corpus/expressions.txt
+++ b/tools/tree-sitter-bsl/test/corpus/expressions.txt
@@ -1,0 +1,386 @@
+==================================================
+Computed bindings and the calendar bind-srcs (§2.5 worked example, D68)
+==================================================
+
+(rule vitality/drain
+  :material-basis "subsistence deficit at the point of reproduction"
+  :fuel 64
+  (bindings
+    (binding wealth      :field social-class/wealth)
+    (binding subsistence :const vitality/subsistence-cost)
+    (binding drained     :expr (- wealth subsistence))
+    (binding now         :tick)
+    (binding y           :year)
+    (binding toy         :tick-of-year)
+    (binding phase       :tick-in-cycle 52))
+  (when (> drained 0$))
+  (effects
+    (update-node self social-class/agitation (add 0.05i))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname)))
+      (binding
+        (symbol)
+        (bind_src
+          (qname)))
+      (binding
+        (symbol)
+        (bind_src
+          (arith_expr
+            (arith)
+            (symbol)
+            (symbol))))
+      (binding
+        (symbol)
+        (bind_src))
+      (binding
+        (symbol)
+        (bind_src))
+      (binding
+        (symbol)
+        (bind_src))
+      (binding
+        (symbol)
+        (bind_src
+          (int_lit))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (literal
+          (scaled_lit))))
+    (effects
+      (update_node
+        (symbol)
+        (qname)
+        (update_op
+          (literal
+            (scaled_lit)))))))
+
+==================================================
+Two-hop fold naming the outer element with :as (§2.6, §2.12 worked example)
+==================================================
+
+(rule community/exposure
+  :material-basis "community exposure is carried by attributed membership"
+  :fuel 4096
+  (bindings
+    (binding peak-exposure :expr
+      (fold max (hyperedges-of self HyperedgeType/COMMUNITY) :as c
+            (fold mean (members-of c HyperedgeType/COMMUNITY)
+                  (membership-field-of c it community/visibility)
+                  :weight (membership-field-of c it community/strength)))))
+  (when (> peak-exposure 0.5p))
+  (effects
+    (update-node self social-class/agitation (add 0.01i))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (fold
+            (fold_op)
+            (hyperedges_of
+              (symbol)
+              (enum_ref))
+            (elem_name
+              (symbol))
+            (fold
+              (fold_op)
+              (members_of
+                (symbol)
+                (enum_ref))
+              (membership_field_of
+                (symbol)
+                (symbol)
+                (qname))
+              (weight
+                (membership_field_of
+                  (symbol)
+                  (symbol)
+                  (qname))))))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (literal
+          (scaled_lit))))
+    (effects
+      (update_node
+        (symbol)
+        (qname)
+        (update_op
+          (literal
+            (scaled_lit)))))))
+
+==================================================
+Weighted mean over an edge query with field-of (§2.10 worked shape)
+==================================================
+
+(rule contradiction/tension
+  :material-basis "tension is carried by the exploitation relation"
+  :fuel 2048
+  (bindings
+    (binding tension :expr
+      (fold mean (edges EdgeType/EXPLOITATION)
+            (field-of it exploitation/tension)
+            :weight (field-of it exploitation/value-flow))))
+  (when (> tension 0.5i))
+  (effects
+    (update-node self social-class/agitation (add 0.02i))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (fold
+            (fold_op)
+            (edges
+              (enum_ref))
+            (field_of
+              (symbol)
+              (qname))
+            (weight
+              (field_of
+                (symbol)
+                (qname)))))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (literal
+          (scaled_lit))))
+    (effects
+      (update_node
+        (symbol)
+        (qname)
+        (update_op
+          (literal
+            (scaled_lit)))))))
+
+==================================================
+Typed neighbours and the self-anchored edge idiom (§2.6 D51, §3.8 item 8)
+==================================================
+
+(rule solidarity/inbound
+  :material-basis "inbound solidarity ties carry the tie weight"
+  :fuel 2048
+  (bindings
+    (binding inbound :expr
+      (fold sum (neighbors self EdgeType/SOLIDARITY :in NodeType/SOCIAL_CLASS)
+            (field-of (edge-between EdgeType/SOLIDARITY it self)
+                      solidarity/strength)))
+    (binding consciousness :expr
+      (fold mean (neighbors self EdgeType/TENANCY :in NodeType/SOCIAL_CLASS)
+            (field-of it social-class/consciousness)
+            :weight (field-of it social-class/population))))
+  (when (> inbound 0c))
+  (effects
+    (update-node self social-class/class-consciousness (add 0.01i))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (fold
+            (fold_op)
+            (neighbors
+              (symbol)
+              (enum_ref)
+              (direction)
+              (enum_ref))
+            (field_of
+              (edge_between
+                (enum_ref)
+                (symbol)
+                (symbol))
+              (qname)))))
+      (binding
+        (symbol)
+        (bind_src
+          (fold
+            (fold_op)
+            (neighbors
+              (symbol)
+              (enum_ref)
+              (direction)
+              (enum_ref))
+            (field_of
+              (symbol)
+              (qname))
+            (weight
+              (field_of
+                (symbol)
+                (qname)))))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (literal
+          (scaled_lit))))
+    (effects
+      (update_node
+        (symbol)
+        (qname)
+        (update_op
+          (literal
+            (scaled_lit)))))))
+
+==================================================
+Selection, the carrier accessor, and reference identity (§2.7, §2.10 worked examples)
+==================================================
+
+(rule electoral/office
+  :material-basis "the strongest claim takes the office it can hold"
+  :fuel 1024
+  (bindings
+    (binding drawn :field polity/draw))
+  (when (= (the NodeType/POLITY) (the NodeType/POLITY)))
+  (effects
+    (update-node (select-max (nodes NodeType/ORGANIZATION)
+                             (field-of it organization/claim-strength))
+                 organization/holds-office (set #t))
+    (update-node (the NodeType/POLITY)
+                 polity/imperial-rent-pool (sub drawn))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname))))
+    (when
+      (comparison
+        (cmp)
+        (the
+          (enum_ref))
+        (the
+          (enum_ref))))
+    (effects
+      (update_node
+        (selection
+          (nodes
+            (enum_ref))
+          (field_of
+            (symbol)
+            (qname)))
+        (qname)
+        (update_op
+          (literal
+            (bool_lit))))
+      (update_node
+        (the
+          (enum_ref))
+        (qname)
+        (update_op
+          (symbol))))))
+
+==================================================
+The intersection idiom — no set algebra (§2.7 D67)
+==================================================
+
+(rule community/shared
+  :material-basis "shared community membership is a material tie"
+  :fuel 4096
+  (bindings
+    (binding shared :expr
+      (fold count (hyperedges-of a HyperedgeType/COMMUNITY) :as ha
+            (if (exists (hyperedges-of b HyperedgeType/COMMUNITY) (= it ha))
+                1 0))))
+  (when (> shared 0))
+  (effects
+    (update-node self social-class/class-consciousness (add 0.01i))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (fold
+            (fold_op)
+            (hyperedges_of
+              (symbol)
+              (enum_ref))
+            (elem_name
+              (symbol))
+            (if_expr
+              (exists
+                (hyperedges_of
+                  (symbol)
+                  (enum_ref))
+                (comparison
+                  (cmp)
+                  (symbol)
+                  (symbol)))
+              (literal
+                (int_lit))
+              (literal
+                (int_lit)))))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (literal
+          (int_lit))))
+    (effects
+      (update_node
+        (symbol)
+        (qname)
+        (update_op
+          (literal
+            (scaled_lit)))))))

--- a/tools/tree-sitter-bsl/test/corpus/expressions.txt
+++ b/tools/tree-sitter-bsl/test/corpus/expressions.txt
@@ -384,3 +384,127 @@ The intersection idiom — no set algebra (§2.7 D67)
         (update_op
           (literal
             (scaled_lit)))))))
+
+==================================================
+An intrinsic call and an if-expression (§2.7, §3.10)
+==================================================
+
+(rule metabolism/decay
+  :material-basis "the metabolic rift compounds against a declared budget"
+  :fuel 256
+  (bindings
+    (binding stock :field territory/biomass)
+    (binding rate  :const metabolism/decay-rate)
+    (binding decayed :expr (* stock (exp (- 0c rate)))))
+  (when (> stock 0$))
+  (effects
+    (update-node self territory/biomass
+                 (set (if (> decayed 0$) decayed 0$)))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname)))
+      (binding
+        (symbol)
+        (bind_src
+          (qname)))
+      (binding
+        (symbol)
+        (bind_src
+          (arith_expr
+            (arith)
+            (symbol)
+            (intrinsic_call
+              (symbol)
+              (arith_expr
+                (arith)
+                (literal
+                  (scaled_lit))
+                (symbol)))))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (literal
+          (scaled_lit))))
+    (effects
+      (update_node
+        (symbol)
+        (qname)
+        (update_op
+          (if_expr
+            (comparison
+              (cmp)
+              (symbol)
+              (literal
+                (scaled_lit)))
+            (symbol)
+            (literal
+              (scaled_lit))))))))
+
+==================================================
+select-min over hyperedges, metric-of, and the remaining boolean forms (§2.4, §2.7, §2.11)
+==================================================
+
+(rule community/weakest
+  :material-basis "the least visible formation is the one repression reaches first"
+  :fuel 2048
+  (bindings
+    (binding centrality :expr (metric-of self betweenness-centrality)))
+  (when (or (not (> centrality 0.9c))
+            (exists (hyperedges HyperedgeType/COMMUNITY))))
+  (effects
+    (update-hyperedge (select-min (hyperedges HyperedgeType/COMMUNITY)
+                                  (field-of it community/size))
+                      community/size (add 1))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (metric_of
+            (symbol)
+            (symbol)))))
+    (when
+      (or_cond
+        (not_cond
+          (comparison
+            (cmp)
+            (symbol)
+            (literal
+              (scaled_lit))))
+        (exists
+          (hyperedges
+            (enum_ref)))))
+    (effects
+      (update_hyperedge
+        (selection
+          (hyperedges
+            (enum_ref))
+          (field_of
+            (symbol)
+            (qname)))
+        (qname)
+        (update_op
+          (literal
+            (int_lit)))))))

--- a/tools/tree-sitter-bsl/test/corpus/fallback.txt
+++ b/tools/tree-sitter-bsl/test/corpus/fallback.txt
@@ -1,0 +1,59 @@
+==================================================
+Scenario file — the unspecified .bscn dialect lands in generic_form
+==================================================
+
+; rust/crates/babylon-tick/content/scenarios/two-classes.bscn, trimmed.
+;
+; The scenario-file format has NO normative home: bsl-language.rst specifies
+; content forms (§2) and the vector fixture format (§6.1) and says nothing
+; about `(scenario …)`, `(node …)` or `(edge …)`. Note also that this
+; dialect's `deffield` is POSITIONAL — `(deffield <qname> <type> <kind>)` —
+; where §2.9's takes `:type` and `:kind` keywords. Both facts are recorded
+; rather than papered over: everything below parses as `generic_form`, the
+; tooling fallback, and none of it is derivable from bsl.ebnf.
+(scenario ft/two-classes
+  (deffield social-class/wages int extensive)
+  (node core NodeType/SOCIAL_CLASS
+    (social-class/wages 120)
+    (social-class/value-produced 80))
+  (edge EdgeType/SOLIDARITY core periphery 1))
+
+---
+
+(source_file
+  (comment)
+  (comment)
+  (comment)
+  (comment)
+  (comment)
+  (comment)
+  (comment)
+  (comment)
+  (comment)
+  (generic_form
+    (symbol)
+    (qname)
+    (generic_form
+      (symbol)
+      (qname)
+      (symbol)
+      (symbol))
+    (generic_form
+      (symbol)
+      (symbol)
+      (enum_ref)
+      (generic_form
+        (qname)
+        (literal
+          (int_lit)))
+      (generic_form
+        (qname)
+        (literal
+          (int_lit))))
+    (generic_form
+      (symbol)
+      (enum_ref)
+      (symbol)
+      (symbol)
+      (literal
+        (int_lit)))))

--- a/tools/tree-sitter-bsl/test/corpus/fallback.txt
+++ b/tools/tree-sitter-bsl/test/corpus/fallback.txt
@@ -1,8 +1,13 @@
 ==================================================
-Scenario file — the unspecified .bscn dialect lands in generic_form
+Scenario file — the unspecified .bscn dialect lands in generic_form (two-classes.bscn TRIMMED and AUGMENTED — see the case note)
 ==================================================
 
-; rust/crates/babylon-tick/content/scenarios/two-classes.bscn, trimmed.
+; rust/crates/babylon-tick/content/scenarios/two-classes.bscn — TRIMMED
+; (two of its three deffields and one of its two nodes are cut) and
+; AUGMENTED: the trailing (edge …) form is NOT in that file, it is taken
+; from scenario.rs's own module-doc example, because nothing in the tree
+; exercises the scenario dialect's edge form. This case is a GRAMMAR
+; witness, not a byte-regression against the file.
 ;
 ; The scenario-file format has NO normative home: bsl-language.rst specifies
 ; content forms (§2) and the vector fixture format (§6.1) and says nothing
@@ -10,7 +15,9 @@ Scenario file — the unspecified .bscn dialect lands in generic_form
 ; dialect's `deffield` is POSITIONAL — `(deffield <qname> <type> <kind>)` —
 ; where §2.9's takes `:type` and `:kind` keywords. Both facts are recorded
 ; rather than papered over: everything below parses as `generic_form`, the
-; tooling fallback, and none of it is derivable from bsl.ebnf.
+; tooling fallback, and none of it is derivable from bsl.ebnf. The
+; normative record of the shape conflict is register row D93; this case
+; is its witness, not its home.
 (scenario ft/two-classes
   (deffield social-class/wages int extensive)
   (node core NodeType/SOCIAL_CLASS
@@ -21,6 +28,13 @@ Scenario file — the unspecified .bscn dialect lands in generic_form
 ---
 
 (source_file
+  (comment)
+  (comment)
+  (comment)
+  (comment)
+  (comment)
+  (comment)
+  (comment)
   (comment)
   (comment)
   (comment)

--- a/tools/tree-sitter-bsl/test/corpus/lexical.txt
+++ b/tools/tree-sitter-bsl/test/corpus/lexical.txt
@@ -1,0 +1,183 @@
+==================================================
+Every atom class (§1.4, §1.5)
+==================================================
+
+; a comment is whitespace, and never reaches the canonical bytes (§5.4)
+(rule demo/atoms
+  :material-basis "every atom class of §1.4, in one derivation"
+  :fuel 1_000
+  (bindings
+    (binding wealth :field social-class/wealth)
+    (binding flag :field social-class/active :optional :default #f))
+  (when (and (< wealth 1000.5$)
+             (> wealth 0$)
+             (>= wealth 007)
+             (<= wealth -5)
+             (= flag #t)
+             (!= NodeType/SOCIAL_CLASS NodeType/POLITY)
+             (>= wealth 0.123456789p)
+             (>= wealth 0.50c)
+             (>= wealth 1.0i)))
+  (effects
+    (update-node self social-class/agitation (add 0.05i))))
+
+---
+
+(source_file
+  (comment)
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname)))
+      (binding
+        (symbol)
+        (bind_src
+          (qname))
+        (bind_opt)
+        (bind_opt
+          (literal
+            (bool_lit)))))
+    (when
+      (and_cond
+        (comparison
+          (cmp)
+          (symbol)
+          (literal
+            (scaled_lit)))
+        (comparison
+          (cmp)
+          (symbol)
+          (literal
+            (scaled_lit)))
+        (comparison
+          (cmp)
+          (symbol)
+          (literal
+            (int_lit)))
+        (comparison
+          (cmp)
+          (symbol)
+          (literal
+            (int_lit)))
+        (comparison
+          (cmp)
+          (symbol)
+          (literal
+            (bool_lit)))
+        (comparison
+          (cmp)
+          (enum_ref)
+          (enum_ref))
+        (comparison
+          (cmp)
+          (symbol)
+          (literal
+            (scaled_lit)))
+        (comparison
+          (cmp)
+          (symbol)
+          (literal
+            (scaled_lit)))
+        (comparison
+          (cmp)
+          (symbol)
+          (literal
+            (scaled_lit)))))
+    (effects
+      (update_node
+        (symbol)
+        (qname)
+        (update_op
+          (literal
+            (scaled_lit)))))))
+
+==================================================
+The §5.6 worked example, verbatim (bsl-language.rst §5.6)
+==================================================
+
+; a rule is data; this comment is not part of the hash
+(rule demo/hunger
+  :material-basis "subsistence deficit at the point of reproduction"
+  :fuel 64
+  (bindings
+    (binding wealth :field social-class/wealth))
+  (when (< wealth 1000.5$))
+  (effects
+    (update-node self social-class/agitation (add 0.05i))))
+
+---
+
+(source_file
+  (comment)
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (literal
+          (scaled_lit))))
+    (effects
+      (update_node
+        (symbol)
+        (qname)
+        (update_op
+          (literal
+            (scaled_lit)))))))
+
+==================================================
+Option order is a formatting concern (§5.3, D21)
+==================================================
+
+(rule demo/hunger
+  :fuel 64
+  :material-basis "subsistence deficit at the point of reproduction"
+  (bindings
+    (binding wealth :field social-class/wealth))
+  (when (< wealth 1000.5$))
+  (effects
+    (update-node self social-class/agitation (add 0.05i))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (fuel
+      (int_lit))
+    (material_basis
+      (string))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (literal
+          (scaled_lit))))
+    (effects
+      (update_node
+        (symbol)
+        (qname)
+        (update_op
+          (literal
+            (scaled_lit)))))))

--- a/tools/tree-sitter-bsl/test/corpus/lexical.txt
+++ b/tools/tree-sitter-bsl/test/corpus/lexical.txt
@@ -181,3 +181,28 @@ Option order is a formatting concern (§5.3, D21)
         (update_op
           (literal
             (scaled_lit)))))))
+
+==================================================
+String escapes — the only four (§1.5)
+==================================================
+
+(rule demo/escapes
+  :material-basis "a quote \" a backslash \\ a newline \n and a tab \t"
+  :fuel 8
+  (bindings)
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT)))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings)
+    (effects
+      (emit
+        (enum_ref)))))

--- a/tools/tree-sitter-bsl/test/corpus/rules.txt
+++ b/tools/tree-sitter-bsl/test/corpus/rules.txt
@@ -352,3 +352,89 @@ Edge query with count, and an empty bindings list (conformance/event_edge_count.
           (symbol)
           (literal
             (int_lit)))))))
+
+==================================================
+:optional / :default and :const bindings (conformance/doctrine_*.bsl)
+==================================================
+
+(rule doctrine/adventurism
+  :material-basis "isolation from the mass base severs the practice loop"
+  :fuel 16
+  (bindings
+    (binding mass-link :field organization/mass-link :optional :default 0))
+  (when (<= mass-link 0))
+  (effects
+    (emit EventType/DOCTRINE_TRAP (trap-id 1))))
+
+(rule doctrine/liquidation-absorbing
+  :material-basis "solidarity collapsed, co-optation dominant"
+  :fuel 32
+  (bindings
+    (binding solidarity-mass :field organization/solidarity-mass :optional :default 0)
+    (binding solidarity-liquidation-floor :const doctrine/solidarity-liquidation-floor))
+  (when (<= solidarity-mass solidarity-liquidation-floor))
+  (effects
+    (emit EventType/DOCTRINE_TRAP (trap-id 3))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname))
+        (bind_opt)
+        (bind_opt
+          (literal
+            (int_lit)))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (literal
+          (int_lit))))
+    (effects
+      (emit
+        (enum_ref)
+        (payload_item
+          (symbol)
+          (literal
+            (int_lit))))))
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname))
+        (bind_opt)
+        (bind_opt
+          (literal
+            (int_lit))))
+      (binding
+        (symbol)
+        (bind_src
+          (qname))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (symbol)))
+    (effects
+      (emit
+        (enum_ref)
+        (payload_item
+          (symbol)
+          (literal
+            (int_lit)))))))

--- a/tools/tree-sitter-bsl/test/corpus/rules.txt
+++ b/tools/tree-sitter-bsl/test/corpus/rules.txt
@@ -1,5 +1,5 @@
 ==================================================
-Fundamental theorem (rust/crates/babylon-tick/content/rules/fundamental-theorem.bsl)
+Fundamental theorem (content/rules/fundamental-theorem.bsl — ABRIDGED: :material-basis truncated, header comment cut)
 ==================================================
 
 ; W_c > V_c: while core wages exceed the value core labour produces, the
@@ -50,7 +50,7 @@ Fundamental theorem (rust/crates/babylon-tick/content/rules/fundamental-theorem.
             (symbol)))))))
 
 ==================================================
-Unconditional rule — an omitted <when> (conformance/unconditional.bsl)
+Unconditional rule — an omitted <when> (conformance/unconditional.bsl — VERBATIM)
 ==================================================
 
 (rule event/unconditional
@@ -79,7 +79,7 @@ Unconditional rule — an omitted <when> (conformance/unconditional.bsl)
             (int_lit)))))))
 
 ==================================================
-Guarded effects (conformance/event_bifurcation.bsl)
+Guarded effects (conformance/event_bifurcation.bsl — ABRIDGED: :material-basis truncated)
 ==================================================
 
 (rule event/bifurcation
@@ -146,7 +146,7 @@ Guarded effects (conformance/event_bifurcation.bsl)
               (scaled_lit))))))))
 
 ==================================================
-Folds, aggregation and a weighted mean (conformance/event_wealth_aggregates.bsl)
+Folds, aggregation and a weighted mean (conformance/event_wealth_aggregates.bsl — VERBATIM)
 ==================================================
 
 (rule event/wealth-aggregates
@@ -234,7 +234,7 @@ Folds, aggregation and a weighted mean (conformance/event_wealth_aggregates.bsl)
             (int_lit)))))))
 
 ==================================================
-exists / forall over a node query (conformance/event_node_condition.bsl, event_forall.bsl)
+exists / forall over a node query (conformance/event_node_condition.bsl + event_forall.bsl — ABRIDGED: both :material-basis strings truncated)
 ==================================================
 
 (rule event/agitation-anywhere
@@ -314,7 +314,7 @@ exists / forall over a node query (conformance/event_node_condition.bsl, event_f
             (scaled_lit)))))))
 
 ==================================================
-Edge query with count, and an empty bindings list (conformance/event_edge_count.bsl)
+Edge query with count, and an empty bindings list (conformance/event_edge_count.bsl — VERBATIM)
 ==================================================
 
 (rule event/solidarity-web
@@ -354,7 +354,7 @@ Edge query with count, and an empty bindings list (conformance/event_edge_count.
             (int_lit)))))))
 
 ==================================================
-:optional / :default and :const bindings (conformance/doctrine_*.bsl)
+:optional / :default and :const bindings (doctrine_adventurism.bsl VERBATIM + doctrine_liquidation_absorbing.bsl ABRIDGED to two of six bindings)
 ==================================================
 
 (rule doctrine/adventurism

--- a/tools/tree-sitter-bsl/test/corpus/rules.txt
+++ b/tools/tree-sitter-bsl/test/corpus/rules.txt
@@ -1,0 +1,354 @@
+==================================================
+Fundamental theorem (rust/crates/babylon-tick/content/rules/fundamental-theorem.bsl)
+==================================================
+
+; W_c > V_c: while core wages exceed the value core labour produces, the
+; difference is imperial rent.
+(rule economics/fundamental-theorem
+  :material-basis "core wages above the value core labour produces is imperial rent"
+  :fuel 64
+  (bindings
+    (binding wages :field social-class/wages)
+    (binding value-produced :field social-class/value-produced))
+  (when (> wages value-produced))
+  (effects
+    (update-node self social-class/imperial-rent (set (- wages value-produced)))))
+
+---
+
+(source_file
+  (comment)
+  (comment)
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname)))
+      (binding
+        (symbol)
+        (bind_src
+          (qname))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (symbol)))
+    (effects
+      (update_node
+        (symbol)
+        (qname)
+        (update_op
+          (arith_expr
+            (arith)
+            (symbol)
+            (symbol)))))))
+
+==================================================
+Unconditional rule — an omitted <when> (conformance/unconditional.bsl)
+==================================================
+
+(rule event/unconditional
+  :material-basis "a standing levy applies every tick by declared intent"
+  :fuel 16
+  (bindings)
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT (standing 1))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings)
+    (effects
+      (emit
+        (enum_ref)
+        (payload_item
+          (symbol)
+          (literal
+            (int_lit)))))))
+
+==================================================
+Guarded effects (conformance/event_bifurcation.bsl)
+==================================================
+
+(rule event/bifurcation
+  :material-basis "agitation routes by solidarity density"
+  :fuel 512
+  (bindings
+    (binding agitation :field social-class/agitation)
+    (binding solidarity-density :metric solidarity-density))
+  (when (>= agitation 0.5p))
+  (effects
+    (guard (< solidarity-density 0.1c)
+      (update-node self social-class/national-identity (add 0.15i)))
+    (guard (>= solidarity-density 0.1c)
+      (update-node self social-class/class-consciousness (add 0.15i)))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname)))
+      (binding
+        (symbol)
+        (bind_src
+          (symbol))))
+    (when
+      (comparison
+        (cmp)
+        (symbol)
+        (literal
+          (scaled_lit))))
+    (effects
+      (guard
+        (comparison
+          (cmp)
+          (symbol)
+          (literal
+            (scaled_lit)))
+        (update_node
+          (symbol)
+          (qname)
+          (update_op
+            (literal
+              (scaled_lit)))))
+      (guard
+        (comparison
+          (cmp)
+          (symbol)
+          (literal
+            (scaled_lit)))
+        (update_node
+          (symbol)
+          (qname)
+          (update_op
+            (literal
+              (scaled_lit))))))))
+
+==================================================
+Folds, aggregation and a weighted mean (conformance/event_wealth_aggregates.bsl)
+==================================================
+
+(rule event/wealth-aggregates
+  :material-basis "total and extremal wealth positions gate the conjuncture"
+  :fuel 1024
+  (bindings
+    (binding wealth :field social-class/wealth)
+    (binding agitation :field social-class/agitation)
+    (binding population :field social-class/population))
+  (when (and (>= (fold sum (nodes NodeType/SOCIAL_CLASS) wealth) 550)
+             (>= (fold max (nodes NodeType/SOCIAL_CLASS) wealth) 500)
+             (<= (fold min (nodes NodeType/SOCIAL_CLASS) wealth) 50)
+             (>= (fold mean (nodes NodeType/SOCIAL_CLASS) agitation :weight population) 0.3i)))
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT (gate 2))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname)))
+      (binding
+        (symbol)
+        (bind_src
+          (qname)))
+      (binding
+        (symbol)
+        (bind_src
+          (qname))))
+    (when
+      (and_cond
+        (comparison
+          (cmp)
+          (fold
+            (fold_op)
+            (nodes
+              (enum_ref))
+            (symbol))
+          (literal
+            (int_lit)))
+        (comparison
+          (cmp)
+          (fold
+            (fold_op)
+            (nodes
+              (enum_ref))
+            (symbol))
+          (literal
+            (int_lit)))
+        (comparison
+          (cmp)
+          (fold
+            (fold_op)
+            (nodes
+              (enum_ref))
+            (symbol))
+          (literal
+            (int_lit)))
+        (comparison
+          (cmp)
+          (fold
+            (fold_op)
+            (nodes
+              (enum_ref))
+            (symbol)
+            (weight
+              (symbol)))
+          (literal
+            (scaled_lit)))))
+    (effects
+      (emit
+        (enum_ref)
+        (payload_item
+          (symbol)
+          (literal
+            (int_lit)))))))
+
+==================================================
+exists / forall over a node query (conformance/event_node_condition.bsl, event_forall.bsl)
+==================================================
+
+(rule event/agitation-anywhere
+  :material-basis "any class fraction past the agitation threshold"
+  :fuel 512
+  (bindings
+    (binding agitation :field social-class/agitation))
+  (when (exists (nodes NodeType/SOCIAL_CLASS) (>= agitation 0.6p)))
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT (threshold 0.6p))))
+
+(rule event/agitation-everywhere
+  :material-basis "a threshold held by every fraction"
+  :fuel 512
+  (bindings
+    (binding agitation :field social-class/agitation))
+  (when (forall (nodes NodeType/SOCIAL_CLASS) (>= agitation 0.5p)))
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT (threshold 0.5p))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname))))
+    (when
+      (exists
+        (nodes
+          (enum_ref))
+        (comparison
+          (cmp)
+          (symbol)
+          (literal
+            (scaled_lit)))))
+    (effects
+      (emit
+        (enum_ref)
+        (payload_item
+          (symbol)
+          (literal
+            (scaled_lit))))))
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings
+      (binding
+        (symbol)
+        (bind_src
+          (qname))))
+    (when
+      (forall
+        (nodes
+          (enum_ref))
+        (comparison
+          (cmp)
+          (symbol)
+          (literal
+            (scaled_lit)))))
+    (effects
+      (emit
+        (enum_ref)
+        (payload_item
+          (symbol)
+          (literal
+            (scaled_lit)))))))
+
+==================================================
+Edge query with count, and an empty bindings list (conformance/event_edge_count.bsl)
+==================================================
+
+(rule event/solidarity-web
+  :material-basis "the solidarity web's existence conditions rupture routing"
+  :fuel 128
+  (bindings)
+  (when (>= (fold count (edges EdgeType/SOLIDARITY) it) 1))
+  (effects
+    (emit EventType/CONSCIOUSNESS_SHIFT (web 1))))
+
+---
+
+(source_file
+  (rule
+    (qname)
+    (material_basis
+      (string))
+    (fuel
+      (int_lit))
+    (bindings)
+    (when
+      (comparison
+        (cmp)
+        (fold
+          (fold_op)
+          (edges
+            (enum_ref))
+          (symbol))
+        (literal
+          (int_lit))))
+    (effects
+      (emit
+        (enum_ref)
+        (payload_item
+          (symbol)
+          (literal
+            (int_lit)))))))

--- a/tools/tree-sitter-bsl/tree-sitter.json
+++ b/tools/tree-sitter-bsl/tree-sitter.json
@@ -1,0 +1,22 @@
+{
+  "grammars": [
+    {
+      "name": "bsl",
+      "camelcase": "Bsl",
+      "scope": "source.bsl",
+      "path": ".",
+      "file-types": ["bsl", "bscn"],
+      "highlights": ["queries/highlights.scm"],
+      "injection-regex": "^bsl$"
+    }
+  ],
+  "metadata": {
+    "version": "0.1.0",
+    "license": "AGPL-3.0-or-later",
+    "description": "Tree-sitter grammar for BSL — DERIVED from docs/reference/bsl.ebnf, non-normative",
+    "authors": [{ "name": "Babylon contributors" }],
+    "links": {
+      "repository": "https://github.com/percy-raskova/babylon"
+    }
+  }
+}


### PR DESCRIPTION
## What this adds

The Director's directive: *"as a proper scripting language we should write out a formal
specification, Backus-Naur normal grammar form, treesitter grammar, all the things a proper
scripting language would need to be rigorous."*

Three artifacts, and one architectural rule they all obey — **`docs/reference/bsl-language.rst`
remains the ONE normative home.**

1. **`docs/reference/bsl.ebnf`** — every production of §§1, 2 and 6.1 collected into one file (71 productions) in
   one stated dialect, each carrying a comment citing its rst section. Included back into the
   document by `literalinclude`, so it is normative **by inclusion**, not as a second home.
2. **§7 "Consolidated grammar"** in the rst (after §6, before the register), with the precedence
   rule written into it — *the grammar collects, it does not amend; on any divergence the section
   text wins and the appendix is the defect* — plus **§7.1, the rigor index** (pointers only) and
   register row **D92**.
3. **`tools/tree-sitter-bsl/`** — a tree-sitter grammar **derived** from `bsl.ebnf`, with 30
   corpus cases from real in-tree content, highlight queries, a README stating derivation status,
   and the `mise run bsl:grammar-test` task. Non-normative, and says so in every file.

Plus a **sync guard**, `tests/unit/reference/test_bsl_grammar_sync.py`, so the collection cannot
silently fall behind the sections it collects.

## The EBNF dialect, and why

**W3C EBNF** (the XML 1.0 5th ed. §6 production notation), stated at the top of the file and used
uniformly.

§1.4 and §2.1 already write their productions with `::=`, `|`, `?`, `*`, `+`, grouping and quoted
terminals — that *is* W3C EBNF's operator set. Collecting them is therefore **transcription**.
ISO 14977 would have meant translating a normative text into comma-concatenation, `{ }`
repetition and `;` termination: transcription risk paid for nothing, against a document whose
whole standard (III.12(a)) is that two implementations be derivable from it.

Two notation-level deviations, both stated in the file, both spellings rather than changes:
nonterminals lose §2's angle brackets (W3C EBNF writes them bare), and §1.4's `"0" … "9"` ranges
become W3C character classes `[0-9]`.

Corroboration that the dialect label is not decorative: Pygments' `ebnf` lexer (ISO 14977) yields
3,257 error tokens over this file; its `bnf` lexer yields **0**, which is why the literalinclude
is tagged `:language: bnf`.

The file also carries what an EBNF *cannot* — maximal munch within a token run, the closed keyword
set, `operator` being head-position-only, the reserved names `self`/`it`, and the whole of §3's
static semantics — as context conditions in the header, so a derivation read from the file alone
is not misled by what a context-free grammar leaves out.

## Three hand-derivations

**1. `rust/crates/babylon-tick/content/rules/fundamental-theorem.bsl`** — the first rule the Rust
engine ever ran.

```
file → top-form                                              [file ::= top-form*]
     → rule
     → "(" "rule" qname ":material-basis" string ":fuel" int-lit
           bindings when effects ")"                          [domain? = ε, anchor? = ε]

  qname    ⇒ economics/fundamental-theorem        [symbol ("/" symbol)+ — 2 segments ≤ 4]
  string   ⇒ "core wages above the value …"       [string-char*; NFC; ≤ 1024 bytes]
  int-lit  ⇒ 64                                   [digits]
  bindings ⇒ "(" "bindings" binding binding ")"
     binding ⇒ "(" "binding" symbol bind-src ")"  [bind-opt* = ε]
        bind-src ⇒ ":field" qname                 ⇒ :field social-class/wages
  when     ⇒ "(" "when" cond ")"
     cond  ⇒ "(" cmp expr expr ")" ; cmp ⇒ ">" ; expr ⇒ symbol, expr ⇒ symbol
  effects  ⇒ "(" "effects" effect-item ")"        [effect-item+ , one item]
     effect-item ⇒ verb ⇒ "(" "update-node" expr qname update-op ")"
        expr      ⇒ symbol                        ⇒ self  (§2.5's reserved subject reference)
        qname     ⇒ social-class/imperial-rent
        update-op ⇒ "(" "set" expr ")"
           expr   ⇒ "(" arith expr expr ")" ; arith ⇒ "-" ; expr ⇒ symbol, symbol
```

The two leading `;` lines are whitespace (§1.2) and never enter a derivation — which is the same
fact §5.4 states as "comments never appear in CAS".

**2. `rust/crates/babylon-bsl/tests/conformance/event_wealth_aggregates.bsl`** — the fold-heavy
one, including the weighted intensive `mean` §3.4 exists to police.

```
when ⇒ "(" "when" cond ")"
cond ⇒ "(" "and" cond cond cond cond ")"                      [and is variadic, ≥ 1]

each cond ⇒ "(" cmp expr expr ")"
  #1  cmp ⇒ ">=" ; expr ⇒ fold ; expr ⇒ literal ⇒ int-lit ⇒ 550
      fold ⇒ "(" "fold" fold-op query expr ")"                [elem-name? = ε, :weight? = ε]
         fold-op ⇒ "sum"
         query   ⇒ "(" "nodes" enum-ref ")"                   [node-pred? = ε]
            enum-ref ⇒ enum-type "/" enum-member ⇒ NodeType/SOCIAL_CLASS
         expr    ⇒ symbol ⇒ wealth
  #2, #3 as #1 with fold-op ⇒ "max" / "min"
  #4  fold ⇒ "(" "fold" "mean" query expr ":weight" expr ")"
         expr(body)   ⇒ symbol ⇒ agitation
         expr(weight) ⇒ symbol ⇒ population
      compared against literal ⇒ scaled-lit ⇒ digits "." digits suffix ; suffix ⇒ "i"  (0.3i)

effects ⇒ "(" "effects" verb ")"
  verb ⇒ "(" "emit" enum-ref payload-item ")"                 [payload-item* , one item]
     payload-item ⇒ "(" symbol expr ")" ⇒ (gate 2)
```

**3. §2.12's two-hop worked shape** — the newest forms in the language (Amendment AG (i)), which
no in-tree file yet exercises, so the rst's own example is the only witness:

```
binding ⇒ "(" "binding" symbol bind-src ")" ; bind-src ⇒ ":expr" expr
expr ⇒ fold
  ⇒ "(" "fold" fold-op query elem-name expr ")"
     fold-op   ⇒ "max"
     query     ⇒ "(" "hyperedges-of" expr enum-ref ")"
                 expr ⇒ symbol ⇒ self ; enum-ref ⇒ HyperedgeType/COMMUNITY
     elem-name ⇒ ":as" symbol ⇒ :as c
     expr      ⇒ fold
       ⇒ "(" "fold" "mean" query expr ":weight" expr ")"
          query        ⇒ "(" "members-of" expr enum-ref ")"   ⇒ (members-of c HyperedgeType/COMMUNITY)
          expr(body)   ⇒ accessor
                       ⇒ "(" "membership-field-of" expr expr qname ")"
                       ⇒ (membership-field-of c it community/visibility)
          expr(weight) ⇒ the same accessor with community/strength
```

## Validation against reality

Every in-tree `.bsl` and `.bscn` file, parsed by the generated tree-sitter parser (exit code, not
eyeball):

| File(s) | Result |
| --- | --- |
| 11 of the 12 conformance vectors | parse clean |
| `content/rules/fundamental-theorem.bsl` | parses clean |
| `conformance/empty_when.bsl` | **does not parse — correct.** `(when)` is `E-PARSE-020`, a rejecting vector by design; the parser reports a missing `#t`, which is §2.3's own advice for spelling "always" |
| `content/scenarios/two-classes.bscn` | parses only through the tooling **fallback** — see findings |
| a synthetic every-form file (all §2 forms in one rule) | parses clean, **zero** fallback nodes |

**Transcription check, mechanical.** Every `::=` production in the rst was extracted (including
continuation lines) and its right-hand side compared against the appendix's, normalized only for
whitespace and §2's angle brackets. **Exactly two differences**, both of them the deviations the
file already documents: `string-char`, which §1.4 spells as the four *resulting* escape values and
the appendix spells as the source sequences that produce them (same set, one factored into an
`escape` production); and `expr`, where the difference is the rst's own inline `; §2.10` comment on
the accessor alternative. Every other production is identical.

Lexical cross-check against the Rust reader (`reader.rs`), not against my reading of §1: the
symbol/qname/enum-ref alphabets, the `;`-to-LF comment rule, the four whitespace characters, the
delimiter set (` `, `\t`, `\n`, `\r`, `(`, `)`, `;`, EOF), maximal munch, the ten operator tokens
as a distinct atom class, and the mandatory kind suffix all match the productions as collected.

## Sync-guard mutation evidence

`tests/unit/reference/test_bsl_grammar_sync.py`, 18 rows, three containments each in the safe
direction (rst productions ⊆ appendix; §5.2 form tags ⊆ appendix terminals; Rust
`RESERVED_FORM_TAGS` ⊆ appendix terminals, and ⊆ §5.2 — **Rust may lag the spec, never lead it**).

Four mutations, each fails its own row, all restored (`bsl.ebnf` byte-identical afterwards,
12/12 green):

| Mutation | Row that fired |
| --- | --- |
| deleted the `selection ::=` production from `bsl.ebnf` | `test_every_rst_production_appears_in_the_appendix` |
| renamed the `"for-each"` terminal | `test_every_rst_form_tag_is_a_terminal_in_the_appendix` |
| pointed the `literalinclude` at another file | `test_the_rst_literalincludes_the_appendix` |
| unflagged the recorded `<type-name>` gap | `test_the_gap_is_still_flagged` |
| deleted a corpus case the way `--update` did | `test_every_form_tag_appears_in_a_corpus_source` |
| emptied `Char`'s right-hand side | `test_every_production_has_a_non_empty_right_hand_side` |
| referenced an undefined nonterminal | `test_every_referenced_nonterminal_is_defined` |
| restored a live comment terminator to the dialect table | `test_stripping_leaves_no_comment_markers` |
| renamed a production in §7's disclosure list | `test_section_seven_discloses_every_prose_sourced_production` |

The guard deliberately does **not** demand the reverse containment (appendix ⊆ Rust): the
Amendment AG forms — `member`, `membership-field-of`, `update-membership`, `rung`, `adjunction` —
are specified and not yet implemented, and a guard failing on that would demand the spec wait for
the code. The guard reads 48 symbol-spellable heads from `RESERVED_FORM_TAGS` against 53 in §5.2; the
five-name difference is exactly that lag.

The §5 exclusion (`atom` / `form` / `opt` — the CAS byte layout, a schema over octets rather than
a production over the token stream) is an **allowlist with its own row**, so a new §5 production
cannot slip through the same hole.

### A defect found and fixed in flight

`tree-sitter test --update` folds a corpus case whose source lacks a trailing `---` into the
PREVIOUS case's expected tree and rewrites the file without it. Five cases — one per corpus file —
vanished that way when the expectations were first generated, and the suite went on reporting 100%:
**a suite cannot fail a case it no longer has.** All five are restored (plus one new case covering
`select-min` / `hyperedges` / `metric-of` / `not` / `or`, the heads nothing else reached), and the
error CLASS now has a gate: the guard measures corpus coverage against §5.2's tag list rather than
against whatever the corpus happens to contain, so a disappearing case is loud. Mutation-verified
by reproducing the exact drop.

## Tree-sitter: generation RAN, and is green

`tree-sitter` CLI **0.25.10** (`~/.cargo/bin/tree-sitter`), node **v26.5.1**. `tree-sitter
generate` + `tree-sitter test`: **30/30 corpus cases pass**, and every one of §5.2's 53
symbol-spellable form tags is exercised by a corpus source. `mise run bsl:grammar-test` runs both
and fails loudly with an install line if the CLI is absent.

Corpus sources are **real content**, never invented: the conformance vectors, the content rule,
the scenario file, and the rst's own worked examples (§2.5, §2.6, §2.8, §2.9, §2.10, §2.11,
§2.12, §3.9, §5.6 verbatim). Every expected tree was read before it was blessed (F1,
eyeball-before-golden).

The generated parser is **git-ignored** — it is a build product of `grammar.js`, and committing
generated C would make the grammar's real source ambiguous.

One engineering note worth surfacing: the grammar declines tree-sitter's `word` token
optimization. With it, a missing `symbol` operand is silently repaired into a zero-width node that
`tree-sitter parse` does not flag — `(remove-node)` parsed clean. A tool that quietly fixes its
input is the silent-degradation shape III.11 rejects, so the optimization is out and the error is
loud.

## Findings — where the rst is ambiguous or silent

Recorded honestly, **none of them silently resolved**. Each is flagged at its production in
`bsl.ebnf`, named in D92, and left to the Phase-1 review. Two may want D-rows of their own; that
is the Director's call, not mine.

1. **`<type-name>` has no atom class.** §2.9, §2.11 and §2.7 use `<type-name>` as a nonterminal
   and never assign it a §1.4 class, while §3.1's table spells the types capitalized (`Currency`,
   `Int`, …) — and a bare capitalized run matches **no** §1.4 atom class at all (an `enum-ref`
   needs its `/`; `symbol` is lowercase-only). The document's own spelling is unlexable as
   written. `bsl.ebnf` collects `type-name ::= symbol` — the only reading §1.4 admits, and the one
   the reference implementation took, which records the same gap at
   `declarations.rs::parse_type_name` and accepts `int` / `bool` / `currency` / `probability` /
   `intensity` / `coefficient`. **Candidate D-row.**
2. **§6.1's vector keywords are written optional-valued.** `<vector>` spells `":graph"
   <graph-lit>?`, `":fuel-used" <int-lit>?` and `":cas" <string>?` with the `?` binding to the
   *value*, which makes the keywords themselves mandatory — against §6.1's own prose, where
   `:fuel-used` is "mandatory on every non-error vector" (so absent on error vectors) and `:cas`
   is "optional" outright. Transcribed verbatim with the divergence named in place. D91 scoped
   the *flag-vs-valued* collision; this is the adjacent question D91 did not reach.
   **Candidate D-row.**
3. **The `.bscn` scenario format has no normative home.** The rst specifies content forms (§2) and
   the §6.1 vector fixtures and says nothing about `(scenario …)`, `(node …)` or `(edge …)` — yet
   `babylon-bsl/src/scenario.rs` reads exactly those, and `content/scenarios/two-classes.bscn`
   is in the tree. `bsl.ebnf` therefore does **not** cover it (collecting an unspecified dialect
   into a normative appendix would be minting language), and the tree-sitter grammar parses it
   through a `generic_form` fallback so the editor works without a second source of truth. Its
   `deffield` is moreover **positional** — `(deffield <qname> <type> <kind>)` — where §2.9's takes
   `:type` and `:kind` keywords: same name, different shape. Whether the scenario format owes a
   §6.5 (or its own document) is a Director call.
4. **`vector` forms are specified but unwitnessed.** No in-tree file spells one, so the
   tree-sitter grammar leaves them to the fallback rather than structuring a form with no corpus
   to hold it honest. `bsl.ebnf` §3 carries the productions regardless, since §6.1 does.

## Adversarial verification: six findings, all closed (`178af73f`)

An independent verification pass confirmed transcription fidelity (62/62 productions), completeness
(53/53 §5.2 tags, 48/48 Rust heads) and both hand-derivations, and returned six repairs. All six are
in:

| # | Finding | Repair |
| --- | --- | --- |
| 1 | `comment` dropped §1.2's "outside a string literal", and the token-run bullet applied to `string` made every non-trivial string literal unlexable from the appendix alone | Carve-out restored on `comment` and `delimiter`; a dedicated string-literal bullet added; the header caveat now runs **both** directions (accepts what the language rejects *and* rejects what it accepts) |
| 2 | `Char`'s entire RHS was a comment — not a production in the declared dialect; a literal reading collapsed `string-char` to escapes | `Char ::= [#x0-#xD7FF] \| [#xE000-#x10FFFF]`, transcribed from §1.1's "Unicode **scalar** values" (surrogates excluded) |
| 3 | The precedence trigger said "production", leaving the nine prose-sourced productions to adjudicate themselves; and "flags the gap instead of choosing" overstated what the file does | Trigger broadened to the section **text**; §7 lists all nine by name and D92 repeats the count; framing corrected in §7, the revision note and D92 to "collects the reference implementation's reading and flags it"; `type-name` now records **§2.11's `:type Coefficient`** as the section text cutting against its reading |
| 4 | The `.bscn` shape conflict had no normative home | **New register row D93** — scope ruling per D91's fixture/content split, the conflict named, both repairs (rename, or a scenario chapter) named and neither chosen |
| 5 | `_ebnf_code`'s strip broke on the dialect table's live comment sample (26 prose lines leaked into "code"); three `prose_only` annotations were factually wrong | Table spells the delimiters in words; new rows for **referenced-nonterminal closure**, **non-empty RHS** and **strip soundness**; `literal`/`payload-item`/`string-char` removed from the exemption set, which is now `PROSE_SOURCED` — a named contract §7 must disclose, with a row enforcing it |
| 6 | Corpus claimed "real content" while five cases abridge a `:material-basis`, one trims six bindings to two, and the scenario case is also *augmented* | Every case title now carries `VERBATIM` / `ABRIDGED` / `TRIMMED and AUGMENTED`, audited case by case; README says "sourced from" and states the corpus is a grammar witness, never a byte-regression |

One correction to the verification's own framing, recorded because it matters for what the guard
buys: the referenced-nonterminal row would **not** have caught finding 2 on its own — an
empty-RHS `Char` still defines the name, so references resolve. The **non-empty-RHS** row is the
one that catches it, and both are in. Running the new scanner also exposed a defect in itself:
stripping double-quoted terminals before single-quoted ones mis-pairs on the `'"'` terminals in
`string`/`string-char`, which made `escape`'s `"n"` and `"t"` read as undefined nonterminals.

## Gates

- `rstcheck` + `doc8` — green (via pre-commit, on both edited rst and the new files).
- `mise run test:q -- tests/unit/reference` — 255 passed, 41 skipped (18/18 sync-guard rows).
- `mise run bsl:grammar-test` — 30/30 green.
- `mise run rust:check` — **not run: no Rust file is touched by this PR.**
- Full Sphinx build (`sphinx-build -b html`, sphinx 9.1.0, local): `reference/bsl-language` both
  **read and written with no warning** — the `literalinclude` resolves and the `:language: bnf`
  lexer runs clean. The tag was chosen against Pygments rather than guessed: its `ebnf` lexer
  (ISO 14977) yields 3,257 error tokens over this file, its `bnf` lexer yields 0.
- Copilot review harvested (ADR181): three inline comments, **all three real**, all three fixed in
  `e9e4771b` with a reply on each — a case-blind production scan that silently excused §1.4's
  `DIGIT`/`LOWER`/`UPPER`, and two documentation claims about `generic_form` head behaviour that
  the behaviour did not have.

## Follow-ups (deliberately not in this PR)

- **CI wiring** for `bsl:grammar-test` and the sync guard — a separate reviewable change.
- **Editor packaging**: no npm publish, no nvim-treesitter registration, no VS Code extension.
  `tree-sitter.json` carries the scope and file types a host needs.
- **Structured `vector` support** in the tree-sitter grammar once a vector file exists in-tree.
- The two candidate D-rows above, if the Director wants the gaps ruled rather than recorded.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
