### PR TITLE
docs(plans): B2 tick-loop implementation plan (P28 client lane)

### DIFF
--- a/docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md
+++ b/docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md
@@ -40,8 +40,9 @@ found two blockers, one defect, and one nit, all fixed in this second revision:
   contradicted an existing normative sentence this plan never read.** `bsl-language.rst:3058-3060`
   (register row D16, §4.2):
   <!-- vale off -->
-  *"Rules at the same anchor position evaluate in ascending rule-id byte order, and their effects
-  apply in that same order. File order and load order are never observable."*
+  *"Rules at the same anchor position evaluate in ascending rule-id byte order [draft ruling —
+  Phase 1 review], and their effects apply in that same order. File order and load order are never
+  observable."*
   <!-- vale on -->
   Verified by reading the section directly — the sentence matches the citation
   exactly, and directly negates the design the first amendment shipped. **Fixed**: the driver orders
@@ -126,8 +127,8 @@ Decision below.
   below for the arithmetic.
 - **D16 (§4.2)** —
   <!-- vale off -->
-  "Rules at the same anchor position evaluate in ascending rule-id byte order… File order and
-  load order are never observable."
+  "Rules at the same anchor position evaluate in ascending rule-id byte order [draft ruling —
+  Phase 1 review]… File order and load order are never observable."
   <!-- vale on -->
   This is the GOVERNING rule for the multi-rule
   evolution's execution order (Phase A, Tasks 2–6) — verified by direct reading
@@ -209,7 +210,7 @@ Decision below.
 
 ---
 
-## Decision: B2 completes B1's Phase C, generalized to two lenses
+## Decision: B2 completes B1's Phase C, generalized to three lenses
 
 **B1's own File Structure table already reserves four files for "Phase C — the lens lane":
 `lens.rs`, `map/bands.rs`'s `band_color`/recolor-system additions, `map/pick.rs`, `map/hud.rs`.
@@ -227,25 +228,36 @@ state change." But §7 criterion 3 says *"see the county map… and watch state 
 together with the Director's own aesthetic-and-pedagogy line (*"what game mechanics are both
 engaging AND instill education about the correct revolutionary theory?"*), a tick loop whose only
 visible effect is a text panel while the map sits inert is a materially weaker demo than one where
-the county the player is watching visibly changes color as the tick fires. The map is already
-built (Phase B); Phase C's reserved files are the ONLY place the county-indexed
-lens/hover/recolor/HUD plumbing this needs was ever going to live.
+watching the county the player has selected shows real state moving. **Stated with the same
+honesty the eyes-on gate (Task 18) later carries in full**: on THIS demo content that means one
+band-color sign-flip per county family at tick 1 (Task 9b's four archetype families split GOLD/
+CRIMSON the moment the first tick runs), and after that, the HUD/state-panel NUMBERS keep moving
+every press even though most counties' band color does not flip again — "watch state change" does
+not promise a repeated color flip on every single press, only that Something Real is moving and a
+player can see it. The map is already built (Phase B); Phase C's reserved files are the ONLY place
+the county-indexed lens/hover/recolor/HUD plumbing this needs was ever going to live.
 
 **Decision: this plan builds Phase C's four reserved files as part of its own task list — it does
 not wait for a separate Phase C PR, and it does not duplicate Phase C's interfaces alongside new
 ones.** Concretely:
 
 1. `lens.rs` carries the ADR170 witness (`county_tension`, ported verbatim from the B1 plan's
-   Task 8 spec, corrected for one thing the B1 plan text predates — see below) **and** a second,
-   new witness (`county_legitimation`) reading the field the tick loop actually moves.
+   Task 8 spec, corrected for one thing the B1 plan text predates — see below), a second witness
+   (`county_legitimation`) reading the field the tick loop writes every tick (Task 9), and a THIRD
+   witness (`county_population_trend`, Task 9b, added this revision) reading the DPD circuit's
+   genuinely per-tick population fields — the lens that actually carries "watch state change" on
+   this demo content.
 2. `map/bands.rs` gains B1 Task 9's `band_color` function and four-row table (ADR191 R11,
-   unmodified) **and** a second, small three-row table for the Legitimation lens, colored per this
-   amendment's ruling 1 — both are pure presentation constants, no `GameDefines`/`defines_hash`
-   ceremony, exactly as ADR191 R11 already ruled for the first table.
+   unmodified), a second, small three-row table for the Legitimation lens colored per this
+   amendment's ruling 1, and a THIRD table for the Population Trend lens (Task 10, sign-only —
+   Director-ruled this revision, see the Open Questions section) — all three are pure presentation
+   constants, no `GameDefines`/`defines_hash` ceremony, exactly as ADR191 R11 already ruled for the
+   first table.
 3. `map/pick.rs` and `map/hud.rs` are B1 Task 10's designs, unmodified, except the HUD now also
-   names which of the two lenses is active — this plan adds that honesty rule because two lenses
-   share the color CRIMSON for two different meanings (Tension's "Φ-source, bled" vs. the
-   Legitimation lens's "CRISIS"), and nothing may let a player read one as the other.
+   names which of the THREE lenses is active — this plan adds that honesty rule because the color
+   CRIMSON now carries THREE separate meanings across the three lenses (Tension's "Φ-source, bled,"
+   the Legitimation lens's "CRISIS," the Population Trend lens's "declining"), and nothing may let
+   a player read one meaning as another.
 
 **One correction to B1's plan text, made explicit so no one silently inherits it wrong:** B1's
 Task 8 spec writes `pub fn county_tension(graph: &MemoryGraph) -> TensionLens`. ADR193 (merged the
@@ -308,8 +320,9 @@ scenario identity). A verification round found the direct, on-point rule this pl
 read first: `bsl-language.rst:3058-3060` (§4.2, register row D16):
 
 <!-- vale off -->
-> Rules at the same anchor position evaluate in **ascending rule-id byte order**, and their
-> effects apply in that same order. **File order and load order are never observable.**
+> Rules at the same anchor position evaluate in **ascending rule-id byte order** [draft ruling —
+> Phase 1 review], and their effects apply in that same order. **File order and load order are
+> never observable.**
 <!-- vale on -->
 
 That last sentence is the exact negation of the first amendment's design. No honest reading keeps
@@ -369,8 +382,20 @@ the registry lands, not as an ordering mechanism this driver reads.
 `vitality/subsistence-and-death`'s bindings read/write only `social-class/*` fields and `economy/*`
 constants; `lifecycle/dpd-circuit`'s bindings read/write only `territory/*` fields and `lifecycle/*`
 constants (both verified by reading each rule's full `(bindings …)` block). Neither rule's subject
-type, field reads, or field writes touch the other's. Two consequences follow, and BOTH matter to
-how Task 5 builds its conformance test:
+type, field reads, or field writes touch the other's. **This is not merely an inference from
+reading the bindings by hand — the driver itself computes and enforces it at runtime.**
+`tick.rs::subject_type_of` derives a rule's subject type from the SINGLE qname prefix its `:field`
+bindings share (loading a rule whose bindings span more than one prefix loudly fails —
+<!-- vale off -->
+`E-LOAD`-shaped: "the rule's :field bindings span N namespaces… so its subject type is ambiguous"
+<!-- vale on -->
+); `run_tick` then calls `graph.nodes(&subject_type)` and iterates ONLY that result. Because
+`vitality`'s bindings resolve to the single prefix `social-class` and `lifecycle`'s to the
+single prefix `territory`, the two rules iterate DISJOINT NODE SETS at the substrate level —
+`graph.nodes("SOCIAL_CLASS")` and `graph.nodes("TERRITORY")` — not merely disjoint field
+prefixes on a shared set. This is the stronger, load-bearing argument; the bindings-reading
+check above is corroborating evidence, not the proof itself. Two consequences follow, and BOTH
+matter to how Task 5 builds its conformance test:
 
 1. **The final canonical state hash is order-invariant for THIS pair, specifically**, because
    `CanonicalState::encode_state` sorts every section before hashing (ADR193) and the two rules'
@@ -413,7 +438,17 @@ The union scenario (Phase B) mints social-class nodes (`vitality`'s fixture) and
 - **`CardinalityCeilings`**: `prepare_rule`'s existing ceiling-building code
   (`scenario.node_types.iter().map(...)`) is already generic over any number of distinct
   `NodeType` members a scenario mints — verified by reading it; no change needed for two node
-  types instead of one, and Task 6 keeps this code path unmodified.
+  types instead of one, and Task 6 keeps this code path unmodified. **Two DIFFERENT string
+  conventions coexist in this crate, both correct in their own place, worth naming explicitly so
+  no one "fixes" one to match the other:** `CardinalityCeilings::new` deliberately keys its map
+  with the PREFIXED form (`format!("NodeType/{member}")` — this is the bound checker's own load-time
+  vocabulary, matching how a rule's `<enum-ref>` looks in SOURCE); `GraphSubstrate::nodes()` and
+  `node_attribute()` key on the BARE form the substrate actually stores (`"TERRITORY"`, never
+  `"NodeType/TERRITORY"` — the BLOCKER this revision fixes at every Rust call site). The two never
+  need to agree with each other, because they answer different questions at different layers — one
+  is "how many of this enum-ref might a rule legally query," the other is "which nodes does the
+  live graph actually hold" — but a reader moving between `prepare_rules` and `lens.rs`/
+  `engine_link.rs` should not assume the same string shape carries across that boundary.
 - **`systems` registry**: the existing fixed `HashSet` in `prepare_rule`/`prepare_rules`
   already contains both `"vitality"` and `"lifecycle"` (it has since the lifecycle port merged) —
   no change needed there either.
@@ -1167,9 +1202,10 @@ directly rather than assumes.
       six social-class nodes (`core`, `bourgeoisie`, `hermit`, `last-worker`, `remnant`,
       `dissolved`, every field value transcribed byte-for-byte) and `lifecycle-conformance.bscn`'s
       four territory nodes (`core-county`, `growing-county`, `recovering-county`, `young-county`,
-      same transcription discipline) into ONE `.bscn` file, combining the `deffield`/`defconst`
-      blocks (21 + 7 declarations — the Multi-Rule Decision section's collision check already confirms
-      zero name overlap so this is a straight concatenation, not a merge requiring judgment calls).
+      same transcription discipline) into ONE `.bscn` file, combining the `deffield` blocks (7 +
+      8 = 15 field declarations) and the `defconst` blocks (2 + 21 = 23 constant declarations) —
+      the Multi-Rule Decision section's collision check already confirms zero name overlap in
+      either category, so this is a straight concatenation, not a merge requiring judgment calls.
       Name it `vitality-lifecycle-combined-conformance.bscn`; a dedicated, small, ALREADY-PROVEN
       fixture, kept separate from Phase B's larger, real-FIPS-flavored demo scenario — this task's
       job is proving the MECHANISM, Phase B's is building the PLAYABLE world, and conflating them
@@ -1196,7 +1232,7 @@ directly rather than assumes.
 // tests/multi_rule_conformance.rs
 use babylon_bsl::structural_verbs::CollectingSink;
 use babylon_graph::hypergraph_store::HypergraphStore;
-use babylon_tick::{run_once_into, hex};
+use babylon_tick::run_once_into; // `hex` is not needed here — neither test formats a hash
 
 const SCENARIO: &str =
     include_str!("../content/scenarios/vitality-lifecycle-combined-conformance.bscn");
@@ -1561,9 +1597,9 @@ fn print_first_twelve() {
 
         | idx | archetype | pop-d | pop-p | pop-d-prime | wealth-d-prime |
         |---|---|---|---|---|---|
-        | 0 | core (×0.95) | 2042 | 5748 | 1710 | 10000000 |
+        | 0 | core (×0.95) | 2042† | 5748† | 1710 | 10000000 |
         | 1 | core (×1.00) | 2150 | 6050 | 1800 | 10000000 |
-        | 2 | core (×1.05) | 2258 | 6352 | 1890 | 10000000 |
+        | 2 | core (×1.05) | 2258† | 6352† | 1890 | 10000000 |
         | 3 | growing (×0.95) | 2850 | 4750 | 1425 | 5000000 |
         | 4 | growing (×1.00) | 3000 | 5000 | 1500 | 5000000 |
         | 5 | growing (×1.05) | 3150 | 5250 | 1575 | 5000000 |
@@ -1574,11 +1610,23 @@ fn print_first_twelve() {
         | 10 | young (×1.00) | 4000 | 5500 | 0 | 0 |
         | 11 | young (×1.05) | 4200 | 5775 | 0 | 0 |
 
-        `dependency-ratio` seeds `0` (computed field) for all twelve; `legitimation-index`/
-        `legitimation-crisis`/`transmitted-ideology` seed at their ARCHETYPE's original value
-        (core/growing/young = `0`/`0`/`0`; recovering = `2`, PRE-crisis CRISIS, so it still fires
-        `LEGITIMATION_RECOVERY` on tick 1 for indices 6-8 exactly as the unperturbed design did —
-        the population scale factor has no bearing on this field). Name each node `county-<fips>`
+        † Four values land on an exact `.5` tie before rounding (`2150×0.95 = 2042.5`,
+        `6050×0.95 = 5747.5`, `2150×1.05 = 2257.5`, `6050×1.05 = 6352.5`) — resolved by
+        round-half-to-even (banker's rounding, the tool that generated this table used Python 3's
+        default `round()`), not round-half-up. Noted explicitly so `2042`/`5748`/`2258`/`6352`
+        read as the deliberate, reproducible result of a named rounding rule rather than as
+        transcription slips — a different rounding convention would legitimately land one tick off
+        `2043`/`5747`/`2257`/`6353` and would still be a correct implementation of THIS table,
+        provided the task states which convention it used, as this one now does.
+
+        `dependency-ratio` seeds `0` (computed field) for all twelve; `legitimation-index` seeds `0`
+        for all twelve; `legitimation-crisis`/`transmitted-ideology` seed at their ARCHETYPE's
+        original value, transcribed exactly from `lifecycle-conformance.bscn` (re-verified against
+        the committed file, not recalled): core = `0`/`0` (STABLE), growing = `1`/`0` (UNSTABLE —
+        corrected this revision; an earlier draft of this table wrote `0`, which is wrong),
+        recovering = `2`/`0` (CRISIS, so it still fires `LEGITIMATION_RECOVERY` on tick 1 for
+        indices 6-8 exactly as the unperturbed design did), young = `0`/`0` (STABLE) — the
+        population scale factor has no bearing on any of these fields. Name each node `county-<fips>`
         (symbols must start with a lowercase letter — §1's `symbol ::= LOWER (LOWER | DIGIT |
         "-")*` — a bare FIPS like `06037` is not a legal symbol, `county-06037` is).
       - **Social-class half.** Reuse `vitality-conformance.bscn`'s `deffield` block (7 fields,
@@ -1698,7 +1746,7 @@ fn the_demo_scenario_loads_and_ticks_both_packs() {
 
 ---
 
-## Phase C — The dual-lens map (completes B1 Phase C)
+## Phase C — The three-lens map (completes B1 Phase C)
 
 ### Task 8: The Tension lens, ported and corrected for `HypergraphStore`
 
@@ -1713,9 +1761,31 @@ fn the_demo_scenario_loads_and_ticks_both_packs() {
 
 ```rust
 pub struct LensReading {
-    pub cells: Vec<(String, Option<f64>)>, // (fips, value) — shared shape both lenses return
+    pub cells: Vec<(String, Option<f64>)>, // (fips, value) — shared shape all three lenses return
     pub absent_reason: Option<String>,
 }
+
+/// The three live `LensReading`s the map can show, refreshed together on
+/// every tick advance (MEDIUM-HIGH fix — this struct was USED across five
+/// call sites in the first cut but never actually DEFINED anywhere; in the
+/// real app `Res<CurrentLensData>` would have failed to resolve and Bevy
+/// 0.18 would have skipped `recolor_on_lens_changed` with a warn-once,
+/// leaving the map permanently uncolored while every test that
+/// hand-installed the resource kept passing). Declared here, alongside
+/// `LensReading` — `map/bands.rs` (Task 10) reads it via `use
+/// crate::lens::CurrentLensData`, never redeclares it. No `Default` derive
+/// — `spawn_engine_session_and_hud` (Task 14) is the ONLY inserter, always
+/// with a fully-computed literal, and it runs in `Startup` (ordered after
+/// `MapPlugin`'s own Startup systems) strictly before `recolor_on_lens_
+/// changed` (an `Update` system) can ever run, so no earlier reader can
+/// observe a missing or default-empty resource.
+#[derive(Resource)]
+pub struct CurrentLensData {
+    pub tension: LensReading,
+    pub legitimation: LensReading,
+    pub population_trend: LensReading,
+}
+
 pub fn county_tension(graph: &dyn GraphSubstrate) -> LensReading;
 ```
 
@@ -1728,9 +1798,16 @@ pub fn county_tension(graph: &dyn GraphSubstrate) -> LensReading;
       `absent_reason.is_some()` and every cell `None`; (e) every returned `w` lands in `[-1, 1]`.
 - [ ] **Step 2:** FAIL, then write it — the ADR170 formula transcribed exactly as B1's Task 8
       specified (`phi = v/(v+s)`, `theta = sum(v)/sum(v+s)`, `w = (phi-theta)/(phi+theta)`,
-      `phi+theta <= 1e-9` collapses to `0.0`), reading `graph.nodes("NodeType/TERRITORY")` and
-      `graph.node_attribute(id, "...")` through `&dyn GraphSubstrate` rather than a concrete store
-      — note this graph, from Task 7 on, ALSO holds six `NodeType/SOCIAL_CLASS` nodes; `nodes()`'s
+      `phi+theta <= 1e-9` collapses to `0.0`), reading `graph.nodes("TERRITORY")` — the BARE enum
+      member string, never `"NodeType/TERRITORY"`: the substrate stores and matches the verb
+      layer's own stamped form (`namespace_to_node_type`'s doc comment, `tick.rs`: *"the verb layer
+      stamps the enum member verbatim (`(add-node NodeType/SOCIAL_CLASS …)` → `"SOCIAL_CLASS"`)"*
+      — confirmed against every live call site in the crate: `structural_verbs.rs:1046`,
+      `scenario.rs:776`, `fundamental_theorem_tick.rs:390`, all bare, none prefixed. `NodeType/…`
+      is BSL SOURCE syntax (the `<enum-ref>` you write inside a `.bscn`/`.bsl` file); a Rust string
+      literal handed to `nodes()` is a RUNTIME key and must match what the substrate actually
+      stores — and `graph.node_attribute(id, "...")` through `&dyn GraphSubstrate` rather than a concrete store
+      — note this graph, from Task 7 on, ALSO holds six `"SOCIAL_CLASS"` nodes; `nodes()`'s
       own type filter (verified in `memory.rs`/`hypergraph_store.rs`) already excludes them, so
       this task's logic needs no change — confirmed by reading, recorded here rather than assumed.
 - [ ] **Step 3:** `cargo test -p babylon-client` → PASS.
@@ -1925,12 +2002,13 @@ the ruling named.
 - [ ] **Step 3: The recolor system.** One system, parameterized by `ActiveLens`:
 
 ```rust
+const ATLAS_BYTES: &[u8] = include_bytes!("../../assets/map/county_atlas.bin");
+
 pub(super) fn recolor_on_lens_changed(
     mut events: EventReader<LensChanged>,
     active: Res<ActiveLens>,
-    lens_data: Res<CurrentLensData>, // holds all THREE LensReading values, refreshed every advance
+    lens_data: Res<crate::lens::CurrentLensData>, // all THREE LensReading values, refreshed every advance
     surface: Res<MapSurface>,
-    atlas_index: Res<FipsIndex>,     // fips -> atlas county index, from Task 12
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
     if events.read().next().is_none() {
@@ -1946,6 +2024,23 @@ pub(super) fn recolor_on_lens_changed(
         ActiveLens::Legitimation => legitimation_band_color,
         ActiveLens::PopulationTrend => population_trend_band_color,
     };
+    // Re-parse the embedded atlas locally rather than reach through a
+    // shared `FipsIndex` resource — MEDIUM-HIGH fix: the first cut
+    // referenced `Res<FipsIndex>` at three call sites with no task ever
+    // defining it, so in the real app this system would never have run at
+    // all (Bevy 0.18 skips a system whose resource param cannot resolve,
+    // warn-once, no panic — the map would have silently stayed
+    // uncolored). `CountyAtlas::parse` is a cheap check-then-decode
+    // (Task 4 of the B1 plan's own design) — no tessellation, no
+    // allocation beyond the decoded tables — so re-parsing it once per
+    // `LensChanged` event (at most once per Space press or Tab press,
+    // never per-frame) costs nothing worth caching, and it matches this
+    // crate's OWN established convention: `map/camera.rs::spawn_camera`
+    // already re-parses the same embedded bytes independently of
+    // `map/mesh.rs::spawn_map_surface`'s own parse, specifically to stay
+    // free of any same-schedule resource-availability assumption.
+    let atlas = crate::atlas::CountyAtlas::parse(ATLAS_BYTES)
+        .unwrap_or_else(|e| panic!("county atlas failed to parse: {e}"));
     let Some(mesh) = meshes.get_mut(&surface.fill_mesh) else {
         return;
     };
@@ -1956,10 +2051,10 @@ pub(super) fn recolor_on_lens_changed(
         return;
     };
     for (fips, value) in &reading.cells {
-        let Some(&county_idx) = atlas_index.by_fips.get(fips) else {
+        let Some(county_idx) = atlas.index_of_fips(fips) else {
             continue;
         };
-        let (start, end) = surface.tessellation.county_vertex_range[county_idx as usize];
+        let (start, end) = surface.tessellation.county_vertex_range[county_idx];
         let rgba = color_fn(*value).to_linear().to_f32_array();
         for v in &mut colors[start as usize..end as usize] {
             *v = [rgba[0], rgba[1], rgba[2]];
@@ -1970,11 +2065,16 @@ pub(super) fn recolor_on_lens_changed(
 
       One pass, one buffer, matching B1 Task 9's own "no mesh rebuild" design — this is the same
       recolor shape B1's plan already specified, now parameterized over which lens is active
-      instead of fixed to Tension alone.
-- [ ] **Step 4: Headless test** — `MinimalPlugins` + `AssetPlugin`, install a `CurrentLensData`
-      with one known Legitimation cell, set `ActiveLens::Legitimation`, fire `LensChanged`, `update()`,
-      assert that county's vertex range shows `legitimation_band_color`'s output and every other
-      county's colors held at `PANEL`. Add a SPECIFIC regression case: a `Some(0.0)` (STABLE) cell
+      instead of fixed to Tension alone, and reading county positions through `atlas.index_of_fips`
+      (`atlas.rs`, B1 Task 4) directly rather than a separate index resource.
+- [ ] **Step 4: Headless test** — `MinimalPlugins` + `AssetPlugin`, install a HAND-BUILT
+      `CurrentLensData` with one known Legitimation cell (this test's own job is proving
+      `recolor_on_lens_changed`'s LOGIC in isolation, with a fixture the test controls — Task 18
+      adds the separate, real-wiring integration test that proves `CurrentLensData` gets populated
+      by the real app at all, which this unit-level test cannot and does not claim to prove), set
+      `ActiveLens::Legitimation`, fire `LensChanged`, `update()`, assert that county's vertex range
+      shows `legitimation_band_color`'s output and every other county's colors held at `PANEL`.
+      Add a SPECIFIC regression case: a `Some(0.0)` (STABLE) cell
       and a genuinely-absent cell (a FIPS with no `LensReading` entry at all) produce the SAME
       vertex color — proving the intentional merge, not just the function's return value in
       isolation. Repeat the shape for `ActiveLens::PopulationTrend`: a positive-delta cell shows
@@ -2044,6 +2144,14 @@ Lens: Tension — no data this tick                    [absence, any of the thre
 **Files:**
 
 - Edit: `rust/crates/babylon-client/src/map/mod.rs`
+- Edit: `rust/crates/babylon-client/src/map/mesh.rs` (widen `spawn_map_surface`'s visibility)
+
+**Housekeeping fix folded in: `spawn_map_surface` needs a `pub` path.** Task 14's `.after(...)`
+ordering call references `crate::map::spawn_map_surface`, but B1 landed it as `pub(super) fn
+spawn_map_surface` in `mesh.rs` — visible inside `map/`'s own module tree, not to sibling modules
+like `loop_ui.rs`. Widen it to `pub fn spawn_map_surface` in `mesh.rs` (a one-word change, no
+behavior change) and add it to this task's `pub use mesh::{...}` line below, alongside the three
+types B1 already re-exports there.
 
 - [ ] **Step 1: Write the failing headless test** — `MinimalPlugins` + `AssetPlugin` +
       `babylon_client::map::MapPlugin`, assert the STARTUP default `ActiveLens` is
@@ -2052,11 +2160,14 @@ Lens: Tension — no data this tick                    [absence, any of the thre
       plan's tests already use, one `update()` per press), assert `ActiveLens` visits `Tension` →
       `Legitimation` → `PopulationTrend` in that cycle order (a 3-way CYCLE, not a 2-way flip — the
       first cut's design only had two lenses), and a `LensChanged` event fires on every press.
-- [ ] **Step 2:** FAIL, then add: `mod pick; mod hud;` (new modules from this task); `pub use
-      bands::{ActiveLens, LensChanged};` alongside the existing `pub use bands::PANEL;` — the same
-      re-export convention B1 already established for `PANEL`, extended to the two new types so
-      `crate::map::ActiveLens`/`crate::map::LensChanged` (the paths Task 14's and Task 18's code
-      use) resolve; **`ActiveLens::PopulationTrend` inserted as the `Startup` default resource —
+- [ ] **Step 2:** FAIL, then add: `mod pick; mod hud;` (new modules from this task); in
+      `mesh.rs`, change `pub(super) fn spawn_map_surface` to `pub fn spawn_map_surface`; `pub use
+      bands::{ActiveLens, LensChanged}; pub use mesh::spawn_map_surface;` alongside the existing
+      `pub use mesh::{MapBorders, MapFill, MapSurface, EXPECTED_VERTEX_COUNT};` and `pub use
+      bands::PANEL;` — the same re-export convention B1 already established, extended to the two
+      new types and the one function so `crate::map::ActiveLens`/`crate::map::LensChanged`/
+      `crate::map::spawn_map_surface` (the paths Task 14's and Task 18's code use) all resolve;
+      **`ActiveLens::PopulationTrend` inserted as the `Startup` default resource —
       NOT `Tension`.** Task 8's own finding: this demo scenario seeds no `v`/`s`/`e`-style economic
       fields at all, so `county_tension` returns fully absent on every county, every tick, on this
       content — defaulting to it would open the app on an absence banner over an all-`PANEL` map.
@@ -2109,16 +2220,23 @@ recomputed.
 **Why `node_by_fips` is a plain `Vec`, not a `babylon-bsl` API addition.** `load_scenario`'s local
 name -> `NodeId` map is deliberately load-time-only and does not outlive the call (`scenario.rs`'s
 own comment). This plan does not widen that API. Instead: the Phase B scenario mints EXACTLY the
-twelve `NodeType/TERRITORY` nodes and six `NodeType/SOCIAL_CLASS` nodes, in file order, and no
-others; `GraphSubstrate::nodes("NodeType/TERRITORY")` filters BY TYPE and returns ascending
-`NodeId`s among territory nodes only, which equal territory-mint order because `NodeId` mints as a
-GLOBAL monotonic counter across the whole scenario (ADR193) and the type filter preserves relative
-order within the filtered subset — verified by reading both `nodes()` implementations
-(`memory.rs`/`hypergraph_store.rs`), not assumed: interleaving social-class and territory node
-declarations in the `.bscn` file changes the ABSOLUTE `NodeId` values but not their RELATIVE order
-among same-typed nodes, so this zip is correct regardless of how the two halves interleave in the
-file. Zipping `graph.nodes("NodeType/TERRITORY")` against a `const DEMO_FIPS: [&str; 12]` array
-**in the same order as the `.bscn` file's twelve territory `(node …)` forms** recovers the
+twelve `NodeType/TERRITORY` nodes and six `NodeType/SOCIAL_CLASS` nodes (that BSL SOURCE syntax —
+the `<enum-ref>` — is what the `.bscn` file itself writes; the RUNTIME string the substrate stores
+and matches is the bare enum member, `"TERRITORY"`/`"SOCIAL_CLASS"`, confirmed against
+`namespace_to_node_type`'s own doc comment and every live `nodes()` call site in the crate), in
+file order, and no others; `GraphSubstrate::nodes("TERRITORY")` — the bare string, NEVER
+`"NodeType/TERRITORY"`, which matches nothing and returns an empty `Vec` silently — filters BY
+TYPE and returns ascending `NodeId`s among territory nodes only, which equal territory-mint order
+because `NodeId` mints as a GLOBAL monotonic counter across the whole scenario (ADR193) and the
+type filter preserves relative order within the filtered subset — verified by reading both
+`nodes()` implementations (`memory.rs`/`hypergraph_store.rs`: both `.filter(...)` on the type
+string THEN `.sort_unstable()` the surviving ids, so the shape holds regardless of which string the
+filter matches — only the STRING itself needed the fix this task now carries): interleaving
+social-class and territory node declarations in the `.bscn` file changes the ABSOLUTE `NodeId`
+values but not their RELATIVE order among same-typed nodes, so this zip is correct regardless of
+how the two halves interleave in the file. Zipping `graph.nodes("TERRITORY")` against a `const
+DEMO_FIPS: [&str; 12]` array **in the same order as the `.bscn` file's twelve territory
+`(node …)` forms** recovers the
 fips↔id mapping with no new babylon-bsl surface — fragile only in the sense that editing the
 `.bscn` file's territory node order without updating `DEMO_FIPS` would silently mislabel a county,
 which Step 2's loud startup assertion turns into an immediate panic instead. **Social-class nodes
@@ -2195,10 +2313,12 @@ impl EngineSession {
         // is deterministic and mints the identical eighteen ids — proven
         // by this task's own Step 1 test, which checks both independently).
         babylon_bsl::scenario::load_scenario(SCENARIO, &mut graph).map_err(|e| e.to_string())?;
-        let ids = babylon_graph::substrate::GraphSubstrate::nodes(&graph, "NodeType/TERRITORY");
+        // "TERRITORY" — the bare enum member the substrate actually stores
+        // (namespace_to_node_type stamps it verbatim), never "NodeType/TERRITORY".
+        let ids = babylon_graph::substrate::GraphSubstrate::nodes(&graph, "TERRITORY");
         if ids.len() != DEMO_FIPS.len() {
             panic!(
-                "demo scenario minted {} NodeType/TERRITORY nodes, DEMO_FIPS names {} — \
+                "demo scenario minted {} TERRITORY nodes, DEMO_FIPS names {} — \
                  the array drifted from the .bscn file, fix DEMO_FIPS",
                 ids.len(),
                 DEMO_FIPS.len()
@@ -2320,15 +2440,15 @@ pub struct TickLoopPlugin;
 impl Plugin for TickLoopPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(TickCounter::default());
-        // `.after(map::spawn_map_surface)` (and, transitively, needs
-        // `map::FipsIndex` to already exist — Task 12's own Startup
-        // system that builds it): this system fires the FIRST
-        // `LensChanged` at tick 0, and `recolor_on_lens_changed` (Task
-        // 10) reads `MapSurface`/`FipsIndex` resources that `MapPlugin`'s
-        // OWN Startup systems create. Bevy does not order same-schedule
-        // systems by plugin-registration order alone — this ordering
-        // constraint must be explicit, not implied by `main.rs` listing
-        // `MapPlugin` before `TickLoopPlugin`.
+        // `.after(map::spawn_map_surface)`: this system fires the FIRST
+        // `LensChanged` at tick 0, and `recolor_on_lens_changed` (Task 10)
+        // reads the `MapSurface` resource `MapPlugin`'s OWN Startup system
+        // creates (Task 10 dropped the separate `FipsIndex` resource this
+        // note used to also require — it re-parses the atlas locally
+        // instead, so no second Startup dependency remains). Bevy does not
+        // order same-schedule systems by plugin-registration order alone —
+        // this ordering constraint must be explicit, not implied by
+        // `main.rs` listing `MapPlugin` before `TickLoopPlugin`.
         app.add_systems(
             Startup,
             spawn_engine_session_and_hud.after(crate::map::spawn_map_surface),
@@ -2836,6 +2956,7 @@ inside):
 // screen), but it proves every INPUT-DRIVEN, hash-provable claim that
 // pass makes, so a future change that silently breaks the loop reds THIS
 // gate in CI before a human ever has to notice by eye.
+use babylon_graph::state_hash::CanonicalState; // trait import — .state_hash() below needs it in scope
 use bevy::asset::AssetPlugin;
 use bevy::prelude::*;
 use std::collections::HashSet;
@@ -2918,13 +3039,77 @@ fn defaults_to_population_trend_and_tab_cycles_through_all_three() {
         "three presses from the default must visit every lens once and return to start"
     );
 }
+
+#[test]
+fn a_known_demo_county_actually_recolors_after_a_space_press() {
+    // THE test the MEDIUM-HIGH finding asked for: real `TickLoopPlugin` +
+    // `MapPlugin` together, no hand-installed `CurrentLensData` (contrast
+    // Task 10 Step 4's own test, which deliberately hand-builds a fixture
+    // to test `recolor_on_lens_changed`'s LOGIC in isolation — this test
+    // proves the real app's WIRING reaches the mesh at all, which a
+    // hand-installed resource cannot prove by construction). Before this
+    // test existed, every automated check in this plan passed even in a
+    // build where `CurrentLensData`/`FipsIndex` never resolved and the map
+    // never recolored — this closes that gap.
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, AssetPlugin::default(), InputPlugin));
+    app.add_plugins(babylon_client::map::MapPlugin);
+    app.add_plugins(babylon_client::loop_ui::TickLoopPlugin);
+    app.update(); // Startup — real EngineSession, real CurrentLensData, real MapSurface.
+
+    fn county_zero_colors(app: &App) -> Vec<[f32; 4]> {
+        let surface = app.world().resource::<babylon_client::map::MapSurface>();
+        let meshes = app.world().resource::<Assets<Mesh>>();
+        let mesh = meshes.get(&surface.fill_mesh).expect("fill mesh is registered");
+        let (start, end) = surface.tessellation.county_vertex_range[0]; // atlas index 0 = DEMO_FIPS[0]
+        match mesh
+            .attribute(Mesh::ATTRIBUTE_COLOR)
+            .expect("fill mesh carries per-vertex color")
+        {
+            bevy::mesh::VertexAttributeValues::Float32x4(colors) => {
+                colors[start as usize..end as usize].to_vec()
+            }
+            other => panic!("unexpected color attribute shape: {other:?}"),
+        }
+    }
+
+    // Tick 0: PopulationTrend is the default lens, and every county reads
+    // `Some(0.0)` (now == baseline, nothing has ticked yet) — DIM.
+    let before = county_zero_colors(&app);
+
+    {
+        let mut input = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+        input.press(KeyCode::Space);
+    }
+    app.update();
+
+    // Atlas index 0 is a `core` (×0.95) family county — Task 9b's own
+    // table has this family net-DECLINING, so after tick 1 it must read
+    // CRIMSON, genuinely different from tick 0's DIM.
+    let after = county_zero_colors(&app);
+
+    assert_ne!(
+        before, after,
+        "the demo county at atlas index 0 must actually recolor after one Space press — \
+         if this fails, CurrentLensData is not reaching the mesh even though the tick itself \
+         advanced (check that advance_on_space's ResMut<CurrentLensData> param and its three \
+         lens.rs calls are wired, and that recolor_on_lens_changed's Res<MapSurface> resolves)"
+    );
+}
 ```
 
-- [ ] **Step 1:** Write both tests as shown, run against Phase C/D's finished code → FAIL until
-      those phases land (this task sits last deliberately).
-- [ ] **Step 2:** Once Phase C and Phase D land, both PASS. `mise run rust:check` → green.
+- [ ] **Step 1:** Write all three tests as shown (the two original plus
+      `a_known_demo_county_actually_recolors_after_a_space_press`, the MEDIUM-HIGH fix's automated
+      color-change proof), run against Phase C/D's finished code → FAIL until those phases land
+      (this task sits last deliberately).
+- [ ] **Step 2:** Once Phase C and Phase D land, all three PASS. `mise run rust:check` → green.
+      The third test is the ONE place in this plan's automated suite that exercises
+      `TickLoopPlugin` and `MapPlugin` together with zero hand-installed resources — if it fails
+      while the other two pass, the bug is in the real wiring between them, not in either
+      plugin's own isolated logic.
 - [ ] **Step 3:** Update `ai/state.yaml` — B2 reached: multi-rule tick loop (vitality + lifecycle),
-      dual-lens map, state panel, event feed, log sink, eyes-on gate defined and CI-proxied. Close
+      three-lens map (Tension/Legitimation/Population Trend), state panel, event feed, log sink,
+      eyes-on gate defined and CI-proxied. Close
       #262 as "superseded — replaced by this gate" per the roadmap spec §5's own instruction,
       citing this plan document.
 - [ ] **Step 4: Commit** (`test(client): the B2 eyes-on gate + its CI-safe proxy (B2)`).
@@ -2981,7 +3166,7 @@ immutability-of-history discipline, and appends what the ruling actually changed
    engineering work, not a flag flip. The Director selected the larger option instead, quoted:
    *"Build the multi-rule content-set evolution into B2 itself so the demo runs vitality+lifecycle
    together from day one. Bigger B2, later criterion-3 close, but a richer first demo."* This
-   ruling is what reshapes the entire plan above: Phase A gained four tasks (2–5) widening
+   ruling is what reshapes the entire plan above: Phase A gained five tasks (2, 3, 3b, 4, 5) widening
    `split_content`, `prepare_rules`, `TickReport`, and proving a conformance vector against the
    frozen engine's own vitality-then-lifecycle tick order; Phase B's demo scenario grew from
    twelve territory nodes to eighteen (twelve territory + six social-class); Phase D's event feed
@@ -2994,5 +3179,41 @@ immutability-of-history discipline, and appends what the ruling actually changed
 3. **Audio (SFX/soundtrack, ADR152/153) — RULED: DEFERRED out of B2, per this plan's own
    recommendation.** No change from the first cut: R3's visual scope names "2D map game + panels
    and charts as the primary surface" with no audio obligation; wiring 39 SFX + 13 tracks properly
-   is real, separately-scoped work, and B2 already carries five phases (now nineteen tasks) of new
-   surface.
+   is real, separately-scoped work, and B2 already carries five phases (now twenty-one tasks,
+   counting Task 3b and Task 9b) of new surface.
+
+**Two more, surfaced and ruled in the third revision round (2026-08-11, same interactive
+session).** The BLOCKER 2 fix (the Population Trend lens) made two presentation calls this plan's
+author took under ruling 1's own authority ("presentation constants, no ceremony follows") rather
+than formally reopening as questions — a verification round flagged that as an overreach: ruling 1
+settled the LEGITIMATION lens's palette specifically, not a blanket license for every later lens
+this plan invents. This section reopens both explicitly and records them RULED, D97/ADR194
+citation discipline (quoted verbatim as presented and selected):
+
+4. **Does the Population Trend lens's GOLD/CRIMSON sign-only mapping need its own sign-off? —
+   RULED: APPROVED AS DESIGNED.** This plan's own reasoning for the choice: a strict sign
+   comparison invents no size threshold, so it reads as machinery under the same "no imposed
+   functional forms" standing this plan already cites for the Legitimation lens, not a new
+   presentation ruling requiring escalation. The Director ruled on it directly rather than letting
+   that reasoning stand unconfirmed, selecting: *"GOLD = growth, CRIMSON = decline, sign-only (no
+   invented threshold — compliant with your no-imposed-forms line). One shared visual vocabulary;
+   the lens picker + HUD label carry which meaning is active."* No change to Task 10's
+   `population_trend_band_color` — the ruling confirms the design this plan already shipped, and
+   records the Director's own reasoning (matching the no-imposed-forms line explicitly, not merely
+   by this plan's own say-so) alongside it.
+5. **Should the app default to `ActiveLens::PopulationTrend` instead of `Tension`? — RULED:
+   APPROVED, WITH A REVERSION CONDITION.** This plan's own reasoning: Task 8's finding that the
+   Tension lens has zero data on this demo scenario (no `v`/`s`/`e` economic fields declared
+   anywhere) means defaulting to it would open the app on an absence banner, so `PopulationTrend`
+   — the one lens guaranteed to carry real, moving data — became the default. The Director ruled:
+   *"The app opens on the lens that actually has data and moves; your Tension lens becomes the
+   default the moment real economic content lands (recorded as the reversion condition)."*
+   **THE REVERSION CONDITION, recorded explicitly per the ruling's own instruction:** the STARTUP
+   default returns to `ActiveLens::Tension` the moment a scenario in this content set declares real
+   `v`/`s`/`e`-shaped economic fields for its territory nodes AND a rule pack writes them per tick
+   (the same "genuinely live, not merely declared" bar Task 9's finding already applies to
+   Legitimation) — most plausibly when the deferred economics BSL port (named in Task 19's own
+   follow-up list) lands. `PopulationTrend` stays the default until a future task satisfies that
+   condition; this is not a standing aesthetic preference, but a fact about which lens the demo
+   content can honestly support, and the reversion condition is the plan's own record of when that
+   fact changes.

--- a/docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md
+++ b/docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md
@@ -1,0 +1,1627 @@
+# Program 28 B2 — The Tick Loop On Screen: implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to execute this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** close Program 28 §7 criterion 3 — a person opens `babylon-client`, sees the county map
+B1 rendered, presses a key to advance the tick, and watches real state change: a tick counter, a
+deterministic state-hash readout, a live per-county legitimation overlay on the map, a state panel
+for the hovered/selected county, and an event feed — all driven by the Rust engine through a new
+persistent tick-loop seam, never a lookalike.
+
+**Architecture:** Five phases in five PRs. Phase A opens a **persistent session** in
+`babylon-tick` — `TickSession<G>`, additive, built by factoring the load half `run_once_into`
+already does into a shared `prepare_rule` helper so the existing one-shot API moves not one byte.
+Phase B authors the **demo content**: a twelve-real-FIPS-county scenario carrying the
+already-conformance-tested `lifecycle/dpd-circuit` rule pack's four archetype value sets, so the
+map has real counties to light up. Phase C **completes B1's still-unbuilt Phase C** (`lens.rs`,
+`map/bands.rs`'s band table, `map/pick.rs`, `map/hud.rs`) but generalizes it to carry TWO lenses
+side by side — ADR170's static Tension lens (ported unmodified) and a new, tick-live Legitimation
+lens reading the field `lifecycle/dpd-circuit` writes every tick — with a lens-picker key so the
+player can see the difference between "declared once" and "moves every tick" honestly. Phase D
+wires the **loop UI**: the advance-tick input, the tick counter, the hash readout, the state
+panel, the event feed. Phase E resurrects the **file-log sink** the deletion ceremony retired,
+proves **determinism** end-to-end, and defines the **eyes-on gate**.
+
+**Tech Stack:** Bevy 0.18.1 (unchanged from B1 — `pan_camera` feature already pinned), the same
+`earcutr`/atlas/tessellate stack B1 built, `log4rs` 1.x (`default-features = false`, the exact
+feature set the deleted `babylon-tui` crate used) resurrected for the client's own file sink,
+`log` 0.4 as the facade that sink listens on — kept fully separate from Bevy's own `tracing`-based
+`LogPlugin`, which keeps printing to the console exactly as `DefaultPlugins` already wires it.
+
+**Source spec:** `docs/superpowers/specs/2026-08-10-program-28-bevy-cutover-roadmap-design.md`
+(§4 client lane, §7 criterion 3, §8 open questions). **Predecessor plan:**
+`docs/superpowers/plans/2026-08-10-b1-county-map-plan.md` (Phase A+B merged as PR #487/#490;
+Phase C `lens.rs`/`map/pick.rs`/`map/hud.rs` and the `band_color` function in `map/bands.rs`
+**were never built** — only `bands.rs`'s `PANEL` constant landed, pre-positioned there by a B1
+adversarial-review fix (F4) specifically so "Task 9 finds one existing declaration to extend, not
+a second one to reconcile." This plan is that extension, generalized — see the Sequencing
+Decision below.
+
+**Governing rulings this plan carries out and does not reopen:**
+
+- **ADR170** — this plan transcribes the Tension lens formula (`phi = v/(v+s)`,
+  `theta = sum(v)/sum(v+s)` as a ratio of sums, `w = (phi-theta)/(phi+theta)`) unchanged, wherever
+  it touches it.
+- **ADR191 R9/R10/R11** — the Director already settled the Iosevka Nerd Font choice, the
+  cartographic insets, and the FOUR-BAND (not continuous-ramp) rendering of the Tension lens; this
+  plan reuses R11's band table verbatim rather than re-deriving it.
+- **ADR193** — `babylon-tick::run_once`/`run_once_into` now construct `HypergraphStore`, not
+  `MemoryGraph`; `state_hash()` calls `encode_state()`, and ADR193 measures that call QUADRATIC in
+  hyperedge count on `HypergraphStore` (22.59 ms at n=2,000 hyperedges; 1.92 s at n=20,000). **This
+  plan's
+  own demo scenario mints twelve `NodeType/TERRITORY` nodes and zero hyperedges** — the cliff does
+  not bite; see the Scale Note below for the arithmetic.
+- **Constitution III.7 (determinism)** and **III.11 (Loud Failure)** — the hash display exists
+  because the hash IS the honesty proof; a county the demo scenario never minted stays `PANEL`,
+  never a fabricated value.
+- **R8/R9 (BSL-first porting, escape by proof)** — nothing in this plan adds Rust simulation logic;
+  the only Rust code this plan writes is client/UI/seam code and a factored-out loader helper. All
+  simulation content stays in the already-merged `lifecycle` rule pack.
+- **No imposed functional forms (2026-07-29 standing ruling)** — the new Legitimation lens invents
+  no threshold and no formula. It colors counties by the **categorical classification the
+  `lifecycle` rule pack already computes and writes** (`territory/legitimation-crisis`: 0 = STABLE,
+  1 = UNSTABLE, 2 = CRISIS), never a newly-derived cut point on the raw index.
+
+## Global Constraints
+
+- Branch from `dev`; conventional commits; every commit ends with
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Worktree execution recipe: symlink `.venv` from the main checkout, copy `data/`, commit with
+  `PYTHONPATH="$PWD/src"` — this plan is docs-only (no Rust build), but a later executor of THIS
+  plan's tasks needs the recipe, so this document carries it for them.
+- Gates for the executing agent: `mise run rust:check` for any `rust/` change (clippy
+  `-D warnings`, workspace, all targets, locked); `mise run check` for the repo-wide fast gate;
+  `mise run qa:regression` and `mise run qa:vault-regression-ci` after any change touching
+  `babylon-tick` — Phase A's refactor must move zero engine bytes, and Phase A Step 4's own test
+  is the first proof of that, not the only one.
+- Vale: `vale <file>` on every Markdown page touched, driven to 0.
+- **CI reality (unchanged from B1):** `rust-gate` runs on `ubuntu-latest`, compile-time Bevy
+  headers only, no display server, no GPU. Every headless test in this plan uses `MinimalPlugins`
+  plus `AssetPlugin`, never `DefaultPlugins`, exactly as B1's `tests/map_mesh.rs` and
+  `tests/map_camera.rs` already establish.
+- **Palette canon** — reuse only already-declared `§9b` tokens (`palette.rs`) and the already-ruled
+  ADR170 four-band table (`PANEL`, `CRIMSON`, `DIM`, `GOLD` from `map/bands.rs`); the new
+  Legitimation lens's three colors (`GREEN_DARK`, `GOLD`, `CRIMSON`) are ALL pre-existing `§9b`
+  tokens — this plan adds no new `Color::srgb_u8` literal anywhere, so
+  `test_no_stray_color_literals_outside_palette_or_a_declared_exemption`'s sweep needs no new
+  exemption entry.
+- **No new babylon-bsl surface.** Every task in this plan reads through `GraphSubstrate`'s existing
+  14 methods (`node_attribute`, `nodes`, …) and `CanonicalState`'s existing `state_hash`. The one
+  API addition anywhere in this plan is `babylon-tick::TickSession` (Phase A) — flagged explicitly,
+  additive only, `run_once`/`run_once_into`/`TickReport` keep their exact current signatures.
+- **Scale note (ADR193 arithmetic, worked here so no task has to re-derive it):** the Phase B demo
+  scenario mints exactly 12 `NodeType/TERRITORY` nodes and declares no `(edge …)`/`(hyperedge …)`
+  forms, so `HypergraphStore::encode_state`'s hyperedge half walks **zero** hyperedges regardless
+  of the measured quadratic constant — the ADR193 table's smallest measured point (n=2,000
+  hyperedges, 22.59 ms) is already ~5,500x this plan's hyperedge count. `state_hash()` runs twice
+  per `advance()` call (pre/post, per `TickSession::advance`, Phase A Task 2) against 12 nodes, ~50
+  scalar attributes and 0 hyperedges — sub-millisecond on the dyadic-half code path both stores
+  share (ADR193: "`nodes`/`edges`/`neighbors` show no consistent direction at any scale"). The
+  cliff is a real, documented future cost (ADR193's own "3,222-US-county target… plausibly crosses
+  10,000 hyperedges once county-level organizational and sector memberships exist") — it belongs to
+  whichever later program mints those memberships, not to this one.
+
+---
+
+## Decision: B2 completes B1's Phase C, generalized to two lenses
+
+**B1's own File Structure table already reserves four files for "Phase C — the lens lane":
+`lens.rs`, `map/bands.rs`'s `band_color`/recolor-system additions, `map/pick.rs`, `map/hud.rs`.
+None of the four landed** — `git log` shows B1 merged only Phase A (#487, the atlas artifact) and
+Phase B (#490, atlas reader/tessellation/mesh/camera); `find rust/crates/babylon-client/src` today
+shows `atlas.rs`, `engine_link.rs`, `lib.rs`, `main.rs`, `palette.rs`, `tessellate.rs`, and
+`map/{bands,camera,mesh,mod}.rs` — `bands.rs` holds only the `PANEL` constant (parked there by a
+B1 adversarial-review fix specifically so a later task would extend, not duplicate, its
+declaration).
+
+The roadmap spec's own B2 line is: *"tick advance, state panels, event feed — the scenario ->
+tick -> hash seam that already runs headless, made visible and playable."* That line does not,
+by itself, require the map to recolor from live ticks — the state panel alone could meet "watch
+state change." But §7 criterion 3 says *"see the county map… and watch state change"* — read
+together with the Director's own aesthetic-and-pedagogy line (*"what game mechanics are both
+engaging AND instill education about the correct revolutionary theory?"*), a tick loop whose only
+visible effect is a text panel while the map sits inert is a materially weaker demo than one where
+the county the player is watching visibly changes color as the tick fires. The map is already
+built (Phase B); Phase C's reserved files are the ONLY place the county-indexed
+lens/hover/recolor/HUD plumbing this needs was ever going to live.
+
+**Decision: this plan builds Phase C's four reserved files as part of its own task list — it does
+not wait for a separate Phase C PR, and it does not duplicate Phase C's interfaces alongside new
+ones.** Concretely:
+
+1. `lens.rs` carries the ADR170 witness (`county_tension`, ported verbatim from the B1 plan's
+   Task 8 spec, corrected for one thing the B1 plan text predates — see below) **and** a second,
+   new witness (`county_legitimation`) reading the field the tick loop actually moves.
+2. `map/bands.rs` gains B1 Task 9's `band_color` function and four-row table (ADR191 R11,
+   unmodified) **and** a second, small three-row table for the Legitimation lens — both are pure
+   presentation constants, no `GameDefines`/`defines_hash` ceremony, exactly as ADR191 R11 already
+   ruled for the first table.
+3. `map/pick.rs` and `map/hud.rs` are B1 Task 10's designs, unmodified, except the HUD now also
+   names which of the two lenses is active (Task 9 below) — this plan adds that honesty rule
+   because two lenses share the color CRIMSON for two different meanings (Tension's "Φ-source,
+   bled" vs. the Legitimation lens's "CRISIS"), and nothing may let a player read one as the other.
+
+**One correction to B1's plan text, made explicit so no one silently inherits it wrong:** B1's
+Task 8 spec writes `pub fn county_tension(graph: &MemoryGraph) -> TensionLens`. ADR193 (merged the
+same day, sequenced textually after B1's plan but landed at the same `dev`-branch tip this plan
+reads) swapped the production substrate from `MemoryGraph` to `HypergraphStore` — `run_once_into`
+and, after Phase A of this plan, `TickSession`, both hold a `HypergraphStore`. **This plan's
+`lens.rs` takes `&dyn GraphSubstrate`, not `&MemoryGraph`** — the trait both stores carry,
+matching what the client actually holds. `MemoryGraph` remains only as the differential-test
+oracle (ADR193's own consequences section).
+
+## Decision: the demo content set is the lifecycle rule pack, alone
+
+Three merged rule packs exist: `fundamental-theorem` and `vitality` (both subject type
+`social-class`) and `lifecycle` (subject type `territory` — the D-P-D' circuit, four bindings
+into `NodeType/TERRITORY` fields, emitting `LIFECYCLE_TRANSITION`/`LEGITIMATION_CRISIS`/
+`LEGITIMATION_RECOVERY` events). `lifecycle` alone, of the three, has a subject type matching
+the map's native unit, and alone produces genuine tick-over-tick numeric change a player can watch
+land on a specific county.
+
+**Running more than one rule pack live in the same session is out of this plan's scope, and here
+is the exact wall it hits:** `babylon-bsl::rule_pipeline::split_content` enforces, by construction
+(`rule_pipeline.rs:299-308`), **exactly one `(rule …)` top-form per content set** —
+
+```text
+"a content set needs exactly one (rule …) top-form, found {N}
+ (§2.2 — intrinsic declarations do not count; deffield/manifest/metric-decl
+ top-forms are not yet split out by this function and would also land here)"
+```
+
+— an `E-LOAD` refusal, not a soft warning. `babylon-tick::run_once`/`run_once_into` (and this
+plan's `TickSession`, which shares the same loader) each take ONE `rule_src` string and can run
+ONE rule pack per session. Wiring `vitality` and `lifecycle` together needs BOTH (a) a
+`babylon-tick` change accepting `Vec<LoadedRule>` and running each in turn against one shared
+graph within one game-tick (their subject types are disjoint — `social-class` vs. `territory` — so
+nothing about running both against one graph is unsound, only never built), and (b) one scenario
+declaring BOTH subject types' fields, since today's conformance scenarios are single-purpose
+(`two-classes.bscn` for social-class content, `lifecycle-conformance.bscn` for territory content).
+**Both are real, scoped follow-up work someone can build later — flagged here as a deferral, not
+attempted in this plan.** Record an issue against the client/engine lane at PR time (mirroring the
+B1 Task 12
+precedent of opening an issue rather than silently narrowing scope).
+
+---
+
+## File Structure
+
+| Phase | File | Action | Responsibility |
+|---|---|---|---|
+| A | `rust/crates/babylon-tick/src/lib.rs` | Edit | Factor `prepare_rule` out of `run_once_into`; add `pub mod session;` |
+| A | `rust/crates/babylon-tick/src/session.rs` | Create | `TickSession<G>` — load once, `advance()` many times |
+| B | `rust/crates/babylon-client/tests/print_demo_counties.rs` | Create (throwaway aid) | One-shot atlas print, deleted after use |
+| B | `rust/crates/babylon-tick/content/scenarios/us-counties-lifecycle-demo.bscn` | Create | 12 real-FIPS territory nodes, lifecycle fields |
+| C | `rust/crates/babylon-client/src/lens.rs` | Create | `county_tension` (ADR170, ported) + `county_legitimation` (new) |
+| C | `rust/crates/babylon-client/src/map/bands.rs` | Edit | ADR191 R11's `band_color` (Tension) + a new legitimation band function |
+| C | `rust/crates/babylon-client/src/map/pick.rs` | Create | Uniform-grid hit test (B1 Task 10's design) |
+| C | `rust/crates/babylon-client/src/map/hud.rs` | Create | Hover/selection readout, active-lens label, absence banner |
+| C | `rust/crates/babylon-client/src/map/mod.rs` | Edit | Wire the three new modules + lens-picker input |
+| D | `rust/crates/babylon-client/src/engine_link.rs` | Edit | `EngineSession` resource: `TickSession<HypergraphStore>` + `CollectingSink` + FIPS↔`NodeId` map |
+| D | `rust/crates/babylon-client/src/main.rs` | Edit | Advance-tick input, tick counter, hash readout, event feed |
+| E | `rust/crates/babylon-client/src/logging.rs` | Create | Resurrected `log4rs` file sink |
+| E | `rust/crates/babylon-client/Cargo.toml` | Edit | `log`, `log4rs` deps |
+| E | `rust/crates/babylon-client/tests/determinism.rs` | Create | Same-content, same-tick-count ⇒ same hash, end to end |
+| E | `rust/crates/babylon-client/tests/eyes_on_smoke.rs` | Create | Headless proxy for the eyes-on gate |
+
+---
+
+## Phase A — The persistent tick session
+
+### Task 1: Factor `prepare_rule` out of `run_once_into`
+
+**Files:**
+
+- Edit: `rust/crates/babylon-tick/src/lib.rs`
+
+**Interfaces:**
+
+- Produces: `pub(crate) struct PreparedRule { loaded: LoadedRule, types: TypeEnv, intrinsics:
+  IntrinsicCosts, consts: HashMap<String, Value> }` and `pub(crate) fn prepare_rule<G:
+  GraphSubstrate + CanonicalState>(scenario_src: &str, rule_src: &str, graph: &mut G) ->
+  Result<PreparedRule, String>` — everything `run_once_into` currently does BEFORE its call to
+  `run_tick`.
+- Consumes (unchanged): `split_content`, `parse_intrinsic_decls`, `IntrinsicCosts::new`,
+  `load_scenario`, `TypeEnv`, `BindingVocabulary`, `CardinalityCeilings`, `LoadContext`,
+  `load_rule_form` — every import already at the top of `lib.rs` stays.
+
+This is a **pure extraction, zero behavior change**: `run_once_into`'s existing 130-odd lines
+split at exactly the point after `let loaded = load_rule_form(...)` — everything before that line
+moves into `prepare_rule`, returning the four values it currently holds locally; everything from
+`run_tick(...)` onward stays in `run_once_into`, now reading `prepared.loaded`,
+`prepared.types`, and so on, instead of local bindings.
+
+- [ ] **Step 1: Write the regression-proof test FIRST** (red only in the sense that it must stay
+      green through the refactor — there is no new behavior to fail on). Confirm the two existing
+      tests already cover this:
+
+```rust
+// already in lib.rs's #[cfg(test)] mod tests — read, do not duplicate:
+//   run_once_is_deterministic (two-classes.bscn / the fundamental-theorem rule)
+// already in tests/engine_link.rs (babylon-client):
+//   startup_tick_matches_the_pinned_hash — hex(&report.after) ==
+//   "783f651d04d32fffd0109e88423eb7a57b1e0836ed4a9f645d3a8a554e427679"
+```
+
+      Run both now, before touching any code: `cargo test -p babylon-tick` and
+      `cargo test -p babylon-client --test engine_link` → both PASS. This is the baseline the
+      refactor must not move.
+- [ ] **Step 2: Extract `prepare_rule`.**
+
+```rust
+/// Everything `run_once_into` does before running a single tick: parse the
+/// intrinsic declarations, load the scenario into `graph`, and load the
+/// one `(rule …)` form against the vocabulary/types/ceilings that scenario
+/// declared. Shared by `run_once_into` (which still runs exactly tick 1)
+/// and `TickSession::new` (`session.rs`), which runs this ONCE and then
+/// calls `run_tick` many times against the result — the split B2 needed
+/// and `run_once_into`'s hardcoded tick number could not express.
+pub(crate) struct PreparedRule {
+    pub loaded: LoadedRule,
+    pub types: TypeEnv,
+    pub intrinsics: IntrinsicCosts,
+    pub consts: HashMap<String, Value>,
+}
+
+pub(crate) fn prepare_rule<G: GraphSubstrate + CanonicalState>(
+    scenario_src: &str,
+    rule_src: &str,
+    graph: &mut G,
+) -> Result<PreparedRule, String> {
+    let (intrinsic_forms, rule_form) = split_content(rule_src).map_err(|e| e.to_string())?;
+    let declared = parse_intrinsic_decls(&intrinsic_forms).map_err(|e| e.to_string())?;
+    let intrinsics = IntrinsicCosts::new(
+        declared
+            .into_iter()
+            .map(|(name, decl)| (name, decl.cost))
+            .collect(),
+    );
+
+    let scenario = load_scenario(scenario_src, graph).map_err(|e| e.to_string())?;
+
+    let types = TypeEnv {
+        fields: scenario.fields.clone(),
+        exemptions: &[],
+    };
+    let vocabulary = BindingVocabulary {
+        fields: scenario.fields.keys().cloned().collect(),
+        consts: scenario.consts.keys().cloned().collect(),
+        metrics: HashSet::new(),
+    };
+    let ceilings = CardinalityCeilings::new(
+        scenario
+            .node_types
+            .iter()
+            .map(|(member, count)| (format!("NodeType/{member}"), *count))
+            .collect(),
+        HashMap::new(),
+    );
+    let systems: HashSet<String> = HashSet::from([
+        "economics".to_owned(),
+        "vitality".to_owned(),
+        "consciousness".to_owned(),
+        "lifecycle".to_owned(),
+    ]);
+
+    let ctx = LoadContext {
+        vocabulary: &vocabulary,
+        types: &types,
+        ceilings: &ceilings,
+        intrinsics: &intrinsics,
+        systems: &systems,
+        vocabulary_registry: None,
+        rule_file: "rule",
+    };
+    let loaded = load_rule_form(rule_form, &ctx).map_err(|e| format!("rule rejected: {e}"))?;
+
+    Ok(PreparedRule {
+        loaded,
+        types,
+        intrinsics,
+        consts: scenario.consts,
+    })
+}
+```
+
+- [ ] **Step 3: Rewrite `run_once_into` to call it.**
+
+```rust
+pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
+    scenario_src: &str,
+    rule_src: &str,
+    graph: &mut G,
+    sink: &mut CollectingSink,
+) -> Result<TickReport, String> {
+    let prepared = prepare_rule(scenario_src, rule_src, graph)?;
+
+    let before = graph
+        .state_hash()
+        .map_err(|e| format!("pre-tick state: {}", e.message))?;
+
+    let outcome = run_tick(
+        &prepared.loaded,
+        &prepared.types,
+        &KernelIntrinsicHost,
+        graph,
+        sink,
+        &prepared.intrinsics,
+        &prepared.consts,
+        1,
+    )
+    .map_err(|e| format!("tick failed: {e}"))?;
+
+    let after = graph
+        .state_hash()
+        .map_err(|e| format!("post-tick state: {}", e.message))?;
+
+    Ok(TickReport {
+        before,
+        after,
+        fired: outcome.fired,
+    })
+}
+```
+
+      Note the pre-tick hash is now taken AFTER `prepare_rule` returns rather than immediately
+      after `load_scenario` — this is the same point in program order (nothing between the old
+      `load_scenario` call and the old `before` computation touches `graph`), so the hash value is
+      identical; only the code that produces it moved.
+- [ ] **Step 4:** Run both Step 1 tests again → PASS, byte-identical hash. `mise run rust:check` →
+      green. `mise run qa:regression` and `mise run qa:vault-regression-ci` → byte-identical (this
+      refactor is inside the engine crate; both gates must stay silent).
+- [ ] **Step 5: Commit** (`refactor(rust): factor prepare_rule out of run_once_into — zero behavior
+      change (B2)`).
+
+### Task 2: `TickSession<G>` — load once, advance many times
+
+**Files:**
+
+- Create: `rust/crates/babylon-tick/src/session.rs`
+- Edit: `rust/crates/babylon-tick/src/lib.rs` (`pub mod session;`, re-export)
+
+**Interfaces:**
+
+- Produces:
+
+```rust
+pub struct TickSession<G> { /* private: graph, prepared, tick */ }
+
+impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
+    pub fn new(scenario_src: &str, rule_src: &str, graph: G) -> Result<Self, String>;
+    pub fn advance(&mut self, sink: &mut CollectingSink) -> Result<TickReport, String>;
+    pub fn tick(&self) -> i64;
+    pub fn graph(&self) -> &G;
+}
+```
+
+  Every later task in this plan (Phase C's lens producers, Phase D's UI) reads state through
+  `session.graph()` and drives the loop through `session.advance(&mut sink)`. This is the ONE
+  babylon-tick API addition this plan makes — `run_once`, `run_once_into` and `TickReport` are
+  untouched (Task 1 proved that); a caller that only ever wants tick 1 still calls `run_once`.
+
+- [ ] **Step 1: Write the failing tests.**
+
+```rust
+use crate::session::TickSession;
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::hypergraph_store::HypergraphStore;
+
+const SCENARIO: &str = include_str!("../content/scenarios/lifecycle-conformance.bscn");
+const RULE: &str = include_str!("../content/rules/lifecycle.bsl");
+
+#[test]
+fn advance_numbers_ticks_starting_at_one() {
+    let mut session = TickSession::new(SCENARIO, RULE, HypergraphStore::new()).expect("load");
+    assert_eq!(session.tick(), 0);
+    let mut sink = CollectingSink::default();
+    session.advance(&mut sink).expect("tick 1");
+    assert_eq!(session.tick(), 1);
+    session.advance(&mut sink).expect("tick 2");
+    assert_eq!(session.tick(), 2);
+}
+
+#[test]
+fn advance_moves_state_and_each_tick_hashes_differently() {
+    let mut session = TickSession::new(SCENARIO, RULE, HypergraphStore::new()).expect("load");
+    let mut sink = CollectingSink::default();
+    let t1 = session.advance(&mut sink).expect("tick 1");
+    let t2 = session.advance(&mut sink).expect("tick 2");
+    assert_ne!(t1.before, t1.after, "tick 1 must move state");
+    assert_eq!(t1.after, t2.before, "tick 2 starts where tick 1 left off");
+    assert_ne!(t2.before, t2.after, "tick 2 must move state too — not a one-shot");
+}
+
+#[test]
+fn two_independent_sessions_over_the_same_content_hash_identically() {
+    // The determinism guard this plan's own instructions require, at the
+    // babylon-tick level — Phase E's test (tests/determinism.rs in
+    // babylon-client) repeats this same property through the client's own
+    // seam end to end.
+    let mut a = TickSession::new(SCENARIO, RULE, HypergraphStore::new()).expect("load a");
+    let mut b = TickSession::new(SCENARIO, RULE, HypergraphStore::new()).expect("load b");
+    let mut sink_a = CollectingSink::default();
+    let mut sink_b = CollectingSink::default();
+    for _ in 0..5 {
+        let ra = a.advance(&mut sink_a).expect("a advances");
+        let rb = b.advance(&mut sink_b).expect("b advances");
+        assert_eq!(ra.after, rb.after, "same content + same tick count must hash identically");
+    }
+}
+```
+
+- [ ] **Step 2:** `cargo test -p babylon-tick` → FAIL (`session` module does not exist).
+- [ ] **Step 3: Write `session.rs`.**
+
+```rust
+//! `TickSession` — the persistent load-once, advance-many seam B2 needs.
+//! `run_once`/`run_once_into` (`lib.rs`) model exactly one tick end to end
+//! and hardcode `run_tick`'s tick argument to `1`; a player-driven loop
+//! needs the split this type provides instead: parse and load cost paid
+//! ONCE in `new`, the SAME `PreparedRule` and the SAME graph reused by
+//! every `advance()` call, with `tick` incremented by this type rather
+//! than by the caller re-guessing a number `run_tick` never exposed.
+
+use crate::{prepare_rule, PreparedRule, TickReport};
+use babylon_bsl::intrinsic_host::KernelIntrinsicHost;
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_bsl::tick::run_tick;
+use babylon_graph::state_hash::CanonicalState;
+use babylon_graph::substrate::GraphSubstrate;
+
+/// One content set, loaded once, advanced tick by tick against ONE held
+/// graph. `G` is caller-supplied (same shape as `run_once_into`) so the
+/// caller picks the substrate — production callers pass `HypergraphStore`
+/// (ADR193).
+pub struct TickSession<G> {
+    graph: G,
+    prepared: PreparedRule,
+    tick: i64,
+}
+
+impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
+    /// Parse `rule_src` and load `scenario_src` into `graph` once.
+    ///
+    /// # Errors
+    /// The same failure modes `run_once_into`'s load half has: an
+    /// intrinsic declaration, a scenario load, or a rule load.
+    pub fn new(scenario_src: &str, rule_src: &str, mut graph: G) -> Result<Self, String> {
+        let prepared = prepare_rule(scenario_src, rule_src, &mut graph)?;
+        Ok(Self {
+            graph,
+            prepared,
+            tick: 0,
+        })
+    }
+
+    /// Run one more tick against the held graph. The first call runs tick
+    /// 1 (matching `run_once`'s own numbering), the second tick 2, and so
+    /// on — `:tick`/`:tick-in-cycle` bindings (§2.5) now see a real,
+    /// advancing count outside a test harness for the first time.
+    ///
+    /// # Errors
+    /// The tick itself, or a pre/post state-hash failure.
+    pub fn advance(&mut self, sink: &mut CollectingSink) -> Result<TickReport, String> {
+        self.tick += 1;
+        let before = self
+            .graph
+            .state_hash()
+            .map_err(|e| format!("pre-tick state: {}", e.message))?;
+        let outcome = run_tick(
+            &self.prepared.loaded,
+            &self.prepared.types,
+            &KernelIntrinsicHost,
+            &mut self.graph,
+            sink,
+            &self.prepared.intrinsics,
+            &self.prepared.consts,
+            self.tick,
+        )
+        .map_err(|e| format!("tick failed: {e}"))?;
+        let after = self
+            .graph
+            .state_hash()
+            .map_err(|e| format!("post-tick state: {}", e.message))?;
+        Ok(TickReport {
+            before,
+            after,
+            fired: outcome.fired,
+        })
+    }
+
+    /// The current tick number — 0 before the first `advance()` call.
+    #[must_use]
+    pub fn tick(&self) -> i64 {
+        self.tick
+    }
+
+    /// Read-only access to the held graph — the client's map lens and
+    /// state panel project live state through this.
+    #[must_use]
+    pub fn graph(&self) -> &G {
+        &self.graph
+    }
+}
+```
+
+      `lib.rs` needs `PreparedRule`/`prepare_rule` visible to `session.rs` (same crate,
+      `pub(crate)` from Task 1 already covers this) plus `pub mod session;` and, for the client's
+      convenience, `pub use session::TickSession;` alongside the existing `pub use` of `TickReport`.
+- [ ] **Step 4:** `cargo test -p babylon-tick` → PASS (all three new tests, plus the two Task 1
+      regression tests still green). `mise run rust:check` → green.
+- [ ] **Step 5: Commit** (`feat(rust): TickSession — persistent load-once/advance-many tick loop
+      seam (B2)`).
+
+---
+
+## Phase B — The demo content
+
+### Task 3: Twelve real-FIPS demo counties
+
+**Files:**
+
+- Create (temporary aid, deleted at Step 4): `rust/crates/babylon-client/tests/print_demo_counties.rs`
+- Create: `rust/crates/babylon-tick/content/scenarios/us-counties-lifecycle-demo.bscn`
+
+**The point of this task:** `lifecycle-conformance.bscn`'s four territory nodes
+(`core-county`/`growing-county`/`recovering-county`/`young-county`) carry proven-correct fixture
+values (Task 2's tests already exercise them through the `lifecycle` rule pack) but carry synthetic local
+names with no FIPS code, so `CountyAtlas::index_of_fips` cannot place them on the B1 map. This
+task re-stamps the SAME four archetype value sets onto twelve REAL FIPS codes so the map has real
+counties to light up, without inventing new numbers this plan's author cannot verify.
+
+- [ ] **Step 1: Select the twelve FIPS, deterministically, from the committed atlas — never
+      guessed.** B1 Task 1 Step 5 sorts the atlas's county table by FIPS ascending before writing,
+      so atlas indices `0..12` are the twelve lowest-FIPS counties in the whole 3,222-county
+      artifact, whatever they are. Print them:
+
+```rust
+// tests/print_demo_counties.rs — a one-shot reporting aid, not a permanent
+// test. Delete this file in Step 4 once its output is transcribed below.
+use babylon_client::atlas::CountyAtlas;
+
+const ATLAS_BYTES: &[u8] = include_bytes!("../assets/map/county_atlas.bin");
+
+#[test]
+#[ignore = "one-shot reporting aid — run manually, transcribe, then this file is deleted"]
+fn print_first_twelve() {
+    let atlas = CountyAtlas::parse(ATLAS_BYTES).expect("committed atlas parses");
+    for i in 0..12 {
+        let c = atlas.county(i).expect("index within range");
+        println!("{i}: fips={} name={}", c.fips, c.name);
+    }
+}
+```
+
+      Run: `cargo test -p babylon-client --test print_demo_counties -- --ignored --nocapture`.
+      Record the twelve printed `(fips, name)` pairs in this task's commit body verbatim — this is
+      the only place in this plan a FIPS code is fixed, and it is fixed by running code against the
+      committed artifact, not by recall.
+- [ ] **Step 2: Write the scenario.** Reuse the `lifecycle-conformance.bscn` header's `deffield`
+      block and all 21 `defconst` rows byte-for-byte (same field types, same coefficient values,
+      same `defines.yaml` line citations in the comments — this task changes WHICH nodes exist,
+      never what the rule pack computes over them). Cycle the four archetype value sets from
+      `lifecycle-conformance.bscn:80-124` across the twelve FIPS in order (indices 0-2 get the
+      `core-county` values, 3-5 `growing-county`, 6-8 `recovering-county`, 9-11 `young-county`),
+      naming each node `county-<fips>` (symbols must start with a lowercase letter — §1's
+      `symbol ::= LOWER (LOWER | DIGIT | "-")*` — a bare FIPS like `06037` is not a legal symbol,
+      `county-06037` is):
+
+```text
+(scenario lifecycle/us-counties-demo
+  (deffield territory/pop-d int extensive)
+  (deffield territory/pop-p int extensive)
+  (deffield territory/pop-d-prime int extensive)
+  (deffield territory/wealth-d-prime int extensive)
+  (deffield territory/dependency-ratio int intensive)
+  (deffield territory/legitimation-index int intensive)
+  (deffield territory/legitimation-crisis int intensive)
+  (deffield territory/transmitted-ideology int intensive)
+
+  ; ... all 21 defconst rows, transcribed verbatim from
+  ; lifecycle-conformance.bscn:56-76, same values, same :NNN citations ...
+
+  ; county-<fips[0]>, county-<fips[1]>, county-<fips[2]>: the core-county
+  ; archetype (DPDState docstring numbers, PRE-crisis STABLE).
+  (node county-<fips[0]> NodeType/TERRITORY
+    (territory/pop-d 2150) (territory/pop-p 6050) (territory/pop-d-prime 1800)
+    (territory/wealth-d-prime 10000000) (territory/dependency-ratio 0)
+    (territory/legitimation-index 0) (territory/legitimation-crisis 0)
+    (territory/transmitted-ideology 0))
+  ; ... repeated for fips[1], fips[2] with the same values ...
+
+  ; county-<fips[3..6]>: the growing-county archetype (PRE-crisis UNSTABLE).
+  ; county-<fips[6..9]>: the recovering-county archetype (PRE-crisis CRISIS,
+  ;   fires LEGITIMATION_RECOVERY on tick 1 under these defconsts, same as
+  ;   the conformance scenario).
+  ; county-<fips[9..12]>: the young-county archetype (no D' cohort).
+  )
+```
+
+      Write out all twelve `(node …)` forms in full — no ellipsis in the committed file, the
+      ellipses above are this plan document's abbreviation only.
+- [ ] **Step 3: A loading test.**
+
+```rust
+// rust/crates/babylon-tick/tests/us_counties_demo.rs (new file)
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::hypergraph_store::HypergraphStore;
+use babylon_tick::TickSession;
+
+const SCENARIO: &str = include_str!("../content/scenarios/us-counties-lifecycle-demo.bscn");
+const RULE: &str = include_str!("../content/rules/lifecycle.bsl");
+
+#[test]
+fn the_demo_scenario_loads_and_ticks() {
+    let mut session = TickSession::new(SCENARIO, RULE, HypergraphStore::new()).expect("load");
+    let mut sink = CollectingSink::default();
+    let report = session.advance(&mut sink).expect("tick 1");
+    assert_ne!(report.before, report.after);
+    // The recovering-county archetype fires LEGITIMATION_RECOVERY on tick 1
+    // under these defconsts (matching lifecycle-conformance.bscn's own
+    // documented behavior) — proves the twelve nodes really run the rule,
+    // not just mint successfully.
+    assert!(sink
+        .events
+        .iter()
+        .any(|(name, _)| name == "EventType/LEGITIMATION_RECOVERY"));
+}
+```
+
+      `cargo test -p babylon-tick --test us_counties_demo` → PASS.
+- [ ] **Step 4:** Delete `tests/print_demo_counties.rs` — it has finished its job, and its own doc
+      comment says so; a stale `#[ignore]`d test that prints fixed array indices against a file
+      that could later change underneath is exactly the kind of orphan CLAUDE.md's Surgical
+      Changes rule asks an author to clean up when a task's own steps create one.
+- [ ] **Step 5: Commit** (`feat(content): twelve-real-FIPS lifecycle demo scenario for the B2 tick
+      loop`), body carrying the Step 1 FIPS/name table.
+
+---
+
+## Phase C — The dual-lens map (completes B1 Phase C)
+
+### Task 4: The Tension lens, ported and corrected for `HypergraphStore`
+
+**Files:**
+
+- Create: `rust/crates/babylon-client/src/lens.rs`
+- Edit: `rust/crates/babylon-client/src/lib.rs` (`pub mod lens;`)
+
+**Interfaces:**
+
+- Produces:
+
+```rust
+pub struct LensReading {
+    pub cells: Vec<(String, Option<f64>)>, // (fips, value) — shared shape both lenses return
+    pub absent_reason: Option<String>,
+}
+pub fn county_tension(graph: &dyn GraphSubstrate) -> LensReading;
+```
+
+- [ ] **Step 1: Write the failing tests**, hand-building small `HypergraphStore`s (not
+      `MemoryGraph` — the Sequencing Decision's correction applies here first): (a) two territories
+      with clean stamps where `theta` (computed internally — `LensReading` carries only `w` per
+      cell) differs from the mean of the two `phi`s; (b) a bled county scores
+      `w < 0`, a bribed county `w > 0`; (c) a territory with `s > 0, e == 0` contributes nothing and
+      reports `None`; (d) a graph with zero data-bearing territory nodes yields
+      `absent_reason.is_some()` and every cell `None`; (e) every returned `w` lands in `[-1, 1]`.
+- [ ] **Step 2:** FAIL, then write it — the ADR170 formula transcribed exactly as B1's Task 8
+      specified (`phi = v/(v+s)`, `theta = sum(v)/sum(v+s)`, `w = (phi-theta)/(phi+theta)`,
+      `phi+theta <= 1e-9` collapses to `0.0`), reading `graph.nodes("NodeType/TERRITORY")` and
+      `graph.node_attribute(id, "...")` through `&dyn GraphSubstrate` rather than a concrete store.
+- [ ] **Step 3:** `cargo test -p babylon-client` → PASS.
+- [ ] **Step 4: Commit** (`feat(client): the ADR170 tension witness over &dyn GraphSubstrate (B2)`).
+
+### Task 5: The Legitimation lens — live, categorical, zero new math
+
+**Files:**
+
+- Edit: `rust/crates/babylon-client/src/lens.rs`
+
+**Interfaces:**
+
+- Produces: `pub fn county_legitimation(graph: &dyn GraphSubstrate, node_by_fips: &[(String,
+  NodeId)]) -> LensReading` and `pub enum LegitimationClass { Stable, Unstable, Crisis }` with
+  `pub fn classify(raw: f64) -> LegitimationClass`.
+
+**Why this reads a field instead of deriving one.** The `lifecycle` rule pack already computes and
+writes `territory/legitimation-crisis` as an encoded classification (0 = STABLE, 1 = UNSTABLE,
+2 = CRISIS — the rule pack's own header comment documents the encoding, quoted in
+`lifecycle-conformance.bscn`'s comments). Coloring the map from THIS field, rather than re-deriving
+a threshold on the raw `territory/legitimation-index`, adds no new cut point and no new math — this is a straight
+categorical pass-through, consistent with the standing "no imposed functional forms" ruling.
+
+- [ ] **Step 1: Write the failing tests.** A territory whose `legitimation-crisis` reads back
+      `0.0`/`1.0`/`2.0` classifies to `Stable`/`Unstable`/`Crisis` respectively; a `node_by_fips`
+      entry naming a `NodeId` the graph never minted (a coding error, not a real absence — the
+      Phase B scenario controls the whole node set) surfaces as an `Err`, never a silent `None`,
+      because unlike Tension's "this county may honestly have no data," a demo-scenario FIPS with
+      no matching node is a wiring bug; only FIPS NOT in `node_by_fips` at all are the honest
+      "outside the demo, no data this tick" absence.
+- [ ] **Step 2:** FAIL, then write it: `classify` is a plain three-arm match on the encoded
+      float (`0.0 => Stable`, `1.0 => Unstable`, `2.0 => Crisis`, anything else a loud panic — the
+      encoding is a closed set the rule pack itself defines); `county_legitimation` reads
+      `territory/legitimation-crisis` for every `(fips, id)` pair in `node_by_fips` and returns
+      `Some(raw_class_as_f64)` per cell (kept as the raw encoded number in `LensReading.cells` so
+      `map/bands.rs`'s consumer, not this module, owns the color mapping — matching the Tension
+      lens's own separation of "compute the value" from "pick the color").
+- [ ] **Step 3:** `cargo test -p babylon-client` → PASS.
+- [ ] **Step 4: Commit** (`feat(client): the legitimation lens — live per-tick classification, zero
+      new thresholds (B2)`).
+
+### Task 6: Two band tables, one recolor system
+
+**Files:**
+
+- Edit: `rust/crates/babylon-client/src/map/bands.rs`
+
+**Interfaces:**
+
+- Produces: `pub fn tension_band_color(w: Option<f64>) -> Color` (ADR191 R11's table, exactly as
+  the B1 plan's Task 9 specified — four rows, `<=` resolution, `PANEL` for absence) and `pub fn
+  legitimation_band_color(class: Option<f64>) -> Color` (three rows: `Some(0.0) => GREEN_DARK`,
+  `Some(1.0) => GOLD`, `Some(2.0) => CRIMSON`, `None => PANEL`) plus `pub enum ActiveLens { Tension,
+  Legitimation }` and `#[derive(Event)] pub struct LensChanged;`.
+
+- [ ] **Step 1: Write the failing tests** for both band functions — the exact `Srgba` byte
+      assertions from the B1 Task 9 spec for `tension_band_color` (CRIMSON at `w <= -0.15`, DIM in
+      `(-0.15, 0.15]`, GOLD above, PANEL for `None`) plus the three-plus-one assertions for
+      `legitimation_band_color`. Assert `tension_band_color(Some(0.0)) != tension_band_color(None)`
+      and the same non-confusion property for `legitimation_band_color` — absence must never read
+      as the neutral/stable band in either lens.
+- [ ] **Step 2:** FAIL, then write both as `const` tables resolved by the same `<=`-walk shape,
+      matching `PANEL`'s existing declaration in this file.
+- [ ] **Step 3: The recolor system.** One system, parameterized by `ActiveLens`:
+
+```rust
+pub(super) fn recolor_on_lens_changed(
+    mut events: EventReader<LensChanged>,
+    active: Res<ActiveLens>,
+    lens_data: Res<CurrentLensData>, // holds both LensReading values, refreshed every advance
+    surface: Res<MapSurface>,
+    atlas_index: Res<FipsIndex>,     // fips -> atlas county index, from Task 9
+    mut meshes: ResMut<Assets<Mesh>>,
+) {
+    if events.read().next().is_none() {
+        return;
+    }
+    let reading = match *active {
+        ActiveLens::Tension => &lens_data.tension,
+        ActiveLens::Legitimation => &lens_data.legitimation,
+    };
+    let color_fn: fn(Option<f64>) -> Color = match *active {
+        ActiveLens::Tension => tension_band_color,
+        ActiveLens::Legitimation => legitimation_band_color,
+    };
+    let Some(mesh) = meshes.get_mut(&surface.fill_mesh) else {
+        return;
+    };
+    let Some(colors) = mesh
+        .attribute_mut(Mesh::ATTRIBUTE_COLOR)
+        .and_then(|a| a.as_float3_mut())
+    else {
+        return;
+    };
+    for (fips, value) in &reading.cells {
+        let Some(&county_idx) = atlas_index.by_fips.get(fips) else {
+            continue;
+        };
+        let (start, end) = surface.tessellation.county_vertex_range[county_idx as usize];
+        let rgba = color_fn(*value).to_linear().to_f32_array();
+        for v in &mut colors[start as usize..end as usize] {
+            *v = [rgba[0], rgba[1], rgba[2]];
+        }
+    }
+}
+```
+
+      One pass, one buffer, matching B1 Task 9's own "no mesh rebuild" design — this is the same
+      recolor shape B1's plan already specified, now parameterized over which lens is active
+      instead of hardcoded to Tension alone.
+- [ ] **Step 4: Headless test** — `MinimalPlugins` + `AssetPlugin`, install a `CurrentLensData`
+      with one known Legitimation cell, set `ActiveLens::Legitimation`, fire `LensChanged`, `update()`,
+      assert that county's vertex range shows `legitimation_band_color`'s output and every other
+      county's colors held at `PANEL`.
+- [ ] **Step 5: Commit** (`feat(client): two-lens band tables + a lens-parameterized recolor system
+      (B2, completes B1 Phase C Task 9)`).
+
+### Task 7: Hover, selection, the active-lens label
+
+**Files:**
+
+- Create: `rust/crates/babylon-client/src/map/pick.rs`, `rust/crates/babylon-client/src/map/hud.rs`
+
+**Interfaces:**
+
+- Produces: `pub struct CountyIndex; pub fn build(atlas: &CountyAtlas) -> CountyIndex; pub fn
+  county_at(&self, p: Vec2) -> Option<usize>` (verbatim B1 Task 10 design — uniform grid over
+  `world_bounds()`, even-odd ring crossing test, holes inverting membership); `HoveredCounty` and
+  `SelectedCounty` resources; the HUD text, now carrying an explicit lens label.
+
+- [ ] **Step 1: Write the failing tests** for `county_at` — the same three properties B1 Task 10
+      specified: each county's own centroid resolves to itself (floor, not 100%, with exceptions
+      listed by FIPS in the test comment); a point in the Gulf of Mexico gives `None`; a point
+      inside a county's bounding box but outside its ring gives `None`; the index is identical
+      across two builds.
+- [ ] **Step 2:** FAIL, then write it: a 128x128 uniform grid, bounding-box candidate lists,
+      even-odd crossing against the winning candidate's rings.
+- [ ] **Step 3: Wire the interaction** — `Camera::viewport_to_world_2d` → `county_at` → `HoveredCounty`;
+      click promotes to `SelectedCounty`; a GOLD outline at `z = 2.0` over the selection.
+- [ ] **Step 4: The HUD**, extended past B1 Task 10's spec with the lens label this plan's honesty
+      rule adds. Bottom-left, BONE text:
+
+```text
+<county name>, <state> (<FIPS>)
+Lens: Tension — w = -0.42 (Φ-source, bled)          [if ActiveLens::Tension]
+Lens: Legitimation — CRISIS (live, tick 7)          [if ActiveLens::Legitimation]
+Lens: Tension — no data this tick                    [absence, either lens]
+```
+
+      Top-left banner whenever the active lens's `absent_reason.is_some()`, in CRIMSON. A
+      persistent DIM footer names which lens is inactive and how to switch (Task 9): "Tab: switch
+      to Legitimation lens" or vice versa — the map must never let a color mean two things without
+      saying which one is live.
+- [ ] **Step 5: Headless test** — hovering a known world point sets `HoveredCounty` to the expected
+      FIPS, cursor position written directly to the resource (B1 Task 10's own precedent, not
+      synthesized window events).
+- [ ] **Step 6: Commit** (`feat(client): county hover, selection and the active-lens HUD (B2,
+      completes B1 Phase C Task 10)`).
+
+### Task 8: Wire `map/mod.rs` — the lens picker
+
+**Files:**
+
+- Edit: `rust/crates/babylon-client/src/map/mod.rs`
+
+- [ ] **Step 1: Write the failing headless test** — `MinimalPlugins` + `AssetPlugin` +
+      `babylon_client::map::MapPlugin`, press `Tab` (write directly into `ButtonInput<KeyCode>`,
+      matching the input-resource-mutation pattern this plan's tests already use), `update()`,
+      assert `ActiveLens` flipped and a `LensChanged` event fired.
+- [ ] **Step 2:** FAIL, then add: `mod pick; mod hud;` (new modules from this task); `pub use
+      bands::{ActiveLens, LensChanged};` alongside the existing `pub use bands::PANEL;` — the same
+      re-export convention B1 already established for `PANEL`, extended to the two new types so
+      `crate::map::ActiveLens`/`crate::map::LensChanged` (the paths Task 10's and Task 14's code
+      use) resolve; `ActiveLens::Tension` inserted as the `Startup` default resource; an `Update`
+      system reading `Tab` and toggling it plus sending `LensChanged`; Task 6's
+      `recolor_on_lens_changed` system registered.
+- [ ] **Step 3:** `cargo test -p babylon-client` → PASS. `mise run rust:check` → green.
+- [ ] **Step 4: Commit** (`feat(client): wire the lens picker into MapPlugin (B2)`). Open the
+      Phase C PR (`feat(client): B2 Phase C — the dual-lens map, completing B1's Phase C`);
+      self-merge on green.
+
+---
+
+## Phase D — The loop UI
+
+### Task 9: `EngineSession` — the client's held tick session
+
+**Files:**
+
+- Edit: `rust/crates/babylon-client/src/engine_link.rs`
+
+**Interfaces:**
+
+- Produces:
+
+```rust
+pub struct EngineSession {
+    pub inner: TickSession<HypergraphStore>,
+    pub sink: CollectingSink,
+    pub node_by_fips: Vec<(String, NodeId)>,
+}
+impl EngineSession {
+    pub fn start() -> Result<Self, String>;
+    pub fn advance(&mut self) -> Result<TickReport, String>;
+}
+```
+
+**Why `node_by_fips` is a plain `Vec`, not a `babylon-bsl` API addition.** `load_scenario`'s local
+name -> `NodeId` map is deliberately load-time-only and does not outlive the call (`scenario.rs:188`'s
+own comment). This plan does not widen that API. Instead: the Phase B scenario mints EXACTLY the
+twelve `NodeType/TERRITORY` nodes, in file order, and no others; `GraphSubstrate::nodes()` returns
+ascending `NodeId`s, which equal mint order because `NodeId` mints as a monotonic counter (ADR193).
+Zipping `graph.nodes("NodeType/TERRITORY")` against a `const DEMO_FIPS: [&str; 12]` array **in
+the same order as the `.bscn` file's twelve `(node …)` forms** recovers the fips↔id mapping with
+no new babylon-bsl surface — fragile only in the sense that editing the `.bscn` file's node order
+without updating `DEMO_FIPS` would silently mislabel a county, which Step 2's loud startup
+assertion turns into an immediate panic instead.
+
+- [ ] **Step 1: Write the failing test.**
+
+```rust
+#[test]
+fn engine_session_starts_and_the_twelve_fips_resolve_on_the_real_atlas() {
+    let session = EngineSession::start().expect("engine session starts");
+    assert_eq!(session.node_by_fips.len(), 12);
+    let atlas = CountyAtlas::parse(include_bytes!("../assets/map/county_atlas.bin")).unwrap();
+    for (fips, _id) in &session.node_by_fips {
+        assert!(
+            atlas.index_of_fips(fips).is_some(),
+            "demo FIPS {fips} must resolve on the committed atlas"
+        );
+    }
+}
+
+#[test]
+fn engine_session_advance_moves_the_hash_and_the_tick_counter() {
+    let mut session = EngineSession::start().expect("start");
+    let r1 = session.advance().expect("tick 1");
+    let r2 = session.advance().expect("tick 2");
+    assert_eq!(session.inner.tick(), 2);
+    assert_ne!(r1.after, r2.after);
+}
+```
+
+- [ ] **Step 2:** FAIL, then write it:
+
+```rust
+const SCENARIO: &str =
+    include_str!("../../babylon-tick/content/scenarios/us-counties-lifecycle-demo.bscn");
+const RULE: &str = include_str!("../../babylon-tick/content/rules/lifecycle.bsl");
+
+/// Same order as `us-counties-lifecycle-demo.bscn`'s twelve `(node …)`
+/// forms — Task 3's Step 1 print output, transcribed. A loud startup
+/// assertion (below) catches the two arrays ever drifting apart.
+const DEMO_FIPS: [&str; 12] = [ /* the twelve FIPS from Task 3 Step 1, in file order */ ];
+
+pub struct EngineSession {
+    pub inner: TickSession<HypergraphStore>,
+    pub sink: CollectingSink,
+    pub node_by_fips: Vec<(String, NodeId)>,
+}
+
+impl EngineSession {
+    pub fn start() -> Result<Self, String> {
+        let mut graph = HypergraphStore::new();
+        // Load through the same prepare path TickSession uses internally —
+        // but we need the node ids BEFORE TickSession takes ownership of
+        // the graph, so load once here to capture them, then hand a FRESH
+        // graph to TickSession::new (it reloads the same scenario, which
+        // is deterministic and mints the identical twelve ids — proven by
+        // this task's own Step 1 test, which checks both independently).
+        let scenario_nodes = babylon_bsl::scenario::load_scenario(SCENARIO, &mut graph)
+            .map_err(|e| e.to_string())?;
+        let _ = scenario_nodes; // node_count only; the ids come from nodes() below
+        let ids = babylon_graph::substrate::GraphSubstrate::nodes(&graph, "NodeType/TERRITORY");
+        if ids.len() != DEMO_FIPS.len() {
+            panic!(
+                "demo scenario minted {} NodeType/TERRITORY nodes, DEMO_FIPS names {} — \
+                 the array drifted from the .bscn file, fix DEMO_FIPS",
+                ids.len(),
+                DEMO_FIPS.len()
+            );
+        }
+        let node_by_fips: Vec<(String, NodeId)> = DEMO_FIPS
+            .iter()
+            .zip(ids.iter())
+            .map(|(fips, id)| ((*fips).to_owned(), *id))
+            .collect();
+
+        let inner = TickSession::new(SCENARIO, RULE, HypergraphStore::new())
+            .map_err(|e| format!("tick session: {e}"))?;
+
+        Ok(Self {
+            inner,
+            sink: CollectingSink::default(),
+            node_by_fips,
+        })
+    }
+
+    pub fn advance(&mut self) -> Result<TickReport, String> {
+        self.inner.advance(&mut self.sink)
+    }
+}
+```
+
+      Note the deliberate double-load (once to recover ids, once inside `TickSession::new`) rather
+      than widening `TickSession` to expose its internal graph mutably before the first `advance` —
+      it costs one extra scenario parse at startup (microseconds against a 12-node scenario) and
+      keeps `TickSession`'s public surface exactly the four methods Task 2 specified.
+- [ ] **Step 3:** `cargo test -p babylon-client` → PASS.
+- [ ] **Step 4: Commit** (`feat(client): EngineSession — the client's held TickSession + fips↔id
+      map (B2)`).
+
+### Task 10: Advance-tick input, tick counter, hash readout
+
+**Files:**
+
+- Edit: `rust/crates/babylon-client/src/main.rs`
+
+- [ ] **Step 1: Write the failing headless test.**
+
+```rust
+// tests/tick_loop.rs
+use bevy::asset::AssetPlugin;
+use bevy::prelude::*;
+
+#[test]
+fn pressing_space_advances_the_tick_and_updates_the_hash_text() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, AssetPlugin::default(), InputPlugin));
+    app.add_plugins(babylon_client::map::MapPlugin);
+    app.add_plugins(babylon_client::loop_ui::TickLoopPlugin);
+    app.update(); // Startup: EngineSession inserted, tick 0
+
+    let counter = app.world().resource::<babylon_client::loop_ui::TickCounter>();
+    assert_eq!(counter.0, 0);
+
+    let mut input = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+    input.press(KeyCode::Space);
+    app.update();
+
+    let counter = app.world().resource::<babylon_client::loop_ui::TickCounter>();
+    assert_eq!(counter.0, 1);
+}
+```
+
+- [ ] **Step 2:** FAIL (`loop_ui` module does not exist).
+- [ ] **Step 3: Write `src/loop_ui.rs`** (new module, `pub mod loop_ui;` in `lib.rs`):
+
+```rust
+//! The B2 tick loop's own UI plumbing: Space advances the tick, a text
+//! node shows the counter and the deterministic hash — the honesty proof
+//! (III.7) rendered where the player can see it move.
+
+use crate::engine_link::EngineSession;
+use bevy::prelude::*;
+
+#[derive(Resource, Default)]
+pub struct TickCounter(pub i64);
+
+#[derive(Component)]
+pub struct HashReadout;
+
+#[derive(Component)]
+pub struct TickCounterReadout;
+
+pub struct TickLoopPlugin;
+
+impl Plugin for TickLoopPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(TickCounter::default());
+        app.add_systems(Startup, spawn_engine_session_and_hud);
+        app.add_systems(Update, (advance_on_space, refresh_readouts).chain());
+    }
+}
+
+fn spawn_engine_session_and_hud(mut commands: Commands) {
+    let session = EngineSession::start()
+        .unwrap_or_else(|e| panic!("engine session failed to start: {e}"));
+    commands.insert_resource(session);
+    commands.spawn((
+        Text::new("tick 0"),
+        TextColor(crate::palette::BONE),
+        Node {
+            position_type: PositionType::Absolute,
+            bottom: px(24),
+            right: px(24),
+            ..default()
+        },
+        TickCounterReadout,
+    ));
+    commands.spawn((
+        Text::new("hash: (not yet run)"),
+        TextColor(crate::palette::DIM),
+        Node {
+            position_type: PositionType::Absolute,
+            bottom: px(4),
+            right: px(24),
+            ..default()
+        },
+        HashReadout,
+    ));
+}
+
+fn advance_on_space(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut session: ResMut<EngineSession>,
+    mut counter: ResMut<TickCounter>,
+    mut lens_changed: EventWriter<crate::map::LensChanged>,
+) {
+    if !keys.just_pressed(KeyCode::Space) {
+        return;
+    }
+    session
+        .advance()
+        .unwrap_or_else(|e| panic!("tick advance failed: {e}"));
+    counter.0 = session.inner.tick();
+    lens_changed.write(crate::map::LensChanged);
+}
+
+fn refresh_readouts(
+    counter: Res<TickCounter>,
+    session: Res<EngineSession>,
+    mut tick_text: Query<&mut Text, (With<TickCounterReadout>, Without<HashReadout>)>,
+    mut hash_text: Query<&mut Text, With<HashReadout>>,
+) {
+    if !counter.is_changed() {
+        return;
+    }
+    if let Ok(mut t) = tick_text.single_mut() {
+        t.0 = format!("tick {}", counter.0);
+    }
+    if let Ok(mut h) = hash_text.single_mut() {
+        // The last hash this session computed — sink carries no hash, so
+        // read it back off the session's own last report by re-deriving
+        // from the graph directly (state_hash is cheap at this scale, see
+        // the Global Constraints Scale Note).
+        if let Ok(hash) = babylon_graph::state_hash::CanonicalState::state_hash(session.inner.graph())
+        {
+            h.0 = format!("hash: {}", babylon_tick::hex(&hash));
+        }
+    }
+}
+```
+
+      Wire `TickLoopPlugin` into `main.rs`'s `App::new()` chain, replacing B0/B1's
+      `log_engine_link` Startup system (superseded — `EngineSession::start` now IS the engine link,
+      and it panics loudly on failure exactly as `log_engine_link` did).
+- [ ] **Step 4:** `cargo test -p babylon-client --test tick_loop` → PASS. `mise run rust:check` →
+      green.
+- [ ] **Step 5: Eyes-on:** `cargo run -p babylon-client` — press Space repeatedly, watch the tick
+      counter and hash text change every press.
+- [ ] **Step 6: Commit** (`feat(client): advance-tick input, tick counter, hash readout (B2)`).
+
+### Task 11: The state panel and the event feed
+
+**Files:**
+
+- Edit: `rust/crates/babylon-client/src/loop_ui.rs`
+
+- [ ] **Step 1: Write the failing headless test** — after two `advance()` calls with a county
+      selected (write `SelectedCounty` directly, matching Task 7's pick-testing precedent), the
+      state panel's text contains that county's live `pop-d`/`pop-p`/`pop-d-prime`/
+      `legitimation-index` values read straight off the graph (not off the lens, which only carries
+      the classification) — proving the panel and the map agree because both read the same graph.
+- [ ] **Step 2:** FAIL, then write `spawn_state_panel`/`refresh_state_panel`. `SelectedCounty`
+      (Task 7) wraps an ATLAS INDEX (`usize`), not a `NodeId` — the map's own vocabulary, matching
+      `county_at`'s return type. Resolve the chain explicitly: atlas index -> `atlas.county(idx).fips`
+      -> a linear scan of `session.node_by_fips` (twelve entries — a `HashMap` is not worth building
+      for this size) for the matching FIPS -> its `NodeId`. A `SelectedCounty`/`HoveredCounty` whose
+      atlas index resolves to a FIPS absent from `node_by_fips` (any of the 3,210 non-demo counties)
+      renders the panel's honest "no data this tick" text, never a lookup panic — this is the same
+      honest-absence shape Task 5's `LensReading` already establishes, applied here to the panel
+      instead of the map. For a resolved `id`, read the four fields via
+      `session.inner.graph().node_attribute(id, "...")` and render:
+
+```text
+<county name> (<fips>)
+  pop-d:            2,150
+  pop-p:            6,050
+  pop-d-prime:      1,800
+  legitimation:     STABLE (0)
+```
+
+- [ ] **Step 3: The event feed.** A scrolling text list, last 10 entries from
+      `session.sink.events`, newest first, rendered as `<EventType> @ <county or n/a>` — reusing
+      `CollectingSink`'s already-populated `events: Vec<(String, Vec<(String, Value)>)>` with no
+      new sink type. Bounded to the last 10 by slicing, not by mutating `sink.events` (the sink
+      accumulates the WHOLE session's history — acceptable at demo scale, a ring buffer is a
+      documented future item if unbounded play sessions become a target, not built here).
+- [ ] **Step 4: Headless test** for the event feed — after an `advance()` that fires
+      `LEGITIMATION_RECOVERY` (Task 3's own recovering-county archetype guarantees this on tick 1),
+      assert the feed's rendered text contains `"LEGITIMATION_RECOVERY"`.
+- [ ] **Step 5:** `cargo test -p babylon-client` → PASS. Eyes-on: select a county, press Space,
+      watch its panel numbers and the event feed both update.
+- [ ] **Step 6: Commit** (`feat(client): the state panel and event feed (B2)`). Open the Phase D PR
+      (`feat(client): B2 Phase D — the tick loop UI`); self-merge on green.
+
+---
+
+## Phase E — Logging, determinism, the eyes-on gate
+
+### Task 12: Resurrect the client file-log sink
+
+**Files:**
+
+- Create: `rust/crates/babylon-client/src/logging.rs`
+- Edit: `rust/crates/babylon-client/Cargo.toml`, `rust/crates/babylon-client/src/lib.rs`,
+  `rust/crates/babylon-client/src/main.rs`
+
+**Why resurrect rather than reinvent.** CLAUDE.md's client-logging directive: *"the deletion
+ceremony retired `rust-client.log` (the Ratatui client's `log4rs` sink); the Bevy client's file
+sink lands at milestone B2."* The deleted module (`git show
+7d9f0d94^:rust/crates/babylon-tui/src/logging.rs`) carries proven, tested code that already solves
+this problem — 10 MB size-triggered rotation, 5 fixed-window archives, file-only (never the
+terminal, though Bevy has no alternate screen to corrupt the way the deleted Ratatui client did —
+the constraint carries over anyway since a console `log4rs` sink would just duplicate Bevy's own
+`tracing`-based `LogPlugin`, not harm it). **`log4rs` listens on the plain `log` facade; Bevy's own
+console/dev logging runs on `tracing` via `bevy::log::LogPlugin`** — the two global dispatchers
+(`log::set_logger` and `tracing::subscriber::set_global_default`) are independent slots, so both
+coexist: Bevy's internals keep printing to the console through `tracing` exactly as
+`DefaultPlugins` already wires it, and THIS crate's own `log::debug!`/`log::info!` calls (not
+`bevy::log::info!`, which is `tracing`) go to the file sink only.
+
+- [ ] **Step 1: Add dependencies**, the exact deleted feature set (`git show
+      7d9f0d94^:rust/crates/babylon-tui/Cargo.toml` lines 36-42):
+
+```toml
+log = "0.4"
+log4rs = { version = "1", default-features = false, features = [
+    "rolling_file_appender",
+    "compound_policy",
+    "size_trigger",
+    "fixed_window_roller",
+    "pattern_encoder",
+] }
+```
+
+- [ ] **Step 2: Resurrect the module**, transcribed from the deleted file with two changes: the
+      sink filename `rust-client.log` → `babylon-client.log` (the retired name stays retired, per
+      CLAUDE.md — this is a new client, not a relaunch of the old one) and the module doc's
+      "terminal takeover" framing replaced with the Bevy-coexistence framing above.
+
+```rust
+//! File-only client logging (Director directive 2026-07-28; resurrected
+//! for the Bevy client at Program 28 B2, per CLAUDE.md: "the Bevy client's
+//! file sink lands at milestone B2"). Built on `log4rs` — the same crate
+//! and the same rotation policy the deleted Ratatui client's
+//! `babylon-tui::logging` used, transcribed here rather than reinvented.
+//!
+//! **Independent of Bevy's own logging.** `bevy::log::LogPlugin` runs on
+//! `tracing` and keeps printing to stderr exactly as `DefaultPlugins`
+//! wires it — untouched by this module. `log4rs` listens on the separate
+//! `log` facade; this crate's OWN `log::debug!`/`log::info!` calls (never
+//! `bevy::log::info!`, which is `tracing`) are what land in the file.
+//!
+//! **No wall-clock in client source.** Timestamps come from `log4rs`'s own
+//! pattern encoder inside the appender.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use log::LevelFilter;
+use log4rs::append::rolling_file::policy::compound::roll::fixed_window::FixedWindowRoller;
+use log4rs::append::rolling_file::policy::compound::trigger::size::SizeTrigger;
+use log4rs::append::rolling_file::policy::compound::CompoundPolicy;
+use log4rs::append::rolling_file::RollingFileAppender;
+use log4rs::config::{Appender, Config, Root};
+use log4rs::encode::pattern::PatternEncoder;
+
+const LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
+const LOG_ARCHIVES: u32 = 5;
+
+static INIT: OnceLock<()> = OnceLock::new();
+
+/// `$XDG_DATA_HOME/babylon/logs` else `~/.local/share/babylon/logs` —
+/// mirrors `src/babylon/config/paths.py::player_data_dir()` /
+/// `src/babylon/config/base.py::LOG_DIR` exactly, transcribed rather than
+/// re-derived (no PyO3 in the play path, Amendment AF, so this cannot call
+/// the Python function — it reproduces its two-line rule instead).
+#[must_use]
+pub fn log_dir() -> std::path::PathBuf {
+    let base = std::env::var_os("XDG_DATA_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            std::path::PathBuf::from(std::env::var_os("HOME").expect("HOME must be set"))
+                .join(".local")
+                .join("share")
+        });
+    base.join("babylon").join("logs")
+}
+
+/// Install the rolling-file logger writing `babylon-client.log` under
+/// `log_dir`. `level` is one of `error|warn|info|debug|trace`.
+///
+/// # Errors
+/// A config defect (bad level, non-UTF-8 log dir, log4rs init failure).
+pub fn init_file_logging(log_dir: &Path, level: &str) -> Result<(), String> {
+    let level_filter = parse_level(level)?;
+    if INIT.get().is_some() {
+        return Ok(());
+    }
+    let roll_pattern = log_dir.join("babylon-client.{}.log");
+    let roller = FixedWindowRoller::builder()
+        .build(
+            roll_pattern
+                .to_str()
+                .ok_or_else(|| format!("log dir is not valid UTF-8: {}", log_dir.display()))?,
+            LOG_ARCHIVES,
+        )
+        .map_err(|e| format!("log roller config: {e}"))?;
+    let policy = CompoundPolicy::new(Box::new(SizeTrigger::new(LOG_MAX_BYTES)), Box::new(roller));
+    let appender = RollingFileAppender::builder()
+        .encoder(Box::new(PatternEncoder::new(
+            "{d(%Y-%m-%dT%H:%M:%S%.3f)} [{l}] {t} — {m}{n}",
+        )))
+        .build(log_dir.join("babylon-client.log"), Box::new(policy))
+        .map_err(|e| format!("log appender: {e}"))?;
+    let config = Config::builder()
+        .appender(Appender::builder().build("file", Box::new(appender)))
+        .build(Root::builder().appender("file").build(level_filter))
+        .map_err(|e| format!("log config: {e}"))?;
+    log4rs::init_config(config).map_err(|e| format!("log init: {e}"))?;
+    let _ = INIT.set(());
+    install_panic_hook();
+    Ok(())
+}
+
+fn parse_level(level: &str) -> Result<LevelFilter, String> {
+    match level {
+        "error" => Ok(LevelFilter::Error),
+        "warn" => Ok(LevelFilter::Warn),
+        "info" => Ok(LevelFilter::Info),
+        "debug" => Ok(LevelFilter::Debug),
+        "trace" => Ok(LevelFilter::Trace),
+        other => Err(format!(
+            "unknown log_level {other:?} (expected error|warn|info|debug|trace)"
+        )),
+    }
+}
+
+fn install_panic_hook() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        log::error!(target: "panic", "client panic: {info}");
+        log::logger().flush();
+        previous(info);
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_unknown_level_fails_loudly_even_after_init() {
+        let err = init_file_logging(Path::new("/nonexistent"), "loudest").unwrap_err();
+        assert!(err.contains("unknown log_level"));
+    }
+
+    #[test]
+    fn init_writes_the_sink_and_reinit_is_a_noop_success() {
+        let dir = std::env::temp_dir().join(format!("babylon-client-logtest-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("test log dir");
+        init_file_logging(&dir, "debug").expect("first init");
+        log::debug!(target: "test", "sink probe line");
+        log::logger().flush();
+        let sink = dir.join("babylon-client.log");
+        let written = std::fs::read_to_string(&sink).expect("sink exists");
+        assert!(written.contains("sink probe line"));
+        init_file_logging(&dir, "debug").expect("re-init is a no-op success");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn log_dir_honors_xdg_data_home() {
+        // SAFETY (single-threaded test process assumption noted, matching
+        // the deleted module's own test posture): temporarily set the env
+        // var, read log_dir(), restore it.
+        let prior = std::env::var_os("XDG_DATA_HOME");
+        std::env::set_var("XDG_DATA_HOME", "/tmp/xdg-probe");
+        assert_eq!(log_dir(), std::path::PathBuf::from("/tmp/xdg-probe/babylon/logs"));
+        match prior {
+            Some(v) => std::env::set_var("XDG_DATA_HOME", v),
+            None => std::env::remove_var("XDG_DATA_HOME"),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Wire it in `main.rs`**, before `App::new()`:
+
+```rust
+fn main() {
+    let log_dir = babylon_client::logging::log_dir();
+    std::fs::create_dir_all(&log_dir).ok();
+    if let Err(e) = babylon_client::logging::init_file_logging(&log_dir, "debug") {
+        eprintln!("warning: client file logging did not start: {e}");
+    }
+    log::info!("babylon-client starting (B2 tick loop)");
+    App::new()
+        // ... unchanged ...
+}
+```
+
+      A logging failure is a `warning`, not a panic — the game must still be playable with no
+      writable log directory (a read-only filesystem, a sandboxed CI runner), which is exactly why
+      Step 4's test needs no log directory to exist.
+- [ ] **Step 4:** `cargo test -p babylon-client --lib logging` → PASS (all three tests). `mise run
+      rust:check` → green. `cargo deny check` — `log4rs`/`log` are the same crates the deleted TUI
+      already carried, and its `deny.toml`'s `allowlist` already names them; confirm rather than
+      assume.
+- [ ] **Step 5: Commit** (`feat(client): resurrect the log4rs file sink — babylon-client.log
+      (B2)`).
+
+### Task 13: End-to-end determinism guard
+
+**Files:**
+
+- Create: `rust/crates/babylon-client/tests/determinism.rs`
+
+**Why this test exists separately from Task 2's `babylon-tick`-level version.** Task 2's test
+proves `TickSession` itself is deterministic. This test proves the SAME property through the
+client's own composed seam — `EngineSession::start` + repeated `advance()` — which is the actual
+path a player's key presses drive, and the one the plan's own instructions ask to see "as a
+committed test."
+
+- [ ] **Step 1: Write the failing test.**
+
+```rust
+use babylon_client::engine_link::EngineSession;
+
+#[test]
+fn same_content_same_tick_count_yields_the_same_hash() {
+    let mut a = EngineSession::start().expect("session a");
+    let mut b = EngineSession::start().expect("session b");
+    for tick in 1..=5 {
+        let ra = a.advance().expect("a advances");
+        let rb = b.advance().expect("b advances");
+        assert_eq!(
+            ra.after, rb.after,
+            "tick {tick}: two independent EngineSessions over the same content must hash identically"
+        );
+    }
+}
+
+#[test]
+fn five_ticks_produce_five_distinct_hashes() {
+    // Regression guard against a driver that silently re-runs tick 1 —
+    // exactly the bug TickSession's own tick-numbering (Task 2) exists to
+    // prevent; this test watches for it at the client's seam too.
+    let mut session = EngineSession::start().expect("session");
+    let mut hashes = std::collections::HashSet::new();
+    for _ in 0..5 {
+        let report = session.advance().expect("advance");
+        hashes.insert(report.after);
+    }
+    assert_eq!(hashes.len(), 5, "each tick must produce a distinct state hash");
+}
+```
+
+- [ ] **Step 2:** FAIL until Task 9's `EngineSession` exists (this task can run any time after
+      Task 9 — placed last only to sit beside Task 12's logging work in one PR).
+- [ ] **Step 3:** `cargo test -p babylon-client --test determinism` → PASS.
+- [ ] **Step 4: Commit** (`test(client): end-to-end determinism guard — same content, same tick
+      count, same hash (B2)`).
+
+### Task 14: The eyes-on gate
+
+**Files:**
+
+- Create: `rust/crates/babylon-client/tests/eyes_on_smoke.rs`
+- Edit: `ai/state.yaml`
+
+**Definition (replaces #262, per the roadmap spec §5's board-hygiene note).** A person satisfies
+B2's eyes-on gate by:
+
+1. Running `cargo run -p babylon-client`.
+2. Seeing the county map render — the same borders and (now, Phase C) an initial band coloring on
+   the twelve demo counties, everything else `PANEL`.
+3. Pressing **Space** at least five times, and after each press observing every one of the
+   following:
+   - the tick counter (bottom-right) increments by exactly one;
+   - the hash readout changes to a new hex string every press (never repeats — Task 13 proves this
+     is a real property, not a hope);
+   - at least one demo county's band color OR the selected/hovered county's state-panel numbers
+     visibly changes (a tick where no county crosses a band boundary still moves the raw
+     `pop-d`/`pop-p`/`pop-d-prime` numbers in the panel — "watch state change" needs no
+     color flip on every single press);
+   - the event feed grows (`LIFECYCLE_TRANSITION` alone fires every tick for every county).
+4. Pressing **Tab**, confirming the active-lens label switches and the map recolors under the
+   other lens's table.
+5. Confirming the client wrote to `~/.local/share/babylon/logs/babylon-client.log` (or
+   `$XDG_DATA_HOME/babylon/logs/`) after the run.
+
+**The CI-safe proxy — everything from step 3 except the human's own eyes**, since no CI runner has
+a display server or GPU (the same CI reality every headless test in this plan already works
+inside):
+
+```rust
+// tests/eyes_on_smoke.rs — the scriptable half of the eyes-on gate. Never
+// a replacement for the human pass above (nothing here can see a color on
+// screen), but it proves every INPUT-DRIVEN, hash-provable claim that
+// pass makes, so a future change that silently breaks the loop reds THIS
+// gate in CI before a human ever has to notice by eye.
+use bevy::asset::AssetPlugin;
+use bevy::prelude::*;
+use std::collections::HashSet;
+
+#[test]
+fn five_space_presses_advance_five_distinct_ticks_and_fire_lifecycle_events() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, AssetPlugin::default(), InputPlugin));
+    app.add_plugins(babylon_client::map::MapPlugin);
+    app.add_plugins(babylon_client::loop_ui::TickLoopPlugin);
+    app.update(); // Startup
+
+    let mut hashes = HashSet::new();
+    for _ in 0..5 {
+        {
+            let mut input = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+            input.press(KeyCode::Space);
+        }
+        app.update();
+        {
+            let mut input = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+            input.release(KeyCode::Space);
+        }
+        let session = app.world().resource::<babylon_client::engine_link::EngineSession>();
+        hashes.insert(session.inner.graph().state_hash().expect("hash"));
+    }
+    assert_eq!(hashes.len(), 5, "five presses, five distinct hashes");
+
+    let session = app.world().resource::<babylon_client::engine_link::EngineSession>();
+    assert!(
+        session
+            .sink
+            .events
+            .iter()
+            .any(|(name, _)| name == "EventType/LIFECYCLE_TRANSITION"),
+        "the event feed must carry at least one real emitted event"
+    );
+}
+
+#[test]
+fn tab_flips_the_active_lens() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, AssetPlugin::default(), InputPlugin));
+    app.add_plugins(babylon_client::map::MapPlugin);
+    app.update();
+
+    let before = *app.world().resource::<babylon_client::map::ActiveLens>();
+    {
+        let mut input = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+        input.press(KeyCode::Tab);
+    }
+    app.update();
+    let after = *app.world().resource::<babylon_client::map::ActiveLens>();
+    assert_ne!(before, after, "Tab must flip the active lens");
+}
+```
+
+- [ ] **Step 1:** Write both tests as shown, run against Phase C/D's finished code → FAIL until
+      those phases land (this task sits last deliberately).
+- [ ] **Step 2:** Once Phase C and Phase D land, both PASS. `mise run rust:check` → green.
+- [ ] **Step 3:** Update `ai/state.yaml` — B2 reached: tick loop, dual-lens map, state panel, event
+      feed, log sink, eyes-on gate defined and CI-proxied. Close #262 as "superseded — replaced by
+      this gate" per the roadmap spec §5's own instruction, citing this plan document.
+- [ ] **Step 4: Commit** (`test(client): the B2 eyes-on gate + its CI-safe proxy (B2)`).
+
+### Task 15: Gates, docs, PR
+
+- [ ] **Step 1:** `mise run rust:check` → green. `mise run check` → green.
+- [ ] **Step 2:** `mise run qa:regression` and `mise run qa:vault-regression-ci` → byte-identical.
+      Phase A's refactor is the only touch to `babylon-tick`'s existing behavior, and Task 1 Step 4
+      already proved it moves nothing — this is the whole-repo confirmation.
+- [ ] **Step 3:** Run `cargo test -p babylon-tick -p babylon-client` once more, full suite, to
+      confirm every test across all five phases is green together, not just phase-by-phase.
+- [ ] **Step 4:** Update `ai/state.yaml`'s Program 28 entry (B2 milestone reached — cite this plan
+      document and the PR numbers) and the GitHub project board's client lane. Open the follow-up
+      issue this plan's Sequencing/Content Decision sections defer (multi-rule-pack sessions;
+      unbounded event-feed memory; the economics BSL port that would make the Tension lens tick-live
+      too) — record it in the PR body per the B1 Task 12 precedent, don't silently drop it.
+- [ ] **Step 5:** Open the PR (`feat(client): B2 — the tick loop on screen`), body carrying: the
+      eyes-on human-pass screenshot/description, the Task 3 Step 1 FIPS table, the pinned
+      determinism-guard output, and a link back to this plan document. Self-merge on green per the
+      standing autonomy rulings.
+
+---
+
+## Open questions for the Director
+
+1. **Does the new Legitimation lens need its own sign-off, the way ADR191 R11 ruled the Tension
+   lens's four bands?** This plan's reasoning for proceeding without escalating: the Legitimation
+   lens invents no new formula (it colors a categorical field the `lifecycle` rule pack already computes),
+   uses only already-declared §9b palette tokens, and is additive to — never a replacement for —
+   the Director-ruled Tension lens (a Tab key switches between them, both visible, neither hidden).
+   But the Director has personally ruled every pixel-level choice on this map so far (font, insets,
+   band count) — if that pattern is a standing expectation rather than a one-time settling of B1's
+   specific open questions, this decision belongs to her, not to this plan's author. Recommend:
+   proceed as specced (self-merge on green per the standing autonomy rulings), flag this plan
+   document in the PR body, and let her veto after the fact if she intends that pattern to bind
+   here too — cheaper than blocking a five-phase plan on a question this plan's own reasoning
+   already answers defensibly.
+2. **Should B2 defer multi-rule-pack sessions (running `vitality` and `lifecycle` together, live),
+   or does the "watch state change" criterion implicitly want BOTH Material Base systems visible at
+   once?** The Content Decision section above lays out the exact technical wall (`E-LOAD-001`, one
+   `(rule …)` form per content set) and the two-part fix it would need. Recommend: defer, file the
+   issue, proceed with the `lifecycle` rule pack alone — of the three merged packs, only its
+   subject type matches the map's own unit, so it demonstrates the criterion fully on its own.
+3. **This plan defers audio (SFX/soundtrack, ADR152/153) out of B2 entirely — it wires none of it,
+   not even minimally.** Reasoning: R3's visual scope names "2D map game + panels and charts as the
+   primary surface" with no audio obligation; wiring 39 SFX + 13 tracks properly (Bevy
+   `AudioPlugin`, the `manifest.toml` trigger-mapping, mixing) is real, separately-scoped work, and
+   B2 already carries five phases of new surface. This plan's author made this scope call rather
+   than asking a question about it — this entry records the deferral so it stays visible rather
+   than silent, per the Documentation philosophy's "immutability of history" discipline.

--- a/docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md
+++ b/docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md
@@ -184,8 +184,8 @@ Decision below.
   `test_no_stray_color_literals_outside_palette_or_a_declared_exemption`'s sweep needs no new
   exemption entry.
 - **The babylon-bsl surface this plan touches, stated exactly.** Every task reads live state
-  through `GraphSubstrate`'s existing 14 methods and `CanonicalState`'s existing `state_hash` —
-  unchanged. Two things ARE new, both flagged explicitly, both machinery rather than new
+  through `GraphSubstrate`'s existing trait surface and `CanonicalState`'s existing `state_hash` —
+  unchanged (no method added, removed, or re-signatured on either). Two things ARE new, both flagged explicitly, both machinery rather than new
   mathematics or a new primitive (Amendment AE's test): (1) `babylon-tick::TickSession`, additive,
   `run_once`/`run_once_into` keep their exact current signatures; (2)
   `babylon-bsl::rule_pipeline::split_content` widens from "exactly one `(rule …)` top-form" to
@@ -2714,13 +2714,22 @@ static INIT: OnceLock<()> = OnceLock::new();
 /// the Python function — it reproduces its two-line rule instead).
 #[must_use]
 pub fn log_dir() -> std::path::PathBuf {
-    let base = std::env::var_os("XDG_DATA_HOME")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| {
-            std::path::PathBuf::from(std::env::var_os("HOME").expect("HOME must be set"))
-                .join(".local")
-                .join("share")
-        });
+    log_dir_from(
+        std::env::var_os("XDG_DATA_HOME").map(std::path::PathBuf::from),
+        std::env::var_os("HOME").map(std::path::PathBuf::from),
+    )
+}
+
+/// The pure resolution rule behind [`log_dir`], with both environment
+/// inputs injected — the test exercises this directly, so it never mutates
+/// process-global env vars (cargo runs tests in parallel; a `set_var` in
+/// one test races every other test's threads).
+fn log_dir_from(
+    xdg_data_home: Option<std::path::PathBuf>,
+    home: Option<std::path::PathBuf>,
+) -> std::path::PathBuf {
+    let base = xdg_data_home
+        .unwrap_or_else(|| home.expect("HOME must be set").join(".local").join("share"));
     base.join("babylon").join("logs")
 }
 
@@ -2808,16 +2817,16 @@ mod tests {
 
     #[test]
     fn log_dir_honors_xdg_data_home() {
-        // SAFETY (single-threaded test process assumption noted, matching
-        // the deleted module's own test posture): temporarily set the env
-        // var, read log_dir(), restore it.
-        let prior = std::env::var_os("XDG_DATA_HOME");
-        std::env::set_var("XDG_DATA_HOME", "/tmp/xdg-probe");
-        assert_eq!(log_dir(), std::path::PathBuf::from("/tmp/xdg-probe/babylon/logs"));
-        match prior {
-            Some(v) => std::env::set_var("XDG_DATA_HOME", v),
-            None => std::env::remove_var("XDG_DATA_HOME"),
-        }
+        // Injected inputs, no env mutation — parallel-safe by construction
+        // (the deleted TUI module's test set XDG_DATA_HOME process-globally
+        // and leaned on a single-threaded assumption; not transcribed).
+        let xdg = log_dir_from(Some(std::path::PathBuf::from("/tmp/xdg-probe")), None);
+        assert_eq!(xdg, std::path::PathBuf::from("/tmp/xdg-probe/babylon/logs"));
+        let fallback = log_dir_from(None, Some(std::path::PathBuf::from("/home/probe")));
+        assert_eq!(
+            fallback,
+            std::path::PathBuf::from("/home/probe/.local/share/babylon/logs")
+        );
     }
 }
 ```

--- a/docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md
+++ b/docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md
@@ -6,21 +6,48 @@
 B1 rendered, presses a key to advance the tick, and watches real state change: a tick counter, a
 deterministic state-hash readout, a live per-county legitimation overlay on the map, a state panel
 for the hovered/selected county, and an event feed — all driven by the Rust engine through a new
-persistent tick-loop seam, never a lookalike.
+persistent tick-loop seam running TWO Material Base systems together, never a lookalike.
 
-**Architecture:** Five phases in five PRs. Phase A opens a **persistent session** in
-`babylon-tick` — `TickSession<G>`, additive, built by factoring the load half `run_once_into`
-already does into a shared `prepare_rule` helper so the existing one-shot API moves not one byte.
-Phase B authors the **demo content**: a twelve-real-FIPS-county scenario carrying the
-already-conformance-tested `lifecycle/dpd-circuit` rule pack's four archetype value sets, so the
-map has real counties to light up. Phase C **completes B1's still-unbuilt Phase C** (`lens.rs`,
-`map/bands.rs`'s band table, `map/pick.rs`, `map/hud.rs`) but generalizes it to carry TWO lenses
-side by side — ADR170's static Tension lens (ported unmodified) and a new, tick-live Legitimation
-lens reading the field `lifecycle/dpd-circuit` writes every tick — with a lens-picker key so the
-player can see the difference between "declared once" and "moves every tick" honestly. Phase D
-wires the **loop UI**: the advance-tick input, the tick counter, the hash readout, the state
-panel, the event feed. Phase E resurrects the **file-log sink** the deletion ceremony retired,
-proves **determinism** end-to-end, and defines the **eyes-on gate**.
+**Amendment record (2026-08-11, Director interactive ruling batch, this plan's own open
+questions).** The first cut of this plan closed with three open questions. The Director ruled all
+three, interactively, options quoted verbatim as presented and selected — the same citation
+discipline ADR194 uses:
+
+1. **Legitimation lens color mapping: APPROVED, reuse the band palette.** Selected option, quoted:
+   *"CRISIS → crimson, UNSTABLE → dim gray, STABLE → gold's absence (panel dark) — reuses the
+   ruled four-band vocabulary so the two lenses share one visual language. No new colors enter the
+   game."*
+2. **Demo content set: MULTI-RULE DRIVER FIRST — the Director OVERRULED this plan's single-pack
+   recommendation.** Selected option, quoted: *"Build the multi-rule content-set evolution into B2
+   itself so the demo runs vitality+lifecycle together from day one. Bigger B2, later criterion-3
+   close, but a richer first demo."*
+3. **Audio: DEFERRED out of B2**, per this plan's own recommendation — no change.
+
+Ruling 2 is load-bearing: it reopens what the first cut called "Decision: the demo content set is
+the lifecycle rule pack, alone" and inserts a new, genuinely non-trivial engine-lane evolution
+(Phase A, Tasks 2–5 below) ahead of the demo-scenario task. This document renumbers and amends
+every task list, file structure entry and cross-reference below to carry that decision out. The
+three rulings'
+full record, with reasoning, sits in the amended "Open questions for the Director" section at the
+end — kept, not deleted, per the Documentation philosophy's immutability-of-history discipline;
+what changed is that each question now carries its ruling instead of standing open.
+
+**Architecture:** Five phases in five PRs, Phase A now doing two jobs. Phase A opens a
+**persistent session** in `babylon-tick` — `TickSession<G>` — AND, ahead of that, widens the
+content-set loader to admit **more than one `(rule …)` form**, in declaration order, the way
+`bsl-language.rst` §2.2's grammar always admitted and `babylon-bsl`'s driver-level loader never
+implemented. Phase B authors the **demo content**: eighteen subjects across two node types — twelve
+real-FIPS territories carrying the already-conformance-tested `lifecycle` rule pack's four
+archetype value sets, and six social classes carrying the already-conformance-tested `vitality`
+rule pack's own fixture verbatim — so the demo runs two Material Base systems together from the
+first tick. Phase C **completes B1's still-unbuilt Phase C** (`lens.rs`, `map/bands.rs`'s band
+table, `map/pick.rs`, `map/hud.rs`) but generalizes it to carry TWO lenses side by side — ADR170's
+static Tension lens (ported unmodified) and a new, tick-live Legitimation lens reading the field
+`lifecycle` writes every tick, colored per the Director's ruling above — with a lens-picker key so
+the player can see the difference between "declared once" and "moves every tick" honestly. Phase D
+wires the **loop UI**: the advance-tick input, the tick counter, the hash readout, the state panel,
+the event feed (now carrying both packs' events). Phase E resurrects the **file-log sink** the
+deletion ceremony retired, proves **determinism** end-to-end, and defines the **eyes-on gate**.
 
 **Tech Stack:** Bevy 0.18.1 (unchanged from B1 — `pan_camera` feature already pinned), the same
 `earcutr`/atlas/tessellate stack B1 built, `log4rs` 1.x (`default-features = false`, the exact
@@ -44,19 +71,25 @@ Decision below.
   it touches it.
 - **ADR191 R9/R10/R11** — the Director already settled the Iosevka Nerd Font choice, the
   cartographic insets, and the FOUR-BAND (not continuous-ramp) rendering of the Tension lens; this
-  plan reuses R11's band table verbatim rather than re-deriving it.
+  plan reuses R11's band table verbatim rather than re-deriving it, and (per this amendment's
+  ruling 1) points the Legitimation lens at the SAME three of its four colors.
 - **ADR193** — `babylon-tick::run_once`/`run_once_into` now construct `HypergraphStore`, not
   `MemoryGraph`; `state_hash()` calls `encode_state()`, and ADR193 measures that call QUADRATIC in
   hyperedge count on `HypergraphStore` (22.59 ms at n=2,000 hyperedges; 1.92 s at n=20,000). **This
-  plan's
-  own demo scenario mints twelve `NodeType/TERRITORY` nodes and zero hyperedges** — the cliff does
-  not bite; see the Scale Note below for the arithmetic.
+  plan's own demo scenario mints eighteen nodes (twelve `NodeType/TERRITORY`, six
+  `NodeType/SOCIAL_CLASS`) and zero hyperedges** — the cliff does not bite; see the Scale Note
+  below for the arithmetic.
+- **D96 (ADR191 R2)** — "a scenario is a canonical committed artifact and its declaration order is
+  part of its identity" for NODE declarations; this plan's multi-rule evolution extends the same
+  PRINCIPLE one level up, to RULE declarations within a content set (Phase A, Tasks 2–5) — it does
+  not reopen D96 itself, which stays about node mint order.
 - **Constitution III.7 (determinism)** and **III.11 (Loud Failure)** — the hash display exists
   because the hash IS the honesty proof; a county the demo scenario never minted stays `PANEL`,
   never a fabricated value.
 - **R8/R9 (BSL-first porting, escape by proof)** — nothing in this plan adds Rust simulation logic;
-  the only Rust code this plan writes is client/UI/seam code and a factored-out loader helper. All
-  simulation content stays in the already-merged `lifecycle` rule pack.
+  the only Rust code this plan writes is client/UI/seam code, a loader-widening change that makes
+  the driver honor grammar §2.2 already admits (not a new primitive), and a factored-out loader
+  helper. All simulation content stays in the already-merged `vitality` and `lifecycle` rule packs.
 - **No imposed functional forms (2026-07-29 standing ruling)** — the new Legitimation lens invents
   no threshold and no formula. It colors counties by the **categorical classification the
   `lifecycle` rule pack already computes and writes** (`territory/legitimation-crisis`: 0 = STABLE,
@@ -72,33 +105,44 @@ Decision below.
 - Gates for the executing agent: `mise run rust:check` for any `rust/` change (clippy
   `-D warnings`, workspace, all targets, locked); `mise run check` for the repo-wide fast gate;
   `mise run qa:regression` and `mise run qa:vault-regression-ci` after any change touching
-  `babylon-tick` — Phase A's refactor must move zero engine bytes, and Phase A Step 4's own test
-  is the first proof of that, not the only one.
+  `babylon-bsl`/`babylon-tick` — Phase A's Task 1 refactor and Task 4 widening must each move zero
+  engine bytes on every EXISTING single-rule content set, and each task's own regression test is
+  the first proof of that, not the only one.
 - Vale: `vale <file>` on every Markdown page touched, driven to 0.
 - **CI reality (unchanged from B1):** `rust-gate` runs on `ubuntu-latest`, compile-time Bevy
   headers only, no display server, no GPU. Every headless test in this plan uses `MinimalPlugins`
   plus `AssetPlugin`, never `DefaultPlugins`, exactly as B1's `tests/map_mesh.rs` and
   `tests/map_camera.rs` already establish.
 - **Palette canon** — reuse only already-declared `§9b` tokens (`palette.rs`) and the already-ruled
-  ADR170 four-band table (`PANEL`, `CRIMSON`, `DIM`, `GOLD` from `map/bands.rs`); the new
-  Legitimation lens's three colors (`GREEN_DARK`, `GOLD`, `CRIMSON`) are ALL pre-existing `§9b`
-  tokens — this plan adds no new `Color::srgb_u8` literal anywhere, so
+  ADR170 four-band table (`PANEL`, `CRIMSON`, `DIM`, `GOLD` from `map/bands.rs`); per this
+  amendment's ruling 1, the Legitimation lens's three colors are `PANEL` (STABLE — "gold's
+  absence"), `DIM` (UNSTABLE), `CRIMSON` (CRISIS), reusing three of the FOUR already-declared
+  `map/bands.rs` constants and minting none — GOLD is deliberately unused by this lens. This plan
+  adds no new `Color::srgb_u8` literal anywhere, so
   `test_no_stray_color_literals_outside_palette_or_a_declared_exemption`'s sweep needs no new
   exemption entry.
-- **No new babylon-bsl surface.** Every task in this plan reads through `GraphSubstrate`'s existing
-  14 methods (`node_attribute`, `nodes`, …) and `CanonicalState`'s existing `state_hash`. The one
-  API addition anywhere in this plan is `babylon-tick::TickSession` (Phase A) — flagged explicitly,
-  additive only, `run_once`/`run_once_into`/`TickReport` keep their exact current signatures.
+- **The babylon-bsl surface this plan touches, stated exactly.** Every task reads live state
+  through `GraphSubstrate`'s existing 14 methods and `CanonicalState`'s existing `state_hash` —
+  unchanged. Two things ARE new, both flagged explicitly, both machinery rather than new
+  mathematics or a new primitive (Amendment AE's test): (1) `babylon-tick::TickSession`, additive,
+  `run_once`/`run_once_into` keep their exact current signatures; (2)
+  `babylon-bsl::rule_pipeline::split_content` widens from "exactly one `(rule …)` top-form" to
+  "one or more, in declaration order, duplicate ids refused" — closing a gap between the DRIVER's
+  own historical restriction and what `bsl-language.rst` §2.2's grammar (`<top-form>*`) and prose
+  ("Duplicate rule ids… across the content set are `E-LOAD-001`") always admitted. See the
+  Multi-Rule Decision section below for the full design and why this is a driver fix, not a spec
+  change.
 - **Scale note (ADR193 arithmetic, worked here so no task has to re-derive it):** the Phase B demo
-  scenario mints exactly 12 `NodeType/TERRITORY` nodes and declares no `(edge …)`/`(hyperedge …)`
-  forms, so `HypergraphStore::encode_state`'s hyperedge half walks **zero** hyperedges regardless
-  of the measured quadratic constant — the ADR193 table's smallest measured point (n=2,000
-  hyperedges, 22.59 ms) is already ~5,500x this plan's hyperedge count. `state_hash()` runs twice
-  per `advance()` call (pre/post, per `TickSession::advance`, Phase A Task 2) against 12 nodes, ~50
-  scalar attributes and 0 hyperedges — sub-millisecond on the dyadic-half code path both stores
-  share (ADR193: "`nodes`/`edges`/`neighbors` show no consistent direction at any scale"). The
-  cliff is a real, documented future cost (ADR193's own "3,222-US-county target… plausibly crosses
-  10,000 hyperedges once county-level organizational and sector memberships exist") — it belongs to
+  scenario mints exactly 18 nodes (12 `NodeType/TERRITORY`, 6 `NodeType/SOCIAL_CLASS`) and declares
+  no `(edge …)`/`(hyperedge …)` forms, so `HypergraphStore::encode_state`'s hyperedge half walks
+  **zero** hyperedges regardless of the measured quadratic constant — the ADR193 table's smallest
+  measured point (n=2,000 hyperedges, 22.59 ms) is already ~5,500x this plan's largest node count.
+  `state_hash()` runs twice per `advance()` call (pre/post, per `TickSession::advance`), now
+  bracketing TWO `run_tick` calls instead of one, against 18 nodes, ~90 scalar attributes and 0
+  hyperedges — still sub-millisecond on the dyadic-half code path both stores share (ADR193:
+  "`nodes`/`edges`/`neighbors` show no consistent direction at any scale"). The cliff is a real,
+  documented future cost (ADR193's own "3,222-US-county target… plausibly crosses 10,000
+  hyperedges once county-level organizational and sector memberships exist") — it belongs to
   whichever later program mints those memberships, not to this one.
 
 ---
@@ -133,13 +177,13 @@ ones.** Concretely:
    Task 8 spec, corrected for one thing the B1 plan text predates — see below) **and** a second,
    new witness (`county_legitimation`) reading the field the tick loop actually moves.
 2. `map/bands.rs` gains B1 Task 9's `band_color` function and four-row table (ADR191 R11,
-   unmodified) **and** a second, small three-row table for the Legitimation lens — both are pure
-   presentation constants, no `GameDefines`/`defines_hash` ceremony, exactly as ADR191 R11 already
-   ruled for the first table.
+   unmodified) **and** a second, small three-row table for the Legitimation lens, colored per this
+   amendment's ruling 1 — both are pure presentation constants, no `GameDefines`/`defines_hash`
+   ceremony, exactly as ADR191 R11 already ruled for the first table.
 3. `map/pick.rs` and `map/hud.rs` are B1 Task 10's designs, unmodified, except the HUD now also
-   names which of the two lenses is active (Task 9 below) — this plan adds that honesty rule
-   because two lenses share the color CRIMSON for two different meanings (Tension's "Φ-source,
-   bled" vs. the Legitimation lens's "CRISIS"), and nothing may let a player read one as the other.
+   names which of the two lenses is active — this plan adds that honesty rule because two lenses
+   share the color CRIMSON for two different meanings (Tension's "Φ-source, bled" vs. the
+   Legitimation lens's "CRISIS"), and nothing may let a player read one as the other.
 
 **One correction to B1's plan text, made explicit so no one silently inherits it wrong:** B1's
 Task 8 spec writes `pub fn county_tension(graph: &MemoryGraph) -> TensionLens`. ADR193 (merged the
@@ -150,18 +194,32 @@ and, after Phase A of this plan, `TickSession`, both hold a `HypergraphStore`. *
 matching what the client actually holds. `MemoryGraph` remains only as the differential-test
 oracle (ADR193's own consequences section).
 
-## Decision: the demo content set is the lifecycle rule pack, alone
+## Decision: the demo content set runs `vitality` AND `lifecycle`, together, in declaration order
 
-Three merged rule packs exist: `fundamental-theorem` and `vitality` (both subject type
-`social-class`) and `lifecycle` (subject type `territory` — the D-P-D' circuit, four bindings
-into `NodeType/TERRITORY` fields, emitting `LIFECYCLE_TRANSITION`/`LEGITIMATION_CRISIS`/
-`LEGITIMATION_RECOVERY` events). `lifecycle` alone, of the three, has a subject type matching
-the map's native unit, and alone produces genuine tick-over-tick numeric change a player can watch
-land on a specific county.
+**Superseded by this amendment.** The first cut of this plan recommended running `lifecycle`
+alone, citing a real technical wall: `babylon-bsl::rule_pipeline::split_content` enforces, by
+construction (`rule_pipeline.rs:299-308`), exactly one `(rule …)` top-form per content set. The
+Director overruled that recommendation (ruling 2, quoted above): B2 builds the multi-rule
+evolution now. This section is the design that discharges that ruling, and it replaces the old
+"Decision: the demo content set is the lifecycle rule pack, alone" section outright — the
+technical-wall description below stays, because it remains the reason the evolution is real
+engineering work and not a one-line flag flip.
 
-**Running more than one rule pack live in the same session is out of this plan's scope, and here
-is the exact wall it hits:** `babylon-bsl::rule_pipeline::split_content` enforces, by construction
-(`rule_pipeline.rs:299-308`), **exactly one `(rule …)` top-form per content set** —
+### What §2.2 already admits, and what the driver never implemented
+
+`bsl-language.rst` §2.2's own grammar has never limited a content set to one rule:
+
+```text
+<file>        ::= <top-form>*
+<top-form>    ::= <rule> | <deffield> | <intrinsic-decl> | <manifest> | <metric-decl>
+```
+
+and its prose says, in the same section: *"A content set is the union of all files under the
+declared content roots. File boundaries and file names carry no semantics… Duplicate rule ids,
+duplicate field declarations, duplicate intrinsic declarations… across the content set are
+`E-LOAD-001`."* Nothing there says "exactly one" — the grammar's `<top-form>*` is zero-or-more, and
+the prose's whole framing (naming DUPLICATE ids as the violation) presupposes a content set can
+legally hold two or more rules with DISTINCT ids. The current refusal text —
 
 ```text
 "a content set needs exactly one (rule …) top-form, found {N}
@@ -169,18 +227,90 @@ is the exact wall it hits:** `babylon-bsl::rule_pipeline::split_content` enforce
  top-forms are not yet split out by this function and would also land here)"
 ```
 
-— an `E-LOAD` refusal, not a soft warning. `babylon-tick::run_once`/`run_once_into` (and this
-plan's `TickSession`, which shares the same loader) each take ONE `rule_src` string and can run
-ONE rule pack per session. Wiring `vitality` and `lifecycle` together needs BOTH (a) a
-`babylon-tick` change accepting `Vec<LoadedRule>` and running each in turn against one shared
-graph within one game-tick (their subject types are disjoint — `social-class` vs. `territory` — so
-nothing about running both against one graph is unsound, only never built), and (b) one scenario
-declaring BOTH subject types' fields, since today's conformance scenarios are single-purpose
-(`two-classes.bscn` for social-class content, `lifecycle-conformance.bscn` for territory content).
-**Both are real, scoped follow-up work someone can build later — flagged here as a deferral, not
-attempted in this plan.** Record an issue against the client/engine lane at PR time (mirroring the
-B1 Task 12
-precedent of opening an issue rather than silently narrowing scope).
+— is `babylon-bsl::rule_pipeline::split_content`'s OWN cardinality check; the spec never demanded
+it. This plan's evolution makes the driver honor what the grammar already admitted, which is why R8/R9
+(BSL-first, escape by proof) and Amendment AE's "mints no new mathematics" test both read this as
+machinery, not a new primitive needing a constitutional amendment.
+
+### Execution order: declaration order in the concatenated content set (D96, extended)
+
+D96 (ADR191 R2) ruled that a scenario's NODE declaration order is part of its identity — no test
+may assert that shuffling `node` forms leaves the tick hash unchanged, because `NodeId` mints top
+to bottom and "a reordered scenario is a different scenario." This plan's multi-rule driver applies
+the SAME principle one level up: **the rules in a content set run in the order their `(rule …)`
+forms appear in the string the driver reads**, and no test in this plan may assert that reordering
+those forms leaves the tick hash — or, more precisely, `TickReport.per_rule_fired`'s own order —
+unchanged. Concretely: `TickSession`/`run_once_into` build `rule_src` as ONE string (unchanged
+signature — the caller concatenates whatever `.bsl` files it wants, in the order it wants them to
+run), `split_content` parses every `(rule …)` top-form via the existing reader in the order it
+encounters them (a plain sequential parse — no new ordering machinery), and the driver runs each
+`LoadedRule` to completion, in that order, against the SAME graph, before moving to the next.
+
+**Why NOT the formal `:anchor` mechanism.** `bsl-language.rst` §2.3 already specifies
+`<anchor> ::= "(" "anchor" ( ":after" | ":before" ) <symbol> ")"` and a default ("a rule with no
+`<anchor>` belongs to the system named by the first segment of its rule id and takes that system's
+declared position") — this READS like the "real" answer to inter-rule ordering, and this plan's
+author checked it first. It does not work here: `mod_anchors.rs`'s own module doc
+says outright, *"this module validates the DECLARATION — shape, and the `E-LOAD-002` no-system
+case. Resolving anchors into a total order belongs to `babylon-engine`'s anchor-based registry
+(Phase 3)… deferred with a name, not silently."* `check_anchor` runs inside `load_rule_form` today
+(`rule_pipeline.rs:245`) and stores the result on `LoadedRule.anchor` — but nothing anywhere reads
+that field for ordering; no system-position registry exists to resolve `:after`/`:before` against.
+Building that registry sits explicitly outside this plan's scope (a Phase 3 BSL-track milestone, not
+a B2 client-lane task) and would be a large, separate undertaking. **Declaration order in the
+concatenated content string is the right-sized INTERIM this specific milestone owns —
+not a replacement for the eventual anchor-resolution engine, and not a claim that one will not
+supersede it.** The `(anchor …)` forms Task 5 adds below remain purely declarative under this
+plan — parsed, validated, and inert for ordering, exactly as they are for every other content set
+in this repo today.
+
+### The two rules' domains are disjoint — a subtlety worth stating precisely
+
+`vitality/subsistence-and-death`'s bindings read/write only `social-class/*` fields and `economy/*`
+constants; `lifecycle/dpd-circuit`'s bindings read/write only `territory/*` fields and `lifecycle/*`
+constants (both verified by reading each rule's full `(bindings …)` block). Neither rule's subject
+type, field reads, or field writes touch the other's. Two consequences follow, and BOTH matter to
+how Task 5 builds its conformance test:
+
+1. **The final canonical state hash is order-invariant for THIS pair, specifically**, because
+   `CanonicalState::encode_state` sorts every section before hashing (ADR193) and the two rules'
+   write-sets never overlap or interact — running vitality-then-lifecycle or lifecycle-then-vitality
+   produces the identical SET of (node, attribute, value) triples, and a canonical sort of an
+   identical set hashes identically either way. **This is an accident of this specific pair's
+   disjoint domains, not a property of the multi-rule mechanism in general** — a future pair that
+   shares a node type or cross-reads a field would NOT enjoy this invariance, and the driver must
+   not (and does not) assume it does.
+2. **Because of (1), a test that only asserts the final hash would NOT catch an order bug in this
+   specific pair.** The load-bearing order-proof has to be something order actually moves:
+   `TickReport.per_rule_fired`'s own sequence (Task 4) and the emitted event stream's sequence.
+   Task 5's conformance test asserts on `per_rule_fired`'s order directly, and separately proves
+   the mechanism reacts to a declaration-order flip, precisely because the hash offers no such
+   guarantee here.
+
+### Field and local-name collisions — checked, none found
+
+The union scenario (Phase B) mints social-class nodes (`vitality`'s fixture) and territory nodes
+(`lifecycle`'s fixture) side by side. Checked explicitly, not assumed:
+
+- **`deffield` qnames**: `vitality-conformance.bscn` declares `social-class/{active, population,
+  wealth, subsistence-multiplier, s-bio, s-class, inequality}` (7 fields, the 7th unread by the
+  rule but seeded for fixture parity). `lifecycle-conformance.bscn` declares `territory/{pop-d,
+  pop-p, pop-d-prime, wealth-d-prime, dependency-ratio, legitimation-index, legitimation-crisis,
+  transmitted-ideology}` (8 fields). The owning node type prefixes every qname, per the
+  language's own convention (§2.9) — the two sets share zero names by construction, not by luck.
+- **`defconst` qnames**: `vitality` declares `economy/{base-subsistence, death-threshold}` (2).
+  `lifecycle` declares 21 `lifecycle/*`-prefixed constants. Zero overlap.
+- **Local node names**: `vitality`'s six fixture nodes carry the names `core`, `bourgeoisie`,
+  `hermit`, `last-worker`, `remnant`, `dissolved`. `lifecycle`'s twelve demo nodes carry the names
+  `county-<fips>` (Phase B, Task 7). Zero overlap — `load_scenario`'s duplicate-local-name
+  check (`scenario.rs`) never fires.
+- **`CardinalityCeilings`**: `prepare_rule`'s existing ceiling-building code
+  (`scenario.node_types.iter().map(...)`) is already generic over any number of distinct
+  `NodeType` members a scenario mints — verified by reading it; no change needed for two node
+  types instead of one, and Task 6 keeps this code path unmodified.
+- **`systems` registry**: the existing fixed `HashSet` in `prepare_rule`/`prepare_rules`
+  already contains both `"vitality"` and `"lifecycle"` (it has since the lifecycle port merged) —
+  no change needed there either.
 
 ---
 
@@ -188,12 +318,17 @@ precedent of opening an issue rather than silently narrowing scope).
 
 | Phase | File | Action | Responsibility |
 |---|---|---|---|
-| A | `rust/crates/babylon-tick/src/lib.rs` | Edit | Factor `prepare_rule` out of `run_once_into`; add `pub mod session;` |
-| A | `rust/crates/babylon-tick/src/session.rs` | Create | `TickSession<G>` — load once, `advance()` many times |
+| A | `rust/crates/babylon-tick/src/lib.rs` | Edit | Factor `prepare_rule` out of `run_once_into`; later widen to `prepare_rules`; add `pub mod session;` |
+| A | `rust/crates/babylon-bsl/src/rule_pipeline.rs` | Edit | `split_content` admits more than one `(rule …)` form, duplicate-id check |
+| A | `docs/reference/bsl-language.rst` | Edit | New D-row (D99) documenting the widened driver + declaration-order semantics |
+| A | `rust/crates/babylon-tick/content/rules/lifecycle.bsl` | Edit | Add `(anchor :after vitality)` — declarative only, inert for ordering today |
+| A | `rust/crates/babylon-tick/content/scenarios/vitality-lifecycle-combined-conformance.bscn` | Create | The 10-node conformance fixture (6 vitality + 4 lifecycle, verbatim) |
+| A | `rust/crates/babylon-tick/tests/multi_rule_conformance.rs` | Create | Declaration-order-reproduces-engine-order proof |
+| A | `rust/crates/babylon-tick/src/session.rs` | Create | `TickSession<G>` — load once, `advance()` many times, now multi-rule |
 | B | `rust/crates/babylon-client/tests/print_demo_counties.rs` | Create (throwaway aid) | One-shot atlas print, deleted after use |
-| B | `rust/crates/babylon-tick/content/scenarios/us-counties-lifecycle-demo.bscn` | Create | 12 real-FIPS territory nodes, lifecycle fields |
+| B | `rust/crates/babylon-tick/content/scenarios/us-counties-lifecycle-demo.bscn` | Create | 18-node demo: 12 real-FIPS territories + 6 social classes |
 | C | `rust/crates/babylon-client/src/lens.rs` | Create | `county_tension` (ADR170, ported) + `county_legitimation` (new) |
-| C | `rust/crates/babylon-client/src/map/bands.rs` | Edit | ADR191 R11's `band_color` (Tension) + a new legitimation band function |
+| C | `rust/crates/babylon-client/src/map/bands.rs` | Edit | ADR191 R11's `band_color` (Tension) + legitimation band function (Director ruling 1) |
 | C | `rust/crates/babylon-client/src/map/pick.rs` | Create | Uniform-grid hit test (B1 Task 10's design) |
 | C | `rust/crates/babylon-client/src/map/hud.rs` | Create | Hover/selection readout, active-lens label, absence banner |
 | C | `rust/crates/babylon-client/src/map/mod.rs` | Edit | Wire the three new modules + lens-picker input |
@@ -206,7 +341,7 @@ precedent of opening an issue rather than silently narrowing scope).
 
 ---
 
-## Phase A — The persistent tick session
+## Phase A — The persistent tick session, and the multi-rule content-set evolution
 
 ### Task 1: Factor `prepare_rule` out of `run_once_into`
 
@@ -224,6 +359,12 @@ precedent of opening an issue rather than silently narrowing scope).
 - Consumes (unchanged): `split_content`, `parse_intrinsic_decls`, `IntrinsicCosts::new`,
   `load_scenario`, `TypeEnv`, `BindingVocabulary`, `CardinalityCeilings`, `LoadContext`,
   `load_rule_form` — every import already at the top of `lib.rs` stays.
+
+**Deliberately single-rule.** This task's `PreparedRule`/`prepare_rule` hold exactly ONE
+`LoadedRule`, matching `split_content`'s CURRENT (pre-Task-2) one-rule cardinality — the smallest,
+safest first step, proven against the existing single-rule goldens before Task 2 widens the loader
+underneath it. Task 4 renames and widens this to `PreparedRules`/`prepare_rules`; this task's job
+is only to prove the pure-extraction refactor is behavior-preserving in isolation first.
 
 This is a **pure extraction, zero behavior change**: `run_once_into`'s existing 130-odd lines
 split at exactly the point after `let loaded = load_rule_form(...)` — everything before that line
@@ -253,9 +394,7 @@ moves into `prepare_rule`, returning the four values it currently holds locally;
 /// intrinsic declarations, load the scenario into `graph`, and load the
 /// one `(rule …)` form against the vocabulary/types/ceilings that scenario
 /// declared. Shared by `run_once_into` (which still runs exactly tick 1)
-/// and `TickSession::new` (`session.rs`), which runs this ONCE and then
-/// calls `run_tick` many times against the result — the split B2 needed
-/// and `run_once_into`'s hardcoded tick number could not express.
+/// and, from Task 4 on, `prepare_rules`'s multi-rule successor.
 pub(crate) struct PreparedRule {
     pub loaded: LoadedRule,
     pub types: TypeEnv,
@@ -358,6 +497,7 @@ pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
         before,
         after,
         fired: outcome.fired,
+        per_rule_fired: vec![(prepared.loaded_rule_id.clone(), outcome.fired)],
     })
 }
 ```
@@ -365,14 +505,549 @@ pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
       Note the pre-tick hash is now taken AFTER `prepare_rule` returns rather than immediately
       after `load_scenario` — this is the same point in program order (nothing between the old
       `load_scenario` call and the old `before` computation touches `graph`), so the hash value is
-      identical; only the code that produces it moved.
+      identical; only the code that produces it moved. **`per_rule_fired` does not exist yet at
+      this step** — Task 4 adds `TickReport.per_rule_fired` and the `loaded_rule_id` field this
+      line anticipates; write `run_once_into` WITHOUT that line for this task (`fired:
+      outcome.fired` only, matching today's struct), and let Task 4 add the field and this line
+      together. Flagged here so the two tasks' interfaces read as one coherent design, not two
+      that happen to agree.
 - [ ] **Step 4:** Run both Step 1 tests again → PASS, byte-identical hash. `mise run rust:check` →
       green. `mise run qa:regression` and `mise run qa:vault-regression-ci` → byte-identical (this
       refactor is inside the engine crate; both gates must stay silent).
 - [ ] **Step 5: Commit** (`refactor(rust): factor prepare_rule out of run_once_into — zero behavior
       change (B2)`).
 
-### Task 2: `TickSession<G>` — load once, advance many times
+### Task 2: Widen `split_content` to admit more than one `(rule …)` form
+
+**Files:**
+
+- Edit: `rust/crates/babylon-bsl/src/rule_pipeline.rs`
+
+**Interfaces:**
+
+- Produces: `pub fn split_content(source: &str) -> Result<(Vec<SExpr>, Vec<SExpr>), LoadError>` —
+  the SAME function name, now returning the intrinsic-decl forms plus a **non-empty, ordered**
+  `Vec<SExpr>` of every `(rule …)` top-form, duplicate ids refused. **Signature change**:
+  the second element of the tuple was `SExpr` (exactly one), is now `Vec<SExpr>` (one or more, in
+  source order) — every caller (`prepare_rule` today, `prepare_rules` from Task 4) updates in the
+  same PR.
+- Also produces: `fn rule_id(rule: &SExpr) -> Result<String, LoadError>` — a small new helper
+  reading a `(rule …)` form's `<qname>` (the second list element, per §2.3's grammar), used by the
+  duplicate-id check and reusable wherever a caller needs a rule's own id without re-parsing.
+
+- [ ] **Step 1: Write the failing tests.** In `rule_pipeline.rs`'s existing `#[cfg(test)] mod
+      tests`:
+
+```rust
+#[test]
+fn split_content_admits_two_rules_in_source_order() {
+    let source = r"
+(rule a/first :material-basis "x" :fuel 10
+  (bindings (binding v :field a/v))
+  (effects (update-node self a/v (set v))))
+(rule b/second :material-basis "y" :fuel 10
+  (bindings (binding v :field b/v))
+  (effects (update-node self b/v (set v))))
+";
+    let (_intrinsics, rules) = split_content(source).expect("two distinct rule ids load");
+    assert_eq!(rules.len(), 2);
+    assert_eq!(rule_id(&rules[0]).unwrap(), "a/first");
+    assert_eq!(rule_id(&rules[1]).unwrap(), "b/second");
+}
+
+#[test]
+fn split_content_still_admits_exactly_one_rule() {
+    // The pre-Task-2 shape stays legal — this widening is additive, never
+    // a floor raise. Every existing single-rule content set in the repo
+    // must keep loading unchanged.
+    let source = r#"(rule a/only :material-basis "x" :fuel 10
+  (bindings (binding v :field a/v))
+  (effects (update-node self a/v (set v))))"#;
+    let (_intrinsics, rules) = split_content(source).expect("one rule still loads");
+    assert_eq!(rules.len(), 1);
+}
+
+#[test]
+fn split_content_refuses_zero_rules() {
+    let err = split_content("").unwrap_err();
+    assert!(err.to_string().contains("found 0"));
+}
+
+#[test]
+fn a_duplicate_rule_id_across_the_content_set_is_e_load_001() {
+    let source = r#"
+(rule a/dup :material-basis "x" :fuel 10
+  (bindings (binding v :field a/v))
+  (effects (update-node self a/v (set v))))
+(rule a/dup :material-basis "y" :fuel 10
+  (bindings (binding v :field a/v2))
+  (effects (update-node self a/v2 (set v))))
+"#;
+    let err = split_content(source).unwrap_err();
+    assert!(err.to_string().contains("E-LOAD-001"));
+    assert!(err.to_string().contains("a/dup"));
+}
+```
+
+- [ ] **Step 2:** `cargo test -p babylon-bsl` → FAIL (the current `<[SExpr; 1]>::try_from` cardinality
+      check refuses two rules; the return type does not compile against `Vec<SExpr>` callers yet).
+- [ ] **Step 3: Widen the function.** Replace the current
+
+```rust
+match <[SExpr; 1]>::try_from(rule_forms) {
+    Ok([rule]) => Ok((intrinsic_forms, rule)),
+    Err(rule_forms) => Err(LoadError::Content(format!(
+        "a content set needs exactly one (rule …) top-form, found {} …",
+        rule_forms.len()
+    ))),
+}
+```
+
+      with:
+
+```rust
+if rule_forms.is_empty() {
+    return Err(LoadError::Content(
+        "a content set needs at least one (rule …) top-form, found 0 \
+         (§2.2 — intrinsic declarations do not count; deffield/manifest/metric-decl \
+         top-forms are not yet split out by this function and would also land here)"
+            .to_owned(),
+    ));
+}
+let mut seen: HashMap<String, ()> = HashMap::with_capacity(rule_forms.len());
+for form in &rule_forms {
+    let id = rule_id(form)?;
+    if seen.contains_key(&id) {
+        return Err(LoadError::Content(format!(
+            "E-LOAD-001: duplicate rule id: {id} (§2.2 — rule ids must be \
+             content-set-unique, the same duplicate-name discipline \
+             parse_intrinsic_decls already enforces for intrinsic \
+             declarations)"
+        )));
+    }
+    seen.insert(id, ());
+}
+Ok((intrinsic_forms, rule_forms))
+```
+
+      matching the EXACT `HashMap::contains_key`-before-insert pattern
+      `declarations::parse_intrinsic_decls` already uses for duplicate intrinsic names (same file
+      family, same §2.2 duplicate-name discipline) — reused, not reinvented, per DRY. Add `rule_id`:
+
+```rust
+/// A `(rule …)` form's own `<qname>` — the second list element, per §2.3's
+/// `<rule> ::= "(" "rule" <qname> …`. Used by the duplicate-id check and by
+/// any caller (Task 4's `prepare_rules`) that needs a rule's id without
+/// re-parsing its surface.
+fn rule_id(rule: &SExpr) -> Result<String, LoadError> {
+    let SExpr::List(items) = rule else {
+        return Err(LoadError::Content(format!(
+            "expected a (rule …) form, found {rule:?}"
+        )));
+    };
+    match items.get(1) {
+        Some(SExpr::Atom(Atom::Symbol(id))) => Ok(id.clone()),
+        other => Err(LoadError::Content(format!(
+            "a (rule …) form's second element must be its qname, found {other:?}"
+        ))),
+    }
+}
+```
+
+- [ ] **Step 4:** `cargo test -p babylon-bsl` → PASS (all four new tests; every EXISTING
+      `split_content`/`load_rule_form` test in the crate still green — this is additive, not a
+      behavior change for single-rule content). Update `prepare_rule` (Task 1) to destructure the
+      now-`Vec<SExpr>` second element as `rule_forms[0].clone()` (still one rule at this point in
+      the plan; Task 4 removes the `[0]` indexing when it widens to multi-rule) — a small,
+      mechanical signature-follow, not a behavior change.
+- [ ] **Step 5:** `mise run rust:check` → green (workspace-wide — this crate's callers in
+      `babylon-tick` must still compile). `mise run qa:regression` → byte-identical.
+- [ ] **Step 6: Commit** (`feat(rust): split_content admits more than one (rule …) form, duplicate ids
+      refused (B2) — honors §2.2's already-ratified grammar`).
+
+### Task 3: The D99 spec row — documenting the widened driver
+
+**Files:**
+
+- Edit: `docs/reference/bsl-language.rst`
+
+**Why this is a task, not a footnote.** The D-row discipline (D80…D98 already in the table) is
+this document's own normative-home rule: a workforce reading that changes what the DRIVER accepts,
+even when the change is "honor what the grammar already said," gets its own row so a future reader
+does not have to reconstruct the reasoning from a Rust doc comment. This follows D97/D98's own
+precedent — "a Phase-1-review reading… open to correction, not a Director ruling" — the same
+posture this row takes.
+
+- [ ] **Step 1: Add D99** to the D-row list-table (after D98, following the exact three-column
+      format every row above it uses):
+
+```rst
+   * - D99
+     - §2.2, §2.3, §5.5
+     - **The content-set loader admits more than one ``(rule …)`` top-form, in
+       declaration order, duplicate ids refused** — a driver-level fix
+       (Program 28 B2), not a spec change. §2.2's grammar (``<top-form>*``)
+       and prose ("Duplicate rule ids… across the content set are
+       ``E-LOAD-001``") never limited a content set to one rule;
+       ``babylon-bsl::rule_pipeline::split_content`` did, by an
+       implementation-level cardinality check with no textual basis in this
+       section. This row lifts that check to match the grammar it was
+       always supposed to implement. **Execution order is declaration
+       order in the content set the driver reads** — the same principle
+       D96 states for node declarations, applied one level up to rule
+       declarations: no test may assert that reordering a content set's
+       ``(rule …)`` forms leaves ``TickReport.per_rule_fired``'s own order
+       unchanged, because it is not meant to. **This is NOT the ``:anchor``
+       mechanism** (§2.3's ``<anchor>``) resolved into a total order —
+       ``mod_anchors.rs``'s own scope note defers anchor RESOLUTION to a
+       future ``babylon-engine`` anchor-based registry (Phase 3), which
+       does not exist yet; ``(anchor …)`` forms remain parseable and
+       validated (``check_anchor``, unchanged) but inert for ordering under
+       this row, exactly as before it. §5.5's ``rules_hash`` stays
+       file-boundary- and (for CAS/identity purposes) order-insensitive —
+       that is a claim about content IDENTITY, separate from the EXECUTION
+       order this row rules on, and the two do not conflict.
+       Reference implementation: ``rule_pipeline::split_content``,
+       ``rule_pipeline::rule_id`` (Program 28 B2, `docs/superpowers/plans/
+       2026-08-11-b2-tick-loop-plan.md` Phase A Tasks 2–4).
+```
+
+- [ ] **Step 2: Sync `bsl.ebnf` if it encodes a rule-cardinality constraint.** Grep it for any
+      `<file>`/`<top-form>` production carrying an explicit "exactly one rule" note; §2.2's own
+      grammar block above (the normative one) never had one, so this step is almost certainly a no-op —
+      confirm rather than assume, per the D95/D98 precedent of keeping the appendix and the section
+      text in the same commit when they diverge.
+- [ ] **Step 3:** `vale docs/reference/bsl-language.rst` → 0 (this file already carries a project
+      vocabulary; this row's prose should clear it without a new exemption).
+- [ ] **Step 4: Commit** (`docs(bsl): D99 — the content-set loader honors §2.2's multi-rule grammar
+      (B2)`), sequenced right after Task 2 since it documents exactly that change.
+
+### Task 4: `prepare_rule` → `prepare_rules`; `run_once_into` runs every rule in order
+
+**Files:**
+
+- Edit: `rust/crates/babylon-tick/src/lib.rs`
+
+**Interfaces:**
+
+- Produces: `pub(crate) struct PreparedRules { rules: Vec<(String, LoadedRule)>, types: TypeEnv,
+  intrinsics: IntrinsicCosts, consts: HashMap<String, Value> }` (each entry pairs a rule's own id
+  with its `LoadedRule`, in DECLARATION order) and `pub(crate) fn prepare_rules<G: GraphSubstrate +
+  CanonicalState>(scenario_src: &str, rule_src: &str, graph: &mut G) -> Result<PreparedRules,
+  String>` — `prepare_rule`'s direct successor, same shape, now walking every rule `split_content`
+  returns instead of indexing `[0]`.
+- **`TickReport` gains one field, existing fields UNCHANGED in type** — this is the compatibility
+  design this task commits to, checked against every current reader of `.fired`:
+
+```rust
+pub struct TickReport {
+    pub before: [u8; 32],
+    pub after: [u8; 32],
+    /// The TOTAL fired-subject count across every rule this tick ran —
+    /// unchanged in meaning and type for a single-rule content set (today
+    /// every existing caller: `run_once`, the CLI, B0's engine-link probe,
+    /// every `*_conformance.rs` test). For a multi-rule tick this is the
+    /// SUM across rules — kept a plain `usize` rather than widened to
+    /// `Vec<usize>` specifically so `report.fired == N` assertions in
+    /// `tests/vitality_conformance.rs`, `tests/lifecycle_conformance.rs`,
+    /// `tests/lifecycle_crisis_conformance.rs` and
+    /// `tests/floor_intrinsic_e2e.rs` (five call sites, grepped and
+    /// confirmed) keep compiling and keep passing unmodified.
+    pub fired: usize,
+    /// Per-rule detail, in DECLARATION/EXECUTION order — `(rule_id,
+    /// fired)`. Length 1 for every existing single-rule content set
+    /// (`fired == per_rule_fired[0].1` always holds); length N for an
+    /// N-rule content set. This is what Task 5's conformance test and
+    /// Phase D's event feed actually need — a summed `fired` alone cannot
+    /// tell "5 subjects fired" from "vitality fired on 3, lifecycle on 2".
+    pub per_rule_fired: Vec<(String, usize)>,
+}
+```
+
+- [ ] **Step 1: Write the failing regression tests FIRST**, proving the additive-field design holds
+      for every EXISTING single-rule caller before writing the multi-rule path:
+
+```rust
+// lib.rs's existing #[cfg(test)] mod tests, extended:
+#[test]
+fn single_rule_content_still_reports_fired_and_a_one_entry_per_rule_fired() {
+    let report = run_once(SCENARIO, RULE).expect("single-rule run");
+    assert_eq!(report.per_rule_fired.len(), 1);
+    assert_eq!(report.per_rule_fired[0].1, report.fired);
+}
+```
+
+      Also re-run, unmodified, the five existing `.fired`-reading tests named in the doc comment
+      above (`tests/vitality_conformance.rs`, `tests/lifecycle_conformance.rs`,
+      `tests/lifecycle_crisis_conformance.rs`, `tests/floor_intrinsic_e2e.rs` ×2 assertions) —
+      these must compile and pass with ZERO edits, since `fired`'s type did not change.
+- [ ] **Step 2:** `cargo test -p babylon-tick -p babylon-bsl` → FAIL (`per_rule_fired` field does
+      not exist; `prepare_rules` does not exist).
+- [ ] **Step 3: Widen `prepare_rule` into `prepare_rules`.**
+
+```rust
+pub(crate) struct PreparedRules {
+    pub rules: Vec<(String, LoadedRule)>,
+    pub types: TypeEnv,
+    pub intrinsics: IntrinsicCosts,
+    pub consts: HashMap<String, Value>,
+}
+
+pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
+    scenario_src: &str,
+    rule_src: &str,
+    graph: &mut G,
+) -> Result<PreparedRules, String> {
+    let (intrinsic_forms, rule_forms) = split_content(rule_src).map_err(|e| e.to_string())?;
+    let declared = parse_intrinsic_decls(&intrinsic_forms).map_err(|e| e.to_string())?;
+    let intrinsics = IntrinsicCosts::new(
+        declared
+            .into_iter()
+            .map(|(name, decl)| (name, decl.cost))
+            .collect(),
+    );
+
+    let scenario = load_scenario(scenario_src, graph).map_err(|e| e.to_string())?;
+
+    let types = TypeEnv {
+        fields: scenario.fields.clone(),
+        exemptions: &[],
+    };
+    let vocabulary = BindingVocabulary {
+        fields: scenario.fields.keys().cloned().collect(),
+        consts: scenario.consts.keys().cloned().collect(),
+        metrics: HashSet::new(),
+    };
+    let ceilings = CardinalityCeilings::new(
+        scenario
+            .node_types
+            .iter()
+            .map(|(member, count)| (format!("NodeType/{member}"), *count))
+            .collect(),
+        HashMap::new(),
+    );
+    let systems: HashSet<String> = HashSet::from([
+        "economics".to_owned(),
+        "vitality".to_owned(),
+        "consciousness".to_owned(),
+        "lifecycle".to_owned(),
+    ]);
+
+    // ONE shared LoadContext for every rule in the content set — the
+    // vocabulary/types/ceilings come from the SCENARIO, not from any one
+    // rule, and each rule's own load only reads the subset its bindings
+    // reference (verified: no cross-rule interference for vitality +
+    // lifecycle, whose bindings are wholly disjoint — see the Multi-Rule
+    // Decision section's domain-disjointness note).
+    let ctx = LoadContext {
+        vocabulary: &vocabulary,
+        types: &types,
+        ceilings: &ceilings,
+        intrinsics: &intrinsics,
+        systems: &systems,
+        vocabulary_registry: None,
+        rule_file: "rule",
+    };
+
+    // rule_forms is already in DECLARATION order (split_content, Task 2) —
+    // load_rule_form runs once per form, in that same order, and this loop
+    // preserves it into `rules`.
+    let mut rules = Vec::with_capacity(rule_forms.len());
+    for form in rule_forms {
+        let id = rule_pipeline::rule_id(&form).map_err(|e| e.to_string())?;
+        let loaded = load_rule_form(form, &ctx)
+            .map_err(|e| format!("rule {id} rejected: {e}"))?;
+        rules.push((id, loaded));
+    }
+
+    Ok(PreparedRules {
+        rules,
+        types,
+        intrinsics,
+        consts: scenario.consts,
+    })
+}
+```
+
+      `rule_id` needs `pub(crate)` visibility from Task 2 (it was `fn`, private to
+      `rule_pipeline.rs`, in babylon-bsl — a different crate from babylon-tick, so it must be
+      `pub` there, not merely `pub(crate)`; correct Task 2's visibility to `pub fn rule_id` if this
+      step needs it externally, which it does).
+- [ ] **Step 4: Rewrite `run_once_into` to loop.**
+
+```rust
+pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
+    scenario_src: &str,
+    rule_src: &str,
+    graph: &mut G,
+    sink: &mut CollectingSink,
+) -> Result<TickReport, String> {
+    let prepared = prepare_rules(scenario_src, rule_src, graph)?;
+
+    let before = graph
+        .state_hash()
+        .map_err(|e| format!("pre-tick state: {}", e.message))?;
+
+    let mut per_rule_fired = Vec::with_capacity(prepared.rules.len());
+    for (id, loaded) in &prepared.rules {
+        let outcome = run_tick(
+            loaded,
+            &prepared.types,
+            &KernelIntrinsicHost,
+            graph,
+            sink,
+            &prepared.intrinsics,
+            &prepared.consts,
+            1,
+        )
+        .map_err(|e| format!("tick failed in rule {id}: {e}"))?;
+        per_rule_fired.push((id.clone(), outcome.fired));
+    }
+    let fired = per_rule_fired.iter().map(|(_, n)| n).sum();
+
+    let after = graph
+        .state_hash()
+        .map_err(|e| format!("post-tick state: {}", e.message))?;
+
+    Ok(TickReport {
+        before,
+        after,
+        fired,
+        per_rule_fired,
+    })
+}
+```
+
+      Every rule in `prepared.rules` runs to COMPLETION (every matching subject) before the next
+      rule starts — never interleaved — against the SAME `graph`, so a later rule sees an EARLIER
+      rule's writes from the SAME tick, matching the frozen engine's own in-place, strict-order
+      mutation semantics (CLAUDE.md: "Systems mutate the shared graph in-place in strict order…
+      each system sees prior systems' mutations") for free, with no new mechanism — this falls out
+      of calling `run_tick` sequentially against one `&mut G`.
+- [ ] **Step 5:** `cargo test -p babylon-tick` → PASS (the new regression test; all five
+      externally-grepped `.fired` call sites still green, unmodified). `mise run rust:check` →
+      green. `mise run qa:regression` and `mise run qa:vault-regression-ci` → byte-identical (this
+      widening must move zero bytes for every EXISTING single-rule content set — the whole point of
+      the additive-field design).
+- [ ] **Step 6: Commit** (`feat(rust): prepare_rules — the multi-rule content-set loader, per-rule
+      fired detail (B2)`).
+
+### Task 5: The multi-rule conformance vector — declaration order reproduces engine order
+
+**Files:**
+
+- Create: `rust/crates/babylon-tick/content/scenarios/vitality-lifecycle-combined-conformance.bscn`
+- Create: `rust/crates/babylon-tick/content/scenarios/vitality_lifecycle_combined_conformance.py`
+- Create: `rust/crates/babylon-tick/tests/multi_rule_conformance.rs`
+- Edit: `rust/crates/babylon-tick/content/rules/lifecycle.bsl` (one line: `(anchor :after
+  vitality)`)
+
+**The point of this task.** Proves the mechanism Tasks 2 and 4 built actually reproduces the frozen
+engine's own two-systems-in-order behavior (`VitalitySystem` @1, `LifecycleSystem` @7) — the
+conformance approach the Director's ruling called for — and, because the two rules' domains are
+disjoint (Multi-Rule Decision section), proves it with the RIGHT assertion (`per_rule_fired`'s
+order), not the assertion that would silently pass even with a broken driver (the final hash).
+
+- [ ] **Step 1: The declarative anchor.** Add `(anchor :after vitality)` to `lifecycle.bsl`'s
+      `(rule lifecycle/dpd-circuit …)` form, between its `:fuel` keyword and its `(bindings …)`
+      form, matching §2.3's grammar position (`<domain>? <anchor>? <bindings>`). This is inert for
+      ordering today (Task 4's driver does not read `.anchor`; no test may assert it does) —
+      forward-documentation for the eventual Phase 3 anchor-resolution registry, landed now while
+      the fact ("lifecycle runs after vitality") is fresh, cheap to state, and already true by
+      construction of this task's own content-string ordering. Confirm `check_anchor` still
+      accepts the form (`cargo test -p babylon-bsl` — the existing `lifecycle.bsl` parse/load
+      tests must stay green; adding a valid, well-formed anchor changes nothing else about the
+      rule's load).
+- [ ] **Step 2: The 10-node combined-conformance scenario.** Union `vitality-conformance.bscn`'s
+      six social-class nodes (`core`, `bourgeoisie`, `hermit`, `last-worker`, `remnant`,
+      `dissolved`, every field value transcribed byte-for-byte) and `lifecycle-conformance.bscn`'s
+      four territory nodes (`core-county`, `growing-county`, `recovering-county`, `young-county`,
+      same transcription discipline) into ONE `.bscn` file, combining the `deffield`/`defconst`
+      blocks (21 + 7 declarations — the Multi-Rule Decision section's collision check already confirms
+      zero name overlap so this is a straight concatenation, not a merge requiring judgment calls).
+      Name it `vitality-lifecycle-combined-conformance.bscn`; a dedicated, small, ALREADY-PROVEN
+      fixture, kept separate from Phase B's larger, real-FIPS-flavored demo scenario — this task's
+      job is proving the MECHANISM, Phase B's is building the PLAYABLE world, and conflating them
+      would make a mechanism bug harder to isolate from a demo-content bug.
+- [ ] **Step 3: The combined Python reference script.** `vitality_lifecycle_combined_conformance.py`
+      mirrors the calling convention `vitality_conformance.py` and `lifecycle_conformance.py`
+      already establish (both exist in this same directory — read them first, match their
+      structure, do not invent a new one): build ONE `WorldState`/graph carrying all ten fixture
+      nodes (the Step 2 values), then call `VitalitySystem().step(state)` FOLLOWED BY
+      `LifecycleSystem().step(state)` — matching the frozen engine's own tick-position order
+      (Vitality @1, Lifecycle @7) — and print every post-tick field this task's Rust test needs to
+      pin, for BOTH the six social-class nodes and the four territory nodes.
+- [ ] **Step 4: Write the failing Rust test.**
+
+```rust
+// tests/multi_rule_conformance.rs
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::hypergraph_store::HypergraphStore;
+use babylon_tick::{run_once_into, hex};
+
+const SCENARIO: &str =
+    include_str!("../content/scenarios/vitality-lifecycle-combined-conformance.bscn");
+const VITALITY: &str = include_str!("../content/rules/vitality.bsl");
+const LIFECYCLE: &str = include_str!("../content/rules/lifecycle.bsl");
+
+#[test]
+fn declaration_order_matching_engine_order_reproduces_the_frozen_engine() {
+    // vitality text FIRST, lifecycle text SECOND — Vitality @1 before
+    // Lifecycle @7, the frozen engine's own tick-position order.
+    let rule_src = format!("{VITALITY}\n{LIFECYCLE}");
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(SCENARIO, &rule_src, &mut graph, &mut sink).expect("tick");
+
+    // THE ORDER PROOF — per Multi-Rule Decision, the final hash would NOT
+    // catch an order bug for this disjoint-domain pair, so this is the
+    // load-bearing assertion, not the hash.
+    assert_eq!(report.per_rule_fired.len(), 2);
+    assert_eq!(report.per_rule_fired[0].0, "vitality/subsistence-and-death");
+    assert_eq!(report.per_rule_fired[1].0, "lifecycle/dpd-circuit");
+    // Exact counts pinned from Step 3's printed Python reference —
+    // transcribe the real numbers here once the script has run; both
+    // vitality-conformance.bscn (5 of 6 subjects pass the guard, per the
+    // existing pinned test) and lifecycle-conformance.bscn's own fixture
+    // are individually proven, so these counts should match those
+    // existing pins exactly, unchanged by union.
+    assert_eq!(report.per_rule_fired[0].1, /* vitality fired count */ 0);
+    assert_eq!(report.per_rule_fired[1].1, /* lifecycle fired count */ 0);
+
+    // Per-node field values match the Step 3 combined Python reference —
+    // both halves, transcribed from its printed output.
+    // (concrete node_attribute assertions per Step 3's script output)
+}
+
+#[test]
+fn flipping_declaration_order_flips_per_rule_fired_order() {
+    // The mechanism proof: swap which text comes first, and the ORDER
+    // Task 4's loop reports flips with it — a hash-based assertion could
+    // not show this for a disjoint pair (Multi-Rule Decision section), so
+    // this test exists specifically to prove the mechanism, not the
+    // content.
+    let rule_src = format!("{LIFECYCLE}\n{VITALITY}");
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(SCENARIO, &rule_src, &mut graph, &mut sink).expect("tick");
+    assert_eq!(report.per_rule_fired[0].0, "lifecycle/dpd-circuit");
+    assert_eq!(report.per_rule_fired[1].0, "vitality/subsistence-and-death");
+    // The FINAL state hash, by contrast, is expected to be IDENTICAL to
+    // the previous test's — documenting the domain-disjointness finding
+    // as a live, checked property rather than an assertion left silent.
+}
+```
+
+- [ ] **Step 5:** Run the Python script, transcribe its printed values into Step 4's placeholder
+      assertions and node-attribute checks (never leave a placeholder number in the committed
+      test — this step exists precisely to replace them with the real, printed values). `cargo
+      test -p babylon-tick --test multi_rule_conformance` → PASS.
+- [ ] **Step 6:** `mise run rust:check` → green. `mise run qa:regression` → byte-identical (this
+      task adds content and a test; it must not move any existing engine byte).
+- [ ] **Step 7: Commit** (`test(content): multi-rule conformance — vitality+lifecycle in
+      declaration order reproduces the frozen engine (B2)`).
+
+### Task 6: `TickSession<G>` — load once, advance many times, now multi-rule
 
 **Files:**
 
@@ -384,7 +1059,7 @@ pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
 - Produces:
 
 ```rust
-pub struct TickSession<G> { /* private: graph, prepared, tick */ }
+pub struct TickSession<G> { /* private: graph, prepared: PreparedRules, tick */ }
 
 impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
     pub fn new(scenario_src: &str, rule_src: &str, graph: G) -> Result<Self, String>;
@@ -394,10 +1069,13 @@ impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
 }
 ```
 
-  Every later task in this plan (Phase C's lens producers, Phase D's UI) reads state through
-  `session.graph()` and drives the loop through `session.advance(&mut sink)`. This is the ONE
-  babylon-tick API addition this plan makes — `run_once`, `run_once_into` and `TickReport` are
-  untouched (Task 1 proved that); a caller that only ever wants tick 1 still calls `run_once`.
+  Same four-method public surface as the first cut of this plan — the multi-rule widening is
+  entirely internal (`PreparedRule` → `PreparedRules`, one `run_tick` call → a loop). Every later
+  task in this plan (Phase C's lens producers, Phase D's UI) reads state through `session.graph()`
+  and drives the loop through `session.advance(&mut sink)`, unchanged. This is the ONE
+  `babylon-tick` API addition this plan makes on top of the language-crate widening — `run_once`,
+  `run_once_into` keep their exact current signatures; `TickReport` gains the additive
+  `per_rule_fired` field (Task 4), which every reader of `.fired` ignores without needing to change.
 
 - [ ] **Step 1: Write the failing tests.**
 
@@ -406,23 +1084,32 @@ use crate::session::TickSession;
 use babylon_bsl::structural_verbs::CollectingSink;
 use babylon_graph::hypergraph_store::HypergraphStore;
 
-const SCENARIO: &str = include_str!("../content/scenarios/lifecycle-conformance.bscn");
-const RULE: &str = include_str!("../content/rules/lifecycle.bsl");
+const SCENARIO: &str =
+    include_str!("../content/scenarios/vitality-lifecycle-combined-conformance.bscn");
+const VITALITY: &str = include_str!("../content/rules/vitality.bsl");
+const LIFECYCLE: &str = include_str!("../content/rules/lifecycle.bsl");
+
+fn rule_src() -> String {
+    format!("{VITALITY}\n{LIFECYCLE}")
+}
 
 #[test]
-fn advance_numbers_ticks_starting_at_one() {
-    let mut session = TickSession::new(SCENARIO, RULE, HypergraphStore::new()).expect("load");
+fn advance_numbers_ticks_starting_at_one_over_a_two_rule_session() {
+    let mut session =
+        TickSession::new(SCENARIO, &rule_src(), HypergraphStore::new()).expect("load");
     assert_eq!(session.tick(), 0);
     let mut sink = CollectingSink::default();
-    session.advance(&mut sink).expect("tick 1");
+    let r1 = session.advance(&mut sink).expect("tick 1");
     assert_eq!(session.tick(), 1);
+    assert_eq!(r1.per_rule_fired.len(), 2);
     session.advance(&mut sink).expect("tick 2");
     assert_eq!(session.tick(), 2);
 }
 
 #[test]
 fn advance_moves_state_and_each_tick_hashes_differently() {
-    let mut session = TickSession::new(SCENARIO, RULE, HypergraphStore::new()).expect("load");
+    let mut session =
+        TickSession::new(SCENARIO, &rule_src(), HypergraphStore::new()).expect("load");
     let mut sink = CollectingSink::default();
     let t1 = session.advance(&mut sink).expect("tick 1");
     let t2 = session.advance(&mut sink).expect("tick 2");
@@ -437,8 +1124,8 @@ fn two_independent_sessions_over_the_same_content_hash_identically() {
     // babylon-tick level — Phase E's test (tests/determinism.rs in
     // babylon-client) repeats this same property through the client's own
     // seam end to end.
-    let mut a = TickSession::new(SCENARIO, RULE, HypergraphStore::new()).expect("load a");
-    let mut b = TickSession::new(SCENARIO, RULE, HypergraphStore::new()).expect("load b");
+    let mut a = TickSession::new(SCENARIO, &rule_src(), HypergraphStore::new()).expect("load a");
+    let mut b = TickSession::new(SCENARIO, &rule_src(), HypergraphStore::new()).expect("load b");
     let mut sink_a = CollectingSink::default();
     let mut sink_b = CollectingSink::default();
     for _ in 0..5 {
@@ -453,15 +1140,16 @@ fn two_independent_sessions_over_the_same_content_hash_identically() {
 - [ ] **Step 3: Write `session.rs`.**
 
 ```rust
-//! `TickSession` — the persistent load-once, advance-many seam B2 needs.
-//! `run_once`/`run_once_into` (`lib.rs`) model exactly one tick end to end
-//! and hardcode `run_tick`'s tick argument to `1`; a player-driven loop
-//! needs the split this type provides instead: parse and load cost paid
-//! ONCE in `new`, the SAME `PreparedRule` and the SAME graph reused by
-//! every `advance()` call, with `tick` incremented by this type rather
-//! than by the caller re-guessing a number `run_tick` never exposed.
+//! `TickSession` — the persistent load-once, advance-many seam B2 needs,
+//! now multi-rule (Phase A, Tasks 2-4). `run_once`/`run_once_into`
+//! (`lib.rs`) model one tick end to end and hardcode `run_tick`'s tick
+//! argument to `1` for every rule the content set holds; a player-driven
+//! loop needs the split this type provides instead: parse and load cost
+//! paid ONCE in `new`, the SAME `PreparedRules` and the SAME graph reused
+//! by every `advance()` call, every rule in the content set run once per
+//! call, in declaration order, with `tick` incremented by this type.
 
-use crate::{prepare_rule, PreparedRule, TickReport};
+use crate::{prepare_rules, PreparedRules, TickReport};
 use babylon_bsl::intrinsic_host::KernelIntrinsicHost;
 use babylon_bsl::structural_verbs::CollectingSink;
 use babylon_bsl::tick::run_tick;
@@ -474,18 +1162,20 @@ use babylon_graph::substrate::GraphSubstrate;
 /// (ADR193).
 pub struct TickSession<G> {
     graph: G,
-    prepared: PreparedRule,
+    prepared: PreparedRules,
     tick: i64,
 }
 
 impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
-    /// Parse `rule_src` and load `scenario_src` into `graph` once.
+    /// Parse `rule_src` (one or more `(rule …)` forms, in declaration
+    /// order) and load `scenario_src` into `graph` once.
     ///
     /// # Errors
     /// The same failure modes `run_once_into`'s load half has: an
-    /// intrinsic declaration, a scenario load, or a rule load.
+    /// intrinsic declaration, a scenario load, or a rule load — named to
+    /// its own rule id when more than one rule is present.
     pub fn new(scenario_src: &str, rule_src: &str, mut graph: G) -> Result<Self, String> {
-        let prepared = prepare_rule(scenario_src, rule_src, &mut graph)?;
+        let prepared = prepare_rules(scenario_src, rule_src, &mut graph)?;
         Ok(Self {
             graph,
             prepared,
@@ -493,30 +1183,40 @@ impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
         })
     }
 
-    /// Run one more tick against the held graph. The first call runs tick
-    /// 1 (matching `run_once`'s own numbering), the second tick 2, and so
-    /// on — `:tick`/`:tick-in-cycle` bindings (§2.5) now see a real,
-    /// advancing count outside a test harness for the first time.
+    /// Run one more tick against the held graph: every rule in the
+    /// content set, in DECLARATION order, each to completion before the
+    /// next starts, against the SAME graph — so a later rule sees an
+    /// earlier rule's writes from this same tick (the frozen engine's own
+    /// in-place strict-order semantics, inherited for free from calling
+    /// `run_tick` sequentially against one `&mut G`). The first call runs
+    /// tick 1 (matching `run_once`'s own numbering), the second tick 2,
+    /// and so on.
     ///
     /// # Errors
-    /// The tick itself, or a pre/post state-hash failure.
+    /// The tick itself (named to its own rule id), or a pre/post
+    /// state-hash failure.
     pub fn advance(&mut self, sink: &mut CollectingSink) -> Result<TickReport, String> {
         self.tick += 1;
         let before = self
             .graph
             .state_hash()
             .map_err(|e| format!("pre-tick state: {}", e.message))?;
-        let outcome = run_tick(
-            &self.prepared.loaded,
-            &self.prepared.types,
-            &KernelIntrinsicHost,
-            &mut self.graph,
-            sink,
-            &self.prepared.intrinsics,
-            &self.prepared.consts,
-            self.tick,
-        )
-        .map_err(|e| format!("tick failed: {e}"))?;
+        let mut per_rule_fired = Vec::with_capacity(self.prepared.rules.len());
+        for (id, loaded) in &self.prepared.rules {
+            let outcome = run_tick(
+                loaded,
+                &self.prepared.types,
+                &KernelIntrinsicHost,
+                &mut self.graph,
+                sink,
+                &self.prepared.intrinsics,
+                &self.prepared.consts,
+                self.tick,
+            )
+            .map_err(|e| format!("tick failed in rule {id}: {e}"))?;
+            per_rule_fired.push((id.clone(), outcome.fired));
+        }
+        let fired = per_rule_fired.iter().map(|(_, n)| n).sum();
         let after = self
             .graph
             .state_hash()
@@ -524,7 +1224,8 @@ impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
         Ok(TickReport {
             before,
             after,
-            fired: outcome.fired,
+            fired,
+            per_rule_fired,
         })
     }
 
@@ -543,19 +1244,19 @@ impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
 }
 ```
 
-      `lib.rs` needs `PreparedRule`/`prepare_rule` visible to `session.rs` (same crate,
-      `pub(crate)` from Task 1 already covers this) plus `pub mod session;` and, for the client's
-      convenience, `pub use session::TickSession;` alongside the existing `pub use` of `TickReport`.
-- [ ] **Step 4:** `cargo test -p babylon-tick` → PASS (all three new tests, plus the two Task 1
-      regression tests still green). `mise run rust:check` → green.
-- [ ] **Step 5: Commit** (`feat(rust): TickSession — persistent load-once/advance-many tick loop
-      seam (B2)`).
+      `lib.rs` needs `PreparedRules`/`prepare_rules` visible to `session.rs` (same crate,
+      `pub(crate)` already covers this) plus `pub mod session;` and, for the client's convenience,
+      `pub use session::TickSession;` alongside the existing `pub use` of `TickReport`.
+- [ ] **Step 4:** `cargo test -p babylon-tick` → PASS (all three tests above, plus Task 4's
+      regression tests and Task 5's conformance tests still green). `mise run rust:check` → green.
+- [ ] **Step 5: Commit** (`feat(rust): TickSession — persistent load-once/advance-many multi-rule
+      tick loop seam (B2)`).
 
 ---
 
 ## Phase B — The demo content
 
-### Task 3: Twelve real-FIPS demo counties
+### Task 7: The eighteen-subject demo world — twelve real-FIPS counties, six social classes
 
 **Files:**
 
@@ -564,10 +1265,15 @@ impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
 
 **The point of this task:** `lifecycle-conformance.bscn`'s four territory nodes
 (`core-county`/`growing-county`/`recovering-county`/`young-county`) carry proven-correct fixture
-values (Task 2's tests already exercise them through the `lifecycle` rule pack) but carry synthetic local
-names with no FIPS code, so `CountyAtlas::index_of_fips` cannot place them on the B1 map. This
-task re-stamps the SAME four archetype value sets onto twelve REAL FIPS codes so the map has real
-counties to light up, without inventing new numbers this plan's author cannot verify.
+values but carry synthetic local names with no FIPS code, so `CountyAtlas::index_of_fips` cannot
+place them on the B1 map. `vitality-conformance.bscn`'s six social-class nodes have no territorial
+binding at all — by construction (Multi-Rule Decision section), vitality's contribution to this
+demo is INVISIBLE on the map surface itself; it shows up only in the event feed
+(`ENTITY_DEATH`-family events) and, if a future task adds a class-scoped panel, in state readouts —
+stated here plainly rather than implied, since "richer demo" should not quietly promise a
+map-visible effect vitality's own subject type cannot honestly produce. This task re-stamps the
+lifecycle archetype value sets onto twelve REAL FIPS codes AND mints the vitality fixture verbatim
+alongside them, in ONE scenario, without inventing new numbers this plan's author cannot verify.
 
 - [ ] **Step 1: Select the twelve FIPS, deterministically, from the committed atlas — never
       guessed.** B1 Task 1 Step 5 sorts the atlas's county table by FIPS ascending before writing,
@@ -596,18 +1302,24 @@ fn print_first_twelve() {
       Record the twelve printed `(fips, name)` pairs in this task's commit body verbatim — this is
       the only place in this plan a FIPS code is fixed, and it is fixed by running code against the
       committed artifact, not by recall.
-- [ ] **Step 2: Write the scenario.** Reuse the `lifecycle-conformance.bscn` header's `deffield`
-      block and all 21 `defconst` rows byte-for-byte (same field types, same coefficient values,
-      same `defines.yaml` line citations in the comments — this task changes WHICH nodes exist,
-      never what the rule pack computes over them). Cycle the four archetype value sets from
-      `lifecycle-conformance.bscn:80-124` across the twelve FIPS in order (indices 0-2 get the
-      `core-county` values, 3-5 `growing-county`, 6-8 `recovering-county`, 9-11 `young-county`),
-      naming each node `county-<fips>` (symbols must start with a lowercase letter — §1's
-      `symbol ::= LOWER (LOWER | DIGIT | "-")*` — a bare FIPS like `06037` is not a legal symbol,
-      `county-06037` is):
+- [ ] **Step 2: Write the scenario.** ONE `.bscn` file, two node-type halves:
+      - **Territory half.** Reuse the `lifecycle-conformance.bscn` header's `deffield` block and
+        all 21 `defconst` rows byte-for-byte. Cycle the four archetype value sets from
+        `lifecycle-conformance.bscn:80-124` across the twelve FIPS in order (indices 0-2 get the
+        `core-county` values, 3-5 `growing-county`, 6-8 `recovering-county`, 9-11 `young-county`),
+        naming each node `county-<fips>` (symbols must start with a lowercase letter — §1's
+        `symbol ::= LOWER (LOWER | DIGIT | "-")*` — a bare FIPS like `06037` is not a legal symbol,
+        `county-06037` is).
+      - **Social-class half.** Reuse `vitality-conformance.bscn`'s `deffield` block (7 fields,
+        `social-class/inequality` included though no rule reads it, for fixture parity with the
+        frozen engine per that file's own comment) and its 2 `defconst` rows, and its six nodes'
+        values, byte-for-byte, keeping the SAME local names (`core`, `bourgeoisie`, `hermit`,
+        `last-worker`, `remnant`, `dissolved` — the Multi-Rule Decision section's collision check
+        already confirms these never collide with `county-<fips>`).
 
 ```text
 (scenario lifecycle/us-counties-demo
+  ; --- territory half (lifecycle) ---
   (deffield territory/pop-d int extensive)
   (deffield territory/pop-p int extensive)
   (deffield territory/pop-d-prime int extensive)
@@ -617,8 +1329,19 @@ fn print_first_twelve() {
   (deffield territory/legitimation-crisis int intensive)
   (deffield territory/transmitted-ideology int intensive)
 
-  ; ... all 21 defconst rows, transcribed verbatim from
+  ; --- social-class half (vitality) ---
+  (deffield social-class/active int extensive)
+  (deffield social-class/population int extensive)
+  (deffield social-class/wealth int extensive)
+  (deffield social-class/subsistence-multiplier int intensive)
+  (deffield social-class/s-bio int intensive)
+  (deffield social-class/s-class int intensive)
+  (deffield social-class/inequality int intensive)
+
+  ; ... all 21 lifecycle/* defconst rows, transcribed verbatim from
   ; lifecycle-conformance.bscn:56-76, same values, same :NNN citations ...
+  ; ... both economy/* defconst rows, transcribed verbatim from
+  ; vitality-conformance.bscn:43-44 ...
 
   ; county-<fips[0]>, county-<fips[1]>, county-<fips[2]>: the core-county
   ; archetype (DPDState docstring numbers, PRE-crisis STABLE).
@@ -634,10 +1357,19 @@ fn print_first_twelve() {
   ;   fires LEGITIMATION_RECOVERY on tick 1 under these defconsts, same as
   ;   the conformance scenario).
   ; county-<fips[9..12]>: the young-county archetype (no D' cohort).
+
+  ; The six vitality-conformance.bscn nodes, values transcribed verbatim
+  ; (fed core, standard-of-living-scaled bourgeoisie, surviving hermit,
+  ; starving last-worker, zombie-failsafe remnant, already-dissolved).
+  (node core NodeType/SOCIAL_CLASS
+    (social-class/active 1) (social-class/population 100) (social-class/wealth 1000)
+    (social-class/subsistence-multiplier 1) (social-class/s-bio 1) (social-class/s-class 1)
+    (social-class/inequality 0))
+  ; ... bourgeoisie, hermit, last-worker, remnant, dissolved, same values ...
   )
 ```
 
-      Write out all twelve `(node …)` forms in full — no ellipsis in the committed file, the
+      Write out all eighteen `(node …)` forms in full — no ellipsis in the committed file, the
       ellipses above are this plan document's abbreviation only.
 - [ ] **Step 3: A loading test.**
 
@@ -648,18 +1380,24 @@ use babylon_graph::hypergraph_store::HypergraphStore;
 use babylon_tick::TickSession;
 
 const SCENARIO: &str = include_str!("../content/scenarios/us-counties-lifecycle-demo.bscn");
-const RULE: &str = include_str!("../content/rules/lifecycle.bsl");
+const VITALITY: &str = include_str!("../content/rules/vitality.bsl");
+const LIFECYCLE: &str = include_str!("../content/rules/lifecycle.bsl");
 
 #[test]
-fn the_demo_scenario_loads_and_ticks() {
-    let mut session = TickSession::new(SCENARIO, RULE, HypergraphStore::new()).expect("load");
+fn the_demo_scenario_loads_and_ticks_both_packs() {
+    let rule_src = format!("{VITALITY}\n{LIFECYCLE}");
+    let mut session =
+        TickSession::new(SCENARIO, &rule_src, HypergraphStore::new()).expect("load");
     let mut sink = CollectingSink::default();
     let report = session.advance(&mut sink).expect("tick 1");
     assert_ne!(report.before, report.after);
+    assert_eq!(report.per_rule_fired.len(), 2);
+    assert_eq!(report.per_rule_fired[0].0, "vitality/subsistence-and-death");
+    assert_eq!(report.per_rule_fired[1].0, "lifecycle/dpd-circuit");
     // The recovering-county archetype fires LEGITIMATION_RECOVERY on tick 1
     // under these defconsts (matching lifecycle-conformance.bscn's own
-    // documented behavior) — proves the twelve nodes really run the rule,
-    // not just mint successfully.
+    // documented behavior) — proves the twelve territory nodes really run
+    // lifecycle, not just mint successfully.
     assert!(sink
         .events
         .iter()
@@ -672,14 +1410,14 @@ fn the_demo_scenario_loads_and_ticks() {
       comment says so; a stale `#[ignore]`d test that prints fixed array indices against a file
       that could later change underneath is exactly the kind of orphan CLAUDE.md's Surgical
       Changes rule asks an author to clean up when a task's own steps create one.
-- [ ] **Step 5: Commit** (`feat(content): twelve-real-FIPS lifecycle demo scenario for the B2 tick
-      loop`), body carrying the Step 1 FIPS/name table.
+- [ ] **Step 5: Commit** (`feat(content): the eighteen-subject B2 demo world — twelve real-FIPS
+      counties + six social classes`), body carrying the Step 1 FIPS/name table.
 
 ---
 
 ## Phase C — The dual-lens map (completes B1 Phase C)
 
-### Task 4: The Tension lens, ported and corrected for `HypergraphStore`
+### Task 8: The Tension lens, ported and corrected for `HypergraphStore`
 
 **Files:**
 
@@ -708,11 +1446,14 @@ pub fn county_tension(graph: &dyn GraphSubstrate) -> LensReading;
 - [ ] **Step 2:** FAIL, then write it — the ADR170 formula transcribed exactly as B1's Task 8
       specified (`phi = v/(v+s)`, `theta = sum(v)/sum(v+s)`, `w = (phi-theta)/(phi+theta)`,
       `phi+theta <= 1e-9` collapses to `0.0`), reading `graph.nodes("NodeType/TERRITORY")` and
-      `graph.node_attribute(id, "...")` through `&dyn GraphSubstrate` rather than a concrete store.
+      `graph.node_attribute(id, "...")` through `&dyn GraphSubstrate` rather than a concrete store
+      — note this graph, from Task 7 on, ALSO holds six `NodeType/SOCIAL_CLASS` nodes; `nodes()`'s
+      own type filter (verified in `memory.rs`/`hypergraph_store.rs`) already excludes them, so
+      this task's logic needs no change — confirmed by reading, recorded here rather than assumed.
 - [ ] **Step 3:** `cargo test -p babylon-client` → PASS.
 - [ ] **Step 4: Commit** (`feat(client): the ADR170 tension witness over &dyn GraphSubstrate (B2)`).
 
-### Task 5: The Legitimation lens — live, categorical, zero new math
+### Task 9: The Legitimation lens — live, categorical, zero new math
 
 **Files:**
 
@@ -728,8 +1469,11 @@ pub fn county_tension(graph: &dyn GraphSubstrate) -> LensReading;
 writes `territory/legitimation-crisis` as an encoded classification (0 = STABLE, 1 = UNSTABLE,
 2 = CRISIS — the rule pack's own header comment documents the encoding, quoted in
 `lifecycle-conformance.bscn`'s comments). Coloring the map from THIS field, rather than re-deriving
-a threshold on the raw `territory/legitimation-index`, adds no new cut point and no new math — this is a straight
-categorical pass-through, consistent with the standing "no imposed functional forms" ruling.
+a threshold on the raw `territory/legitimation-index`, adds no new cut point and no new math — this
+is a straight categorical pass-through, consistent with the standing "no imposed functional forms"
+ruling. **This module produces the raw classification number only** — Task 10's `bands.rs` owns
+the color mapping (Director ruling 1), matching the Tension lens's own separation of "compute the
+value" from "pick the color."
 
 - [ ] **Step 1: Write the failing tests.** A territory whose `legitimation-crisis` reads back
       `0.0`/`1.0`/`2.0` classifies to `Stable`/`Unstable`/`Crisis` respectively; a `node_by_fips`
@@ -742,14 +1486,12 @@ categorical pass-through, consistent with the standing "no imposed functional fo
       float (`0.0 => Stable`, `1.0 => Unstable`, `2.0 => Crisis`, anything else a loud panic — the
       encoding is a closed set the rule pack itself defines); `county_legitimation` reads
       `territory/legitimation-crisis` for every `(fips, id)` pair in `node_by_fips` and returns
-      `Some(raw_class_as_f64)` per cell (kept as the raw encoded number in `LensReading.cells` so
-      `map/bands.rs`'s consumer, not this module, owns the color mapping — matching the Tension
-      lens's own separation of "compute the value" from "pick the color").
+      `Some(raw_class_as_f64)` per cell.
 - [ ] **Step 3:** `cargo test -p babylon-client` → PASS.
 - [ ] **Step 4: Commit** (`feat(client): the legitimation lens — live per-tick classification, zero
       new thresholds (B2)`).
 
-### Task 6: Two band tables, one recolor system
+### Task 10: Two band tables, one recolor system
 
 **Files:**
 
@@ -759,18 +1501,37 @@ categorical pass-through, consistent with the standing "no imposed functional fo
 
 - Produces: `pub fn tension_band_color(w: Option<f64>) -> Color` (ADR191 R11's table, exactly as
   the B1 plan's Task 9 specified — four rows, `<=` resolution, `PANEL` for absence) and `pub fn
-  legitimation_band_color(class: Option<f64>) -> Color` (three rows: `Some(0.0) => GREEN_DARK`,
-  `Some(1.0) => GOLD`, `Some(2.0) => CRIMSON`, `None => PANEL`) plus `pub enum ActiveLens { Tension,
-  Legitimation }` and `#[derive(Event)] pub struct LensChanged;`.
+  legitimation_band_color(class: Option<f64>) -> Color` (per this amendment's Director ruling 1:
+  three rows, `Some(0.0) => PANEL`, `Some(1.0) => DIM`, `Some(2.0) => CRIMSON`, `None => PANEL`)
+  plus `pub enum ActiveLens { Tension, Legitimation }` and `#[derive(Event)] pub struct
+  LensChanged;`.
+
+**Director ruling 1, applied exactly.** Selected option, quoted: *"CRISIS → crimson, UNSTABLE →
+dim gray, STABLE → gold's absence (panel dark) — reuses the ruled four-band vocabulary so the two
+lenses share one visual language. No new colors enter the game."* This REPLACES the first cut's
+design (which had invented `GREEN_DARK`/`GOLD` mappings for STABLE/UNSTABLE — neither ships).
+**STABLE and "no data this tick" render the SAME color, `PANEL`, on purpose** — a deliberate
+INVERSION of the Tension lens's own rule (ADR191 R11, carried unmodified in `tension_band_color`):
+"nothing may confuse absence with the neutral band" there means Tension's neutral band is `DIM`,
+distinct from `PANEL`. Here, the Director's own ruling makes STABLE deliberately indistinguishable
+from absence BY COLOR — "gold's absence" reads as "nothing here needs your attention," which is
+thematically apt for a stable county fading into the background. The HUD (Task 11) is, as a
+result, the ONLY channel that can tell a player "this county is STABLE" from "this county has no data" —
+its literal text label carries weight the color alone cannot, and Task 11's steps make that
+explicit.
 
 - [ ] **Step 1: Write the failing tests** for both band functions — the exact `Srgba` byte
       assertions from the B1 Task 9 spec for `tension_band_color` (CRIMSON at `w <= -0.15`, DIM in
-      `(-0.15, 0.15]`, GOLD above, PANEL for `None`) plus the three-plus-one assertions for
-      `legitimation_band_color`. Assert `tension_band_color(Some(0.0)) != tension_band_color(None)`
-      and the same non-confusion property for `legitimation_band_color` — absence must never read
-      as the neutral/stable band in either lens.
+      `(-0.15, 0.15]`, GOLD above, PANEL for `None`; `tension_band_color(Some(0.0)) !=
+      tension_band_color(None)`, the Tension lens's OWN non-confusion property, unchanged) plus,
+      for `legitimation_band_color`: `Some(0.0)` and `None` BOTH give `PANEL` (the intentional
+      equality Director ruling 1 creates — assert them EQUAL, not distinct, and comment why,
+      citing this ruling by name so a future reader does not "fix" it back to the first cut's
+      design); `Some(1.0)` gives `DIM`; `Some(2.0)` gives `CRIMSON`.
 - [ ] **Step 2:** FAIL, then write both as `const` tables resolved by the same `<=`-walk shape,
-      matching `PANEL`'s existing declaration in this file.
+      matching `PANEL`'s existing declaration in this file. `legitimation_band_color` needs no new
+      color constant — it imports `PANEL`, `DIM`, `CRIMSON`, all already declared in this file or
+      `crate::palette`.
 - [ ] **Step 3: The recolor system.** One system, parameterized by `ActiveLens`:
 
 ```rust
@@ -779,7 +1540,7 @@ pub(super) fn recolor_on_lens_changed(
     active: Res<ActiveLens>,
     lens_data: Res<CurrentLensData>, // holds both LensReading values, refreshed every advance
     surface: Res<MapSurface>,
-    atlas_index: Res<FipsIndex>,     // fips -> atlas county index, from Task 9
+    atlas_index: Res<FipsIndex>,     // fips -> atlas county index, from Task 12
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
     if events.read().next().is_none() {
@@ -817,15 +1578,18 @@ pub(super) fn recolor_on_lens_changed(
 
       One pass, one buffer, matching B1 Task 9's own "no mesh rebuild" design — this is the same
       recolor shape B1's plan already specified, now parameterized over which lens is active
-      instead of hardcoded to Tension alone.
+      instead of fixed to Tension alone.
 - [ ] **Step 4: Headless test** — `MinimalPlugins` + `AssetPlugin`, install a `CurrentLensData`
       with one known Legitimation cell, set `ActiveLens::Legitimation`, fire `LensChanged`, `update()`,
       assert that county's vertex range shows `legitimation_band_color`'s output and every other
-      county's colors held at `PANEL`.
-- [ ] **Step 5: Commit** (`feat(client): two-lens band tables + a lens-parameterized recolor system
-      (B2, completes B1 Phase C Task 9)`).
+      county's colors held at `PANEL`. Add a SPECIFIC regression case: a `Some(0.0)` (STABLE) cell
+      and a genuinely-absent cell (a FIPS with no `LensReading` entry at all) produce the SAME
+      vertex color — proving the intentional merge, not just the function's return value in
+      isolation.
+- [ ] **Step 5: Commit** (`feat(client): two-lens band tables — legitimation reuses PANEL/DIM/
+      CRIMSON per Director ruling 1 (B2, completes B1 Phase C Task 9)`).
 
-### Task 7: Hover, selection, the active-lens label
+### Task 11: Hover, selection, the active-lens label
 
 **Files:**
 
@@ -848,26 +1612,33 @@ pub(super) fn recolor_on_lens_changed(
 - [ ] **Step 3: Wire the interaction** — `Camera::viewport_to_world_2d` → `county_at` → `HoveredCounty`;
       click promotes to `SelectedCounty`; a GOLD outline at `z = 2.0` over the selection.
 - [ ] **Step 4: The HUD**, extended past B1 Task 10's spec with the lens label this plan's honesty
-      rule adds. Bottom-left, BONE text:
+      rule adds — and, under the Legitimation lens specifically, carrying MORE weight than usual
+      per Task 10's finding that STABLE and absence share a color:
 
 ```text
 <county name>, <state> (<FIPS>)
 Lens: Tension — w = -0.42 (Φ-source, bled)          [if ActiveLens::Tension]
-Lens: Legitimation — CRISIS (live, tick 7)          [if ActiveLens::Legitimation]
+Lens: Legitimation — CRISIS (live, tick 7)          [if ActiveLens::Legitimation, class 2]
+Lens: Legitimation — STABLE (live, tick 7)          [class 0 — SAME map color as absence;
+                                                       this line is the only place a player
+                                                       can tell the two apart]
 Lens: Tension — no data this tick                    [absence, either lens]
 ```
 
       Top-left banner whenever the active lens's `absent_reason.is_some()`, in CRIMSON. A
-      persistent DIM footer names which lens is inactive and how to switch (Task 9): "Tab: switch
+      persistent DIM footer names which lens is inactive and how to switch (Task 12): "Tab: switch
       to Legitimation lens" or vice versa — the map must never let a color mean two things without
-      saying which one is live.
+      saying which one is live, and (per Task 10) a STABLE county must never let its color alone
+      be mistaken for "no data."
 - [ ] **Step 5: Headless test** — hovering a known world point sets `HoveredCounty` to the expected
       FIPS, cursor position written directly to the resource (B1 Task 10's own precedent, not
-      synthesized window events).
+      synthesized window events). Add a case hovering a STABLE demo county and asserting the HUD
+      text renders the literal string `"STABLE"` (not merely a color check, since Task 10
+      established the color cannot carry this distinction alone).
 - [ ] **Step 6: Commit** (`feat(client): county hover, selection and the active-lens HUD (B2,
       completes B1 Phase C Task 10)`).
 
-### Task 8: Wire `map/mod.rs` — the lens picker
+### Task 12: Wire `map/mod.rs` — the lens picker
 
 **Files:**
 
@@ -880,9 +1651,9 @@ Lens: Tension — no data this tick                    [absence, either lens]
 - [ ] **Step 2:** FAIL, then add: `mod pick; mod hud;` (new modules from this task); `pub use
       bands::{ActiveLens, LensChanged};` alongside the existing `pub use bands::PANEL;` — the same
       re-export convention B1 already established for `PANEL`, extended to the two new types so
-      `crate::map::ActiveLens`/`crate::map::LensChanged` (the paths Task 10's and Task 14's code
+      `crate::map::ActiveLens`/`crate::map::LensChanged` (the paths Task 14's and Task 18's code
       use) resolve; `ActiveLens::Tension` inserted as the `Startup` default resource; an `Update`
-      system reading `Tab` and toggling it plus sending `LensChanged`; Task 6's
+      system reading `Tab` and toggling it plus sending `LensChanged`; Task 10's
       `recolor_on_lens_changed` system registered.
 - [ ] **Step 3:** `cargo test -p babylon-client` → PASS. `mise run rust:check` → green.
 - [ ] **Step 4: Commit** (`feat(client): wire the lens picker into MapPlugin (B2)`). Open the
@@ -893,7 +1664,7 @@ Lens: Tension — no data this tick                    [absence, either lens]
 
 ## Phase D — The loop UI
 
-### Task 9: `EngineSession` — the client's held tick session
+### Task 13: `EngineSession` — the client's held tick session
 
 **Files:**
 
@@ -916,15 +1687,23 @@ impl EngineSession {
 ```
 
 **Why `node_by_fips` is a plain `Vec`, not a `babylon-bsl` API addition.** `load_scenario`'s local
-name -> `NodeId` map is deliberately load-time-only and does not outlive the call (`scenario.rs:188`'s
+name -> `NodeId` map is deliberately load-time-only and does not outlive the call (`scenario.rs`'s
 own comment). This plan does not widen that API. Instead: the Phase B scenario mints EXACTLY the
-twelve `NodeType/TERRITORY` nodes, in file order, and no others; `GraphSubstrate::nodes()` returns
-ascending `NodeId`s, which equal mint order because `NodeId` mints as a monotonic counter (ADR193).
-Zipping `graph.nodes("NodeType/TERRITORY")` against a `const DEMO_FIPS: [&str; 12]` array **in
-the same order as the `.bscn` file's twelve `(node …)` forms** recovers the fips↔id mapping with
-no new babylon-bsl surface — fragile only in the sense that editing the `.bscn` file's node order
-without updating `DEMO_FIPS` would silently mislabel a county, which Step 2's loud startup
-assertion turns into an immediate panic instead.
+twelve `NodeType/TERRITORY` nodes and six `NodeType/SOCIAL_CLASS` nodes, in file order, and no
+others; `GraphSubstrate::nodes("NodeType/TERRITORY")` filters BY TYPE and returns ascending
+`NodeId`s among territory nodes only, which equal territory-mint order because `NodeId` mints as a
+GLOBAL monotonic counter across the whole scenario (ADR193) and the type filter preserves relative
+order within the filtered subset — verified by reading both `nodes()` implementations
+(`memory.rs`/`hypergraph_store.rs`), not assumed: interleaving social-class and territory node
+declarations in the `.bscn` file changes the ABSOLUTE `NodeId` values but not their RELATIVE order
+among same-typed nodes, so this zip is correct regardless of how the two halves interleave in the
+file. Zipping `graph.nodes("NodeType/TERRITORY")` against a `const DEMO_FIPS: [&str; 12]` array
+**in the same order as the `.bscn` file's twelve territory `(node …)` forms** recovers the
+fips↔id mapping with no new babylon-bsl surface — fragile only in the sense that editing the
+`.bscn` file's territory node order without updating `DEMO_FIPS` would silently mislabel a county,
+which Step 2's loud startup assertion turns into an immediate panic instead. **Social-class nodes
+get no matching index** — the event feed (Task 15) reads `sink.events` generically and needs no
+per-class lookup; a class-scoped state panel sits outside this task's scope (noted, not built).
 
 - [ ] **Step 1: Write the failing test.**
 
@@ -943,12 +1722,13 @@ fn engine_session_starts_and_the_twelve_fips_resolve_on_the_real_atlas() {
 }
 
 #[test]
-fn engine_session_advance_moves_the_hash_and_the_tick_counter() {
+fn engine_session_advance_moves_the_hash_and_runs_both_rules_every_tick() {
     let mut session = EngineSession::start().expect("start");
     let r1 = session.advance().expect("tick 1");
     let r2 = session.advance().expect("tick 2");
     assert_eq!(session.inner.tick(), 2);
     assert_ne!(r1.after, r2.after);
+    assert_eq!(r1.per_rule_fired.len(), 2, "both packs run every tick");
 }
 ```
 
@@ -957,12 +1737,13 @@ fn engine_session_advance_moves_the_hash_and_the_tick_counter() {
 ```rust
 const SCENARIO: &str =
     include_str!("../../babylon-tick/content/scenarios/us-counties-lifecycle-demo.bscn");
-const RULE: &str = include_str!("../../babylon-tick/content/rules/lifecycle.bsl");
+const VITALITY: &str = include_str!("../../babylon-tick/content/rules/vitality.bsl");
+const LIFECYCLE: &str = include_str!("../../babylon-tick/content/rules/lifecycle.bsl");
 
-/// Same order as `us-counties-lifecycle-demo.bscn`'s twelve `(node …)`
-/// forms — Task 3's Step 1 print output, transcribed. A loud startup
-/// assertion (below) catches the two arrays ever drifting apart.
-const DEMO_FIPS: [&str; 12] = [ /* the twelve FIPS from Task 3 Step 1, in file order */ ];
+/// Same order as `us-counties-lifecycle-demo.bscn`'s twelve territory
+/// `(node …)` forms — Task 7's Step 1 print output, transcribed. A loud
+/// startup assertion (below) catches the two arrays ever drifting apart.
+const DEMO_FIPS: [&str; 12] = [ /* the twelve FIPS from Task 7 Step 1, in file order */ ];
 
 pub struct EngineSession {
     pub inner: TickSession<HypergraphStore>,
@@ -973,15 +1754,14 @@ pub struct EngineSession {
 impl EngineSession {
     pub fn start() -> Result<Self, String> {
         let mut graph = HypergraphStore::new();
-        // Load through the same prepare path TickSession uses internally —
-        // but we need the node ids BEFORE TickSession takes ownership of
-        // the graph, so load once here to capture them, then hand a FRESH
-        // graph to TickSession::new (it reloads the same scenario, which
-        // is deterministic and mints the identical twelve ids — proven by
-        // this task's own Step 1 test, which checks both independently).
-        let scenario_nodes = babylon_bsl::scenario::load_scenario(SCENARIO, &mut graph)
-            .map_err(|e| e.to_string())?;
-        let _ = scenario_nodes; // node_count only; the ids come from nodes() below
+        // Load through the same load path TickSession uses internally —
+        // but we need the territory node ids BEFORE TickSession takes
+        // ownership of the graph, so load once here to capture them, then
+        // hand a FRESH graph to TickSession::new (it reloads the same
+        // scenario, which is deterministic and mints the identical
+        // eighteen ids — proven by this task's own Step 1 test, which
+        // checks both independently).
+        babylon_bsl::scenario::load_scenario(SCENARIO, &mut graph).map_err(|e| e.to_string())?;
         let ids = babylon_graph::substrate::GraphSubstrate::nodes(&graph, "NodeType/TERRITORY");
         if ids.len() != DEMO_FIPS.len() {
             panic!(
@@ -997,7 +1777,11 @@ impl EngineSession {
             .map(|(fips, id)| ((*fips).to_owned(), *id))
             .collect();
 
-        let inner = TickSession::new(SCENARIO, RULE, HypergraphStore::new())
+        // vitality text FIRST, lifecycle text SECOND — Vitality @1 before
+        // Lifecycle @7, per the Multi-Rule Decision section's declaration-
+        // order design (Phase A, Tasks 2-6).
+        let rule_src = format!("{VITALITY}\n{LIFECYCLE}");
+        let inner = TickSession::new(SCENARIO, &rule_src, HypergraphStore::new())
             .map_err(|e| format!("tick session: {e}"))?;
 
         Ok(Self {
@@ -1013,15 +1797,16 @@ impl EngineSession {
 }
 ```
 
-      Note the deliberate double-load (once to recover ids, once inside `TickSession::new`) rather
-      than widening `TickSession` to expose its internal graph mutably before the first `advance` —
-      it costs one extra scenario parse at startup (microseconds against a 12-node scenario) and
-      keeps `TickSession`'s public surface exactly the four methods Task 2 specified.
+      Note the deliberate double-load (once to recover territory ids, once inside
+      `TickSession::new`) rather than widening `TickSession` to expose its internal graph mutably
+      before the first `advance` — it costs one extra scenario parse at startup (still
+      microseconds against an 18-node scenario) and keeps `TickSession`'s public surface exactly
+      the four methods Task 6 specified.
 - [ ] **Step 3:** `cargo test -p babylon-client` → PASS.
-- [ ] **Step 4: Commit** (`feat(client): EngineSession — the client's held TickSession + fips↔id
-      map (B2)`).
+- [ ] **Step 4: Commit** (`feat(client): EngineSession — the client's held two-rule TickSession +
+      fips↔id map (B2)`).
 
-### Task 10: Advance-tick input, tick counter, hash readout
+### Task 14: Advance-tick input, tick counter, hash readout
 
 **Files:**
 
@@ -1144,7 +1929,7 @@ fn refresh_readouts(
         // The last hash this session computed — sink carries no hash, so
         // read it back off the session's own last report by re-deriving
         // from the graph directly (state_hash is cheap at this scale, see
-        // the Global Constraints Scale Note).
+        // the Global Constraints Scale Note — 18 nodes, 0 hyperedges).
         if let Ok(hash) = babylon_graph::state_hash::CanonicalState::state_hash(session.inner.graph())
         {
             h.0 = format!("hash: {}", babylon_tick::hex(&hash));
@@ -1162,25 +1947,25 @@ fn refresh_readouts(
       counter and hash text change every press.
 - [ ] **Step 6: Commit** (`feat(client): advance-tick input, tick counter, hash readout (B2)`).
 
-### Task 11: The state panel and the event feed
+### Task 15: The state panel and the event feed
 
 **Files:**
 
 - Edit: `rust/crates/babylon-client/src/loop_ui.rs`
 
 - [ ] **Step 1: Write the failing headless test** — after two `advance()` calls with a county
-      selected (write `SelectedCounty` directly, matching Task 7's pick-testing precedent), the
+      selected (write `SelectedCounty` directly, matching Task 11's pick-testing precedent), the
       state panel's text contains that county's live `pop-d`/`pop-p`/`pop-d-prime`/
       `legitimation-index` values read straight off the graph (not off the lens, which only carries
       the classification) — proving the panel and the map agree because both read the same graph.
 - [ ] **Step 2:** FAIL, then write `spawn_state_panel`/`refresh_state_panel`. `SelectedCounty`
-      (Task 7) wraps an ATLAS INDEX (`usize`), not a `NodeId` — the map's own vocabulary, matching
+      (Task 11) wraps an ATLAS INDEX (`usize`), not a `NodeId` — the map's own vocabulary, matching
       `county_at`'s return type. Resolve the chain explicitly: atlas index -> `atlas.county(idx).fips`
       -> a linear scan of `session.node_by_fips` (twelve entries — a `HashMap` is not worth building
       for this size) for the matching FIPS -> its `NodeId`. A `SelectedCounty`/`HoveredCounty` whose
       atlas index resolves to a FIPS absent from `node_by_fips` (any of the 3,210 non-demo counties)
       renders the panel's honest "no data this tick" text, never a lookup panic — this is the same
-      honest-absence shape Task 5's `LensReading` already establishes, applied here to the panel
+      honest-absence shape Task 8's `LensReading` already establishes, applied here to the panel
       instead of the map. For a resolved `id`, read the four fields via
       `session.inner.graph().node_attribute(id, "...")` and render:
 
@@ -1192,25 +1977,40 @@ fn refresh_readouts(
   legitimation:     STABLE (0)
 ```
 
-- [ ] **Step 3: The event feed.** A scrolling text list, last 10 entries from
-      `session.sink.events`, newest first, rendered as `<EventType> @ <county or n/a>` — reusing
-      `CollectingSink`'s already-populated `events: Vec<(String, Vec<(String, Value)>)>` with no
-      new sink type. Bounded to the last 10 by slicing, not by mutating `sink.events` (the sink
-      accumulates the WHOLE session's history — acceptable at demo scale, a ring buffer is a
-      documented future item if unbounded play sessions become a target, not built here).
+- [ ] **Step 3: The event feed — now genuinely two-pack.** A scrolling text list, last 10 entries
+      from `session.sink.events`, newest first, rendered as `<EventType> @ <county or n/a>` —
+      reusing `CollectingSink`'s already-populated `events: Vec<(String, Vec<(String, Value)>)>`
+      with no new sink type. Because `EngineSession` (Task 13) now runs vitality THEN lifecycle
+      every tick, `sink.events` genuinely mixes BOTH packs' emissions in execution order:
+      `vitality`'s `EventType/ENTITY_DEATH` (its own payload carries `entity-id`, no county
+      binding — rendered as `@ n/a`) alongside `lifecycle`'s
+      `LIFECYCLE_TRANSITION`/`LEGITIMATION_CRISIS`/`LEGITIMATION_RECOVERY` (county-bound, rendered
+      with the county's name where the payload's `entity-id` resolves through `node_by_fips`) —
+      this IS the "richer first demo" the Director's ruling asked for, concretely: the feed is
+      where the vitality half of the demo becomes visible at all, since Task 7 already established
+      it has no map-color counterpart. Bounded to the last 10 by slicing, not by mutating
+      `sink.events` (the sink accumulates the WHOLE session's history — acceptable at demo scale, a
+      ring buffer is a documented future item if unbounded play sessions become a target, not built
+      here).
 - [ ] **Step 4: Headless test** for the event feed — after an `advance()` that fires
-      `LEGITIMATION_RECOVERY` (Task 3's own recovering-county archetype guarantees this on tick 1),
-      assert the feed's rendered text contains `"LEGITIMATION_RECOVERY"`.
+      `LEGITIMATION_RECOVERY` (Task 7's own recovering-county archetype guarantees this on tick 1),
+      assert the feed's rendered text contains `"LEGITIMATION_RECOVERY"`. Add a second assertion
+      proving the two-pack mix specifically: over enough ticks for the fixture's `last-worker`
+      subject to starve (its own conformance fixture already proves this fires within a handful of
+      ticks — `vitality-conformance.bscn`'s own comment names it "Starvation"), the feed also
+      contains `"ENTITY_DEATH"` — both event families visible in one feed, not merely present in
+      the sink.
 - [ ] **Step 5:** `cargo test -p babylon-client` → PASS. Eyes-on: select a county, press Space,
-      watch its panel numbers and the event feed both update.
-- [ ] **Step 6: Commit** (`feat(client): the state panel and event feed (B2)`). Open the Phase D PR
-      (`feat(client): B2 Phase D — the tick loop UI`); self-merge on green.
+      watch its panel numbers and the event feed both update, and confirm `ENTITY_DEATH` events
+      appear alongside the lifecycle events over a longer run.
+- [ ] **Step 6: Commit** (`feat(client): the state panel and event feed — now two packs deep (B2)`).
+      Open the Phase D PR (`feat(client): B2 Phase D — the tick loop UI`); self-merge on green.
 
 ---
 
 ## Phase E — Logging, determinism, the eyes-on gate
 
-### Task 12: Resurrect the client file-log sink
+### Task 16: Resurrect the client file-log sink
 
 **Files:**
 
@@ -1423,17 +2223,17 @@ fn main() {
 - [ ] **Step 5: Commit** (`feat(client): resurrect the log4rs file sink — babylon-client.log
       (B2)`).
 
-### Task 13: End-to-end determinism guard
+### Task 17: End-to-end determinism guard
 
 **Files:**
 
 - Create: `rust/crates/babylon-client/tests/determinism.rs`
 
-**Why this test exists separately from Task 2's `babylon-tick`-level version.** Task 2's test
-proves `TickSession` itself is deterministic. This test proves the SAME property through the
-client's own composed seam — `EngineSession::start` + repeated `advance()` — which is the actual
-path a player's key presses drive, and the one the plan's own instructions ask to see "as a
-committed test."
+**Why this test exists separately from Task 6's `babylon-tick`-level version.** Task 6's test
+proves `TickSession` itself is deterministic across a multi-rule content set. This test proves the
+SAME property through the client's own composed seam — `EngineSession::start` + repeated
+`advance()` — which is the actual path a player's key presses drive, and the one the plan's own
+instructions ask to see "as a committed test."
 
 - [ ] **Step 1: Write the failing test.**
 
@@ -1451,14 +2251,18 @@ fn same_content_same_tick_count_yields_the_same_hash() {
             ra.after, rb.after,
             "tick {tick}: two independent EngineSessions over the same content must hash identically"
         );
+        assert_eq!(
+            ra.per_rule_fired, rb.per_rule_fired,
+            "tick {tick}: per-rule detail must also match — the order proof, not just the hash"
+        );
     }
 }
 
 #[test]
 fn five_ticks_produce_five_distinct_hashes() {
     // Regression guard against a driver that silently re-runs tick 1 —
-    // exactly the bug TickSession's own tick-numbering (Task 2) exists to
-    // prevent; this test watches for it at the client's seam too.
+    // exactly the bug TickSession's own tick-numbering exists to prevent;
+    // this test watches for it at the client's seam too.
     let mut session = EngineSession::start().expect("session");
     let mut hashes = std::collections::HashSet::new();
     for _ in 0..5 {
@@ -1469,13 +2273,13 @@ fn five_ticks_produce_five_distinct_hashes() {
 }
 ```
 
-- [ ] **Step 2:** FAIL until Task 9's `EngineSession` exists (this task can run any time after
-      Task 9 — placed last only to sit beside Task 12's logging work in one PR).
+- [ ] **Step 2:** FAIL until Task 13's `EngineSession` exists (this task can run any time after
+      Task 13 — placed last only to sit beside Task 16's logging work in one PR).
 - [ ] **Step 3:** `cargo test -p babylon-client --test determinism` → PASS.
 - [ ] **Step 4: Commit** (`test(client): end-to-end determinism guard — same content, same tick
-      count, same hash (B2)`).
+      count, same hash and same per-rule order (B2)`).
 
-### Task 14: The eyes-on gate
+### Task 18: The eyes-on gate
 
 **Files:**
 
@@ -1491,13 +2295,16 @@ B2's eyes-on gate by:
 3. Pressing **Space** at least five times, and after each press observing every one of the
    following:
    - the tick counter (bottom-right) increments by exactly one;
-   - the hash readout changes to a new hex string every press (never repeats — Task 13 proves this
+   - the hash readout changes to a new hex string every press (never repeats — Task 17 proves this
      is a real property, not a hope);
    - at least one demo county's band color OR the selected/hovered county's state-panel numbers
      visibly changes (a tick where no county crosses a band boundary still moves the raw
      `pop-d`/`pop-p`/`pop-d-prime` numbers in the panel — "watch state change" needs no
      color flip on every single press);
-   - the event feed grows (`LIFECYCLE_TRANSITION` alone fires every tick for every county).
+   - the event feed grows, carrying BOTH event families over a long-enough run —
+     `LIFECYCLE_TRANSITION` fires every tick for every county, and `ENTITY_DEATH` fires at least
+     once by the tick the fixture's `last-worker` subject starves (Task 15's own conformance
+     citation).
 4. Pressing **Tab**, confirming the active-lens label switches and the map recolors under the
    other lens's table.
 5. Confirming the client wrote to `~/.local/share/babylon/logs/babylon-client.log` (or
@@ -1518,7 +2325,7 @@ use bevy::prelude::*;
 use std::collections::HashSet;
 
 #[test]
-fn five_space_presses_advance_five_distinct_ticks_and_fire_lifecycle_events() {
+fn five_space_presses_advance_five_distinct_ticks_and_fire_both_packs_events() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, AssetPlugin::default(), InputPlugin));
     app.add_plugins(babylon_client::map::MapPlugin);
@@ -1548,7 +2355,16 @@ fn five_space_presses_advance_five_distinct_ticks_and_fire_lifecycle_events() {
             .events
             .iter()
             .any(|(name, _)| name == "EventType/LIFECYCLE_TRANSITION"),
-        "the event feed must carry at least one real emitted event"
+        "the event feed must carry lifecycle's own emitted events"
+    );
+    assert!(
+        session
+            .sink
+            .events
+            .iter()
+            .any(|(name, _)| name == "EventType/ENTITY_DEATH"),
+        "the event feed must carry vitality's own emitted events too — \
+         proving both packs actually ran, not just lifecycle"
     );
 }
 
@@ -1573,55 +2389,76 @@ fn tab_flips_the_active_lens() {
 - [ ] **Step 1:** Write both tests as shown, run against Phase C/D's finished code → FAIL until
       those phases land (this task sits last deliberately).
 - [ ] **Step 2:** Once Phase C and Phase D land, both PASS. `mise run rust:check` → green.
-- [ ] **Step 3:** Update `ai/state.yaml` — B2 reached: tick loop, dual-lens map, state panel, event
-      feed, log sink, eyes-on gate defined and CI-proxied. Close #262 as "superseded — replaced by
-      this gate" per the roadmap spec §5's own instruction, citing this plan document.
+- [ ] **Step 3:** Update `ai/state.yaml` — B2 reached: multi-rule tick loop (vitality + lifecycle),
+      dual-lens map, state panel, event feed, log sink, eyes-on gate defined and CI-proxied. Close
+      #262 as "superseded — replaced by this gate" per the roadmap spec §5's own instruction,
+      citing this plan document.
 - [ ] **Step 4: Commit** (`test(client): the B2 eyes-on gate + its CI-safe proxy (B2)`).
 
-### Task 15: Gates, docs, PR
+### Task 19: Gates, docs, PR
 
 - [ ] **Step 1:** `mise run rust:check` → green. `mise run check` → green.
 - [ ] **Step 2:** `mise run qa:regression` and `mise run qa:vault-regression-ci` → byte-identical.
-      Phase A's refactor is the only touch to `babylon-tick`'s existing behavior, and Task 1 Step 4
-      already proved it moves nothing — this is the whole-repo confirmation.
-- [ ] **Step 3:** Run `cargo test -p babylon-tick -p babylon-client` once more, full suite, to
-      confirm every test across all five phases is green together, not just phase-by-phase.
+      Phase A's Task 1 refactor and Task 4 widening are the only touches to `babylon-bsl`'s and
+      `babylon-tick`'s existing behavior, and each task's own regression test already proved it
+      moves nothing for existing single-rule content — this is the whole-repo confirmation.
+- [ ] **Step 3:** Run `cargo test -p babylon-bsl -p babylon-tick -p babylon-client` once more, full
+      suite, to confirm every test across all five phases is green together, not just
+      phase-by-phase.
 - [ ] **Step 4:** Update `ai/state.yaml`'s Program 28 entry (B2 milestone reached — cite this plan
       document and the PR numbers) and the GitHub project board's client lane. Open the follow-up
-      issue this plan's Sequencing/Content Decision sections defer (multi-rule-pack sessions;
-      unbounded event-feed memory; the economics BSL port that would make the Tension lens tick-live
-      too) — record it in the PR body per the B1 Task 12 precedent, don't silently drop it.
-- [ ] **Step 5:** Open the PR (`feat(client): B2 — the tick loop on screen`), body carrying: the
-      eyes-on human-pass screenshot/description, the Task 3 Step 1 FIPS table, the pinned
-      determinism-guard output, and a link back to this plan document. Self-merge on green per the
-      standing autonomy rulings.
+      issue this plan's own sections defer (the Phase 3 anchor-resolution registry the Multi-Rule
+      Decision section names explicitly; unbounded event-feed memory; the economics BSL port that
+      would make the Tension lens tick-live too) — record it in the PR body per the B1 Task 12
+      precedent, don't silently drop it.
+- [ ] **Step 5:** Open the PR (`feat(client): B2 — the tick loop on screen, two packs deep`), body
+      carrying: the eyes-on human-pass screenshot/description, the Task 7 Step 1 FIPS table, the
+      pinned multi-rule conformance output (Task 5), the pinned determinism-guard output, and a
+      link back to this plan document. Self-merge on green per the standing autonomy rulings.
 
 ---
 
 ## Open questions for the Director
 
+**All three ruled, 2026-08-11, interactive batch — full record.** This document's Amendment
+record (top of file) quotes the rulings verbatim and applies them throughout the task list above; this
+section keeps each original question's full reasoning intact per the Documentation philosophy's
+immutability-of-history discipline, and appends what the ruling actually changed.
+
 1. **Does the new Legitimation lens need its own sign-off, the way ADR191 R11 ruled the Tension
-   lens's four bands?** This plan's reasoning for proceeding without escalating: the Legitimation
-   lens invents no new formula (it colors a categorical field the `lifecycle` rule pack already computes),
-   uses only already-declared §9b palette tokens, and is additive to — never a replacement for —
-   the Director-ruled Tension lens (a Tab key switches between them, both visible, neither hidden).
-   But the Director has personally ruled every pixel-level choice on this map so far (font, insets,
-   band count) — if that pattern is a standing expectation rather than a one-time settling of B1's
-   specific open questions, this decision belongs to her, not to this plan's author. Recommend:
-   proceed as specced (self-merge on green per the standing autonomy rulings), flag this plan
-   document in the PR body, and let her veto after the fact if she intends that pattern to bind
-   here too — cheaper than blocking a five-phase plan on a question this plan's own reasoning
-   already answers defensibly.
-2. **Should B2 defer multi-rule-pack sessions (running `vitality` and `lifecycle` together, live),
-   or does the "watch state change" criterion implicitly want BOTH Material Base systems visible at
-   once?** The Content Decision section above lays out the exact technical wall (`E-LOAD-001`, one
-   `(rule …)` form per content set) and the two-part fix it would need. Recommend: defer, file the
-   issue, proceed with the `lifecycle` rule pack alone — of the three merged packs, only its
-   subject type matches the map's own unit, so it demonstrates the criterion fully on its own.
-3. **This plan defers audio (SFX/soundtrack, ADR152/153) out of B2 entirely — it wires none of it,
-   not even minimally.** Reasoning: R3's visual scope names "2D map game + panels and charts as the
-   primary surface" with no audio obligation; wiring 39 SFX + 13 tracks properly (Bevy
-   `AudioPlugin`, the `manifest.toml` trigger-mapping, mixing) is real, separately-scoped work, and
-   B2 already carries five phases of new surface. This plan's author made this scope call rather
-   than asking a question about it — this entry records the deferral so it stays visible rather
-   than silent, per the Documentation philosophy's "immutability of history" discipline.
+   lens's four bands? — RULED: APPROVED, reuse the band palette.** This plan's original reasoning
+   for proceeding without escalating: the Legitimation lens invents no new formula (it colors a
+   categorical field the `lifecycle` rule pack already computes), uses only already-declared §9b
+   palette tokens, and is additive to — never a replacement for — the Director-ruled Tension lens
+   (a Tab key switches between them, both visible, neither hidden). The Director ruled rather than
+   letting the recommendation stand by default, selecting: *"CRISIS → crimson, UNSTABLE → dim
+   gray, STABLE → gold's absence (panel dark) — reuses the ruled four-band vocabulary so the two
+   lenses share one visual language. No new colors enter the game."* Task 10 carries this exactly —
+   `legitimation_band_color` maps `{0.0: PANEL, 1.0: DIM, 2.0: CRIMSON}`, replacing this plan's
+   first-cut `GREEN_DARK`/`GOLD` invention outright. Task 11 carries the consequence: STABLE and
+   "no data" now share a map color on purpose, so the HUD's literal text is the only channel that
+   distinguishes them.
+2. **Should B2 defer multi-rule-pack sessions, or does "watch state change" implicitly want BOTH
+   Material Base systems visible at once? — RULED: MULTI-RULE DRIVER FIRST, this plan's
+   recommendation OVERRULED.** This plan's original recommendation was to defer, run `lifecycle`
+   alone, and file an issue — reasoning: `lifecycle` alone, of the three merged packs, has a
+   subject type matching the map's own unit, so it demonstrates the criterion fully on its own; the
+   technical wall (`E-LOAD-001`, `split_content`'s "exactly one rule" cardinality check) is real
+   engineering work, not a flag flip. The Director selected the larger option instead, quoted:
+   *"Build the multi-rule content-set evolution into B2 itself so the demo runs vitality+lifecycle
+   together from day one. Bigger B2, later criterion-3 close, but a richer first demo."* This
+   ruling is what reshapes the entire plan above: Phase A gained four tasks (2–5) widening
+   `split_content`, `prepare_rules`, `TickReport`, and proving a conformance vector against the
+   frozen engine's own vitality-then-lifecycle tick order; Phase B's demo scenario grew from
+   twelve territory nodes to eighteen (twelve territory + six social-class); Phase D's event feed
+   and Phase E's eyes-on gate both now assert on BOTH packs' events, not just the lifecycle rule
+   pack's. The Multi-Rule Decision section (above the File Structure table) is the full design this
+   ruling required, including the finding — checked, not assumed — that vitality's own subject type
+   has no territorial binding, so the "richer demo" ruling 2 asked for is genuinely richer in the
+   event feed and the state panel, not on the map surface itself, which only the lifecycle rule
+   pack paints.
+3. **Audio (SFX/soundtrack, ADR152/153) — RULED: DEFERRED out of B2, per this plan's own
+   recommendation.** No change from the first cut: R3's visual scope names "2D map game + panels
+   and charts as the primary surface" with no audio obligation; wiring 39 SFX + 13 tracks properly
+   is real, separately-scoped work, and B2 already carries five phases (now nineteen tasks) of new
+   surface.

--- a/docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md
+++ b/docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md
@@ -25,29 +25,74 @@ discipline ADR194 uses:
 
 Ruling 2 is load-bearing: it reopens what the first cut called "Decision: the demo content set is
 the lifecycle rule pack, alone" and inserts a new, genuinely non-trivial engine-lane evolution
-(Phase A, Tasks 2–5 below) ahead of the demo-scenario task. This document renumbers and amends
+(Phase A, Tasks 2–6 below) ahead of the demo-scenario task. This document renumbers and amends
 every task list, file structure entry and cross-reference below to carry that decision out. The
 three rulings'
 full record, with reasoning, sits in the amended "Open questions for the Director" section at the
 end — kept, not deleted, per the Documentation philosophy's immutability-of-history discipline;
 what changed is that each question now carries its ruling instead of standing open.
 
+**Revision record (2026-08-11, adversarial three-lens verification round on this amended plan).**
+A verification panel checked every §2.2/driver/D96/anchor claim in the first amendment TRUE, and
+found two blockers, one defect, and one nit, all fixed in this second revision:
+
+- **Blocker 1 — the multi-rule design's "declaration order is execution order" directly
+  contradicted an existing normative sentence this plan never read.** `bsl-language.rst:3058-3060`
+  (register row D16, §4.2):
+  <!-- vale off -->
+  *"Rules at the same anchor position evaluate in ascending rule-id byte order, and their effects
+  apply in that same order. File order and load order are never observable."*
+  <!-- vale on -->
+  Verified by reading the section directly — the sentence matches the citation
+  exactly, and directly negates the design the first amendment shipped. **Fixed**: the driver orders
+  rules by ascending rule-id BYTE ORDER (D16), not by declaration/concatenation order — see the
+  rewritten Execution Order subsection below. Every task and test asserting declaration-order
+  behavior now asserts byte order instead; a file-order-INVARIANCE test replaces the order-flip
+  test, matching what §4.2 actually promises.
+- **Blocker 2 — the "live legitimation overlay" headline was provably constant, and invisible
+  under the Director's own palette ruling.** Verified by reading `lifecycle.bsl`'s Block 2 in
+  full: `legit-index` is a weighted sum of five `:const` bindings ONLY — no `:field` binding
+  anywhere in its computation — so it evaluates to the SAME number for every territory, every
+  tick, forever (the pack's own D-1 note already said this; this plan's first cut never followed
+  the implication through). Every territory classifies STABLE (0) from tick 2 onward as a result,
+  and STABLE renders `PANEL` under ruling 1 — the same color as no data. A player pressing Space
+  five times would watch an unchanging dark map. **Fixed**: a new Population Trend lens, keyed to
+  the DPD circuit's genuinely per-tick, per-territory population fields (verified against the
+  actual formulas — five-tick trajectories worked out below), carries "watch state change." The
+  Legitimation lens ships exactly as ruled, with its current-uniform behavior stated plainly
+  rather than implied away.
+- **Defect — a D-row number collision.** Open PR #500 (director-ruled 2026-08-11, ADR194 R2, the
+  Currency-scale operation) mints its OWN `D99` row, verified by diffing its branch against `dev`.
+  **Fixed**: this plan names every row number it mints as "the next free register row," resolved
+  at execution time, never hard-coded — plus a new task closing the general defect class (a
+  register-row uniqueness guard; the existing sync-guard's `re.search` existence checks would pass
+  even with two `D99` rows in the file).
+- **Nit — a third `rule_id` extractor.** `babylon-bsl` already carries two
+  (`canonical_ast.rs:65`, `bound_checker.rs:678`), verified by reading both. **Fixed**: Task 2
+  widens `canonical_ast::rule_id`'s visibility and reuses it; no third implementation.
+
 **Architecture:** Five phases in five PRs, Phase A now doing two jobs. Phase A opens a
 **persistent session** in `babylon-tick` — `TickSession<G>` — AND, ahead of that, widens the
-content-set loader to admit **more than one `(rule …)` form**, in declaration order, the way
-`bsl-language.rst` §2.2's grammar always admitted and `babylon-bsl`'s driver-level loader never
-implemented. Phase B authors the **demo content**: eighteen subjects across two node types — twelve
-real-FIPS territories carrying the already-conformance-tested `lifecycle` rule pack's four
-archetype value sets, and six social classes carrying the already-conformance-tested `vitality`
-rule pack's own fixture verbatim — so the demo runs two Material Base systems together from the
-first tick. Phase C **completes B1's still-unbuilt Phase C** (`lens.rs`, `map/bands.rs`'s band
-table, `map/pick.rs`, `map/hud.rs`) but generalizes it to carry TWO lenses side by side — ADR170's
-static Tension lens (ported unmodified) and a new, tick-live Legitimation lens reading the field
-`lifecycle` writes every tick, colored per the Director's ruling above — with a lens-picker key so
-the player can see the difference between "declared once" and "moves every tick" honestly. Phase D
-wires the **loop UI**: the advance-tick input, the tick counter, the hash readout, the state panel,
-the event feed (now carrying both packs' events). Phase E resurrects the **file-log sink** the
-deletion ceremony retired, proves **determinism** end-to-end, and defines the **eyes-on gate**.
+content-set loader to admit **more than one `(rule …)` form**, executed in **ascending rule-id
+byte order** (§4.2, register row D16 — never declaration order, which the same section rules
+"never observable"), the way `bsl-language.rst` §2.2's grammar always admitted and `babylon-bsl`'s
+driver-level loader never implemented. Phase B authors the **demo content**: eighteen subjects
+across two node types — twelve real-FIPS territories, each seeded with its OWN distinct population
+figures (not three bare repeats of four archetypes) so their DPD trajectories visibly diverge tick
+by tick, carrying the already-conformance-tested `lifecycle` rule pack, and six social classes
+carrying the already-conformance-tested `vitality` rule pack's own fixture verbatim — so the demo
+runs two Material Base systems together from the first tick. Phase C **completes B1's still-unbuilt
+Phase C** (`lens.rs`, `map/bands.rs`'s band table, `map/pick.rs`, `map/hud.rs`) but generalizes it
+to carry THREE lenses side by side — ADR170's static Tension lens (ported unmodified), the
+Director-ruled Legitimation lens (shipped as ruled, though this plan states plainly that it renders
+uniformly today — `legit-index` is const-only, verified from the pack's own math), and a new
+Population Trend lens that carries "watch state change" for real, keyed to the DPD circuit's
+genuinely evolving per-territory population fields — with a lens-picker key cycling all three so
+the player can see the difference between "declared once," "moves every tick but not yet
+per-territory," and "moves and diverges by county" honestly. Phase D wires the **loop UI**: the
+advance-tick input, the tick counter, the hash readout, the state panel, the event feed (now
+carrying both packs' events). Phase E resurrects the **file-log sink** the deletion ceremony
+retired, proves **determinism** end-to-end, and defines the **eyes-on gate**.
 
 **Tech Stack:** Bevy 0.18.1 (unchanged from B1 — `pan_camera` feature already pinned), the same
 `earcutr`/atlas/tessellate stack B1 built, `log4rs` 1.x (`default-features = false`, the exact
@@ -79,10 +124,21 @@ Decision below.
   plan's own demo scenario mints eighteen nodes (twelve `NodeType/TERRITORY`, six
   `NodeType/SOCIAL_CLASS`) and zero hyperedges** — the cliff does not bite; see the Scale Note
   below for the arithmetic.
+- **D16 (§4.2)** —
+  <!-- vale off -->
+  "Rules at the same anchor position evaluate in ascending rule-id byte order… File order and
+  load order are never observable."
+  <!-- vale on -->
+  This is the GOVERNING rule for the multi-rule
+  evolution's execution order (Phase A, Tasks 2–6) — verified by direct reading
+  (`bsl-language.rst:3058-3060`) after the first amendment's design contradicted it. The driver
+  applies D16 to the whole slice-1 rule set (no anchor-position registry exists to differentiate
+  positions across systems yet — Phase 3, not built), not a new ordering law this plan invents.
 - **D96 (ADR191 R2)** — "a scenario is a canonical committed artifact and its declaration order is
-  part of its identity" for NODE declarations; this plan's multi-rule evolution extends the same
-  PRINCIPLE one level up, to RULE declarations within a content set (Phase A, Tasks 2–5) — it does
-  not reopen D96 itself, which stays about node mint order.
+  part of its identity," strictly for NODE declarations within a scenario. This plan does NOT
+  extend D96 to rule declarations (the first amendment's error, corrected here) — D16 already
+  governs rule order, on its own textual authority, and needs no analogy borrowed from a different
+  register row.
 - **Constitution III.7 (determinism)** and **III.11 (Loud Failure)** — the hash display exists
   because the hash IS the honesty proof; a county the demo scenario never minted stays `PANEL`,
   never a fabricated value.
@@ -90,10 +146,13 @@ Decision below.
   the only Rust code this plan writes is client/UI/seam code, a loader-widening change that makes
   the driver honor grammar §2.2 already admits (not a new primitive), and a factored-out loader
   helper. All simulation content stays in the already-merged `vitality` and `lifecycle` rule packs.
-- **No imposed functional forms (2026-07-29 standing ruling)** — the new Legitimation lens invents
-  no threshold and no formula. It colors counties by the **categorical classification the
-  `lifecycle` rule pack already computes and writes** (`territory/legitimation-crisis`: 0 = STABLE,
-  1 = UNSTABLE, 2 = CRISIS), never a newly-derived cut point on the raw index.
+- **No imposed functional forms (2026-07-29 standing ruling)** — the Legitimation lens invents no
+  threshold and no formula. It colors counties by the **categorical classification the `lifecycle`
+  rule pack already computes and writes** (`territory/legitimation-crisis`: 0 = STABLE, 1 =
+  UNSTABLE, 2 = CRISIS), never a newly-derived cut point on the raw index. The new Population Trend
+  lens (Task 10, added this revision) reads the same standing: it colors by the SIGN of a
+  territory's own total-population change since tick 0 — a strict `>`/`<`/`=` comparison, no
+  size threshold invented, no cut point chosen.
 
 ## Global Constraints
 
@@ -117,8 +176,10 @@ Decision below.
   ADR170 four-band table (`PANEL`, `CRIMSON`, `DIM`, `GOLD` from `map/bands.rs`); per this
   amendment's ruling 1, the Legitimation lens's three colors are `PANEL` (STABLE — "gold's
   absence"), `DIM` (UNSTABLE), `CRIMSON` (CRISIS), reusing three of the FOUR already-declared
-  `map/bands.rs` constants and minting none — GOLD is deliberately unused by this lens. This plan
-  adds no new `Color::srgb_u8` literal anywhere, so
+  `map/bands.rs` constants. The new Population Trend lens (this revision) reuses all FOUR —
+  `CRIMSON` (declining), `GOLD` (growing), `DIM` (unchanged, unreachable on real float trajectories
+  but included for totality), `PANEL` (absence) — the same four tokens ADR191 R11 already declared,
+  applied to a third variable. This plan adds no new `Color::srgb_u8` literal anywhere, so
   `test_no_stray_color_literals_outside_palette_or_a_declared_exemption`'s sweep needs no new
   exemption entry.
 - **The babylon-bsl surface this plan touches, stated exactly.** Every task reads live state
@@ -127,11 +188,12 @@ Decision below.
   mathematics or a new primitive (Amendment AE's test): (1) `babylon-tick::TickSession`, additive,
   `run_once`/`run_once_into` keep their exact current signatures; (2)
   `babylon-bsl::rule_pipeline::split_content` widens from "exactly one `(rule …)` top-form" to
-  "one or more, in declaration order, duplicate ids refused" — closing a gap between the DRIVER's
-  own historical restriction and what `bsl-language.rst` §2.2's grammar (`<top-form>*`) and prose
-  ("Duplicate rule ids… across the content set are `E-LOAD-001`") always admitted. See the
-  Multi-Rule Decision section below for the full design and why this is a driver fix, not a spec
-  change.
+  "one or more, EXECUTED IN ASCENDING RULE-ID BYTE ORDER per §4.2/D16, duplicate ids refused" —
+  closing a gap between the DRIVER's own historical restriction and what `bsl-language.rst` §2.2's
+  grammar (`<top-form>*`) and prose ("Duplicate rule ids… across the content set are
+  `E-LOAD-001`") always admitted. See the Multi-Rule Decision section below for the full design
+  and why this counts as a driver fix, not a spec change — and why the order is byte order, never
+  declaration order (§4.2's own words: "File order and load order are never observable").
 - **Scale note (ADR193 arithmetic, worked here so no task has to re-derive it):** the Phase B demo
   scenario mints exactly 18 nodes (12 `NodeType/TERRITORY`, 6 `NodeType/SOCIAL_CLASS`) and declares
   no `(edge …)`/`(hyperedge …)` forms, so `HypergraphStore::encode_state`'s hyperedge half walks
@@ -194,7 +256,7 @@ and, after Phase A of this plan, `TickSession`, both hold a `HypergraphStore`. *
 matching what the client actually holds. `MemoryGraph` remains only as the differential-test
 oracle (ADR193's own consequences section).
 
-## Decision: the demo content set runs `vitality` AND `lifecycle`, together, in declaration order
+## Decision: the demo content set runs `vitality` AND `lifecycle`, together, in rule-id byte order
 
 **Superseded by this amendment.** The first cut of this plan recommended running `lifecycle`
 alone, citing a real technical wall: `babylon-bsl::rule_pipeline::split_content` enforces, by
@@ -204,6 +266,12 @@ evolution now. This section is the design that discharges that ruling, and it re
 "Decision: the demo content set is the lifecycle rule pack, alone" section outright — the
 technical-wall description below stays, because it remains the reason the evolution is real
 engineering work and not a one-line flag flip.
+
+**Revision note.** This section's FIRST amendment shipped a "declaration order is execution
+order" design. A verification round caught it contradicting `bsl-language.rst` §4.2's own text —
+see the Execution order subsection below, rewritten in full. Everything else in this section
+(the grammar-admits-more-than-one-rule argument, the field/name-collision audit) stood up to
+verification unchanged.
 
 ### What §2.2 already admits, and what the driver never implemented
 
@@ -232,37 +300,69 @@ it. This plan's evolution makes the driver honor what the grammar already admitt
 (BSL-first, escape by proof) and Amendment AE's "mints no new mathematics" test both read this as
 machinery, not a new primitive needing a constitutional amendment.
 
-### Execution order: declaration order in the concatenated content set (D96, extended)
+### Execution order: ascending rule-id byte order (§4.2, register row D16) — NOT declaration order
 
-D96 (ADR191 R2) ruled that a scenario's NODE declaration order is part of its identity — no test
-may assert that shuffling `node` forms leaves the tick hash unchanged, because `NodeId` mints top
-to bottom and "a reordered scenario is a different scenario." This plan's multi-rule driver applies
-the SAME principle one level up: **the rules in a content set run in the order their `(rule …)`
-forms appear in the string the driver reads**, and no test in this plan may assert that reordering
-those forms leaves the tick hash — or, more precisely, `TickReport.per_rule_fired`'s own order —
-unchanged. Concretely: `TickSession`/`run_once_into` build `rule_src` as ONE string (unchanged
-signature — the caller concatenates whatever `.bsl` files it wants, in the order it wants them to
-run), `split_content` parses every `(rule …)` top-form via the existing reader in the order it
-encounters them (a plain sequential parse — no new ordering machinery), and the driver runs each
-`LoadedRule` to completion, in that order, against the SAME graph, before moving to the next.
+**This subsection replaces the first amendment's design outright.** That design made load/
+concatenation order the execution order, reasoning by analogy from D96 (node declaration order is
+scenario identity). A verification round found the direct, on-point rule this plan should have
+read first: `bsl-language.rst:3058-3060` (§4.2, register row D16):
 
-**Why NOT the formal `:anchor` mechanism.** `bsl-language.rst` §2.3 already specifies
-`<anchor> ::= "(" "anchor" ( ":after" | ":before" ) <symbol> ")"` and a default ("a rule with no
-`<anchor>` belongs to the system named by the first segment of its rule id and takes that system's
-declared position") — this READS like the "real" answer to inter-rule ordering, and this plan's
-author checked it first. It does not work here: `mod_anchors.rs`'s own module doc
-says outright, *"this module validates the DECLARATION — shape, and the `E-LOAD-002` no-system
-case. Resolving anchors into a total order belongs to `babylon-engine`'s anchor-based registry
-(Phase 3)… deferred with a name, not silently."* `check_anchor` runs inside `load_rule_form` today
-(`rule_pipeline.rs:245`) and stores the result on `LoadedRule.anchor` — but nothing anywhere reads
-that field for ordering; no system-position registry exists to resolve `:after`/`:before` against.
-Building that registry sits explicitly outside this plan's scope (a Phase 3 BSL-track milestone, not
-a B2 client-lane task) and would be a large, separate undertaking. **Declaration order in the
-concatenated content string is the right-sized INTERIM this specific milestone owns —
-not a replacement for the eventual anchor-resolution engine, and not a claim that one will not
-supersede it.** The `(anchor …)` forms Task 5 adds below remain purely declarative under this
-plan — parsed, validated, and inert for ordering, exactly as they are for every other content set
-in this repo today.
+<!-- vale off -->
+> Rules at the same anchor position evaluate in **ascending rule-id byte order**, and their
+> effects apply in that same order. **File order and load order are never observable.**
+<!-- vale on -->
+
+That last sentence is the exact negation of the first amendment's design. No honest reading keeps
+"declaration order governs" after seeing it — this section corrects course rather than
+defending the original error.
+
+**The corrected design.** No anchor-position registry exists yet (see below) to place `vitality`
+at position 1 and `lifecycle` at position 7 the way the frozen engine's tick order would — so
+every rule in a slice-1 content set is, from the driver's point of view, UNPOSITIONED: it cannot
+tell two systems' rules apart by position any more than it could tell two rules at the SAME
+position apart. Treating the whole set as if it sat at one shared (unresolved) anchor position and
+applying D16's fallback — ascending rule-id byte order — gives the honest, spec-grounded answer
+available today, not an invented alternative: **`split_content` collects every `(rule …)`
+form (in whatever order the reader encounters them — this remains unchanged from Task 2 below),
+and `prepare_rules` SORTS the resulting list by rule-id byte order before returning it.** Every
+later stage (`TickSession::advance`, `run_once_into`) simply iterates the already-sorted list, so
+sorting happens exactly once, at load time, not per tick.
+
+**Worked for the demo pair.** `"lifecycle/dpd-circuit"` sorts before `"vitality/subsistence-and-
+death"` in ascending byte order (`l` = 0x6C < `v` = 0x76) — the REVERSE of the frozen engine's own
+tick-position order (Vitality @1, Lifecycle @7). `TickReport.per_rule_fired[0]` holds
+`lifecycle`'s entry and `[1]` holds `vitality`'s, throughout this plan — every task and test below
+uses that order, corrected from the first amendment's vitality-first assumption.
+
+**Why the reversal is safe for THIS pair, and why the driver must not generalize that safety.**
+The two rules' domains are fully disjoint (verified by reading both rules' complete `(bindings …)`
+blocks — see the subsection below), so their write-sets never interact and the CANONICAL
+(sorted-before-hashing) state after one tick is identical whichever of the two orders ran. That is
+a property of THIS pair, not of the mechanism: two rules sharing a node type, or one reading a
+field the other writes, would produce genuinely different post-tick state under the two orders,
+and D16's byte-order rule is exactly what decides which one is correct — never file order, never
+which pack a demo author happened to list first. **This is precisely why §4.2 scopes byte order to
+rules "at the same anchor position"**: the moment two systems need to run in a specific ENGINE
+order regardless of their rule ids' spelling (an OODA-adjacent example, or any pair where sequence
+carries real material meaning), that is the anchor-position registry's job, not byte order's — and
+that job stays deferred, with a name, exactly as before this revision.
+
+**Why NOT the formal `:anchor` mechanism (unchanged finding, restated).** `bsl-language.rst` §2.3
+already specifies `<anchor> ::= "(" "anchor" ( ":after" | ":before" ) <symbol> ")"` and a default
+("a rule with no `<anchor>` belongs to the system named by the first segment of its rule id and
+takes that system's declared position"). `mod_anchors.rs`'s own module doc says outright, *"this
+module validates the DECLARATION — shape, and the `E-LOAD-002` no-system case. Resolving anchors
+into a total order belongs to `babylon-engine`'s anchor-based registry (Phase 3)… deferred with a
+name, not silently."* `check_anchor` runs inside `load_rule_form` today (`rule_pipeline.rs:245`)
+and stores the result on `LoadedRule.anchor` — but nothing anywhere reads that field for ordering;
+no system-position registry exists to resolve `:after`/`:before`, or a system name to a numeric
+position, against. Building that registry sits explicitly outside this plan's scope (a Phase 3
+BSL-track milestone, not a B2 client-lane task). D16's byte-order rule, by contrast, needs NO
+registry — already fully specified and already implementable, which is exactly why it stands as
+the correct fallback rather than an interim invented for this plan. The `(anchor …)` forms Task 5 adds
+below remain purely declarative — parsed, validated, and inert for ordering, exactly as they are
+for every other content set in this repo today; they exist as forward documentation for the day
+the registry lands, not as an ordering mechanism this driver reads.
 
 ### The two rules' domains are disjoint — a subtlety worth stating precisely
 
@@ -274,18 +374,24 @@ how Task 5 builds its conformance test:
 
 1. **The final canonical state hash is order-invariant for THIS pair, specifically**, because
    `CanonicalState::encode_state` sorts every section before hashing (ADR193) and the two rules'
-   write-sets never overlap or interact — running vitality-then-lifecycle or lifecycle-then-vitality
-   produces the identical SET of (node, attribute, value) triples, and a canonical sort of an
-   identical set hashes identically either way. **This is an accident of this specific pair's
-   disjoint domains, not a property of the multi-rule mechanism in general** — a future pair that
-   shares a node type or cross-reads a field would NOT enjoy this invariance, and the driver must
-   not (and does not) assume it does.
-2. **Because of (1), a test that only asserts the final hash would NOT catch an order bug in this
-   specific pair.** The load-bearing order-proof has to be something order actually moves:
-   `TickReport.per_rule_fired`'s own sequence (Task 4) and the emitted event stream's sequence.
-   Task 5's conformance test asserts on `per_rule_fired`'s order directly, and separately proves
-   the mechanism reacts to a declaration-order flip, precisely because the hash offers no such
-   guarantee here.
+   write-sets never overlap or interact — running lifecycle-then-vitality (byte order) or
+   vitality-then-lifecycle (engine order) produces the identical SET of (node, attribute, value)
+   triples, and a canonical sort of an identical set hashes identically either way. **This is an
+   accident of this specific pair's disjoint domains, not a property of the multi-rule mechanism in
+   general** — a future pair that shares a node type or cross-reads a field would NOT enjoy this
+   invariance, and the driver must not (and does not) assume it does.
+2. **Because of (1), a test that only asserts the final hash would NOT, by itself, prove the
+   driver sorts by rule id rather than by file order** — both orderings happen to produce the same
+   hash for this pair, so a hash-only test could not distinguish "the driver correctly sorts by
+   byte order" from "the driver still (incorrectly) preserves file order" if someone happened to
+   concatenate the two `.bsl` files in byte-sorted order already. Task 5's conformance test asserts
+   on TWO things as a result: `per_rule_fired`'s own order (must always read
+   `["lifecycle/dpd-circuit", "vitality/subsistence-and-death"]`, regardless of which order the
+   caller concatenates the two `.bsl` files in — the direct proof the driver sorts, not
+   preserves), and, separately, that two content sets built from the SAME two rules in DIFFERENT
+   file/concatenation order produce byte-IDENTICAL `TickReport`s — the actual property §4.2
+   promises ("file order and load order are never observable"), now a committed test rather than
+   an assertion left implicit.
 
 ### Field and local-name collisions — checked, none found
 
@@ -319,25 +425,34 @@ The union scenario (Phase B) mints social-class nodes (`vitality`'s fixture) and
 | Phase | File | Action | Responsibility |
 |---|---|---|---|
 | A | `rust/crates/babylon-tick/src/lib.rs` | Edit | Factor `prepare_rule` out of `run_once_into`; later widen to `prepare_rules`; add `pub mod session;` |
-| A | `rust/crates/babylon-bsl/src/rule_pipeline.rs` | Edit | `split_content` admits more than one `(rule …)` form, duplicate-id check |
-| A | `docs/reference/bsl-language.rst` | Edit | New D-row (D99) documenting the widened driver + declaration-order semantics |
+| A | `rust/crates/babylon-bsl/src/rule_pipeline.rs` | Edit | `split_content` admits more than one `(rule …)` form, duplicate-id check, reuses `canonical_ast::rule_id` |
+| A | `rust/crates/babylon-bsl/src/canonical_ast.rs` | Edit | Widen `rule_id`'s visibility to `pub(crate)` so `rule_pipeline.rs` can reuse it (NIT fix — no third extractor) |
+| A | `docs/reference/bsl-language.rst` | Edit | New D-row (next free register number — see the D-row Numbering note) applying D16/§4.2 to the widened driver |
+| A | `tests/unit/reference/test_bsl_grammar_sync.py` | Edit | New register-row-uniqueness guard (DEFECT fix — closes the "second `* - D99` row" class) |
 | A | `rust/crates/babylon-tick/content/rules/lifecycle.bsl` | Edit | Add `(anchor :after vitality)` — declarative only, inert for ordering today |
 | A | `rust/crates/babylon-tick/content/scenarios/vitality-lifecycle-combined-conformance.bscn` | Create | The 10-node conformance fixture (6 vitality + 4 lifecycle, verbatim) |
-| A | `rust/crates/babylon-tick/tests/multi_rule_conformance.rs` | Create | Declaration-order-reproduces-engine-order proof |
+| A | `rust/crates/babylon-tick/tests/multi_rule_conformance.rs` | Create | Byte-order-sort + file-order-invariance proof (§4.2/D16) |
 | A | `rust/crates/babylon-tick/src/session.rs` | Create | `TickSession<G>` — load once, `advance()` many times, now multi-rule |
 | B | `rust/crates/babylon-client/tests/print_demo_counties.rs` | Create (throwaway aid) | One-shot atlas print, deleted after use |
-| B | `rust/crates/babylon-tick/content/scenarios/us-counties-lifecycle-demo.bscn` | Create | 18-node demo: 12 real-FIPS territories + 6 social classes |
-| C | `rust/crates/babylon-client/src/lens.rs` | Create | `county_tension` (ADR170, ported) + `county_legitimation` (new) |
-| C | `rust/crates/babylon-client/src/map/bands.rs` | Edit | ADR191 R11's `band_color` (Tension) + legitimation band function (Director ruling 1) |
+| B | `rust/crates/babylon-tick/content/scenarios/us-counties-lifecycle-demo.bscn` | Create | 18-node demo: 12 real-FIPS territories (twelve DISTINCT population seeds) + 6 social classes |
+| C | `rust/crates/babylon-client/src/lens.rs` | Create | `county_tension` (ADR170, ported) + `county_legitimation` (new) + `county_population_trend` (new, BLOCKER 2 fix) |
+| C | `rust/crates/babylon-client/src/map/bands.rs` | Edit | ADR191 R11's `band_color` (Tension) + legitimation band function (Director ruling 1) + population-trend band function |
 | C | `rust/crates/babylon-client/src/map/pick.rs` | Create | Uniform-grid hit test (B1 Task 10's design) |
-| C | `rust/crates/babylon-client/src/map/hud.rs` | Create | Hover/selection readout, active-lens label, absence banner |
-| C | `rust/crates/babylon-client/src/map/mod.rs` | Edit | Wire the three new modules + lens-picker input |
-| D | `rust/crates/babylon-client/src/engine_link.rs` | Edit | `EngineSession` resource: `TickSession<HypergraphStore>` + `CollectingSink` + FIPS↔`NodeId` map |
+| C | `rust/crates/babylon-client/src/map/hud.rs` | Create | Hover/selection readout, active-lens label (now 3-way), absence banner |
+| C | `rust/crates/babylon-client/src/map/mod.rs` | Edit | Wire the four new modules + 3-way lens-picker input |
+| D | `rust/crates/babylon-client/src/engine_link.rs` | Edit | `EngineSession` resource: `TickSession<HypergraphStore>` + `CollectingSink` + FIPS↔`NodeId` map + tick-0 population baseline |
 | D | `rust/crates/babylon-client/src/main.rs` | Edit | Advance-tick input, tick counter, hash readout, event feed |
 | E | `rust/crates/babylon-client/src/logging.rs` | Create | Resurrected `log4rs` file sink |
 | E | `rust/crates/babylon-client/Cargo.toml` | Edit | `log`, `log4rs` deps |
 | E | `rust/crates/babylon-client/tests/determinism.rs` | Create | Same-content, same-tick-count ⇒ same hash, end to end |
 | E | `rust/crates/babylon-client/tests/eyes_on_smoke.rs` | Create | Headless proxy for the eyes-on gate |
+
+**D-row numbering note (DEFECT fix).** Open PR #500 (ADR194 R2, the Currency-scale operation) also
+mints a `D99` register row and has not merged as of this revision. This plan never hard-codes a
+row number as a result: Task 3 below reads `docs/reference/bsl-language.rst`'s register table AT
+EXECUTION TIME, finds the highest existing `D<N>` row, and mints `D<N+1>` — `D99` if #500 has not
+landed yet, `D100` if it has. Every reference in this plan to "the D-row this task adds" means
+that resolved number, not a literal "D99."
 
 ---
 
@@ -525,15 +640,30 @@ pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
 
 **Interfaces:**
 
-- Produces: `pub fn split_content(source: &str) -> Result<(Vec<SExpr>, Vec<SExpr>), LoadError>` —
-  the SAME function name, now returning the intrinsic-decl forms plus a **non-empty, ordered**
-  `Vec<SExpr>` of every `(rule …)` top-form, duplicate ids refused. **Signature change**:
-  the second element of the tuple was `SExpr` (exactly one), is now `Vec<SExpr>` (one or more, in
-  source order) — every caller (`prepare_rule` today, `prepare_rules` from Task 4) updates in the
-  same PR.
-- Also produces: `fn rule_id(rule: &SExpr) -> Result<String, LoadError>` — a small new helper
-  reading a `(rule …)` form's `<qname>` (the second list element, per §2.3's grammar), used by the
-  duplicate-id check and reusable wherever a caller needs a rule's own id without re-parsing.
+- Produces: `pub fn split_content(source: &str) -> Result<(Vec<SExpr>, Vec<(String, SExpr)>),
+  LoadError>` — the SAME function name, now returning the intrinsic-decl forms plus a
+  **non-empty** `Vec<(String, SExpr)>` of `(rule_id, rule_form)` pairs, one per `(rule …)`
+  top-form (in reader-encounter order — Task 4 sorts this into rule-id byte order,
+  `split_content` itself makes no ordering claim), duplicate ids refused. **Signature change**:
+  the second element of the tuple was `SExpr` (exactly one, un-paired), is now `Vec<(String,
+  SExpr)>` (one or more, PRE-PAIRED with each rule's own id) — every caller (`prepare_rule` today,
+  `prepare_rules` from Task 4) updates in the same PR. Returning the id alongside the form, rather
+  than making the caller re-extract it, is deliberate: `split_content` already computes every
+  rule's id internally for the duplicate-id check, so handing it back avoids a second extraction
+  downstream AND avoids needing to expose a `rule_id` function outside this crate at all —
+  `babylon-tick` (Task 4's crate) never needs to call one.
+- **No new `rule_id` function — reuses the crate's existing one, kept crate-internal.**
+  `babylon-bsl` already carries TWO rule-id extractors (`canonical_ast.rs:65`, private `fn
+  rule_id(expr: &SExpr) -> Result<&str, CasError>`, used by the CAS hashing code; `bound_checker.rs:678`,
+  `fn rule_id(items: &[SExpr]) -> String`, a lenient error-reporting helper that never fails) —
+  found by reading both before writing a third. `canonical_ast::rule_id` is the right one to
+  share: strict (errors rather than guessing), matches the duplicate-id check's own strictness
+  need, and already pattern-matches the qname correctly as `Atom::QName` (not `Atom::Symbol` — the
+  shape this task's FIRST draft got wrong before this revision caught it against the working
+  implementation). This task widens its visibility from private to `pub(crate)` — same-crate only,
+  since `split_content` (also this crate) is its only new caller — and reuses it, converting
+  `CasError` to `LoadError::Content` at the one call site. No third implementation, and no widening
+  to fully `pub` either, since nothing outside `babylon-bsl` needs to call it directly.
 
 - [ ] **Step 1: Write the failing tests.** In `rule_pipeline.rs`'s existing `#[cfg(test)] mod
       tests`:
@@ -551,8 +681,8 @@ fn split_content_admits_two_rules_in_source_order() {
 ";
     let (_intrinsics, rules) = split_content(source).expect("two distinct rule ids load");
     assert_eq!(rules.len(), 2);
-    assert_eq!(rule_id(&rules[0]).unwrap(), "a/first");
-    assert_eq!(rule_id(&rules[1]).unwrap(), "b/second");
+    assert_eq!(rules[0].0, "a/first");
+    assert_eq!(rules[1].0, "b/second");
 }
 
 #[test]
@@ -615,8 +745,11 @@ if rule_forms.is_empty() {
     ));
 }
 let mut seen: HashMap<String, ()> = HashMap::with_capacity(rule_forms.len());
-for form in &rule_forms {
-    let id = rule_id(form)?;
+let mut paired = Vec::with_capacity(rule_forms.len());
+for form in rule_forms {
+    let id = crate::canonical_ast::rule_id(&form)
+        .map_err(|e| LoadError::Content(e.message))?
+        .to_owned();
     if seen.contains_key(&id) {
         return Err(LoadError::Content(format!(
             "E-LOAD-001: duplicate rule id: {id} (§2.2 — rule ids must be \
@@ -625,47 +758,41 @@ for form in &rule_forms {
              declarations)"
         )));
     }
-    seen.insert(id, ());
+    seen.insert(id.clone(), ());
+    paired.push((id, form));
 }
-Ok((intrinsic_forms, rule_forms))
+Ok((intrinsic_forms, paired))
 ```
 
       matching the EXACT `HashMap::contains_key`-before-insert pattern
       `declarations::parse_intrinsic_decls` already uses for duplicate intrinsic names (same file
-      family, same §2.2 duplicate-name discipline) — reused, not reinvented, per DRY. Add `rule_id`:
+      family, same §2.2 duplicate-name discipline) — reused, not reinvented, per DRY. In
+      `canonical_ast.rs`, widen the existing private extractor's visibility only — no signature
+      change, no behavior change, and its own CAS-hashing callers keep compiling unmodified:
 
 ```rust
-/// A `(rule …)` form's own `<qname>` — the second list element, per §2.3's
-/// `<rule> ::= "(" "rule" <qname> …`. Used by the duplicate-id check and by
-/// any caller (Task 4's `prepare_rules`) that needs a rule's id without
-/// re-parsing its surface.
-fn rule_id(rule: &SExpr) -> Result<String, LoadError> {
-    let SExpr::List(items) = rule else {
-        return Err(LoadError::Content(format!(
-            "expected a (rule …) form, found {rule:?}"
-        )));
-    };
-    match items.get(1) {
-        Some(SExpr::Atom(Atom::Symbol(id))) => Ok(id.clone()),
-        other => Err(LoadError::Content(format!(
-            "a (rule …) form's second element must be its qname, found {other:?}"
-        ))),
-    }
+// canonical_ast.rs — was `fn rule_id`, now `pub(crate) fn rule_id`, so
+// rule_pipeline.rs (same crate) can reuse it instead of writing a second
+// strict extractor. Body unchanged.
+pub(crate) fn rule_id(expr: &SExpr) -> Result<&str, CasError> {
+    // ... existing body, verbatim ...
 }
 ```
 
 - [ ] **Step 4:** `cargo test -p babylon-bsl` → PASS (all four new tests; every EXISTING
-      `split_content`/`load_rule_form` test in the crate still green — this is additive, not a
-      behavior change for single-rule content). Update `prepare_rule` (Task 1) to destructure the
-      now-`Vec<SExpr>` second element as `rule_forms[0].clone()` (still one rule at this point in
-      the plan; Task 4 removes the `[0]` indexing when it widens to multi-rule) — a small,
-      mechanical signature-follow, not a behavior change.
+      `split_content`/`load_rule_form`/`canonical_ast` test in the crate still green — this is
+      additive, not a behavior change for single-rule content or for the CAS hashing code). Update
+      `prepare_rule` (Task 1) to destructure the now-`Vec<(String, SExpr)>` second element as
+      `rule_forms[0].1.clone()` (still one rule at this point in the plan, and `prepare_rule`
+      never needed the id anyway — Task 4 removes the `[0]` indexing and starts consuming the
+      paired id when it widens to multi-rule) — a small, mechanical signature-follow, not a
+      behavior change.
 - [ ] **Step 5:** `mise run rust:check` → green (workspace-wide — this crate's callers in
       `babylon-tick` must still compile). `mise run qa:regression` → byte-identical.
 - [ ] **Step 6: Commit** (`feat(rust): split_content admits more than one (rule …) form, duplicate ids
       refused (B2) — honors §2.2's already-ratified grammar`).
 
-### Task 3: The D99 spec row — documenting the widened driver
+### Task 3: The next-free-register spec row — documenting the widened driver
 
 **Files:**
 
@@ -678,37 +805,48 @@ does not have to reconstruct the reasoning from a Rust doc comment. This follows
 precedent — "a Phase-1-review reading… open to correction, not a Director ruling" — the same
 posture this row takes.
 
-- [ ] **Step 1: Add D99** to the D-row list-table (after D98, following the exact three-column
-      format every row above it uses):
+**Row number — resolve at execution time, never hard-code.** Open PR #500 (ADR194 R2) also mints a
+`D99` row and has not merged as of this plan. Before writing anything, run
+`rg -o '\* - D[0-9]+' docs/reference/bsl-language.rst | grep -oE '[0-9]+' | sort -n | tail -1` (or
+a similar command) to find the highest existing row number N, and use **D(N+1)**. If #500 has
+already merged, that is D100; if not, D99. Every occurrence of "D99" anywhere else in this plan document
+(this task, the File Structure table, later cross-references) means this resolved number, not a
+literal string — search the plan for the literal text `D99` before executing this task and confirm
+none of the OTHER occurrences got hard-coded into committed code or test strings by mistake.
+
+- [ ] **Step 1: Add the row** to the D-row list-table (after the current last row, following the
+      exact three-column format every row above it uses; the block below uses `D<N>` as a
+      placeholder for the resolved number from the paragraph above — substitute it, do not commit
+      the literal string `D<N>`):
 
 ```rst
-   * - D99
-     - §2.2, §2.3, §5.5
-     - **The content-set loader admits more than one ``(rule …)`` top-form, in
-       declaration order, duplicate ids refused** — a driver-level fix
-       (Program 28 B2), not a spec change. §2.2's grammar (``<top-form>*``)
-       and prose ("Duplicate rule ids… across the content set are
-       ``E-LOAD-001``") never limited a content set to one rule;
-       ``babylon-bsl::rule_pipeline::split_content`` did, by an
-       implementation-level cardinality check with no textual basis in this
-       section. This row lifts that check to match the grammar it was
-       always supposed to implement. **Execution order is declaration
-       order in the content set the driver reads** — the same principle
-       D96 states for node declarations, applied one level up to rule
-       declarations: no test may assert that reordering a content set's
-       ``(rule …)`` forms leaves ``TickReport.per_rule_fired``'s own order
-       unchanged, because it is not meant to. **This is NOT the ``:anchor``
-       mechanism** (§2.3's ``<anchor>``) resolved into a total order —
-       ``mod_anchors.rs``'s own scope note defers anchor RESOLUTION to a
-       future ``babylon-engine`` anchor-based registry (Phase 3), which
-       does not exist yet; ``(anchor …)`` forms remain parseable and
-       validated (``check_anchor``, unchanged) but inert for ordering under
-       this row, exactly as before it. §5.5's ``rules_hash`` stays
-       file-boundary- and (for CAS/identity purposes) order-insensitive —
-       that is a claim about content IDENTITY, separate from the EXECUTION
-       order this row rules on, and the two do not conflict.
+   * - D<N>
+     - §2.2, §4.2
+     - **The content-set loader admits more than one ``(rule …)`` top-form,
+       executed in ascending rule-id byte order (register row D16, §4.2),
+       duplicate ids refused** — a driver-level fix (Program 28 B2), not a
+       spec change. §2.2's grammar (``<top-form>*``) and prose ("Duplicate
+       rule ids… across the content set are ``E-LOAD-001``") never limited
+       a content set to one rule; ``babylon-bsl::rule_pipeline::
+       split_content`` did, by an implementation-level cardinality check
+       with no textual basis in this section. This row lifts that check to
+       match the grammar it was always supposed to implement, and applies
+       an EXISTING ruling to the result — D16 already says "rules at the
+       same anchor position evaluate in ascending rule-id byte order… file
+       order and load order are never observable"; a slice-1 content set
+       carries no anchor-position registry to differentiate positions
+       across systems (Phase 3, unbuilt), so every rule in it is
+       effectively at one shared, unresolved position, and D16's byte-order
+       fallback is what governs. **This row mints no new ordering law** —
+       it is an application of D16 to a case D16's own text already
+       covers, not a second rule alongside it. ``(anchor …)`` forms stay
+       parseable and validated (``check_anchor``, unchanged) but inert for
+       ordering under this row, exactly as before it — resolving them into
+       a cross-system total order remains Phase 3's job, deferred with a
+       name.
        Reference implementation: ``rule_pipeline::split_content``,
-       ``rule_pipeline::rule_id`` (Program 28 B2, `docs/superpowers/plans/
+       ``canonical_ast::rule_id`` (widened to ``pub(crate)``),
+       ``lib::prepare_rules`` (Program 28 B2, `docs/superpowers/plans/
        2026-08-11-b2-tick-loop-plan.md` Phase A Tasks 2–4).
 ```
 
@@ -719,8 +857,58 @@ posture this row takes.
       text in the same commit when they diverge.
 - [ ] **Step 3:** `vale docs/reference/bsl-language.rst` → 0 (this file already carries a project
       vocabulary; this row's prose should clear it without a new exemption).
-- [ ] **Step 4: Commit** (`docs(bsl): D99 — the content-set loader honors §2.2's multi-rule grammar
-      (B2)`), sequenced right after Task 2 since it documents exactly that change.
+- [ ] **Step 4: Commit** (`docs(bsl): D<N> — the content-set loader applies D16's byte order to the
+      multi-rule case (B2)`, with the resolved number substituted in the message), sequenced right
+      after Task 2 since it documents exactly that change.
+
+### Task 3b: The register-row uniqueness guard (DEFECT fix — closes the collision class)
+
+**Files:**
+
+- Edit: `tests/unit/reference/test_bsl_grammar_sync.py`
+
+**The exact gap this closes.** The existing sync-guard file only ever asserts a SPECIFIC row
+EXISTS (`test_the_register_carries_d92`, `test_d98_is_recorded_in_the_register`, both a
+`re.search(r"^\s+\* - D\d+$", ...)` on one fixed number). That style of test cannot catch a
+DUPLICATE — `re.search` returns on the FIRST match and never asks whether a second one exists.
+Verified directly: if this plan's Task 3 and PR #500 both land a `* - D99` row (the exact
+collision this revision's own D-row numbering note exists to avoid, but a FUTURE pair of
+concurrent PRs could reproduce the same class of bug), every existing `test_the_register_carries_
+d*` test for either row would still PASS, silently. This task adds the general guard so the CLASS
+closes, not just this one instance.
+
+- [ ] **Step 1: Write the failing test.**
+
+```python
+def test_every_register_row_number_is_unique() -> None:
+    """No two D-rows may share a number — `re.search`'s existence checks
+    above cannot catch this (first-match semantics), so this test walks
+    every row instead. Verified as a real gap during Program 28 B2's
+    adversarial review: PR #500 and this plan's own D-row task both
+    proposed `D99` independently, and every existing per-row test would
+    have passed with both landed. See docs/superpowers/plans/
+    2026-08-11-b2-tick-loop-plan.md for the incident this test answers.
+    """
+    body = _read(RST)
+    numbers = re.findall(r"^\s+\* - D(\d+)$", body, re.MULTILINE)
+    assert numbers, "the register table must contain at least one D-row"
+    counts = Counter(numbers)
+    duplicates = {n: c for n, c in counts.items() if c > 1}
+    assert not duplicates, (
+        f"duplicate register row numbers: {duplicates} — each D<N> must be "
+        "unique; renumber the later-landed row to the next free number"
+    )
+```
+
+      `Counter` needs `from collections import Counter` added to the file's existing imports.
+- [ ] **Step 2:** Run it now, before this plan's own D-row lands — PASS (the register currently has
+      no duplicates). This is the regression-proof baseline, not a red phase in the usual TDD
+      sense: there is no bug to fix yet, only a gap in coverage to close.
+- [ ] **Step 3:** `mise run test:q -- tests/unit/reference/test_bsl_grammar_sync.py` → PASS (this
+      new test plus every existing test in the file, unmodified).
+- [ ] **Step 4: Commit** (`test(bsl): register-row uniqueness guard — closes the silent-duplicate
+      class (B2)`), landed independently of Task 3 so it protects Task 3's own row from the moment
+      it lands, not after.
 
 ### Task 4: `prepare_rule` → `prepare_rules`; `run_once_into` runs every rule in order
 
@@ -732,10 +920,12 @@ posture this row takes.
 
 - Produces: `pub(crate) struct PreparedRules { rules: Vec<(String, LoadedRule)>, types: TypeEnv,
   intrinsics: IntrinsicCosts, consts: HashMap<String, Value> }` (each entry pairs a rule's own id
-  with its `LoadedRule`, in DECLARATION order) and `pub(crate) fn prepare_rules<G: GraphSubstrate +
-  CanonicalState>(scenario_src: &str, rule_src: &str, graph: &mut G) -> Result<PreparedRules,
-  String>` — `prepare_rule`'s direct successor, same shape, now walking every rule `split_content`
-  returns instead of indexing `[0]`.
+  with its `LoadedRule`, SORTED into ascending rule-id BYTE order — §4.2, register row D16, never
+  the order `split_content` happened to encounter the forms in) and `pub(crate) fn
+  prepare_rules<G: GraphSubstrate + CanonicalState>(scenario_src: &str, rule_src: &str, graph: &mut
+  G) -> Result<PreparedRules, String>` — `prepare_rule`'s direct successor, same shape, now
+  walking every rule `split_content` returns, loading each, and sorting the result by id before
+  returning.
 - **`TickReport` gains one field, existing fields UNCHANGED in type** — this is the compatibility
   design this task commits to, checked against every current reader of `.fired`:
 
@@ -754,12 +944,15 @@ pub struct TickReport {
     /// `tests/floor_intrinsic_e2e.rs` (five call sites, grepped and
     /// confirmed) keep compiling and keep passing unmodified.
     pub fired: usize,
-    /// Per-rule detail, in DECLARATION/EXECUTION order — `(rule_id,
-    /// fired)`. Length 1 for every existing single-rule content set
-    /// (`fired == per_rule_fired[0].1` always holds); length N for an
-    /// N-rule content set. This is what Task 5's conformance test and
-    /// Phase D's event feed actually need — a summed `fired` alone cannot
-    /// tell "5 subjects fired" from "vitality fired on 3, lifecycle on 2".
+    /// Per-rule detail, in ASCENDING RULE-ID BYTE ORDER (§4.2, register row
+    /// D16) — `(rule_id, fired)`. NEVER declaration order or file order;
+    /// §4.2 says those "are never observable", and this field's own order
+    /// is the driver's proof that it honors that. Length 1 for every
+    /// existing single-rule content set (`fired == per_rule_fired[0].1`
+    /// always holds); length N for an N-rule content set. This is what
+    /// Task 5's conformance test and Phase D's event feed actually need —
+    /// a summed `fired` alone cannot tell "5 subjects fired" from
+    /// "vitality fired on 3, lifecycle on 2".
     pub per_rule_fired: Vec<(String, usize)>,
 }
 ```
@@ -849,16 +1042,21 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
         rule_file: "rule",
     };
 
-    // rule_forms is already in DECLARATION order (split_content, Task 2) —
-    // load_rule_form runs once per form, in that same order, and this loop
-    // preserves it into `rules`.
+    // rule_forms is `Vec<(String, SExpr)>` — each rule's id already paired
+    // with its form by split_content (Task 2), so no second extraction
+    // here. Loaded in WHATEVER order split_content returned them (reader-
+    // encounter order, unspecified) — then SORTED by id, ascending byte
+    // order, before returning. This is the one place execution order gets
+    // decided (§4.2, register row D16): sorting here, once, at load time,
+    // means every later stage (TickSession::advance, run_once_into) just
+    // iterates the already-correct order and never re-derives it.
     let mut rules = Vec::with_capacity(rule_forms.len());
-    for form in rule_forms {
-        let id = rule_pipeline::rule_id(&form).map_err(|e| e.to_string())?;
+    for (id, form) in rule_forms {
         let loaded = load_rule_form(form, &ctx)
             .map_err(|e| format!("rule {id} rejected: {e}"))?;
         rules.push((id, loaded));
     }
+    rules.sort_by(|(a, _), (b, _)| a.as_bytes().cmp(b.as_bytes()));
 
     Ok(PreparedRules {
         rules,
@@ -869,10 +1067,9 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
 }
 ```
 
-      `rule_id` needs `pub(crate)` visibility from Task 2 (it was `fn`, private to
-      `rule_pipeline.rs`, in babylon-bsl — a different crate from babylon-tick, so it must be
-      `pub` there, not merely `pub(crate)`; correct Task 2's visibility to `pub fn rule_id` if this
-      step needs it externally, which it does).
+      No `rule_id` call anywhere in this function — Task 2's `split_content` already hands back
+      each rule's id paired with its form, so `babylon-tick` never needs to reach into
+      `babylon-bsl`'s internal extractor at all, crate boundary respected by construction.
 - [ ] **Step 4: Rewrite `run_once_into` to loop.**
 
 ```rust
@@ -923,7 +1120,12 @@ pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
       rule's writes from the SAME tick, matching the frozen engine's own in-place, strict-order
       mutation semantics (CLAUDE.md: "Systems mutate the shared graph in-place in strict order…
       each system sees prior systems' mutations") for free, with no new mechanism — this falls out
-      of calling `run_tick` sequentially against one `&mut G`.
+      of calling `run_tick` sequentially against one `&mut G`. **The ORDER `prepared.rules`
+      iterates in is rule-id byte order (Step 3's sort), not the frozen engine's tick-position
+      order** — for the demo pair this means `lifecycle` runs before `vitality`, backwards from
+      the frozen engine's Vitality-@1-before-Lifecycle-@7 — safe only because the Multi-Rule
+      Decision section proved their domains disjoint; this loop does not know that and must not be
+      read as if it did.
 - [ ] **Step 5:** `cargo test -p babylon-tick` → PASS (the new regression test; all five
       externally-grepped `.fired` call sites still green, unmodified). `mise run rust:check` →
       green. `mise run qa:regression` and `mise run qa:vault-regression-ci` → byte-identical (this
@@ -932,7 +1134,7 @@ pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
 - [ ] **Step 6: Commit** (`feat(rust): prepare_rules — the multi-rule content-set loader, per-rule
       fired detail (B2)`).
 
-### Task 5: The multi-rule conformance vector — declaration order reproduces engine order
+### Task 5: The multi-rule conformance vector — byte-order sort, file-order invariance
 
 **Files:**
 
@@ -942,22 +1144,25 @@ pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
 - Edit: `rust/crates/babylon-tick/content/rules/lifecycle.bsl` (one line: `(anchor :after
   vitality)`)
 
-**The point of this task.** Proves the mechanism Tasks 2 and 4 built actually reproduces the frozen
-engine's own two-systems-in-order behavior (`VitalitySystem` @1, `LifecycleSystem` @7) — the
-conformance approach the Director's ruling called for — and, because the two rules' domains are
-disjoint (Multi-Rule Decision section), proves it with the RIGHT assertion (`per_rule_fired`'s
-order), not the assertion that would silently pass even with a broken driver (the final hash).
+**The point of this task, corrected.** Proves TWO things about the mechanism Tasks 2 and 4 built:
+(1) it sorts by rule-id byte order regardless of how the caller concatenates `.bsl` text (§4.2,
+D16 — "file order and load order are never observable"), and (2) the sorted result reproduces the
+frozen engine's own combined output for the demo pair, DESPITE running in the reverse of the
+frozen engine's own tick-position order — safe here only because the two rules' domains are
+disjoint (Multi-Rule Decision section), which this task's own Python reference script proves
+directly rather than assumes.
 
 - [ ] **Step 1: The declarative anchor.** Add `(anchor :after vitality)` to `lifecycle.bsl`'s
       `(rule lifecycle/dpd-circuit …)` form, between its `:fuel` keyword and its `(bindings …)`
-      form, matching §2.3's grammar position (`<domain>? <anchor>? <bindings>`). This is inert for
-      ordering today (Task 4's driver does not read `.anchor`; no test may assert it does) —
+      form, matching §2.3's grammar position (`<domain>? <anchor>? <bindings>`). This stays
+      INERT for ordering today — Task 4's driver sorts by rule-id byte order (D16), never reads
+      `.anchor`, and no test in this plan may assert that it does. The anchor is
       forward-documentation for the eventual Phase 3 anchor-resolution registry, landed now while
-      the fact ("lifecycle runs after vitality") is fresh, cheap to state, and already true by
-      construction of this task's own content-string ordering. Confirm `check_anchor` still
-      accepts the form (`cargo test -p babylon-bsl` — the existing `lifecycle.bsl` parse/load
-      tests must stay green; adding a valid, well-formed anchor changes nothing else about the
-      rule's load).
+      the fact ("lifecycle belongs after vitality in true engine order") is fresh and cheap to
+      state, EVEN THOUGH the current driver runs them the opposite way (byte order: lifecycle
+      first). Confirm `check_anchor` still accepts the form (`cargo test -p babylon-bsl` — the
+      existing `lifecycle.bsl` parse/load tests must stay green; adding a valid, well-formed
+      anchor changes nothing else about the rule's load).
 - [ ] **Step 2: The 10-node combined-conformance scenario.** Union `vitality-conformance.bscn`'s
       six social-class nodes (`core`, `bourgeoisie`, `hermit`, `last-worker`, `remnant`,
       `dissolved`, every field value transcribed byte-for-byte) and `lifecycle-conformance.bscn`'s
@@ -973,11 +1178,19 @@ order), not the assertion that would silently pass even with a broken driver (th
       mirrors the calling convention `vitality_conformance.py` and `lifecycle_conformance.py`
       already establish (both exist in this same directory — read them first, match their
       structure, do not invent a new one): build ONE `WorldState`/graph carrying all ten fixture
-      nodes (the Step 2 values), then call `VitalitySystem().step(state)` FOLLOWED BY
-      `LifecycleSystem().step(state)` — matching the frozen engine's own tick-position order
-      (Vitality @1, Lifecycle @7) — and print every post-tick field this task's Rust test needs to
-      pin, for BOTH the six social-class nodes and the four territory nodes.
-- [ ] **Step 4: Write the failing Rust test.**
+      nodes (the Step 2 values), call `VitalitySystem().step(state)` FOLLOWED BY
+      `LifecycleSystem().step(state)` (the frozen engine's own tick-position order, Vitality @1
+      before Lifecycle @7 — the reference stays in TRUE engine order regardless of which order the
+      Rust driver runs in, since this script serves as the independent oracle), and ALSO run the two systems in the
+      REVERSE order against a second, separately-built copy of the same ten-node state. Print both
+      runs' post-tick fields for every node. **This is the step that actually verifies the
+      disjoint-domain claim** — the Multi-Rule Decision section asserts it from reading the
+      bindings; this script checks it empirically, against the real frozen systems, and the two
+      printed outputs must match field-for-field before this task proceeds. If they do not match,
+      STOP — the disjoint-domain premise this whole task (and the byte-order-is-safe-here argument)
+      rests on would be false, and the plan's design needs to go back to the Multi-Rule Decision
+      section rather than paper over the mismatch here.
+- [ ] **Step 4: Write the failing Rust tests.**
 
 ```rust
 // tests/multi_rule_conformance.rs
@@ -991,50 +1204,66 @@ const VITALITY: &str = include_str!("../content/rules/vitality.bsl");
 const LIFECYCLE: &str = include_str!("../content/rules/lifecycle.bsl");
 
 #[test]
-fn declaration_order_matching_engine_order_reproduces_the_frozen_engine() {
-    // vitality text FIRST, lifecycle text SECOND — Vitality @1 before
-    // Lifecycle @7, the frozen engine's own tick-position order.
+fn byte_order_sort_reproduces_the_frozen_engine_despite_running_reversed() {
+    // Concatenation order here is arbitrary on purpose (vitality text
+    // first) — Step 2 below proves the OTHER concatenation order gives an
+    // identical report, which is the actual claim this task makes.
     let rule_src = format!("{VITALITY}\n{LIFECYCLE}");
     let mut graph = HypergraphStore::new();
     let mut sink = CollectingSink::default();
     let report = run_once_into(SCENARIO, &rule_src, &mut graph, &mut sink).expect("tick");
 
-    // THE ORDER PROOF — per Multi-Rule Decision, the final hash would NOT
-    // catch an order bug for this disjoint-domain pair, so this is the
-    // load-bearing assertion, not the hash.
+    // THE ORDER PROOF — ascending rule-id byte order puts lifecycle
+    // FIRST ('l' < 'v'), the reverse of the frozen engine's Vitality-@1-
+    // before-Lifecycle-@7. Per the Multi-Rule Decision section, the final
+    // hash would not, by itself, distinguish "sorts by id" from
+    // "preserves file order" for this pair, so per_rule_fired's own
+    // order is the load-bearing assertion.
     assert_eq!(report.per_rule_fired.len(), 2);
-    assert_eq!(report.per_rule_fired[0].0, "vitality/subsistence-and-death");
-    assert_eq!(report.per_rule_fired[1].0, "lifecycle/dpd-circuit");
+    assert_eq!(report.per_rule_fired[0].0, "lifecycle/dpd-circuit");
+    assert_eq!(report.per_rule_fired[1].0, "vitality/subsistence-and-death");
     // Exact counts pinned from Step 3's printed Python reference —
     // transcribe the real numbers here once the script has run; both
     // vitality-conformance.bscn (5 of 6 subjects pass the guard, per the
     // existing pinned test) and lifecycle-conformance.bscn's own fixture
     // are individually proven, so these counts should match those
     // existing pins exactly, unchanged by union.
-    assert_eq!(report.per_rule_fired[0].1, /* vitality fired count */ 0);
-    assert_eq!(report.per_rule_fired[1].1, /* lifecycle fired count */ 0);
+    assert_eq!(report.per_rule_fired[0].1, /* lifecycle fired count */ 0);
+    assert_eq!(report.per_rule_fired[1].1, /* vitality fired count */ 0);
 
-    // Per-node field values match the Step 3 combined Python reference —
-    // both halves, transcribed from its printed output.
+    // Per-node field values match Step 3's printed Python reference — BOTH
+    // halves, transcribed from its printed output. Step 3 proved the two
+    // engine-order and reverse-order Python runs agree, so this assertion
+    // is legitimate against EITHER printed run.
     // (concrete node_attribute assertions per Step 3's script output)
 }
 
 #[test]
-fn flipping_declaration_order_flips_per_rule_fired_order() {
-    // The mechanism proof: swap which text comes first, and the ORDER
-    // Task 4's loop reports flips with it — a hash-based assertion could
-    // not show this for a disjoint pair (Multi-Rule Decision section), so
-    // this test exists specifically to prove the mechanism, not the
-    // content.
-    let rule_src = format!("{LIFECYCLE}\n{VITALITY}");
-    let mut graph = HypergraphStore::new();
-    let mut sink = CollectingSink::default();
-    let report = run_once_into(SCENARIO, &rule_src, &mut graph, &mut sink).expect("tick");
-    assert_eq!(report.per_rule_fired[0].0, "lifecycle/dpd-circuit");
-    assert_eq!(report.per_rule_fired[1].0, "vitality/subsistence-and-death");
-    // The FINAL state hash, by contrast, is expected to be IDENTICAL to
-    // the previous test's — documenting the domain-disjointness finding
-    // as a live, checked property rather than an assertion left silent.
+fn file_order_is_never_observable_per_section_4_2() {
+    // The actual promise §4.2/D16 makes, now a committed test: two content
+    // sets built from the SAME two rules in DIFFERENT concatenation order
+    // must produce BYTE-IDENTICAL TickReports — not merely the same hash,
+    // the same report in full, including per_rule_fired's order (which
+    // must be IDENTICAL, not flipped, because the driver sorts rather
+    // than preserving file order).
+    let forward = format!("{VITALITY}\n{LIFECYCLE}");
+    let reversed = format!("{LIFECYCLE}\n{VITALITY}");
+
+    let mut graph_a = HypergraphStore::new();
+    let mut sink_a = CollectingSink::default();
+    let report_a = run_once_into(SCENARIO, &forward, &mut graph_a, &mut sink_a).expect("tick a");
+
+    let mut graph_b = HypergraphStore::new();
+    let mut sink_b = CollectingSink::default();
+    let report_b = run_once_into(SCENARIO, &reversed, &mut graph_b, &mut sink_b).expect("tick b");
+
+    assert_eq!(report_a.before, report_b.before);
+    assert_eq!(report_a.after, report_b.after);
+    assert_eq!(report_a.fired, report_b.fired);
+    assert_eq!(
+        report_a.per_rule_fired, report_b.per_rule_fired,
+        "file/concatenation order must never be observable in the report — §4.2"
+    );
 }
 ```
 
@@ -1044,8 +1273,8 @@ fn flipping_declaration_order_flips_per_rule_fired_order() {
       test -p babylon-tick --test multi_rule_conformance` → PASS.
 - [ ] **Step 6:** `mise run rust:check` → green. `mise run qa:regression` → byte-identical (this
       task adds content and a test; it must not move any existing engine byte).
-- [ ] **Step 7: Commit** (`test(content): multi-rule conformance — vitality+lifecycle in
-      declaration order reproduces the frozen engine (B2)`).
+- [ ] **Step 7: Commit** (`test(content): multi-rule conformance — byte-order sort reproduces the
+      frozen engine, file order proven never observable (B2)`).
 
 ### Task 6: `TickSession<G>` — load once, advance many times, now multi-rule
 
@@ -1147,7 +1376,9 @@ fn two_independent_sessions_over_the_same_content_hash_identically() {
 //! loop needs the split this type provides instead: parse and load cost
 //! paid ONCE in `new`, the SAME `PreparedRules` and the SAME graph reused
 //! by every `advance()` call, every rule in the content set run once per
-//! call, in declaration order, with `tick` incremented by this type.
+//! call, in ascending rule-id byte order (§4.2, register row D16 —
+//! `prepare_rules` sorts once at load time), with `tick` incremented by
+//! this type.
 
 use crate::{prepare_rules, PreparedRules, TickReport};
 use babylon_bsl::intrinsic_host::KernelIntrinsicHost;
@@ -1167,8 +1398,10 @@ pub struct TickSession<G> {
 }
 
 impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
-    /// Parse `rule_src` (one or more `(rule …)` forms, in declaration
-    /// order) and load `scenario_src` into `graph` once.
+    /// Parse `rule_src` (one or more `(rule …)` forms) and load
+    /// `scenario_src` into `graph` once. `prepare_rules` sorts the forms
+    /// into ascending rule-id byte order (§4.2, D16) before this returns —
+    /// the caller's own concatenation order is never observable.
     ///
     /// # Errors
     /// The same failure modes `run_once_into`'s load half has: an
@@ -1184,8 +1417,9 @@ impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
     }
 
     /// Run one more tick against the held graph: every rule in the
-    /// content set, in DECLARATION order, each to completion before the
-    /// next starts, against the SAME graph — so a later rule sees an
+    /// content set, in ASCENDING RULE-ID BYTE ORDER (§4.2, D16 — sorted
+    /// once, at load time, by `prepare_rules`), each to completion before
+    /// the next starts, against the SAME graph — so a later rule sees an
     /// earlier rule's writes from this same tick (the frozen engine's own
     /// in-place strict-order semantics, inherited for free from calling
     /// `run_tick` sequentially against one `&mut G`). The first call runs
@@ -1275,6 +1509,23 @@ map-visible effect vitality's own subject type cannot honestly produce. This tas
 lifecycle archetype value sets onto twelve REAL FIPS codes AND mints the vitality fixture verbatim
 alongside them, in ONE scenario, without inventing new numbers this plan's author cannot verify.
 
+**BLOCKER 2 correction — the twelve counties now get TWELVE DISTINCT population seeds, not four
+archetypes repeated three times each.** The first cut of this task cycled the four
+`lifecycle-conformance.bscn` archetypes verbatim across the twelve FIPS (indices 0-2 all getting
+`core-county`'s exact numbers, and so on) — legal, but it means three of the twelve counties would
+render and evolve IDENTICALLY, which understates "watch state change" more than necessary and
+was never required by anything this task cites. Each of the twelve now takes its archetype's
+`pop-d`/`pop-p`/`pop-d-prime` values SCALED by a disclosed, deterministic factor — `{0.95, 1.00,
+1.05}` across the three repeats of each archetype, each result rounded to the nearest integer
+(the `.bscn` loader accepts only integer literals into `int`-declared fields — verified against
+`dispossession.bsl`'s own header note on this exact constraint) — so every county starts from a
+distinct, real number while staying visibly the same FAMILY as its archetype (a 5% swing changes
+the DPD trajectory's size, never its sign or its rough shape). `wealth-d-prime`,
+`dependency-ratio` (a computed field, always seeded `0`) and the legitimation fields stay at their
+archetype's exact original values — the initial `legitimation-crisis` seed matters
+only for the tick-1 crisis/recovery EDGE detection (Task 5's own `prev-crisis` mechanism), which a
+population perturbation has no bearing on.
+
 - [ ] **Step 1: Select the twelve FIPS, deterministically, from the committed atlas — never
       guessed.** B1 Task 1 Step 5 sorts the atlas's county table by FIPS ascending before writing,
       so atlas indices `0..12` are the twelve lowest-FIPS counties in the whole 3,222-county
@@ -1304,12 +1555,32 @@ fn print_first_twelve() {
       committed artifact, not by recall.
 - [ ] **Step 2: Write the scenario.** ONE `.bscn` file, two node-type halves:
       - **Territory half.** Reuse the `lifecycle-conformance.bscn` header's `deffield` block and
-        all 21 `defconst` rows byte-for-byte. Cycle the four archetype value sets from
-        `lifecycle-conformance.bscn:80-124` across the twelve FIPS in order (indices 0-2 get the
-        `core-county` values, 3-5 `growing-county`, 6-8 `recovering-county`, 9-11 `young-county`),
-        naming each node `county-<fips>` (symbols must start with a lowercase letter — §1's
-        `symbol ::= LOWER (LOWER | DIGIT | "-")*` — a bare FIPS like `06037` is not a legal symbol,
-        `county-06037` is).
+        all 21 `defconst` rows byte-for-byte. Apply the `{0.95, 1.00, 1.05}` scale factors (rounded
+        to nearest integer) to each archetype's `pop-d`/`pop-p`/`pop-d-prime` across its three
+        repeats — the exact twelve values, computed and verified for this plan:
+
+        | idx | archetype | pop-d | pop-p | pop-d-prime | wealth-d-prime |
+        |---|---|---|---|---|---|
+        | 0 | core (×0.95) | 2042 | 5748 | 1710 | 10000000 |
+        | 1 | core (×1.00) | 2150 | 6050 | 1800 | 10000000 |
+        | 2 | core (×1.05) | 2258 | 6352 | 1890 | 10000000 |
+        | 3 | growing (×0.95) | 2850 | 4750 | 1425 | 5000000 |
+        | 4 | growing (×1.00) | 3000 | 5000 | 1500 | 5000000 |
+        | 5 | growing (×1.05) | 3150 | 5250 | 1575 | 5000000 |
+        | 6 | recovering (×0.95) | 1900 | 6650 | 1900 | 20000000 |
+        | 7 | recovering (×1.00) | 2000 | 7000 | 2000 | 20000000 |
+        | 8 | recovering (×1.05) | 2100 | 7350 | 2100 | 20000000 |
+        | 9 | young (×0.95) | 3800 | 5225 | 0 | 0 |
+        | 10 | young (×1.00) | 4000 | 5500 | 0 | 0 |
+        | 11 | young (×1.05) | 4200 | 5775 | 0 | 0 |
+
+        `dependency-ratio` seeds `0` (computed field) for all twelve; `legitimation-index`/
+        `legitimation-crisis`/`transmitted-ideology` seed at their ARCHETYPE's original value
+        (core/growing/young = `0`/`0`/`0`; recovering = `2`, PRE-crisis CRISIS, so it still fires
+        `LEGITIMATION_RECOVERY` on tick 1 for indices 6-8 exactly as the unperturbed design did —
+        the population scale factor has no bearing on this field). Name each node `county-<fips>`
+        (symbols must start with a lowercase letter — §1's `symbol ::= LOWER (LOWER | DIGIT |
+        "-")*` — a bare FIPS like `06037` is not a legal symbol, `county-06037` is).
       - **Social-class half.** Reuse `vitality-conformance.bscn`'s `deffield` block (7 fields,
         `social-class/inequality` included though no rule reads it, for fixture parity with the
         frozen engine per that file's own comment) and its 2 `defconst` rows, and its six nodes'
@@ -1344,19 +1615,29 @@ fn print_first_twelve() {
   ; vitality-conformance.bscn:43-44 ...
 
   ; county-<fips[0]>, county-<fips[1]>, county-<fips[2]>: the core-county
-  ; archetype (DPDState docstring numbers, PRE-crisis STABLE).
+  ; archetype (DPDState docstring numbers, PRE-crisis STABLE), scaled
+  ; 0.95/1.00/1.05 per Step 2's table so all three are DISTINCT.
   (node county-<fips[0]> NodeType/TERRITORY
+    (territory/pop-d 2042) (territory/pop-p 5748) (territory/pop-d-prime 1710)
+    (territory/wealth-d-prime 10000000) (territory/dependency-ratio 0)
+    (territory/legitimation-index 0) (territory/legitimation-crisis 0)
+    (territory/transmitted-ideology 0))
+  (node county-<fips[1]> NodeType/TERRITORY
     (territory/pop-d 2150) (territory/pop-p 6050) (territory/pop-d-prime 1800)
     (territory/wealth-d-prime 10000000) (territory/dependency-ratio 0)
     (territory/legitimation-index 0) (territory/legitimation-crisis 0)
     (territory/transmitted-ideology 0))
-  ; ... repeated for fips[1], fips[2] with the same values ...
+  ; ... fips[2] (×1.05: 2258/6352/1890) same pattern; the committed file
+  ; writes all twelve nodes in full, Step 2's table above is the source.
 
-  ; county-<fips[3..6]>: the growing-county archetype (PRE-crisis UNSTABLE).
+  ; county-<fips[3..6]>: the growing-county archetype (PRE-crisis UNSTABLE),
+  ;   scaled 0.95/1.00/1.05.
   ; county-<fips[6..9]>: the recovering-county archetype (PRE-crisis CRISIS,
   ;   fires LEGITIMATION_RECOVERY on tick 1 under these defconsts, same as
-  ;   the conformance scenario).
-  ; county-<fips[9..12]>: the young-county archetype (no D' cohort).
+  ;   the conformance scenario, unaffected by the population scale), scaled
+  ;   0.95/1.00/1.05.
+  ; county-<fips[9..12]>: the young-county archetype (no D' cohort), scaled
+  ;   0.95/1.00/1.05.
 
   ; The six vitality-conformance.bscn nodes, values transcribed verbatim
   ; (fed core, standard-of-living-scaled bourgeoisie, surviving hermit,
@@ -1392,8 +1673,10 @@ fn the_demo_scenario_loads_and_ticks_both_packs() {
     let report = session.advance(&mut sink).expect("tick 1");
     assert_ne!(report.before, report.after);
     assert_eq!(report.per_rule_fired.len(), 2);
-    assert_eq!(report.per_rule_fired[0].0, "vitality/subsistence-and-death");
-    assert_eq!(report.per_rule_fired[1].0, "lifecycle/dpd-circuit");
+    // Ascending rule-id byte order (§4.2, D16) — lifecycle before vitality,
+    // regardless of the rule_src concatenation order above.
+    assert_eq!(report.per_rule_fired[0].0, "lifecycle/dpd-circuit");
+    assert_eq!(report.per_rule_fired[1].0, "vitality/subsistence-and-death");
     // The recovering-county archetype fires LEGITIMATION_RECOVERY on tick 1
     // under these defconsts (matching lifecycle-conformance.bscn's own
     // documented behavior) — proves the twelve territory nodes really run
@@ -1453,6 +1736,19 @@ pub fn county_tension(graph: &dyn GraphSubstrate) -> LensReading;
 - [ ] **Step 3:** `cargo test -p babylon-client` → PASS.
 - [ ] **Step 4: Commit** (`feat(client): the ADR170 tension witness over &dyn GraphSubstrate (B2)`).
 
+**Related finding, checked while fixing BLOCKER 2, stated here for the same honesty reason.** Task
+7's demo scenario declares only `lifecycle`'s territory fields (`pop-d`/`pop-p`/`pop-d-prime`/
+`wealth-d-prime`/`dependency-ratio`/`legitimation-*`/`transmitted-ideology`) — it seeds NO `v`/`s`/
+`e`-style economic stamps anywhere, because nothing in this plan's two rule packs writes them, so
+`county_tension` returns `absent_reason.is_some()` and every cell `None` on THIS demo,
+unconditionally — not merely static like Legitimation, genuinely EMPTY. This is not a new defect:
+B1's own Task 12 already named the same fact ("the ADR170 lens is scenario-baked and tick-invariant
+under currently-ported content") and built its own declared-fallback path for exactly this case
+(the absence banner Task 11 renders). The consequence for THIS plan: **the app must not default
+to `ActiveLens::Tension`** — a player's first launch would show the absence banner over an
+all-`PANEL` map, which is a worse first impression than any of this plan's other findings and an
+easy one to avoid. Task 12 defaults to `ActiveLens::PopulationTrend` instead — see its own note.
+
 ### Task 9: The Legitimation lens — live, categorical, zero new math
 
 **Files:**
@@ -1491,7 +1787,83 @@ value" from "pick the color."
 - [ ] **Step 4: Commit** (`feat(client): the legitimation lens — live per-tick classification, zero
       new thresholds (B2)`).
 
-### Task 10: Two band tables, one recolor system
+**BLOCKER 2 finding, stated here rather than left implied.** This lens's own code is correct and
+ships exactly as Director ruling 1 specified. What it displays is a different matter: reading
+`lifecycle.bsl`'s Block 2 in full (`legit-index`'s five weighted terms — `home-ownership-rate`,
+`healthcare-security`, `retirement-confidence`, `pension-coverage-rate`, `ss-replacement-rate`,
+each a `:const`, none a `:field`) shows `legit-index` computes to the SAME value for every
+territory, every tick — there is no per-territory or per-tick input anywhere in its formula.
+Under the shipped `defines.yaml` values that number is `0.6039`, above
+`legitimation-unstable-threshold` (`0.5`), so `new-crisis-class` evaluates to `0` (STABLE) for
+every territory from tick 2 onward (tick 1 still fires the recovering-archetype counties'
+`LEGITIMATION_RECOVERY` edge, since `prev-crisis` reads the SEEDED value before the rule
+overwrites it). Under ruling 1's color mapping (Task 10), STABLE renders `PANEL` — the same color
+as no data. **This lens is real, ships as ruled, and will animate the moment `lifecycle.bsl`'s
+inputs become per-territory fields (the typed-attribute Phase-2 revision) — but until then, a
+player watching ONLY this lens sees an unchanging dark map from tick 2 on.** Task 9b (new
+Population Trend lens, below) exists because "watch state change" needs a lens that moves TODAY,
+not a promise about a future port.
+
+### Task 9b: The Population Trend lens — the lens that actually moves (BLOCKER 2 fix)
+
+**Files:**
+
+- Edit: `rust/crates/babylon-client/src/lens.rs`
+
+**Interfaces:**
+
+- Produces: `pub fn county_population_trend(graph: &dyn GraphSubstrate, node_by_fips: &[(String,
+  NodeId)], baseline: &[(String, f64)]) -> LensReading` — `baseline` is the tick-0 total
+  population per demo county, captured once by `EngineSession::start` (Task 13) before any
+  `advance()` runs, in the SAME `(fips, value)` shape `node_by_fips` already establishes.
+
+**Why this is the lens that carries "watch state change."** `lifecycle.bsl`'s Block 1 (the DPD
+population flow) reads and writes GENUINE per-tick, per-territory `:field`s —
+`territory/{pop-d,pop-p,pop-d-prime}` — unlike Block 2's const-only legitimation math (Task 9's
+finding). Verified by computing the actual five-tick trajectory from the pack's own formulas
+(`births = birth-rate * pop-p`, `d-to-p = rate-d-to-p * pop-d`, `p-to-d-prime = rate-p-to-d-prime *
+pop-p`, `deaths = rate-d-prime-to-death * pop-d-prime`, then the three `new-pop-*` updates) against
+Task 7's twelve seeded county values:
+
+| county family | total pop, tick 0 | total pop, tick 5 | Δ over 5 ticks |
+|---|---|---|---|
+| core (×1.00 repeat) | 10,000 | 9,949.5 | −50.5 (−0.51%) |
+| growing (×1.00 repeat) | 9,500 | 9,462.2 | −37.8 (−0.40%) |
+| recovering (×1.00 repeat) | 11,000 | 10,954.0 | −46.0 (−0.42%) |
+| young (×1.00 repeat) | 9,500 | 9,759.6 | **+259.6 (+2.73%)** |
+
+Three of the four archetype families NET-DECLINE (death drain from an already-large D'
+cohort outpaces the birth/transition inflow over a short horizon); `young`'s family — seeded with
+ZERO D' population — has no death term to speak of yet and NET-GROWS. This is not a coincidence
+engineered for the demo: it falls straight out of the pack's own formulas, verified by direct
+computation, and it happens to be thematically apt (an aging, established county's population
+slowly contracts; a young one grows) without this plan asserting anything about that beyond what
+the arithmetic gives. The `±5%` per-county scale factors (Task 7) shift each county's own
+size without flipping any family's sign — every core/growing/recovering-family county
+declines, every young-family county grows, twelve genuinely distinct trajectories, four groups by
+sign-and-shape, not twelve unrelated numbers and not three silent repeats.
+
+- [ ] **Step 1: Write the failing tests.** A territory whose current `pop-d + pop-p + pop-d-prime`
+      exceeds its `baseline` entry reports a POSITIVE value; below baseline reports NEGATIVE;
+      exactly equal (an edge case no real tick reaches, included for totality since `baseline` and
+      "now" could coincide before the first `advance()`) reports exactly `0.0`; a FIPS present in
+      `node_by_fips` but ABSENT from `baseline` is a wiring bug (both come from the same
+      `EngineSession::start` call, Task 13) and surfaces as a loud panic, never a silent `None` —
+      the same strictness argument Task 9 makes for its own `node_by_fips` mismatch case; a FIPS
+      outside BOTH slices (any of the 3,210 non-demo counties) is the one legitimate `None`.
+- [ ] **Step 2:** FAIL, then write it: for each `(fips, id)` in `node_by_fips`, read
+      `territory/pop-d`, `territory/pop-p`, `territory/pop-d-prime` off `graph` and sum them; look
+      up `fips` in `baseline` (linear scan — twelve entries, the same "not worth a `HashMap` at
+      this size" call Task 15 already makes for `node_by_fips`); return `Some(now - baseline)` as
+      the cell's raw value. **No sign normalization, no size threshold, no clamping** — the
+      raw signed delta travels to `map/bands.rs` (Task 10), which does the `> 0.0` / `< 0.0` / `==
+      0.0` classification; this module states a number, it does not classify one, matching Task 8
+      and Task 9's own division of labor.
+- [ ] **Step 3:** `cargo test -p babylon-client` → PASS.
+- [ ] **Step 4: Commit** (`feat(client): the population trend lens — genuinely per-tick, per-county
+      state change (B2, BLOCKER 2 fix)`).
+
+### Task 10: Three band tables, one recolor system
 
 **Files:**
 
@@ -1500,11 +1872,17 @@ value" from "pick the color."
 **Interfaces:**
 
 - Produces: `pub fn tension_band_color(w: Option<f64>) -> Color` (ADR191 R11's table, exactly as
-  the B1 plan's Task 9 specified — four rows, `<=` resolution, `PANEL` for absence) and `pub fn
+  the B1 plan's Task 9 specified — four rows, `<=` resolution, `PANEL` for absence); `pub fn
   legitimation_band_color(class: Option<f64>) -> Color` (per this amendment's Director ruling 1:
-  three rows, `Some(0.0) => PANEL`, `Some(1.0) => DIM`, `Some(2.0) => CRIMSON`, `None => PANEL`)
-  plus `pub enum ActiveLens { Tension, Legitimation }` and `#[derive(Event)] pub struct
-  LensChanged;`.
+  three rows, `Some(0.0) => PANEL`, `Some(1.0) => DIM`, `Some(2.0) => CRIMSON`, `None => PANEL`);
+  `pub fn population_trend_band_color(delta: Option<f64>) -> Color` (NEW this revision, BLOCKER 2
+  fix — a strict sign comparison, no invented size threshold: `Some(d) if d > 0.0 => GOLD`
+  (growing), `Some(d) if d < 0.0 => CRIMSON` (declining), `Some(0.0) => DIM` (unchanged — no real
+  demo tick reaches this, included for totality), `None => PANEL`); plus `#[derive(Resource, Debug,
+  Clone, Copy, PartialEq, Eq)] pub enum ActiveLens { Tension, Legitimation, PopulationTrend }`
+  (THREE variants, was two — `Debug`/`PartialEq` because Task 12's and Task 18's tests both compare
+  and print it directly, `Copy` because every reader takes it by value off a `Res<ActiveLens>`) and
+  `#[derive(Event)] pub struct LensChanged;`.
 
 **Director ruling 1, applied exactly.** Selected option, quoted: *"CRISIS → crimson, UNSTABLE →
 dim gray, STABLE → gold's absence (panel dark) — reuses the ruled four-band vocabulary so the two
@@ -1518,27 +1896,39 @@ from absence BY COLOR — "gold's absence" reads as "nothing here needs your att
 thematically apt for a stable county fading into the background. The HUD (Task 11) is, as a
 result, the ONLY channel that can tell a player "this county is STABLE" from "this county has no data" —
 its literal text label carries weight the color alone cannot, and Task 11's steps make that
-explicit.
+explicit. **The new Population Trend lens (Task 9b) is additive to this ruling, not a variance
+from it** — it reuses the SAME four `map/bands.rs` tokens (`GOLD` and `DIM` newly put to use here,
+`CRIMSON`/`PANEL` shared with the other two lenses), applies them to a THIRD variable, and invents
+no fifth color — "no new colors enter the game" holds across all three lenses, not just the one
+the ruling named.
 
-- [ ] **Step 1: Write the failing tests** for both band functions — the exact `Srgba` byte
+- [ ] **Step 1: Write the failing tests** for all three band functions — the exact `Srgba` byte
       assertions from the B1 Task 9 spec for `tension_band_color` (CRIMSON at `w <= -0.15`, DIM in
       `(-0.15, 0.15]`, GOLD above, PANEL for `None`; `tension_band_color(Some(0.0)) !=
-      tension_band_color(None)`, the Tension lens's OWN non-confusion property, unchanged) plus,
-      for `legitimation_band_color`: `Some(0.0)` and `None` BOTH give `PANEL` (the intentional
+      tension_band_color(None)`, the Tension lens's OWN non-confusion property, unchanged); for
+      `legitimation_band_color`: `Some(0.0)` and `None` BOTH give `PANEL` (the intentional
       equality Director ruling 1 creates — assert them EQUAL, not distinct, and comment why,
       citing this ruling by name so a future reader does not "fix" it back to the first cut's
-      design); `Some(1.0)` gives `DIM`; `Some(2.0)` gives `CRIMSON`.
-- [ ] **Step 2:** FAIL, then write both as `const` tables resolved by the same `<=`-walk shape,
-      matching `PANEL`'s existing declaration in this file. `legitimation_band_color` needs no new
-      color constant — it imports `PANEL`, `DIM`, `CRIMSON`, all already declared in this file or
-      `crate::palette`.
+      design); `Some(1.0)` gives `DIM`; `Some(2.0)` gives `CRIMSON`; for
+      `population_trend_band_color`: any positive value gives `GOLD` (spot-check `Some(0.001)` and
+      a large value alike — no size cutoff to find the edge of), any negative value gives
+      `CRIMSON` (same spot-check shape), `Some(0.0)` gives `DIM`, `None` gives `PANEL`, and
+      `population_trend_band_color(Some(0.0)) != population_trend_band_color(None)` (the SAME
+      non-confusion property Tension's own table carries — unlike Legitimation, this lens's
+      "unchanged" state is NOT meant to look like absence, since a genuinely unchanged county is a
+      real, meaningful reading here, not a stand-in for "nothing to report").
+- [ ] **Step 2:** FAIL, then write all three as `const` tables (or, for `population_trend_band_color`,
+      a plain sign match — a two-row table plus its own zero/absence arms would overstate what is
+      really an `if`/`else if`/`else`) resolved by the same shape, matching `PANEL`'s existing
+      declaration in this file. Neither new function needs a new color constant — both import
+      `PANEL`/`DIM`/`CRIMSON`/`GOLD`, all already declared in this file or `crate::palette`.
 - [ ] **Step 3: The recolor system.** One system, parameterized by `ActiveLens`:
 
 ```rust
 pub(super) fn recolor_on_lens_changed(
     mut events: EventReader<LensChanged>,
     active: Res<ActiveLens>,
-    lens_data: Res<CurrentLensData>, // holds both LensReading values, refreshed every advance
+    lens_data: Res<CurrentLensData>, // holds all THREE LensReading values, refreshed every advance
     surface: Res<MapSurface>,
     atlas_index: Res<FipsIndex>,     // fips -> atlas county index, from Task 12
     mut meshes: ResMut<Assets<Mesh>>,
@@ -1549,10 +1939,12 @@ pub(super) fn recolor_on_lens_changed(
     let reading = match *active {
         ActiveLens::Tension => &lens_data.tension,
         ActiveLens::Legitimation => &lens_data.legitimation,
+        ActiveLens::PopulationTrend => &lens_data.population_trend,
     };
     let color_fn: fn(Option<f64>) -> Color = match *active {
         ActiveLens::Tension => tension_band_color,
         ActiveLens::Legitimation => legitimation_band_color,
+        ActiveLens::PopulationTrend => population_trend_band_color,
     };
     let Some(mesh) = meshes.get_mut(&surface.fill_mesh) else {
         return;
@@ -1585,9 +1977,13 @@ pub(super) fn recolor_on_lens_changed(
       county's colors held at `PANEL`. Add a SPECIFIC regression case: a `Some(0.0)` (STABLE) cell
       and a genuinely-absent cell (a FIPS with no `LensReading` entry at all) produce the SAME
       vertex color — proving the intentional merge, not just the function's return value in
-      isolation.
-- [ ] **Step 5: Commit** (`feat(client): two-lens band tables — legitimation reuses PANEL/DIM/
-      CRIMSON per Director ruling 1 (B2, completes B1 Phase C Task 9)`).
+      isolation. Repeat the shape for `ActiveLens::PopulationTrend`: a positive-delta cell shows
+      `GOLD`, a negative-delta cell shows `CRIMSON`, and (unlike Legitimation) confirm a
+      genuinely-absent cell does NOT match either — `population_trend_band_color`'s own
+      non-confusion property, tested at the recolor-system level too, not only the pure function.
+- [ ] **Step 5: Commit** (`feat(client): three-lens band tables — legitimation reuses PANEL/DIM/
+      CRIMSON per Director ruling 1, population trend adds GOLD (B2, completes B1 Phase C Task 9,
+      BLOCKER 2 fix)`).
 
 ### Task 11: Hover, selection, the active-lens label
 
@@ -1622,19 +2018,24 @@ Lens: Legitimation — CRISIS (live, tick 7)          [if ActiveLens::Legitimati
 Lens: Legitimation — STABLE (live, tick 7)          [class 0 — SAME map color as absence;
                                                        this line is the only place a player
                                                        can tell the two apart]
-Lens: Tension — no data this tick                    [absence, either lens]
+Lens: Population Trend — +37 since tick 0 (growing) [if ActiveLens::PopulationTrend, delta > 0]
+Lens: Population Trend — -19 since tick 0 (declining) [delta < 0]
+Lens: Tension — no data this tick                    [absence, any of the three lenses]
 ```
 
       Top-left banner whenever the active lens's `absent_reason.is_some()`, in CRIMSON. A
-      persistent DIM footer names which lens is inactive and how to switch (Task 12): "Tab: switch
-      to Legitimation lens" or vice versa — the map must never let a color mean two things without
-      saying which one is live, and (per Task 10) a STABLE county must never let its color alone
-      be mistaken for "no data."
+      persistent DIM footer names which lens is ACTIVE and how to cycle (Task 12): "Tab: Tension →
+      Legitimation → Population Trend → Tension" — the map must never let a color mean two things
+      without saying which one is live, and (per Task 10) a STABLE Legitimation county must never
+      let its color alone be mistaken for "no data."
 - [ ] **Step 5: Headless test** — hovering a known world point sets `HoveredCounty` to the expected
       FIPS, cursor position written directly to the resource (B1 Task 10's own precedent, not
       synthesized window events). Add a case hovering a STABLE demo county and asserting the HUD
       text renders the literal string `"STABLE"` (not merely a color check, since Task 10
-      established the color cannot carry this distinction alone).
+      established the color cannot carry this distinction alone), and a case hovering a demo
+      county under `ActiveLens::PopulationTrend` and asserting the rendered delta's SIGN matches
+      the county's known trajectory direction (Task 9b's table — a `young`-family county must read
+      "growing", every other family "declining").
 - [ ] **Step 6: Commit** (`feat(client): county hover, selection and the active-lens HUD (B2,
       completes B1 Phase C Task 10)`).
 
@@ -1645,19 +2046,29 @@ Lens: Tension — no data this tick                    [absence, either lens]
 - Edit: `rust/crates/babylon-client/src/map/mod.rs`
 
 - [ ] **Step 1: Write the failing headless test** — `MinimalPlugins` + `AssetPlugin` +
-      `babylon_client::map::MapPlugin`, press `Tab` (write directly into `ButtonInput<KeyCode>`,
-      matching the input-resource-mutation pattern this plan's tests already use), `update()`,
-      assert `ActiveLens` flipped and a `LensChanged` event fired.
+      `babylon_client::map::MapPlugin`, assert the STARTUP default `ActiveLens` is
+      `PopulationTrend` (not `Tension` — see the note below), then press `Tab` three times (write
+      directly into `ButtonInput<KeyCode>`, matching the input-resource-mutation pattern this
+      plan's tests already use, one `update()` per press), assert `ActiveLens` visits `Tension` →
+      `Legitimation` → `PopulationTrend` in that cycle order (a 3-way CYCLE, not a 2-way flip — the
+      first cut's design only had two lenses), and a `LensChanged` event fires on every press.
 - [ ] **Step 2:** FAIL, then add: `mod pick; mod hud;` (new modules from this task); `pub use
       bands::{ActiveLens, LensChanged};` alongside the existing `pub use bands::PANEL;` — the same
       re-export convention B1 already established for `PANEL`, extended to the two new types so
       `crate::map::ActiveLens`/`crate::map::LensChanged` (the paths Task 14's and Task 18's code
-      use) resolve; `ActiveLens::Tension` inserted as the `Startup` default resource; an `Update`
-      system reading `Tab` and toggling it plus sending `LensChanged`; Task 10's
-      `recolor_on_lens_changed` system registered.
+      use) resolve; **`ActiveLens::PopulationTrend` inserted as the `Startup` default resource —
+      NOT `Tension`.** Task 8's own finding: this demo scenario seeds no `v`/`s`/`e`-style economic
+      fields at all, so `county_tension` returns fully absent on every county, every tick, on this
+      content — defaulting to it would open the app on an absence banner over an all-`PANEL` map.
+      `PopulationTrend` is the one lens guaranteed to carry real, changing, non-absent data on this
+      demo from tick 0. An `Update` system reads `Tab` and CYCLES the active lens
+      (`Tension -> Legitimation -> PopulationTrend -> Tension`, a `match` naming all three arms
+      explicitly, so no wraparound bug can hide — the STARTING point is
+      `PopulationTrend`, and the cycle ORDER keeps matching the test above) plus sends
+      `LensChanged`; Task 10's `recolor_on_lens_changed` system registered.
 - [ ] **Step 3:** `cargo test -p babylon-client` → PASS. `mise run rust:check` → green.
-- [ ] **Step 4: Commit** (`feat(client): wire the lens picker into MapPlugin (B2)`). Open the
-      Phase C PR (`feat(client): B2 Phase C — the dual-lens map, completing B1's Phase C`);
+- [ ] **Step 4: Commit** (`feat(client): wire the 3-way lens picker into MapPlugin (B2)`). Open the
+      Phase C PR (`feat(client): B2 Phase C — the three-lens map, completing B1's Phase C`);
       self-merge on green.
 
 ---
@@ -1679,12 +2090,21 @@ pub struct EngineSession {
     pub inner: TickSession<HypergraphStore>,
     pub sink: CollectingSink,
     pub node_by_fips: Vec<(String, NodeId)>,
+    pub population_baseline: Vec<(String, f64)>,
 }
 impl EngineSession {
     pub fn start() -> Result<Self, String>;
     pub fn advance(&mut self) -> Result<TickReport, String>;
 }
 ```
+
+**`population_baseline` (NEW this revision, BLOCKER 2 fix)** carries each demo territory's tick-0
+total population (`pop-d + pop-p + pop-d-prime`, read straight off the graph the moment
+`load_scenario` returns, before any `advance()` runs) — Task 9b's Population Trend lens needs a
+fixed reference point to measure change AGAINST, and tick 0 (the scenario's own declared, un-ticked
+state) is the only point that is honestly "before" every tick this session ever runs. Captured
+once, in the SAME shape as `node_by_fips` (`(fips, value)` pairs, same twelve-entry order), never
+recomputed.
 
 **Why `node_by_fips` is a plain `Vec`, not a `babylon-bsl` API addition.** `load_scenario`'s local
 name -> `NodeId` map is deliberately load-time-only and does not outlive the call (`scenario.rs`'s
@@ -1722,6 +2142,18 @@ fn engine_session_starts_and_the_twelve_fips_resolve_on_the_real_atlas() {
 }
 
 #[test]
+fn population_baseline_matches_the_seeded_tick_zero_totals() {
+    let session = EngineSession::start().expect("engine session starts");
+    assert_eq!(session.population_baseline.len(), 12);
+    // Task 7's Step 2 table: index 0 (core ×0.95) seeds pop-d=2042,
+    // pop-p=5748, pop-d-prime=1710 — total 9,500 exactly. Same fips order
+    // as node_by_fips/DEMO_FIPS.
+    let (fips0, total0) = &session.population_baseline[0];
+    assert_eq!(fips0, &session.node_by_fips[0].0);
+    assert!((total0 - 9500.0).abs() < 1e-6, "got {total0}");
+}
+
+#[test]
 fn engine_session_advance_moves_the_hash_and_runs_both_rules_every_tick() {
     let mut session = EngineSession::start().expect("start");
     let r1 = session.advance().expect("tick 1");
@@ -1749,18 +2181,19 @@ pub struct EngineSession {
     pub inner: TickSession<HypergraphStore>,
     pub sink: CollectingSink,
     pub node_by_fips: Vec<(String, NodeId)>,
+    pub population_baseline: Vec<(String, f64)>,
 }
 
 impl EngineSession {
     pub fn start() -> Result<Self, String> {
         let mut graph = HypergraphStore::new();
         // Load through the same load path TickSession uses internally —
-        // but we need the territory node ids BEFORE TickSession takes
-        // ownership of the graph, so load once here to capture them, then
-        // hand a FRESH graph to TickSession::new (it reloads the same
-        // scenario, which is deterministic and mints the identical
-        // eighteen ids — proven by this task's own Step 1 test, which
-        // checks both independently).
+        // but we need the territory node ids (and their SEEDED, pre-tick
+        // population totals) BEFORE TickSession takes ownership of the
+        // graph, so load once here to capture both, then hand a FRESH
+        // graph to TickSession::new (it reloads the same scenario, which
+        // is deterministic and mints the identical eighteen ids — proven
+        // by this task's own Step 1 test, which checks both independently).
         babylon_bsl::scenario::load_scenario(SCENARIO, &mut graph).map_err(|e| e.to_string())?;
         let ids = babylon_graph::substrate::GraphSubstrate::nodes(&graph, "NodeType/TERRITORY");
         if ids.len() != DEMO_FIPS.len() {
@@ -1776,10 +2209,28 @@ impl EngineSession {
             .zip(ids.iter())
             .map(|(fips, id)| ((*fips).to_owned(), *id))
             .collect();
+        // The tick-0 baseline Task 9b's Population Trend lens measures
+        // against — read from THIS graph, before it is discarded, while
+        // it still holds only the scenario's seeded (un-ticked) values.
+        let population_baseline: Vec<(String, f64)> = node_by_fips
+            .iter()
+            .map(|(fips, id)| {
+                let pop_d = graph.node_attribute(*id, "territory/pop-d").unwrap_or(0.0);
+                let pop_p = graph.node_attribute(*id, "territory/pop-p").unwrap_or(0.0);
+                let pop_dp = graph
+                    .node_attribute(*id, "territory/pop-d-prime")
+                    .unwrap_or(0.0);
+                (fips.clone(), pop_d + pop_p + pop_dp)
+            })
+            .collect();
 
-        // vitality text FIRST, lifecycle text SECOND — Vitality @1 before
-        // Lifecycle @7, per the Multi-Rule Decision section's declaration-
-        // order design (Phase A, Tasks 2-6).
+        // Concatenation order below is arbitrary — Phase A's driver sorts
+        // by rule-id BYTE ORDER (§4.2, D16) regardless of which text comes
+        // first, so this order has no bearing on execution order or on
+        // the resulting TickReport (Task 5 proves the file-order
+        // invariance directly). Vitality text stays first here only
+        // because it reads naturally next to the const list above it, not
+        // because it changes anything.
         let rule_src = format!("{VITALITY}\n{LIFECYCLE}");
         let inner = TickSession::new(SCENARIO, &rule_src, HypergraphStore::new())
             .map_err(|e| format!("tick session: {e}"))?;
@@ -1788,6 +2239,7 @@ impl EngineSession {
             inner,
             sink: CollectingSink::default(),
             node_by_fips,
+            population_baseline,
         })
     }
 
@@ -1797,14 +2249,18 @@ impl EngineSession {
 }
 ```
 
-      Note the deliberate double-load (once to recover territory ids, once inside
-      `TickSession::new`) rather than widening `TickSession` to expose its internal graph mutably
-      before the first `advance` — it costs one extra scenario parse at startup (still
-      microseconds against an 18-node scenario) and keeps `TickSession`'s public surface exactly
-      the four methods Task 6 specified.
+      Note the deliberate double-load (once to recover territory ids and the population baseline,
+      once inside `TickSession::new`) rather than widening `TickSession` to expose its internal
+      graph mutably before the first `advance` — it costs one extra scenario parse at startup
+      (still microseconds against an 18-node scenario) and keeps `TickSession`'s public surface
+      exactly the four methods Task 6 specified. `graph.node_attribute` returning `Result<f64,
+      GraphError>`, not `Option`, per `GraphSubstrate`'s existing signature — `unwrap_or(0.0)` is
+      safe here specifically because Task 7's scenario declares EVERY population field on EVERY
+      territory node explicitly (no field is ever unset at mint time), so the error path is
+      unreachable for this scenario, not silently papered over for one that might omit a field.
 - [ ] **Step 3:** `cargo test -p babylon-client` → PASS.
-- [ ] **Step 4: Commit** (`feat(client): EngineSession — the client's held two-rule TickSession +
-      fips↔id map (B2)`).
+- [ ] **Step 4: Commit** (`feat(client): EngineSession — the client's held two-rule TickSession,
+      fips↔id map, and tick-0 population baseline (B2)`).
 
 ### Task 14: Advance-tick input, tick counter, hash readout
 
@@ -1864,15 +2320,46 @@ pub struct TickLoopPlugin;
 impl Plugin for TickLoopPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(TickCounter::default());
-        app.add_systems(Startup, spawn_engine_session_and_hud);
+        // `.after(map::spawn_map_surface)` (and, transitively, needs
+        // `map::FipsIndex` to already exist — Task 12's own Startup
+        // system that builds it): this system fires the FIRST
+        // `LensChanged` at tick 0, and `recolor_on_lens_changed` (Task
+        // 10) reads `MapSurface`/`FipsIndex` resources that `MapPlugin`'s
+        // OWN Startup systems create. Bevy does not order same-schedule
+        // systems by plugin-registration order alone — this ordering
+        // constraint must be explicit, not implied by `main.rs` listing
+        // `MapPlugin` before `TickLoopPlugin`.
+        app.add_systems(
+            Startup,
+            spawn_engine_session_and_hud.after(crate::map::spawn_map_surface),
+        );
         app.add_systems(Update, (advance_on_space, refresh_readouts).chain());
     }
 }
 
-fn spawn_engine_session_and_hud(mut commands: Commands) {
+fn spawn_engine_session_and_hud(
+    mut commands: Commands,
+    mut lens_changed: EventWriter<crate::map::LensChanged>,
+) {
     let session = EngineSession::start()
         .unwrap_or_else(|e| panic!("engine session failed to start: {e}"));
+    // Tick 0's own LensReadings — the map must show something correct
+    // (or correctly absent) on first launch, before any Space press. The
+    // Population Trend reading is `Some(0.0)` (DIM) everywhere at this
+    // point, since `population_baseline` IS the tick-0 state — real
+    // divergence appears only after the first `advance()`.
+    let lens_data = crate::map::CurrentLensData {
+        tension: crate::lens::county_tension(session.inner.graph()),
+        legitimation: crate::lens::county_legitimation(session.inner.graph(), &session.node_by_fips),
+        population_trend: crate::lens::county_population_trend(
+            session.inner.graph(),
+            &session.node_by_fips,
+            &session.population_baseline,
+        ),
+    };
+    commands.insert_resource(lens_data);
     commands.insert_resource(session);
+    lens_changed.write(crate::map::LensChanged);
     commands.spawn((
         Text::new("tick 0"),
         TextColor(crate::palette::BONE),
@@ -1901,6 +2388,7 @@ fn advance_on_space(
     keys: Res<ButtonInput<KeyCode>>,
     mut session: ResMut<EngineSession>,
     mut counter: ResMut<TickCounter>,
+    mut lens_data: ResMut<crate::map::CurrentLensData>,
     mut lens_changed: EventWriter<crate::map::LensChanged>,
 ) {
     if !keys.just_pressed(KeyCode::Space) {
@@ -1910,6 +2398,21 @@ fn advance_on_space(
         .advance()
         .unwrap_or_else(|e| panic!("tick advance failed: {e}"));
     counter.0 = session.inner.tick();
+    // Recompute all THREE LensReadings against the POST-tick graph before
+    // firing LensChanged — the recolor system (Task 10) only ever reads
+    // whatever is already in CurrentLensData when the event fires, so a
+    // press that advanced the tick but never refreshed this resource would
+    // leave the map showing stale (or, on the very first press, entirely
+    // absent) data forever. This is the wiring that makes "watch state
+    // change" literally true rather than merely possible.
+    lens_data.tension = crate::lens::county_tension(session.inner.graph());
+    lens_data.legitimation =
+        crate::lens::county_legitimation(session.inner.graph(), &session.node_by_fips);
+    lens_data.population_trend = crate::lens::county_population_trend(
+        session.inner.graph(),
+        &session.node_by_fips,
+        &session.population_baseline,
+    );
     lens_changed.write(crate::map::LensChanged);
 }
 
@@ -1980,8 +2483,9 @@ fn refresh_readouts(
 - [ ] **Step 3: The event feed — now genuinely two-pack.** A scrolling text list, last 10 entries
       from `session.sink.events`, newest first, rendered as `<EventType> @ <county or n/a>` —
       reusing `CollectingSink`'s already-populated `events: Vec<(String, Vec<(String, Value)>)>`
-      with no new sink type. Because `EngineSession` (Task 13) now runs vitality THEN lifecycle
-      every tick, `sink.events` genuinely mixes BOTH packs' emissions in execution order:
+      with no new sink type. Because `EngineSession` (Task 13) now runs `lifecycle` THEN `vitality`
+      every tick (ascending rule-id byte order, §4.2/D16 — see the Multi-Rule Decision section),
+      `sink.events` genuinely mixes BOTH packs' emissions, with the `lifecycle` events first each tick:
       `vitality`'s `EventType/ENTITY_DEATH` (its own payload carries `entity-id`, no county
       binding — rendered as `@ n/a`) alongside `lifecycle`'s
       `LIFECYCLE_TRANSITION`/`LEGITIMATION_CRISIS`/`LEGITIMATION_RECOVERY` (county-bound, rendered
@@ -2290,23 +2794,35 @@ fn five_ticks_produce_five_distinct_hashes() {
 B2's eyes-on gate by:
 
 1. Running `cargo run -p babylon-client`.
-2. Seeing the county map render — the same borders and (now, Phase C) an initial band coloring on
-   the twelve demo counties, everything else `PANEL`.
+2. Seeing the county map render on the DEFAULT `PopulationTrend` lens (Task 12's finding: `Tension`
+   defaults would open on an absence banner over an all-`PANEL` map on this demo content, so the
+   app does not default there) — the same borders, and `DIM` on all twelve demo counties, everything
+   else `PANEL`. **DIM, not GOLD/CRIMSON, at this exact moment** — `population_trend` measures
+   change SINCE the tick-0 baseline, and tick 0 IS the baseline (`Some(0.0)` everywhere, `0.0` maps
+   to `DIM` per Task 10's own table), so the honest opening view is uniform, not pre-differentiated.
 3. Pressing **Space** at least five times, and after each press observing every one of the
    following:
    - the tick counter (bottom-right) increments by exactly one;
    - the hash readout changes to a new hex string every press (never repeats — Task 17 proves this
      is a real property, not a hope);
-   - at least one demo county's band color OR the selected/hovered county's state-panel numbers
-     visibly changes (a tick where no county crosses a band boundary still moves the raw
-     `pop-d`/`pop-p`/`pop-d-prime` numbers in the panel — "watch state change" needs no
-     color flip on every single press);
+   - **after the FIRST press**, the twelve demo counties split into GOLD (`young`-family, net
+     growth — Task 9b's table) and CRIMSON (the other three families, net decline) — this is the
+     moment "watch state change" becomes visible ON THE MAP, not merely in a readout, and every
+     press after the first should show the same GOLD/CRIMSON counties growing further apart in
+     size (visible in the HUD when hovered, or in the state panel's raw numbers), never
+     flipping color family; the Legitimation lens's own map color will NOT change tick to tick on
+     this content (Task 9's own finding), so a human running this gate should not expect it to and
+     should not read a
+     static Legitimation view as a failure;
    - the event feed grows, carrying BOTH event families over a long-enough run —
      `LIFECYCLE_TRANSITION` fires every tick for every county, and `ENTITY_DEATH` fires at least
      once by the tick the fixture's `last-worker` subject starves (Task 15's own conformance
      citation).
-4. Pressing **Tab**, confirming the active-lens label switches and the map recolors under the
-   other lens's table.
+4. Pressing **Tab** three times, confirming the active-lens label cycles `PopulationTrend ->
+   Tension -> Legitimation -> PopulationTrend` and the map recolors at each step — including
+   confirming `Tension`'s own step shows the absence banner over an all-`PANEL` map (the expected,
+   honest behavior on this demo content, not a bug) and `Legitimation`'s step shows its own
+   colored-but-static band assignment.
 5. Confirming the client wrote to `~/.local/share/babylon/logs/babylon-client.log` (or
    `$XDG_DATA_HOME/babylon/logs/`) after the run.
 
@@ -2369,20 +2885,38 @@ fn five_space_presses_advance_five_distinct_ticks_and_fire_both_packs_events() {
 }
 
 #[test]
-fn tab_flips_the_active_lens() {
+fn defaults_to_population_trend_and_tab_cycles_through_all_three() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, AssetPlugin::default(), InputPlugin));
     app.add_plugins(babylon_client::map::MapPlugin);
     app.update();
 
-    let before = *app.world().resource::<babylon_client::map::ActiveLens>();
-    {
-        let mut input = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
-        input.press(KeyCode::Tab);
+    // Task 8's finding: Tension has zero data on this demo content, so the
+    // app must not default to it.
+    assert_eq!(
+        *app.world().resource::<babylon_client::map::ActiveLens>(),
+        babylon_client::map::ActiveLens::PopulationTrend
+    );
+
+    let mut seen = vec![*app.world().resource::<babylon_client::map::ActiveLens>()];
+    for _ in 0..3 {
+        {
+            let mut input = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+            input.press(KeyCode::Tab);
+        }
+        app.update();
+        {
+            let mut input = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+            input.release(KeyCode::Tab);
+        }
+        seen.push(*app.world().resource::<babylon_client::map::ActiveLens>());
     }
-    app.update();
-    let after = *app.world().resource::<babylon_client::map::ActiveLens>();
-    assert_ne!(before, after, "Tab must flip the active lens");
+    use babylon_client::map::ActiveLens::{Legitimation, PopulationTrend, Tension};
+    assert_eq!(
+        seen,
+        vec![PopulationTrend, Tension, Legitimation, PopulationTrend],
+        "three presses from the default must visit every lens once and return to start"
+    );
 }
 ```
 


### PR DESCRIPTION
## Summary

- Planning-only PR (no code) for Program 28 B2 — the milestone closing §7 criterion 3 of the Bevy-cutover roadmap: a person opens `babylon-client`, sees the county map, advances ticks, and watches state change against the Rust engine with the deterministic hash intact.
- Five phases: (A) a new additive `babylon-tick` API, `TickSession<G>`, built by factoring `run_once_into`'s load half into a shared `prepare_rule` helper — the existing one-shot seam (`run_once`/`run_once_into`/`TickReport`) moves zero bytes; (B) a twelve-real-FIPS demo scenario re-stamping `lifecycle-conformance.bscn`'s four proven archetypes; (C) completes B1's own still-unbuilt Phase C (`lens.rs`, `map/bands.rs`'s `band_color`, `map/pick.rs`, `map/hud.rs`), generalized to carry the ADR170 Tension lens alongside a new, tick-live Legitimation lens; (D) the tick-advance input, tick counter, hash readout, state panel, event feed; (E) resurrects the deleted Ratatui client's `log4rs` file sink, an end-to-end determinism guard, and the B2 eyes-on gate definition (replaces #262) with a CI-safe headless proxy.
- Key findings recorded in the plan: ADR193's `HypergraphStore::encode_state` quadratic cliff does not bite at B2 scale (12 territory nodes, 0 hyperedges — ~5,500x below the smallest measured cliff point, 22.59 ms at n=2,000); running more than one BSL rule pack live hits a hard `E-LOAD-001` wall (exactly one `(rule …)` form per content set) — flagged as an explicit, scoped deferral, not attempted; B1's own `lens.rs` spec text predates the same-day ADR193 storage swap and gets corrected here to target `&dyn GraphSubstrate` rather than `&MemoryGraph`.
- Three Director-gate open questions recorded at the end (Legitimation-lens sign-off, multi-rule-pack deferral, audio deferral) — none block the plan; each carries this plan's reasoning and a recommendation.

## Test plan

- [x] `vale docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md` — 0 errors, 0 warnings, 0 suggestions.
- [ ] Director review of the plan's task list and the three open questions.
- [ ] Execute via `superpowers:subagent-driven-development` or `superpowers:executing-plans` in a follow-up implementation session (out of scope for this planning PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)