### PR TITLE
feat(bsl): the declared-domain Currency scale operation (D99, #492/ADR194)

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -430,7 +430,13 @@ the multiply never evaluates at all (an empty event list, not a zero-valued
 one) when the flag is ``#f`` — in
 ``rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs``
 (``a_guard_gated_ratio_multiply_fires_when_the_channel_is_active`` /
-``…_never_evaluates_when_the_channel_is_off``). **What this does NOT
+``…_never_evaluates_when_the_channel_is_off``). The absence holds
+**because the multiply sits inline in the guarded effect body**: guarded
+effect bodies are genuinely lazy, while ``:expr`` BINDINGS resolve before
+any guard runs (§4.2's binding-then-guard order), so a binding-shaped
+multiply would still evaluate — and fuel-charge, and surface any eval
+error — under a false guard. Content wanting the absence must write the
+multiply inline, exactly as the example above does. **What this does NOT
 settle**: WHICH signal a real Lifecycle port gates on — a dedicated
 activation const, a doctrine tag, a field read — is that port's own
 content-modeling decision, the same way this whole addendum ports no
@@ -5291,7 +5297,9 @@ consequences are the ordinary kind of review item.
        magnitude. Proved end-to-end rather than merely reasoned about (two
        tests in ``currency_scale_op_e2e.rs``: the guarded effect fires and
        the product is observed when a `Bool` `:const` is `#t`; the multiply
-       never evaluates — an empty event list — when it is `#f`). WHICH
+       never evaluates — an empty event list — when it is `#f`, which holds
+       because the multiply sits INLINE in the guarded effect body; a
+       binding-shaped multiply would resolve before the guard). WHICH
        signal a real Lifecycle port gates on is that port's own
        content-modeling decision, left open by design; this row proves only
        that the mechanism is available.

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -331,31 +331,112 @@ other bounded scalar) that this document did not previously expose to BSL —
 this row and §3.2's addendum are what expose it, minting no new mathematics
 ("scalar multiplication isn't new mathematics" is the ruling's own framing).
 It exists to name a positive scale factor outside ``Coefficient``'s
-``[0,1]`` domain — the construct gap director-gate #492 named Blocker-1:
-Territory's eviction pipeline (``rent_spike_multiplier``, declared domain
-``(0, ∞)``), Metabolism's ``entropy_factor`` and Lifecycle's ``pareto_alpha``/
-``early_mortality_modifier``/``carceral_transition_modifier`` are all
-runtime-moddable coefficients with a declared domain beyond ``[0,1]`` that had
+``[0,1]`` domain — the construct gap director-gate #492 named Blocker-1: five
+runtime-moddable coefficients had a declared domain beyond ``[0,1]`` with
 **no BSL representation at all** before this addendum — not merely "cannot
-multiply Currency", literally "cannot be written". Maximum scale is 9, the
-same cap and the same reuse of ``E-LEX-023`` as ``p``/``i``/``c`` (§1.5's own
-documented reuse discipline for "too many fractional digits"). Unlike
-``p``/``i``/``c``, ``Ratio`` is **not** one of the six ``deffield``/``metric``
-``:type`` names (§3.1) — it joins ``Real`` as a typechecker type no
-``<type-name>`` position can name, not a widening of that closed table.
+multiply Currency", literally "cannot be written":
 
