### PR TITLE
fix(persistence): P-F completion — declare synchronous_commit=off for the player (#382)

### DIFF
--- a/docker/postgres/initdb/01-babylon-init.sql
+++ b/docker/postgres/initdb/01-babylon-init.sql
@@ -19,8 +19,13 @@ CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
 
--- FR-005: async commit for the sim/test role ONLY (not cluster-wide).
--- Safe: per-tick writes are idempotent (ON CONFLICT DO NOTHING, spec-056)
--- and crash-resume replays deterministically from the last committed tick
--- (Constitution III.7) — a lost async tail is re-created bit-exact.
+-- FR-005: async commit for the sim/test role. On the dev/player config
+-- (docker/postgres/postgresql.conf) this is now redundant with a
+-- cluster-wide `synchronous_commit = off` DECLARED there (ADR176 ruling 32
+-- / P-F completion, issue #382) — kept here so CI (postgresql.ci.conf,
+-- which stays cluster-wide ON) still gets it for the `test` role it shares
+-- with dev. Safe: per-tick writes are idempotent (ON CONFLICT DO NOTHING,
+-- spec-056) and crash-resume replays deterministically from the last
+-- committed tick (Constitution III.7) — a lost async tail is re-created
+-- bit-exact.
 ALTER ROLE test SET synchronous_commit = off;

--- a/docker/postgres/postgresql.ci.conf
+++ b/docker/postgres/postgresql.ci.conf
@@ -33,7 +33,8 @@ shared_preload_libraries = 'pg_stat_statements'
 track_io_timing = on
 log_min_duration_statement = 1000
 
-# NOTE: synchronous_commit stays ON cluster-wide here (unlike the dev/player
-# config, which DECLARES it off cluster-wide per ADR176 ruling 32); CI keeps
-# relying on the `test` role switch via docker/postgres/initdb/01-babylon-init.sql
+# NOTE: synchronous_commit stays at its DEFAULT of ON cluster-wide here — it
+# is deliberately NOT declared in this file (unlike the dev/player config,
+# which DECLARES it off cluster-wide per ADR176 ruling 32); CI keeps relying
+# on the `test` role switch via docker/postgres/initdb/01-babylon-init.sql
 # (shared with dev) — same resulting value for the `test` role either way.

--- a/docker/postgres/postgresql.ci.conf
+++ b/docker/postgres/postgresql.ci.conf
@@ -33,5 +33,7 @@ shared_preload_libraries = 'pg_stat_statements'
 track_io_timing = on
 log_min_duration_statement = 1000
 
-# NOTE: synchronous_commit stays ON cluster-wide; the `test` role switches it
-# off via docker/postgres/initdb/01-babylon-init.sql exactly as on dev.
+# NOTE: synchronous_commit stays ON cluster-wide here (unlike the dev/player
+# config, which DECLARES it off cluster-wide per ADR176 ruling 32); CI keeps
+# relying on the `test` role switch via docker/postgres/initdb/01-babylon-init.sql
+# (shared with dev) — same resulting value for the `test` role either way.

--- a/docker/postgres/postgresql.conf
+++ b/docker/postgres/postgresql.conf
@@ -31,7 +31,16 @@ shared_preload_libraries = 'pg_stat_statements'
 track_io_timing = on
 log_min_duration_statement = 1000     # log statements slower than 1s
 
-# NOTE: synchronous_commit stays ON cluster-wide; it is switched off for the
-# `test` role only (docker/postgres/initdb/01-babylon-init.sql, FR-005) —
-# safe because per-tick writes are idempotent and crash-resume replays
-# deterministically from the last committed tick (Constitution III.7).
+# --- Durability (ADR176 ruling 32 / P-F completion, issue #382) ---------------
+# DECLARED cluster-wide (not hidden behind a role, per the Director's own
+# framing: "currently set invisibly via ALTER ROLE test, which no config
+# audit would catch"). Worst case one in-flight tick lost (~600 ms, ~452 kB),
+# re-simulated bit-identically on resume — safe because per-tick writes are
+# idempotent and crash-resume replays deterministically from the last
+# committed tick (Constitution III.7). No separate "player" role/cluster
+# exists yet (that lands with the game-managed cluster, rust-port); this
+# dev config template is today's player-equivalent surface. The `test` role
+# ALSO gets it via ALTER ROLE (docker/postgres/initdb/01-babylon-init.sql,
+# spec-087 FR-005) — redundant with this GUC today, kept for CI parity
+# (postgresql.ci.conf relies on that same ALTER, unchanged by this ruling).
+synchronous_commit = off

--- a/specs/087-storage-foundations/spec.md
+++ b/specs/087-storage-foundations/spec.md
@@ -75,8 +75,8 @@ missing:
   `ALTER ROLE`. `docker/postgres/postgresql.conf` (today's player-equivalent
   surface — the game-managed player cluster is still rust-port future work)
   now also declares `synchronous_commit = off` cluster-wide; the `test`-role
-  `ALTER ROLE` stays for CI parity (`postgresql.ci.conf` remains
-  cluster-wide ON).
+  `ALTER ROLE` stays for CI parity (`postgresql.ci.conf` deliberately makes
+  no declaration, leaving that cluster at PostgreSQL's default of ON).
 - **FR-006**: The data volume MUST default to a named docker volume (portable)
   and honor `BABYLON_PG_DATA` (path ⇒ bind mount) via compose interpolation;
   Percy's `.env` points it at the 3.6 TB data drive so the DB leaves the

--- a/specs/087-storage-foundations/spec.md
+++ b/specs/087-storage-foundations/spec.md
@@ -68,6 +68,15 @@ missing:
   idempotent (`ON CONFLICT DO NOTHING`, spec-056 monotonicity) and
   crash-resume replays deterministically from the last committed tick
   (Constitution III.7) — an async-commit tail loss is re-created bit-exact.
+  **Superseded in part** (2026-08-11, ADR176 ruling 32 / P-F completion,
+  issue #382): the "not cluster-wide" clause held only while the setting
+  applied exclusively to the `test` role; the Director ruled it must also be
+  DECLARED for the player, and no config audit could see a role-scoped
+  `ALTER ROLE`. `docker/postgres/postgresql.conf` (today's player-equivalent
+  surface — the game-managed player cluster is still rust-port future work)
+  now also declares `synchronous_commit = off` cluster-wide; the `test`-role
+  `ALTER ROLE` stays for CI parity (`postgresql.ci.conf` remains
+  cluster-wide ON).
 - **FR-006**: The data volume MUST default to a named docker volume (portable)
   and honor `BABYLON_PG_DATA` (path ⇒ bind mount) via compose interpolation;
   Percy's `.env` points it at the 3.6 TB data drive so the DB leaves the

--- a/tests/unit/persistence/test_synchronous_commit_declared.py
+++ b/tests/unit/persistence/test_synchronous_commit_declared.py
@@ -1,0 +1,73 @@
+"""Player-role ``synchronous_commit=off`` DECLARED in the config template
+(ADR176 ruling 32 / P-F completion — issue #382).
+
+Ruling 32 read in full: "synchronous_commit=off on the player, DECLARED in
+the config template (worst case one in-flight tick, re-simulated
+bit-identically)". The 2026-08-11 bundle-closure audit found P-F only
+half-landed: ``ALTER ROLE test SET synchronous_commit = off``
+(``docker/postgres/initdb/01-babylon-init.sql``, spec-087 FR-005) covers the
+``test`` role but is *invisible* to a config audit (Director's own framing,
+postgres-brief-2026-07-29.md D-list item 6) — no separate "player" role
+exists yet (the game-managed player cluster is rust-port future work, ADR176
+ruling 33 change-table item #27), so today's player-equivalent surface is
+the dev config template docker-compose.yml selects
+(``docker/postgres/postgresql.conf``). "Declared" means: a cluster-wide GUC
+any auditor can grep, not a value hidden in ``pg_db_role_setting``.
+
+Pure text assertions against the tracked config file — no Postgres needed,
+mirrors ``tests/unit/cli/test_uv_migration.py``'s config-parsing pattern.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAYER_CONF = (ROOT / "docker/postgres/postgresql.conf").read_text(encoding="utf-8")
+CI_CONF = (ROOT / "docker/postgres/postgresql.ci.conf").read_text(encoding="utf-8")
+INITDB_SQL = (ROOT / "docker/postgres/initdb/01-babylon-init.sql").read_text(encoding="utf-8")
+
+
+def _guc_lines(conf_text: str) -> list[str]:
+    return [
+        line.strip()
+        for line in conf_text.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+def test_player_config_declares_synchronous_commit_off() -> None:
+    """The dev/player config template sets ``synchronous_commit = off`` as
+    a cluster-wide GUC — grep-able, not hidden behind a role name."""
+    guc_lines = _guc_lines(PLAYER_CONF)
+    assert "synchronous_commit = off" in guc_lines, (
+        "docker/postgres/postgresql.conf must DECLARE synchronous_commit = off "
+        "(ADR176 ruling 32) instead of relying solely on the invisible "
+        "ALTER ROLE test mechanism"
+    )
+
+
+def test_player_config_no_longer_claims_cluster_wide_on() -> None:
+    """The stale comment claiming synchronous_commit 'stays ON cluster-wide'
+    must not survive next to a cluster-wide OFF declaration — an accurate
+    comment matters as much as the GUC itself for an audit trail."""
+    assert "synchronous_commit stays ON cluster-wide" not in PLAYER_CONF
+
+
+def test_test_role_alter_still_present_for_ci_parity() -> None:
+    """The original spec-087 FR-005 mechanism (ALTER ROLE test) stays —
+    surgical addition, not a replacement; CI's fork explicitly promises
+    identical behavioral settings to dev (docker/postgres/postgresql.ci.conf
+    docstring), and CI shares this initdb script via the base compose file."""
+    assert "ALTER ROLE test SET synchronous_commit = off;" in INITDB_SQL
+
+
+def test_ci_config_behaviorally_consistent_with_player() -> None:
+    """postgresql.ci.conf's own docstring promises every BEHAVIORAL setting
+    stays identical to the dev/player config, memory sizing the only
+    divergence. The resulting synchronous_commit value for role `test` must
+    therefore still be `off` on both — CI keeps relying on the initdb ALTER
+    (untouched), the player config now also declares it at the cluster
+    level. Neither file may declare the opposite value."""
+    assert "synchronous_commit = on" not in _guc_lines(PLAYER_CONF)
+    assert "synchronous_commit = on" not in _guc_lines(CI_CONF)

--- a/tests/unit/persistence/test_synchronous_commit_declared.py
+++ b/tests/unit/persistence/test_synchronous_commit_declared.py
@@ -30,9 +30,7 @@ INITDB_SQL = (ROOT / "docker/postgres/initdb/01-babylon-init.sql").read_text(enc
 
 def _guc_lines(conf_text: str) -> list[str]:
     return [
-        line.strip()
-        for line in conf_text.splitlines()
-        if line.strip() and not line.strip().startswith("#")
+        stripped for line in conf_text.splitlines() if (stripped := line.split("#", 1)[0].strip())
     ]
 
 


### PR DESCRIPTION
## Summary

Closes the P-F half of ADR176 ruling 32 that the 2026-08-11 bundle-closure audit (#495) found incomplete: `synchronous_commit=off` existed for the `test` role only (`ALTER ROLE`, spec-087 FR-005) — invisible to a config audit, per the Director's own framing in the postgres brief. The ruling named "the player"; no separate player role/cluster exists yet (that's rust-port future work per ADR176 ruling 33's change-table item #27), so today's player-equivalent surface is the dev config template `docker-compose.yml` selects (`docker/postgres/postgresql.conf`).

- `docker/postgres/postgresql.conf` now DECLARES `synchronous_commit = off` as a cluster-wide GUC — grep-able, matching the ruling's literal "DECLARED in the config template" language.
- The `test`-role `ALTER ROLE` stays (surgical addition, not a replacement) — CI's fork (`postgresql.ci.conf`) explicitly promises identical *behavioral* settings to dev and keeps relying on that same ALTER via the shared initdb script; both files' comments corrected for accuracy.
- `specs/087-storage-foundations/spec.md` FR-005 gets a supersession annotation (repo convention: preserve history, annotate rather than rewrite).

## P-B (ref_digest re-key) — NOT implemented, STOP reported

Issue #382's remaining periphery item, P-B (ruling 29: "Reference tier: ref_digest RE-KEY, content-identity verified across cohorts before any collapse; determinism pin preserved exactly"), is **not** included in this PR. Investigation found the migration path for existing rows genuinely ambiguous with a real data-loss risk on the wrong branch — full reasoning posted on issue #382.

## Test plan

- [x] TDD red→green: `tests/unit/persistence/test_synchronous_commit_declared.py` (4 pure-text assertions against the tracked config files, no Postgres needed) — written first, confirmed failing, then made to pass.
- [x] `mise run test:q -- tests/unit/persistence/test_synchronous_commit_declared.py` — 4 passed
- [x] `mise run check:quick` — ruff lint/format + mypy strict, all green
- [x] No files under `src/babylon/engine/` or `src/babylon/formulas/` touched (freeze respected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)