### PR TITLE
feat(bsl): Lifecycle as the second Material Base rule pack (P28 R9)

### DIFF
--- a/rust/crates/babylon-tick/content/rules/lifecycle.bsl
+++ b/rust/crates/babylon-tick/content/rules/lifecycle.bsl
@@ -1,0 +1,366 @@
+; LifecycleSystem (Material Base @7.0) — the D-P-D' circuit.
+;
+; Every county cycles population through three phases every tick: D
+; (pre-productive, raised out of household/community labor), P (productive,
+; sells labor-power), D' (post-productive, lives on the legitimation
+; bargain — pensions, Social Security, home equity, the promise that a
+; lifetime of production earns a floor under old age). The circuit computes
+; population flow between the phases, the index that measures how credibly
+; the D' promise is underwritten, and the ideology a new P-phase cohort
+; inherits from its caregivers and its institutions.
+;
+; THIS PACK PORTS THREE OF THE FROZEN SYSTEM'S FIVE FLAT RULES (the R8 gap
+; analysis's own count, reports/bsl-gap-analysis-2026-08-10.md row 7.0):
+; DPD population flow, the legitimation index (+ crisis/recovery detection),
+; and ideology transmission. Two do NOT land — inheritance flow and class
+; mobility — for ONE shared reason, recorded precisely in WHAT DOES NOT LAND
+; below. Both blocked rules are confirmed dead ends on the canonical graph
+; today (grep-verified against dev tip 6c33b42c): `adjusted_p_to_d_prime`
+; and `differential_p_to_d_prime` are read by no other system, and inheritance
+; flow's only consumer is chronicle narration off an event, never simulation
+; state (`LifecycleSystem.step()` calls no `graph.update_node` for the
+; inheritance amounts at all — it is event-emission only). The three ported
+; rules carry the system's load-bearing output: `legitimation_index` feeds
+; `domain/bifurcation/analysis.py`, `engine/systems/struggle.py` and
+; `engine/systems/electoral.py` directly.
+;
+; ============================================================================
+; WHAT DOES NOT LAND, AND EXACTLY WHY
+; ============================================================================
+;
+; `pareto_alpha` (inheritance Gini), `early_mortality_modifier` and
+; `carceral_transition_modifier` (class mobility) are runtime-moddable
+; LifecycleDefines coefficients whose declared domain is `(0, 10]` /
+; `[0, 10]` — `src/babylon/data/defines.yaml:528,533,534`, each comment
+; self-documenting the overflow ("Fed SCF... (> 0.0, <= 10.0)", "Chetty...
+; (>= 0.0, <= 10.0)" twice). `bsl-language.rst` §1.5 caps every non-Currency
+; scaled literal at `[0.0, 1.0]` (the `p`/`i`/`c` suffixes) and §3.1 declares
+; "no coercions" — there is no legal `defconst` for a value like `1.5`,
+; `2.8` or `1.24` that is not itself a dollar amount (`$`, which is also
+; wrong: `Currency`'s own operator table, §3.2, admits no `Currency ×
+; Currency`, so two such moddables could not even combine). This is the
+; SAME construct gap the Territory BSL assessment (2026-08-11) named
+; Blocker-1 and put behind director-gate #492: a runtime-moddable define
+; with domain beyond `[0,1]` has no BSL representation today, full stop —
+; not "multiplies Currency" specifically, "cannot be written at all"
+; generally. Rounding `pareto_alpha` to the nearest int-storable value would
+; not dodge the gap; it would silently change `compute_pareto_gini`'s
+; output by construction (`1/(2·1.5−1) = 0.5` vs `1/(2·1−1) = 1.0`), which
+; the port-as-is directive and the no-silent-degradation standard both
+; forbid. Per §6 of `docs/superpowers/plans/2026-08-10-vitality-bsl-rule-
+; pack.md`, this port transcribes no formula and invents no substitute —
+; it waits on #492's resolution, same as Territory.
+;
+; What that blocks precisely:
+;   - `DefaultInheritanceCalculator.compute_inheritance_flow` (`domain/
+;     economics/lifecycle/inheritance.py:108-140`) — `compute_pareto_gini`
+;     needs `pareto_alpha`. Blocks the `INHERITANCE_TRANSFER` event only;
+;     the frozen system writes no graph state from this branch at all.
+;   - `DefaultClassMobilityCalculator.compute_premature_exit_rate` and
+;     `DefaultCohortDynamicsCalculator.apply_differential_rates` (system
+;     Steps 6-7) — both read `early_mortality_modifier`/
+;     `carceral_transition_modifier` off `ClassMobilityParams`. Blocks
+;     `adjusted_p_to_d_prime` and `differential_p_to_d_prime`, confirmed
+;     dead-end fields (see header).
+;
+; ============================================================================
+; MODELING CHOICE — D-1: the five constant-in-practice inputs become `:const`
+; ============================================================================
+;
+; `LegitimationState`'s five components (`pension_coverage`,
+; `ss_replacement_rate`, `healthcare_security`, `home_ownership_rate`,
+; `retirement_confidence`) and `DPDState`'s four rate fields (`rate_d_to_p`,
+; `rate_p_to_d_prime`, `rate_d_prime_to_death`, `birth_rate`) are read
+; per-node-with-defines-fallback in the frozen Python
+; (`LifecycleSystem._read_legitimation_state`, `LifecycleSystem.step` lines
+; 85-102). But nothing else in the tree ever writes divergent per-territory
+; values for any of these nine fields (grep-verified: `legitimation_state`,
+; `caregiver_ideology`, `institutional_hegemony`, `community_tendency` and
+; `mobility_params` are written ONLY by `LifecycleSystem` itself, and
+; `compute_transitions`/`apply_differential_rates` always echo the DPDState
+; rate fields back unchanged) — so on tick 1 EVERY territory falls into the
+; "initialize from defines" branch, and every tick after that reads back the
+; SAME defines-derived value it started with. The per-node storage never
+; observably diverges from "read the global constant" in the shipped
+; engine. This pack transcribes the OBSERVABLE behavior — one value, shared
+; by every territory — as `:const` bindings, which is also the only legal
+; move: `bsl-language.rst`'s known constraint that "the slice-1 scenario
+; loader seeds ONLY int-declared node attributes" (`scenario.rs::
+; attribute_value`) refuses a fractional per-node seed outright, and these
+; nine values are fractional by nature. If per-county legitimation or rate
+; data is ever wired for real (it is not today — a genuine gap, independent
+; of this port), that is new content work, not a retrofit of this rule.
+; Mirrors D-2's dead-branch reasoning in the Vitality plan.
+;
+; `caregiver_ideology` and `institutional_hegemony` are a sharper case of
+; the same thing: they are not even `LifecycleDefines` fields. Python reads
+; them with a bare inline default of `0.5` (`engine/systems/lifecycle.py:
+; 191-192`) that no `defines.yaml` entry backs, and — per the same grep —
+; nothing ever writes them either, so they are permanently `0.5` in the
+; shipped engine. Recorded as **D-2**: a modding-contract gap in the frozen
+; engine (the same class as Vitality's D-3), transcribed as `:const`
+; bindings this pack names `lifecycle/caregiver-ideology-default` and
+; `lifecycle/institutional-hegemony-default` rather than reading a
+; `defines.yaml` line that does not exist. `community_tendency` is always
+; absent in production (nothing writes it, confirmed by the same grep), so
+; its amplification term (`cohort_dynamics.py:214-215`) is a dead branch
+; and this pack drops it — recorded as **D-3**, mirroring the Vitality
+; plan's D-2.
+;
+; ============================================================================
+; §5.4 DEFECT REPAIR — D-5: the crisis/recovery edge check is case-broken
+; ============================================================================
+;
+; `engine/systems/lifecycle.py:146,157` compares `prev_crisis` — read off
+; the graph, holding whatever a PRIOR tick wrote via `crisis_class.value`
+; — against the LITERAL string `"CRISIS"`. But
+; `LegitimationClassification` is a `StrEnum` whose values are lowercase
+; (`models/enums/legal.py:24-26`: `CRISIS = "crisis"`), so `prev_crisis`
+; is always `"crisis"`, `"unstable"`, `"stable"` or `None` — **never**
+; `"CRISIS"`. Concretely: `prev_crisis != "CRISIS"` is true on every tick
+; regardless of the actual previous state, so `LEGITIMATION_CRISIS` fires
+; EVERY tick a territory classifies CRISIS rather than only on the
+; transition into it; and `prev_crisis == "CRISIS"` is false on every
+; tick, so `LEGITIMATION_RECOVERY` is permanently dead code. No test in
+; the frozen estate exercises either branch
+; (`rg LEGITIMATION_CRISIS|LEGITIMATION_RECOVERY tests/integration/
+; test_lifecycle_system.py` — no hits), which is how this went unnoticed.
+;
+; This pack's crisis classification has no string-case axis to inherit the
+; bug through — `LegitimationClassification` has no BSL representation
+; (see Block 2 below), so it is encoded as an `int` this pack controls
+; both ends of. Writing the SAME case-mismatch bug back in would mean
+; deliberately comparing the int encoding against the wrong constant on
+; purpose, which is unauditable nonsense, not a transcription. **Repair:**
+; this pack implements genuinely edge-triggered semantics — `!= 2` vs `= 2`
+; where both sides share one encoding — which is what the frozen code's
+; own structure and comment ("Emit crisis/recovery events") plainly
+; intend. This is a real, deliberate behavioral difference from the
+; frozen engine for the TWO EVENT TYPES ONLY; every state field this pack
+; writes (`legitimation-index`, `legitimation-crisis` itself, and
+; everything Blocks 1/3 touch) is unaffected and matches the frozen engine
+; exactly. The conformance test asserts the correct edge-triggered firing
+; pattern rather than replaying the frozen engine's buggy event log for
+; these two event types — see `lifecycle_conformance.rs`'s header for the
+; exact vectors on both sides.
+;
+; ============================================================================
+; MODELING CHOICE — D-4: three saturating clamps are provably redundant
+; ============================================================================
+;
+; Three places the frozen Python defensively clamps a value this pack
+; leaves unclamped, because the clamp cannot fire given the declared
+; domains of its own inputs (all rates/fractions here are `[0,1]`-bounded
+; `c`-literals, checked at LOAD by `bsl-language.rst` §1.5's `E-LEX-024`,
+; and every population/wealth field is non-negative by construction):
+;
+;   1. `compute_population_flow`'s three `max(0.0, …)` calls
+;      (`formulas/lifecycle.py:57-59`). `d_to_p = rate_d_to_p × pop_d` with
+;      `rate_d_to_p ∈ [0,1]` gives `d_to_p ≤ pop_d`, so
+;      `(pop_d + births) − d_to_p ≥ births ≥ 0` always — same argument for
+;      the other two. §3.10's rider slate declines a scalar min/max
+;      operator precisely so a saturation stays legible in the source
+;      (the reason Vitality's plan gives for spelling its own clamp as an
+;      `if`); here there is nothing to spell, because the saturation never
+;      triggers.
+;   2. `wealth_d_prime`'s `surviving_fraction = max(0.0, 1.0 − deaths /
+;      old_total)` (`cohort_dynamics.py:151`) — `deaths ≤ old_total` by the
+;      same rate-bound argument, so the fraction is always in `[0,1]`.
+;   3. `compute_legitimation_index`'s `max(0.0, min(1.0, index))`
+;      (`formulas/lifecycle.py:140`) — the five `legit_w_*` weights sum to
+;      exactly `1.0` at their current `defines.yaml` values (`0.35 + 0.30 +
+;      0.20 + 0.10 + 0.05`), and each component is a `[0,1]`-bounded `c`
+;      literal, so the weighted sum is a convex combination and cannot
+;      leave `[0,1]`.
+;
+; Recorded honestly: this is a fact about the CURRENT `defines.yaml`
+; values, not a law the type system enforces. A mod that changes the
+; `legit_w_*` weights to no longer sum to `1.0`, or a modder editing the
+; rate defines to something the `c`-literal load-time check would still
+; accept, could in principle break case 3 (case 1/2 hold for ANY `[0,1]`
+; rate, so they are safe under any legal mod). Python's `max`/`min` would
+; silently absorb that; this pack's `int`-declared output fields carry no
+; automatic range check at all (§3.3's store-boundary check is specific to
+; `Probability`/`Coefficient`/`Intensity`-declared fields, and every
+; per-node field in this pack is `int` per the seeding constraint above),
+; so an out-of-range legitimation index would silently store instead of
+; failing loudly. This is a modding-contract gap inherited from the
+; int-workaround every slice-1 rule pack needs, not introduced by this
+; port — recorded so a later reader does not have to re-derive it.
+;
+; ideology transmission's own clamp (`cohort_dynamics.py:217`,
+; `max(0.0, min(1.0, raw))`) is redundant by the identical convex-
+; combination argument: `caregiver_weight + institutional_weight = 1.0`
+; (`0.7 + 0.3`) blends two `[0,1]` inputs, and the regression step
+; `raw·(1−r) + 0.5·r` blends `raw` (now proven `[0,1]`) with the constant
+; `0.5` by weights that also sum to `1.0`.
+;
+; verify_conservation (system Step 2) only calls `logger.warning` — no
+; graph write, no event. BSL's eight structural verbs (§2.8) include no
+; logging verb, so this step has no BSL transcription and is dropped
+; without a behavioral difference (nothing it does is observable).
+;
+; ============================================================================
+; ENGINE MACHINERY — the anchor's registered-system set, and one rule not three
+; ============================================================================
+;
+; `babylon-tick/src/lib.rs`'s `run_once_into` hardcodes the driver's
+; registered-system set at `{economics, vitality, consciousness}` (Vitality
+; landed the second of those). This port adds `lifecycle`, the same class
+; of minimal, precedented change Vitality made to `tick.rs` for `:const`
+; serving — driver scaffolding, not rule content, not BSL grammar.
+;
+; **One rule, not three — a slice-1 driver limit, not a modeling choice.**
+; `run_once`/`run_once_into`'s `split_content` accepts exactly one `(rule …)`
+; top-form per content set ("a content set needs exactly one (rule …)
+; top-form", `rule_pipeline.rs`); Vitality never tested the other case
+; because its own three phases already collapsed into one rule for an
+; independent reason (§4.2's same-pre-state rule). This pack's three
+; material processes ARE independent — none reads another's binding or
+; effect — so nothing here is a re-derivation the way Vitality's phases
+; were; they are grouped into one `(rule lifecycle/dpd-circuit …)` form
+; purely because slice 1 has no multi-rule pack runner yet. Each of the
+; three material processes below is commented as its own block and could
+; split back into separate rules the moment the driver supports more than
+; one per tick.
+
+(rule lifecycle/dpd-circuit
+  :material-basis "a county's population moves through three material phases every tick — pre-productive (raised out of household labor), productive (sells labor-power), post-productive (lives on the legitimation bargain) — at rates set by birth and mortality data and by the age structure of production; a cohort that dies takes a proportional share of whatever wealth its members held with it; the D' bargain's credibility and the ideology a new productive cohort inherits are computed alongside it every tick"
+  :fuel 3072
+  (bindings
+    ; --- Block 1: DPD population flow (formulas/lifecycle.py:16-61,
+    ; domain/economics/lifecycle/cohort_dynamics.py:129-163) ---
+    (binding pop-d :field territory/pop-d)
+    (binding pop-p :field territory/pop-p)
+    (binding pop-d-prime :field territory/pop-d-prime)
+    (binding wealth-d-prime :field territory/wealth-d-prime)
+    (binding birth-rate :const lifecycle/birth-rate)
+    (binding rate-d-to-p :const lifecycle/rate-d-to-p)
+    (binding rate-p-to-d-prime :const lifecycle/rate-p-to-d-prime)
+    (binding rate-d-prime-to-death :const lifecycle/rate-d-prime-to-death)
+    ; compute_population_flow, the frozen engine's exact association order
+    ; (`formulas/lifecycle.py:52-59`): births/transitions first, then each
+    ; new population as (old + inflow) - outflow, left to right.
+    (binding births :expr (* birth-rate pop-p))
+    (binding d-to-p :expr (* rate-d-to-p pop-d))
+    (binding p-to-d-prime :expr (* rate-p-to-d-prime pop-p))
+    (binding deaths :expr (* rate-d-prime-to-death pop-d-prime))
+    (binding new-pop-d :expr (- (+ pop-d births) d-to-p))
+    (binding new-pop-p :expr (- (+ pop-p d-to-p) p-to-d-prime))
+    (binding new-pop-d-prime :expr (- (+ pop-d-prime p-to-d-prime) deaths))
+    ; `cohort_dynamics.py:150-152`: the surviving fraction only applies when
+    ; there was a D' cohort to begin with AND deaths actually occurred;
+    ; otherwise wealth is unchanged. The `(- 1 0)` else-branch is not a
+    ; stray computation — an `if`'s two branches must share one static type
+    ; (E-TYPE-020), and a bare `wealth-d-prime` reference (kind `int`,
+    ; unpromoted) would not match the Real-typed `if`-branch below it. `(-
+    ; 1 0)` is itself a binary64 arithmetic form, so it types Real like its
+    ; sibling, and multiplying by exactly 1.0 is lossless in binary64 — an
+    ; identity, not an approximation.
+    (binding surviving-fraction :expr
+      (if (and (> pop-d-prime 0) (> deaths 0))
+          (- 1 (/ deaths pop-d-prime))
+          (- 1 0)))
+    (binding new-wealth-d-prime :expr (* wealth-d-prime surviving-fraction))
+    ; `DPDState.dependency_ratio`, computed off the NEW (post-transition)
+    ; populations, matching `new_state.dependency_ratio` in
+    ; `engine/systems/lifecycle.py:124`. Undefined at `new-pop-p == 0`
+    ; (`E-EVAL-012`, division by zero in the binary64 lane) — the frozen
+    ; Python special-cases that as `math.inf`, which `Real`'s "binary64,
+    ; finite" domain (§3.1) cannot represent at all. This pack's
+    ; conformance fixtures keep every subject's post-tick `pop-p` strictly
+    ; positive, so the case is out of scope rather than silently mishandled
+    ; — the same "the fixture stays inside the envelope this pack claims"
+    ; discipline Vitality's own conformance fixture uses.
+    (binding dependency-ratio :expr
+      (/ (+ new-pop-d new-pop-d-prime) new-pop-p))
+
+    ; --- Block 2: legitimation index + crisis/recovery detection
+    ; (formulas/lifecycle.py:89-140,
+    ; domain/economics/lifecycle/legitimation.py:99-128) ---
+    (binding home-ownership-rate :const lifecycle/home-ownership-rate)
+    (binding healthcare-security :const lifecycle/healthcare-security)
+    (binding retirement-confidence :const lifecycle/retirement-confidence)
+    (binding pension-coverage-rate :const lifecycle/pension-coverage-rate)
+    (binding ss-replacement-rate :const lifecycle/ss-replacement-rate)
+    (binding w-home :const lifecycle/legit-w-home-ownership)
+    (binding w-health :const lifecycle/legit-w-healthcare-security)
+    (binding w-retire :const lifecycle/legit-w-retirement-confidence)
+    (binding w-pension :const lifecycle/legit-w-pension-coverage)
+    (binding w-ss :const lifecycle/legit-w-ss-replacement)
+    (binding crisis-threshold :const lifecycle/legitimation-crisis-threshold)
+    (binding unstable-threshold :const lifecycle/legitimation-unstable-threshold)
+    ; The PRE-tick classification, read before this rule overwrites it —
+    ; needed to detect a crisis/recovery EDGE, not just a level.
+    (binding prev-crisis :field territory/legitimation-crisis)
+    ; `compute_legitimation_index`'s exact left-to-right association
+    ; (`formulas/lifecycle.py:133-139`).
+    (binding legit-index :expr
+      (+ (+ (+ (+ (* w-home home-ownership-rate)
+                  (* w-health healthcare-security))
+               (* w-retire retirement-confidence))
+            (* w-pension pension-coverage-rate))
+         (* w-ss ss-replacement-rate)))
+    ; `LegitimationClassification` has no BSL representation (§3.1's six
+    ; `deffield`-able types exclude every `Enum<T>`; a custom content enum
+    ; cannot be a field's static type). Encoded as this pack's own
+    ; convention: 0 = STABLE, 1 = UNSTABLE, 2 = CRISIS — matching
+    ; `classify_crisis`'s exact threshold ladder
+    ; (`legitimation.py:118-128`): index < crisis_threshold -> CRISIS,
+    ; elif index < unstable_threshold -> UNSTABLE, else STABLE. Both `if`
+    ; branches at every level are bare Int literals (no arithmetic
+    ; operator touches them), so they share one static type without
+    ; needing the Real-promotion trick the population rule above needs.
+    (binding new-crisis-class :expr
+      (if (< legit-index crisis-threshold)
+          2
+          (if (< legit-index unstable-threshold) 1 0)))
+
+    ; --- Block 3: ideology transmission (formulas/lifecycle.py:168-196,
+    ; domain/economics/lifecycle/cohort_dynamics.py:193-217) ---
+    ; D-2: hardcoded Python literals with no `defines.yaml` backing
+    ; (`engine/systems/lifecycle.py:191-192`) — see the pack header.
+    (binding caregiver-ideology :const lifecycle/caregiver-ideology-default)
+    (binding institutional-hegemony :const lifecycle/institutional-hegemony-default)
+    (binding caregiver-weight :const lifecycle/ideology-caregiver-weight)
+    (binding institutional-weight :const lifecycle/ideology-institutional-weight)
+    (binding regression-coefficient :const lifecycle/ideology-regression-coefficient)
+    ; `formulas/lifecycle.py:196` then `cohort_dynamics.py:209-211`. D-3:
+    ; the community-tendency amplification term
+    ; (`cohort_dynamics.py:214-215`) is dropped — always dead in production,
+    ; see the pack header.
+    (binding raw :expr
+      (+ (* caregiver-weight caregiver-ideology)
+         (* institutional-weight institutional-hegemony)))
+    (binding transmitted :expr
+      (+ (* raw (- 1 regression-coefficient))
+         (* 0.5c regression-coefficient))))
+  (effects
+    ; Block 1 writes + event.
+    (update-node self territory/pop-d (set new-pop-d))
+    (update-node self territory/pop-p (set new-pop-p))
+    (update-node self territory/pop-d-prime (set new-pop-d-prime))
+    (update-node self territory/wealth-d-prime (set new-wealth-d-prime))
+    (update-node self territory/dependency-ratio (set dependency-ratio))
+    (emit EventType/LIFECYCLE_TRANSITION
+      (territory-id self)
+      (pop-d new-pop-d)
+      (pop-p new-pop-p)
+      (pop-d-prime new-pop-d-prime)
+      (dependency-ratio dependency-ratio))
+    ; Block 2 writes + crisis/recovery events. `engine/systems/lifecycle.py:
+    ; 144-167`: two mutually exclusive edges (a territory cannot enter
+    ; CRISIS and STABLE in the same tick), so two independent guards
+    ; reproduce the frozen `if`/`elif` exactly.
+    (update-node self territory/legitimation-index (set legit-index))
+    (update-node self territory/legitimation-crisis (set new-crisis-class))
+    (guard (and (= new-crisis-class 2) (!= prev-crisis 2))
+      (emit EventType/LEGITIMATION_CRISIS
+        (territory-id self)
+        (legitimation-index legit-index)))
+    (guard (and (= new-crisis-class 0) (= prev-crisis 2))
+      (emit EventType/LEGITIMATION_RECOVERY
+        (territory-id self)
+        (legitimation-index legit-index)))
+    ; Block 3 write.
+    (update-node self territory/transmitted-ideology (set transmitted))))

--- a/rust/crates/babylon-tick/content/rules/lifecycle.bsl
+++ b/rust/crates/babylon-tick/content/rules/lifecycle.bsl
@@ -271,17 +271,31 @@
     (binding new-pop-d-prime :expr (- (+ pop-d-prime p-to-d-prime) deaths))
     ; `cohort_dynamics.py:150-152`: the surviving fraction only applies when
     ; there was a D' cohort to begin with AND deaths actually occurred;
-    ; otherwise wealth is unchanged. The `(- 1 0)` else-branch is not a
-    ; stray computation — an `if`'s two branches must share one static type
+    ; otherwise wealth is unchanged. The else-branch is not a stray
+    ; computation — an `if`'s two branches must share one static type
     ; (E-TYPE-020), and a bare `wealth-d-prime` reference (kind `int`,
-    ; unpromoted) would not match the Real-typed `if`-branch below it. `(-
-    ; 1 0)` is itself a binary64 arithmetic form, so it types Real like its
-    ; sibling, and multiplying by exactly 1.0 is lossless in binary64 — an
-    ; identity, not an approximation.
+    ; unpromoted) would not match the Real-typed `if`-branch below it.
+    ; PREVIOUSLY spelled `(- 1 0)`: WRONG, caught by Copilot review on
+    ; PR #493 — `Int - Int` does NOT promote to `Real`. §3.3's promotion
+    ; only fires when an `Int` operand appears ALONGSIDE a genuine
+    ; binary64-float type (`Probability`/`Intensity`/`Coefficient`/`Real`)
+    ; in one arithmetic form; `1` and `0` alone are both plain `Int`
+    ; literals, so `(- 1 0)` stays `Int`, mismatching the `Real`
+    ; then-branch under E-TYPE-020 (`score_class.rs`'s coarse `Scalar`
+    ; class does not distinguish `Int` from `Real` and so did not catch
+    ; this; the normative rule at `bsl-language.rst:1070` does). Copilot's
+    ; own suggested `1c` is equally wrong in the other direction: a BARE
+    ; `Coefficient` literal, not mixed with anything, stays typed
+    ; `Coefficient` — a third static type, matching neither branch. `(- 1
+    ; 0c)` mixes a genuine `Coefficient` operand into the subtraction,
+    ; which promotes the WHOLE form — including the `Int` `1` — to `Real`,
+    ; matching the then-branch exactly. `0c` is canonical zero (§1.5), so
+    ; the value is unchanged: `1.0 - 0.0 = 1.0` exactly, still an identity
+    ; multiply below, not an approximation.
     (binding surviving-fraction :expr
       (if (and (> pop-d-prime 0) (> deaths 0))
           (- 1 (/ deaths pop-d-prime))
-          (- 1 0)))
+          (- 1 0c)))
     (binding new-wealth-d-prime :expr (* wealth-d-prime surviving-fraction))
     ; `DPDState.dependency_ratio`, computed off the NEW (post-transition)
     ; populations, matching `new_state.dependency_ratio` in

--- a/rust/crates/babylon-tick/content/rules/lifecycle.bsl
+++ b/rust/crates/babylon-tick/content/rules/lifecycle.bsl
@@ -201,6 +201,27 @@
 ; without a behavioral difference (nothing it does is observable).
 ;
 ; ============================================================================
+; TRANSCRIPTION DEVIATION — D-6: the regression-step guard is elided
+; ============================================================================
+;
+; `cohort_dynamics.py:209-211` guards the regression-toward-mean step with
+; `if r > 0.0: raw = raw * (1.0 - r) + 0.5 * r`, skipping the update
+; entirely at `r == 0.0`. Block 3's `transmitted` binding applies the
+; formula unconditionally. This is not case 4 of D-4's redundant-clamp
+; argument (there is no saturation here to prove away) — it is a genuine
+; transcription deviation, recorded because §5.4 asks for one whenever the
+; BSL differs in STRUCTURE from the frozen code, even when the two are
+; behaviorally identical everywhere the guarded value can occur. And they
+; are identical everywhere on `r`'s declared domain (`ideology_regression_
+; coefficient`, `[0,1]`, `defines.yaml:542`), including the boundary the
+; guard exists for: at `r = 0.0`, `raw * (1.0 - 0.0) + 0.5 * 0.0 = raw`,
+; the exact value the skipped branch would have left in place — a
+; multiply-by-zero-and-add-zero is an identity in IEEE-754, not an
+; approximation. The guard only has observable effect for `r < 0.0`, which
+; `ideology-regression-coefficient`'s declared `c`-literal range (`[0,1]`,
+; §1.5) cannot express in the first place.
+;
+; ============================================================================
 ; ENGINE MACHINERY — the anchor's registered-system set, and one rule not three
 ; ============================================================================
 ;

--- a/rust/crates/babylon-tick/content/scenarios/lifecycle-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/lifecycle-conformance.bscn
@@ -24,10 +24,16 @@
 ; (matching what the frozen engine's own per-territory-with-defines-
 ; fallback pattern always resolves to in production, grep-verified), EVERY
 ; territory computes the SAME classification every tick: STABLE. The
-; frozen Python is in exactly the same position under its own shipped
-; defines — LEGITIMATION_CRISIS is not reachable today, ported or not.
-; recovering-county exercises the guard's mechanics from the other
-; direction instead, which is the reachable half of the same code path.
+; frozen Python is in exactly the same position under its own SHIPPED
+; defines.yaml values — LEGITIMATION_CRISIS is not reachable under those
+; particular numbers. That is a fact about one tuning, not about the
+; mechanism: the classification ladder and its CRISIS branch ARE
+; exercised, and the D-5 guard's positive half proven, under a
+; deliberately different (still in-domain) `:const` environment —
+; content/scenarios/lifecycle-crisis-conformance.bscn and
+; tests/lifecycle_crisis_conformance.rs. recovering-county here exercises
+; the guard's RECOVERY half from the other direction, which is the
+; reachable half of the same code path under THIS scenario's tuning.
 (scenario lifecycle/conformance
   (deffield territory/pop-d int extensive)
   (deffield territory/pop-p int extensive)

--- a/rust/crates/babylon-tick/content/scenarios/lifecycle-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/lifecycle-conformance.bscn
@@ -1,0 +1,118 @@
+; The conformance world for the lifecycle/* rule pack (dpd-population-flow,
+; legitimation-index, ideology-transmission).
+;
+; Four counties, each a case the pack has to tell apart:
+;   - core-county:      the DPDState docstring's own example numbers
+;                        (types.py:48-53) — the "nothing unusual" case,
+;                        PRE-crisis STABLE, stays STABLE (no event).
+;   - growing-county:    a younger population mix, PRE-crisis UNSTABLE —
+;                         proves "was troubled, still not CRISIS" emits
+;                         neither LEGITIMATION_CRISIS nor _RECOVERY.
+;   - recovering-county: PRE-crisis CRISIS, so the tick's classification
+;                        (always STABLE under the current defconsts — see
+;                        the .bsl header's D-1) fires LEGITIMATION_RECOVERY.
+;   - young-county:      pop-d-prime AND wealth-d-prime both zero — no D'
+;                        cohort exists yet, so `deaths == 0` and the
+;                        surviving-fraction guard's ELSE branch is what
+;                        this subject is for.
+;
+; LEGITIMATION_CRISIS itself has no fixture here: with the current
+; defines.yaml legitimation weights (0.35/0.30/0.20/0.10/0.05) and
+; component values (0.656/0.60/0.50/0.73/0.426), the weighted index is
+; 0.6039 — comfortably above legitimation_unstable_threshold (0.5) — and
+; since the .bsl header's D-1 makes those five components GLOBAL consts
+; (matching what the frozen engine's own per-territory-with-defines-
+; fallback pattern always resolves to in production, grep-verified), EVERY
+; territory computes the SAME classification every tick: STABLE. The
+; frozen Python is in exactly the same position under its own shipped
+; defines — LEGITIMATION_CRISIS is not reachable today, ported or not.
+; recovering-county exercises the guard's mechanics from the other
+; direction instead, which is the reachable half of the same code path.
+(scenario lifecycle/conformance
+  (deffield territory/pop-d int extensive)
+  (deffield territory/pop-p int extensive)
+  (deffield territory/pop-d-prime int extensive)
+  (deffield territory/wealth-d-prime int extensive)
+  ; Per-county ratios/indices: an unweighted mean across counties is the
+  ; variance error §3.4 exists to reject, so these are intensive.
+  (deffield territory/dependency-ratio int intensive)
+  (deffield territory/legitimation-index int intensive)
+  ; 0 = STABLE, 1 = UNSTABLE, 2 = CRISIS — this pack's own encoding; see
+  ; the .bsl header (LegitimationClassification has no BSL representation).
+  (deffield territory/legitimation-crisis int intensive)
+  (deffield territory/transmitted-ideology int intensive)
+
+  ; The defines environment. Values transcribed from the canonical single
+  ; source of truth, src/babylon/data/defines.yaml:507-543 (`lifecycle:`).
+  ; `lifecycle/caregiver-ideology-default` and
+  ; `lifecycle/institutional-hegemony-default` are NOT in that file — see
+  ; the .bsl header's D-2 (a modding-contract gap in the frozen engine).
+  (defconst lifecycle/birth-rate 0.0107c)                         ; :508
+  (defconst lifecycle/rate-d-to-p 0.0556c)                        ; :509
+  (defconst lifecycle/rate-p-to-d-prime 0.0213c)                  ; :510
+  (defconst lifecycle/rate-d-prime-to-death 0.039c)               ; :511
+  (defconst lifecycle/pension-coverage-rate 0.73c)                ; :515
+  (defconst lifecycle/home-ownership-rate 0.656c)                 ; :516
+  (defconst lifecycle/ss-replacement-rate 0.426c)                 ; :517
+  (defconst lifecycle/healthcare-security 0.6c)                   ; :518
+  (defconst lifecycle/retirement-confidence 0.5c)                 ; :519
+  (defconst lifecycle/legit-w-home-ownership 0.35c)               ; :520
+  (defconst lifecycle/legit-w-healthcare-security 0.3c)           ; :521
+  (defconst lifecycle/legit-w-retirement-confidence 0.2c)         ; :522
+  (defconst lifecycle/legit-w-pension-coverage 0.1c)              ; :523
+  (defconst lifecycle/legit-w-ss-replacement 0.05c)               ; :524
+  (defconst lifecycle/legitimation-crisis-threshold 0.3c)         ; :526
+  (defconst lifecycle/legitimation-unstable-threshold 0.5c)       ; :527
+  (defconst lifecycle/ideology-caregiver-weight 0.7c)             ; :540
+  (defconst lifecycle/ideology-institutional-weight 0.3c)         ; :541
+  (defconst lifecycle/ideology-regression-coefficient 0.4c)       ; :542
+  (defconst lifecycle/caregiver-ideology-default 0.5c)            ; D-2, not in defines.yaml
+  (defconst lifecycle/institutional-hegemony-default 0.5c)        ; D-2, not in defines.yaml
+
+  ; DPDState docstring's own numbers (domain/economics/lifecycle/types.py:
+  ; 48-53), total population 10,000. PRE-crisis STABLE.
+  (node core-county NodeType/TERRITORY
+    (territory/pop-d 2150)
+    (territory/pop-p 6050)
+    (territory/pop-d-prime 1800)
+    (territory/wealth-d-prime 10000000)
+    (territory/dependency-ratio 0)
+    (territory/legitimation-index 0)
+    (territory/legitimation-crisis 0)
+    (territory/transmitted-ideology 0))
+
+  ; A younger mix, more D-phase relative to P. PRE-crisis UNSTABLE.
+  (node growing-county NodeType/TERRITORY
+    (territory/pop-d 3000)
+    (territory/pop-p 5000)
+    (territory/pop-d-prime 1500)
+    (territory/wealth-d-prime 5000000)
+    (territory/dependency-ratio 0)
+    (territory/legitimation-index 0)
+    (territory/legitimation-crisis 1)
+    (territory/transmitted-ideology 0))
+
+  ; An older, wealthier D' cohort. PRE-crisis CRISIS — this tick's
+  ; classification (STABLE, see header) must fire LEGITIMATION_RECOVERY.
+  (node recovering-county NodeType/TERRITORY
+    (territory/pop-d 2000)
+    (territory/pop-p 7000)
+    (territory/pop-d-prime 2000)
+    (territory/wealth-d-prime 20000000)
+    (territory/dependency-ratio 0)
+    (territory/legitimation-index 0)
+    (territory/legitimation-crisis 2)
+    (territory/transmitted-ideology 0))
+
+  ; No D' cohort at all: pop-d-prime and wealth-d-prime both zero, so
+  ; deaths == 0 and the surviving-fraction guard takes its ELSE branch
+  ; (wealth stays exactly 0, unchanged rather than "decayed from zero").
+  (node young-county NodeType/TERRITORY
+    (territory/pop-d 4000)
+    (territory/pop-p 5500)
+    (territory/pop-d-prime 0)
+    (territory/wealth-d-prime 0)
+    (territory/dependency-ratio 0)
+    (territory/legitimation-index 0)
+    (territory/legitimation-crisis 0)
+    (territory/transmitted-ideology 0)))

--- a/rust/crates/babylon-tick/content/scenarios/lifecycle-crisis-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/lifecycle-crisis-conformance.bscn
@@ -1,0 +1,113 @@
+; The DISCRIMINATING conformance world for `lifecycle/dpd-circuit` — a
+; second, deliberately-different-from-shipped-defaults `:const` environment
+; that exercises the two regions `lifecycle-conformance.bscn` cannot reach.
+;
+; Verifier finding (adversarial review of PR #493): under the SHIPPED
+; defines.yaml values, all four subjects in `lifecycle-conformance.bscn`
+; compute the identical legitimation index (0.6039), the identical STABLE
+; classification, and — since `caregiver-ideology-default` and
+; `institutional-hegemony-default` are both `0.5c` — the identical
+; `transmitted_ideology` (0.5) regardless of `caregiver-weight`/
+; `institutional-weight`. Two mutations that should be caught by the
+; conformance suite were NOT: swapping the two ideology weights, and
+; collapsing the whole crisis-classification ladder to a constant. Both are
+; real coverage gaps, not artifacts of a wrong test — D-1 (the `.bsl`
+; header) correctly models these nine values as global `:const` because the
+; SHIPPED engine never diverges them per territory, but "never diverges
+; under shipped defaults" is not "cannot be tested": every one of these
+; values is a genuinely runtime-moddable `defines.yaml` coefficient, and
+; the classification ladder and the ideology weights are both real,
+; player-reachable mechanics under a different tuning.
+;
+; This scenario is that different tuning, not a hypothetical: it feeds the
+; SAME rule pack a `:const` environment in which
+;   (a) the legitimation index falls to 0.1 (all five components lowered to
+;       0.1, weights unchanged and still summing to 1.0) — below
+;       legitimation-crisis-threshold (0.3c) — so CRISIS entry and the
+;       repaired D-5 guard's positive half (LEGITIMATION_CRISIS firing on
+;       the STABLE/UNSTABLE -> CRISIS edge, and NOT re-firing on an
+;       already-CRISIS subject) both actually execute; and
+;   (b) `caregiver-ideology-default`/`institutional-hegemony-default` are
+;       `0.3c`/`0.8c` — the frozen `compute_ideology_transmission` doctest's
+;       own worked example (`formulas/lifecycle.py:189-194`) — so
+;       `caregiver-weight`/`institutional-weight` are no longer
+;       interchangeable inputs.
+;
+; Two subjects: one crossing INTO crisis this tick (proves the guard fires
+; on the edge), one already CRISIS and staying CRISIS (proves the guard
+; does NOT re-fire — edge-triggered, not level-triggered, which is the
+; whole point of D-5's repair). Population/wealth seeds are reused verbatim
+; from `lifecycle-conformance.bscn`'s core-county/growing-county so the DPD
+; block's post-tick numbers are already-verified values, not new arithmetic
+; to re-derive.
+(scenario lifecycle/crisis-conformance
+  (deffield territory/pop-d int extensive)
+  (deffield territory/pop-p int extensive)
+  (deffield territory/pop-d-prime int extensive)
+  (deffield territory/wealth-d-prime int extensive)
+  (deffield territory/dependency-ratio int intensive)
+  (deffield territory/legitimation-index int intensive)
+  (deffield territory/legitimation-crisis int intensive)
+  (deffield territory/transmitted-ideology int intensive)
+
+  ; Rates: unchanged from defines.yaml (same as lifecycle-conformance.bscn).
+  (defconst lifecycle/birth-rate 0.0107c)
+  (defconst lifecycle/rate-d-to-p 0.0556c)
+  (defconst lifecycle/rate-p-to-d-prime 0.0213c)
+  (defconst lifecycle/rate-d-prime-to-death 0.039c)
+  ; Legitimation weights: unchanged (sum to 1.0, per D-4's own argument).
+  (defconst lifecycle/legit-w-home-ownership 0.35c)
+  (defconst lifecycle/legit-w-healthcare-security 0.3c)
+  (defconst lifecycle/legit-w-retirement-confidence 0.2c)
+  (defconst lifecycle/legit-w-pension-coverage 0.1c)
+  (defconst lifecycle/legit-w-ss-replacement 0.05c)
+  ; Legitimation COMPONENTS: lowered uniformly to 0.1c (NOT the defines.yaml
+  ; values) so the weighted index is 0.1*(0.35+0.3+0.2+0.1+0.05) = 0.1 —
+  ; below the crisis threshold below. A deliberately different, but still
+  ; in-domain [0,1], modded tuning; see the header.
+  (defconst lifecycle/pension-coverage-rate 0.1c)
+  (defconst lifecycle/home-ownership-rate 0.1c)
+  (defconst lifecycle/ss-replacement-rate 0.1c)
+  (defconst lifecycle/healthcare-security 0.1c)
+  (defconst lifecycle/retirement-confidence 0.1c)
+  ; Thresholds: unchanged.
+  (defconst lifecycle/legitimation-crisis-threshold 0.3c)
+  (defconst lifecycle/legitimation-unstable-threshold 0.5c)
+  ; Ideology weights: unchanged.
+  (defconst lifecycle/ideology-caregiver-weight 0.7c)
+  (defconst lifecycle/ideology-institutional-weight 0.3c)
+  (defconst lifecycle/ideology-regression-coefficient 0.4c)
+  ; The frozen doctest's own worked example
+  ; (formulas/lifecycle.py:189-194): 0.3 / 0.8, NOT 0.5 / 0.5, so the two
+  ; weights above are discriminated inputs rather than interchangeable
+  ; ones.
+  (defconst lifecycle/caregiver-ideology-default 0.3c)
+  (defconst lifecycle/institutional-hegemony-default 0.8c)
+
+  ; Same pop-d/pop-p/pop-d-prime/wealth-d-prime seed as core-county
+  ; (lifecycle-conformance.bscn) — post-tick DPD numbers are therefore
+  ; already-verified values. PRE-crisis STABLE; this tick's index (0.1)
+  ; is CRISIS, so this subject crosses the edge.
+  (node entering-crisis NodeType/TERRITORY
+    (territory/pop-d 2150)
+    (territory/pop-p 6050)
+    (territory/pop-d-prime 1800)
+    (territory/wealth-d-prime 10000000)
+    (territory/dependency-ratio 0)
+    (territory/legitimation-index 0)
+    (territory/legitimation-crisis 0)
+    (territory/transmitted-ideology 0))
+
+  ; Same seed as growing-county. PRE-crisis CRISIS already; this tick's
+  ; index (0.1) is ALSO CRISIS, so this subject must NOT re-fire
+  ; LEGITIMATION_CRISIS (D-5's edge-triggered repair, proven from the
+  ; other direction).
+  (node already-crisis NodeType/TERRITORY
+    (territory/pop-d 3000)
+    (territory/pop-p 5000)
+    (territory/pop-d-prime 1500)
+    (territory/wealth-d-prime 5000000)
+    (territory/dependency-ratio 0)
+    (territory/legitimation-index 0)
+    (territory/legitimation-crisis 2)
+    (territory/transmitted-ideology 0)))

--- a/rust/crates/babylon-tick/content/scenarios/lifecycle_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/lifecycle_conformance.py
@@ -1,0 +1,201 @@
+"""Conformance vectors for the ``lifecycle/*`` rule pack, from the frozen engine.
+
+This script is the PROVENANCE of every number pinned in
+``rust/crates/babylon-tick/tests/lifecycle_conformance.rs``. It builds the
+four territories of ``lifecycle-conformance.bscn`` node for node, runs the
+frozen ``LifecycleSystem`` once against them, and prints the post-tick state
+plus every event the tick emitted.
+
+Run it from the repository root, single process::
+
+    PYTHONPATH="$PWD/src" uv run python \\
+        rust/crates/babylon-tick/content/scenarios/lifecycle_conformance.py
+
+The frozen system is the contract source for STRUCTURE and ORDERING, not a
+correctness oracle (ADR183). This pack ports three of the frozen system's
+five flat rules (DPD population flow, legitimation index + crisis/recovery,
+ideology transmission) — see the ``.bsl`` header for exactly why inheritance
+flow and class mobility do not land (director-gate #492, the domain-beyond-
+[0,1] construct gap). Unlike Vitality, the un-ported computations here are
+STRUCTURALLY isolated, not just fixture-conditionally inert: inheritance
+flow writes no graph state at all (event-emission only), and class
+mobility's outputs (``adjusted_p_to_d_prime``, ``differential_p_to_d_prime``)
+are never read back into ``compute_transitions`` on a later tick (which
+reads ``dpd_state.rate_p_to_d_prime``, not the differential field) — so no
+fixture envelope is required to keep them from perturbing the ported
+fields.
+
+D-5 (see ``.bsl`` header): the frozen engine's crisis/recovery edge check
+compares a lowercase ``StrEnum.value`` against the literal ``"CRISIS"``,
+which never matches — LEGITIMATION_CRISIS re-fires every tick a territory
+is classified CRISIS (not edge-triggered) and LEGITIMATION_RECOVERY is dead
+code. This script prints the frozen engine's ACTUAL (buggy) event output
+for the record; the Rust conformance test asserts the pack's DELIBERATELY
+DIFFERENT, edge-triggered behavior for those two event types only, per the
+documented §5.4 repair. Every state field below matches the frozen engine
+exactly regardless.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from babylon.engine.context import TickContext
+from babylon.engine.services import ServiceContainer
+from babylon.engine.systems.lifecycle import LifecycleSystem
+from babylon.models.enums import NodeType
+from babylon.topology.graph import BabylonGraph
+
+#: The four territories, in the declaration order of
+#: lifecycle-conformance.bscn. ``dpd_state`` is supplied explicitly (rather
+#: than left absent for lazy defines-derived initialization) so this script
+#: can set exactly the pop_d/pop_p/pop_d_prime/wealth_d_prime/rate seeds the
+#: .bscn declares, matching them value for value instead of going through
+#: the initial_pop_*_frac branch. The four rate fields inside dpd_state are
+#: the same values this pack's :const bindings carry
+#: (src/babylon/data/defines.yaml:508-511). ``legitimation_state``,
+#: ``caregiver_ideology``, ``institutional_hegemony`` and
+#: ``community_tendency`` are left ABSENT so the frozen system falls into
+#: its defines-derived defaults — matching this pack's D-1 modeling choice
+#: (those five/two values never diverge from the defines defaults in the
+#: live engine either, per the .bsl header's grep-verified claim).
+RATES: dict[str, float] = {
+    "rate_d_to_p": 0.0556,
+    "rate_p_to_d_prime": 0.0213,
+    "rate_d_prime_to_death": 0.039,
+    "birth_rate": 0.0107,
+}
+
+SUBJECTS: list[tuple[str, dict[str, Any]]] = [
+    (
+        "core-county",
+        {
+            "dpd_state": {
+                "pop_d": 2150.0,
+                "pop_p": 6050.0,
+                "pop_d_prime": 1800.0,
+                "wealth_d_prime": 10_000_000.0,
+                **RATES,
+            },
+            "legitimation_crisis": "stable",
+        },
+    ),
+    (
+        "growing-county",
+        {
+            "dpd_state": {
+                "pop_d": 3000.0,
+                "pop_p": 5000.0,
+                "pop_d_prime": 1500.0,
+                "wealth_d_prime": 5_000_000.0,
+                **RATES,
+            },
+            "legitimation_crisis": "unstable",
+        },
+    ),
+    (
+        "recovering-county",
+        {
+            "dpd_state": {
+                "pop_d": 2000.0,
+                "pop_p": 7000.0,
+                "pop_d_prime": 2000.0,
+                "wealth_d_prime": 20_000_000.0,
+                **RATES,
+            },
+            "legitimation_crisis": "crisis",
+        },
+    ),
+    (
+        "young-county",
+        {
+            "dpd_state": {
+                "pop_d": 4000.0,
+                "pop_p": 5500.0,
+                "pop_d_prime": 0.0,
+                "wealth_d_prime": 0.0,
+                **RATES,
+            },
+            "legitimation_crisis": "stable",
+        },
+    ),
+]
+
+#: This pack's own crisis-classification encoding (see the .bsl header):
+#: 0 = STABLE, 1 = UNSTABLE, 2 = CRISIS.
+CRISIS_CODE = {"stable": 0, "unstable": 1, "crisis": 2}
+
+
+def build_graph() -> BabylonGraph:
+    """Build the four-territory world, in scenario declaration order."""
+    graph = BabylonGraph()
+    for node_id, attrs in SUBJECTS:
+        graph.add_node(node_id, NodeType.TERRITORY, **attrs)
+    return graph
+
+
+def main() -> None:
+    """Run one tick of the frozen LifecycleSystem and print the vectors."""
+    services = ServiceContainer.create()
+    try:
+        d = services.defines.lifecycle
+        print("defines (src/babylon/data/defines.yaml, lifecycle: section):")
+        for name in (
+            "birth_rate",
+            "rate_d_to_p",
+            "rate_p_to_d_prime",
+            "rate_d_prime_to_death",
+            "pension_coverage_rate",
+            "home_ownership_rate",
+            "ss_replacement_rate",
+            "healthcare_security",
+            "retirement_confidence",
+            "legit_w_home_ownership",
+            "legit_w_healthcare_security",
+            "legit_w_retirement_confidence",
+            "legit_w_pension_coverage",
+            "legit_w_ss_replacement",
+            "legitimation_crisis_threshold",
+            "legitimation_unstable_threshold",
+            "ideology_caregiver_weight",
+            "ideology_institutional_weight",
+            "ideology_regression_coefficient",
+        ):
+            print(f"  lifecycle.{name} = {getattr(d, name)!r}")
+        print()
+
+        graph = build_graph()
+        LifecycleSystem().step(graph, services, TickContext(tick=1))
+        events = services.event_bus.get_history()
+
+        print("post-tick state:")
+        for node_id, _ in SUBJECTS:
+            node = graph.get_node(node_id)
+            if node is None:
+                raise SystemExit(f"node {node_id} vanished during the tick")
+            a = node.attributes
+            dpd = a["dpd_state"]
+            crisis_str = a["legitimation_crisis"]
+            print(
+                f"  {node_id:<18} "
+                f"pop_d={dpd['pop_d']!r} pop_p={dpd['pop_p']!r} "
+                f"pop_d_prime={dpd['pop_d_prime']!r} "
+                f"wealth_d_prime={dpd['wealth_d_prime']!r} "
+                f"dependency_ratio={a['dependency_ratio']!r} "
+                f"legitimation_index={a['legitimation_index']!r} "
+                f"legitimation_crisis={crisis_str!r} (code={CRISIS_CODE[crisis_str]}) "
+                f"transmitted_ideology={a['transmitted_ideology']!r}"
+            )
+        print()
+
+        print("events (frozen engine's ACTUAL output, D-5 bug included):")
+        for event in events:
+            print(f"  {event.type} {event.payload!r}")
+        if not events:
+            print("  (none)")
+    finally:
+        services.database.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/crates/babylon-tick/content/scenarios/lifecycle_crisis_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/lifecycle_crisis_conformance.py
@@ -1,0 +1,178 @@
+"""Conformance vectors for the DISCRIMINATING `:const` environment, from the
+frozen engine — companion to ``lifecycle_conformance.py``.
+
+This script is the PROVENANCE of every number pinned in
+``rust/crates/babylon-tick/tests/lifecycle_crisis_conformance.rs``. It runs
+the frozen ``LifecycleSystem`` against a `:const` environment DIFFERENT from
+`defines.yaml`'s shipped values — see
+``content/scenarios/lifecycle-crisis-conformance.bscn``'s header for why:
+under the shipped defaults, the legitimation index is the same 0.6039 for
+every subject and `caregiver-ideology-default`/`institutional-hegemony-
+default` are both 0.5, so neither the crisis-classification ladder's CRISIS
+branch nor the ideology weights are exercised by ``lifecycle_conformance.py``
+alone (an adversarial review of PR #493 caught this: two mutations — an
+ideology-weight swap, and collapsing the classification ladder to a
+constant — passed the original 8-test suite unnoticed).
+
+Run it from the repository root, single process::
+
+    PYTHONPATH="$PWD/src" uv run python \\
+        rust/crates/babylon-tick/content/scenarios/lifecycle_crisis_conformance.py
+
+Frozen system = contract source for STRUCTURE and ORDERING, not a
+correctness oracle (ADR183). D-5 (see the `.bsl` header) applies here too:
+`already-crisis` is seeded PRE-crisis `"crisis"` and stays classified
+CRISIS this tick, so under a CORRECT edge-triggered check
+`LEGITIMATION_CRISIS` must NOT re-fire for it — but the frozen engine's
+broken comparison (`prev_crisis != "CRISIS"`, comparing a lowercase
+`StrEnum.value` against the uppercase literal) fires it anyway, every tick,
+for every CRISIS-classified subject regardless of the previous state. This
+script prints the frozen engine's ACTUAL (buggy, over-firing) event output
+for the record; the Rust test asserts the pack's deliberately different,
+correctly edge-triggered behavior, per the documented §5.4 repair.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from babylon.engine.context import TickContext
+from babylon.engine.services import ServiceContainer
+from babylon.engine.systems.lifecycle import LifecycleSystem
+from babylon.models.enums import NodeType
+from babylon.topology.graph import BabylonGraph
+
+RATES: dict[str, float] = {
+    "rate_d_to_p": 0.0556,
+    "rate_p_to_d_prime": 0.0213,
+    "rate_d_prime_to_death": 0.039,
+    "birth_rate": 0.0107,
+}
+
+#: The DISCRIMINATING legitimation_state — NOT `defines.yaml`'s shipped
+#: values. All five components lowered to 0.1 so the weighted index
+#: (weights unchanged, still summing to 1.0) is 0.1, below
+#: legitimation_crisis_threshold (0.3).
+LEGITIMATION_STATE: dict[str, float] = {
+    "pension_coverage": 0.1,
+    "ss_replacement_rate": 0.1,
+    "healthcare_security": 0.1,
+    "home_ownership_rate": 0.1,
+    "retirement_confidence": 0.1,
+}
+
+SUBJECTS: list[tuple[str, dict[str, Any]]] = [
+    (
+        "entering-crisis",
+        {
+            "dpd_state": {
+                "pop_d": 2150.0,
+                "pop_p": 6050.0,
+                "pop_d_prime": 1800.0,
+                "wealth_d_prime": 10_000_000.0,
+                **RATES,
+            },
+            "legitimation_state": dict(LEGITIMATION_STATE),
+            "legitimation_crisis": "stable",
+        },
+    ),
+    (
+        "already-crisis",
+        {
+            "dpd_state": {
+                "pop_d": 3000.0,
+                "pop_p": 5000.0,
+                "pop_d_prime": 1500.0,
+                "wealth_d_prime": 5_000_000.0,
+                **RATES,
+            },
+            "legitimation_state": dict(LEGITIMATION_STATE),
+            "legitimation_crisis": "crisis",
+        },
+    ),
+]
+
+#: This pack's own crisis-classification encoding (see the .bsl header):
+#: 0 = STABLE, 1 = UNSTABLE, 2 = CRISIS.
+CRISIS_CODE = {"stable": 0, "unstable": 1, "crisis": 2}
+
+
+def build_graph() -> BabylonGraph:
+    """Build the two-territory world, in scenario declaration order."""
+    graph = BabylonGraph()
+    for node_id, attrs in SUBJECTS:
+        graph.add_node(node_id, NodeType.TERRITORY, **attrs)
+    return graph
+
+
+def main() -> None:
+    """Run one tick of the frozen LifecycleSystem and print the vectors."""
+    services = ServiceContainer.create()
+    try:
+        # Monkeypatch the ideology defaults the same way `:const`
+        # `lifecycle/caregiver-ideology-default`/
+        # `institutional-hegemony-default` do — those two values have no
+        # `defines.yaml` backing at all (D-2), so LifecycleSystem reads a
+        # bare Python literal (`0.5`) that no ServiceContainer field can
+        # override. Reading the exact worked example off the frozen
+        # `compute_ideology_transmission` doctest instead:
+        # `formulas/lifecycle.py:189-194` (`caregiver_ideology=0.3,
+        # institutional_hegemony=0.8`).
+        import babylon.engine.systems.lifecycle as lifecycle_module
+
+        original_step = lifecycle_module.LifecycleSystem.step
+
+        def patched_step(self: Any, graph: Any, services: Any, context: Any) -> None:  # noqa: ANN401
+            for node in graph.query_nodes(node_type=NodeType.TERRITORY):
+                graph.update_node(node.id, caregiver_ideology=0.3, institutional_hegemony=0.8)
+            original_step(self, graph, services, context)
+
+        lifecycle_module.LifecycleSystem.step = patched_step  # type: ignore[method-assign]
+
+        d = services.defines.lifecycle
+        print("defines used (deliberately DISCRIMINATING, not defines.yaml's shipped values):")
+        print(f"  legitimation_state components = {LEGITIMATION_STATE!r}")
+        print("  caregiver_ideology = 0.3, institutional_hegemony = 0.8 (doctest example)")
+        print(f"  lifecycle.legitimation_crisis_threshold = {d.legitimation_crisis_threshold!r}")
+        print(f"  lifecycle.ideology_caregiver_weight = {d.ideology_caregiver_weight!r}")
+        print(f"  lifecycle.ideology_institutional_weight = {d.ideology_institutional_weight!r}")
+        print(
+            f"  lifecycle.ideology_regression_coefficient = {d.ideology_regression_coefficient!r}"
+        )
+        print()
+
+        graph = build_graph()
+        LifecycleSystem().step(graph, services, TickContext(tick=1))
+        events = services.event_bus.get_history()
+
+        print("post-tick state:")
+        for node_id, _ in SUBJECTS:
+            node = graph.get_node(node_id)
+            if node is None:
+                raise SystemExit(f"node {node_id} vanished during the tick")
+            a = node.attributes
+            dpd = a["dpd_state"]
+            crisis_str = a["legitimation_crisis"]
+            print(
+                f"  {node_id:<18} "
+                f"pop_d={dpd['pop_d']!r} pop_p={dpd['pop_p']!r} "
+                f"pop_d_prime={dpd['pop_d_prime']!r} "
+                f"wealth_d_prime={dpd['wealth_d_prime']!r} "
+                f"dependency_ratio={a['dependency_ratio']!r} "
+                f"legitimation_index={a['legitimation_index']!r} "
+                f"legitimation_crisis={crisis_str!r} (code={CRISIS_CODE[crisis_str]}) "
+                f"transmitted_ideology={a['transmitted_ideology']!r}"
+            )
+        print()
+
+        print("events (frozen engine's ACTUAL output, D-5 bug included):")
+        for event in events:
+            print(f"  {event.type} {event.payload!r}")
+        if not events:
+            print("  (none)")
+    finally:
+        services.database.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -134,6 +134,10 @@ pub fn run_once_into(
         "economics".to_owned(),
         "vitality".to_owned(),
         "consciousness".to_owned(),
+        // The lifecycle/* rule pack (Material Base @7.0, the D-P-D'
+        // circuit) — same class of minimal driver-scaffolding addition as
+        // "vitality" above.
+        "lifecycle".to_owned(),
     ]);
 
     let ctx = LoadContext {

--- a/rust/crates/babylon-tick/tests/lifecycle_conformance.rs
+++ b/rust/crates/babylon-tick/tests/lifecycle_conformance.rs
@@ -1,0 +1,395 @@
+//! Conformance vectors for `lifecycle/dpd-circuit`, taken from the frozen
+//! Python engine's live behaviour.
+//!
+//! # Provenance
+//!
+//! Every state value below was printed by the frozen `LifecycleSystem`
+//! running one `step()` over a fixture that mirrors
+//! `content/scenarios/lifecycle-conformance.bscn` node for node. The
+//! command, from the repository root:
+//!
+//! ```text
+//! PYTHONPATH="$PWD/src" uv run python \
+//!     rust/crates/babylon-tick/content/scenarios/lifecycle_conformance.py
+//! ```
+//!
+//! Its output on 2026-08-11, verbatim:
+//!
+//! ```text
+//! defines (src/babylon/data/defines.yaml, lifecycle: section):
+//!   lifecycle.birth_rate = 0.0107
+//!   lifecycle.rate_d_to_p = 0.0556
+//!   lifecycle.rate_p_to_d_prime = 0.0213
+//!   lifecycle.rate_d_prime_to_death = 0.039
+//!   lifecycle.pension_coverage_rate = 0.73
+//!   lifecycle.home_ownership_rate = 0.656
+//!   lifecycle.ss_replacement_rate = 0.426
+//!   lifecycle.healthcare_security = 0.6
+//!   lifecycle.retirement_confidence = 0.5
+//!   lifecycle.legit_w_home_ownership = 0.35
+//!   lifecycle.legit_w_healthcare_security = 0.3
+//!   lifecycle.legit_w_retirement_confidence = 0.2
+//!   lifecycle.legit_w_pension_coverage = 0.1
+//!   lifecycle.legit_w_ss_replacement = 0.05
+//!   lifecycle.legitimation_crisis_threshold = 0.3
+//!   lifecycle.legitimation_unstable_threshold = 0.5
+//!   lifecycle.ideology_caregiver_weight = 0.7
+//!   lifecycle.ideology_institutional_weight = 0.3
+//!   lifecycle.ideology_regression_coefficient = 0.4
+//!
+//! post-tick state:
+//!   core-county        pop_d=2095.195 pop_p=6040.675 pop_d_prime=1858.665
+//!     wealth_d_prime=9610000.0 dependency_ratio=0.6545394347486001
+//!     legitimation_index=0.6038999999999999 legitimation_crisis='stable'
+//!     (code=0) transmitted_ideology=0.5
+//!   growing-county     pop_d=2886.7 pop_p=5060.3 pop_d_prime=1548.0
+//!     wealth_d_prime=4805000.0 dependency_ratio=0.876370966148252
+//!     legitimation_index=0.6038999999999999 legitimation_crisis='stable'
+//!     (code=0) transmitted_ideology=0.5
+//!   recovering-county  pop_d=1963.7 pop_p=6962.099999999999
+//!     pop_d_prime=2071.1 wealth_d_prime=19220000.0
+//!     dependency_ratio=0.5795377831401446
+//!     legitimation_index=0.6038999999999999 legitimation_crisis='stable'
+//!     (code=0) transmitted_ideology=0.5
+//!   young-county       pop_d=3836.45 pop_p=5605.25
+//!     pop_d_prime=117.14999999999999 wealth_d_prime=0.0
+//!     dependency_ratio=0.7053387449266313
+//!     legitimation_index=0.6038999999999999 legitimation_crisis='stable'
+//!     (code=0) transmitted_ideology=0.5
+//!
+//! events (frozen engine's ACTUAL output, D-5 bug included):
+//!   lifecycle_transition {'territory_id': 'core-county', ...}
+//!   inheritance_transfer {'territory_id': 'core-county', ...}
+//!   lifecycle_transition {'territory_id': 'growing-county', ...}
+//!   inheritance_transfer {'territory_id': 'growing-county', ...}
+//!   lifecycle_transition {'territory_id': 'recovering-county', ...}
+//!   inheritance_transfer {'territory_id': 'recovering-county', ...}
+//!   lifecycle_transition {'territory_id': 'young-county', ...}
+//!   inheritance_transfer {'territory_id': 'young-county', ...}
+//! ```
+//!
+//! Notably absent from the frozen engine's event log: **no**
+//! `legitimation_crisis`/`legitimation_recovery` event fires anywhere,
+//! including for `recovering-county`, which is seeded `legitimation_crisis:
+//! "crisis"` and ends the tick classified `stable`. That is D-5 (the `.bsl`
+//! header): the frozen comparison `prev_crisis == "CRISIS"` (uppercase)
+//! never matches a `StrEnum.value` (`"crisis"`, lowercase), so
+//! `LEGITIMATION_RECOVERY` is dead code in the frozen engine. This pack's
+//! int-coded classification has no case axis to inherit that bug through,
+//! so it implements the edge-triggered semantics the frozen code's own
+//! structure intends — a documented, deliberate divergence for the two
+//! event types only. Every state field matches the frozen engine exactly
+//! (see the table below): `inheritance_transfer` is the OTHER un-ported
+//! branch (director-gate #492), and it writes no graph state in the frozen
+//! engine either, so its absence here changes nothing this pack claims.
+//!
+//! # Why exact equality and no tolerance
+//!
+//! Both sides run IEEE-754 basic operations on binary64 — `+ − × ÷` and
+//! comparison, correctly rounded, reproducing bit-exactly across
+//! implementations (`bsl-language.rst` §4.3). `<arith>` is strictly binary
+//! (`E-PARSE-040`), so the rule states each association Python's formulas
+//! use rather than implying it (`formulas/lifecycle.py:52-59` for
+//! population flow, `:133-139` for the legitimation index). The decimals
+//! below are Python `repr` output — the shortest round-tripping decimal for
+//! each double — and Rust parses a float literal correctly rounded, so
+//! e.g. `2095.195_f64` IS the double Python printed. A tolerance here would
+//! hide exactly the transcription error it would appear to absorb.
+
+use babylon_bsl::evaluator::Value;
+use babylon_bsl::scenario::load_scenario;
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::memory::MemoryGraph;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::{run_once, run_once_into};
+
+const SCENARIO: &str = include_str!("../content/scenarios/lifecycle-conformance.bscn");
+const RULE: &str = include_str!("../content/rules/lifecycle.bsl");
+
+/// One subject's post-tick vector, in scenario declaration order.
+struct Expected {
+    name: &'static str,
+    id: u64,
+    pop_d: f64,
+    pop_p: f64,
+    pop_d_prime: f64,
+    wealth_d_prime: f64,
+    dependency_ratio: f64,
+    legitimation_index: f64,
+    legitimation_crisis: f64,
+    transmitted_ideology: f64,
+}
+
+const EXPECTED: [Expected; 4] = [
+    Expected {
+        name: "core-county",
+        id: 0,
+        pop_d: 2095.195,
+        pop_p: 6040.675,
+        pop_d_prime: 1858.665,
+        wealth_d_prime: 9_610_000.0,
+        dependency_ratio: 0.6545394347486001,
+        legitimation_index: 0.6038999999999999,
+        legitimation_crisis: 0.0,
+        transmitted_ideology: 0.5,
+    },
+    Expected {
+        name: "growing-county",
+        id: 1,
+        pop_d: 2886.7,
+        pop_p: 5060.3,
+        pop_d_prime: 1548.0,
+        wealth_d_prime: 4_805_000.0,
+        dependency_ratio: 0.876370966148252,
+        legitimation_index: 0.6038999999999999,
+        legitimation_crisis: 0.0,
+        transmitted_ideology: 0.5,
+    },
+    Expected {
+        name: "recovering-county",
+        id: 2,
+        pop_d: 1963.7,
+        pop_p: 6962.099999999999,
+        pop_d_prime: 2071.1,
+        wealth_d_prime: 19_220_000.0,
+        dependency_ratio: 0.5795377831401446,
+        legitimation_index: 0.6038999999999999,
+        legitimation_crisis: 0.0,
+        transmitted_ideology: 0.5,
+    },
+    Expected {
+        name: "young-county",
+        id: 3,
+        pop_d: 3836.45,
+        pop_p: 5605.25,
+        pop_d_prime: 117.14999999999999,
+        wealth_d_prime: 0.0,
+        dependency_ratio: 0.7053387449266313,
+        legitimation_index: 0.6038999999999999,
+        legitimation_crisis: 0.0,
+        transmitted_ideology: 0.5,
+    },
+];
+
+fn run() -> (MemoryGraph, CollectingSink) {
+    let mut graph = MemoryGraph::new();
+    let mut sink = CollectingSink::default();
+    run_once_into(SCENARIO, RULE, &mut graph, &mut sink).expect("the lifecycle pack must run");
+    (graph, sink)
+}
+
+fn attribute(graph: &MemoryGraph, id: u64, field: &str) -> f64 {
+    graph
+        .node_attribute(NodeId(id), field)
+        .unwrap_or_else(|e| panic!("node {id} field {field}: {}", e.message))
+}
+
+/// Every ported state field, against the frozen engine's own numbers,
+/// exactly (no tolerance).
+#[test]
+fn post_tick_state_matches_the_frozen_engine_exactly() {
+    let (graph, _) = run();
+    for e in &EXPECTED {
+        assert_eq!(
+            attribute(&graph, e.id, "territory/pop-d"),
+            e.pop_d,
+            "{}: pop-d",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/pop-p"),
+            e.pop_p,
+            "{}: pop-p",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/pop-d-prime"),
+            e.pop_d_prime,
+            "{}: pop-d-prime",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/wealth-d-prime"),
+            e.wealth_d_prime,
+            "{}: wealth-d-prime",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/dependency-ratio"),
+            e.dependency_ratio,
+            "{}: dependency-ratio",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/legitimation-index"),
+            e.legitimation_index,
+            "{}: legitimation-index",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/legitimation-crisis"),
+            e.legitimation_crisis,
+            "{}: legitimation-crisis",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/transmitted-ideology"),
+            e.transmitted_ideology,
+            "{}: transmitted-ideology",
+            e.name
+        );
+    }
+}
+
+/// `young-county` seeds `pop-d-prime` and `wealth-d-prime` at zero: no D'
+/// cohort exists yet, so `deaths == 0` and the surviving-fraction guard
+/// takes its ELSE branch — wealth stays exactly `0.0`, not "decayed from
+/// zero". `pop-d-prime` itself is NOT zero post-tick (the P->D' inflow
+/// still runs), which is why this checks wealth specifically rather than
+/// asserting the whole cohort stayed empty.
+#[test]
+fn a_territory_with_no_d_prime_cohort_leaves_its_wealth_untouched() {
+    let (graph, _) = run();
+    assert_eq!(attribute(&graph, 3, "territory/wealth-d-prime"), 0.0);
+}
+
+/// The Drain-equivalent for D': wealth decays by the surviving fraction of
+/// the D' cohort exactly, at every subject that HAS a D' cohort to begin
+/// with (every subject but young-county).
+#[test]
+fn wealth_d_prime_decays_by_the_surviving_fraction() {
+    let (graph, _) = run();
+    // core-county: old_total 1800, deaths = 0.039 * 1800 = 70.2,
+    // surviving_fraction = 1 - 70.2/1800 = 0.961.
+    let surviving = 1.0 - (0.039_f64 * 1800.0) / 1800.0;
+    assert_eq!(
+        attribute(&graph, 0, "territory/wealth-d-prime"),
+        10_000_000.0 * surviving
+    );
+}
+
+/// D-5's empirical proof: `recovering-county` is seeded PRE-crisis
+/// `"crisis"` and this tick's classification is STABLE for every subject
+/// (§ the .bsl header's D-1) — the frozen engine's own case-broken
+/// comparison never fires `LEGITIMATION_RECOVERY` here (see this file's
+/// header), but this pack's int-coded, correctly edge-triggered guard
+/// does. `core-county`/`growing-county`/`young-county` start STABLE or
+/// UNSTABLE and stay non-CRISIS, so neither guard fires for them.
+#[test]
+fn the_repaired_edge_check_fires_recovery_exactly_where_the_frozen_engine_should_have() {
+    let (_, sink) = run();
+    let recoveries: Vec<_> = sink
+        .events
+        .iter()
+        .filter(|(ty, _)| ty == "LEGITIMATION_RECOVERY")
+        .collect();
+    assert_eq!(
+        recoveries.len(),
+        1,
+        "exactly recovering-county crosses CRISIS -> non-CRISIS this tick"
+    );
+    let (_, payload) = recoveries[0];
+    assert_eq!(
+        payload[0],
+        ("territory-id".to_owned(), Value::NodeRef(NodeId(2)))
+    );
+    assert_eq!(
+        payload[1],
+        (
+            "legitimation-index".to_owned(),
+            Value::Real(0.6038999999999999)
+        )
+    );
+
+    let crises: Vec<_> = sink
+        .events
+        .iter()
+        .filter(|(ty, _)| ty == "LEGITIMATION_CRISIS")
+        .collect();
+    assert!(
+        crises.is_empty(),
+        "no subject classifies CRISIS under the current defines (legit-index 0.6039 > \
+         unstable-threshold 0.5) — matches the frozen engine exactly, D-1's own point"
+    );
+}
+
+/// One `LIFECYCLE_TRANSITION` per subject, unconditionally.
+#[test]
+fn every_subject_emits_lifecycle_transition() {
+    let (_, sink) = run();
+    let transitions = sink
+        .events
+        .iter()
+        .filter(|(ty, _)| ty == "LIFECYCLE_TRANSITION")
+        .count();
+    assert_eq!(transitions, 4);
+}
+
+/// Byte-determinism: the same content twice is the same post-state hash,
+/// and the tick moved state at all.
+#[test]
+fn the_lifecycle_tick_is_deterministic() {
+    let a = run_once(SCENARIO, RULE).expect("first run");
+    let b = run_once(SCENARIO, RULE).expect("second run");
+    assert_eq!(a.after, b.after, "two runs, one post-state");
+    assert_ne!(a.before, a.after, "the pack must move state");
+    assert_eq!(
+        a.fired, 4,
+        "all four territories pass the (unconditional) rule"
+    );
+}
+
+/// A rule reading a coefficient the scenario never declared fails at LOAD,
+/// with the coefficient named — the same discipline Vitality's own
+/// conformance suite pins.
+#[test]
+fn a_rule_reading_an_undeclared_coefficient_is_refused_at_load() {
+    let rule = "(rule lifecycle/typo \
+                :material-basis \"a population has a birth rate\" :fuel 32 \
+                (bindings \
+                  (binding pop-p :field territory/pop-p) \
+                  (binding rate :const lifecycle/birth-rat)) \
+                (effects (update-node self territory/pop-p (set (* rate pop-p)))))";
+    let Err(err) = run_once(SCENARIO, rule) else {
+        panic!("a mistyped coefficient must not load");
+    };
+    assert!(
+        err.contains("lifecycle/birth-rat"),
+        "the rejection must name the coefficient: {err}"
+    );
+}
+
+/// Sanity check on this file's own provenance claim: the scenario's
+/// `:const` rows carry the exact `defines.yaml` values the conformance
+/// script printed, so a future edit to either side cannot silently drift
+/// out of step with the other.
+#[test]
+fn the_scenario_consts_match_the_provenance_script_exactly() {
+    let mut seeds = MemoryGraph::new();
+    let scenario = load_scenario(SCENARIO, &mut seeds).expect("the scenario must load");
+    let expect_const = |name: &str, value: f64| {
+        let Some(Value::Real(actual)) = scenario.consts.get(name) else {
+            panic!("the scenario must declare {name} as a scaled literal");
+        };
+        assert_eq!(*actual, value, "{name}");
+    };
+    expect_const("lifecycle/birth-rate", 0.0107);
+    expect_const("lifecycle/rate-d-to-p", 0.0556);
+    expect_const("lifecycle/rate-p-to-d-prime", 0.0213);
+    expect_const("lifecycle/rate-d-prime-to-death", 0.039);
+    expect_const("lifecycle/pension-coverage-rate", 0.73);
+    expect_const("lifecycle/home-ownership-rate", 0.656);
+    expect_const("lifecycle/ss-replacement-rate", 0.426);
+    expect_const("lifecycle/healthcare-security", 0.6);
+    expect_const("lifecycle/retirement-confidence", 0.5);
+    expect_const("lifecycle/legit-w-home-ownership", 0.35);
+    expect_const("lifecycle/legit-w-healthcare-security", 0.3);
+    expect_const("lifecycle/legit-w-retirement-confidence", 0.2);
+    expect_const("lifecycle/legit-w-pension-coverage", 0.1);
+    expect_const("lifecycle/legit-w-ss-replacement", 0.05);
+    expect_const("lifecycle/legitimation-crisis-threshold", 0.3);
+    expect_const("lifecycle/legitimation-unstable-threshold", 0.5);
+    expect_const("lifecycle/ideology-caregiver-weight", 0.7);
+    expect_const("lifecycle/ideology-institutional-weight", 0.3);
+    expect_const("lifecycle/ideology-regression-coefficient", 0.4);
+}

--- a/rust/crates/babylon-tick/tests/lifecycle_crisis_conformance.rs
+++ b/rust/crates/babylon-tick/tests/lifecycle_crisis_conformance.rs
@@ -1,0 +1,276 @@
+//! Conformance vectors for `lifecycle/dpd-circuit` under the DISCRIMINATING
+//! `:const` environment — companion to `lifecycle_conformance.rs`.
+//!
+//! # Why this file exists
+//!
+//! Adversarial review of PR #493 found that `lifecycle-conformance.bscn`'s
+//! shipped-defaults `:const` environment makes the legitimation index
+//! identical (0.6039, STABLE) for every subject, and — since
+//! `caregiver-ideology-default`/`institutional-hegemony-default` are both
+//! `0.5c` — `transmitted_ideology` identical (0.5) regardless of
+//! `caregiver-weight`/`institutional-weight`. Two mutations that should have
+//! been caught passed the original 8-test suite unnoticed: swapping the two
+//! ideology weights, and collapsing the crisis-classification ladder to a
+//! constant. Both are real coverage gaps in the ORIGINAL suite (confirmed:
+//! after this file was added, both mutations flip a test here — see the
+//! PR body for the exact mutation-verification transcript).
+//!
+//! This file exercises the same rule pack (`lifecycle.bsl` is unchanged)
+//! against `lifecycle-crisis-conformance.bscn`, a `:const` environment
+//! DIFFERENT from `defines.yaml`'s shipped values: legitimation components
+//! lowered to 0.1 (index 0.1, below the 0.3 crisis threshold) and the
+//! ideology defaults set to the frozen `compute_ideology_transmission`
+//! doctest's own worked example (0.3/0.8, not 0.5/0.5). See that file's
+//! header for the full justification — these are genuinely runtime-moddable
+//! `defines.yaml` coefficients (D-1 in the `.bsl` header), not made-up
+//! numbers.
+//!
+//! # Provenance
+//!
+//! ```text
+//! PYTHONPATH="$PWD/src" uv run python \
+//!     rust/crates/babylon-tick/content/scenarios/lifecycle_crisis_conformance.py
+//! ```
+//!
+//! Its output on 2026-08-11, verbatim:
+//!
+//! ```text
+//! defines used (deliberately DISCRIMINATING, not defines.yaml's shipped values):
+//!   legitimation_state components = {'pension_coverage': 0.1, 'ss_replacement_rate': 0.1,
+//!     'healthcare_security': 0.1, 'home_ownership_rate': 0.1, 'retirement_confidence': 0.1}
+//!   caregiver_ideology = 0.3, institutional_hegemony = 0.8 (doctest example)
+//!   lifecycle.legitimation_crisis_threshold = 0.3
+//!   lifecycle.ideology_caregiver_weight = 0.7
+//!   lifecycle.ideology_institutional_weight = 0.3
+//!   lifecycle.ideology_regression_coefficient = 0.4
+//!
+//! post-tick state:
+//!   entering-crisis    pop_d=2095.195 pop_p=6040.675 pop_d_prime=1858.665
+//!     wealth_d_prime=9610000.0 dependency_ratio=0.6545394347486001
+//!     legitimation_index=0.1 legitimation_crisis='crisis' (code=2)
+//!     transmitted_ideology=0.47
+//!   already-crisis     pop_d=2886.7 pop_p=5060.3 pop_d_prime=1548.0
+//!     wealth_d_prime=4805000.0 dependency_ratio=0.876370966148252
+//!     legitimation_index=0.1 legitimation_crisis='crisis' (code=2)
+//!     transmitted_ideology=0.47
+//!
+//! events (frozen engine's ACTUAL output, D-5 bug included):
+//!   lifecycle_transition {'territory_id': 'entering-crisis', ...}
+//!   legitimation_crisis {'territory_id': 'entering-crisis', 'legitimation_index': 0.1}
+//!   inheritance_transfer {'territory_id': 'entering-crisis', ...}
+//!   lifecycle_transition {'territory_id': 'already-crisis', ...}
+//!   legitimation_crisis {'territory_id': 'already-crisis', 'legitimation_index': 0.1}
+//!   inheritance_transfer {'territory_id': 'already-crisis', ...}
+//! ```
+//!
+//! The frozen engine fires `legitimation_crisis` for BOTH subjects — D-5's
+//! over-firing bug, now demonstrated on the CRISIS side too:
+//! `already-crisis` is seeded PRE-crisis `"crisis"` and stays classified
+//! CRISIS, so a correct edge check must NOT re-fire for it, but
+//! `prev_crisis != "CRISIS"` (comparing a lowercase `StrEnum.value` against
+//! the uppercase literal) is true regardless of the actual previous state.
+//! This pack's int-coded, genuinely edge-triggered guard fires
+//! `LEGITIMATION_CRISIS` for `entering-crisis` ONLY.
+
+use babylon_bsl::evaluator::Value;
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::memory::MemoryGraph;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::{run_once, run_once_into};
+
+const SCENARIO: &str = include_str!("../content/scenarios/lifecycle-crisis-conformance.bscn");
+const RULE: &str = include_str!("../content/rules/lifecycle.bsl");
+
+struct Expected {
+    name: &'static str,
+    id: u64,
+    pop_d: f64,
+    pop_p: f64,
+    pop_d_prime: f64,
+    wealth_d_prime: f64,
+    dependency_ratio: f64,
+    legitimation_index: f64,
+    legitimation_crisis: f64,
+    transmitted_ideology: f64,
+}
+
+const EXPECTED: [Expected; 2] = [
+    Expected {
+        name: "entering-crisis",
+        id: 0,
+        pop_d: 2095.195,
+        pop_p: 6040.675,
+        pop_d_prime: 1858.665,
+        wealth_d_prime: 9_610_000.0,
+        dependency_ratio: 0.6545394347486001,
+        legitimation_index: 0.1,
+        legitimation_crisis: 2.0,
+        transmitted_ideology: 0.47,
+    },
+    Expected {
+        name: "already-crisis",
+        id: 1,
+        pop_d: 2886.7,
+        pop_p: 5060.3,
+        pop_d_prime: 1548.0,
+        wealth_d_prime: 4_805_000.0,
+        dependency_ratio: 0.876370966148252,
+        legitimation_index: 0.1,
+        legitimation_crisis: 2.0,
+        transmitted_ideology: 0.47,
+    },
+];
+
+fn run() -> (MemoryGraph, CollectingSink) {
+    let mut graph = MemoryGraph::new();
+    let mut sink = CollectingSink::default();
+    run_once_into(SCENARIO, RULE, &mut graph, &mut sink).expect("the lifecycle pack must run");
+    (graph, sink)
+}
+
+fn attribute(graph: &MemoryGraph, id: u64, field: &str) -> f64 {
+    graph
+        .node_attribute(NodeId(id), field)
+        .unwrap_or_else(|e| panic!("node {id} field {field}: {}", e.message))
+}
+
+/// Every ported state field, against the frozen engine's own numbers,
+/// exactly (no tolerance) — under the DISCRIMINATING `:const` environment.
+#[test]
+fn post_tick_state_matches_the_frozen_engine_exactly() {
+    let (graph, _) = run();
+    for e in &EXPECTED {
+        assert_eq!(
+            attribute(&graph, e.id, "territory/pop-d"),
+            e.pop_d,
+            "{}: pop-d",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/pop-p"),
+            e.pop_p,
+            "{}: pop-p",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/pop-d-prime"),
+            e.pop_d_prime,
+            "{}: pop-d-prime",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/wealth-d-prime"),
+            e.wealth_d_prime,
+            "{}: wealth-d-prime",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/dependency-ratio"),
+            e.dependency_ratio,
+            "{}: dependency-ratio",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/legitimation-index"),
+            e.legitimation_index,
+            "{}: legitimation-index",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/legitimation-crisis"),
+            e.legitimation_crisis,
+            "{}: legitimation-crisis",
+            e.name
+        );
+        assert_eq!(
+            attribute(&graph, e.id, "territory/transmitted-ideology"),
+            e.transmitted_ideology,
+            "{}: transmitted-ideology",
+            e.name
+        );
+    }
+}
+
+/// Kills the "collapse the classification ladder to a constant" mutation:
+/// both subjects must land CRISIS (code 2) under an index of 0.1 against a
+/// 0.3 threshold. If `new-crisis-class` were hardcoded (or the threshold
+/// comparisons were no-ops), this index/classification pair would not hold.
+#[test]
+fn the_index_actually_drives_the_classification_ladder_into_crisis() {
+    let (graph, _) = run();
+    assert_eq!(attribute(&graph, 0, "territory/legitimation-index"), 0.1);
+    assert_eq!(attribute(&graph, 0, "territory/legitimation-crisis"), 2.0);
+    assert_eq!(attribute(&graph, 1, "territory/legitimation-index"), 0.1);
+    assert_eq!(attribute(&graph, 1, "territory/legitimation-crisis"), 2.0);
+}
+
+/// D-5's repair, from the CRISIS side: `entering-crisis` (PRE-crisis
+/// STABLE, this tick CRISIS) fires `LEGITIMATION_CRISIS`; `already-crisis`
+/// (PRE-crisis CRISIS, this tick STILL CRISIS) must NOT re-fire it — the
+/// frozen engine's broken comparison fires for BOTH (see this file's
+/// header). Exactly one event, naming the territory that actually crossed
+/// the edge.
+#[test]
+fn the_repaired_edge_check_fires_crisis_only_on_the_transition_into_it() {
+    let (_, sink) = run();
+    let crises: Vec<_> = sink
+        .events
+        .iter()
+        .filter(|(ty, _)| ty == "LEGITIMATION_CRISIS")
+        .collect();
+    assert_eq!(
+        crises.len(),
+        1,
+        "exactly entering-crisis crosses non-CRISIS -> CRISIS this tick"
+    );
+    let (_, payload) = crises[0];
+    assert_eq!(
+        payload[0],
+        ("territory-id".to_owned(), Value::NodeRef(NodeId(0)))
+    );
+    assert_eq!(
+        payload[1],
+        ("legitimation-index".to_owned(), Value::Real(0.1))
+    );
+
+    let recoveries: Vec<_> = sink
+        .events
+        .iter()
+        .filter(|(ty, _)| ty == "LEGITIMATION_RECOVERY")
+        .collect();
+    assert!(
+        recoveries.is_empty(),
+        "no subject transitions out of CRISIS under this :const environment"
+    );
+}
+
+/// Kills the "swap caregiver-weight <-> institutional-weight" mutation:
+/// with the doctest's discriminated inputs (0.3/0.8), the two weights are
+/// no longer interchangeable, so `transmitted_ideology` pins the
+/// weight-to-input pairing exactly. Swapping the weights would instead pair
+/// `caregiver-weight` (0.7) with `institutional-hegemony` (0.8) and
+/// `institutional-weight` (0.3) with `caregiver-ideology` (0.3), producing a
+/// materially different `raw` (0.65 vs 0.45) and hence a different
+/// `transmitted` value — this pins the CORRECT pairing's frozen-engine
+/// number (see this file's header) so that swap is a real, catchable
+/// mutation rather than a coincidental match.
+#[test]
+fn ideology_transmission_discriminates_the_two_weights() {
+    let (graph, _) = run();
+    for id in [0, 1] {
+        assert_eq!(
+            attribute(&graph, id, "territory/transmitted-ideology"),
+            0.47
+        );
+    }
+}
+
+/// Byte-determinism, same shape as the shipped-defaults suite.
+#[test]
+fn the_crisis_environment_tick_is_deterministic() {
+    let a = run_once(SCENARIO, RULE).expect("first run");
+    let b = run_once(SCENARIO, RULE).expect("second run");
+    assert_eq!(a.after, b.after, "two runs, one post-state");
+    assert_ne!(a.before, a.after, "the pack must move state");
+    assert_eq!(a.fired, 2, "both territories pass the (unconditional) rule");
+}


### PR DESCRIPTION
## Summary

Ports `LifecycleSystem` (Material Base @7.0, the D-P-D' circuit) to a BSL
rule pack, following Vitality's precedent
(`docs/superpowers/plans/2026-08-10-vitality-bsl-rule-pack.md`) as an
**honest-partial port** — 3 of the frozen system's 5 flat rules land, 2 are
documented verified-inert.

- **Lands** (one combined `(rule lifecycle/dpd-circuit ...)` form — slice
  1's driver accepts exactly one `(rule ...)` per content set):
  - DPD population flow (births/transitions/deaths, D' wealth decay)
  - legitimation index + crisis/recovery detection
  - ideology transmission (D→P cohort)
- **Does NOT land**: inheritance flow (Pareto Gini) and class mobility
  (rate adjustment) — both blocked by the same construct gap the Territory
  BSL assessment (2026-08-11) named **Blocker-1**, director-gate #492:
  `pareto_alpha`, `early_mortality_modifier` and
  `carceral_transition_modifier` are runtime-moddable defines with domain
  `(0,10]`/`[0,10]`, and BSL's `defconst` literals cap non-Currency
  constants at `[0,1]` with no coercion path. Both un-ported outputs are
  confirmed dead ends on the canonical graph (grep-verified):
  `adjusted_p_to_d_prime`/`differential_p_to_d_prime` are read by no other
  system, and inheritance flow writes no graph state at all
  (event-emission only). The ported subset carries the system's
  load-bearing output — `legitimation_index` feeds
  `domain/bifurcation/analysis.py`, `engine/systems/struggle.py` and
  `engine/systems/electoral.py` directly.

## D-records (§5.4, `ADR183`)

- **D-1**: the five `LegitimationState` components + four `DPDState` rate
  fields are modeled as global `:const` bindings — matching what the
  frozen engine's per-node-with-defines-fallback pattern always resolves
  to in production (grep-verified: no writer ever diverges them
  per-territory).
- **D-2**: `caregiver_ideology`/`institutional_hegemony` have no
  `defines.yaml` backing in the frozen engine (hardcoded Python literals);
  transcribed as `:const` under this pack's own names.
- **D-3**: `community_tendency`'s amplification term is always-dead in
  production (nothing writes the field); dropped.
- **D-4**: three saturating clamps are provably redundant given the
  `[0,1]`-bounded domain of every input, with the modding-contract caveat
  documented (BSL's `int`-declared fields carry no automatic range check,
  unlike Python's `max`/`min`).
- **D-5** (a genuine defect found while porting): the frozen crisis/recovery
  edge check compares a lowercase `StrEnum.value` against the literal
  `"CRISIS"`, which never matches — `LEGITIMATION_CRISIS` re-fires every
  tick a territory is classified CRISIS instead of only on the transition,
  and `LEGITIMATION_RECOVERY` is permanently dead code (untested in the
  frozen estate — confirmed via `rg`). This pack's int-coded classification
  has no case axis to inherit the bug through, so it implements the
  edge-triggered semantics the frozen code's own structure and comment
  plainly intend — a deliberate, documented divergence for the two event
  types only. Every state field matches the frozen engine exactly.
- **D-6**: the frozen `if r > 0.0` guard on the ideology regression step is
  applied unconditionally in this pack — behaviorally identical across `r`'s
  entire declared `[0,1]` domain including the `r=0` boundary the guard
  exists for (multiply-by-zero-and-add-zero is an IEEE-754 identity, not an
  approximation), recorded as a transcription deviation.

## Conformance evidence — two `:const` environments, 13 tests

**Round 1** (`rust/crates/babylon-tick/tests/lifecycle_conformance.rs`, 8
tests) uses `defines.yaml`'s SHIPPED values. **Adversarial review found this
alone made the "all mutation-verified" claim false**: under shipped
defaults every subject computes the identical legitimation index (0.6039,
STABLE) and — since `caregiver-ideology-default ==
institutional-hegemony-default` (0.5 == 0.5) — the identical
`transmitted_ideology` (0.5) regardless of the ideology weights. Two
mutations passed all 8 tests unnoticed: swapping
`caregiver-weight`↔`institutional-weight`, and collapsing the whole
crisis-classification ladder to a constant (the CRISIS half of the very
guard D-5 repairs had zero coverage).

**Round 2** (`tests/lifecycle_crisis_conformance.rs`, 5 tests) closes both
gaps with a second, deliberately different (still in-domain `[0,1]`)
`:const` environment — `content/scenarios/lifecycle-crisis-conformance.bscn`
— that lowers the legitimation components to 0.1 (index 0.1, below the 0.3
crisis threshold, so CRISIS entry and the D-5 guard's positive half fire)
and sets the ideology defaults to the frozen `compute_ideology_transmission`
doctest's own worked example (0.3/0.8, `formulas/lifecycle.py:189-194`, not
0.5/0.5). Two subjects: one crossing into CRISIS (guard fires), one already
CRISIS staying CRISIS (guard must NOT re-fire — the frozen engine's broken
comparison fires for BOTH, confirmed empirically in
`lifecycle_crisis_conformance.py`'s printed event log).

Both rounds: vectors from a fresh, single-process frozen-engine run,
byte-exact `f64`, no tolerance.

**Mutation-verified for real** (all three probes, applied then reverted):

1. **Weight swap** (`caregiver-weight`↔`institutional-weight`): all 8 Round-1
   tests still pass (as expected — undiscriminated there); 2 Round-2 tests
   fail (`post_tick_state_matches_the_frozen_engine_exactly`,
   `ideology_transmission_discriminates_the_two_weights`).
2. **Ladder collapse** (`new-crisis-class` hardcoded to `(- 0 0)`): all 8
   Round-1 tests still pass; 3 Round-2 tests fail
   (`post_tick_state_matches_the_frozen_engine_exactly`,
   `the_index_actually_drives_the_classification_ladder_into_crisis`,
   `the_repaired_edge_check_fires_crisis_only_on_the_transition_into_it`).
3. **Positive control** (Round-1's `birth-rate` zeroed): 2 Round-1 tests
   fail (`post_tick_state_matches_the_frozen_engine_exactly`,
   `the_scenario_consts_match_the_provenance_script_exactly`) — confirms
   Round 1 was never vacuous, only incomplete on the two axes above.

## Engine machinery

Adds `"lifecycle"` to `babylon-tick`'s hardcoded registered-system set
(`src/lib.rs`) — the same class of minimal driver addition Vitality made
for `:const` serving.

## Cross-PR sequencing

This branch overlaps **#494** (the hypergraph-rs storage swap) on
`rust/crates/babylon-tick/src/lib.rs`: #494 changes `run_once_into` to a
generic `<G: GraphSubstrate + CanonicalState>` signature and repoints
`run_once` to `HypergraphStore`, and both `lifecycle_conformance.rs` and
`lifecycle_crisis_conformance.rs` call `run_once`/`run_once_into` directly.
Neither CI has compiled the combination yet. **Whichever of #493/#494 merges
second must rebase and re-run `cargo test -p babylon-tick` before merging.**
Not rebasing yet per orchestrator instruction — merge order TBD pending
#494's own verification.

## Test plan

- [x] `cargo test -p babylon-bsl -p babylon-tick` — 278+19+9+121+1+7+8+5+8 =
      all green (no regressions to the existing Vitality/floor-intrinsic
      suites)
- [x] `cargo clippy -p babylon-bsl -p babylon-tick --all-targets` clean at
      default lint level
- [x] `cargo fmt -p babylon-tick -- --check` clean
- [x] Manual mutation verification, 5 probes total (2 from the original
      round, 3 from the fix round — see above), each applied and reverted
- [x] `ruff check` / `mypy` clean on both conformance scripts
- [x] Pre-existing Python `LifecycleSystem` test suite (25 tests) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)