-*A declared ceiling, narrower than* ``(0, ∞)``. ``Ratio``'s own domain is
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Consumer
+     - Declared domain
+     - Ratio lane carries
+   * - Territory's ``rent_spike_multiplier``
+     - ``(0, ∞)``
+     - the whole domain — no ``:cap``/``:floor`` needed
+   * - Metabolism's ``entropy_factor``
+     - ``(1.0, 3.0]``
+     - the whole domain — ``:floor 1r :cap 3r``
+   * - Lifecycle's ``pareto_alpha``
+     - ``(0, 10]``
+     - the whole domain — ``:cap 10r``
+   * - Lifecycle's ``early_mortality_modifier``
+     - ``[0, 10]``
+     - the OPEN INTERIOR ``(0, 10]`` only — ``:cap 10r``; the zero
+       endpoint's disposition follows separately, below
+   * - Lifecycle's ``carceral_transition_modifier``
+     - ``[0, 10]``
+     - the OPEN INTERIOR ``(0, 10]`` only — ``:cap 10r``; as above
+
+Maximum scale is 9, the same cap and the same reuse of ``E-LEX-023`` as
+``p``/``i``/``c`` (§1.5's own documented reuse discipline for "too many
+fractional digits"). Unlike ``p``/``i``/``c``, ``Ratio`` is **not** one of
+the six ``deffield``/``metric`` ``:type`` names (§3.1) — it joins ``Real``
+as a typechecker type no ``<type-name>`` position can name, not a widening
+of that closed table.
+
+**A bare (undeclared) ``Ratio`` literal is legal in ordinary expression
+position, with no ``defconst`` involved at all** — the reader classifies
+every literal class position-independently (§1.4's whole design;
+``Currency`` itself is the precedent: a ``$`` literal is legal directly in a
+rule body, not only via ``:const``), and gating ``r`` specifically to
+"inside a ``defconst`` only" would need a context-sensitive lexer rule this
+reader's architecture does not have and this addendum does not add. The
+ruling's own wording, "a defconst-declared positive coefficient", names the
+INTENDED use for moddability (§3.2's `Why this closes director-gate #492`
+paragraph) — it is not a syntactic restriction, and this document does not
+read it as one.
+
+*Declared bounds, narrower than* ``(0, ∞)``. ``Ratio``'s own domain is
 already stated by construction — this literal's row IS the "domain stated at
 declaration" the ruling asks for, for a consumer whose real domain is
 genuinely unbounded (``rent_spike_multiplier``). A consumer with a tighter
-domain (``pareto_alpha``'s ``(0, 10]``) narrows it further via the Rust
-reference's ``defconst`` ``:cap`` extension (``rust/crates/babylon-bsl/src/
+domain narrows it further via the Rust reference's ``defconst``
+``:floor``/``:cap`` extension (``rust/crates/babylon-bsl/src/
 scenario.rs::load_defconst``) — **stated here for orientation, not specified
 here**: ``defconst``, like the rest of the ``.bscn`` scenario-file dialect, is
 outside this document's grammar (§7, D93: "no section specifies it"), so
-``:cap`` is Rust-implementation machinery rather than an rst production or a
-§1.6 keyword-table row. What §3.2 DOES specify, because it belongs to the
-language proper, is the operator ``:cap`` exists to feed: ``Currency × Ratio``.
+neither keyword is an rst production or a §1.6 keyword-table row. What §3.2
+DOES specify, because it belongs to the language proper, is the operator
+both keywords exist to feed: ``Currency × Ratio``. ``:cap`` narrows the
+UPPER end, INCLUSIVE (``pareto_alpha``'s ``(0, 10]``: ``:cap 10r``);
+``:floor`` narrows the LOWER end, EXCLUSIVE — matching ``Ratio``'s own
+open-at-zero law — for a consumer whose floor is load-bearing, not
+decorative: ``entropy_factor``'s domain is ``(1.0, 3.0]`` because "extraction
+costs more than it yields" is the entire thermodynamic point, and a modded
+value at or below ``1.0`` is the exact violation the floor exists to forbid.
+The worked example, both bounds together:
+``(defconst metabolism/entropy-factor 1.5r :floor 1r :cap 3r)``.
+
+**The zero endpoint — what the Ratio lane does NOT carry, and why.**
+``early_mortality_modifier``'s and ``carceral_transition_modifier``'s
+declared domain is ``[0, 10]`` — CLOSED at zero — and the frozen engine
+actively PRODUCES ``0.0`` for them (``mobility.py:187-188``): the mortality
+channel OFF, semantically meaningful, not an error case. ``Ratio`` cannot
+represent that ``0`` — not as a gap in this addendum's coverage but as the
+same structural law that makes the whole construct a "POSITIVE coefficient"
+(the ruling's own phrase) rather than a general bounded scalar: the reader's
+``E-LEX-027`` refuses a ``0r`` literal before it is even a token, and
+``Ratio::new(0.0)`` refuses at the kernel layer independently. Widening the
+sort to admit zero — the seemingly obvious fix — is explicitly declined:
+"zero-scaling is the multiply's ABSENCE, not a scale," and admitting a
+zero-valued ``Ratio`` would be exactly the sort-widening the ruling's
+"scalar multiplication isn't new mathematics" framing forbids re-opening.
+
+The content-layer answer needs no new construct: ``guard`` (§2.8) already
+gates whether an EFFECT fires at all, on a signal separate from the
+``Ratio``-typed magnitude — never "the ``Ratio`` equals zero" (unwritable),
+always "the multiply does not run this tick." A rule wanting the frozen
+engine's "``0.0`` ⇒ no effect" behavior guards the ``Currency × Ratio``
+effect on an ordinary ``Bool`` ``:const`` (or a field, or a doctrine-derived
+condition — whatever the content authors), for instance
+``(guard channel-active (emit … (scaled-mortality (* base-rate modifier))))``.
+This is proved end-to-end, not merely reasoned about: the guarded-effect
+mechanism clears the whole ``run_once`` seam in both directions — the
+effect fires and the exact product is observed when the flag is ``#t``, and
+the multiply never evaluates at all (an empty event list, not a zero-valued
+one) when the flag is ``#f`` — in
+``rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs``
+(``a_guard_gated_ratio_multiply_fires_when_the_channel_is_active`` /
+``…_never_evaluates_when_the_channel_is_off``). **What this does NOT
+settle**: WHICH signal a real Lifecycle port gates on — a dedicated
+activation const, a doctrine tag, a field read — is that port's own
+content-modeling decision, the same way this whole addendum ports no
+consumer. This paragraph proves the mechanism is available and typechecks
+cleanly through the real entry point; it does not pre-choose Lifecycle's
+answer.
 
 *Decimal canonicalization.* Every scaled literal is reduced to its minimal
 scale: trailing zeros of the fractional part are stripped, and zero canonicalizes
@@ -2194,40 +2275,47 @@ text stays an exact quotation.
 (``rent_spike_multiplier``, declared domain ``(0, ∞)``), Metabolism's
 ``entropy_factor`` (``(1.0, 3.0]``) and Lifecycle's ``pareto_alpha``
 (``(0, 10]``), ``early_mortality_modifier`` and
-``carceral_transition_modifier`` (``[0, 10]``) are runtime-moddable
-coefficients whose declared domain exceeds ``[0,1]`` — §1.5's ``p``/``i``/
-``c`` cap and §3.2's original table gave them no legal way to multiply
-``Currency`` **or even to be written as a literal at all** (`content/rules/
-lifecycle.bsl`'s header, recorded while porting Lifecycle: "there is no
-legal ``defconst`` for a value like ``1.5``… that is not itself a dollar
-amount"). ``Ratio`` closes the literal gap (§1.5); this addendum closes the
-operator gap. Porting these five rules to BSL is explicitly OUT of scope for
-the change that adds this addendum — it lands the machinery only, in its own
-right-sized, reviewable unit; each consumer ports in its own train.
+``carceral_transition_modifier`` (``[0, 10]``, of which this addendum's
+``Ratio`` lane carries the open interior ``(0, 10]`` — the zero endpoint's
+disposition follows separately, §1.5) are runtime-moddable coefficients whose
+declared domain exceeds ``[0,1]`` — §1.5's ``p``/``i``/``c`` cap and §3.2's
+original table gave them no legal way to multiply ``Currency`` **or even to
+be written as a literal at all** (`content/rules/lifecycle.bsl`'s header,
+recorded while porting Lifecycle: "there is no legal ``defconst`` for a
+value like ``1.5``… that is not itself a dollar amount"). ``Ratio`` closes
+the literal gap (§1.5); this addendum closes the operator gap. Porting
+these five rules to BSL is explicitly OUT of scope for the change that adds
+this addendum — it lands the machinery only, in its own right-sized,
+reviewable unit; each consumer ports in its own train.
 
 *Domain rule and error codes.* ``Ratio``'s own domain is ``(0, ∞)`` — a
 literal outside it is ``E-LEX-027`` (§1.5), loud at lex time, exactly as
 ``p``/``i``/``c``'s ``[0,1]`` cap is ``E-LEX-024``. A consumer needing a
-TIGHTER domain (e.g. ``pareto_alpha``'s ``(0, 10]``) narrows it via the Rust
-reference's ``defconst`` ``:cap`` extension — Rust/``.bscn``-dialect
-machinery, not an rst production (§1.5's addendum explains the D93 boundary
-this respects) — checked **twice**, per III.11's loud-failure standard
-applied at both checkpoints rather than trusted once: at the ``defconst``'s
-own declaration (``E-LOAD-052`` — the declared literal itself must not
-exceed the ceiling it declares) and again at every ``Currency × Ratio``
-evaluation that consumes it (``E-EVAL-041`` — the operation re-checks rather
-than trusting a value handed to it, the same defense-in-depth the store
-boundary already practices at ``E-EVAL-020``). Through ``defconst`` — the
-only producer of a capped ``Ratio`` this revision wires — the two checks can
-never disagree (the value is fixed between load and use), so
-``E-EVAL-041``'s live case today is a value reaching the operator through
-any OTHER path a future revision adds; the check exists now so that path
-inherits it rather than needing to invent it. Reference implementation:
-``reader::classify_ratio`` (``E-LEX-027``), ``scenario::load_defconst``/
-``load_ratio_defconst`` (``:cap``, ``E-LOAD-052``),
-``evaluator::Value::Ratio``/``currency_mul_ratio`` (``E-EVAL-041``),
-``babylon_kernel::Currency::mul_ratio`` (the arithmetic, mirroring
-``mul_coefficient``) — all in ``rust/crates/babylon-bsl/src/`` and
+TIGHTER domain narrows it via the Rust reference's ``defconst``
+``:floor``/``:cap`` extension — Rust/``.bscn``-dialect machinery, not an rst
+production (§1.5's addendum explains the D93 boundary this respects).
+``:cap`` narrows the UPPER end INCLUSIVE (``pareto_alpha``'s ``(0, 10]``:
+``:cap 10r``); ``:floor`` narrows the LOWER end EXCLUSIVE
+(``entropy_factor``'s ``(1.0, 3.0]``: ``:floor 1r``, load-bearing — the
+floor IS the thermodynamic point, not decoration). Each declared bound is
+checked **twice**, per III.11's loud-failure standard applied at both
+checkpoints rather than trusted once: at the ``defconst``'s own declaration
+(``E-LOAD-052`` — the declared literal itself must not violate the domain it
+declares, including ``floor < cap`` self-consistency when both are present)
+and again at every ``Currency × Ratio`` evaluation that consumes it
+(``E-EVAL-041`` — the operation re-checks rather than trusting a value
+handed to it, the same defense-in-depth the store boundary already
+practices at ``E-EVAL-020``). Through ``defconst`` — the only producer of a
+bounded ``Ratio`` this revision wires — the two checks can never disagree
+(the value is fixed between load and use), so ``E-EVAL-041``'s live case
+today is a value reaching the operator through any OTHER path a future
+revision adds; the check exists now so that path inherits it rather than
+needing to invent it. Reference implementation: ``reader::classify_ratio``
+(``E-LEX-027``), ``scenario::load_defconst``/``load_ratio_defconst``
+(``:floor``/``:cap``, ``E-LOAD-052``), ``evaluator::Value::Ratio``/
+``currency_mul_ratio`` (``E-EVAL-041``), ``babylon_kernel::Currency::
+mul_ratio`` (the arithmetic, mirroring ``mul_coefficient``) — all in
+``rust/crates/babylon-bsl/src/`` and
 ``rust/crates/babylon-kernel/src/currency.rs``. Recorded as **D99**; see the
 Draft-Ruling Register.
 
@@ -5157,36 +5245,78 @@ consequences are the ordinary kind of review item.
        **The domain declaration.** ``Ratio``'s own lexical domain,
        ``(0, ∞)``, already satisfies "domain stated at declaration" for a
        consumer whose real domain is unbounded (``rent_spike_multiplier``).
-       A consumer needing a tighter ceiling (``pareto_alpha``'s ``(0, 10]``)
-       states it via the Rust reference's ``defconst`` ``:cap`` extension.
-       ``:cap`` is deliberately **not** an rst production or a §1.6 keyword-
-       table row: ``defconst``, like ``node``/``edge``/``scenario``, is the
-       ``.bscn`` scenario-file dialect §7 already records as out of this
-       document's grammar (D93 — "no section specifies it"). Extending that
-       boundary — making ``defconst`` rst-normative — would have been a
+       A consumer needing a tighter bound states it via the Rust reference's
+       ``defconst`` ``:floor``/``:cap`` extension — ``:cap`` narrows the
+       UPPER end INCLUSIVE (``pareto_alpha``'s ``(0, 10]``), ``:floor``
+       narrows the LOWER end EXCLUSIVE (``entropy_factor``'s ``(1.0, 3.0]``
+       — the floor IS the thermodynamic point "extraction costs more than
+       it yields", not decoration a ceiling-only design could omit; a first
+       revision of this row shipped ``:cap`` alone and was found
+       ceiling-only by adversarial review before this ruling landed, exactly
+       the defect ``entropy_factor``'s own domain exists to catch). Both
+       keywords are deliberately **not** rst productions or §1.6
+       keyword-table rows: ``defconst``, like ``node``/``edge``/``scenario``,
+       is the ``.bscn`` scenario-file dialect §7 already records as out of
+       this document's grammar (D93 — "no section specifies it"). Extending
+       that boundary — making ``defconst`` rst-normative — would have been a
        second, larger and unrelated decision riding along with this one;
-       D93 stands as recorded, and ``:cap`` is documented in ``scenario.rs``
-       itself, at the construct it belongs to, cited here for orientation
-       only. This IS "keeps defines' moddable shape intact": no new
-       top-level form, no change to how a scenario declares a coefficient —
-       one existing form (``defconst``) gains one optional keyword.
+       D93 stands as recorded, and both keywords are documented in
+       ``scenario.rs`` itself, at the construct they belong to, cited here
+       for orientation only. This IS "keeps defines' moddable shape intact":
+       no new top-level form, no change to how a scenario declares a
+       coefficient — one existing form (``defconst``) gains two optional
+       keywords.
+
+       **A bare (undeclared) ``r`` literal needs no ``defconst`` at all** —
+       it is an ordinary ``<expr>`` atom, legal wherever any other literal
+       is, matching ``Currency``'s own precedent (a ``$`` literal is legal
+       directly in a rule body). The ruling's "defconst-declared" wording
+       names the INTENDED authoring pattern for moddability, not a syntactic
+       gate the reader enforces — rejected explicitly as design choice (b)
+       above, for the same position-independence reason.
+
+       **The zero endpoint.** ``early_mortality_modifier`` and
+       ``carceral_transition_modifier`` are ``[0, 10]`` — CLOSED at zero —
+       and the frozen engine actively PRODUCES ``0.0`` for them
+       (``mobility.py:187-188``, the mortality channel OFF, semantically
+       meaningful). ``Ratio`` cannot hold that ``0``: not a gap in this
+       row's coverage but the SAME structural law that makes the construct a
+       "positive coefficient" at all (``E-LEX-027`` at the reader,
+       ``Ratio::new(0.0)`` refusing independently at the kernel). This row
+       does NOT widen the sort to admit zero — that would be exactly the
+       re-opened mathematics the ruling's own framing forbids. Instead:
+       "zero-scaling is the multiply's ABSENCE, not a scale" — the content-
+       layer answer is ``guard`` (§2.8), which already gates whether an
+       EFFECT fires at all, on a signal separate from the ``Ratio``-typed
+       magnitude. Proved end-to-end rather than merely reasoned about (two
+       tests in ``currency_scale_op_e2e.rs``: the guarded effect fires and
+       the product is observed when a `Bool` `:const` is `#t`; the multiply
+       never evaluates — an empty event list — when it is `#f`). WHICH
+       signal a real Lifecycle port gates on is that port's own
+       content-modeling decision, left open by design; this row proves only
+       that the mechanism is available.
 
        **Error codes**, contiguous with the existing sequences (§4.6):
        ``E-LEX-027`` (a non-positive ``r`` literal — lex time, every
        occurrence, position-independent, exactly as ``E-LEX-024`` gates
        ``p``/``i``/``c``), ``E-LOAD-052`` (a ``defconst``'s own ``Ratio``
-       value exceeding the ``:cap`` it declares — load time, self-
-       consistency of the declaration), ``E-EVAL-041`` (a ``Currency ×
-       Ratio`` operand exceeding its declared ceiling — evaluation time, the
-       operation's own re-check). The load- and eval-time checks are
-       DELIBERATE duplication, not redundant dead code: through ``defconst``
-       — the only producer of a capped ``Ratio`` this revision wires — they
-       can never disagree (III.11's loud-failure standard applied at both
-       checkpoints anyway, the same discipline the store boundary already
-       practices at ``E-EVAL-020`` alongside a field's own load-time type
-       check); ``E-EVAL-041``'s independent value is for whatever OTHER path
-       a later revision adds to produce a ``Value::Ratio``, which inherits
-       the check rather than needing to invent it.
+       value violating a declared bound, OR the bounds disagreeing with
+       each other (``floor`` not strictly below ``cap``) — load time,
+       self-consistency of the declaration, checked in THAT order so an
+       inconsistent declaration is diagnosed as inconsistent rather than
+       misreported against whichever bound the value happens to fail),
+       ``E-EVAL-041`` (a ``Currency × Ratio`` operand falling outside its
+       declared domain, at or below an EXCLUSIVE floor or above an
+       INCLUSIVE cap — evaluation time, the operation's own re-check). The
+       load- and eval-time checks are DELIBERATE duplication, not redundant
+       dead code: through ``defconst`` — the only producer of a bounded
+       ``Ratio`` this revision wires — they can never disagree (III.11's
+       loud-failure standard applied at both checkpoints anyway, the same
+       discipline the store boundary already practices at ``E-EVAL-020``
+       alongside a field's own load-time type check); ``E-EVAL-041``'s
+       independent value is for whatever OTHER path a later revision adds to
+       produce a ``Value::Ratio``, which inherits the check rather than
+       needing to invent it.
 
        **CAS round-trip.** A ``Ratio`` literal is `Atom::Scaled`
        (`reader.rs`) with a new `ScaledKind::Ratio`, encoding with its own
@@ -5198,14 +5328,16 @@ consequences are the ordinary kind of review item.
        the identical rule every other scaled literal already has (§1.5).
 
        Reference implementation: ``reader::classify_ratio`` (lexing,
-       `E-LEX-027`), ``scenario::load_defconst``/``load_ratio_defconst``
-       (`:cap`, `E-LOAD-052`), ``evaluator::Value::Ratio``/
-       ``currency_mul_ratio`` (`E-EVAL-041`),
+       `E-LEX-027`), ``scenario::load_defconst``/``load_ratio_defconst``/
+       ``parse_bound_keywords`` (`:floor`/`:cap`, `E-LOAD-052`),
+       ``evaluator::Value::Ratio``/``currency_mul_ratio`` (`E-EVAL-041`),
        ``canonical_ast::encode_atom`` (the `"ratio"` CAS tag),
        ``babylon_kernel::Currency::mul_ratio`` (the arithmetic, mirroring
        ``mul_coefficient`` exactly) — ``rust/crates/babylon-bsl/src/`` and
        ``rust/crates/babylon-kernel/src/currency.rs``. End-to-end proof
-       through ``babylon_tick::run_once``:
+       through ``babylon_tick::run_once``, including the floored-and-capped
+       ``entropy_factor`` worked example and the guard-gated zero-endpoint
+       disposition:
        ``rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs``.
 
 See Also

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -307,6 +307,12 @@ floats.
      - ``Coefficient``
      - ``[0.0, 1.0]``
      - As ``p``.
+   * - ``r``
+     - ``Ratio``
+     - ``(0, ∞)``
+     - As ``p``, canonicalized to ``(unscaled: i128, scale: u8)`` — but open
+       at zero and unbounded above rather than unit-interval. A non-positive
+       (zero or negative) literal is ``E-LEX-027``.
 
 The ranges are those of the kernel scalars as they exist today
 (``src/babylon/models/types.py``): ``Probability``, ``Intensity`` and
@@ -317,6 +323,39 @@ for ``p``/``i``/``c`` is 9 (``E-LEX-023``); **[draft ruling — Phase 1 review]*
 the engine's existing quantization grid is ``1e-5`` (``SnapToGrid``), so 9
 digits is comfortably beyond any authored precision while remaining exactly
 representable in the ``i128`` unscaled form.
+
+**``r`` — ``Ratio`` (Director ruling 2026-08-11, #492/ADR194: the
+declared-domain Currency scale operation).** ``babylon_kernel::scalars::Ratio``
+is a **pre-existing** kernel sort (`𝔾 ∩ (0, ∞)`, grid-quantized like every
+other bounded scalar) that this document did not previously expose to BSL —
+this row and §3.2's addendum are what expose it, minting no new mathematics
+("scalar multiplication isn't new mathematics" is the ruling's own framing).
+It exists to name a positive scale factor outside ``Coefficient``'s
+``[0,1]`` domain — the construct gap director-gate #492 named Blocker-1:
+Territory's eviction pipeline (``rent_spike_multiplier``, declared domain
+``(0, ∞)``), Metabolism's ``entropy_factor`` and Lifecycle's ``pareto_alpha``/
+``early_mortality_modifier``/``carceral_transition_modifier`` are all
+runtime-moddable coefficients with a declared domain beyond ``[0,1]`` that had
+**no BSL representation at all** before this addendum — not merely "cannot
+multiply Currency", literally "cannot be written". Maximum scale is 9, the
+same cap and the same reuse of ``E-LEX-023`` as ``p``/``i``/``c`` (§1.5's own
+documented reuse discipline for "too many fractional digits"). Unlike
+``p``/``i``/``c``, ``Ratio`` is **not** one of the six ``deffield``/``metric``
+``:type`` names (§3.1) — it joins ``Real`` as a typechecker type no
+``<type-name>`` position can name, not a widening of that closed table.
+
+*A declared ceiling, narrower than* ``(0, ∞)``. ``Ratio``'s own domain is
+already stated by construction — this literal's row IS the "domain stated at
+declaration" the ruling asks for, for a consumer whose real domain is
+genuinely unbounded (``rent_spike_multiplier``). A consumer with a tighter
+domain (``pareto_alpha``'s ``(0, 10]``) narrows it further via the Rust
+reference's ``defconst`` ``:cap`` extension (``rust/crates/babylon-bsl/src/
+scenario.rs::load_defconst``) — **stated here for orientation, not specified
+here**: ``defconst``, like the rest of the ``.bscn`` scenario-file dialect, is
+outside this document's grammar (§7, D93: "no section specifies it"), so
+``:cap`` is Rust-implementation machinery rather than an rst production or a
+§1.6 keyword-table row. What §3.2 DOES specify, because it belongs to the
+language proper, is the operator ``:cap`` exists to feed: ``Currency × Ratio``.
 
 *Decimal canonicalization.* Every scaled literal is reduced to its minimal
 scale: trailing zeros of the fractional part are stripped, and zero canonicalizes
@@ -2040,6 +2079,12 @@ degraded mode, and no rule that loads "partially".
    * - ``Real``
      - ``binary64``, finite
      - The **unbounded intermediate** type (§3.3). Not storable.
+   * - ``Ratio``
+     - ``binary64``, ``(0, ∞)``
+     - **§1.5 addendum** (Director ruling 2026-08-11, #492/ADR194): a
+       declared-domain positive scale factor. Not storable — joins ``Real``
+       in this row's category, not the six above. Its one legal operation is
+       ``Currency × Ratio`` (§3.2).
    * - ``Enum<T>``
      - members of closed enum ``T``
      - Comparable with ``=``/``!=`` only, and only to the same ``T``.
@@ -2084,6 +2129,11 @@ because those names are this document's, not tokens; nothing lexes them, so
 nothing needed re-spelling. Recorded as D94, closing the first of the two
 repairs §7 deferred to this review.
 
+``Ratio`` (added by the §1.5/§3.2 addendum below, #492/ADR194 — recorded as
+D99, not a re-opening of D94) joins this same non-storable category for the
+same reason ``Real`` does: it is produced by a literal and consumed by one
+operator, never declared as a field's or a metric's type.
+
 3.2 Currency operator and rounding table
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2099,10 +2149,16 @@ Copied **verbatim** from the design document §6.1, which is the authority:
     Truncation is never implicit; intermediate widths and rounding points live
     in the III.12(a) reference with conformance vectors.
 
-Those are the **only** legal operations mixing ``Currency`` with anything else.
-Every other mixed-lane expression is ``E-TYPE-030``. In particular
-``Currency + Real``, ``Currency × Currency``, and ``Currency × Int`` are type
-errors; multiply by a ``Coefficient`` or divide by an ``Int`` instead.
+Those are the **only** legal operations mixing ``Currency`` with anything
+else — **plus the one addendum below** (Director ruling 2026-08-11,
+#492/ADR194): ``Currency × Ratio``. Every other mixed-lane expression is
+``E-TYPE-030``. In particular ``Currency + Real``, ``Currency × Currency``,
+and ``Currency × Int`` are type errors; multiply by a ``Coefficient`` or a
+declared-domain ``Ratio``, or divide by an ``Int``, instead. An UNDECLARED
+coefficient greater than ``1`` in Currency-multiply position — a bare
+``Real`` (a computed value, or a ``p``/``i``/``c`` binding) outside
+``[0,1]`` — stays exactly ``E-TYPE-030``: the fifth operation is legal only
+for the ``Ratio`` type specifically, never for an out-of-range ``Real``.
 
 Filling in the three points the verbatim table leaves to this document:
 
@@ -2122,6 +2178,58 @@ compute this from exact integer arithmetic at the stated intermediate width
 (``i256`` for ``Currency ÷ Currency``) — never by converting to ``binary64``
 and rounding there. The same algorithm is what the ``round-half-even``
 intrinsic exposes to rules.
+
+**Addendum — the declared-domain scale operation (Director ruling
+2026-08-11, #492/ADR194).** ``Currency × Ratio → Currency``, rounded
+half-even to micro-units — the identical algorithm and rounding law as
+``Currency × Coefficient`` above, over ``Ratio``'s ``(0, ∞)`` domain (§1.5)
+instead of ``Coefficient``'s ``[0,1]``. Commutative in source position, like
+``Currency × Coefficient``: both ``(* currency ratio)`` and
+``(* ratio currency)`` are legal. This is the ONE new operation the ruling
+selected — "scalar multiplication isn't new mathematics" — added to the
+verbatim table above rather than inside it, so the design document's own
+text stays an exact quotation.
+
+*Why this closes director-gate #492.* Territory's eviction pipeline
+(``rent_spike_multiplier``, declared domain ``(0, ∞)``), Metabolism's
+``entropy_factor`` (``(1.0, 3.0]``) and Lifecycle's ``pareto_alpha``
+(``(0, 10]``), ``early_mortality_modifier`` and
+``carceral_transition_modifier`` (``[0, 10]``) are runtime-moddable
+coefficients whose declared domain exceeds ``[0,1]`` — §1.5's ``p``/``i``/
+``c`` cap and §3.2's original table gave them no legal way to multiply
+``Currency`` **or even to be written as a literal at all** (`content/rules/
+lifecycle.bsl`'s header, recorded while porting Lifecycle: "there is no
+legal ``defconst`` for a value like ``1.5``… that is not itself a dollar
+amount"). ``Ratio`` closes the literal gap (§1.5); this addendum closes the
+operator gap. Porting these five rules to BSL is explicitly OUT of scope for
+the change that adds this addendum — it lands the machinery only, in its own
+right-sized, reviewable unit; each consumer ports in its own train.
+
+*Domain rule and error codes.* ``Ratio``'s own domain is ``(0, ∞)`` — a
+literal outside it is ``E-LEX-027`` (§1.5), loud at lex time, exactly as
+``p``/``i``/``c``'s ``[0,1]`` cap is ``E-LEX-024``. A consumer needing a
+TIGHTER domain (e.g. ``pareto_alpha``'s ``(0, 10]``) narrows it via the Rust
+reference's ``defconst`` ``:cap`` extension — Rust/``.bscn``-dialect
+machinery, not an rst production (§1.5's addendum explains the D93 boundary
+this respects) — checked **twice**, per III.11's loud-failure standard
+applied at both checkpoints rather than trusted once: at the ``defconst``'s
+own declaration (``E-LOAD-052`` — the declared literal itself must not
+exceed the ceiling it declares) and again at every ``Currency × Ratio``
+evaluation that consumes it (``E-EVAL-041`` — the operation re-checks rather
+than trusting a value handed to it, the same defense-in-depth the store
+boundary already practices at ``E-EVAL-020``). Through ``defconst`` — the
+only producer of a capped ``Ratio`` this revision wires — the two checks can
+never disagree (the value is fixed between load and use), so
+``E-EVAL-041``'s live case today is a value reaching the operator through
+any OTHER path a future revision adds; the check exists now so that path
+inherits it rather than needing to invent it. Reference implementation:
+``reader::classify_ratio`` (``E-LEX-027``), ``scenario::load_defconst``/
+``load_ratio_defconst`` (``:cap``, ``E-LOAD-052``),
+``evaluator::Value::Ratio``/``currency_mul_ratio`` (``E-EVAL-041``),
+``babylon_kernel::Currency::mul_ratio`` (the arithmetic, mirroring
+``mul_coefficient``) — all in ``rust/crates/babylon-bsl/src/`` and
+``rust/crates/babylon-kernel/src/currency.rs``. Recorded as **D99**; see the
+Draft-Ruling Register.
 
 3.3 The two numeric lanes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3196,7 +3304,9 @@ two times at which an error can occur.
        incomplete payload, a ``:member`` declaration whose owner segment is
        not a hyperedge type, a ``:substrate`` rung over a type that is not
        ``:invariant``, an intensive adjunction with no weight, and an
-       adjunction that does not fit the schema at its declared rung.
+       adjunction that does not fit the schema at its declared rung; and, from
+       the §3.2 addendum (#492/ADR194), a ``defconst``'s own ``Ratio`` value
+       exceeding its declared ``:cap`` ceiling.
    * - Evaluation
      - ``E-EVAL-0xx``
      - During a tick — checked-arithmetic failure, range violation at a store,
@@ -3206,7 +3316,9 @@ two times at which an error can occur.
        an ``edge-between`` that resolves to no edge, a ``the`` against an
        unhydrated carrier, and a ``metric-of`` against the wrong element type
        or a value the provider did not produce; and, from the Amendment AG
-       sections, a named *(hyperedge, member)* pair that is not a membership.
+       sections, a named *(hyperedge, member)* pair that is not a membership;
+       and, from the §3.2 addendum (#492/ADR194), a ``Currency × Ratio``
+       operand exceeding its declared domain ceiling.
 
 **Every code the R9 chapters add continues an existing sequence, and no code
 that existed before this revision is renumbered.** The new codes are
@@ -3230,13 +3342,22 @@ defect D75 ruled against.
 
 Sequence continuation is meant literally, and is checkable by inspection: every
 decade block of every family is **contiguous**, with no reserved and no
-skipped number — ``E-LOAD`` 001–004, 010–013, 020–025, 030–033, 040–051;
+skipped number — ``E-LOAD`` 001–004, 010–013, 020–025, 030–033, 040–052;
 ``E-PARSE`` 010–015, 020–022, 030–033, 040–042; ``E-TYPE`` 010–017, 020, 030,
-040–043; ``E-EVAL`` 010–014, 020–021, 030–038, 040; ``E-LEX`` 001–003,
-010–011, 020–026. The ``E-LOAD`` 040 block now runs past its own decade, and
+040–043; ``E-EVAL`` 010–014, 020–021, 030–041; ``E-LEX`` 001–003,
+010–011, 020–027. The ``E-LOAD`` 040 block now runs past its own decade, and
 deliberately: opening a fresh block at 050 for the Amendment AG codes would
 have **reserved** 046–049, and a reserved number is precisely what the rule
-above forbids. Contiguity outranks decade tidiness.
+above forbids. Contiguity outranks decade tidiness. The §3.2 addendum
+(#492/ADR194) continues the SAME overrun block with ``E-LOAD-052``, and
+continues ``E-EVAL`` with ``E-LEX-027`` and ``E-EVAL-041`` — the next free
+number in each family at the time of allocation, per the same rule.
+**Repair, found while allocating those numbers:** this paragraph's ``E-EVAL``
+range previously read "030–038, 040", silently skipping ``E-EVAL-039``
+(``floor``'s domain check, D97/ADR188 Row 2) — a transcription gap in this
+paragraph specifically, not a gap in the actual sequence (``039`` has been
+allocated and implemented since D97 landed). Folded into the corrected range
+above rather than left standing as a second inconsistency next to a new one.
 The R9 chapters allocated per chapter and left two holes in
 the ``E-TYPE`` sequence; they were closed by renumbering the two offending
 **new** codes before any implementation pinned them, which is a liberty
@@ -4990,6 +5111,102 @@ consequences are the ordinary kind of review item.
        kernel_signature}``; the composed load path is
        ``rule_pipeline::split_content`` + ``load_rule_form``, wired into
        ``babylon_tick::run_once``.
+   * - D99
+     - §1.5, §3.1, §3.2, §4.6
+     - **The declared-domain Currency scale operation** (Director ruling
+       2026-08-11, #492/ADR194 — "Add one legal operation: Currency scaled
+       by a defconst-declared positive coefficient whose domain is stated at
+       declaration and enforced loudly at load/eval. Scalar multiplication
+       isn't new mathematics — this reads as machinery, keeps defines'
+       moddable shape intact"). Closes director-gate #492 (Blocker-1: a
+       runtime-moddable coefficient with a declared domain beyond ``[0,1]``
+       had no BSL representation at all — not merely "cannot multiply
+       Currency", literally unwritable).
+
+       **Design chosen, and what was rejected.** A NEW literal suffix,
+       ``r`` → ``Ratio`` (§1.5), reusing ``babylon_kernel::scalars::Ratio`` —
+       a kernel sort that ALREADY existed (`𝔾 ∩ (0, ∞)`, grid-quantized like
+       every other bounded scalar) and simply had no BSL literal exposing
+       it — rather than widening ``Coefficient``'s own ``[0,1]`` cap or
+       introducing a distinct bounded-scalar type. Rejected: (a) widening
+       ``p``/``i``/``c``'s existing ``E-LEX-024`` cap, which would silently
+       change the domain of every EXISTING coefficient in the language, the
+       exact "no silent widening of the whole language" director-gate #492
+       forbade; (b) a context-sensitive lexer rule ("uncapped only inside
+       ``defconst``"), which the reader's position-independent classification
+       architecture cannot express without becoming a parser (every other
+       literal class classifies identically regardless of where it appears —
+       ``Currency`` itself is legal in general expression position, and
+       ``Ratio`` follows that same precedent rather than being singled out);
+       (c) minting a brand-new bounded-scalar kernel type, when ``Ratio``
+       already states exactly the needed law and reuse is what "not new
+       mathematics" means concretely.
+
+       **The operation**, added to §3.2 rather than inside its verbatim
+       design-doc quotation: ``Currency × Ratio → Currency``, rounded
+       half-even — identical arithmetic to ``Currency × Coefficient``,
+       commutative in source position. ``Ratio`` gets exactly this one
+       operator and no other (no ``+``, no ``Ratio × Ratio``, no ordering) —
+       "scalar multiplication isn't new mathematics" read literally: the
+       addendum does not grow a second arithmetic subsystem alongside the
+       binary64 lane, it adds one multiply rule to the existing Currency
+       lane. An undeclared ``Real`` above ``1`` in Currency-multiply
+       position remains ``E-TYPE-030``, unchanged — the new operation is
+       keyed to the ``Ratio`` type specifically, not to "any number over 1".
+
+       **The domain declaration.** ``Ratio``'s own lexical domain,
+       ``(0, ∞)``, already satisfies "domain stated at declaration" for a
+       consumer whose real domain is unbounded (``rent_spike_multiplier``).
+       A consumer needing a tighter ceiling (``pareto_alpha``'s ``(0, 10]``)
+       states it via the Rust reference's ``defconst`` ``:cap`` extension.
+       ``:cap`` is deliberately **not** an rst production or a §1.6 keyword-
+       table row: ``defconst``, like ``node``/``edge``/``scenario``, is the
+       ``.bscn`` scenario-file dialect §7 already records as out of this
+       document's grammar (D93 — "no section specifies it"). Extending that
+       boundary — making ``defconst`` rst-normative — would have been a
+       second, larger and unrelated decision riding along with this one;
+       D93 stands as recorded, and ``:cap`` is documented in ``scenario.rs``
+       itself, at the construct it belongs to, cited here for orientation
+       only. This IS "keeps defines' moddable shape intact": no new
+       top-level form, no change to how a scenario declares a coefficient —
+       one existing form (``defconst``) gains one optional keyword.
+
+       **Error codes**, contiguous with the existing sequences (§4.6):
+       ``E-LEX-027`` (a non-positive ``r`` literal — lex time, every
+       occurrence, position-independent, exactly as ``E-LEX-024`` gates
+       ``p``/``i``/``c``), ``E-LOAD-052`` (a ``defconst``'s own ``Ratio``
+       value exceeding the ``:cap`` it declares — load time, self-
+       consistency of the declaration), ``E-EVAL-041`` (a ``Currency ×
+       Ratio`` operand exceeding its declared ceiling — evaluation time, the
+       operation's own re-check). The load- and eval-time checks are
+       DELIBERATE duplication, not redundant dead code: through ``defconst``
+       — the only producer of a capped ``Ratio`` this revision wires — they
+       can never disagree (III.11's loud-failure standard applied at both
+       checkpoints anyway, the same discipline the store boundary already
+       practices at ``E-EVAL-020`` alongside a field's own load-time type
+       check); ``E-EVAL-041``'s independent value is for whatever OTHER path
+       a later revision adds to produce a ``Value::Ratio``, which inherits
+       the check rather than needing to invent it.
+
+       **CAS round-trip.** A ``Ratio`` literal is `Atom::Scaled`
+       (`reader.rs`) with a new `ScaledKind::Ratio`, encoding with its own
+       `"ratio"` kind tag (`canonical_ast.rs`) — purely additive, proved by
+       pinning §5.6's worked example unmoved (421 bytes, both digests) before
+       asserting the new atom encodes at all
+       (`a_ratio_literal_encodes_with_its_own_kind_tag_additively`).
+       Canonicalization (minimal scale, e.g. ``2.50r`` ≡ ``2.5r``) follows
+       the identical rule every other scaled literal already has (§1.5).
+
+       Reference implementation: ``reader::classify_ratio`` (lexing,
+       `E-LEX-027`), ``scenario::load_defconst``/``load_ratio_defconst``
+       (`:cap`, `E-LOAD-052`), ``evaluator::Value::Ratio``/
+       ``currency_mul_ratio`` (`E-EVAL-041`),
+       ``canonical_ast::encode_atom`` (the `"ratio"` CAS tag),
+       ``babylon_kernel::Currency::mul_ratio`` (the arithmetic, mirroring
+       ``mul_coefficient`` exactly) — ``rust/crates/babylon-bsl/src/`` and
+       ``rust/crates/babylon-kernel/src/currency.rs``. End-to-end proof
+       through ``babylon_tick::run_once``:
+       ``rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs``.
 
 See Also
 ----------

--- a/docs/reference/bsl.ebnf
+++ b/docs/reference/bsl.ebnf
@@ -188,13 +188,14 @@ scaled-lit  ::= "-"? digits ( "." digits )? suffix            /* §1.4, §1.5 */
                    integer micro-units, so `0.50c` ≡ `0.5c` and `1000.5$`
                    ≡ `1000.500$` (D4). */
 
-suffix      ::= "$" | "p" | "i" | "c"                         /* §1.4, §1.5 */
+suffix      ::= "$" | "p" | "i" | "c" | "r"                   /* §1.4, §1.5 */
                 /* The kind suffix is MANDATORY on every non-integer
                    literal — a bare `0.5` is E-LEX-021, which is the
                    lexical enforcement of the house prohibition on bare
                    floats (D3). $ = Currency [0,∞), scale ≤ 6;
                    p/i/c = Probability/Intensity/Coefficient [0,1],
-                   scale ≤ 9. */
+                   scale ≤ 9. r = Ratio (0,∞), scale ≤ 9, non-positive is
+                   E-LEX-027 (§1.5 addendum, D99, #492/ADR194). */
 
 string      ::= '"' string-char* '"'                          /* §1.4, §1.5 */
                 /* NFC-checked at load (E-LEX-002, D1); max 1024 bytes

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -398,6 +398,7 @@ version = "0.1.0"
 dependencies = [
  "babylon-bsl",
  "babylon-graph",
+ "babylon-kernel",
 ]
 
 [[package]]

--- a/rust/crates/babylon-bsl/src/canonical_ast.rs
+++ b/rust/crates/babylon-bsl/src/canonical_ast.rs
@@ -97,6 +97,9 @@ fn encode_atom(atom: &Atom, out: &mut Vec<u8>) -> Result<(), CasError> {
                 ScaledKind::Probability => "prob",
                 ScaledKind::Intensity => "intn",
                 ScaledKind::Coefficient => "coef",
+                // §1.5 addendum (#492/ADR194): additive — no existing kind
+                // tag is reused, so no prior canonical bytes move.
+                ScaledKind::Ratio => "ratio",
             };
             let mut payload = s.unscaled.to_be_bytes().to_vec();
             payload.push(s.scale);
@@ -423,6 +426,35 @@ mod tests {
             canonical_bytes(&expr).unwrap(),
             canonical_bytes(&demo_rule()).unwrap()
         );
+    }
+
+    /// §1.5 addendum (#492/ADR194): a `Ratio` literal encodes with its own
+    /// `"ratio"` kind tag — a purely additive change, proved by pinning the
+    /// §5.6 worked example's byte count unmoved (it declares no `r`
+    /// literal) before asserting the new atom encodes at all.
+    #[test]
+    fn a_ratio_literal_encodes_with_its_own_kind_tag_additively() {
+        assert_eq!(
+            canonical_bytes(&demo_rule()).unwrap().len(),
+            421,
+            "the golden program must be unmoved before this row is trusted"
+        );
+        let bytes = canonical_bytes(&read("2.5r").unwrap().0).unwrap();
+        let mut expected = Vec::new();
+        push_atom(&mut expected, b"ratio", &{
+            let mut payload = 25i128.to_be_bytes().to_vec();
+            payload.push(1); // scale
+            payload
+        });
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn ratio_literal_canonicalization_reaches_the_bytes() {
+        // §1.5: 2.50r ≡ 2.5r — identical bytes, same law as p/i/c/$.
+        let a = read("(x 2.50r)").unwrap().0;
+        let b = read("(x 2.5r)").unwrap().0;
+        assert_eq!(canonical_bytes(&a).unwrap(), canonical_bytes(&b).unwrap());
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -59,20 +59,28 @@ pub enum Value {
     /// cap must NOT silently widen for `Probability`/`Intensity`/
     /// `Coefficient` — those stay `Value::Real` exactly as before. The
     /// single legal use is the new `Currency × Ratio` operator
-    /// ([`apply_arith`]'s `*` arm); `Ratio` has no other operator. `cap` is
-    /// the declared ceiling this value's origin narrowed the sort to (a
-    /// `defconst`'s `:cap`, `scenario.rs`) — `None` for a bare literal or an
-    /// uncapped `defconst`, matching `Ratio`'s own `(0, ∞)` domain exactly.
-    /// Re-checked at THIS multiply (`E-EVAL-041`), not just at the
-    /// `defconst`'s own load (`E-LOAD-052`) — defense in depth, per III.11:
-    /// the operation does not trust that nothing between declaration and
-    /// use could hand it a stale or foreign value.
+    /// ([`apply_arith`]'s `*` arm); `Ratio` has no other operator. `floor`
+    /// and `cap` are the declared bounds this value's origin narrowed the
+    /// sort to (a `defconst`'s `:floor`/`:cap`, `scenario.rs`) — `None` for
+    /// a bare literal or an undeclared bound, matching `Ratio`'s own
+    /// `(0, ∞)` domain exactly on that end. `floor` is EXCLUSIVE (a value
+    /// must be strictly greater than it — matching `Ratio`'s own open-at-
+    /// zero law and a `>`-bounded consumer like `entropy_factor`'s
+    /// `(1.0, 3.0]`); `cap` is INCLUSIVE (matching a `<=`-bounded consumer
+    /// like `pareto_alpha`'s `(0, 10]`). Re-checked at THIS multiply
+    /// (`E-EVAL-041`), not just at the `defconst`'s own load
+    /// (`E-LOAD-052`) — defense in depth, per III.11: the operation does
+    /// not trust that nothing between declaration and use could hand it a
+    /// stale or foreign value.
     Ratio {
         /// The scale factor itself — always finite and `> 0` by
         /// construction (the kernel sort's own invariant).
         value: Ratio,
-        /// The declared ceiling this value's `Ratio` sort was narrowed to,
-        /// if any.
+        /// The declared EXCLUSIVE floor this value's `Ratio` sort was
+        /// narrowed to, if any.
+        floor: Option<Ratio>,
+        /// The declared INCLUSIVE ceiling this value's `Ratio` sort was
+        /// narrowed to, if any.
         cap: Option<Ratio>,
     },
     /// `Bool`.
@@ -107,12 +115,14 @@ pub enum EvalCode {
     DivisionByZero,
     /// `E-EVAL-013` — a `Currency ÷ Currency` ratio outside `[0, 1]`.
     CoefficientOutOfRange,
-    /// `E-EVAL-041` — a `Currency × Ratio` operand exceeds the declared
-    /// ceiling its origin narrowed it to (§3.2 addendum, Director ruling
-    /// 2026-08-11, #492/ADR194). Distinct from `E-LOAD-052`, which is the
-    /// SAME domain rule checked at the `defconst` declaration itself — this
-    /// is the operation's own re-check at the point of use.
-    RatioExceedsDeclaredCap,
+    /// `E-EVAL-041` — a `Currency × Ratio` operand falls outside the
+    /// declared domain its origin narrowed it to — at or below an
+    /// EXCLUSIVE `:floor`, or above an INCLUSIVE `:cap` (§3.2 addendum,
+    /// Director ruling 2026-08-11, #492/ADR194). Distinct from
+    /// `E-LOAD-052`, which is the SAME domain rule checked at the
+    /// `defconst` declaration itself — this is the operation's own
+    /// re-check at the point of use.
+    RatioOutsideDeclaredDomain,
     /// `E-EVAL-014` — a binary64 operation producing a non-finite result.
     NonFinite,
     /// `E-EVAL-020` — a store whose resulting value falls outside the
@@ -171,7 +181,7 @@ impl EvalCode {
             Self::Overflow => "E-EVAL-011",
             Self::DivisionByZero => "E-EVAL-012",
             Self::CoefficientOutOfRange => "E-EVAL-013",
-            Self::RatioExceedsDeclaredCap => "E-EVAL-041",
+            Self::RatioOutsideDeclaredDomain => "E-EVAL-041",
             Self::NonFinite => "E-EVAL-014",
             Self::StoreRangeViolation => "E-EVAL-020",
             Self::EmptyAggregate => "E-EVAL-021",
@@ -299,9 +309,10 @@ fn atom_value(atom: &Atom, env: &EvalEnv<'_>) -> Result<Value, EvalError> {
         Atom::Scaled(s) if s.kind == ScaledKind::Ratio => {
             // §1.5 addendum: scale ≤ 9, so the unscaled integer is < 10⁹ —
             // exact in f64 by construction, same reasoning as the p/i/c arm
-            // below. A bare literal carries no declared ceiling of its own
-            // (`cap: None`, i.e. the full `(0, ∞)` domain) — a ceiling is
-            // something only a `defconst`'s `:cap` narrows (`scenario.rs`).
+            // below. A bare literal carries no declared bound of its own
+            // (`floor`/`cap: None`, i.e. the full `(0, ∞)` domain) — a bound
+            // is something only a `defconst`'s `:floor`/`:cap` narrows
+            // (`scenario.rs`).
             #[allow(clippy::cast_precision_loss)]
             let raw = s.unscaled as f64 / 10f64.powi(i32::from(s.scale));
             let value = Ratio::new(raw).map_err(|e| {
@@ -312,7 +323,11 @@ fn atom_value(atom: &Atom, env: &EvalEnv<'_>) -> Result<Value, EvalError> {
                      sort disagreement, not a content error"
                 ))
             })?;
-            Ok(Value::Ratio { value, cap: None })
+            Ok(Value::Ratio {
+                value,
+                floor: None,
+                cap: None,
+            })
         }
         Atom::Scaled(s) => {
             // A p/i/c literal is unit-interval with scale ≤ 9, so the
@@ -542,11 +557,11 @@ fn apply_arith(op: &str, lhs: &Value, rhs: &Value) -> Result<Value, EvalError> {
         // construction (`atom_value` never produces `Real` for an `r`
         // literal), so there is no ordering ambiguity, only two independent
         // positive matches.
-        (Value::Currency(c), Value::Ratio { value, cap })
-        | (Value::Ratio { value, cap }, Value::Currency(c))
+        (Value::Currency(c), Value::Ratio { value, floor, cap })
+        | (Value::Ratio { value, floor, cap }, Value::Currency(c))
             if op == "*" =>
         {
-            currency_mul_ratio(*c, *value, *cap)
+            currency_mul_ratio(*c, *value, *floor, *cap)
         }
         (Value::Currency(c), other) | (other, Value::Currency(c)) if op == "*" => {
             // §3.2: Currency multiplies by a Coefficient ONLY (Ratio is
@@ -711,18 +726,39 @@ fn currency_mul_coefficient(c: Currency, coeff: f64) -> Result<Value, EvalError>
 /// already a valid [`Ratio`] by construction (the reader's `E-LEX-027` and
 /// `scenario.rs`'s `defconst` loader both gate it before it ever reaches a
 /// [`Value`]), so the only thing left to check HERE, at the point of use, is
-/// the declared ceiling (`E-EVAL-041`) — the re-check `Value::Ratio`'s own
+/// the declared bounds (`E-EVAL-041`) — the re-check `Value::Ratio`'s own
 /// doc comment explains (defense in depth, not redundant structure: nothing
-/// re-derives `cap` from `ratio` itself, so this is the one place that can
-/// still catch a `cap` that drifted from the value it was declared against).
-fn currency_mul_ratio(c: Currency, ratio: Ratio, cap: Option<Ratio>) -> Result<Value, EvalError> {
+/// re-derives `floor`/`cap` from `ratio` itself, so this is the one place
+/// that can still catch a bound that drifted from the value it was declared
+/// against). `floor` is EXCLUSIVE (`ratio` must be strictly greater than
+/// it); `cap` is INCLUSIVE (`ratio` may equal it) — the same asymmetry
+/// `scenario.rs::load_ratio_defconst` checks at load.
+fn currency_mul_ratio(
+    c: Currency,
+    ratio: Ratio,
+    floor: Option<Ratio>,
+    cap: Option<Ratio>,
+) -> Result<Value, EvalError> {
+    if let Some(floor) = floor {
+        if ratio.get() <= floor.get() {
+            return Err(EvalError::coded(
+                EvalCode::RatioOutsideDeclaredDomain,
+                format!(
+                    "Currency × {} — the Ratio does not exceed its declared \
+                     :floor of {} (EXCLUSIVE; §3.2 addendum, #492/ADR194)",
+                    ratio.get(),
+                    floor.get()
+                ),
+            ));
+        }
+    }
     if let Some(cap) = cap {
         if ratio.get() > cap.get() {
             return Err(EvalError::coded(
-                EvalCode::RatioExceedsDeclaredCap,
+                EvalCode::RatioOutsideDeclaredDomain,
                 format!(
                     "Currency × {} — the Ratio exceeds its declared :cap of \
-                     {} (§3.2 addendum, #492/ADR194)",
+                     {} (INCLUSIVE; §3.2 addendum, #492/ADR194)",
                     ratio.get(),
                     cap.get()
                 ),
@@ -967,25 +1003,27 @@ mod tests {
             "k".to_owned(),
             Value::Ratio {
                 value: Ratio::new(12.0).unwrap(),
+                floor: None,
                 cap: Some(Ratio::new(10.0).unwrap()),
             },
         )]);
         let mut fuel = 10_000;
         let err = eval_with("(* 100$ k)", bindings, &mut fuel).unwrap_err();
-        assert_eq!(err.code, Some(EvalCode::RatioExceedsDeclaredCap));
+        assert_eq!(err.code, Some(EvalCode::RatioOutsideDeclaredDomain));
         assert_eq!(err.code.unwrap().spec_code(), "E-EVAL-041");
     }
 
     /// The mirror image: a capped Ratio AT or under its cap still multiplies
     /// cleanly — the check is `>`, not `>=`, matching every other
     /// closed-interval-at-the-top domain in this spec (e.g. `p`/`i`/`c`'s
-    /// `[0,1]` accepts the endpoint).
+    /// `[0,1]` accepts the endpoint) — `:cap` is INCLUSIVE.
     #[test]
     fn a_ratio_at_exactly_its_declared_cap_is_legal() {
         let bindings = HashMap::from([(
             "k".to_owned(),
             Value::Ratio {
                 value: Ratio::new(10.0).unwrap(),
+                floor: None,
                 cap: Some(Ratio::new(10.0).unwrap()),
             },
         )]);
@@ -993,6 +1031,64 @@ mod tests {
         assert_eq!(
             eval_with("(* 100$ k)", bindings, &mut fuel).unwrap(),
             Value::Currency(Currency::from_micro_units(1_000_000_000))
+        );
+    }
+
+    /// `:floor` is EXCLUSIVE — matching `entropy_factor`'s own `> 1.0` and
+    /// `Ratio`'s own open-at-zero law — so a value AT the floor is refused,
+    /// the mirror image of `:cap`'s INCLUSIVE endpoint above.
+    #[test]
+    fn a_ratio_at_exactly_its_declared_floor_is_e_eval_041() {
+        let bindings = HashMap::from([(
+            "k".to_owned(),
+            Value::Ratio {
+                value: Ratio::new(1.0).unwrap(),
+                floor: Some(Ratio::new(1.0).unwrap()),
+                cap: None,
+            },
+        )]);
+        let mut fuel = 10_000;
+        let err = eval_with("(* 100$ k)", bindings, &mut fuel).unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::RatioOutsideDeclaredDomain));
+        assert_eq!(err.code.unwrap().spec_code(), "E-EVAL-041");
+    }
+
+    /// A value strictly above its declared floor multiplies cleanly —
+    /// `entropy_factor`'s exact worked shape: `(defconst
+    /// metabolism/entropy-factor 1.5r :floor 1r :cap 3r)`, `1.5 > 1.0`.
+    #[test]
+    fn a_ratio_strictly_above_its_declared_floor_is_legal() {
+        let bindings = HashMap::from([(
+            "k".to_owned(),
+            Value::Ratio {
+                value: Ratio::new(1.5).unwrap(),
+                floor: Some(Ratio::new(1.0).unwrap()),
+                cap: Some(Ratio::new(3.0).unwrap()),
+            },
+        )]);
+        let mut fuel = 10_000;
+        assert_eq!(
+            eval_with("(* 100$ k)", bindings, &mut fuel).unwrap(),
+            Value::Currency(Currency::from_micro_units(150_000_000))
+        );
+    }
+
+    /// A value AT the inclusive cap alongside a floor also multiplies
+    /// cleanly — `entropy_factor`'s own upper endpoint, `3.0 <= 3.0`.
+    #[test]
+    fn a_ratio_at_its_declared_cap_alongside_a_floor_is_legal() {
+        let bindings = HashMap::from([(
+            "k".to_owned(),
+            Value::Ratio {
+                value: Ratio::new(3.0).unwrap(),
+                floor: Some(Ratio::new(1.0).unwrap()),
+                cap: Some(Ratio::new(3.0).unwrap()),
+            },
+        )]);
+        let mut fuel = 10_000;
+        assert_eq!(
+            eval_with("(* 100$ k)", bindings, &mut fuel).unwrap(),
+            Value::Currency(Currency::from_micro_units(300_000_000))
         );
     }
 

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -35,8 +35,8 @@
 
 use crate::fuel::{cost, IntrinsicCosts};
 use crate::intrinsic_host::IntrinsicHost;
-use crate::reader::{Atom, SExpr};
-use babylon_kernel::{Coefficient, Currency};
+use crate::reader::{Atom, SExpr, ScaledKind};
+use babylon_kernel::{Coefficient, Currency, Ratio};
 use std::collections::HashMap;
 
 /// A runtime BSL value. The static type system (§3.1) is finer than this —
@@ -53,6 +53,28 @@ pub enum Value {
     /// The binary64 lane (§3.3): `Probability` / `Intensity` /
     /// `Coefficient` / `Real`, always finite (`E-EVAL-014` otherwise).
     Real(f64),
+    /// `Ratio` — §3.2 addendum (Director ruling 2026-08-11, #492/ADR194): a
+    /// declared-domain positive scalar, `𝔾 ∩ (0, ∞)`, kept as its OWN
+    /// variant rather than folded into `Real` precisely because the [0,1]
+    /// cap must NOT silently widen for `Probability`/`Intensity`/
+    /// `Coefficient` — those stay `Value::Real` exactly as before. The
+    /// single legal use is the new `Currency × Ratio` operator
+    /// ([`apply_arith`]'s `*` arm); `Ratio` has no other operator. `cap` is
+    /// the declared ceiling this value's origin narrowed the sort to (a
+    /// `defconst`'s `:cap`, `scenario.rs`) — `None` for a bare literal or an
+    /// uncapped `defconst`, matching `Ratio`'s own `(0, ∞)` domain exactly.
+    /// Re-checked at THIS multiply (`E-EVAL-041`), not just at the
+    /// `defconst`'s own load (`E-LOAD-052`) — defense in depth, per III.11:
+    /// the operation does not trust that nothing between declaration and
+    /// use could hand it a stale or foreign value.
+    Ratio {
+        /// The scale factor itself — always finite and `> 0` by
+        /// construction (the kernel sort's own invariant).
+        value: Ratio,
+        /// The declared ceiling this value's `Ratio` sort was narrowed to,
+        /// if any.
+        cap: Option<Ratio>,
+    },
     /// `Bool`.
     Bool(bool),
     /// A member of a closed enum — comparable with `=`/`!=` only, and only
@@ -85,6 +107,12 @@ pub enum EvalCode {
     DivisionByZero,
     /// `E-EVAL-013` — a `Currency ÷ Currency` ratio outside `[0, 1]`.
     CoefficientOutOfRange,
+    /// `E-EVAL-041` — a `Currency × Ratio` operand exceeds the declared
+    /// ceiling its origin narrowed it to (§3.2 addendum, Director ruling
+    /// 2026-08-11, #492/ADR194). Distinct from `E-LOAD-052`, which is the
+    /// SAME domain rule checked at the `defconst` declaration itself — this
+    /// is the operation's own re-check at the point of use.
+    RatioExceedsDeclaredCap,
     /// `E-EVAL-014` — a binary64 operation producing a non-finite result.
     NonFinite,
     /// `E-EVAL-020` — a store whose resulting value falls outside the
@@ -143,6 +171,7 @@ impl EvalCode {
             Self::Overflow => "E-EVAL-011",
             Self::DivisionByZero => "E-EVAL-012",
             Self::CoefficientOutOfRange => "E-EVAL-013",
+            Self::RatioExceedsDeclaredCap => "E-EVAL-041",
             Self::NonFinite => "E-EVAL-014",
             Self::StoreRangeViolation => "E-EVAL-020",
             Self::EmptyAggregate => "E-EVAL-021",
@@ -267,6 +296,24 @@ fn atom_value(atom: &Atom, env: &EvalEnv<'_>) -> Result<Value, EvalError> {
     match atom {
         Atom::Int(n) => Ok(Value::Int(*n)),
         Atom::Currency(c) => Ok(Value::Currency(*c)),
+        Atom::Scaled(s) if s.kind == ScaledKind::Ratio => {
+            // §1.5 addendum: scale ≤ 9, so the unscaled integer is < 10⁹ —
+            // exact in f64 by construction, same reasoning as the p/i/c arm
+            // below. A bare literal carries no declared ceiling of its own
+            // (`cap: None`, i.e. the full `(0, ∞)` domain) — a ceiling is
+            // something only a `defconst`'s `:cap` narrows (`scenario.rs`).
+            #[allow(clippy::cast_precision_loss)]
+            let raw = s.unscaled as f64 / 10f64.powi(i32::from(s.scale));
+            let value = Ratio::new(raw).map_err(|e| {
+                EvalError::plain(format!(
+                    "r literal {raw} failed Ratio construction at eval \
+                     ({e:?}) — the reader's E-LEX-027 should have refused \
+                     this at lex time; reaching here is a reader/kernel \
+                     sort disagreement, not a content error"
+                ))
+            })?;
+            Ok(Value::Ratio { value, cap: None })
+        }
         Atom::Scaled(s) => {
             // A p/i/c literal is unit-interval with scale ≤ 9, so the
             // unscaled integer is < 10⁹ — exact in f64 by construction.
@@ -488,17 +535,32 @@ fn apply_arith(op: &str, lhs: &Value, rhs: &Value) -> Result<Value, EvalError> {
         (Value::Currency(c), Value::Int(divisor)) if op == "/" => {
             currency_div_integer(*c, *divisor)
         }
+        // §3.2 addendum (#492/ADR194): Currency × Ratio, the fifth legal
+        // mixed operation. Matched BEFORE the Coefficient arm below so a
+        // `Value::Ratio` operand never falls through to the "must be
+        // Value::Real" refusal — the two carriers are disjoint by
+        // construction (`atom_value` never produces `Real` for an `r`
+        // literal), so there is no ordering ambiguity, only two independent
+        // positive matches.
+        (Value::Currency(c), Value::Ratio { value, cap })
+        | (Value::Ratio { value, cap }, Value::Currency(c))
+            if op == "*" =>
+        {
+            currency_mul_ratio(*c, *value, *cap)
+        }
         (Value::Currency(c), other) | (other, Value::Currency(c)) if op == "*" => {
-            // §3.2: Currency multiplies by a Coefficient ONLY. `Real` is the
-            // runtime coefficient carrier (c-literals and bindings land
-            // there; the [0,1] domain is enforced below) — `Int` is a type
-            // error at ANY value (bsl-language.rst:849), so it must not
-            // slip through the promoting lane even where its f64 image
-            // would be a legal coefficient (0 and 1).
+            // §3.2: Currency multiplies by a Coefficient ONLY (Ratio is
+            // handled above). `Real` is the runtime coefficient carrier
+            // (c-literals and bindings land there; the [0,1] domain is
+            // enforced below) — `Int` is a type error at ANY value
+            // (bsl-language.rst:849), so it must not slip through the
+            // promoting lane even where its f64 image would be a legal
+            // coefficient (0 and 1).
             let Value::Real(coeff) = other else {
                 return Err(EvalError::plain(format!(
                     "Currency × {other:?} is not in the §3.2 operator table \
-                     (E-TYPE-030) — multiply by a Coefficient instead"
+                     (E-TYPE-030) — multiply by a Coefficient or a declared-\
+                     domain Ratio instead"
                 )));
             };
             currency_mul_coefficient(*c, *coeff)
@@ -506,8 +568,8 @@ fn apply_arith(op: &str, lhs: &Value, rhs: &Value) -> Result<Value, EvalError> {
         (Value::Currency(_), other) | (other, Value::Currency(_)) => {
             Err(EvalError::plain(format!(
                 "Currency {op} {other:?} is not in the §3.2 operator table \
-                 (E-TYPE-030) — the four pinned operations are ± Currency, \
-                 × Coefficient, ÷ Currency, ÷ integer"
+                 (E-TYPE-030) — the five pinned operations are ± Currency, \
+                 × Coefficient, × Ratio, ÷ Currency, ÷ integer"
             )))
         }
         _ => match (real_lane(lhs), real_lane(rhs)) {
@@ -641,6 +703,34 @@ fn currency_mul_coefficient(c: Currency, coeff: f64) -> Result<Value, EvalError>
     })?;
     let result = c
         .mul_coefficient(coefficient)
+        .map_err(|e| EvalError::coded(EvalCode::Overflow, format!("{} left i128", e.op)))?;
+    Ok(Value::Currency(result))
+}
+
+/// `Currency × Ratio → Currency` (§3.2 addendum, #492/ADR194). `ratio` is
+/// already a valid [`Ratio`] by construction (the reader's `E-LEX-027` and
+/// `scenario.rs`'s `defconst` loader both gate it before it ever reaches a
+/// [`Value`]), so the only thing left to check HERE, at the point of use, is
+/// the declared ceiling (`E-EVAL-041`) — the re-check `Value::Ratio`'s own
+/// doc comment explains (defense in depth, not redundant structure: nothing
+/// re-derives `cap` from `ratio` itself, so this is the one place that can
+/// still catch a `cap` that drifted from the value it was declared against).
+fn currency_mul_ratio(c: Currency, ratio: Ratio, cap: Option<Ratio>) -> Result<Value, EvalError> {
+    if let Some(cap) = cap {
+        if ratio.get() > cap.get() {
+            return Err(EvalError::coded(
+                EvalCode::RatioExceedsDeclaredCap,
+                format!(
+                    "Currency × {} — the Ratio exceeds its declared :cap of \
+                     {} (§3.2 addendum, #492/ADR194)",
+                    ratio.get(),
+                    cap.get()
+                ),
+            ));
+        }
+    }
+    let result = c
+        .mul_ratio(ratio)
         .map_err(|e| EvalError::coded(EvalCode::Overflow, format!("{} left i128", e.op)))?;
     Ok(Value::Currency(result))
 }
@@ -836,6 +926,86 @@ mod tests {
         let half = Value::Currency(Currency::from_micro_units(500_000_000));
         assert_eq!(eval("(* 1000$ 0.5c)").unwrap(), half);
         assert_eq!(eval("(* 0.5c 1000$)").unwrap(), half);
+    }
+
+    /// §3.2 addendum (#492/ADR194): the whole point — a Ratio OUTSIDE
+    /// Coefficient's [0,1] domain multiplies Currency cleanly, in either
+    /// operand order, same rounding law as Coefficient.
+    #[test]
+    fn currency_times_ratio_accepts_values_above_one_and_commutes() {
+        let expected = Value::Currency(Currency::from_micro_units(2_000_000_000));
+        assert_eq!(eval("(* 1000$ 2r)").unwrap(), expected);
+        assert_eq!(eval("(* 2r 1000$)").unwrap(), expected);
+        // rent_spike_multiplier's exact moddable-to-2.0 shape from the
+        // fixture the Territory port train cites.
+        assert_eq!(
+            eval("(* 1500.5$ 2.0r)").unwrap(),
+            Value::Currency(Currency::from_micro_units(3_001_000_000))
+        );
+    }
+
+    #[test]
+    fn a_bare_ratio_literal_carries_no_cap_so_any_positive_value_is_legal() {
+        // A literal `10r` in source has no declared ceiling (`cap: None`) —
+        // only a `defconst`'s `:cap` narrows it (`scenario.rs`). Values far
+        // beyond any of the four named consumers' domains are still legal
+        // arithmetic here; the type itself is unbounded above.
+        assert_eq!(
+            eval("(* 1$ 1000000r)").unwrap(),
+            Value::Currency(Currency::from_micro_units(1_000_000_000_000))
+        );
+    }
+
+    /// The declared-ceiling re-check (`E-EVAL-041`) needs a `Value::Ratio`
+    /// carrying `Some(cap)`, which only a `defconst`'s `:cap` produces in
+    /// real content (`scenario.rs`, tested there end-to-end). Constructing
+    /// one directly through `eval_with`'s binding map is the evaluator-level
+    /// unit test for the SAME check, isolated from the loader.
+    #[test]
+    fn a_ratio_exceeding_its_declared_cap_is_e_eval_041_at_the_multiply() {
+        let bindings = HashMap::from([(
+            "k".to_owned(),
+            Value::Ratio {
+                value: Ratio::new(12.0).unwrap(),
+                cap: Some(Ratio::new(10.0).unwrap()),
+            },
+        )]);
+        let mut fuel = 10_000;
+        let err = eval_with("(* 100$ k)", bindings, &mut fuel).unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::RatioExceedsDeclaredCap));
+        assert_eq!(err.code.unwrap().spec_code(), "E-EVAL-041");
+    }
+
+    /// The mirror image: a capped Ratio AT or under its cap still multiplies
+    /// cleanly — the check is `>`, not `>=`, matching every other
+    /// closed-interval-at-the-top domain in this spec (e.g. `p`/`i`/`c`'s
+    /// `[0,1]` accepts the endpoint).
+    #[test]
+    fn a_ratio_at_exactly_its_declared_cap_is_legal() {
+        let bindings = HashMap::from([(
+            "k".to_owned(),
+            Value::Ratio {
+                value: Ratio::new(10.0).unwrap(),
+                cap: Some(Ratio::new(10.0).unwrap()),
+            },
+        )]);
+        let mut fuel = 10_000;
+        assert_eq!(
+            eval_with("(* 100$ k)", bindings, &mut fuel).unwrap(),
+            Value::Currency(Currency::from_micro_units(1_000_000_000))
+        );
+    }
+
+    /// Ratio has exactly one operator (Currency ×) — no addition, no
+    /// comparison, no Ratio-Ratio arithmetic. "Scalar multiplication isn't
+    /// new mathematics" (the ruling's own framing) — the evaluator must not
+    /// quietly grow a second one.
+    #[test]
+    fn ratio_has_no_operator_but_the_currency_multiply() {
+        for src in ["(+ 1 2r)", "(* 2r 3r)", "(< 1r 2r)", "(/ 10$ 2r)"] {
+            let err = eval(src).expect_err(src);
+            assert_eq!(err.code, None, "{src}: {err}");
+        }
     }
 
     /// §3.2 (bsl-language.rst:849): "``Currency × Int`` [is a] type error;

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -55,11 +55,11 @@ pub enum Value {
     Real(f64),
     /// `Ratio` — §3.2 addendum (Director ruling 2026-08-11, #492/ADR194): a
     /// declared-domain positive scalar, `𝔾 ∩ (0, ∞)`, kept as its OWN
-    /// variant rather than folded into `Real` precisely because the [0,1]
+    /// variant rather than folded into `Real` precisely because the `[0,1]`
     /// cap must NOT silently widen for `Probability`/`Intensity`/
     /// `Coefficient` — those stay `Value::Real` exactly as before. The
     /// single legal use is the new `Currency × Ratio` operator
-    /// ([`apply_arith`]'s `*` arm); `Ratio` has no other operator. `floor`
+    /// (`apply_arith`'s `*` arm); `Ratio` has no other operator. `floor`
     /// and `cap` are the declared bounds this value's origin narrowed the
     /// sort to (a `defconst`'s `:floor`/`:cap`, `scenario.rs`) — `None` for
     /// a bare literal or an undeclared bound, matching `Ratio`'s own

--- a/rust/crates/babylon-bsl/src/reader.rs
+++ b/rust/crates/babylon-bsl/src/reader.rs
@@ -71,7 +71,15 @@ pub enum Atom {
     Str(String),
 }
 
-/// The unit-interval scaled-literal kinds (`p` / `i` / `c` suffixes).
+/// The unit-interval scaled-literal kinds (`p` / `i` / `c` suffixes), plus
+/// the `r`-suffixed `Ratio` kind (§1.5 addendum, Director ruling 2026-08-11
+/// #492/ADR194): unlike `p`/`i`/`c`, `Ratio` is NOT unit-interval — its
+/// domain is `(0, ∞)`, the kernel's existing `babylon_kernel::Ratio` sort.
+/// It shares this struct's canonical decimal representation (and therefore
+/// this reader's canonicalization and CAS encoding machinery) rather than
+/// inventing a parallel literal shape, which is the whole point: scalar
+/// multiplication by a declared-domain constant is machinery reusing an
+/// existing closed-algebra sort, not new mathematics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScaledKind {
     /// `p` suffix.
@@ -80,14 +88,19 @@ pub enum ScaledKind {
     Intensity,
     /// `c` suffix.
     Coefficient,
+    /// `r` suffix — `Ratio`, domain `(0, ∞)` (§1.5 addendum).
+    Ratio,
 }
 
-/// A canonicalized `p`/`i`/`c` literal: value = `unscaled / 10^scale`,
+/// A canonicalized `p`/`i`/`c`/`r` literal: value = `unscaled / 10^scale`,
 /// trailing fractional zeros stripped, zero as `(0, 0)` (§1.5 *Decimal
 /// canonicalization* — `0.50c` and `0.5c` are ONE value and hash identically).
+/// `r` (`Ratio`) is excepted from the "zero as `(0,0)`" case: its domain
+/// excludes zero, so a canonicalized `Ratio` literal is never `(0, 0)`
+/// (`classify_ratio` rejects the input before canonicalization reaches it).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ScaledLit {
-    /// Which unit-interval kind the suffix named.
+    /// Which unit-interval kind the suffix named — or `Ratio` (§1.5 addendum).
     pub kind: ScaledKind,
     /// The canonical unscaled integer.
     pub unscaled: i128,
@@ -122,6 +135,14 @@ pub enum LexCode {
     BadStringEscape,
     /// `E-LEX-026` — a string over 1024 bytes after escape processing.
     StringTooLong,
+    /// `E-LEX-027` — an `r` (`Ratio`) literal that is not strictly positive
+    /// (§1.5 addendum, Director ruling 2026-08-11 #492/ADR194). `Ratio`'s
+    /// domain is `(0, ∞)`, open at zero — matching
+    /// `babylon_kernel::scalars::Ratio`'s existing law exactly — so both a
+    /// lexically negative literal and a literal that canonicalizes to `0`
+    /// are refused here, at lex time, the same way `p`/`i`/`c`'s `[0,1]`
+    /// bound is `E-LEX-024`.
+    NonPositiveRatio,
 }
 
 impl LexCode {
@@ -141,6 +162,7 @@ impl LexCode {
             Self::UnitIntervalOutOfRange => "E-LEX-024",
             Self::BadStringEscape => "E-LEX-025",
             Self::StringTooLong => "E-LEX-026",
+            Self::NonPositiveRatio => "E-LEX-027",
         }
     }
 }
@@ -658,6 +680,7 @@ fn classify_numeric(run: &str, start: usize) -> Result<Atom, ReadError> {
                 negative,
                 start,
             ),
+            "r" => classify_ratio(&int_digits, &frac_digits, negative, start),
             _ => Err(unclassifiable()),
         };
     }
@@ -666,6 +689,7 @@ fn classify_numeric(run: &str, start: usize) -> Result<Atom, ReadError> {
         "p" | "i" | "c" => {
             classify_unit_interval(&int_digits, "", suffix_kind(rest), negative, start)
         }
+        "r" => classify_ratio(&int_digits, "", negative, start),
         _ => Err(unclassifiable()),
     }
 }
@@ -776,6 +800,61 @@ fn classify_unit_interval(
     let scale = u8::try_from(scale).expect("scale is at most 9 by the check above");
     Ok(Atom::Scaled(ScaledLit {
         kind,
+        unscaled,
+        scale,
+    }))
+}
+
+/// An `r` literal (§1.5 addendum, Director ruling 2026-08-11 #492/ADR194):
+/// scale ≤ 9 (`E-LEX-023`, the same reuse `classify_unit_interval` documents
+/// for the same reason — a second numbered code for "too many fractional
+/// digits" would duplicate the one that already exists), value strictly
+/// positive (`E-LEX-027`), canonical minimal scale. Unlike
+/// [`classify_unit_interval`] there is no upper bound: `Ratio`'s domain is
+/// `(0, ∞)`, matching `babylon_kernel::scalars::Ratio` exactly.
+fn classify_ratio(
+    int_digits: &str,
+    frac_digits: &str,
+    negative: bool,
+    start: usize,
+) -> Result<Atom, ReadError> {
+    if frac_digits.len() > 9 {
+        return Err(lex_error(
+            LexCode::ExcessScale,
+            "r literals take at most 9 fractional digits, the same cap p/i/c \
+             use (§1.5)",
+            start,
+        ));
+    }
+    let non_positive = || {
+        lex_error(
+            LexCode::NonPositiveRatio,
+            "r literals are bounded to (0, ∞) — strictly positive, matching \
+             babylon_kernel::Ratio's domain",
+            start,
+        )
+    };
+    if negative {
+        // §1.5 names the LITERAL negative for Currency (`-0$` rejects too);
+        // the same reading applies here — a lexically negative Ratio
+        // literal is refused before its magnitude is even inspected.
+        return Err(non_positive());
+    }
+    let mut unscaled: i128 = format!("{int_digits}{frac_digits}")
+        .parse()
+        .map_err(|_| lex_error(LexCode::IntOutOfRange, "r literal does not fit i128", start))?;
+    if unscaled == 0 {
+        // Zero is in range but not in Ratio's OPEN lower bound.
+        return Err(non_positive());
+    }
+    let mut scale = frac_digits.len();
+    while scale > 0 && unscaled % 10 == 0 {
+        unscaled /= 10;
+        scale -= 1;
+    }
+    let scale = u8::try_from(scale).expect("scale is at most 9 by the check above");
+    Ok(Atom::Scaled(ScaledLit {
+        kind: ScaledKind::Ratio,
         unscaled,
         scale,
     }))
@@ -1063,6 +1142,63 @@ mod tests {
                 scale: 0
             })
         );
+    }
+
+    // ---- E-LEX-027: Ratio literals (§1.5 addendum, #492/ADR194) ----
+
+    #[test]
+    fn ratio_literals_lex_with_no_upper_bound() {
+        assert_eq!(
+            atom("2.0r"),
+            Atom::Scaled(ScaledLit {
+                kind: ScaledKind::Ratio,
+                unscaled: 2,
+                scale: 0
+            })
+        );
+        assert_eq!(
+            atom("10r"),
+            Atom::Scaled(ScaledLit {
+                kind: ScaledKind::Ratio,
+                unscaled: 10,
+                scale: 0
+            })
+        );
+        // Comfortably beyond [0,1] — the whole point of the sort.
+        assert_eq!(
+            atom("1000000r"),
+            Atom::Scaled(ScaledLit {
+                kind: ScaledKind::Ratio,
+                unscaled: 1_000_000,
+                scale: 0
+            })
+        );
+    }
+
+    #[test]
+    fn ratio_literals_reject_zero_and_negative() {
+        assert_eq!(lex_err("0r"), LexCode::NonPositiveRatio);
+        assert_eq!(lex_err("0.0r"), LexCode::NonPositiveRatio);
+        assert_eq!(lex_err("-1r"), LexCode::NonPositiveRatio);
+        assert_eq!(lex_err("-0r"), LexCode::NonPositiveRatio);
+    }
+
+    #[test]
+    fn ratio_literals_take_at_most_scale_9() {
+        assert_eq!(
+            atom("0.123456789r"),
+            Atom::Scaled(ScaledLit {
+                kind: ScaledKind::Ratio,
+                unscaled: 123_456_789,
+                scale: 9
+            })
+        );
+        assert_eq!(lex_err("0.1234567891r"), LexCode::ExcessScale);
+    }
+
+    #[test]
+    fn ratio_literals_canonicalize_to_minimal_scale() {
+        assert_eq!(atom("2.50r"), atom("2.5r"));
     }
 
     // ---- E-LEX-025: string escapes ----

--- a/rust/crates/babylon-bsl/src/reader.rs
+++ b/rust/crates/babylon-bsl/src/reader.rs
@@ -852,6 +852,22 @@ fn classify_ratio(
         unscaled /= 10;
         scale -= 1;
     }
+    // A positive literal strictly below the kernel grid's half-step
+    // (5e-7) quantizes to 0.0 under `babylon_kernel::grid::quantize`'s
+    // half-up law (`(v * 1e6 + 0.5).floor()`), which `Ratio::new` then
+    // rejects — non-positive AFTER the sort's law, so the reader refuses
+    // it here rather than letting the loader's "the reader should have
+    // refused this" path claim otherwise. Exactly 0.0000005 rounds UP to
+    // the first grid point and stays legal.
+    if scale >= 7 && 2 * unscaled < 10_i128.pow(u32::try_from(scale).unwrap() - 6) {
+        return Err(lex_error(
+            LexCode::NonPositiveRatio,
+            "r literal quantizes to zero on the kernel's 1e-6 grid — \
+             non-positive after the sort's law (positive values below \
+             0.0000005 have no representable magnitude)",
+            start,
+        ));
+    }
     let scale = u8::try_from(scale).expect("scale is at most 9 by the check above");
     Ok(Atom::Scaled(ScaledLit {
         kind: ScaledKind::Ratio,
@@ -1181,6 +1197,28 @@ mod tests {
         assert_eq!(lex_err("0.0r"), LexCode::NonPositiveRatio);
         assert_eq!(lex_err("-1r"), LexCode::NonPositiveRatio);
         assert_eq!(lex_err("-0r"), LexCode::NonPositiveRatio);
+    }
+
+    /// A positive literal strictly below the kernel grid's half-step
+    /// (5e-7) quantizes to 0.0 and `Ratio::new` would reject it — the
+    /// reader refuses it as `E-LEX-027` so the loader's "the reader
+    /// should have refused this" framing stays true. Exactly `0.0000005r`
+    /// rounds UP to the first grid point and is legal; killing the
+    /// under-grid check accepts `0.0000004r` and flips this test.
+    #[test]
+    fn ratio_literals_reject_values_that_quantize_to_zero_on_the_grid() {
+        assert_eq!(lex_err("0.0000004r"), LexCode::NonPositiveRatio);
+        assert_eq!(lex_err("0.0000001r"), LexCode::NonPositiveRatio);
+        assert_eq!(lex_err("0.000000001r"), LexCode::NonPositiveRatio);
+        // The half-step itself rounds UP and stays legal.
+        assert_eq!(
+            atom("0.0000005r"),
+            Atom::Scaled(ScaledLit {
+                kind: ScaledKind::Ratio,
+                unscaled: 5,
+                scale: 7,
+            })
+        );
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -242,8 +242,9 @@ pub fn load_scenario(
 }
 
 /// `(defconst <qname> <literal>)`, or `(defconst <qname> <ratio-literal>
-/// :cap <ratio-literal>)` (§3.2 addendum, Director ruling 2026-08-11,
-/// #492/ADR194 — the declared-domain scale operation).
+/// [:floor <ratio-literal>] [:cap <ratio-literal>])` (§3.2 addendum,
+/// Director ruling 2026-08-11, #492/ADR194 — the declared-domain scale
+/// operation).
 ///
 /// The defines environment in miniature (§2.5's `:const`, §4.2's
 /// "the defines environment (coefficients)"). Slice 1 has no
@@ -259,53 +260,48 @@ pub fn load_scenario(
 /// define is a value, not an expression, and an expression would need an
 /// evaluation environment that does not exist at scenario-load time.
 ///
-/// **`:cap` (#492/ADR194).** `defconst`/`node`/`edge`/`scenario` are the
-/// `.bscn`-dialect construct `bsl-language.rst` §7 records as OUT of the
-/// consolidated grammar's scope (D93: "no section specifies it") — so
-/// `:cap` is Rust-implementation machinery, not an RST production, and does
-/// NOT go through the closed §1.6 keyword vocabulary or its `E-PARSE-013`
-/// enforcement (this function's own hand-rolled positional match is that
-/// enforcement, same as it already is for `defconst`'s base shape). It is
-/// legal ONLY on a `Ratio` (`r`-suffixed) literal: `Ratio`'s own domain is
-/// already `(0, ∞)` (§1.5 addendum), so `:cap` NARROWS it to `(0, cap]` —
-/// stated at declaration, loud and visible in the source text, and checked
-/// twice: HERE at load (`E-LOAD-052`, the literal must not itself exceed
-/// the cap it declares) and again at every `Currency × Ratio` evaluation
+/// **`:floor`/`:cap` (#492/ADR194).** `defconst`/`node`/`edge`/`scenario`
+/// are the `.bscn`-dialect construct `bsl-language.rst` §7 records as OUT
+/// of the consolidated grammar's scope (D93: "no section specifies it") —
+/// so both keywords are Rust-implementation machinery, not an RST
+/// production, and do NOT go through the closed §1.6 keyword vocabulary or
+/// its `E-PARSE-013` enforcement ([`parse_bound_keywords`] is that
+/// enforcement, same as this function's own hand-rolled positional match is
+/// for `defconst`'s base shape). Both are legal ONLY on a `Ratio`
+/// (`r`-suffixed) literal: `Ratio`'s own domain is already `(0, ∞)` (§1.5
+/// addendum), and each keyword narrows ONE end of it —
+/// `:cap` to `(0, cap]` (INCLUSIVE, matching a `<=`-bounded consumer like
+/// `pareto_alpha`'s `(0, 10]`), `:floor` to `(floor, ∞)` (EXCLUSIVE,
+/// matching Ratio's own open-at-zero law AND a `>`-bounded consumer like
+/// `entropy_factor`'s `(1.0, 3.0]`), together `(floor, cap]`. Stated at
+/// declaration, loud and visible in the source text, and each bound checked
+/// twice: HERE at load (`E-LOAD-052`, the literal must not itself violate
+/// the domain it declares) and again at every `Currency × Ratio` evaluation
 /// (`E-EVAL-041`, `evaluator::currency_mul_ratio`) — defense in depth, per
-/// III.11. An UNDECLARED (bare, uncapped) `Ratio` defconst is exactly as
-/// legal as before this addendum; the `[0,1]` cap on `p`/`i`/`c` defconsts
-/// is completely untouched — this is a new, disjoint literal kind, not a
+/// III.11. An UNDECLARED (bare) `Ratio` defconst is exactly as legal as
+/// before this addendum; the `[0,1]` cap on `p`/`i`/`c` defconsts is
+/// completely untouched — this is a new, disjoint literal kind, not a
 /// widening of the existing three.
 fn load_defconst(
     parts: &[SExpr],
     consts: &mut HashMap<String, Value>,
 ) -> Result<(), ScenarioError> {
-    let (qname, literal, cap_literal) = match parts {
-        [_, SExpr::Atom(Atom::QName(qname)), SExpr::Atom(literal)] => (qname, literal, None),
-        [_, SExpr::Atom(Atom::QName(qname)), SExpr::Atom(literal), SExpr::Atom(Atom::Keyword(kw)), SExpr::Atom(cap_literal)]
-            if kw == "cap" =>
-        {
-            (qname, literal, Some(cap_literal))
-        }
-        _ => {
-            return Err(err(
-                "expected (defconst <qname> <literal>) or (defconst <qname> \
-                 <ratio-literal> :cap <ratio-literal>) — one qualified name, \
-                 one literal, and an optional :cap ceiling on a Ratio literal \
-                 only (§3.2 addendum, #492/ADR194)",
-            ))
-        }
+    let [_, SExpr::Atom(Atom::QName(qname)), SExpr::Atom(literal), rest @ ..] = parts else {
+        return Err(err(
+            "expected (defconst <qname> <literal>) — one qualified name, one literal",
+        ));
     };
+    let (floor_literal, cap_literal) = parse_bound_keywords(qname, rest)?;
     let value = match literal {
         Atom::Int(value) => {
-            reject_stray_cap(qname, cap_literal, "an Int")?;
+            reject_stray_bounds(qname, floor_literal, cap_literal, "an Int")?;
             Value::Int(*value)
         }
         Atom::Scaled(scaled) if scaled.kind == ScaledKind::Ratio => {
-            load_ratio_defconst(qname, scaled, cap_literal)?
+            load_ratio_defconst(qname, scaled, floor_literal, cap_literal)?
         }
         Atom::Scaled(scaled) => {
-            reject_stray_cap(qname, cap_literal, "a p/i/c literal")?;
+            reject_stray_bounds(qname, floor_literal, cap_literal, "a p/i/c literal")?;
             // `unscaled / 10^scale`, the canonical minimal-scale form, and
             // the SAME arithmetic `tick.rs::atom_to_value` performs on a
             // `:default` literal — so a scaled coefficient reads identically
@@ -315,7 +311,7 @@ fn load_defconst(
             Value::Real(numerator / 10_f64.powi(i32::from(scaled.scale)))
         }
         Atom::Bool(value) => {
-            reject_stray_cap(qname, cap_literal, "a Bool")?;
+            reject_stray_bounds(qname, floor_literal, cap_literal, "a Bool")?;
             Value::Bool(*value)
         }
         // Refused, not carried. `tick.rs::atom_to_value` refuses a Currency
@@ -352,61 +348,173 @@ fn load_defconst(
     Ok(())
 }
 
-/// `:cap` is legal only on a `Ratio` literal (see [`load_defconst`]'s doc);
-/// this names the refusal by the OTHER literal kind found instead, rather
-/// than routing through the generic "expected an int, scaled or boolean
-/// literal" arm, which would misdiagnose a well-formed-but-misplaced `:cap`
-/// as a malformed literal.
-fn reject_stray_cap(
+/// Scan the trailing `[:floor <literal>] [:cap <literal>]` keyword-operand
+/// pairs after a `defconst`'s required `<qname> <literal>` (in either
+/// order, either or both present) — the same hand-rolled enforcement
+/// [`load_defconst`]'s doc describes: `.bscn` machinery, not the closed
+/// §1.6 vocabulary.
+///
+/// # Errors
+/// A structural (uncoded) [`ScenarioError`] on an unrecognized keyword, a
+/// duplicated one, a keyword with no operand, or a non-keyword atom in this
+/// position — never a silent drop of the extra tokens.
+fn parse_bound_keywords<'a>(
     qname: &str,
+    rest: &'a [SExpr],
+) -> Result<(Option<&'a Atom>, Option<&'a Atom>), ScenarioError> {
+    let mut floor_literal = None;
+    let mut cap_literal = None;
+    let mut i = 0;
+    while i < rest.len() {
+        let SExpr::Atom(Atom::Keyword(kw)) = &rest[i] else {
+            return Err(err(format!(
+                "defconst `{qname}`: expected :floor or :cap here, found {:?}",
+                rest[i]
+            )));
+        };
+        let Some(SExpr::Atom(operand)) = rest.get(i + 1) else {
+            return Err(err(format!(
+                "defconst `{qname}`: :{kw} takes an operand but ends the form"
+            )));
+        };
+        let slot = match kw.as_str() {
+            "floor" => &mut floor_literal,
+            "cap" => &mut cap_literal,
+            other => {
+                return Err(err(format!(
+                    "defconst `{qname}`: unrecognized keyword :{other} — only \
+                     :floor and :cap are legal here (§3.2 addendum, #492/ADR194)"
+                )))
+            }
+        };
+        if slot.replace(operand).is_some() {
+            return Err(err(format!(
+                "defconst `{qname}`: :{kw} given twice — a bound has one \
+                 value, and silently rebinding it would make the check \
+                 depend on declaration order"
+            )));
+        }
+        i += 2;
+    }
+    Ok((floor_literal, cap_literal))
+}
+
+/// `:floor`/`:cap` are legal only on a `Ratio` literal (see
+/// [`load_defconst`]'s doc); this names the refusal by the OTHER literal
+/// kind found instead, rather than routing through the generic "expected an
+/// int, scaled or boolean literal" arm, which would misdiagnose a
+/// well-formed-but-misplaced bound as a malformed literal.
+fn reject_stray_bounds(
+    qname: &str,
+    floor_literal: Option<&Atom>,
     cap_literal: Option<&Atom>,
     found: &str,
 ) -> Result<(), ScenarioError> {
-    if cap_literal.is_some() {
+    if floor_literal.is_some() || cap_literal.is_some() {
         return Err(err(format!(
-            "defconst `{qname}`: :cap is legal only on a Ratio (r-suffixed) \
-             literal (§3.2 addendum, #492/ADR194), found {found}"
+            "defconst `{qname}`: :floor/:cap are legal only on a Ratio \
+             (r-suffixed) literal (§3.2 addendum, #492/ADR194), found {found}"
         )));
     }
     Ok(())
 }
 
 /// The `Ratio`-literal half of [`load_defconst`]: builds
-/// `Value::Ratio { value, cap }`, checking the declared ceiling at load
-/// (`E-LOAD-052`) when `:cap` is present.
+/// `Value::Ratio { value, floor, cap }`, checking the declared bounds at
+/// load (`E-LOAD-052`) — the bounds against EACH OTHER first (when both are
+/// present), then the value against each declared bound.
+///
+/// **Order matters, and is checked by
+/// `a_floor_not_strictly_below_its_cap_is_e_load_052`.** `(floor, cap]` is
+/// only a non-empty domain when `floor < cap`; when it is NOT, `floor >=
+/// cap` implies `value > floor` and `value <= cap` can never BOTH hold (if
+/// they could, `floor < value <= cap` would prove `floor < cap`, the
+/// contrapositive of what triggered this branch) — so checking the value
+/// against either bound FIRST would always fire on ONE of them, misreporting
+/// a self-inconsistent DECLARATION as a bad VALUE. Checking the bounds
+/// against each other first names the actual defect.
 fn load_ratio_defconst(
     qname: &str,
     scaled: &crate::reader::ScaledLit,
+    floor_literal: Option<&Atom>,
     cap_literal: Option<&Atom>,
 ) -> Result<Value, ScenarioError> {
     let value = ratio_from_scaled(qname, scaled)?;
-    let cap = match cap_literal {
-        None => None,
-        Some(Atom::Scaled(cap_scaled)) if cap_scaled.kind == ScaledKind::Ratio => {
-            let cap = ratio_from_scaled(qname, cap_scaled)?;
-            if value.get() > cap.get() {
-                return Err(coded_err(
-                    "E-LOAD-052",
-                    format!(
-                        "defconst `{qname}`: declared value {} exceeds its own \
-                         :cap {} — a defconst's :cap states the const's OWN \
-                         domain ceiling, so the literal must satisfy it \
-                         (§3.2 addendum, #492/ADR194)",
-                        value.get(),
-                        cap.get()
-                    ),
-                ));
-            }
-            Some(cap)
+    let floor = parse_ratio_bound(qname, "floor", floor_literal)?;
+    let cap = parse_ratio_bound(qname, "cap", cap_literal)?;
+    if let (Some(floor), Some(cap)) = (floor, cap) {
+        if floor.get() >= cap.get() {
+            return Err(coded_err(
+                "E-LOAD-052",
+                format!(
+                    "defconst `{qname}`: declared :floor {} is not strictly \
+                     below its own :cap {} — (floor, cap] is empty unless \
+                     floor < cap (§3.2 addendum, #492/ADR194)",
+                    floor.get(),
+                    cap.get()
+                ),
+            ));
         }
-        Some(other) => {
-            return Err(err(format!(
-                "defconst `{qname}`: :cap's operand must be a Ratio \
-                 (r-suffixed) literal, found {other:?}"
-            )))
+    }
+    if let Some(floor) = floor {
+        // EXCLUSIVE: value must be STRICTLY greater than its declared floor
+        // (matches Ratio's own open-at-zero law and entropy_factor's own
+        // `> 1.0`). `floor > 0` needs no separate check here: `floor` is
+        // itself a `Ratio`, whose constructor already refused a
+        // non-positive value (and the reader's `E-LEX-027` refused it
+        // earlier still) — re-checking it would be provably redundant, the
+        // same class of already-guaranteed check D-4 of
+        // `content/rules/lifecycle.bsl` records rather than re-asserting.
+        if value.get() <= floor.get() {
+            return Err(coded_err(
+                "E-LOAD-052",
+                format!(
+                    "defconst `{qname}`: declared value {} does not exceed its \
+                     own :floor {} — a defconst's :floor states the const's OWN \
+                     domain floor EXCLUSIVE, so the literal must be strictly \
+                     greater than it (§3.2 addendum, #492/ADR194)",
+                    value.get(),
+                    floor.get()
+                ),
+            ));
         }
-    };
-    Ok(Value::Ratio { value, cap })
+    }
+    if let Some(cap) = cap {
+        if value.get() > cap.get() {
+            return Err(coded_err(
+                "E-LOAD-052",
+                format!(
+                    "defconst `{qname}`: declared value {} exceeds its own \
+                     :cap {} — a defconst's :cap states the const's OWN \
+                     domain ceiling INCLUSIVE, so the literal must satisfy it \
+                     (§3.2 addendum, #492/ADR194)",
+                    value.get(),
+                    cap.get()
+                ),
+            ));
+        }
+    }
+    Ok(Value::Ratio { value, floor, cap })
+}
+
+/// One `:floor`/`:cap` operand, as a [`Ratio`] — `None` when the keyword was
+/// absent, else the parsed bound or a structural refusal if its literal is
+/// not itself a `Ratio`.
+fn parse_ratio_bound(
+    qname: &str,
+    keyword: &str,
+    literal: Option<&Atom>,
+) -> Result<Option<Ratio>, ScenarioError> {
+    match literal {
+        None => Ok(None),
+        Some(Atom::Scaled(scaled)) if scaled.kind == ScaledKind::Ratio => {
+            ratio_from_scaled(qname, scaled).map(Some)
+        }
+        Some(other) => Err(err(format!(
+            "defconst `{qname}`: :{keyword}'s operand must be a Ratio \
+             (r-suffixed) literal, found {other:?}"
+        ))),
+    }
 }
 
 /// Convert a canonicalized `r`-literal to a kernel [`Ratio`]. Should never
@@ -823,8 +931,9 @@ mod tests {
         let mut graph = MemoryGraph::new();
         let loaded = load_scenario(source, &mut graph).unwrap();
         match &loaded.consts["territory/rent-spike-multiplier"] {
-            crate::evaluator::Value::Ratio { value, cap } => {
+            crate::evaluator::Value::Ratio { value, floor, cap } => {
                 assert!((value.get() - 2.0).abs() < 1e-12);
+                assert_eq!(*floor, None);
                 assert_eq!(*cap, None);
             }
             other => panic!("expected Value::Ratio, got {other:?}"),
@@ -841,8 +950,9 @@ mod tests {
         let mut graph = MemoryGraph::new();
         let loaded = load_scenario(source, &mut graph).unwrap();
         match &loaded.consts["lifecycle/pareto-alpha"] {
-            crate::evaluator::Value::Ratio { value, cap } => {
+            crate::evaluator::Value::Ratio { value, floor, cap } => {
                 assert!((value.get() - 1.5).abs() < 1e-12);
+                assert_eq!(*floor, None);
                 assert!((cap.expect("cap declared").get() - 10.0).abs() < 1e-12);
             }
             other => panic!("expected Value::Ratio, got {other:?}"),
@@ -876,8 +986,9 @@ mod tests {
         let mut graph = MemoryGraph::new();
         let loaded = load_scenario(source, &mut graph).unwrap();
         match &loaded.consts["lifecycle/pareto-alpha"] {
-            crate::evaluator::Value::Ratio { value, cap } => {
+            crate::evaluator::Value::Ratio { value, floor, cap } => {
                 assert!((value.get() - 10.0).abs() < 1e-12);
+                assert_eq!(*floor, None);
                 assert!((cap.unwrap().get() - 10.0).abs() < 1e-12);
             }
             other => panic!("expected Value::Ratio, got {other:?}"),
@@ -897,7 +1008,8 @@ mod tests {
             let mut graph = MemoryGraph::new();
             let err = load_scenario(&source, &mut graph).unwrap_err();
             assert!(
-                err.message.contains(":cap is legal only on a Ratio"),
+                err.message
+                    .contains(":floor/:cap are legal only on a Ratio"),
                 "{label}: {}",
                 err.message
             );
@@ -914,6 +1026,167 @@ mod tests {
         let err = load_scenario(source, &mut graph).unwrap_err();
         assert!(
             err.message.contains(":cap's operand must be a Ratio"),
+            "{}",
+            err.message
+        );
+    }
+
+    // ---- :floor (DEFECT 1 fix round, adversarial verification of #500) ----
+
+    #[test]
+    fn a_floored_ratio_defconst_within_bounds_loads() {
+        // entropy_factor's exact shape: declared domain (1.0, 3.0], value
+        // 1.5. `content/rules/metabolism.bsl`'s eventual port will read
+        // this exact const once that train lands.
+        let source = r"
+(scenario ft/floored-ratio
+  (defconst metabolism/entropy-factor 1.5r :floor 1r :cap 3r))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph).unwrap();
+        match &loaded.consts["metabolism/entropy-factor"] {
+            crate::evaluator::Value::Ratio { value, floor, cap } => {
+                assert!((value.get() - 1.5).abs() < 1e-12);
+                assert!((floor.expect("floor declared").get() - 1.0).abs() < 1e-12);
+                assert!((cap.expect("cap declared").get() - 3.0).abs() < 1e-12);
+            }
+            other => panic!("expected Value::Ratio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn floor_alone_with_no_cap_loads() {
+        let source = r"
+(scenario ft/floor-only
+  (defconst metabolism/entropy-factor 1.5r :floor 1r))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph).unwrap();
+        match &loaded.consts["metabolism/entropy-factor"] {
+            crate::evaluator::Value::Ratio { value, floor, cap } => {
+                assert!((value.get() - 1.5).abs() < 1e-12);
+                assert!((floor.expect("floor declared").get() - 1.0).abs() < 1e-12);
+                assert_eq!(*cap, None);
+            }
+            other => panic!("expected Value::Ratio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cap_before_floor_in_source_order_still_parses() {
+        // parse_bound_keywords accepts either order.
+        let source = r"
+(scenario ft/cap-then-floor
+  (defconst metabolism/entropy-factor 1.5r :cap 3r :floor 1r))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph).unwrap();
+        match &loaded.consts["metabolism/entropy-factor"] {
+            crate::evaluator::Value::Ratio { value, floor, cap } => {
+                assert!((value.get() - 1.5).abs() < 1e-12);
+                assert!((floor.unwrap().get() - 1.0).abs() < 1e-12);
+                assert!((cap.unwrap().get() - 3.0).abs() < 1e-12);
+            }
+            other => panic!("expected Value::Ratio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_value_at_exactly_its_declared_floor_is_e_load_052() {
+        // EXCLUSIVE: the declared value must be STRICTLY greater than its
+        // own floor — matching entropy_factor's `> 1.0`, not `>= 1.0`.
+        let source = r"
+(scenario ft/at-floor
+  (defconst metabolism/entropy-factor 1r :floor 1r :cap 3r))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-052"));
+        assert!(
+            err.message.contains("does not exceed its own :floor"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn a_value_below_its_declared_floor_is_e_load_052() {
+        let source = r"
+(scenario ft/below-floor
+  (defconst metabolism/entropy-factor 0.5r :floor 1r :cap 3r))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-052"));
+        assert!(
+            err.message.contains("does not exceed its own :floor"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn a_floor_not_strictly_below_its_cap_is_e_load_052() {
+        // (floor, cap] is empty unless floor < cap — floor == cap and
+        // floor > cap are both refused.
+        for (label, src) in [
+            (
+                "equal",
+                "(defconst metabolism/entropy-factor 2r :floor 2r :cap 2r)",
+            ),
+            (
+                "inverted",
+                "(defconst metabolism/entropy-factor 2r :floor 3r :cap 2r)",
+            ),
+        ] {
+            let source = format!("(scenario ft/bad-floor-cap {src})");
+            let mut graph = MemoryGraph::new();
+            let err = load_scenario(&source, &mut graph).unwrap_err();
+            assert_eq!(err.code, Some("E-LOAD-052"), "{label}: {}", err.message);
+            assert!(
+                err.message.contains("is not strictly below its own :cap"),
+                "{label}: {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
+    fn floors_own_operand_must_itself_be_a_ratio_literal() {
+        let source = r"
+(scenario ft/bad-floor-operand
+  (defconst metabolism/entropy-factor 1.5r :floor 0.5c))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(
+            err.message.contains(":floor's operand must be a Ratio"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn a_repeated_bound_keyword_is_loud_never_last_one_wins() {
+        let source = r"
+(scenario ft/dup-floor
+  (defconst metabolism/entropy-factor 1.5r :floor 1r :floor 0.5r))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(err.message.contains("given twice"), "{}", err.message);
+    }
+
+    #[test]
+    fn an_unrecognized_bound_keyword_is_refused() {
+        let source = r"
+(scenario ft/bad-keyword
+  (defconst metabolism/entropy-factor 1.5r :ceiling 3r))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(
+            err.message.contains("unrecognized keyword"),
             "{}",
             err.message
         );

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -51,9 +51,10 @@
 //!   defeat that at the one place it is easiest to defeat.
 
 use crate::evaluator::Value;
-use crate::reader::{read_all, Atom, ReadError, SExpr};
+use crate::reader::{read_all, Atom, ReadError, SExpr, ScaledKind};
 use crate::types::{BslType, FieldDecl, FieldKind};
 use babylon_graph::substrate::{GraphError, GraphSubstrate, NodeId};
+use babylon_kernel::Ratio;
 use std::collections::{HashMap, HashSet};
 
 /// Why a scenario would not load.
@@ -240,7 +241,9 @@ pub fn load_scenario(
     })
 }
 
-/// `(defconst <qname> <literal>)`
+/// `(defconst <qname> <literal>)`, or `(defconst <qname> <ratio-literal>
+/// :cap <ratio-literal>)` (§3.2 addendum, Director ruling 2026-08-11,
+/// #492/ADR194 — the declared-domain scale operation).
 ///
 /// The defines environment in miniature (§2.5's `:const`, §4.2's
 /// "the defines environment (coefficients)"). Slice 1 has no
@@ -248,25 +251,61 @@ pub fn load_scenario(
 /// source, so the alternative to declaring the value here is writing it
 /// into the rule — putting a magnitude in the file that owns the shape.
 ///
-/// Of the four literal atom classes §2.2 admits at `:default`, three are
-/// legal here — `Int`, `Scaled`, and `Bool` (defines carry toggles as well
-/// as magnitudes); `Currency` is refused exactly as `:default` refuses it
-/// (no i128 storage in slice 1). The literal-only rule holds for the same
-/// reason `:default`'s does: a define is a value, not an expression, and
-/// an expression would need an evaluation environment that does not exist
-/// at scenario-load time.
+/// Of the five literal atom classes §2.2 admits at `:default` plus §1.5's
+/// addendum, four are legal here — `Int`, `Scaled` (`p`/`i`/`c`/`r`), and
+/// `Bool` (defines carry toggles as well as magnitudes); `Currency` is
+/// refused exactly as `:default` refuses it (no i128 storage in slice 1).
+/// The literal-only rule holds for the same reason `:default`'s does: a
+/// define is a value, not an expression, and an expression would need an
+/// evaluation environment that does not exist at scenario-load time.
+///
+/// **`:cap` (#492/ADR194).** `defconst`/`node`/`edge`/`scenario` are the
+/// `.bscn`-dialect construct `bsl-language.rst` §7 records as OUT of the
+/// consolidated grammar's scope (D93: "no section specifies it") — so
+/// `:cap` is Rust-implementation machinery, not an RST production, and does
+/// NOT go through the closed §1.6 keyword vocabulary or its `E-PARSE-013`
+/// enforcement (this function's own hand-rolled positional match is that
+/// enforcement, same as it already is for `defconst`'s base shape). It is
+/// legal ONLY on a `Ratio` (`r`-suffixed) literal: `Ratio`'s own domain is
+/// already `(0, ∞)` (§1.5 addendum), so `:cap` NARROWS it to `(0, cap]` —
+/// stated at declaration, loud and visible in the source text, and checked
+/// twice: HERE at load (`E-LOAD-052`, the literal must not itself exceed
+/// the cap it declares) and again at every `Currency × Ratio` evaluation
+/// (`E-EVAL-041`, `evaluator::currency_mul_ratio`) — defense in depth, per
+/// III.11. An UNDECLARED (bare, uncapped) `Ratio` defconst is exactly as
+/// legal as before this addendum; the `[0,1]` cap on `p`/`i`/`c` defconsts
+/// is completely untouched — this is a new, disjoint literal kind, not a
+/// widening of the existing three.
 fn load_defconst(
     parts: &[SExpr],
     consts: &mut HashMap<String, Value>,
 ) -> Result<(), ScenarioError> {
-    let [_, SExpr::Atom(Atom::QName(qname)), SExpr::Atom(literal)] = parts else {
-        return Err(err(
-            "expected (defconst <qname> <literal>) — one qualified name, one literal",
-        ));
+    let (qname, literal, cap_literal) = match parts {
+        [_, SExpr::Atom(Atom::QName(qname)), SExpr::Atom(literal)] => (qname, literal, None),
+        [_, SExpr::Atom(Atom::QName(qname)), SExpr::Atom(literal), SExpr::Atom(Atom::Keyword(kw)), SExpr::Atom(cap_literal)]
+            if kw == "cap" =>
+        {
+            (qname, literal, Some(cap_literal))
+        }
+        _ => {
+            return Err(err(
+                "expected (defconst <qname> <literal>) or (defconst <qname> \
+                 <ratio-literal> :cap <ratio-literal>) — one qualified name, \
+                 one literal, and an optional :cap ceiling on a Ratio literal \
+                 only (§3.2 addendum, #492/ADR194)",
+            ))
+        }
     };
     let value = match literal {
-        Atom::Int(value) => Value::Int(*value),
+        Atom::Int(value) => {
+            reject_stray_cap(qname, cap_literal, "an Int")?;
+            Value::Int(*value)
+        }
+        Atom::Scaled(scaled) if scaled.kind == ScaledKind::Ratio => {
+            load_ratio_defconst(qname, scaled, cap_literal)?
+        }
         Atom::Scaled(scaled) => {
+            reject_stray_cap(qname, cap_literal, "a p/i/c literal")?;
             // `unscaled / 10^scale`, the canonical minimal-scale form, and
             // the SAME arithmetic `tick.rs::atom_to_value` performs on a
             // `:default` literal — so a scaled coefficient reads identically
@@ -275,7 +314,10 @@ fn load_defconst(
             let numerator = scaled.unscaled as f64;
             Value::Real(numerator / 10_f64.powi(i32::from(scaled.scale)))
         }
-        Atom::Bool(value) => Value::Bool(*value),
+        Atom::Bool(value) => {
+            reject_stray_cap(qname, cap_literal, "a Bool")?;
+            Value::Bool(*value)
+        }
         // Refused, not carried. `tick.rs::atom_to_value` refuses a Currency
         // `:default` and `attribute_value` above refuses a Currency
         // attribute, both because slice 1 has no typed storage for i128
@@ -308,6 +350,83 @@ fn load_defconst(
         )));
     }
     Ok(())
+}
+
+/// `:cap` is legal only on a `Ratio` literal (see [`load_defconst`]'s doc);
+/// this names the refusal by the OTHER literal kind found instead, rather
+/// than routing through the generic "expected an int, scaled or boolean
+/// literal" arm, which would misdiagnose a well-formed-but-misplaced `:cap`
+/// as a malformed literal.
+fn reject_stray_cap(
+    qname: &str,
+    cap_literal: Option<&Atom>,
+    found: &str,
+) -> Result<(), ScenarioError> {
+    if cap_literal.is_some() {
+        return Err(err(format!(
+            "defconst `{qname}`: :cap is legal only on a Ratio (r-suffixed) \
+             literal (§3.2 addendum, #492/ADR194), found {found}"
+        )));
+    }
+    Ok(())
+}
+
+/// The `Ratio`-literal half of [`load_defconst`]: builds
+/// `Value::Ratio { value, cap }`, checking the declared ceiling at load
+/// (`E-LOAD-052`) when `:cap` is present.
+fn load_ratio_defconst(
+    qname: &str,
+    scaled: &crate::reader::ScaledLit,
+    cap_literal: Option<&Atom>,
+) -> Result<Value, ScenarioError> {
+    let value = ratio_from_scaled(qname, scaled)?;
+    let cap = match cap_literal {
+        None => None,
+        Some(Atom::Scaled(cap_scaled)) if cap_scaled.kind == ScaledKind::Ratio => {
+            let cap = ratio_from_scaled(qname, cap_scaled)?;
+            if value.get() > cap.get() {
+                return Err(coded_err(
+                    "E-LOAD-052",
+                    format!(
+                        "defconst `{qname}`: declared value {} exceeds its own \
+                         :cap {} — a defconst's :cap states the const's OWN \
+                         domain ceiling, so the literal must satisfy it \
+                         (§3.2 addendum, #492/ADR194)",
+                        value.get(),
+                        cap.get()
+                    ),
+                ));
+            }
+            Some(cap)
+        }
+        Some(other) => {
+            return Err(err(format!(
+                "defconst `{qname}`: :cap's operand must be a Ratio \
+                 (r-suffixed) literal, found {other:?}"
+            )))
+        }
+    };
+    Ok(Value::Ratio { value, cap })
+}
+
+/// Convert a canonicalized `r`-literal to a kernel [`Ratio`]. Should never
+/// fail — the reader's `E-LEX-027` already refused a non-positive value at
+/// lex time — but a defensive, named error (rather than an `expect`) keeps
+/// a reader/kernel sort disagreement a loud `ScenarioError`, not a panic.
+fn ratio_from_scaled(
+    qname: &str,
+    scaled: &crate::reader::ScaledLit,
+) -> Result<Ratio, ScenarioError> {
+    #[allow(clippy::cast_precision_loss)]
+    let raw = scaled.unscaled as f64 / 10_f64.powi(i32::from(scaled.scale));
+    Ratio::new(raw).map_err(|e| {
+        err(format!(
+            "defconst `{qname}`: r literal {raw} failed Ratio construction \
+             ({e:?}) — the reader's E-LEX-027 should have refused this at lex \
+             time; reaching here is a reader/kernel sort disagreement, not a \
+             content error"
+        ))
+    })
 }
 
 /// `(deffield <qname> <type-symbol> <kind-symbol>)`
@@ -687,6 +806,116 @@ mod tests {
         assert_eq!(
             loaded.consts["economy/tick-budget"],
             crate::evaluator::Value::Int(12)
+        );
+    }
+
+    // ---- §3.2 addendum, #492/ADR194: Ratio defconsts + :cap ----
+
+    #[test]
+    fn a_bare_ratio_defconst_carries_no_cap() {
+        // No :cap — the domain is Ratio's own (0, ∞), unbounded above.
+        // Matches rent_spike_multiplier's declared domain exactly (Territory
+        // eviction pipeline; "moddable to 2.0" is well inside it).
+        let source = r"
+(scenario ft/uncapped-ratio
+  (defconst territory/rent-spike-multiplier 2.0r))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph).unwrap();
+        match &loaded.consts["territory/rent-spike-multiplier"] {
+            crate::evaluator::Value::Ratio { value, cap } => {
+                assert!((value.get() - 2.0).abs() < 1e-12);
+                assert_eq!(*cap, None);
+            }
+            other => panic!("expected Value::Ratio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_capped_ratio_defconst_within_bounds_loads() {
+        // pareto_alpha's shape: declared domain (0, 10], value 1.5.
+        let source = r"
+(scenario ft/capped-ratio
+  (defconst lifecycle/pareto-alpha 1.5r :cap 10r))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph).unwrap();
+        match &loaded.consts["lifecycle/pareto-alpha"] {
+            crate::evaluator::Value::Ratio { value, cap } => {
+                assert!((value.get() - 1.5).abs() < 1e-12);
+                assert!((cap.expect("cap declared").get() - 10.0).abs() < 1e-12);
+            }
+            other => panic!("expected Value::Ratio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_ratio_defconst_exceeding_its_own_declared_cap_is_e_load_052() {
+        let source = r"
+(scenario ft/over-cap
+  (defconst lifecycle/pareto-alpha 12r :cap 10r))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-052"));
+        assert!(
+            err.message.contains("exceeds its own :cap"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn a_ratio_defconst_exactly_at_its_cap_loads() {
+        // Closed at the top, like every other closed-interval-at-the-top
+        // domain this spec uses (p/i/c's [0,1] accepts the endpoint).
+        let source = r"
+(scenario ft/at-cap
+  (defconst lifecycle/pareto-alpha 10r :cap 10r))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph).unwrap();
+        match &loaded.consts["lifecycle/pareto-alpha"] {
+            crate::evaluator::Value::Ratio { value, cap } => {
+                assert!((value.get() - 10.0).abs() < 1e-12);
+                assert!((cap.unwrap().get() - 10.0).abs() < 1e-12);
+            }
+            other => panic!("expected Value::Ratio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cap_on_a_non_ratio_literal_is_refused() {
+        // :cap narrows Ratio's own (0, ∞) domain specifically — it has no
+        // meaning on a p/i/c literal (already capped [0,1] at lex time) or
+        // an Int, and silently ignoring it would hide an authoring mistake.
+        for (label, src) in [
+            ("c", "(defconst economy/rate 0.5c :cap 10r)"),
+            ("int", "(defconst economy/count 5 :cap 10r)"),
+        ] {
+            let source = format!("(scenario ft/stray-cap {src})");
+            let mut graph = MemoryGraph::new();
+            let err = load_scenario(&source, &mut graph).unwrap_err();
+            assert!(
+                err.message.contains(":cap is legal only on a Ratio"),
+                "{label}: {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
+    fn caps_own_operand_must_itself_be_a_ratio_literal() {
+        let source = r"
+(scenario ft/bad-cap-operand
+  (defconst lifecycle/pareto-alpha 1.5r :cap 0.5c))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(
+            err.message.contains(":cap's operand must be a Ratio"),
+            "{}",
+            err.message
         );
     }
 

--- a/rust/crates/babylon-kernel/src/currency.rs
+++ b/rust/crates/babylon-kernel/src/currency.rs
@@ -15,8 +15,10 @@
 //! ``docs/reference/determinism-contract.rst`` (*Currency Operator
 //! Semantics*): `± Currency`, `× Coefficient` (half-even),
 //! `÷ Currency → Coefficient` (i256 intermediate, half-even),
-//! `÷ integer` (half-even).
-use crate::scalars::Coefficient;
+//! `÷ integer` (half-even). A fifth, `× Ratio` (half-even), joins them per
+//! `bsl-language.rst` §3.2's addendum (Director ruling 2026-08-11,
+//! #492/ADR194) — see [`Currency::mul_ratio`].
+use crate::scalars::{Coefficient, Ratio};
 use bnum::types::I256;
 
 /// A loud, non-recoverable-by-the-algebra overflow (III.11: run-time loud
@@ -100,6 +102,43 @@ impl Currency {
         let numerator = (coeff.get() * MICRO_F64).round() as i128;
         let product = self.0.checked_mul(numerator).ok_or(CurrencyOverflow {
             op: "Currency * Coefficient (pre-round)",
+        })?;
+        Ok(Self(round_half_even_div(product, MICRO)))
+    }
+
+    /// `Currency × Ratio → Currency`, rounded half-even to micro-units
+    /// (`bsl-language.rst` §3.2 addendum, Director ruling 2026-08-11,
+    /// #492/ADR194).
+    ///
+    /// The **only** other legal Currency-mixing operation beyond the
+    /// original four (§6.1's design-doc table): a defconst-declared
+    /// positive coefficient outside `Coefficient`'s `[0,1]` domain — the
+    /// construct gap the Territory eviction pipeline's `rent_spike_multiplier`
+    /// (declared domain `(0, ∞)`), Metabolism's `entropy_factor` and
+    /// Lifecycle's `pareto_alpha`/`early_mortality_modifier`/
+    /// `carceral_transition_modifier` all hit (director-gate #492). `Ratio`
+    /// is the kernel's OWN pre-existing `𝔾 ∩ (0, ∞)` sort (`scalars.rs`) —
+    /// reusing it, rather than minting a new bounded scalar, is what makes
+    /// this "scalar multiplication, not new mathematics" (the ruling's own
+    /// framing).
+    ///
+    /// Identical arithmetic to [`Currency::mul_coefficient`]: `Ratio` lives
+    /// on the same `10⁻⁶` grid (`grid::quantize`), so its exact value is
+    /// `numerator / 1_000_000` with an integer numerator — unbounded above
+    /// unlike `Coefficient`'s `[0, 1_000_000]`, but still comfortably exact
+    /// in `f64` for any realistic scale factor (magnitudes far beyond
+    /// 2⁵³/10⁶ ≈ 9.0×10⁹ are not ratios this algebra produces), and the
+    /// `checked_mul` below catches a product that would leave `i128`
+    /// regardless of how large the numerator is.
+    ///
+    /// # Errors
+    /// Returns [`CurrencyOverflow`] if the pre-rounding product leaves the
+    /// i128 range.
+    pub fn mul_ratio(self, ratio: Ratio) -> Result<Self, CurrencyOverflow> {
+        #[allow(clippy::cast_possible_truncation)]
+        let numerator = (ratio.get() * MICRO_F64).round() as i128;
+        let product = self.0.checked_mul(numerator).ok_or(CurrencyOverflow {
+            op: "Currency * Ratio (pre-round)",
         })?;
         Ok(Self(round_half_even_div(product, MICRO)))
     }
@@ -205,7 +244,7 @@ fn round_half_even_div_i256(numerator: I256, denominator: I256) -> I256 {
 #[cfg(test)]
 mod tests {
     use super::{round_half_even_div, Currency, CurrencyOverflow};
-    use crate::scalars::Coefficient;
+    use crate::scalars::{Coefficient, Ratio};
 
     #[test]
     fn half_even_div_survives_the_most_negative_denominator() {
@@ -300,6 +339,60 @@ mod tests {
             beyond.mul_coefficient(one).unwrap().micro_units(),
             (1_i128 << 53) + 1
         );
+    }
+
+    #[test]
+    fn mul_ratio_is_exact_integer_arithmetic() {
+        // 10.000000 units × 1.5 = 15.000000 units, exactly — the whole
+        // point: 1.5 is outside Coefficient's [0,1] domain (#492/ADR194).
+        let c = Currency::from_micro_units(10 * 1_000_000);
+        let one_point_five = Ratio::new(1.5).unwrap();
+        assert_eq!(
+            c.mul_ratio(one_point_five).unwrap().micro_units(),
+            15_000_000
+        );
+    }
+
+    #[test]
+    fn mul_ratio_half_even_on_the_micro_unit_tie() {
+        // 1 micro-unit × 0.5 would tie, but Ratio's domain is (0, ∞) with
+        // no relation to Coefficient — use an equivalent tie via a Ratio
+        // value: 1 micro-unit × 2.5 = 2.5 -> 2 (even), not 3.
+        let c = Currency::from_micro_units(1);
+        let two_point_five = Ratio::new(2.5).unwrap();
+        assert_eq!(c.mul_ratio(two_point_five).unwrap().micro_units(), 2);
+        // 3 micro-units × 2.5 = 7.5 -> 8 (even), not 7.
+        let c3 = Currency::from_micro_units(3);
+        assert_eq!(c3.mul_ratio(two_point_five).unwrap().micro_units(), 8);
+    }
+
+    #[test]
+    fn mul_ratio_survives_beyond_f64_exact_range() {
+        let beyond = Currency::from_micro_units((1_i128 << 53) + 1);
+        let one = Ratio::new(1.0).unwrap();
+        assert_eq!(
+            beyond.mul_ratio(one).unwrap().micro_units(),
+            (1_i128 << 53) + 1
+        );
+    }
+
+    #[test]
+    fn mul_ratio_accepts_values_far_outside_the_unit_interval() {
+        // rent_spike_multiplier's declared domain is (0, ∞) — moddable to
+        // 2.0 per the port train's fixture; a large ratio (10x, matching
+        // pareto_alpha/carceral_transition_modifier's (0,10] ceiling class)
+        // is ordinary arithmetic here, not a special case.
+        let c = Currency::from_micro_units(1_000_000); // 1.0
+        let ten = Ratio::new(10.0).unwrap();
+        assert_eq!(c.mul_ratio(ten).unwrap().micro_units(), 10_000_000);
+    }
+
+    #[test]
+    fn mul_ratio_overflow_is_loud() {
+        let huge = Currency::from_micro_units(i128::MAX);
+        let two = Ratio::new(2.0).unwrap();
+        let err = huge.mul_ratio(two).unwrap_err();
+        assert_eq!(err.op, "Currency * Ratio (pre-round)");
     }
 
     #[test]

--- a/rust/crates/babylon-tick/Cargo.toml
+++ b/rust/crates/babylon-tick/Cargo.toml
@@ -11,6 +11,12 @@ publish = false
 babylon-bsl = { path = "../babylon-bsl" }
 babylon-graph = { path = "../babylon-graph" }
 
+[dev-dependencies]
+# Test-only: the currency-scale-op E2E test asserts an exact `Currency`
+# value (#492/ADR194) — babylon-kernel is a transitive dependency already
+# (via babylon-bsl), this makes it a direct one for the test's own use.
+babylon-kernel = { path = "../babylon-kernel" }
+
 [lib]
 name = "babylon_tick"
 path = "src/lib.rs"

--- a/rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs
+++ b/rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs
@@ -1,0 +1,159 @@
+//! The composed-path proof for the declared-domain Currency scale operation
+//! (`bsl-language.rst` §3.2 addendum, Director ruling 2026-08-11,
+//! #492/ADR194): a scenario declaring a `defconst`-with-`:cap` Ratio and a
+//! rule computing `Currency × Ratio` clear content, load and evaluation
+//! through the SAME `run_once`/`run_once_into` the CLI driver and
+//! `babylon-client`'s engine link both call — the composed-path lesson
+//! `floor_intrinsic_e2e.rs` records (round 1 of ADR188 Row 2's review
+//! shipped a helper only a test called; this crate's E2E tests exist so a
+//! seam is proved through the REAL entry point, not a lookalike).
+//!
+//! **Why the money value is an inline literal, not a `:field`.** Slice 1's
+//! `GraphSubstrate` attributes are plain `f64` (`scenario.rs`'s own module
+//! doc: "No `Currency` attributes" — typed i128 attribute storage is a
+//! declared Phase-2 trait revision) and `defconst` refuses a `Currency`
+//! literal for the identical reason (`scenario.rs::load_defconst`,
+//! unchanged by this addendum). A `Currency` value can currently enter a
+//! rule's evaluation ONLY as a literal written directly in the rule body —
+//! true before this change and after it; this test's rule reads that
+//! literal exactly the way an eviction-pipeline rule will once Territory's
+//! own port train lands (out of scope here — this proves the MACHINERY).
+//!
+//! **Why the result is `emit`ted, not `update-node`d.** The identical gap:
+//! `update-node` refuses a `Currency` write (`structural_verbs.rs`'s
+//! `currency_writes_are_a_loud_declared_gap_never_a_lossy_cast`), while
+//! `emit`'s payload is an evaluated [`babylon_bsl::evaluator::Value`] with
+//! no type restriction (`emit_collects_the_evaluated_payload`). Observing
+//! the product through the event sink sidesteps the graph-storage gap
+//! entirely rather than working around it.
+//!
+//! Territory's real `rent_spike_multiplier` is `1500.5$ × 2.0` — the exact
+//! shape this test proves, with the exact numbers the port train's fixture
+//! cites (§492's issue body: "tested moddable to 2.0").
+
+use babylon_bsl::evaluator::Value;
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::memory::MemoryGraph;
+use babylon_tick::run_once_into;
+
+const SCENARIO: &str = r#"
+(scenario scale-op-e2e/one-territory
+  (deffield territory/population int extensive)
+  (defconst territory/rent-spike-multiplier 2.0r :cap 10r)
+
+  (node core NodeType/TERRITORY
+    (territory/population 1)))
+"#;
+
+const RULE: &str = r#"
+(rule vitality/scale-op-e2e-rent-spike
+  :material-basis "prove Currency x declared-domain Ratio clears content, load and evaluation (#492/ADR194)"
+  :fuel 64
+  (bindings
+    (binding population :field territory/population)
+    (binding multiplier :const territory/rent-spike-multiplier)
+    (binding spiked-rent :expr (* 1500.5$ multiplier)))
+  (when (> population 0))
+  (effects
+    (emit EventType/RUPTURE (spiked-rent spiked-rent))))
+"#;
+
+#[test]
+fn a_rule_scaling_currency_by_a_declared_domain_ratio_runs_through_run_once() {
+    let mut graph = MemoryGraph::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(SCENARIO, RULE, &mut graph, &mut sink)
+        .expect("Currency x declared-domain Ratio must clear the whole seam");
+
+    assert_eq!(report.fired, 1);
+
+    assert_eq!(sink.events.len(), 1);
+    let (event_type, payload) = &sink.events[0];
+    assert_eq!(event_type, "RUPTURE");
+    let (name, value) = &payload[0];
+    assert_eq!(name, "spiked-rent");
+
+    // 1500.5$ x 2.0 = 3001.0$ exactly — a fixed-point x grid-quantized
+    // multiply, no binary64 rounding ambiguity at these values.
+    assert_eq!(
+        *value,
+        Value::Currency(babylon_kernel::Currency::from_micro_units(3_001_000_000)),
+        "1500.5$ * 2.0r must equal exactly 3001.0$"
+    );
+}
+
+#[test]
+fn the_declared_call_is_deterministic_across_two_full_runs() {
+    let mut graph_a = MemoryGraph::new();
+    let mut sink_a = CollectingSink::default();
+    let a = run_once_into(SCENARIO, RULE, &mut graph_a, &mut sink_a).expect("first run");
+
+    let mut graph_b = MemoryGraph::new();
+    let mut sink_b = CollectingSink::default();
+    let b = run_once_into(SCENARIO, RULE, &mut graph_b, &mut sink_b).expect("second run");
+
+    assert_eq!(a.after, b.after);
+    assert_eq!(sink_a.events, sink_b.events);
+}
+
+/// The declared `:cap` fails the WHOLE tick, loudly, when the scenario
+/// itself is inconsistent (`E-LOAD-052`) — proved through the full
+/// `run_once` seam, not just `scenario::tests`' narrower call into
+/// `load_scenario` alone (this is the same "prove it through the real
+/// entry point" argument the module doc makes for the whole file).
+///
+/// **This does NOT reach `E-EVAL-041`, and that absence is itself
+/// recorded rather than papered over.** `load_scenario` runs before
+/// `load_rule_form`/`run_tick` in `run_once_into`, so an inconsistent
+/// `(value, cap)` pair is refused before a rule ever evaluates it — through
+/// `defconst`, the ONLY producer of a capped `Value::Ratio` today, the two
+/// checks can never observe different verdicts. `E-EVAL-041`'s own defense-
+/// in-depth case (a `Value::Ratio` whose `cap` and `value` disagree despite
+/// having passed load — e.g. a future non-`defconst` source) is unit-tested
+/// directly in `evaluator.rs`, where it CAN be constructed.
+#[test]
+fn a_ratio_over_its_declared_cap_fails_the_whole_tick_loudly() {
+    const OVER_CAP_SCENARIO: &str = r#"
+(scenario scale-op-e2e/over-cap
+  (deffield territory/population int extensive)
+  (defconst territory/rent-spike-multiplier 12r :cap 10r)
+
+  (node core NodeType/TERRITORY
+    (territory/population 1)))
+"#;
+    let mut graph = MemoryGraph::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(OVER_CAP_SCENARIO, RULE, &mut graph, &mut sink).unwrap_err();
+    assert!(
+        err.contains("exceeds its own :cap"),
+        "unexpected message: {err}"
+    );
+}
+
+/// The mirror success case: a bare (uncapped) declared-domain Ratio — the
+/// exact shape `rent_spike_multiplier`'s real `(0, ∞)` domain has — still
+/// clears the whole seam and multiplies cleanly for a value an ordinary
+/// `Coefficient` could never have carried (well above `1.0`).
+#[test]
+fn an_uncapped_declared_domain_ratio_also_clears_the_whole_seam() {
+    const UNCAPPED_SCENARIO: &str = r#"
+(scenario scale-op-e2e/uncapped
+  (deffield territory/population int extensive)
+  (defconst territory/rent-spike-multiplier 5r)
+
+  (node core NodeType/TERRITORY
+    (territory/population 1)))
+"#;
+    let mut graph = MemoryGraph::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(UNCAPPED_SCENARIO, RULE, &mut graph, &mut sink)
+        .expect("an uncapped declared-domain Ratio must still clear the seam");
+    assert_eq!(report.fired, 1);
+    let (_, payload) = &sink.events[0];
+    let (_, value) = &payload[0];
+    assert_eq!(
+        *value,
+        Value::Currency(babylon_kernel::Currency::from_micro_units(7_502_500_000)),
+        "1500.5$ * 5.0r must equal exactly 7502.5$"
+    );
+}

--- a/rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs
+++ b/rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs
@@ -302,12 +302,11 @@ const GATED_RULE_TEMPLATE: &str = r#"
   (bindings
     (binding population :field territory/population)
     (binding channel-active :const lifecycle/channel-active)
-    (binding modifier :const lifecycle/early-mortality-modifier)
-    (binding scaled-mortality :expr (* 1000$ modifier)))
+    (binding modifier :const lifecycle/early-mortality-modifier))
   (when (> population 0))
   (effects
     (guard channel-active
-      (emit EventType/RUPTURE (scaled-mortality scaled-mortality)))))
+      (emit EventType/RUPTURE (scaled-mortality (* 1000$ modifier))))))
 "#;
 
 /// The channel-ACTIVE case: the guard's condition is `#t`, so the
@@ -341,8 +340,13 @@ fn a_guard_gated_ratio_multiply_fires_when_the_channel_is_active() {
 /// The channel-OFF case — the frozen engine's `early_mortality_modifier =
 /// 0.0` behavior, expressed WITHOUT ever writing `0r` (which cannot exist):
 /// the guard's condition is `#f`, so the `Currency × Ratio` multiply is
-/// never even evaluated, and no event is emitted — "the multiply's
-/// absence", proved by an EMPTY event list, not a zero-valued one.
+/// never evaluated and no event is emitted — "the multiply's absence",
+/// proved by an EMPTY event list. The multiply sits INLINE in the guarded
+/// `emit`, which is what makes that claim true: `run_tick` resolves
+/// `:expr` BINDINGS before any guard (the #498 lesson), so a
+/// binding-shaped multiply would run — and fuel-charge, and surface any
+/// eval error — under a false guard. Guarded effect bodies are genuinely
+/// lazy; bindings are not.
 #[test]
 fn a_guard_gated_ratio_multiply_never_evaluates_when_the_channel_is_off() {
     let scenario = GATED_SCENARIO.replace(

--- a/rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs
+++ b/rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs
@@ -157,3 +157,209 @@ fn an_uncapped_declared_domain_ratio_also_clears_the_whole_seam() {
         "1500.5$ * 5.0r must equal exactly 7502.5$"
     );
 }
+
+// ---- :floor (DEFECT 1 fix round, adversarial verification of #500) ----
+//
+// Metabolism's `entropy_factor` is the exemplar consumer the addendum
+// itself names for `:floor`: declared domain `(1.0, 3.0]` — the floor is
+// the whole thermodynamic point ("extraction costs more than it yields"),
+// not decoration. The worked example, byte for byte:
+// `(defconst metabolism/entropy-factor 1.5r :floor 1r :cap 3r)`.
+
+const FLOOR_SCENARIO: &str = r#"
+(scenario scale-op-e2e/entropy-factor
+  (deffield territory/population int extensive)
+  (defconst metabolism/entropy-factor 1.5r :floor 1r :cap 3r)
+
+  (node core NodeType/TERRITORY
+    (territory/population 1)))
+"#;
+
+const FLOOR_RULE: &str = r#"
+(rule vitality/scale-op-e2e-entropy-factor
+  :material-basis "prove Currency x a floored-AND-capped declared-domain Ratio (#492/ADR194) — entropy_factor's exact shape"
+  :fuel 64
+  (bindings
+    (binding population :field territory/population)
+    (binding factor :const metabolism/entropy-factor)
+    (binding scaled-extraction :expr (* 1000$ factor)))
+  (when (> population 0))
+  (effects
+    (emit EventType/RUPTURE (scaled-extraction scaled-extraction))))
+"#;
+
+/// `entropy_factor`'s own worked example clears the whole seam: `1000$ ×
+/// 1.5 = 1500.0$` exactly, with BOTH bounds declared and satisfied.
+#[test]
+fn a_rule_scaling_currency_by_a_floored_and_capped_ratio_runs_through_run_once() {
+    let mut graph = MemoryGraph::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(FLOOR_SCENARIO, FLOOR_RULE, &mut graph, &mut sink)
+        .expect("Currency x a floored-and-capped Ratio must clear the whole seam");
+    assert_eq!(report.fired, 1);
+    let (_, payload) = &sink.events[0];
+    let (_, value) = &payload[0];
+    assert_eq!(
+        *value,
+        Value::Currency(babylon_kernel::Currency::from_micro_units(1_500_000_000)),
+        "1000$ * 1.5r must equal exactly 1500.0$"
+    );
+}
+
+/// The defect this train fixes, proved at the entry point: a modded
+/// `entropy_factor 0.5r` — BELOW the floor `> 1.0` exists to forbid,
+/// exactly the violation the ceiling-only machinery could not catch — now
+/// fails the whole tick loudly at load, never evaluating silently.
+#[test]
+fn a_modded_entropy_factor_below_its_floor_fails_the_whole_tick_loudly() {
+    const BELOW_FLOOR_SCENARIO: &str = r#"
+(scenario scale-op-e2e/entropy-factor-modded-low
+  (deffield territory/population int extensive)
+  (defconst metabolism/entropy-factor 0.5r :floor 1r :cap 3r)
+
+  (node core NodeType/TERRITORY
+    (territory/population 1)))
+"#;
+    let mut graph = MemoryGraph::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(BELOW_FLOOR_SCENARIO, FLOOR_RULE, &mut graph, &mut sink).unwrap_err();
+    assert!(
+        err.contains("does not exceed its own :floor"),
+        "unexpected message: {err}"
+    );
+}
+
+/// The exact boundary `entropy_factor`'s `> 1.0` (not `>= 1.0`) exists to
+/// forbid: a value AT the floor is still refused, even though it is not
+/// BELOW it — the exclusive endpoint, proved through the full seam.
+#[test]
+fn a_modded_entropy_factor_exactly_at_its_floor_fails_the_whole_tick_loudly() {
+    const AT_FLOOR_SCENARIO: &str = r#"
+(scenario scale-op-e2e/entropy-factor-at-floor
+  (deffield territory/population int extensive)
+  (defconst metabolism/entropy-factor 1r :floor 1r :cap 3r)
+
+  (node core NodeType/TERRITORY
+    (territory/population 1)))
+"#;
+    let mut graph = MemoryGraph::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(AT_FLOOR_SCENARIO, FLOOR_RULE, &mut graph, &mut sink).unwrap_err();
+    assert!(
+        err.contains("does not exceed its own :floor"),
+        "unexpected message: {err}"
+    );
+}
+
+// ---- the zero-endpoint disposition (DEFECT 2 fix round, adversarial
+// verification of #500) ----
+//
+// `Ratio` cannot hold `0` — that is structural, not an oversight: the
+// ruling's own text says "positive coefficient", the reader's `E-LEX-027`
+// refuses a `0r` literal before it is even a token, and `Ratio::new(0.0)`
+// itself refuses at the kernel layer (`scalars.rs`, `Ratio`'s law is
+// `𝔾 ∩ (0, ∞)`, open at zero). Lifecycle's `early_mortality_modifier`/
+// `carceral_transition_modifier` are `ge=0.0` in the frozen engine, and the
+// frozen engine actively PRODUCES `0.0` for them (`mobility.py:187-188` —
+// the mortality channel OFF, semantically meaningful, not an error case).
+// This addendum's Ratio lane carries these two consumers' domain `(0, 10]`
+// INTERIOR only — the open zero endpoint is not representable as a Ratio
+// value, full stop, by the same law that makes the whole construct "a
+// POSITIVE coefficient" rather than a general-purpose bounded scalar.
+//
+// "Zero-scaling is the multiply's ABSENCE, not a scale" (the fix-round
+// instruction's own framing): the general MECHANISM for expressing "this
+// channel is off, contribute nothing" already exists in the language and
+// needs no new construct — `guard` (§2.8) gates whether an EFFECT fires at
+// all, on a signal SEPARATE from the Ratio-typed magnitude (never "the
+// Ratio equals zero", which cannot be written). This proves that mechanism
+// clears the whole seam, empirically, not just by static reasoning about
+// the grammar: a `guard`-gated `Currency × Ratio` effect, keyed off an
+// ordinary Bool `:const`, fires when the flag is true and is skipped
+// (never evaluating the multiply at all) when it is false — exactly "the
+// multiply's absence".
+//
+// **What this does NOT settle, and says so plainly**: WHICH signal a real
+// Lifecycle port gates on (a dedicated activation const? a doctrine tag? a
+// field read?) is that port's own content-modeling decision, not
+// machinery — the same way this whole train ports no consumer. This proves
+// only that the MECHANISM is available and typechecks/evaluates cleanly
+// through the real entry point; it does not pre-choose Lifecycle's answer.
+
+const GATED_SCENARIO: &str = r#"
+(scenario scale-op-e2e/gated-modifier
+  (deffield territory/population int extensive)
+  (defconst lifecycle/early-mortality-modifier 1.24r)
+
+  (node core NodeType/TERRITORY
+    (territory/population 1)))
+"#;
+
+const GATED_RULE_TEMPLATE: &str = r#"
+(rule vitality/scale-op-e2e-gated-modifier
+  :material-basis "prove a guard-gated Currency x Ratio effect is the content-layer answer to a zero-valued frozen-engine modifier — the multiply's absence, never a Ratio of zero (#492/ADR194)"
+  :fuel 64
+  (bindings
+    (binding population :field territory/population)
+    (binding channel-active :const lifecycle/channel-active)
+    (binding modifier :const lifecycle/early-mortality-modifier)
+    (binding scaled-mortality :expr (* 1000$ modifier)))
+  (when (> population 0))
+  (effects
+    (guard channel-active
+      (emit EventType/RUPTURE (scaled-mortality scaled-mortality)))))
+"#;
+
+/// The channel-ACTIVE case: the guard's condition is `#t`, so the
+/// `Currency × Ratio` effect fires and the exact product is observed —
+/// `1000$ × 1.24 = 1240.0$`.
+#[test]
+fn a_guard_gated_ratio_multiply_fires_when_the_channel_is_active() {
+    let scenario = GATED_SCENARIO.replace(
+        "(node core",
+        "(defconst lifecycle/channel-active #t)\n\n  (node core",
+    );
+    let mut graph = MemoryGraph::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(&scenario, GATED_RULE_TEMPLATE, &mut graph, &mut sink)
+        .expect("a guard-gated Currency x Ratio effect must clear the whole seam");
+    assert_eq!(report.fired, 1);
+    assert_eq!(
+        sink.events.len(),
+        1,
+        "the guard must have let the effect through"
+    );
+    let (_, payload) = &sink.events[0];
+    let (_, value) = &payload[0];
+    assert_eq!(
+        *value,
+        Value::Currency(babylon_kernel::Currency::from_micro_units(1_240_000_000)),
+        "1000$ * 1.24r must equal exactly 1240.0$"
+    );
+}
+
+/// The channel-OFF case — the frozen engine's `early_mortality_modifier =
+/// 0.0` behavior, expressed WITHOUT ever writing `0r` (which cannot exist):
+/// the guard's condition is `#f`, so the `Currency × Ratio` multiply is
+/// never even evaluated, and no event is emitted — "the multiply's
+/// absence", proved by an EMPTY event list, not a zero-valued one.
+#[test]
+fn a_guard_gated_ratio_multiply_never_evaluates_when_the_channel_is_off() {
+    let scenario = GATED_SCENARIO.replace(
+        "(node core",
+        "(defconst lifecycle/channel-active #f)\n\n  (node core",
+    );
+    let mut graph = MemoryGraph::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(&scenario, GATED_RULE_TEMPLATE, &mut graph, &mut sink)
+        .expect("a false guard must skip its effect, not fail the tick");
+    assert_eq!(
+        report.fired, 1,
+        "the rule still ran — only the guarded effect was skipped"
+    );
+    assert!(
+        sink.events.is_empty(),
+        "the multiply must never evaluate when the channel is off: {:?}",
+        sink.events
+    );
+}

--- a/tests/unit/reference/test_bsl_grammar_sync.py
+++ b/tests/unit/reference/test_bsl_grammar_sync.py
@@ -560,3 +560,32 @@ class TestTheRatioLiteralStaysInSync:
             "the declared-domain Currency scale operation is a decision and "
             "owes a Draft-Ruling Register row (#492/ADR194)"
         )
+
+
+class TestTheDraftRulingRegisterHasNoDuplicateRowNumbers:
+    """A second row naming a D-number already in use passes every
+    existence-only check above — each of D94/D95/D98/D99's own tests just
+    confirms ITS OWN number appears somewhere, which stays true whether
+    that number appears once or twice. This is the guard a numbering
+    COLLISION between two concurrently-drafted PRs needs: #500 (this
+    addendum) and a parallel plan both independently reached for D99, and
+    the collision was caught by a human noticing during review, not by any
+    test — this row makes the next one mechanical.
+    """
+
+    def test_every_register_row_number_is_unique(self) -> None:
+        body = _read(RST)
+        start = body.index("\nDraft-Ruling Register\n")
+        end = body.index("\nSee Also\n", start)
+        section = body[start:end]
+        numbers = re.findall(r"^   \* - D(\d+)$", section, re.MULTILINE)
+        assert len(numbers) >= 90, (
+            f"only found {len(numbers)} register rows — the section "
+            "boundaries this test scans between may have drifted"
+        )
+        duplicates = sorted({n for n in numbers if numbers.count(n) > 1}, key=int)
+        assert not duplicates, (
+            f"the Draft-Ruling Register has duplicate row numbers: {duplicates} "
+            "— two rows claiming the same D-number, exactly the collision "
+            "class a concurrently-drafted PR can introduce"
+        )

--- a/tests/unit/reference/test_bsl_grammar_sync.py
+++ b/tests/unit/reference/test_bsl_grammar_sync.py
@@ -501,3 +501,62 @@ class TestTheIntrinsicTypeNameVocabulary:
         assert re.search(r"^\s+\* - D98$", body, re.MULTILINE), (
             "the intrinsic-type-name widening is a decision and owes a Draft-Ruling Register row"
         )
+
+
+class TestTheRatioLiteralStaysInSync:
+    """D99's own drift class (#492/ADR194, the declared-domain Currency scale
+    operation) — guarded at the RIGHT-HAND-SIDE grain, the same class of gap
+    ``TestTheIntrinsicTypeNameVocabulary`` guards for D98.
+
+    ``suffix`` is a normal production by every generic test above — its
+    left-hand-side name is defined in both the rst and the appendix, so
+    ``TestTheAppendixCollectsTheSections`` is satisfied whether or not its
+    alternatives actually agree. A silent regression that dropped the ``r``
+    alternative from ONE side (or added it to the appendix without §1.5's
+    literal-table row backing it) would leave every generic row green while
+    the declared-domain scale operation quietly lost its only way to be
+    WRITTEN. These rows read the production body and the section prose, not
+    just the production's name.
+    """
+
+    def test_the_ebnf_suffix_production_admits_r(self) -> None:
+        rhs = _ebnf_production_rhs("suffix")
+        assert '"r"' in rhs, (
+            "bsl.ebnf's suffix production dropped the `r` alternative (D99, "
+            "#492/ADR194) — the declared-domain Ratio literal has no other "
+            "way to be written"
+        )
+
+    def test_the_rst_documents_the_r_literal_row(self) -> None:
+        body = _read(RST)
+        assert re.search(r"\*\s*-\s*``r``\s*\n\s*-\s*``Ratio``", body), (
+            "bsl-language.rst §1.5's literal table must carry the `r` / "
+            "Ratio row (D99, #492/ADR194)"
+        )
+
+    def test_e_lex_027_is_the_non_positive_ratio_code(self) -> None:
+        body = _read(RST)
+        assert "E-LEX-027" in body, (
+            "a non-positive Ratio literal needs its own lex-time code "
+            "(D99, #492/ADR194) — the reference names E-LEX-027"
+        )
+
+    def test_currency_times_ratio_is_documented_in_section_3_2(self) -> None:
+        body = _read(RST)
+        start = body.index("3.2 Currency operator")
+        end = body.index("3.3 The two numeric lanes", start)
+        section = body[start:end]
+        assert "Currency × Ratio" in section, (
+            "§3.2 must state the Currency × Ratio operation (D99, "
+            "#492/ADR194) — the whole point of the addendum"
+        )
+        assert "E-EVAL-041" in section, (
+            "§3.2 must name the eval-time declared-domain check's code (E-EVAL-041, D99)"
+        )
+
+    def test_d99_is_recorded_in_the_register(self) -> None:
+        body = _read(RST)
+        assert re.search(r"^\s+\* - D99$", body, re.MULTILINE), (
+            "the declared-domain Currency scale operation is a decision and "
+            "owes a Draft-Ruling Register row (#492/ADR194)"
+        )

--- a/tools/tree-sitter-bsl/grammar.js
+++ b/tools/tree-sitter-bsl/grammar.js
@@ -454,8 +454,12 @@ module.exports = grammar({
     int_lit: (_$) => token(/-?[0-9](_?[0-9])*/),
 
     /* §1.5: the kind suffix is mandatory; a bare `0.5` is E-LEX-021 and is
-     * therefore not a token of this grammar at all. */
-    scaled_lit: (_$) => token(/-?[0-9](_?[0-9])*(\.[0-9](_?[0-9])*)?[$pic]/),
+     * therefore not a token of this grammar at all. `r` (Ratio) joins
+     * `$`/`p`/`i`/`c` per the §1.5 addendum (D99, #492/ADR194) — this
+     * grammar does not distinguish a literal's DOMAIN (E-LEX-024/027 are
+     * load-time-shaped checks the reference implementation makes, not a
+     * syntactic one this tokenizer can express), only its lexical SHAPE. */
+    scaled_lit: (_$) => token(/-?[0-9](_?[0-9])*(\.[0-9](_?[0-9])*)?[$picr]/),
 
     /* §1.5: the only four escapes; strings are single-line. */
     string: (_$) => token(/"([^"\\\n]|\\["\\nt])*"/),

--- a/tools/tree-sitter-bsl/grammar.js
+++ b/tools/tree-sitter-bsl/grammar.js
@@ -457,8 +457,8 @@ module.exports = grammar({
      * therefore not a token of this grammar at all. `r` (Ratio) joins
      * `$`/`p`/`i`/`c` per the §1.5 addendum (D99, #492/ADR194) — this
      * grammar does not distinguish a literal's DOMAIN (E-LEX-024/027 are
-     * load-time-shaped checks the reference implementation makes, not a
-     * syntactic one this tokenizer can express), only its lexical SHAPE. */
+     * lex-time domain checks the reference reader makes semantically, not
+     * something this tokenizer can express), only its lexical SHAPE. */
     scaled_lit: (_$) => token(/-?[0-9](_?[0-9])*(\.[0-9](_?[0-9])*)?[$picr]/),
 
     /* §1.5: the only four escapes; strings are single-line. */

--- a/tools/tree-sitter-bsl/test/corpus/lexical.txt
+++ b/tools/tree-sitter-bsl/test/corpus/lexical.txt
@@ -17,7 +17,8 @@ Every atom class (§1.4, §1.5)
              (!= NodeType/SOCIAL_CLASS NodeType/POLITY)
              (>= wealth 0.123456789p)
              (>= wealth 0.50c)
-             (>= wealth 1.0i)))
+             (>= wealth 1.0i)
+             (>= wealth 2.0r)))
   (effects
     (update-node self social-class/agitation (add 0.05i))))
 
@@ -75,6 +76,11 @@ Every atom class (§1.4, §1.5)
           (cmp)
           (enum_ref)
           (enum_ref))
+        (comparison
+          (cmp)
+          (symbol)
+          (literal
+            (scaled_lit)))
         (comparison
           (cmp)
           (symbol)


### PR DESCRIPTION
## Summary

Implements Director ruling 2026-08-11 (#492, ADR194): **the declared-domain Currency scale operation**.

> Add one legal operation: Currency scaled by a defconst-declared positive coefficient whose domain is stated at declaration and enforced loudly at load/eval. Scalar multiplication isn't new mathematics — this reads as machinery, keeps defines' moddable shape intact.

Closes director-gate #492 Blocker-1: Territory's `rent_spike_multiplier`, Metabolism's `entropy_factor`, and Lifecycle's `pareto_alpha`/`early_mortality_modifier`/`carceral_transition_modifier` are runtime-moddable coefficients with a declared domain beyond `[0,1]` that had **no BSL representation at all** — not just "cannot multiply Currency", literally unwritable. This PR lands the machinery only; each consumer ports in its own train.

## Design

- **New literal**: `r`-suffixed `Ratio`, domain `(0, ∞)`, reusing the **pre-existing** kernel sort `babylon_kernel::scalars::Ratio` rather than minting a new bounded scalar or widening `Coefficient`'s `[0,1]` cap. Non-positive is `E-LEX-027`.
- **New operator**: `Currency × Ratio → Currency`, half-even, commutative — added to §3.2 as an addendum after the verbatim design-doc quotation, never editing it in place. `Ratio` gets exactly this one operator, nothing else — "scalar multiplication isn't new mathematics" read literally.
- **Declared ceiling**: `defconst`'s new optional `:cap` keyword narrows `Ratio`'s `(0, ∞)` to `(0, cap]` — e.g. `(defconst lifecycle/pareto-alpha 1.5r :cap 10r)`. Checked at load (`E-LOAD-052`, self-consistency) and again at every `Currency × Ratio` evaluation (`E-EVAL-041`, defense in depth). `:cap` is Rust/`.bscn`-dialect machinery, not RST grammar — `defconst` is already recorded (D93) as outside the consolidated grammar's scope, and extending that boundary would have been a second, unrelated decision.
- **Rejected**: widening `p`/`i`/`c`'s existing `[0,1]` cap (would silently change every existing coefficient's domain); a context-sensitive lexer rule (the reader classifies position-independently, same as `Currency`); minting a new bounded-scalar kernel type (when `Ratio` already states the needed law).

Recorded as **D99** in the Draft-Ruling Register (`docs/reference/bsl-language.rst`).

## Changes

- `rust/crates/babylon-kernel/src/currency.rs` — `Currency::mul_ratio`, mirroring `mul_coefficient`.
- `rust/crates/babylon-bsl/src/reader.rs` — `ScaledKind::Ratio`, `E-LEX-027`.
- `rust/crates/babylon-bsl/src/canonical_ast.rs` — additive `"ratio"` CAS kind tag (§5.6 worked example's 421 bytes proved unmoved).
- `rust/crates/babylon-bsl/src/evaluator.rs` — `Value::Ratio{value, cap}`, `currency_mul_ratio`, `E-EVAL-041`.
- `rust/crates/babylon-bsl/src/scenario.rs` — `defconst`'s `:cap`, `E-LOAD-052`.
- `rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs` — E2E proof through `run_once`/`run_once_into` (the composed-path lesson `floor_intrinsic_e2e.rs` established): `1500.5$ × 2.0r = 3001.0$` exactly, observed through `emit` (Currency has no field-storage path in slice 1 on either read or write side yet — a pre-existing, documented gap, not something this PR introduces).
- `docs/reference/bsl-language.rst`, `docs/reference/bsl.ebnf` — §1.5 literal row, §3.1 non-storable type, §3.2 operator addendum, §4.6 error taxonomy (+ a repair of a pre-existing transcription gap: `E-EVAL-039` was missing from the contiguity range, found while allocating `E-EVAL-041` in the same family), D99.
- `tools/tree-sitter-bsl/grammar.js` + `test/corpus/lexical.txt` — the `r` suffix, corpus-exercised.
- `tests/unit/reference/test_bsl_grammar_sync.py` — new `TestTheRatioLiteralStaysInSync` guard class (5 rows), mirroring D98's pattern.

## Test plan

- [x] `cargo test --workspace --exclude babylon-client` — 100% green, all pre-existing golden hashes unmoved.
- [x] `cargo clippy --workspace --exclude babylon-client --lib --tests --bins` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `mise run bsl:grammar-test` (tree-sitter, 30/30 corpus cases) — green.
- [x] `uv run pytest tests/unit/reference/test_bsl_grammar_sync.py` — 27/27 green.
- [x] Mutation-verified by hand (perturb, confirm red, restore): all 5 new sync-guard rows; 4 Rust-side invariants (declared-domain ignored, wrong domain bound at the boundary, silent-clamp-instead-of-loud-refusal at load, non-positive check bypassed at lex).
- [x] E2E: `1500.5$ × 2.0r = 3001.0$` and `× 5.0r = 7502.5$`, exact, through the real `run_once` entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)