### PR TITLE
feat(rust): port MetabolismSystem to a BSL rule pack (P27)

### DIFF
--- a/reports/metabolism-port-assessment-2026-08-11.md
+++ b/reports/metabolism-port-assessment-2026-08-11.md
@@ -185,16 +185,49 @@ hold for the actual port.
 scaled bare-`Int` `:const`, the same escape hatch Dispossession's own D-2/D-4 already
 use and document (`dispossession.bsl:118-139`: *"`defconst` also accepts a BARE
 `Atom::Int`... a bare Int carries NO domain check at all"*) — `entropy_factor` is
-declared `(defconst metabolism/entropy-factor-x1e6 1200000)` (scaled ×1,000,000 to carry
-the coefficient's full fractional precision as an exact integer) and divided back out
-inline: `(/ (* raw-extraction entropy-factor-x1e6) 1000000)`. This preserves the
-formula's exact value for the DEFAULT `entropy_factor = 1.2` and for any legal
-`(1.0, 3.0]` modded value (no domain narrowing, unlike a Coefficient-decomposition
-attempt — see the rule pack's D-1 for why that alternative was rejected) — at the cost
-of the SAME load-time domain-enforcement gap Dispossession's own weights already carry
-without objection. **This is recorded as an open finding for the language surface, not
-resolved by this port**: `Real × Ratio` (or `Ratio`-typed field storage) is a genuine
-follow-up the BSL spec owners should rule on; this port does not attempt that ruling.
+declared `(defconst metabolism/entropy-factor-x1e6 1200000)` (scaled ×1,000,000) and
+divided back out inline: `(/ (* raw-extraction entropy-factor-x1e6) 1000000)`.
+
+**Correction (F1 fix round, adversarial review of PR #501): this workaround is NOT
+bit-exact against the frozen engine, for ANY input, including the shipped default.** An
+earlier revision of this document and of `metabolism.bsl`'s own D-1 claimed the
+workaround "preserves the formula's exact value ... for ANY legal `(1.0, 3.0]` modded
+value" and "carries the coefficient's full fractional precision as an exact integer" —
+both FALSE, disproved by execution. The frozen engine computes `raw_extraction *
+entropy_factor` as ONE binary64 multiply; this pack computes `(raw_extraction *
+entropy_factor_x1e6) / 1000000` — an exact integer multiply followed by a
+correctly-rounded division. These are the same real-valued function but different
+floating-point PROGRAMS, and can round to adjacent doubles (double rounding). Two
+independent, honestly-bounded error sources (full derivation in `metabolism.bsl`'s own
+D-1, condensed here):
+
+1. **Grid quantization** (dominant for an arbitrary modded value): a content author
+   writes the `:const` as `round(entropy_factor × 1,000,000)`, so any true value needing
+   more than 6 decimal digits is quantized to the nearest `1e-6` — absolute error up to
+   `5e-7`. Zero for the shipped default `1.2` (`1200000 / 1e6 == 1.2` exactly).
+2. **Double rounding** (the residual even at zero quantization error): this pack's
+   value is a SINGLE correctly-rounded division of an EXACT numerator (the correctly-
+   rounded double nearest the TRUE mathematical product); the frozen engine's value is a
+   correctly-rounded multiply of an ALREADY-rounded coefficient. Measured, not merely
+   bounded: `metabolism-rounding-divergence-conformance.bscn`
+   (`biocapacity=3`, `entropy_factor` at the shipped default, zero quantization error)
+   diverges from the frozen engine by EXACTLY 2 ULP — `0x3ff6666666666666` (this pack)
+   versus `0x3ff6666666666668` (frozen Python), both printing as `1.4` /
+   `1.4000000000000004`. Pinned, not denied, by
+   `metabolism_rounding_divergence_conformance.py`/`.rs`.
+
+**Why this is acceptable (ADR183 §5.4): the frozen Python engine is the contract source
+for STRUCTURE and ORDERING, never a bit-exact correctness oracle.** What is
+constitutional (III.7) is the Rust engine's OWN determinism — reproducible, not
+Python-identical — which integer-scaled arithmetic satisfies exactly. The en-masse
+retirement of this whole workaround class (a genuine `Real × Ratio` operator, or
+`Ratio`-typed field storage) is chartered as **workstream 3 of the post-port refactor
+program** (Director directive 2026-08-11, tracked at GitHub issue #502), not attempted
+by this port. `metabolism-entropy-low-conformance.bscn`/
+`metabolism-entropy-high-conformance.bscn` still mutation-verify the workaround carries
+the coefficient's EFFECT (a magnitude check); `metabolism-rounding-divergence-
+conformance.bscn` is the bit-exactness check, and it PASSES for "bounded ULP deviation",
+not for "identical to the frozen engine".
 
 ---
 

--- a/reports/metabolism-port-assessment-2026-08-11.md
+++ b/reports/metabolism-port-assessment-2026-08-11.md
@@ -1,0 +1,346 @@
+# Metabolism BSL Port — Assessment (Phase 1 gate)
+
+**Date.** 2026-08-11. **Author.** Implementation engineer, Metabolism port train
+(worktree `wt-metabolism-port`, branch `feat/metabolism-bsl-port`, cut from dev tip
+`a0caab02`, PR #500 Currency×Ratio `:floor`/`:cap` included).
+
+**Purpose.** The Phase 1 assessment gate required before any `.bsl` is written
+(`docs/superpowers/plans/` port-train convention, mirrored from the Dispossession port,
+PR #498). Every constant, clamp, branch, default and event in `MetabolismSystem`
+(`src/babylon/engine/systems/metabolism.py`, position 13.0, `MATERIAL_BASE`,
+`creates_value=False`) is inventoried below, with a PORT NOW / D-record / BLOCKED
+disposition per block, grounded in direct reads of the frozen Python, the three
+formulas it calls, `MetabolismDefines`, the Dispossession/Lifecycle/fundamental-theorem
+BSL packs, the BSL spec (`docs/reference/bsl-language.rst`), and the actual Rust engine
+source (`rust/crates/babylon-bsl/src/{tick,domain,scenario,evaluator,metrics}.rs`).
+
+**Headline finding the task brief did not anticipate** (reported per this train's
+standing instruction to surface contradictions loudly): **`entropy_factor` cannot
+legally be declared as a `Ratio` (`r`-suffixed) literal for this formula**, despite
+`bsl-language.rst`'s own Draft-Ruling Register row D99 naming `entropy_factor` as the
+Currency×Ratio addendum's own worked example. The reason, verified at the code level,
+is in §3 below. A workaround is used to still deliver a working port; the gap is
+recorded as a genuine open finding, not silently routed around.
+
+---
+
+## 1. The frozen system, verbatim math
+
+`MetabolismSystem.step()` (`metabolism.py:56-153`) has four blocks, in source order:
+
+1. **Spec-070 sovereign channel** (`:78-88`): reads
+   `context.persistent_data["balkanization.metabolic_impact_by_territory"]`
+   (a `dict[territory_id, float]` written by `SovereigntySystem`, one tick earlier —
+   Sovereignty runs @17.5, AFTER Metabolism @13.0, so this is genuinely a
+   **previous-tick** handoff, read at the START of Metabolism's own tick) and adds it to
+   `territory.habitability`, clamped (`_write_clamped`, bounds not shown in the excerpt
+   but implied `[0,1]` by the field's own declared type).
+2. **Phase 1 — per-territory biocapacity update** (`:90-118`): for every `TERRITORY`
+   node, computes `calculate_biocapacity_delta` and `calculate_hysteresis_damage`, then
+   writes `biocapacity`/`max_biocapacity`.
+3. **Phase 2 — global aggregates** (`:120-132`): sums `biocapacity` over every
+   `TERRITORY` node; sums `(s_bio + s_class) * population` over every **active**
+   `SOCIAL_CLASS` node (Mass Line: inactive/dead classes excluded).
+4. **Phase 3 — overshoot check** (`:134-153`): `calculate_overshoot_ratio`, then
+   `if ratio > overshoot_threshold: emit ECOLOGICAL_OVERSHOOT`.
+
+### The three formulas (`src/babylon/formulas/metabolic_rift.py`)
+
+```text
+calculate_biocapacity_delta(regeneration_rate, max_biocapacity, extraction_intensity,
+                             current_biocapacity, entropy_factor=1.2) -> float:
+    regeneration = regeneration_rate * max_biocapacity
+    if current_biocapacity >= max_biocapacity: regeneration = 0.0
+    raw_extraction = extraction_intensity * current_biocapacity
+    ecological_cost = raw_extraction * entropy_factor
+    return regeneration - ecological_cost
+
+calculate_hysteresis_damage(extraction_intensity, current_biocapacity,
+                             hysteresis_rate) -> float:
+    raw_extraction = extraction_intensity * current_biocapacity   # SAME product
+    return raw_extraction * hysteresis_rate
+
+calculate_overshoot_ratio(total_consumption, total_biocapacity, max_ratio=999.0) -> float:
+    if total_biocapacity <= 0: return max_ratio
+    return total_consumption / total_biocapacity
+```
+
+`raw_extraction = extraction_intensity * current_biocapacity` is computed **identically**
+in both `calculate_biocapacity_delta` (line 47) and `calculate_hysteresis_damage`
+(line 86), called from `metabolism.py` with the *same* `extraction_intensity` and
+`current_biocapacity` values in both cases (`:98`/`:109`, `:95`/`:99`/`:103`). Sharing one
+binding for it in the BSL port is a value-preserving consolidation, not a transcription
+deviation — noted inline in the rule, not filed as a D-record.
+
+`metabolism.py`'s own step, lines 90-118:
+
+```python
+delta = calculate_biocapacity_delta(
+    regeneration_rate=attrs.get("regeneration_rate", 0.02),
+    max_biocapacity=attrs.get("max_biocapacity", 100.0),
+    extraction_intensity=attrs.get("extraction_intensity", 0.0),
+    current_biocapacity=attrs.get("biocapacity", 100.0),
+    entropy_factor=entropy_factor,          # GameDefines
+)
+current = attrs.get("biocapacity", 100.0)
+max_cap = attrs.get("max_biocapacity", 100.0)
+damage = calculate_hysteresis_damage(
+    extraction_intensity=attrs.get("extraction_intensity", 0.0),
+    current_biocapacity=current,
+    hysteresis_rate=hysteresis_rate,        # GameDefines
+)
+new_max = max(0.0, max_cap - damage)
+new_biocapacity = max(0.0, min(new_max, current + delta))
+graph.update_node(node.id, biocapacity=new_biocapacity, max_biocapacity=new_max)
+```
+
+### `MetabolismDefines` (`src/babylon/config/defines/territory.py:209-245`)
+
+| field | default | bounds | used in |
+|---|---|---|---|
+| `entropy_factor` | 1.2 | `gt=1.0, le=3.0` | Phase 1 (ecological cost) |
+| `overshoot_threshold` | 1.0 | `gt=0.0, le=2.0` | Phase 3 (BLOCKED) |
+| `max_overshoot_ratio` | 999.0 | `gt=0.0` (unbounded above) | Phase 3 (BLOCKED) |
+| `hysteresis_rate` | 0.005 | `ge=0.001, le=0.01` | Phase 1 (hysteresis damage) |
+
+---
+
+## 2. Per-block disposition
+
+| Block | Disposition | Notes |
+|---|---|---|
+| Spec-070 sovereign pre-pass (`:78-88`) | **BLOCKED** | §4(a) below |
+| Phase 1 — per-territory biocapacity/hysteresis (`:90-118`) | **PORT NOW**, with one workaround-plus-D-record for `entropy_factor` | §3, §5 |
+| Phase 2 — global aggregates (`:120-132`) | **BLOCKED** | §4(b) below |
+| Phase 3 — overshoot check + `ECOLOGICAL_OVERSHOOT` emit (`:134-153`) | **BLOCKED** | §4(b) below (same root cause as Phase 2 — the two are one rule in the frozen source and cannot be split without the aggregates Phase 2 produces) |
+
+This matches `reports/bsl-gap-analysis-2026-08-10.md` row 13.0 exactly: *"Per-territory
+biocapacity/hysteresis rule plus one graph-scoped overshoot rule; blocked on
+graph-scoped evaluation only."* The per-territory block is genuinely portable; the
+global check is not — confirmed below at the source level, not merely cited.
+
+---
+
+## 3. New finding: `entropy_factor` has no legal BSL representation in the actual formula
+
+The task brief's working assumption was: *"`entropy_factor` becomes a defconst with
+`1.2r :floor 1r :cap 3r`"* — citing `bsl-language.rst`'s Draft-Ruling Register row **D99**
+(the Currency×Ratio scale operation, PR #500/ADR194), whose own worked example is,
+verbatim: `(defconst metabolism/entropy-factor 1.5r :floor 1r :cap 3r)`, proved through
+`rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs`.
+
+**This does not work for `MetabolismSystem`'s actual arithmetic**, and the reason is
+precise, not a matter of style:
+
+1. `entropy_factor`'s declared domain is `(1.0, 3.0]` — above what any `p`/`i`/`c`
+   scaled literal can hold (`[0.0, 1.0]` closed, `bsl-language.rst` §1.5,
+   `E-LEX-024`). The **only** literal suffix that can hold `1.2` at all is `r`
+   (`Ratio`) — confirmed at the lexer: a bare, unsuffixed decimal literal (`1.2` with
+   no letter) is unconditionally `E-LEX-021` (`reader.rs:159`, `BareFloat`); there is
+   no "plain Real literal" escape hatch the way there is a "plain Int literal" one
+   (dispossession's own `:const`s use exactly that Int escape hatch, D-2/D-4 below).
+2. **`Ratio` has exactly one legal operator: `Currency × Ratio → Currency`**
+   (`bsl-language.rst` D99: *"`Ratio` gets exactly this one operator and no other (no
+   `+`, no `Ratio × Ratio`, no ordering)"*), confirmed in the evaluator:
+   `apply_arith`'s only `Value::Ratio`-matching arm is the `(Currency, Ratio) | (Ratio,
+   Currency) if op == "*"` pair (`rust/crates/babylon-bsl/src/evaluator.rs:560-565`).
+   Every other combination involving a `Value::Ratio` falls through to the generic
+   `_ => match (real_lane(lhs), real_lane(rhs))` arm (`:590-595`), and `real_lane`
+   (`:535-544`) only recognizes `Value::Real`/`Value::Int` — a `Value::Ratio` operand
+   there is a hard `EvalError` ("no arithmetic is defined on ...").
+3. The formula's actual multiplicand, `raw_extraction = extraction_intensity *
+   current_biocapacity`, is **never `Currency`**. Both `extraction_intensity` and
+   `biocapacity` must be `:field` reads (per §5 below — they genuinely vary
+   per-territory), and slice-1's scenario/attribute layer refuses to store **any**
+   field as anything but `int`-declared: `attribute_value` (`scenario.rs:653-667`)
+   unconditionally rejects a non-`Int`-typed `deffield`, with the comment *"slice 1
+   stores only `int`-declared fields — the scaled and Currency lanes need typed
+   attribute storage (a declared Phase-2 trait revision)"*. So `raw_extraction` is
+   `Value::Real` (via `Int → Real` promotion), by construction, always — there is no
+   way to make it `Value::Currency`, because `Currency` values can only enter a BSL
+   rule as an **inline literal in the rule body** (`currency_scale_op_e2e.rs`'s own
+   module doc: *"A `Currency` value can currently enter a rule's evaluation ONLY as a
+   literal written directly in the rule body"*), never as the result of a field read.
+
+So `ecological_cost = raw_extraction * entropy_factor` needs `Real × Ratio`, which does
+not exist. `entropy_factor` declared as `1.2r :floor 1r :cap 3r` would **load** cleanly
+(the scenario-level check has no idea what the rule body will do with it) and then
+**fail at evaluation**, the first time any subject's guard passes far enough to reach
+the multiply.
+
+**This is not a new gap invented by this port — it is the exact residual gap
+`reports/bsl-gap-analysis-2026-08-10.md`'s own Appendix item 3 already named, one day
+before D99 landed**: *"The residual gap is real only for a runtime-valued `:const`
+outside `[0,1]` (`entropy_factor`, domain `(1.0, 3.0]`), which authors cannot split at
+load time."* D99/ADR194's ruling closes director-gate #492 for the shape its own worked
+example tests — `Currency × Ratio`, e.g. `1000$ × factor` — but `entropy_factor`'s real
+consumer needs `Real × Ratio`, a shape D99 never added an operator for. The gap-analysis
+report's framing ("Currency × unbounded coefficient") appears to have assumed
+`biocapacity` would carry a `Currency`-typed BSL field, matching its `Currency` type
+annotation in the Python Pydantic model (`territory.py:155-163`) — but slice-1 BSL has
+no `Currency`-typed field storage at all (point 3 above), so that assumption does not
+hold for the actual port.
+
+**Workaround used, D-recorded in the rule pack (see `metabolism.bsl`'s own D-1):** a
+scaled bare-`Int` `:const`, the same escape hatch Dispossession's own D-2/D-4 already
+use and document (`dispossession.bsl:118-139`: *"`defconst` also accepts a BARE
+`Atom::Int`... a bare Int carries NO domain check at all"*) — `entropy_factor` is
+declared `(defconst metabolism/entropy-factor-x1e6 1200000)` (scaled ×1,000,000 to carry
+the coefficient's full fractional precision as an exact integer) and divided back out
+inline: `(/ (* raw-extraction entropy-factor-x1e6) 1000000)`. This preserves the
+formula's exact value for the DEFAULT `entropy_factor = 1.2` and for any legal
+`(1.0, 3.0]` modded value (no domain narrowing, unlike a Coefficient-decomposition
+attempt — see the rule pack's D-1 for why that alternative was rejected) — at the cost
+of the SAME load-time domain-enforcement gap Dispossession's own weights already carry
+without objection. **This is recorded as an open finding for the language surface, not
+resolved by this port**: `Real × Ratio` (or `Ratio`-typed field storage) is a genuine
+follow-up the BSL spec owners should rule on; this port does not attempt that ruling.
+
+---
+
+## 4. The two flagged structural wrinkles
+
+### (a) Spec-070 sovereign channel — BLOCKED, confirmed
+
+`context.persistent_data["balkanization.metabolic_impact_by_territory"]` has no BSL
+read path. `bsl-language.rst` §2.5 closes `<bind-src>` at exactly four forms —
+`:field`/`:const`/`:metric`/`:tick` — none of which can name `context.persistent_data`.
+`reports/bsl-gap-analysis-2026-08-10.md`'s **Q6** section ("Graph-scope state, read and
+write... the single most pervasive gap in the estate") lists **Metabolism** by name
+among its 22 affected systems (line 246) and names this exact handoff explicitly:
+*"three of these values are one-tick-lagged handoffs (**Sovereignty → Metabolism**,
+MarketScissors → WealthDistribution, Production → ImperialRent)... the Metabolism survey
+proved this by construction"* (lines 277-281). Q6's own recommended fix (route (a):
+model the channel as an ordinary singleton-carrier `NodeType` field) is spec-level
+content work this port does not perform — it is exactly the kind of new-content-not-a-
+retrofit decision Lifecycle's own D-1 declined to make unilaterally. **Disposition
+confirmed BLOCKED, not assumed**: dropped whole, matching the pattern Lifecycle's own
+header uses for its two dropped rules, D-4 below records it.
+
+### (b) Phases 2-3 (global overshoot) — BLOCKED, confirmed at the execution-engine level
+
+This is not simply "no cross-namespace fold exists" — it is that **the mechanism the
+BSL spec and its load-time validator already support for this exact case
+(`(domain :graph)`) is not wired into the tick-execution engine at all**:
+
+- `rust/crates/babylon-bsl/src/domain.rs` fully implements `(domain :graph)` resolution
+  at **load time** — `RuleDomain::Graph`, `resolve_domain`, `check_graph_domain` — and
+  its own test suite proves a `(domain :graph)` rule with a `fold sum` over
+  `(nodes NodeType/ORGANIZATION)` resolves cleanly (`domain.rs:401-414`,
+  `442-453`).
+- But `rust/crates/babylon-bsl/src/tick.rs::run_tick` (the function every entry point —
+  `run_once`/`run_once_into`, hence the CLI and `babylon-client`'s engine link — actually
+  calls) **never reads `loaded.domain` at all**: it unconditionally calls
+  `subject_type_of(&loaded.bindings)` (`tick.rs:367`), which derives a subject type
+  purely from `:field` binding namespaces and knows nothing about `RuleDomain::Graph`.
+  A `(domain :graph)` rule would either fail outright at `subject_type_of` ("the rule
+  declares no `:field` binding, so it names no subject type" — if it has none at rule
+  scope) or, worse, be silently misinterpreted as an ordinary per-node rule over
+  whatever type a `fold`'s own `:field` binding happens to name (since
+  `subject_type_of` does not distinguish a binding referenced only inside a fold body
+  from one referenced at rule scope, unlike `domain.rs`'s own `self_scoped_segments`,
+  which correctly excludes fold-body-only references).
+- Confirmed independently: `rust/crates/babylon-tick/src/lib.rs` constructs its
+  `DefinesEnv`/driver state with `metrics: HashSet::new()` (line 122) — **zero graph-level
+  metrics are registered anywhere in the actual driver** — and `rg -rn "domain :graph"
+  rust/crates/babylon-tick/` and `rg -n "\(fold " rust/crates/babylon-tick/` both return
+  **zero hits**: no scenario, rule, or test in the crate that actually runs a tick has
+  ever exercised `(domain :graph)` or `fold` end to end.
+- `reports/bsl-gap-analysis-2026-08-10.md`'s **Q12** section states this precisely:
+  *"Three of them perform exactly one graph-level check per tick — ControlRatio's
+  four-phase state machine, **Metabolism's overshoot check**, FieldDerivative's
+  principal-contradiction pick. Under per-node inference those would emit once per
+  node"* (lines 386-389) — i.e. even the SPEC's own inference rule would fire this
+  check once per `TERRITORY` (or per `SOCIAL_CLASS`, depending which namespace won),
+  never once per tick, which is why an explicit `(domain :graph)` declaration is
+  required and why that declaration's absence from the execution engine is fatal to
+  this block specifically.
+
+Even setting the engine gap aside, the aggregation itself spans **two** node-type
+namespaces in one rule — `sum(TERRITORY.biocapacity)` and
+`sum(SOCIAL_CLASS.(s_bio+s_class)*population) filtered by active` — which would need
+**two** `fold`s over two different `(nodes NodeType/...)` queries inside one
+`(domain :graph)` rule. Nothing in `fundamental-theorem.bsl` (single-namespace,
+`social-class` only) or any other landed pack exercises a two-namespace fold, so this
+compounding question is recorded but is moot while the driver cannot run a
+`(domain :graph)` rule at all.
+
+**Disposition: BLOCKED, confirmed rather than assumed**, on two independent, precisely
+cited grounds (Q6/Q12's own spec-level gap, AND the deeper execution-engine gap this
+assessment found by reading `tick.rs` directly). Phases 2 and 3 are dropped from this
+port whole; recorded as **D-4** in the rule pack.
+
+---
+
+## 5. Defaulted-attribute trap sweep (`.get(field, default)` fallbacks)
+
+Every `attrs.get(...)` fallback in `metabolism.py`'s Phase 1 block was checked against
+who else in the live engine writes that attribute onto `TERRITORY` nodes — the same
+question Dispossession's D-1 answered for its five rate inputs, and the SAME reasoning
+does not give the same answer for every field here:
+
+| Field | `:const` or `:field`? | Evidence |
+|---|---|---|
+| `extraction_intensity` | **`:field`** | Written live, per-territory, by `ProductionSystem` (`production.py:268`, `graph.update_node(node.id, extraction_intensity=intensity)`), itself derived from `total_production / max_biocapacity` (`:251-268`) — genuinely varying data, confirmed by `reports/bsl-gap-analysis-2026-08-10.md` row 13.0 marking Metabolism **"No"** under "Dormant on canonical" (unlike Dispossession's "Yes (zero-rate inputs)"). Treating this as `:const` would misrepresent a live production channel, the opposite of Dispossession's D-1 justification. |
+| `biocapacity` / `max_biocapacity` | **`:field`** | Self-evidently per-node evolving state (this system's own primary output) AND seeded with genuinely different values per territory at scenario-build time — `src/babylon/engine/scenarios/_legacy.py:673-677`: `biocap = 150.0` / `40.0` / `100.0` depending on sector classification, not a uniform constant. |
+| `regeneration_rate` | **`:const`** (D-record) | Grep-verified: no scenario builder anywhere in `src/babylon/engine/scenarios/` ever assigns a `regeneration_rate=` distinct from the `Territory` Pydantic model's own default (`models/entities/territory.py:165-170`, `default=0.02`), and nothing else in the engine writes it onto a `TERRITORY` node (only `metabolism.py`'s own `.get()` read and `SubstrateSystem`'s **unrelated** `raw_material_stock`-side `regeneration_rate` — a different `SubstrateDefines` coefficient feeding a different formula call on a different attribute; `substrate.py`'s own module doc states explicitly *"Does NOT touch `Territory.biocapacity`/`MetabolismSystem`"*). Every territory in the shipped engine reads the same 0.02 — the exact "per-node storage never observably diverges from the global constant" shape Dispossession's D-1 and Lifecycle's D-1 both name. |
+| `entropy_factor` | **`:const`** (GameDefines global coefficient, not per-node at all) | See §3 for the representation problem; not a defaulted-attribute question — it is read from `services.defines.metabolism.entropy_factor` in the frozen Python, never off a node. |
+| `hysteresis_rate` | **`:const`** (GameDefines global coefficient) | Same — `services.defines.metabolism.hysteresis_rate`, `[0.001, 0.01]`, fits an ordinary `c`-suffixed Coefficient literal with no representation problem (well under the `[0,1]` cap). |
+
+---
+
+## 6. D-record numbering — a second contradiction of the task brief, flagged
+
+The task brief's instruction was to find "the register" (bsl-language.rst's
+Draft-Ruling Register, currently D1-D99) and "use the next free numbers" for this
+port's D-records, citing the sync-guard test that "enforces register uniqueness."
+**Read directly, that sync-guard test does not cover what the brief assumed.**
+`tests/unit/reference/test_bsl_grammar_sync.py::TestTheDraftRulingRegisterHasNoDuplicateRowNumbers`
+(landed in commit `723a4c23`, read in full) scans **only** the text strictly between
+`"\nDraft-Ruling Register\n"` and `"\nSee Also\n"` inside `docs/reference/bsl-language.rst`
+itself, for rows matching the literal pattern `"   * - D<n>"`. That register is for
+**language-level** draft rulings about BSL's own grammar/semantics (D97 = the `floor`
+intrinsic, D98 = the `real` intrinsic-type-name, D99 = Currency×Ratio) — it has nothing
+to do with, and does not enumerate, the **port-content** `D-1`, `D-2`, ... convention
+used *inside* individual `.bsl` rule-pack files. Read directly: `dispossession.bsl` uses
+its own `D-1` through `D-5`, and `lifecycle.bsl` uses its own `D-1` through `D-6`, each
+**restarting at D-1**, entirely independent of the spec register — neither file's
+D-records appear as `"   * - D<n>"` rows in `bsl-language.rst` at all (grep-confirmed:
+zero hits for `dispossession` or `lifecycle` inside the Draft-Ruling Register section).
+
+**This port follows the actual precedent** (file-local numbering, mirroring
+Dispossession and Lifecycle exactly) rather than the brief's assumption of continuing
+the global spec register at D100+. `metabolism.bsl`'s own D-1 through D-4 are local to
+that file. No new row is added to `bsl-language.rst`'s Draft-Ruling Register by this
+port — the §3 finding (`Real × Ratio` has no operator) is a genuine candidate for a
+FUTURE such row, but minting one is a language-surface ruling this port's scope does
+not license; it is recorded here and in the rule pack's own D-1 for the spec owners.
+
+---
+
+## 7. Plan for the BSL rule pack
+
+One rule, `metabolism/biocapacity-update`, domain `TERRITORY` (inferred from its
+`:field` bindings, matching the fundamental-theorem/dispossession precedent — no
+explicit `(domain ...)` needed since every reference is self-scoped to one namespace).
+
+Bindings: `current` (`:field territory/biocapacity`), `max-cap`
+(`:field territory/max-biocapacity`), `extraction-intensity`
+(`:field territory/extraction-intensity`), `regeneration-rate`
+(`:const metabolism/regeneration-rate`, D-2), `entropy-factor-x1e6`
+(`:const metabolism/entropy-factor-x1e6`, D-1's workaround), `hysteresis-rate`
+(`:const metabolism/hysteresis-rate`).
+
+No `(when ...)` guard in the frozen source (the Phase 1 loop has no `continue`) — every
+`TERRITORY` node gets its effects unconditionally, matching `metabolism.py:91-118`
+exactly (no `when` form needed, mirroring `lifecycle.bsl`'s unconditional Block 1).
+
+Effects: two unconditional `update-node` writes (`biocapacity`, `max-biocapacity`) — no
+`emit`, since Phase 1 publishes no event in the frozen source.
+
+Conformance fixtures (Phase 2 of this train) will cover: nominal trajectory (regen >
+extraction), the ratcheted-ceiling clamp binding (`new_max < current + delta`), the
+zero-floor binding (heavy extraction drives biocapacity to exactly 0), `extraction_intensity
+= 0` (hysteresis inert, pure regeneration), and `entropy_factor` near its declared domain
+boundary (just above 1.0, and at 3.0) to mutation-verify the scaled-Int workaround
+actually carries the coefficient's effect end to end.

--- a/reports/metabolism-port-assessment-2026-08-11.md
+++ b/reports/metabolism-port-assessment-2026-08-11.md
@@ -275,10 +275,17 @@ BSL spec and its load-time validator already support for this exact case
   which correctly excludes fold-body-only references).
 - Confirmed independently: `rust/crates/babylon-tick/src/lib.rs` constructs its
   `DefinesEnv`/driver state with `metrics: HashSet::new()` (line 122) — **zero graph-level
-  metrics are registered anywhere in the actual driver** — and `rg -rn "domain :graph"
-  rust/crates/babylon-tick/` and `rg -n "\(fold " rust/crates/babylon-tick/` both return
-  **zero hits**: no scenario, rule, or test in the crate that actually runs a tick has
-  ever exercised `(domain :graph)` or `fold` end to end.
+  metrics are registered anywhere in the actual driver** — and (corrected citation: an
+  earlier revision of this row ran `rg -rn "domain :graph|domain.*graph" rust/crates/
+  babylon-tick/`, which — per the repo's own known gotcha, `-r` is ripgrep's REPLACE flag,
+  not "recursive", and `rg -rn` silently rewrites matches to the literal string `n` rather
+  than searching — actually printed a mangled two-line excerpt of this very assessment's
+  own `metabolism.bsl`, not a real crate-wide search; the conclusion below happened to
+  still be true, but that command never proved it) `rg -n '\(fold ' rust/crates/babylon-tick/`
+  and `rg -n 'domain :graph' rust/crates/babylon-tick/ -g'*.bscn' -g'*.rs'` (scoped to
+  scenario and Rust-test files, excluding this pack's own prose commentary describing the
+  gap) both return **zero hits**: no scenario, rule, or test in the crate that actually
+  runs a tick has ever exercised `(domain :graph)` or `fold` end to end.
 - `reports/bsl-gap-analysis-2026-08-10.md`'s **Q12** section states this precisely:
   *"Three of them perform exactly one graph-level check per tick — ControlRatio's
   four-phase state machine, **Metabolism's overshoot check**, FieldDerivative's
@@ -343,11 +350,14 @@ zero hits for `dispossession` or `lifecycle` inside the Draft-Ruling Register se
 
 **This port follows the actual precedent** (file-local numbering, mirroring
 Dispossession and Lifecycle exactly) rather than the brief's assumption of continuing
-the global spec register at D100+. `metabolism.bsl`'s own D-1 through D-4 are local to
-that file. No new row is added to `bsl-language.rst`'s Draft-Ruling Register by this
-port — the §3 finding (`Real × Ratio` has no operator) is a genuine candidate for a
-FUTURE such row, but minting one is a language-surface ruling this port's scope does
-not license; it is recorded here and in the rule pack's own D-1 for the spec owners.
+the global spec register at D100+. `metabolism.bsl`'s own D-1 through D-5 are local to
+that file (D-5 added in the F1-F5 fix round: the four dropped `.get(attr, default)`
+fallbacks now have an explicit disposition). No new row is added to `bsl-language.rst`'s
+Draft-Ruling Register by this port — the §3 finding (`Real × Ratio` has no operator) is
+a genuine candidate for a FUTURE such row, but minting one is a language-surface ruling
+this port's scope does not license; it is recorded here and in the rule pack's own D-1
+for the spec owners, alongside its scheduled retirement as workstream 3 of the
+post-port refactor program (Director directive 2026-08-11, GitHub issue #502).
 
 ---
 
@@ -371,9 +381,39 @@ exactly (no `when` form needed, mirroring `lifecycle.bsl`'s unconditional Block 
 Effects: two unconditional `update-node` writes (`biocapacity`, `max-biocapacity`) — no
 `emit`, since Phase 1 publishes no event in the frozen source.
 
-Conformance fixtures (Phase 2 of this train) will cover: nominal trajectory (regen >
-extraction), the ratcheted-ceiling clamp binding (`new_max < current + delta`), the
-zero-floor binding (heavy extraction drives biocapacity to exactly 0), `extraction_intensity
-= 0` (hysteresis inert, pure regeneration), and `entropy_factor` near its declared domain
-boundary (just above 1.0, and at 3.0) to mutation-verify the scaled-Int workaround
-actually carries the coefficient's effect end to end.
+Conformance fixtures, as actually delivered across Phase 3 and the F1-F5 fix round
+(eight scenarios, 28 tests across 8 Rust test files) — the original plan's four vectors
+undersold what turned out to be necessary once adversarial review checked each clamp's
+operand choice for mutation-liveness, not just its presence:
+
+- **Nominal trajectory** (`metabolism-conformance.bscn`): regen > extraction, neither
+  clamp binds.
+- **Hysteresis inert** (`metabolism-conformance.bscn`): `extraction_intensity = 0`, pure
+  regeneration, `max_biocapacity` bit-identical to its seed.
+- **Zero floor + ratchet** (`metabolism-conformance.bscn`): heavy extraction at the
+  ceiling floors `biocapacity` to exactly `0` AND strictly ratchets `max_biocapacity`.
+- **Ceiling clamp binds, unratcheted** (`metabolism-ceiling-conformance.bscn`): boosted
+  `regeneration_rate`, `extraction_intensity=0`.
+- **Ceiling clamp binds against the RATCHETED value**
+  (`metabolism-ratcheted-ceiling-conformance.bscn`, added F2): the operand the clamp
+  compares against (`new-max`, not `max-cap`) was mutation-dead until this vector —
+  needs `entropy_factor`/`hysteresis_rate` ALSO pushed off their production defaults,
+  not just `regeneration_rate`.
+- **Regeneration suppressed exactly at the ceiling boundary**
+  (`metabolism-ceiling-suppression-conformance.bscn`, added F3): `current == max_cap`
+  chosen so the `>=`-vs-`>` guard's two branches land on different sides of the `max(0,
+  ...)` floor — the earlier `zero-floor-county` vector floored both branches to the
+  identical `0.0`, hiding the guard's boundary entirely.
+- **`new-max` floor clamp binds** (`metabolism-extreme-damage-conformance.bscn`, added
+  F4): an unbounded `biocapacity` seed pushes `damage` past `max_biocapacity`, legal
+  because neither field carries a Pydantic upper bound.
+- **Entropy-factor magnitude pair** (`metabolism-entropy-{low,high}-conformance.bscn`):
+  the identical territory at `entropy_factor=1.01` vs `3.0`, mutation-verifying the D-1
+  workaround carries the coefficient's EFFECT.
+- **Rounding-divergence pin** (`metabolism-rounding-divergence-conformance.bscn`, added
+  F1): PINS the D-1 workaround's bit-level deviation from the frozen engine rather than
+  claiming exactness — see §3's correction.
+
+Every clamp/guard/branch load-bearing enough to change the port's OUTPUT is now backed
+by at least one vector where mutating it flips a specific, named test — verified by
+hand for each (§3, and the F2/F3/F4 commits' own mutation records).

--- a/reports/metabolism-port-assessment-2026-08-11.md
+++ b/reports/metabolism-port-assessment-2026-08-11.md
@@ -188,46 +188,88 @@ use and document (`dispossession.bsl:118-139`: *"`defconst` also accepts a BARE
 declared `(defconst metabolism/entropy-factor-x1e6 1200000)` (scaled ×1,000,000) and
 divided back out inline: `(/ (* raw-extraction entropy-factor-x1e6) 1000000)`.
 
-**Correction (F1 fix round, adversarial review of PR #501): this workaround is NOT
-bit-exact against the frozen engine, for ANY input, including the shipped default.** An
-earlier revision of this document and of `metabolism.bsl`'s own D-1 claimed the
-workaround "preserves the formula's exact value ... for ANY legal `(1.0, 3.0]` modded
-value" and "carries the coefficient's full fractional precision as an exact integer" —
-both FALSE, disproved by execution. The frozen engine computes `raw_extraction *
-entropy_factor` as ONE binary64 multiply; this pack computes `(raw_extraction *
-entropy_factor_x1e6) / 1000000` — an exact integer multiply followed by a
-correctly-rounded division. These are the same real-valued function but different
-floating-point PROGRAMS, and can round to adjacent doubles (double rounding). Two
-independent, honestly-bounded error sources (full derivation in `metabolism.bsl`'s own
-D-1, condensed here):
+**Correction, round 1 (F1 fix round, adversarial review of PR #501): this workaround is
+NOT bit-exact against the frozen engine in general.** An earlier revision of this
+document and of `metabolism.bsl`'s own D-1 claimed the workaround "preserves the
+formula's exact value ... for ANY legal `(1.0, 3.0]` modded value" and "carries the
+coefficient's full fractional precision as an exact integer" — both FALSE, disproved by
+execution.
 
-1. **Grid quantization** (dominant for an arbitrary modded value): a content author
-   writes the `:const` as `round(entropy_factor × 1,000,000)`, so any true value needing
-   more than 6 decimal digits is quantized to the nearest `1e-6` — absolute error up to
-   `5e-7`. Zero for the shipped default `1.2` (`1200000 / 1e6 == 1.2` exactly).
-2. **Double rounding** (the residual even at zero quantization error): this pack's
-   value is a SINGLE correctly-rounded division of an EXACT numerator (the correctly-
-   rounded double nearest the TRUE mathematical product); the frozen engine's value is a
-   correctly-rounded multiply of an ALREADY-rounded coefficient. Measured, not merely
-   bounded: `metabolism-rounding-divergence-conformance.bscn`
-   (`biocapacity=3`, `entropy_factor` at the shipped default, zero quantization error)
-   diverges from the frozen engine by EXACTLY 2 ULP — `0x3ff6666666666666` (this pack)
-   versus `0x3ff6666666666668` (frozen Python), both printing as `1.4` /
-   `1.4000000000000004`. Pinned, not denied, by
-   `metabolism_rounding_divergence_conformance.py`/`.rs`.
+**Correction, round 2 (independent re-verification of round 1's own restatement): round
+1's fix bounded the WRONG QUANTITY, and introduced two further false claims in the
+process of fixing the first one.** Corrected findings, all verified by direct execution
+against both engines:
 
-**Why this is acceptable (ADR183 §5.4): the frozen Python engine is the contract source
-for STRUCTURE and ORDERING, never a bit-exact correctness oracle.** What is
-constitutional (III.7) is the Rust engine's OWN determinism — reproducible, not
-Python-identical — which integer-scaled arithmetic satisfies exactly. The en-masse
-retirement of this whole workaround class (a genuine `Real × Ratio` operator, or
-`Ratio`-typed field storage) is chartered as **workstream 3 of the post-port refactor
-program** (Director directive 2026-08-11, tracked at GitHub issue #502), not attempted
-by this port. `metabolism-entropy-low-conformance.bscn`/
-`metabolism-entropy-high-conformance.bscn` still mutation-verify the workaround carries
-the coefficient's EFFECT (a magnitude check); `metabolism-rounding-divergence-
-conformance.bscn` is the bit-exactness check, and it PASSES for "bounded ULP deviation",
-not for "identical to the frozen engine".
+1. **The frozen engine computes `raw_extraction * entropy_factor` as ONE binary64
+   multiply; this pack computes `(raw_extraction * entropy_factor_x1e6) / 1000000`** —
+   the same real-valued function, different floating-point PROGRAMS.
+2. **The `<= 2 ULP` derivable / `<= 1 ULP` measured bound applies to the
+   `ecological-cost` TERM, not to this rule's OUTPUT** — round 1 derived its bound over
+   `ecological-cost` correctly, then measured `biocapacity` (the output) and reported it
+   under the same bound, which does not hold: `ecological-cost` is subtracted from a
+   comparable-magnitude quantity (`current + delta`) under CANCELLATION and then
+   clamped, and cancellation is exactly the operation that turns a small relative input
+   error into an arbitrarily large one. Measured counterexamples, both engines:
+   - A: `biocapacity=149, max_biocapacity=150, extraction_intensity=1,
+     regeneration_rate=0.005, entropy_factor=1.005` — frozen `0.005000000000023874`
+     (`0x3f747ae147ae8000`) vs this pack `0.0049999999999954525`
+     (`0x3f747ae147ae0000`) — **32768 ULP (2^15) apart**, relative difference `5.7e-12`.
+   - B: `biocapacity=1, max_biocapacity=10, extraction_intensity=3,
+     regeneration_rate=0.26, entropy_factor=1.2` (the SHIPPED DEFAULT) — frozen
+     `4.440892098500626e-16` vs this pack `0.0`: the two engines land on OPPOSITE SIDES
+     of the `max(0.0, ...)` floor. A broader round-value sweep found 305 such
+     floor-branch splits — this is not a cherry-picked edge case.
+3. **"An EXACT integer multiply (both operands fit well inside 2^53)" named the wrong
+   condition** — exactness of `raw_extraction * entropy_factor_x1e6` depends on the
+   PRODUCT's significand fitting 53 bits, not on either operand's magnitude
+   individually; re-derived correctly in `metabolism.bsl`'s own D-1.
+4. **Tick-1 exactness is a special case, not the general rule** — `raw_extraction` is
+   an exact integer only when every field is freshly int-seeded (true of every
+   conformance fixture in this pack, on tick 1). From tick 2 onward `biocapacity` feeds
+   back as a computed float, and in live gameplay `extraction_intensity` is a genuine
+   float written by `ProductionSystem`, never an integer. Verified by multi-tick replay
+   of both engines: for a `biocapacity=5` seed at the production defaults, the two
+   engines already disagree by tick 3.
+
+The `ecological-cost` term's own bound is still real and still measured: an exhaustive
+sweep (int `raw_extraction` 1-2000 x every point of the 6-digit `entropy_factor` grid in
+`(1.0, 3.0]` — 2,000,000 grid points, 4,000,000,000 combinations total) found a worst
+deviation of exactly 1 ULP for that term alone, zero exceeding it. What changed is the
+claim about what that bound implies for the rule's actual output — nothing, once the
+term is subtracted under cancellation and clamped.
+
+**One more undisclosed consequence of the bare-Int bypass itself, beyond the numeric
+deviation**: the same `E-LEX-024`-exempt unsuffixed-`Int` `:const` that makes the
+workaround possible also means nothing on the BSL surface refuses an
+`entropy-factor-x1e6` outside `MetabolismDefines.entropy_factor`'s declared `(1.0, 3.0]`
+domain, including negative — verified directly (a scenario declaring
+`entropy-factor-x1e6` as `-500000` loads and runs through the real engine without
+refusal). Only this rule's own in-body clamps contain the resulting value; nothing
+enforces the coefficient's own domain.
+
+**Why the (unbounded) numeric deviation is acceptable anyway (ADR183 §5.4): the frozen
+Python engine is the contract source for STRUCTURE and ORDERING, never a bit-exact
+correctness oracle.** What is constitutional (III.7) is the Rust engine's OWN
+determinism — reproducible, not Python-identical — which integer-scaled arithmetic
+satisfies exactly regardless of how far any single tick's output deviates from the
+frozen engine's own number. The en-masse retirement of this whole workaround class (a
+genuine `Real × Ratio` operator, or `Ratio`-typed field storage) is chartered as
+**workstream 3 of the post-port refactor program** (Director directive 2026-08-11,
+tracked at GitHub issue #502), not attempted by this port. `metabolism-entropy-low-
+conformance.bscn`/`metabolism-entropy-high-conformance.bscn` still mutation-verify the
+workaround carries the coefficient's EFFECT (a magnitude check); `metabolism-rounding-
+divergence-conformance.bscn` pins ONE concrete, reproducible deviation (`biocapacity=3`,
+2 ULP) — not the general (unbounded) case — and a PASS there means "matches this pack's
+own prior deterministic output", never "matches the frozen engine".
+
+**This port's conformance suite is NOT guaranteed bit-exact against the frozen engine in
+general — it is bit-IDENTICAL for several of its own vectors (including `nominal-county`
+at the shipped default `entropy_factor=1.2`, and `low-entropy-county`/three others) and
+DIVERGENT for others** (the dedicated `metabolism-rounding-divergence-conformance.bscn`
+vector, and, per counterexamples A/B above, plausibly others this pack does not
+exercise). Every vector this pack actually pins was independently verified against the
+frozen engine at authoring time; which specific seeds land on which side is a fact about
+each seed's own cancellation pattern, not a property this port controls or claims to.
 
 ---
 

--- a/rust/crates/babylon-tick/content/rules/metabolism.bsl
+++ b/rust/crates/babylon-tick/content/rules/metabolism.bsl
@@ -66,13 +66,13 @@
 ;
 ; **The frozen engine computes `raw_extraction * entropy_factor` as ONE
 ; binary64 multiply.** This pack computes `(raw_extraction *
-; entropy_factor_x1e6) / 1000000` — an EXACT integer multiply (both
-; operands fit well inside 2^53 for any biocapacity magnitude this game
-; uses) followed by a correctly-rounded division. Both are the SAME
-; real-valued function; they are DIFFERENT floating-point PROGRAMS for it,
-; and correctly-rounded operations composed in a different order are not
-; guaranteed to agree. Two independent error sources, bounded honestly
-; rather than asserted away:
+; entropy_factor_x1e6) / 1000000` — this pack's own inner multiply, then a
+; correctly-rounded division. Both are the SAME real-valued function; they
+; are DIFFERENT floating-point PROGRAMS for it, and correctly-rounded
+; operations composed in a different order are not guaranteed to agree.
+; **Round 2 correction (adversarial re-verification of the F1 fix round
+; found this restatement itself bounded the WRONG quantity and introduced
+; two further false claims — corrected here, not merely reworded):**
 ;
 ;   1. **Grid quantization** (dominant for an arbitrary modded value). A
 ;      content author writes `entropy-factor-x1e6` as `round(entropy_factor
@@ -84,61 +84,119 @@
 ;      shipped default `1.2` (and any value exactly representable in <= 6
 ;      decimal digits) has ZERO quantization error, `1200000 / 1e6 == 1.2`
 ;      exactly as a real number.
-;   2. **Double rounding** (the residual even at zero quantization error).
-;      Let `k` = the exact integer `entropy-factor-x1e6`. This pack's value
-;      is `round_f64(raw_extraction * k / 1e6)` — ONE correctly-rounded
-;      division of an EXACT numerator, i.e. the correctly-rounded `f64`
-;      nearest the TRUE mathematical product `raw_extraction x
-;      entropy_factor`. The frozen engine's value is `raw_extraction *_f64
-;      entropy_factor_f64`, where `entropy_factor_f64 =
-;      round_f64(entropy_factor)` already carries its OWN rounding error
-;      (<= 0.5 ULP, i.e. relative error <= 2^-53) from the decimal literal.
-;      The real number Python's multiply rounds therefore differs from the
-;      real number this pack's division rounds by a relative factor of
-;      <= 2^-53 — small, but two INDEPENDENT correctly-rounded results of
-;      two real numbers that close can still land on ADJACENT (or
-;      near-adjacent) representable doubles, because each result is itself
-;      only correct to within 0.5 ULP of ITS OWN input. Measured, not just
-;      bounded: `metabolism-rounding-divergence-conformance.bscn`
-;      (`biocapacity=3`, `entropy_factor` at the shipped default `1.2`,
-;      hence ZERO quantization error) diverges from the frozen engine by
-;      EXACTLY 2 ULP — `0x3ff6666666666666` (this pack) versus
-;      `0x3ff6666666666668` (frozen Python) for `biocapacity`, both
-;      printing as `1.4` / `1.4000000000000004`. See
-;      `metabolism_rounding_divergence_conformance.py` and
-;      `metabolism_rounding_divergence_conformance.rs`, which PIN this
-;      deviation rather than deny it.
+;   2. **Double rounding bounds the `ecological-cost` TERM, NOT this rule's
+;      final output.** This pack's `ecological-cost` is a SINGLE
+;      correctly-rounded division of an EXACT numerator whenever the inner
+;      product `raw_extraction * entropy_factor_x1e6` fits `f64`'s 53-bit
+;      significand EXACTLY — a fact about the PRODUCT's magnitude, not
+;      about either operand's (an earlier revision claimed "both operands
+;      fit well inside 2^53", which is not the relevant condition: two
+;      values each under 2^53 can still multiply to a product whose
+;      SIGNIFICAND does not fit, if the product itself needs more than 53
+;      significant bits — not an issue at the magnitudes this system's
+;      conformance fixtures use, but the justification needed to name the
+;      actual constraint). Under that condition, `ecological-cost` is
+;      DERIVABLY within 2 ULP of the frozen engine's own
+;      `raw_extraction * entropy_factor_f64` (a relative-error propagation
+;      argument: the real number this pack's division rounds and the real
+;      number the frozen engine's multiply rounds differ by a factor of
+;      at most `2^-53`, from `entropy_factor_f64`'s own rounding error off
+;      the decimal literal — two independent correctly-rounded results of
+;      inputs that close land within a small constant number of ULP of
+;      each other). **Measured**, over an exhaustive sweep of the
+;      `ecological-cost` TERM alone (int `raw_extraction` 1-2000 x every
+;      point of the 6-digit `entropy_factor` grid in `(1.0, 3.0]`
+;      — 2,000,000 grid points, 4,000,000,000 combinations total): the
+;      worst observed deviation is exactly 1 ULP, zero combinations exceed
+;      it.
 ;
-; **Why this is acceptable rather than a defect this port must repair
-; (ADR183 §5.4): the frozen Python engine is the contract source for
-; STRUCTURE and ORDERING, never a bit-exact correctness oracle.** What is
-; constitutional (III.7) is THIS engine's own determinism — the same
+; **The rule's OUTPUT (`biocapacity`) is NOT ULP-bounded, and an earlier
+; revision of this record implied it was by measuring the wrong quantity
+; — `ecological-cost`'s own ~1 ULP deviation feeds into a SUBTRACTION
+; against a comparable-magnitude term (`current + delta`) under
+; cancellation, then a clamp, and cancellation is exactly the operation
+; that turns a tiny relative error into an arbitrarily large ONE.**
+; Measured counterexamples, both engines, at seeds no more exotic than
+; this pack's own conformance fixtures:
+;
+;   - A: `biocapacity=149`, `max_biocapacity=150`, `extraction_intensity=1`,
+;     `regeneration_rate=0.005`, `entropy_factor=1.005` — frozen engine
+;     `0.005000000000023874` (`0x3f747ae147ae8000`) versus this pack
+;     `0.0049999999999954525` (`0x3f747ae147ae0000`) — **32768 ULP
+;     (2^15) apart**, a relative difference of `5.7e-12`, from a `~1 ULP`
+;     input deviation.
+;   - B: `biocapacity=1`, `max_biocapacity=10`, `extraction_intensity=3`,
+;     `regeneration_rate=0.26`, `entropy_factor=1.2` (the SHIPPED
+;     DEFAULT) — frozen engine `4.440892098500626e-16` versus this pack
+;     `0.0`: the two engines land on OPPOSITE SIDES of the
+;     `max(0.0, ...)` floor. The clamp-branch split is not a corner case
+;     invented for this record — a broad round-value sweep found 305 such
+;     splits.
+;
+; **This record's job is therefore not "the deviation is small" — it is
+; "the deviation is UNBOUNDED in general, deterministic on each side, and
+; accepted anyway under ADR183/III.7" (below), never silently denied.**
+;
+; **Tick-1 exactness is a special case, not the general rule.** On tick 1
+; with every field freshly int-seeded, `raw_extraction` is itself an exact
+; integer, which is what makes the inner-product exactness of item 2
+; reachable at all in this pack's own conformance fixtures. From tick 2
+; onward `biocapacity` feeds back as whatever float the PREVIOUS tick
+; computed — generally not an integer — and in live gameplay
+; `extraction_intensity` is a genuine float written by `ProductionSystem`
+; (`production.py:268`), never an integer at all. Verified directly
+; (multi-tick replay, both engines, `extraction_intensity=1` fixed): the
+; two engines already disagree by tick 3 for a `biocapacity=5` seed at the
+; production defaults, then coincide again at some later ticks and diverge
+; at others — divergence is a property of the SPECIFIC trajectory, not a
+; fixed tick number, and item 2's `<= 1 ULP` bound on `ecological-cost`
+; is NOT claimed to hold once its own inputs stop being exact integers.
+;
+; **The bare-Int bypass's consequence, not just its mechanism.** D-1's
+; workaround uses the SAME unsuffixed-`Int` `:const` escape hatch
+; Dispossession's own D-2/D-4 document (`E-LEX-024` only bounds
+; SCALED/suffixed literals) — which means, beyond the numeric deviation
+; above, the load-time check ALSO admits an `entropy-factor-x1e6` outside
+; `MetabolismDefines.entropy_factor`'s declared `(1.0, 3.0]` domain
+; entirely, including negative — nothing on the BSL surface refuses it;
+; only this rule's OWN in-body clamps (the `new-max`/`new-biocapacity`
+; floors) contain the resulting value, the same defense-in-depth gap
+; Dispossession's own D-2 already names for its weights.
+;
+; **Why the numeric deviation is acceptable anyway, and what is not
+; resolved (ADR183 §5.4): the frozen Python engine is the contract source
+; for STRUCTURE and ORDERING, never a bit-exact correctness oracle.** What
+; is constitutional (III.7) is THIS engine's own determinism — the same
 ; content and the same inputs produce the same output, every time, on any
 ; conforming implementation — which integer-scaled arithmetic satisfies
-; exactly (`the_metabolism_tick_is_deterministic` and its siblings in the
+; exactly regardless of how far it deviates from the frozen engine's own
+; number (`the_metabolism_tick_is_deterministic` and its siblings in the
 ; conformance suites already prove this). Bit parity with a Python
 ; reference the Constitution never asked this port to reproduce exactly is
-; not the bar; a bounded, documented, reproducible deviation is. The
-; en-masse retirement of this whole workaround class — a genuine `Real x
-; Ratio` operator, or `Ratio`-typed field storage, closing the gap at its
-; root instead of per-consumer — is chartered as **workstream 3 of the
-; post-port refactor program** (Director directive 2026-08-11, tracked at
-; GitHub issue #502), not attempted by this port.
+; not the bar; a documented, reproducible, DETERMINISTIC deviation is —
+; even an unbounded one. The en-masse retirement of this whole workaround
+; class — a genuine `Real x Ratio` operator, or `Ratio`-typed field
+; storage, closing the gap at its root instead of per-consumer — is
+; chartered as **workstream 3 of the post-port refactor program**
+; (Director directive 2026-08-11, tracked at GitHub issue #502), not
+; attempted by this port.
 ;
 ; `metabolism-entropy-low-conformance.bscn` /
 ; `metabolism-entropy-high-conformance.bscn` mutation-verify the workaround
 ; carries the coefficient's EFFECT end to end (a floor-inert result at
 ; `1.01` swinging to a floor-bound result at `3.0`) — a magnitude check,
 ; not a bit-exactness one; `metabolism-rounding-divergence-conformance.bscn`
-; is the bit-exactness check, and it is a PASS for "bounded ULP deviation
-; from the frozen engine", not a pass for "identical to the frozen engine".
+; PINS one concrete, reproducible deviation (`biocapacity=3`, 2 ULP) rather
+; than the general (unbounded) case — a PASS there means "matches this
+; pack's own prior deterministic output", never "matches the frozen
+; engine".
 ;
 ; **Recorded as an OPEN finding for the language surface, not resolved
 ; here**: `Real x Ratio` (or `Ratio`-typed field storage) is a genuine
 ; follow-up the BSL spec owners should rule on. Minting a new operator or a
 ; new Draft-Ruling Register row is a language-surface decision outside this
 ; port's scope — this D-record exists so a later reader does not have to
-; re-derive the gap. (Note on numbering: this file's `D-1`..`D-4` are
+; re-derive the gap. (Note on numbering: this file's `D-1`..`D-5` are
 ; LOCAL to this pack, mirroring `dispossession.bsl`'s own `D-1`..`D-5` and
 ; `lifecycle.bsl`'s own `D-1`..`D-6` exactly — `bsl-language.rst`'s
 ; Draft-Ruling Register (`D97`-`D99`, sync-guarded by

--- a/rust/crates/babylon-tick/content/rules/metabolism.bsl
+++ b/rust/crates/babylon-tick/content/rules/metabolism.bsl
@@ -1,0 +1,247 @@
+; MetabolismSystem (Material Base @13.0) — the metabolic rift between
+; extraction and regeneration.
+;
+; Every tick, a territory's biocapacity regenerates toward its ceiling and
+; is depleted by extraction, at an entropic loss (extraction always costs
+; more than it yields — the thermodynamic point behind `entropy_factor`).
+; Extraction also PERMANENTLY damages the ceiling itself (the Epoch 1
+; hysteresis doctrine, "The Earth Remembers") — the earth cannot recover
+; its original ceiling even if extraction stops entirely.
+;
+; THIS PACK PORTS ONLY PHASE 1 of the frozen system (per-territory
+; biocapacity delta + hysteresis ratchet + double clamp) — the gap report's
+; own verdict on this system: "Per-territory biocapacity/hysteresis rule
+; plus one graph-scoped overshoot rule; blocked on graph-scoped evaluation
+; only" (`reports/bsl-gap-analysis-2026-08-10.md` row 13.0). The spec-070
+; sovereign pre-pass and Phases 2-3 (global overshoot aggregate +
+; `ECOLOGICAL_OVERSHOOT`) are BLOCKED — D-3/D-4 below, full derivation in
+; `reports/metabolism-port-assessment-2026-08-11.md`.
+;
+; ============================================================================
+; §5.4 FINDING — D-1: `entropy_factor` cannot be a `Ratio` for THIS formula;
+; scaled-Int workaround, open language-surface finding
+; ============================================================================
+;
+; The obvious move — `(defconst metabolism/entropy-factor 1.2r :floor 1r
+; :cap 3r)`, `bsl-language.rst` Draft-Ruling Register row D99's OWN worked
+; example (#492/ADR194, `currency_scale_op_e2e.rs`) — DOES NOT WORK for
+; `calculate_biocapacity_delta`'s actual arithmetic. `Ratio` has exactly one
+; legal operator, `Currency x Ratio -> Currency` (D99: "Ratio gets exactly
+; this one operator and no other"), confirmed in `evaluator.rs::apply_arith`
+; — every `Value::Ratio` operand not paired with a `Value::Currency` falls
+; to the generic `real_lane` catch-all, which does not recognize
+; `Value::Ratio` at all and refuses outright. This formula's multiplicand,
+; `raw_extraction = extraction_intensity * current_biocapacity`
+; (`metabolic_rift.py:47`), is NEVER `Currency` — both factors are `:field`
+; reads (D-2 below explains why `extraction_intensity`/`biocapacity` must
+; be per-node fields, not consts), and slice 1's `scenario.rs::
+; attribute_value` refuses to store ANY field as anything but
+; `int`-declared — there is no Currency-typed field storage to route
+; through. `Currency` can only enter a rule as an inline literal
+; (`currency_scale_op_e2e.rs`'s own module doc), never as the result of a
+; field read. So `Real x Ratio` is the only shape available, and no such
+; operator exists.
+;
+; This is not a new gap this port invented: `reports/bsl-gap-analysis-2026-
+; 08-10.md`'s Appendix item 3, written ONE DAY BEFORE D99 landed, already
+; named it precisely — "The residual gap is real only for a runtime-valued
+; `:const` outside `[0,1]` (`entropy_factor`, domain `(1.0, 3.0]`), which
+; authors cannot split at load time." D99 closes director-gate #492 for the
+; shape its OWN worked example tests (`Currency x Ratio`); `entropy_factor`'s
+; REAL consumer needs `Real x Ratio`, a shape D99 never added an operator
+; for — apparently on the assumption (matching `biocapacity`'s `Currency`
+; type annotation in the Python Pydantic model, `territory.py:155-163`)
+; that the multiplicand would itself be `Currency`-typed in BSL, which it
+; is not and cannot be in slice 1.
+;
+; **Workaround, not a resolution.** `entropy_factor` is declared as a
+; scaled bare-`Int` `:const` — `(defconst metabolism/entropy-factor-x1e6
+; 1200000)`, `x1,000,000` to carry the coefficient's full fractional
+; precision as an exact integer — and divided back out inline
+; (`ecological-cost` below). This is the SAME escape hatch Dispossession's
+; own D-2/D-4 already use and document: a bare, unsuffixed `Int` `:const`
+; carries NO domain check at all (`E-LEX-024` only bounds SCALED/suffixed
+; literals). It preserves the formula's exact value for the default
+; `entropy_factor = 1.2` and for ANY legal `(1.0, 3.0]` modded value — unlike
+; a Coefficient-decomposition alternative (`entropy_factor = 1 + (entropy_
+; factor - 1)`, splitting the excess into a `c`-literal), which would
+; SILENTLY miscompute for any modded value above `2.0` (the excess would
+; itself exceed Coefficient's own `[0,1]` cap) — at the cost of the SAME
+; load-time domain-enforcement gap Dispossession's own weights already carry
+; without objection. `metabolism-entropy-low-conformance.bscn` /
+; `metabolism-entropy-high-conformance.bscn` mutation-verify the workaround
+; end to end: the IDENTICAL territory, differing only in
+; `entropy-factor-x1e6`, produces a floor-inert result at `1.01` and a
+; floor-bound result at `3.0`.
+;
+; **Recorded as an OPEN finding for the language surface, not resolved
+; here**: `Real x Ratio` (or `Ratio`-typed field storage) is a genuine
+; follow-up the BSL spec owners should rule on. Minting a new operator or a
+; new Draft-Ruling Register row is a language-surface decision outside this
+; port's scope — this D-record exists so a later reader does not have to
+; re-derive the gap. (Note on numbering: this file's `D-1`..`D-4` are
+; LOCAL to this pack, mirroring `dispossession.bsl`'s own `D-1`..`D-5` and
+; `lifecycle.bsl`'s own `D-1`..`D-6` exactly — `bsl-language.rst`'s
+; Draft-Ruling Register (`D97`-`D99`, sync-guarded by
+; `TestTheDraftRulingRegisterHasNoDuplicateRowNumbers`) is a SEPARATE,
+; language-spec-level register that neither Dispossession's nor Lifecycle's
+; own D-records participate in; this pack follows their actual precedent,
+; not a same-named-but-different register.)
+;
+; ============================================================================
+; MODELING CHOICE — D-2: `regeneration_rate` becomes `:const`;
+; `extraction_intensity`/`biocapacity`/`max_biocapacity` stay `:field`
+; ============================================================================
+;
+; Applying Dispossession's own D-1 reasoning ("is it PROVABLY uniform, or
+; genuinely live?") to each of this system's `attrs.get(field, default)`
+; reads gives DIFFERENT answers for different fields — unlike Dispossession,
+; where all five rate inputs landed the same way:
+;
+;   - `regeneration_rate`: grep-verified UNIFORM. No scenario builder in
+;     `src/babylon/engine/scenarios/` ever assigns it a value distinct from
+;     `Territory.regeneration_rate`'s own Pydantic default (`models/
+;     entities/territory.py:165-170`, `default=0.02`), and nothing else in
+;     the engine writes it onto a `TERRITORY` node (`SubstrateSystem`'s own
+;     `regeneration_rate` reference is a DIFFERENT `SubstrateDefines`
+;     coefficient feeding a DIFFERENT formula call on a DIFFERENT attribute,
+;     `raw_material_stock` — `substrate.py`'s own module doc: "Does NOT
+;     touch `Territory.biocapacity`/`MetabolismSystem`"). Every territory in
+;     the shipped engine reads the same `0.02` — exactly the "per-node
+;     storage never observably diverges from the global constant" shape
+;     Dispossession's D-1 and Lifecycle's D-1 both name.
+;   - `extraction_intensity`: NOT uniform, NOT dormant. Written live,
+;     per-territory, by `ProductionSystem` (`production.py:268`,
+;     `graph.update_node(node.id, extraction_intensity=intensity)`, derived
+;     from `total_production / max_biocapacity`) — confirmed by the gap
+;     report marking Metabolism "No" under "Dormant on canonical" (row
+;     13.0), unlike Dispossession's "Yes (zero-rate inputs)". Treating this
+;     as `:const` would misrepresent a live production channel — the
+;     OPPOSITE of what justified Dispossession's own choice. Stays `:field`.
+;   - `biocapacity`/`max_biocapacity`: self-evidently per-node evolving
+;     state (this system's own primary output), AND seeded with genuinely
+;     different values per territory at scenario-build time
+;     (`_legacy.py:673-677`: `150.0`/`40.0`/`100.0` by sector
+;     classification, not a uniform constant). Stay `:field`.
+;
+; ============================================================================
+; TRANSCRIPTION NOTE — one shared `raw-extraction` binding, not two
+; ============================================================================
+;
+; `calculate_biocapacity_delta`'s `raw_extraction = extraction_intensity *
+; current_biocapacity` (`metabolic_rift.py:47`) and `calculate_hysteresis_
+; damage`'s `raw_extraction = extraction_intensity * current_biocapacity`
+; (`:86`) are the IDENTICAL formula over the IDENTICAL inputs — both called
+; from `metabolism.py` with the same `attrs.get("extraction_intensity",
+; 0.0)` and the same `biocapacity` read (`:98`/`:109`, `:95`/`:99`/`:103`).
+; This pack computes it once (`raw-extraction` below) and reuses it for both
+; the ecological cost AND the hysteresis damage — a value-preserving
+; consolidation, not a transcription deviation (no output changes).
+;
+; ============================================================================
+; BLOCKED — D-3: the spec-070 sovereign pre-pass has no BSL bind-src
+; ============================================================================
+;
+; `metabolism.py:78-88` reads `context.persistent_data["balkanization.
+; metabolic_impact_by_territory"]` (a one-tick-lagged handoff from
+; `SovereigntySystem` @17.5) and adds it to `territory.habitability` before
+; the biocapacity update. `bsl-language.rst` §2.5 closes `<bind-src>` at
+; exactly four forms (`:field`/`:const`/`:metric`/`:tick`) — none can name
+; `context.persistent_data`. `reports/bsl-gap-analysis-2026-08-10.md`'s Q6
+; section ("Graph-scope state... the single most pervasive gap in the
+; estate") names Metabolism by name among its 22 affected systems and names
+; this EXACT handoff: "three of these values are one-tick-lagged handoffs
+; (Sovereignty -> Metabolism..." Dropped whole, matching how Lifecycle's own
+; header drops its two blocked rules — this is content-modeling work (Q6's
+; own recommended fix routes it onto an ordinary graph field) this port does
+; not perform unilaterally.
+;
+; ============================================================================
+; BLOCKED — D-4: Phases 2-3 (global overshoot aggregate + emit)
+; ============================================================================
+;
+; `metabolism.py:120-153` sums `biocapacity` over every `TERRITORY` and
+; `(s_bio + s_class) * population` over every ACTIVE `SOCIAL_CLASS`, then
+; emits `ECOLOGICAL_OVERSHOOT` when the ratio exceeds a threshold. Confirmed
+; BLOCKED at the EXECUTION-ENGINE level, not merely cited: `bsl-language.
+; rst`'s `(domain :graph)` construct (the mechanism this exact case needs —
+; Q12's own text: "Metabolism's overshoot check... under per-node inference
+; [it] would emit once per node") is fully implemented at LOAD time
+; (`domain.rs::resolve_domain`/`RuleDomain::Graph`) but
+; `tick.rs::run_tick` NEVER reads `loaded.domain` — it unconditionally calls
+; `subject_type_of`, which only understands per-node `:field` namespaces.
+; `babylon-tick/src/lib.rs` registers zero metrics (`metrics:
+; HashSet::new()`), and no scenario/rule/test anywhere in
+; `rust/crates/babylon-tick/` exercises `(domain :graph)` or `fold` end to
+; end (grep-confirmed, zero hits for both). Even setting the engine gap
+; aside, the aggregation spans TWO node-type namespaces in one rule, which
+; no landed pack (including `fundamental-theorem.bsl`, single-namespace)
+; has ever exercised. Dropped whole; full derivation in
+; `reports/metabolism-port-assessment-2026-08-11.md` §4(b).
+;
+; ============================================================================
+; ENGINE MACHINERY
+; ============================================================================
+;
+; `babylon-tick/src/lib.rs`'s `run_once_into` registered-system set gains
+; `metabolism`, the same minimal driver-scaffolding addition Vitality,
+; Lifecycle and Dispossession each made for their own anchors.
+
+(rule metabolism/biocapacity-update
+  :material-basis "a territory's biocapacity regenerates toward its ceiling and is depleted by extraction at an entropic loss every tick, and extraction permanently damages the ceiling itself — the earth cannot recover its original capacity even if extraction stops"
+  :fuel 4096
+  (bindings
+    (binding current :field territory/biocapacity)
+    (binding max-cap :field territory/max-biocapacity)
+    (binding extraction-intensity :field territory/extraction-intensity)
+    (binding regeneration-rate :const metabolism/regeneration-rate)
+    ; D-1: scaled bare-Int workaround for entropy_factor's (1.0, 3.0]
+    ; domain — Ratio's only operator is Currency x Ratio, and this
+    ; formula's multiplicand is never Currency.
+    (binding entropy-factor-x1e6 :const metabolism/entropy-factor-x1e6)
+    (binding hysteresis-rate :const metabolism/hysteresis-rate)
+    ; `regeneration = regeneration_rate * max_biocapacity; if current >=
+    ; max_biocapacity: regeneration = 0.0` (`metabolic_rift.py:40-44`).
+    ; The Real-zero promotion trick (dispossession.bsl's D-4 header, cited
+    ; above): the THEN branch must share regeneration-raw's Real type.
+    (binding regeneration-raw :expr (* regeneration-rate max-cap))
+    (binding regeneration :expr
+      (if (>= current max-cap) (- 0 0c) regeneration-raw))
+    ; Shared by both formulas (see the header's TRANSCRIPTION NOTE).
+    ; Promoted to Real via +0.0 (the SAME trick, needed here because
+    ; `extraction-intensity * current` is Int x Int, which stays Int, and
+    ; `Int / Int` has no pinned semantics (`evaluator.rs::arith_int`) —
+    ; the division below needs at least one Real operand to reach the
+    ; binary64 lane.
+    (binding raw-extraction :expr
+      (+ (* extraction-intensity current) (- 0 0c)))
+    ; `ecological_cost = raw_extraction * entropy_factor`
+    ; (`metabolic_rift.py:47-50`) — D-1's scaled-Int workaround, descaled
+    ; inline.
+    (binding ecological-cost-scaled :expr (* raw-extraction entropy-factor-x1e6))
+    (binding ecological-cost :expr (/ ecological-cost-scaled 1000000))
+    (binding delta :expr (- regeneration ecological-cost))
+    ; `damage = raw_extraction * hysteresis_rate`
+    ; (`metabolic_rift.py:86-87`).
+    (binding damage :expr (* raw-extraction hysteresis-rate))
+    ; `new_max = max(0.0, max_cap - damage)` (`metabolism.py:113`) — the
+    ; hysteresis ratchet. No scalar min/max in the grammar (the gap
+    ; report's own Appendix item 2 recommends against a min/max rider,
+    ; "nested `if` is doctrinally preferable under §3.3") — spelled with
+    ; `if`, matching Dispossession/Lifecycle's own clamps.
+    (binding max-cap-minus-damage :expr (- max-cap damage))
+    (binding new-max :expr
+      (if (> max-cap-minus-damage 0) max-cap-minus-damage (- 0 0c)))
+    ; `new_biocapacity = max(0.0, min(new_max, current + delta))`
+    ; (`metabolism.py:116`) — the double clamp, min then max, exactly.
+    (binding current-plus-delta :expr (+ current delta))
+    (binding capped-at-ceiling :expr
+      (if (< current-plus-delta new-max) current-plus-delta new-max))
+    (binding new-biocapacity :expr
+      (if (> capped-at-ceiling 0) capped-at-ceiling (- 0 0c))))
+  ; No `(when ...)` guard: the frozen Phase 1 loop has no `continue`
+  ; (`metabolism.py:91-118`) — every TERRITORY node gets its effects
+  ; unconditionally, matching Lifecycle's own unconditional Block 1.
+  (effects
+    (update-node self territory/biocapacity (set new-biocapacity))
+    (update-node self territory/max-biocapacity (set new-max))))

--- a/rust/crates/babylon-tick/content/rules/metabolism.bsl
+++ b/rust/crates/babylon-tick/content/rules/metabolism.bsl
@@ -239,6 +239,45 @@
 ; `reports/metabolism-port-assessment-2026-08-11.md` §4(b).
 ;
 ; ============================================================================
+; TRANSCRIPTION DEVIATION — D-5: the four `.get(attr, default)` fallbacks
+; become LOUD FAILURES on an absent field, not silent defaults (F5 fix
+; round, adversarial review of PR #501 — dropped with no disposition in an
+; earlier revision, a bare gap rather than an argued one)
+; ============================================================================
+;
+; `metabolism.py:96-109` reads all four Phase 1 inputs via
+; `attrs.get(field, default)`: `regeneration_rate` (default `0.02`),
+; `max_biocapacity` (`100.0`), `extraction_intensity` (`0.0`) and
+; `biocapacity` (`100.0`) — silently substituting the default whenever the
+; graph dict lacks the key at all (not merely when it holds a falsy value).
+;
+; This pack's four corresponding bindings (`regeneration-rate`,
+; `max-cap`, `extraction-intensity`, `current`) are all declared without
+; `:optional`/`:default` — the ordinary, un-annotated shape every binding
+; in this pack (and Dispossession's, and Lifecycle's) uses. On an ABSENT
+; value they do NOT silently substitute anything: `regeneration-rate` is a
+; `:const`, so a scenario missing its `(defconst metabolism/
+; regeneration-rate …)` row fails to LOAD at all, naming the coefficient
+; (`E-LOAD-010`); `max-cap`/`extraction-intensity`/`current` are `:field`
+; reads, so a `TERRITORY` node missing the attribute fails the TICK loudly
+; — `tick.rs::bind_subject`'s field-read arm propagates the substrate's own
+; error rather than defaulting (its own comment: "the substrate's loud
+; error, because III.11 says absence is not zero").
+;
+; **This is a DELIBERATE divergence, not an oversight, and not a defect
+; this port must repair to match (ADR183 §5.4 asks the opposite: the
+; frozen engine's own silent-default pattern here is the kind of thing a
+; port need not carry forward).** Constitution III.11 ("Loud Failure") is
+; exactly the standard the frozen Python's `.get(field, default)` shape
+; violates for a required simulation input — a territory silently missing
+; `biocapacity` reads as "fully charged at 100.0" in Python, masking what
+; would otherwise be a visible data bug. This pack's every conformance
+; fixture supplies all three fields on every node (matching how every
+; other landed pack's own fixtures behave), so the loud-failure path is
+; untested here by construction rather than by omission — recorded so a
+; later reader does not have to re-derive why no vector exercises it.
+;
+; ============================================================================
 ; ENGINE MACHINERY
 ; ============================================================================
 ;
@@ -266,14 +305,22 @@
     (binding regeneration-raw :expr (* regeneration-rate max-cap))
     (binding regeneration :expr
       (if (>= current max-cap) (- 0 0c) regeneration-raw))
-    ; Shared by both formulas (see the header's TRANSCRIPTION NOTE).
-    ; Promoted to Real via +0.0 (the SAME trick, needed here because
-    ; `extraction-intensity * current` is Int x Int, which stays Int, and
-    ; `Int / Int` has no pinned semantics (`evaluator.rs::arith_int`) —
-    ; the division below needs at least one Real operand to reach the
-    ; binary64 lane.
-    (binding raw-extraction :expr
-      (+ (* extraction-intensity current) (- 0 0c)))
+    ; Shared by both formulas (see the header's TRANSCRIPTION NOTE). NO
+    ; promotion trick needed here (unlike `regeneration` above, or
+    ; dispossession.bsl's bare-Int `:const` bindings): a `:field` read
+    ; ALWAYS resolves to `Value::Real` regardless of the field's declared
+    ; `int` `deffield` type — `tick.rs::bind_subject`'s field-read arm is
+    ; unconditionally `Ok(value) => Value::Real(value)`, because
+    ; `GraphSubstrate`'s own storage is plain `f64` (`scenario.rs`'s module
+    ; doc). `extraction-intensity` and `current` are both `:field`
+    ; bindings, so `extraction-intensity * current` is `Real x Real` from
+    ; the start — an earlier revision of this line wrapped it in a
+    ; `(+ … (- 0 0c))` promotion, on the FALSE premise that the product
+    ; would be `Int x Int` (adversarial review of PR #501 caught this: the
+    ; premise does not hold for `:field`-sourced operands, only for
+    ; `:const`-sourced ones, which CAN be bare, unsuffixed `Int` literals —
+    ; D-1/D-4's own escape hatch).
+    (binding raw-extraction :expr (* extraction-intensity current))
     ; `ecological_cost = raw_extraction * entropy_factor`
     ; (`metabolic_rift.py:47-50`) — D-1's scaled-Int workaround, descaled
     ; inline.

--- a/rust/crates/babylon-tick/content/rules/metabolism.bsl
+++ b/rust/crates/babylon-tick/content/rules/metabolism.bsl
@@ -54,25 +54,84 @@
 ; that the multiplicand would itself be `Currency`-typed in BSL, which it
 ; is not and cannot be in slice 1.
 ;
-; **Workaround, not a resolution.** `entropy_factor` is declared as a
-; scaled bare-`Int` `:const` — `(defconst metabolism/entropy-factor-x1e6
-; 1200000)`, `x1,000,000` to carry the coefficient's full fractional
-; precision as an exact integer — and divided back out inline
-; (`ecological-cost` below). This is the SAME escape hatch Dispossession's
-; own D-2/D-4 already use and document: a bare, unsuffixed `Int` `:const`
-; carries NO domain check at all (`E-LEX-024` only bounds SCALED/suffixed
-; literals). It preserves the formula's exact value for the default
-; `entropy_factor = 1.2` and for ANY legal `(1.0, 3.0]` modded value — unlike
-; a Coefficient-decomposition alternative (`entropy_factor = 1 + (entropy_
-; factor - 1)`, splitting the excess into a `c`-literal), which would
-; SILENTLY miscompute for any modded value above `2.0` (the excess would
-; itself exceed Coefficient's own `[0,1]` cap) — at the cost of the SAME
-; load-time domain-enforcement gap Dispossession's own weights already carry
-; without objection. `metabolism-entropy-low-conformance.bscn` /
+; **Workaround, not a resolution — and NOT bit-exact against the frozen
+; engine. Declared, bounded, deterministic deviation, corrected here after
+; adversarial review found the original "exact ... for ANY legal value"
+; claim FALSE by execution.** `entropy_factor` is declared as a scaled
+; bare-`Int` `:const` — `(defconst metabolism/entropy-factor-x1e6
+; 1200000)`, `x1,000,000` — and divided back out inline (`ecological-cost`
+; below). This is the SAME escape hatch Dispossession's own D-2/D-4 already
+; use and document: a bare, unsuffixed `Int` `:const` carries NO domain
+; check at all (`E-LEX-024` only bounds SCALED/suffixed literals).
+;
+; **The frozen engine computes `raw_extraction * entropy_factor` as ONE
+; binary64 multiply.** This pack computes `(raw_extraction *
+; entropy_factor_x1e6) / 1000000` — an EXACT integer multiply (both
+; operands fit well inside 2^53 for any biocapacity magnitude this game
+; uses) followed by a correctly-rounded division. Both are the SAME
+; real-valued function; they are DIFFERENT floating-point PROGRAMS for it,
+; and correctly-rounded operations composed in a different order are not
+; guaranteed to agree. Two independent error sources, bounded honestly
+; rather than asserted away:
+;
+;   1. **Grid quantization** (dominant for an arbitrary modded value). A
+;      content author writes `entropy-factor-x1e6` as `round(entropy_factor
+;      x 1,000,000)` — an integer, so any TRUE value needing more than 6
+;      decimal digits is quantized to the nearest 1e-6, an absolute error
+;      up to `5e-7`. `MetabolismDefines.entropy_factor` is a plain `float`
+;      with no stated digit-count limit, so this is a real, not merely
+;      hypothetical, degradation for SOME legal `(1.0, 3.0]` values — the
+;      shipped default `1.2` (and any value exactly representable in <= 6
+;      decimal digits) has ZERO quantization error, `1200000 / 1e6 == 1.2`
+;      exactly as a real number.
+;   2. **Double rounding** (the residual even at zero quantization error).
+;      Let `k` = the exact integer `entropy-factor-x1e6`. This pack's value
+;      is `round_f64(raw_extraction * k / 1e6)` — ONE correctly-rounded
+;      division of an EXACT numerator, i.e. the correctly-rounded `f64`
+;      nearest the TRUE mathematical product `raw_extraction x
+;      entropy_factor`. The frozen engine's value is `raw_extraction *_f64
+;      entropy_factor_f64`, where `entropy_factor_f64 =
+;      round_f64(entropy_factor)` already carries its OWN rounding error
+;      (<= 0.5 ULP, i.e. relative error <= 2^-53) from the decimal literal.
+;      The real number Python's multiply rounds therefore differs from the
+;      real number this pack's division rounds by a relative factor of
+;      <= 2^-53 — small, but two INDEPENDENT correctly-rounded results of
+;      two real numbers that close can still land on ADJACENT (or
+;      near-adjacent) representable doubles, because each result is itself
+;      only correct to within 0.5 ULP of ITS OWN input. Measured, not just
+;      bounded: `metabolism-rounding-divergence-conformance.bscn`
+;      (`biocapacity=3`, `entropy_factor` at the shipped default `1.2`,
+;      hence ZERO quantization error) diverges from the frozen engine by
+;      EXACTLY 2 ULP — `0x3ff6666666666666` (this pack) versus
+;      `0x3ff6666666666668` (frozen Python) for `biocapacity`, both
+;      printing as `1.4` / `1.4000000000000004`. See
+;      `metabolism_rounding_divergence_conformance.py` and
+;      `metabolism_rounding_divergence_conformance.rs`, which PIN this
+;      deviation rather than deny it.
+;
+; **Why this is acceptable rather than a defect this port must repair
+; (ADR183 §5.4): the frozen Python engine is the contract source for
+; STRUCTURE and ORDERING, never a bit-exact correctness oracle.** What is
+; constitutional (III.7) is THIS engine's own determinism — the same
+; content and the same inputs produce the same output, every time, on any
+; conforming implementation — which integer-scaled arithmetic satisfies
+; exactly (`the_metabolism_tick_is_deterministic` and its siblings in the
+; conformance suites already prove this). Bit parity with a Python
+; reference the Constitution never asked this port to reproduce exactly is
+; not the bar; a bounded, documented, reproducible deviation is. The
+; en-masse retirement of this whole workaround class — a genuine `Real x
+; Ratio` operator, or `Ratio`-typed field storage, closing the gap at its
+; root instead of per-consumer — is chartered as **workstream 3 of the
+; post-port refactor program** (Director directive 2026-08-11, tracked at
+; GitHub issue #502), not attempted by this port.
+;
+; `metabolism-entropy-low-conformance.bscn` /
 ; `metabolism-entropy-high-conformance.bscn` mutation-verify the workaround
-; end to end: the IDENTICAL territory, differing only in
-; `entropy-factor-x1e6`, produces a floor-inert result at `1.01` and a
-; floor-bound result at `3.0`.
+; carries the coefficient's EFFECT end to end (a floor-inert result at
+; `1.01` swinging to a floor-bound result at `3.0`) — a magnitude check,
+; not a bit-exactness one; `metabolism-rounding-divergence-conformance.bscn`
+; is the bit-exactness check, and it is a PASS for "bounded ULP deviation
+; from the frozen engine", not a pass for "identical to the frozen engine".
 ;
 ; **Recorded as an OPEN finding for the language surface, not resolved
 ; here**: `Real x Ratio` (or `Ratio`-typed field storage) is a genuine

--- a/rust/crates/babylon-tick/content/rules/metabolism.bsl
+++ b/rust/crates/babylon-tick/content/rules/metabolism.bsl
@@ -55,9 +55,10 @@
 ; is not and cannot be in slice 1.
 ;
 ; **Workaround, not a resolution — and NOT bit-exact against the frozen
-; engine. Declared, bounded, deterministic deviation, corrected here after
-; adversarial review found the original "exact ... for ANY legal value"
-; claim FALSE by execution.** `entropy_factor` is declared as a scaled
+; engine. Declared, deterministic deviation (term-bounded, output-UNBOUNDED
+; under cancellation — see the round-2 correction below), corrected here
+; after adversarial review found the original "exact ... for ANY legal
+; value" claim FALSE by execution.** `entropy_factor` is declared as a scaled
 ; bare-`Int` `:const` — `(defconst metabolism/entropy-factor-x1e6
 ; 1200000)`, `x1,000,000` — and divided back out inline (`ecological-cost`
 ; below). This is the SAME escape hatch Dispossession's own D-2/D-4 already

--- a/rust/crates/babylon-tick/content/scenarios/metabolism-ceiling-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism-ceiling-conformance.bscn
@@ -1,0 +1,29 @@
+; The CEILING conformance world for `metabolism/biocapacity-update` — proves
+; the min(new-max, current + delta) half of the double clamp actually binds.
+;
+; regeneration-rate is boosted to 0.9 here (legal per
+; Territory.regeneration_rate's own Field(ge=0.0, le=1.0) — no bypass
+; needed), because the production-default 0.02 can never push
+; current + delta above max-biocapacity for either int-seedable
+; extraction-intensity value (0 or 1) — see `metabolism_ceiling_
+; conformance.py`'s module docstring for the full algebra, including why
+; this vector is deliberately NOT also a "ratcheted ceiling" vector
+; (extraction-intensity 0 here makes the hysteresis damage exactly zero,
+; so this clamp binds against the ORIGINAL ceiling — the ratchet itself is
+; proven separately, by zero-floor-county in metabolism-conformance.bscn).
+;
+; See `metabolism_ceiling_conformance.py` for the provenance script.
+(scenario metabolism/ceiling-conformance
+  (deffield territory/biocapacity int extensive)
+  (deffield territory/max-biocapacity int extensive)
+  (deffield territory/extraction-intensity int intensive)
+
+  ; Boosted from the 0.02 production default — see the header.
+  (defconst metabolism/regeneration-rate 0.9c)
+  (defconst metabolism/entropy-factor-x1e6 1200000)
+  (defconst metabolism/hysteresis-rate 0.005c)
+
+  (node ceiling-county NodeType/TERRITORY
+    (territory/biocapacity 50)
+    (territory/max-biocapacity 100)
+    (territory/extraction-intensity 0)))

--- a/rust/crates/babylon-tick/content/scenarios/metabolism-ceiling-suppression-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism-ceiling-suppression-conformance.bscn
@@ -1,0 +1,33 @@
+; The AT-THE-CEILING conformance world for `metabolism/biocapacity-update`
+; — proves the `(>= current max-cap)` regeneration-suppression guard fires
+; at the EXACT boundary `current == max-cap` (F3 fix round, adversarial
+; review of PR #501: mutating this guard's comparator to `>` left all 16
+; prior tests green, because `zero-floor-county`'s discriminating case
+; floors BOTH branches' results to the identical `0.0`).
+;
+; `biocapacity` and `max-biocapacity` are seeded EQUAL (`10`), so the
+; guard's boundary condition is exercised exactly. `entropy-factor-x1e6`
+; near its floor (`1.005`) and a boosted `regeneration-rate` (`0.5`) push
+; the CORRECT branch (regeneration suppressed) just below zero — floored to
+; `0.0` — and the WRONG branch (regeneration firing) comfortably above zero
+; — surviving the floor untouched at `4.949999999999999` — so the two
+; branches are distinguishable in the FINAL clamped output, not merely in
+; an intermediate the floor would otherwise erase.
+;
+; See `metabolism_ceiling_suppression_conformance.py` for the provenance
+; script.
+(scenario metabolism/ceiling-suppression-conformance
+  (deffield territory/biocapacity int extensive)
+  (deffield territory/max-biocapacity int extensive)
+  (deffield territory/extraction-intensity int intensive)
+
+  (defconst metabolism/regeneration-rate 0.5c)
+  ; 1.005 x 1,000,000 — barely above the declared floor (1.0, exclusive).
+  (defconst metabolism/entropy-factor-x1e6 1005000)
+  ; Legal maximum.
+  (defconst metabolism/hysteresis-rate 0.01c)
+
+  (node at-ceiling-county NodeType/TERRITORY
+    (territory/biocapacity 10)
+    (territory/max-biocapacity 10)
+    (territory/extraction-intensity 1)))

--- a/rust/crates/babylon-tick/content/scenarios/metabolism-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism-conformance.bscn
@@ -1,0 +1,52 @@
+; The ACTIVE conformance world for `metabolism/biocapacity-update`.
+;
+; Three counties, sharing the PRODUCTION-DEFAULT MetabolismDefines
+; coefficients (entropy_factor=1.2, hysteresis_rate=0.005) and the
+; production-default per-node regeneration_rate=0.02 (D-2 in
+; metabolism.bsl: grep-verified uniform across every scenario builder in
+; the frozen engine), discriminated entirely by their per-node
+; biocapacity/max-biocapacity/extraction-intensity seeds:
+;
+;   - nominal-county: a small current stock, full extraction — neither
+;     clamp binds.
+;   - hysteresis-inert-county: extraction-intensity 0 — both the
+;     ecological cost AND the hysteresis damage are exactly zero (pure
+;     regeneration); max-biocapacity is unchanged bit for bit.
+;   - zero-floor-county: at its own ceiling (biocapacity == max-biocapacity,
+;     so the frozen formula suppresses regeneration) with full extraction —
+;     the ecological cost alone drives it deeply negative and the
+;     max(0.0, ...) floor binds at exactly 0.0; max-biocapacity also
+;     strictly decreases from its seed, proving the hysteresis ratchet is
+;     live.
+;
+; See `metabolism_conformance.py` for the provenance script these numbers
+; come from.
+(scenario metabolism/conformance
+  (deffield territory/biocapacity int extensive)
+  (deffield territory/max-biocapacity int extensive)
+  (deffield territory/extraction-intensity int intensive)
+
+  ; MetabolismDefines, src/babylon/data/defines.yaml (metabolism: section) —
+  ; production defaults.
+  (defconst metabolism/regeneration-rate 0.02c)
+  ; D-1 (metabolism.bsl): entropy_factor's declared domain (1.0, 3.0]
+  ; exceeds every [0,1]-capped scaled literal, and Ratio's only operator is
+  ; Currency x Ratio -> Currency (this formula needs Real x Ratio, which
+  ; does not exist) — scaled bare-Int workaround, x1,000,000.
+  (defconst metabolism/entropy-factor-x1e6 1200000)
+  (defconst metabolism/hysteresis-rate 0.005c)
+
+  (node nominal-county NodeType/TERRITORY
+    (territory/biocapacity 5)
+    (territory/max-biocapacity 100)
+    (territory/extraction-intensity 1))
+
+  (node hysteresis-inert-county NodeType/TERRITORY
+    (territory/biocapacity 50)
+    (territory/max-biocapacity 100)
+    (territory/extraction-intensity 0))
+
+  (node zero-floor-county NodeType/TERRITORY
+    (territory/biocapacity 100)
+    (territory/max-biocapacity 100)
+    (territory/extraction-intensity 1)))

--- a/rust/crates/babylon-tick/content/scenarios/metabolism-entropy-high-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism-entropy-high-conformance.bscn
@@ -1,0 +1,26 @@
+; The HIGH-ENTROPY conformance world for `metabolism/biocapacity-update` —
+; the other half of the mutation-verification pair for the D-1 scaled-Int
+; workaround. Seeds the IDENTICAL territory as
+; metabolism-entropy-low-conformance.bscn (same biocapacity/
+; max-biocapacity/extraction-intensity/regeneration-rate), with
+; entropy-factor-x1e6 at the declared cap instead (3.0, inclusive — legal,
+; MetabolismDefines(entropy_factor=3.0) constructs cleanly). At this cap the
+; ecological cost is high enough that the max(0.0, ...) floor binds, unlike
+; the low-entropy companion — the clearest possible proof the scaled-Int
+; workaround carries the coefficient's effect end to end.
+;
+; See `metabolism_entropy_high_conformance.py` for the provenance script.
+(scenario metabolism/entropy-high-conformance
+  (deffield territory/biocapacity int extensive)
+  (deffield territory/max-biocapacity int extensive)
+  (deffield territory/extraction-intensity int intensive)
+
+  (defconst metabolism/regeneration-rate 0.02c)
+  ; 3.0 x 1,000,000 — at the cap, inclusive.
+  (defconst metabolism/entropy-factor-x1e6 3000000)
+  (defconst metabolism/hysteresis-rate 0.005c)
+
+  (node high-entropy-county NodeType/TERRITORY
+    (territory/biocapacity 10)
+    (territory/max-biocapacity 100)
+    (territory/extraction-intensity 1)))

--- a/rust/crates/babylon-tick/content/scenarios/metabolism-entropy-low-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism-entropy-low-conformance.bscn
@@ -1,0 +1,23 @@
+; The LOW-ENTROPY conformance world for `metabolism/biocapacity-update` —
+; one half of the mutation-verification pair for the D-1 scaled-Int
+; workaround. entropy-factor-x1e6 here encodes 1.01 (near the declared
+; floor of 1.0, exclusive — legal, MetabolismDefines(entropy_factor=1.01)
+; constructs cleanly with no Pydantic bypass). Its companion,
+; metabolism-entropy-high-conformance.bscn, seeds the IDENTICAL territory
+; with entropy-factor-x1e6 at the declared cap (3.0) instead.
+;
+; See `metabolism_entropy_low_conformance.py` for the provenance script.
+(scenario metabolism/entropy-low-conformance
+  (deffield territory/biocapacity int extensive)
+  (deffield territory/max-biocapacity int extensive)
+  (deffield territory/extraction-intensity int intensive)
+
+  (defconst metabolism/regeneration-rate 0.02c)
+  ; 1.01 x 1,000,000 — near the floor (1.0, exclusive).
+  (defconst metabolism/entropy-factor-x1e6 1010000)
+  (defconst metabolism/hysteresis-rate 0.005c)
+
+  (node low-entropy-county NodeType/TERRITORY
+    (territory/biocapacity 10)
+    (territory/max-biocapacity 100)
+    (territory/extraction-intensity 1)))

--- a/rust/crates/babylon-tick/content/scenarios/metabolism-extreme-damage-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism-extreme-damage-conformance.bscn
@@ -1,0 +1,40 @@
+; The EXTREME-DAMAGE conformance world for `metabolism/biocapacity-update`
+; — proves the `new-max` floor clamp (`max(0.0, max_cap - damage)`) is
+; reachable and mutation-catchable (F4 fix round, adversarial review of PR
+; #501: this clamp was never exercised by any prior fixture — deleting it
+; left all prior tests green).
+;
+; `damage > max-biocapacity` IS reachable inside every field's declared
+; domain: `Territory.biocapacity`/`max_biocapacity` are `Currency` fields
+; with only `ge=0.0` (NO upper bound) in the Pydantic model, and
+; `MetabolismSystem`'s own formulas never clamp `extraction_intensity`
+; either (only `ProductionSystem`'s WRITE side does, at `min(1.0, ...)` —
+; irrelevant to a synthetic conformance fixture that seeds the field
+; directly, bypassing Production entirely). A territory with
+; `biocapacity=100000` (an unusually large but legal stock — e.g. the
+; result of prior gameplay dynamics this fixture does not model) and
+; `extraction_intensity=1` at the PRODUCTION-DEFAULT `hysteresis_rate`
+; (`0.005`) already gives `damage = 100000 * 0.005 = 500`, far exceeding
+; `max_biocapacity = 100` — `max_cap - damage = -400`, and the frozen
+; formula's `max(0.0, ...)` must floor `new_max` to exactly `0.0`, not
+; leave it negative.
+;
+; `biocapacity` itself floors to `0.0` regardless of whether this clamp
+; fires (the ecological cost alone drives `current + delta` far more
+; negative than `-400`), so this clamp's mutation signal lives entirely in
+; `max-biocapacity`, not `biocapacity` — see
+; `metabolism_extreme_damage_conformance.py` for the exact numbers.
+(scenario metabolism/extreme-damage-conformance
+  (deffield territory/biocapacity int extensive)
+  (deffield territory/max-biocapacity int extensive)
+  (deffield territory/extraction-intensity int intensive)
+
+  ; Production defaults — no boost needed, the SEED does the work here.
+  (defconst metabolism/regeneration-rate 0.02c)
+  (defconst metabolism/entropy-factor-x1e6 1200000)
+  (defconst metabolism/hysteresis-rate 0.005c)
+
+  (node extreme-county NodeType/TERRITORY
+    (territory/biocapacity 100000)
+    (territory/max-biocapacity 100)
+    (territory/extraction-intensity 1)))

--- a/rust/crates/babylon-tick/content/scenarios/metabolism-ratcheted-ceiling-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism-ratcheted-ceiling-conformance.bscn
@@ -1,0 +1,41 @@
+; The RATCHETED-CEILING conformance world for `metabolism/biocapacity-update`
+; — proves the ceiling clamp binds AGAINST THE RATCHETED VALUE
+; (`new-max`), not the original `max-biocapacity` seed (F2 fix round,
+; adversarial review of PR #501: the earlier `metabolism-ceiling-
+; conformance.bscn` alone left the `capped-at-ceiling` binding's operand
+; choice (`new-max` vs `max-cap`) mutation-dead — swapping it left all
+; prior tests green).
+;
+; `metabolism_ceiling_conformance.py`'s own earlier "provably unreachable"
+; argument fixed `entropy_factor`/`hysteresis_rate` at their PRODUCTION
+; DEFAULTS while reasoning about reachability — an analytical error: both
+; are ALSO per-scenario `:const`s, exactly like `regeneration_rate`. Pushed
+; to more extreme (still legal) values — `regeneration_rate=1.0` (the
+; declared `le=1.0` maximum), `entropy_factor=1.005` (barely above its
+; declared `gt=1.0` floor, so the ecological-cost coefficient
+; `(1 - entropy_factor)` is nearly zero instead of the default's `-0.2`),
+; `hysteresis_rate=0.01` (the declared `le=0.01` maximum) — a single
+; `extraction_intensity=1` territory hits BOTH conditions at once: damage
+; is nonzero (`raw_extraction * hysteresis_rate = 50 * 0.01 = 0.5`, so
+; `new_max = 99.5`, strictly ratcheted below the `100` seed) AND
+; `current + delta` (`99.75`) exceeds that RATCHETED ceiling — so the
+; clamp must bind against `99.5`, not `100`.
+;
+; See `metabolism_ratcheted_ceiling_conformance.py` for the provenance
+; script.
+(scenario metabolism/ratcheted-ceiling-conformance
+  (deffield territory/biocapacity int extensive)
+  (deffield territory/max-biocapacity int extensive)
+  (deffield territory/extraction-intensity int intensive)
+
+  ; Legal maximum — see the header.
+  (defconst metabolism/regeneration-rate 1.0c)
+  ; 1.005 x 1,000,000 — barely above the declared floor (1.0, exclusive).
+  (defconst metabolism/entropy-factor-x1e6 1005000)
+  ; Legal maximum — see the header.
+  (defconst metabolism/hysteresis-rate 0.01c)
+
+  (node ratcheted-ceiling-county NodeType/TERRITORY
+    (territory/biocapacity 50)
+    (territory/max-biocapacity 100)
+    (territory/extraction-intensity 1)))

--- a/rust/crates/babylon-tick/content/scenarios/metabolism-rounding-divergence-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism-rounding-divergence-conformance.bscn
@@ -1,0 +1,29 @@
+; The ROUNDING-DIVERGENCE conformance world for `metabolism/biocapacity-update`
+; — pins the D-1 scaled-Int workaround's DEVIATION from the frozen engine
+; rather than denying it exists (F1 fix round, adversarial review of PR
+; #501). See `metabolism.bsl`'s own D-1 for the derivation: the frozen
+; engine computes `raw_extraction * entropy_factor` as ONE binary64
+; multiply; this pack computes `(raw_extraction * entropy_factor_x1e6) /
+; 1000000` — an exact integer multiply followed by a correctly-rounded
+; division. These are the SAME real-valued function but DIFFERENT
+; floating-point programs, and can round to adjacent doubles. This
+; territory (`biocapacity=3`, `extraction_intensity=1`, entropy_factor at
+; its production default 1.2) is the smallest int-seedable case that
+; demonstrates the divergence.
+;
+; See `metabolism_rounding_divergence_conformance.py` for the provenance
+; script that prints BOTH the frozen engine's value and confirms the BSL
+; value below, with hex float dumps of both.
+(scenario metabolism/rounding-divergence-conformance
+  (deffield territory/biocapacity int extensive)
+  (deffield territory/max-biocapacity int extensive)
+  (deffield territory/extraction-intensity int intensive)
+
+  (defconst metabolism/regeneration-rate 0.02c)
+  (defconst metabolism/entropy-factor-x1e6 1200000)
+  (defconst metabolism/hysteresis-rate 0.005c)
+
+  (node divergent-county NodeType/TERRITORY
+    (territory/biocapacity 3)
+    (territory/max-biocapacity 100)
+    (territory/extraction-intensity 1)))

--- a/rust/crates/babylon-tick/content/scenarios/metabolism_ceiling_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism_ceiling_conformance.py
@@ -1,0 +1,104 @@
+"""Conformance vector for `metabolism/biocapacity-update`'s ceiling clamp,
+from the frozen engine — the DISCRIMINATING scenario for the
+``min(new_max, current + delta)`` half of the frozen formula's double clamp.
+
+This script is the PROVENANCE of every number pinned in
+``rust/crates/babylon-tick/tests/metabolism_ceiling_conformance.rs``.
+
+**Why this needs its own scenario, and why extraction is zero here.**
+``metabolism-conformance.bscn`` uses the production-default
+``regeneration_rate=0.02``, which can never push ``current + delta`` above
+``max_biocapacity`` for any legal ``extraction_intensity`` in ``{0, 1}`` --
+the only two values `int`-declared field seeding can carry (slice 1's
+scenario loader accepts only integer literals for node attributes,
+``bsl-language.rst``/``scenario.rs::attribute_value``). This scenario
+deliberately boosts ``regeneration_rate`` to ``0.9`` (legal per
+``Territory.regeneration_rate``'s own ``Field(ge=0.0, le=1.0)`` -- no
+Pydantic bypass needed) with ``extraction_intensity=0`` so the ceiling is
+approached purely through regeneration: ``regeneration_rate * max_biocapacity
+= 90``, against a ``current_biocapacity`` of ``50`` -- ``current + delta =
+140``, comfortably past ``max_biocapacity = 100``, and the frozen formula's
+``max(0.0, min(new_max, current + delta))`` must clamp it back to exactly
+``100.0``.
+
+**Why this is NOT also a "ratcheted ceiling" vector, and why that
+combination is provably unreachable with int-seeded fields.** With
+``extraction_intensity=0``, ``raw_extraction = extraction_intensity *
+current_biocapacity`` is exactly zero, so
+``calculate_hysteresis_damage`` returns exactly ``0.0`` and
+``new_max = max(0.0, max_biocapacity - 0.0) = max_biocapacity`` unchanged --
+the clamp here binds against the ORIGINAL ceiling, not a ratcheted one. For
+``extraction_intensity=1`` (the only other int-seedable value),
+algebraically ``current + delta = current * (1 - entropy_factor) +
+regeneration_rate * max_biocapacity``, which is DECREASING in
+``current_biocapacity`` since ``entropy_factor > 1`` always (declared domain
+``(1.0, 3.0]``) -- and ``regeneration_rate * max_biocapacity <=
+max_biocapacity`` (``regeneration_rate <= 1.0``), so ``current + delta``
+can approach but never EXCEED ``max_biocapacity`` at ``extraction_intensity
+= 1``, for any current/max_biocapacity/regeneration_rate combination. A
+node with BOTH a strictly-ratcheted ceiling (``damage > 0``, needing
+``extraction_intensity > 0``) AND a binding ceiling clamp
+(``current + delta`` exceeding that ceiling) needs a FRACTIONAL
+``extraction_intensity`` strictly between ``0`` and roughly ``1 /
+entropy_factor`` -- unreachable through slice 1's int-only field seeding.
+The hysteresis ratchet itself (``new_max`` strictly below its seed) is
+proven separately, by ``zero-floor-county`` in ``metabolism_conformance.py``,
+whose ``max_biocapacity`` ends the tick at ``99.5`` against a ``100.0``
+seed.
+
+Run it from the repository root, single process::
+
+    PYTHONPATH="$PWD/src" uv run python \\
+        rust/crates/babylon-tick/content/scenarios/metabolism_ceiling_conformance.py
+"""
+
+from __future__ import annotations
+
+from babylon.engine.context import TickContext
+from babylon.engine.services import ServiceContainer
+from babylon.engine.systems.metabolism import MetabolismSystem
+from babylon.models.enums import NodeType
+from babylon.topology.graph import BabylonGraph
+
+SUBJECT_ID = "ceiling-county"
+SEED = {
+    "biocapacity": 50.0,
+    "max_biocapacity": 100.0,
+    "extraction_intensity": 0.0,
+    # Boosted from the 0.02 production default -- see the module docstring.
+    # Legal per Territory.regeneration_rate's own Field(ge=0.0, le=1.0).
+    "regeneration_rate": 0.9,
+}
+
+
+def build_graph() -> BabylonGraph:
+    """Build the one-territory world."""
+    graph = BabylonGraph()
+    graph.add_node(SUBJECT_ID, NodeType.TERRITORY, **SEED)
+    return graph
+
+
+def main() -> None:
+    """Run one tick of the frozen MetabolismSystem and print the vectors."""
+    services = ServiceContainer.create()
+    try:
+        graph = build_graph()
+        MetabolismSystem().step(graph, services, TickContext(tick=1))
+
+        node = graph.get_node(SUBJECT_ID)
+        if node is None:
+            raise SystemExit(f"node {SUBJECT_ID} vanished during the tick")
+        a = node.attributes
+        print("post-tick state:")
+        print(
+            f"  {SUBJECT_ID:<14} biocapacity={a['biocapacity']!r} "
+            f"max_biocapacity={a['max_biocapacity']!r} "
+            f"(seed biocapacity={SEED['biocapacity']!r} "
+            f"seed max_biocapacity={SEED['max_biocapacity']!r})"
+        )
+    finally:
+        services.database.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/crates/babylon-tick/content/scenarios/metabolism_ceiling_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism_ceiling_conformance.py
@@ -7,44 +7,44 @@ This script is the PROVENANCE of every number pinned in
 
 **Why this needs its own scenario, and why extraction is zero here.**
 ``metabolism-conformance.bscn`` uses the production-default
-``regeneration_rate=0.02``, which can never push ``current + delta`` above
-``max_biocapacity`` for any legal ``extraction_intensity`` in ``{0, 1}`` --
-the only two values `int`-declared field seeding can carry (slice 1's
-scenario loader accepts only integer literals for node attributes,
-``bsl-language.rst``/``scenario.rs::attribute_value``). This scenario
-deliberately boosts ``regeneration_rate`` to ``0.9`` (legal per
-``Territory.regeneration_rate``'s own ``Field(ge=0.0, le=1.0)`` -- no
-Pydantic bypass needed) with ``extraction_intensity=0`` so the ceiling is
-approached purely through regeneration: ``regeneration_rate * max_biocapacity
-= 90``, against a ``current_biocapacity`` of ``50`` -- ``current + delta =
-140``, comfortably past ``max_biocapacity = 100``, and the frozen formula's
-``max(0.0, min(new_max, current + delta))`` must clamp it back to exactly
-``100.0``.
+``regeneration_rate=0.02``. That default does NOT make the ceiling clamp
+unreachable in general -- a ``current`` close enough to ``max_biocapacity``
+(e.g. ``current=99``, ``max_biocapacity=100``: ``regen = 0.02*100 = 2``,
+``current + delta = 101 > 100`` at ``extraction_intensity=0``) already
+exceeds it, by a margin of roughly ``regeneration_rate`` itself. What the
+default rules out is a DRAMATIC, unambiguous margin from an ORDINARY,
+mid-range stock level: this scenario boosts ``regeneration_rate`` to
+``0.9`` (legal per ``Territory.regeneration_rate``'s own
+``Field(ge=0.0, le=1.0)`` -- no Pydantic bypass needed) precisely so the
+clamp fires from ``current_biocapacity=50`` -- nowhere near the ceiling --
+rather than needing a seed sitting within a hair of it. With
+``extraction_intensity=0`` (so the ecological cost is exactly zero and the
+ceiling is approached PURELY through regeneration): ``regeneration_rate *
+max_biocapacity = 90``, against ``current_biocapacity=50`` --
+``current + delta = 140``, comfortably past ``max_biocapacity = 100``, and
+the frozen formula's ``max(0.0, min(new_max, current + delta))`` must clamp
+it back to exactly ``100.0``.
 
-**Why this is NOT also a "ratcheted ceiling" vector, and why that
-combination is provably unreachable with int-seeded fields.** With
+**Why this is NOT also a "ratcheted ceiling" vector.** With
 ``extraction_intensity=0``, ``raw_extraction = extraction_intensity *
 current_biocapacity`` is exactly zero, so
 ``calculate_hysteresis_damage`` returns exactly ``0.0`` and
 ``new_max = max(0.0, max_biocapacity - 0.0) = max_biocapacity`` unchanged --
-the clamp here binds against the ORIGINAL ceiling, not a ratcheted one. For
-``extraction_intensity=1`` (the only other int-seedable value),
-algebraically ``current + delta = current * (1 - entropy_factor) +
-regeneration_rate * max_biocapacity``, which is DECREASING in
-``current_biocapacity`` since ``entropy_factor > 1`` always (declared domain
-``(1.0, 3.0]``) -- and ``regeneration_rate * max_biocapacity <=
-max_biocapacity`` (``regeneration_rate <= 1.0``), so ``current + delta``
-can approach but never EXCEED ``max_biocapacity`` at ``extraction_intensity
-= 1``, for any current/max_biocapacity/regeneration_rate combination. A
-node with BOTH a strictly-ratcheted ceiling (``damage > 0``, needing
-``extraction_intensity > 0``) AND a binding ceiling clamp
-(``current + delta`` exceeding that ceiling) needs a FRACTIONAL
-``extraction_intensity`` strictly between ``0`` and roughly ``1 /
-entropy_factor`` -- unreachable through slice 1's int-only field seeding.
-The hysteresis ratchet itself (``new_max`` strictly below its seed) is
-proven separately, by ``zero-floor-county`` in ``metabolism_conformance.py``,
-whose ``max_biocapacity`` ends the tick at ``99.5`` against a ``100.0``
-seed.
+the clamp here binds against the ORIGINAL ceiling, not a ratcheted one. **An
+earlier revision of this docstring claimed the combination (damage > 0 AND
+the ceiling clamp binding against the RATCHETED value) was "provably
+unreachable with int-seeded fields" -- that argument fixed
+``entropy_factor``/``hysteresis_rate`` at their PRODUCTION DEFAULTS while
+reasoning about reachability, missing that both are ALSO per-scenario
+``MetabolismDefines`` coefficients, exactly like ``regeneration_rate``.
+FALSE, disproved by execution: see
+``metabolism_ratcheted_ceiling_conformance.py``
+(``regeneration_rate=1.0``, ``entropy_factor=1.005``,
+``hysteresis_rate=0.01``, all legal at their declared extremes) for a
+territory that hits both conditions at once.** This scenario stays useful
+in its own right -- it isolates the UNRATCHETED ceiling clamp with no
+hysteresis interaction at all, which the ratcheted-ceiling scenario does
+not (there the two clamps interact).
 
 Run it from the repository root, single process::
 

--- a/rust/crates/babylon-tick/content/scenarios/metabolism_ceiling_suppression_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism_ceiling_suppression_conformance.py
@@ -1,0 +1,97 @@
+"""Conformance vector for `metabolism/biocapacity-update`'s
+regeneration-suppression-AT-THE-CEILING boundary (F3 fix round, adversarial
+review of PR #501: mutating `metabolism.bsl`'s `(>= current max-cap)` guard
+to `(> current max-cap)` left all 16 prior tests green, because
+`zero-floor-county`'s discriminating case floors BOTH branches' results to
+the identical `0.0` -- the mutation was hidden by the downstream `max(0.0,
+...)` clamp, not caught by it).
+
+This script is the PROVENANCE of every number pinned in
+``rust/crates/babylon-tick/tests/metabolism_ceiling_suppression_conformance.rs``.
+
+The frozen formula's own guard, verbatim (`metabolic_rift.py:42-44`):
+
+.. code-block:: python
+
+    regeneration = regeneration_rate * max_biocapacity
+    if current_biocapacity >= max_biocapacity:
+        regeneration = 0.0
+
+At ``current_biocapacity == max_biocapacity`` EXACTLY, this suppresses
+regeneration (the ``>=`` fires). A rule using ``>`` instead would WRONGLY
+let regeneration fire at this exact boundary. To make that difference
+survive to the FINAL clamped output (not get floored away like
+``zero-floor-county``'s vector), this territory is chosen so the CORRECT
+branch (`regeneration` suppressed) lands JUST BELOW zero (and floors to
+`0.0`) while the WRONG branch (`regeneration` firing) lands comfortably
+ABOVE zero (and survives the floor untouched) -- ``entropy_factor`` near its
+declared floor (`1.005`, so the ecological cost barely exceeds the stock
+itself) and a boosted ``regeneration_rate`` (`0.5`) make the gap between
+the two branches large and unambiguous.
+
+Run it from the repository root, single process::
+
+    PYTHONPATH="$PWD/src" uv run python \\
+        rust/crates/babylon-tick/content/scenarios/metabolism_ceiling_suppression_conformance.py
+"""
+
+from __future__ import annotations
+
+from babylon.config.defines import MetabolismDefines
+from babylon.engine.context import TickContext
+from babylon.engine.services import ServiceContainer
+from babylon.engine.systems.metabolism import MetabolismSystem
+from babylon.models.enums import NodeType
+from babylon.topology.graph import BabylonGraph
+
+SUBJECT_ID = "at-ceiling-county"
+SEED = {
+    "biocapacity": 10.0,
+    "max_biocapacity": 10.0,
+    "extraction_intensity": 1.0,
+    # Boosted -- legal per Territory.regeneration_rate's own
+    # Field(ge=0.0, le=1.0).
+    "regeneration_rate": 0.5,
+}
+#: Barely above the declared floor -- legal, ordinary construction.
+ENTROPY_FACTOR = 1.005
+#: Legal maximum (MetabolismDefines.hysteresis_rate: Field(ge=0.001, le=0.01)).
+HYSTERESIS_RATE = 0.01
+
+
+def build_graph() -> BabylonGraph:
+    """Build the one-territory world, seeded EXACTLY at its own ceiling."""
+    graph = BabylonGraph()
+    graph.add_node(SUBJECT_ID, NodeType.TERRITORY, **SEED)
+    return graph
+
+
+def main() -> None:
+    """Run one tick of the frozen MetabolismSystem at the current==max_biocapacity boundary."""
+    services = ServiceContainer.create()
+    try:
+        object.__setattr__(
+            services.defines,
+            "metabolism",
+            MetabolismDefines(entropy_factor=ENTROPY_FACTOR, hysteresis_rate=HYSTERESIS_RATE),
+        )
+
+        graph = build_graph()
+        MetabolismSystem().step(graph, services, TickContext(tick=1))
+
+        node = graph.get_node(SUBJECT_ID)
+        if node is None:
+            raise SystemExit(f"node {SUBJECT_ID} vanished during the tick")
+        a = node.attributes
+        print(f"entropy_factor = {ENTROPY_FACTOR!r}, hysteresis_rate = {HYSTERESIS_RATE!r}")
+        print("post-tick state:")
+        print(
+            f"  {SUBJECT_ID:<20} biocapacity={a['biocapacity']!r} "
+            f"max_biocapacity={a['max_biocapacity']!r}"
+        )
+    finally:
+        services.database.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/crates/babylon-tick/content/scenarios/metabolism_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism_conformance.py
@@ -1,0 +1,138 @@
+"""Conformance vectors for `metabolism/biocapacity-update`, from the frozen engine.
+
+This script is the PROVENANCE of every number pinned in
+``rust/crates/babylon-tick/tests/metabolism_conformance.rs``. It builds the
+three territories of ``metabolism-conformance.bscn`` node for node, runs the
+frozen ``MetabolismSystem`` once against them, and prints the post-tick
+state.
+
+Run it from the repository root, single process::
+
+    PYTHONPATH="$PWD/src" uv run python \\
+        rust/crates/babylon-tick/content/scenarios/metabolism_conformance.py
+
+The frozen system is the contract source for STRUCTURE and ORDERING, not a
+correctness oracle (ADR183). This pack ports only Phase 1 of the frozen
+system (per-territory biocapacity delta + hysteresis ratchet + double
+clamp) — the spec-070 sovereign pre-pass and Phases 2-3 (global overshoot
+aggregate + ``ECOLOGICAL_OVERSHOOT``) are BLOCKED, per
+``reports/metabolism-port-assessment-2026-08-11.md``.
+
+All three territories share the PRODUCTION-DEFAULT ``MetabolismDefines``
+coefficients (``entropy_factor=1.2``, ``hysteresis_rate=0.005``) and the
+production-default per-node ``regeneration_rate=0.02`` (grep-verified
+uniform across every scenario builder — the assessment's D-2). They are
+discriminated entirely by their per-node ``biocapacity``/``max_biocapacity``/
+``extraction_intensity`` seeds:
+
+- ``nominal-county``: a small current stock, full extraction — neither clamp
+  binds (regeneration is small and positive, the ecological cost pulls it
+  down but not to zero, and the hysteresis damage barely dents the ceiling).
+- ``hysteresis-inert-county``: ``extraction_intensity=0`` — the frozen
+  formula's ``raw_extraction = extraction_intensity * current_biocapacity``
+  is exactly zero, so BOTH the ecological cost AND the hysteresis damage are
+  exactly zero: pure regeneration, and ``max_biocapacity`` is unchanged bit
+  for bit.
+- ``zero-floor-county``: at its ceiling (``biocapacity == max_biocapacity``,
+  so regeneration is suppressed per the frozen formula's own
+  ``if current_biocapacity >= max_biocapacity: regeneration = 0.0``) with
+  full extraction — the ecological cost alone drives ``current + delta``
+  deeply negative, and the ``max(0.0, ...)`` floor binds exactly at ``0.0``.
+  Its ``max_biocapacity`` also strictly decreases from its seed, proving the
+  hysteresis ratchet (``new_max = max(0.0, max_cap - damage)``) is live.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from babylon.engine.context import TickContext
+from babylon.engine.services import ServiceContainer
+from babylon.engine.systems.metabolism import MetabolismSystem
+from babylon.models.enums import NodeType
+from babylon.topology.graph import BabylonGraph
+
+SUBJECTS: list[tuple[str, dict[str, Any]]] = [
+    (
+        "nominal-county",
+        {
+            "biocapacity": 5.0,
+            "max_biocapacity": 100.0,
+            "extraction_intensity": 1.0,
+            "regeneration_rate": 0.02,
+        },
+    ),
+    (
+        "hysteresis-inert-county",
+        {
+            "biocapacity": 50.0,
+            "max_biocapacity": 100.0,
+            "extraction_intensity": 0.0,
+            "regeneration_rate": 0.02,
+        },
+    ),
+    (
+        "zero-floor-county",
+        {
+            "biocapacity": 100.0,
+            "max_biocapacity": 100.0,
+            "extraction_intensity": 1.0,
+            "regeneration_rate": 0.02,
+        },
+    ),
+]
+
+
+def build_graph() -> BabylonGraph:
+    """Build the three-territory world, in scenario declaration order."""
+    graph = BabylonGraph()
+    for node_id, attrs in SUBJECTS:
+        graph.add_node(node_id, NodeType.TERRITORY, **attrs)
+    return graph
+
+
+def main() -> None:
+    """Run one tick of the frozen MetabolismSystem and print the vectors."""
+    services = ServiceContainer.create()
+    try:
+        d = services.defines.metabolism
+        print("defines (src/babylon/data/defines.yaml, metabolism: section):")
+        for name in (
+            "entropy_factor",
+            "overshoot_threshold",
+            "hysteresis_rate",
+            "max_overshoot_ratio",
+        ):
+            print(f"  metabolism.{name} = {getattr(d, name)!r}")
+        print()
+
+        graph = build_graph()
+        MetabolismSystem().step(graph, services, TickContext(tick=1))
+        events = services.event_bus.get_history()
+
+        print("post-tick state:")
+        for node_id, seed in SUBJECTS:
+            node = graph.get_node(node_id)
+            if node is None:
+                raise SystemExit(f"node {node_id} vanished during the tick")
+            a = node.attributes
+            print(
+                f"  {node_id:<24} "
+                f"biocapacity={a['biocapacity']!r} "
+                f"max_biocapacity={a['max_biocapacity']!r} "
+                f"(seed biocapacity={seed['biocapacity']!r} "
+                f"seed max_biocapacity={seed['max_biocapacity']!r})"
+            )
+        print()
+
+        print("events:")
+        for event in events:
+            print(f"  {event.type} {event.payload!r}")
+        if not events:
+            print("  (none)")
+    finally:
+        services.database.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/crates/babylon-tick/content/scenarios/metabolism_entropy_high_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism_entropy_high_conformance.py
@@ -1,0 +1,79 @@
+"""Conformance vector for `metabolism/biocapacity-update` at `entropy_factor`
+AT its declared cap, from the frozen engine -- the other half of the
+mutation-verification pair for the D-1 scaled-`Int` workaround. See
+``metabolism_entropy_low_conformance.py``'s module docstring for the full
+rationale; this script seeds the IDENTICAL territory (same
+``biocapacity``/``max_biocapacity``/``extraction_intensity``/
+``regeneration_rate``) with ``entropy_factor`` at ``3.0`` -- the declared
+``le=3.0`` cap, inclusive -- instead of near the floor.
+
+At this cap the ecological cost is high enough (``raw_extraction *
+entropy_factor = 10 * 3.0 = 30``, against a regeneration of only ``2``) that
+``current + delta`` goes negative and the ``max(0.0, ...)`` floor binds --
+unlike the low-entropy companion script, where the same territory stays
+comfortably positive. That swing, from a positive floor-inert result to an
+exact ``0.0`` floor-bound result, driven by nothing but ``entropy_factor``,
+is the clearest possible proof the scaled-``Int`` workaround is live.
+
+Run it from the repository root, single process::
+
+    PYTHONPATH="$PWD/src" uv run python \\
+        rust/crates/babylon-tick/content/scenarios/metabolism_entropy_high_conformance.py
+"""
+
+from __future__ import annotations
+
+from babylon.config.defines import MetabolismDefines
+from babylon.engine.context import TickContext
+from babylon.engine.services import ServiceContainer
+from babylon.engine.systems.metabolism import MetabolismSystem
+from babylon.models.enums import NodeType
+from babylon.topology.graph import BabylonGraph
+
+SUBJECT_ID = "high-entropy-county"
+SEED = {
+    "biocapacity": 10.0,
+    "max_biocapacity": 100.0,
+    "extraction_intensity": 1.0,
+    "regeneration_rate": 0.02,
+}
+#: At the cap (3.0, inclusive) -- legal, ordinary construction.
+ENTROPY_FACTOR = 3.0
+
+
+def build_graph() -> BabylonGraph:
+    """Build the one-territory world."""
+    graph = BabylonGraph()
+    graph.add_node(SUBJECT_ID, NodeType.TERRITORY, **SEED)
+    return graph
+
+
+def main() -> None:
+    """Run one tick of the frozen MetabolismSystem with entropy_factor at its cap."""
+    services = ServiceContainer.create()
+    try:
+        object.__setattr__(
+            services.defines,
+            "metabolism",
+            MetabolismDefines(entropy_factor=ENTROPY_FACTOR),
+        )
+
+        graph = build_graph()
+        MetabolismSystem().step(graph, services, TickContext(tick=1))
+
+        node = graph.get_node(SUBJECT_ID)
+        if node is None:
+            raise SystemExit(f"node {SUBJECT_ID} vanished during the tick")
+        a = node.attributes
+        print(f"entropy_factor = {ENTROPY_FACTOR!r}")
+        print("post-tick state:")
+        print(
+            f"  {SUBJECT_ID:<20} biocapacity={a['biocapacity']!r} "
+            f"max_biocapacity={a['max_biocapacity']!r}"
+        )
+    finally:
+        services.database.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/crates/babylon-tick/content/scenarios/metabolism_entropy_low_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism_entropy_low_conformance.py
@@ -1,0 +1,84 @@
+"""Conformance vector for `metabolism/biocapacity-update` at `entropy_factor`
+NEAR its declared floor, from the frozen engine -- one half of the
+mutation-verification pair for the D-1 scaled-`Int` workaround (see
+``metabolism.bsl``'s own D-1 and
+``reports/metabolism-port-assessment-2026-08-11.md`` §3).
+
+This script is the PROVENANCE of every number pinned in
+``rust/crates/babylon-tick/tests/metabolism_entropy_low_conformance.rs``.
+Its companion, ``metabolism_entropy_high_conformance.py``, seeds the
+IDENTICAL territory with ``entropy_factor`` at its declared cap (``3.0``)
+instead of near its floor (``1.01``) -- the two scripts together prove the
+scaled-``Int`` `:const` (``metabolism/entropy-factor-x1e6``) actually
+carries the coefficient's effect end to end: a bug in the ``/ 1000000``
+descaling (an off-by-a-factor-of-ten, say) would make one or both of these
+diverge from what the frozen engine actually computes.
+
+``1.01`` is legal under ``MetabolismDefines.entropy_factor``'s own
+``Field(gt=1.0, le=3.0)`` -- ordinary Pydantic construction, no
+``model_construct`` bypass needed (unlike Dispossession's saturation/
+negative-weight scripts, which push OUTSIDE their coefficients' declared
+domains on purpose).
+
+Run it from the repository root, single process::
+
+    PYTHONPATH="$PWD/src" uv run python \\
+        rust/crates/babylon-tick/content/scenarios/metabolism_entropy_low_conformance.py
+"""
+
+from __future__ import annotations
+
+from babylon.config.defines import MetabolismDefines
+from babylon.engine.context import TickContext
+from babylon.engine.services import ServiceContainer
+from babylon.engine.systems.metabolism import MetabolismSystem
+from babylon.models.enums import NodeType
+from babylon.topology.graph import BabylonGraph
+
+SUBJECT_ID = "low-entropy-county"
+SEED = {
+    "biocapacity": 10.0,
+    "max_biocapacity": 100.0,
+    "extraction_intensity": 1.0,
+    "regeneration_rate": 0.02,
+}
+#: Near the floor (1.0, exclusive) -- legal, ordinary construction.
+ENTROPY_FACTOR = 1.01
+
+
+def build_graph() -> BabylonGraph:
+    """Build the one-territory world."""
+    graph = BabylonGraph()
+    graph.add_node(SUBJECT_ID, NodeType.TERRITORY, **SEED)
+    return graph
+
+
+def main() -> None:
+    """Run one tick of the frozen MetabolismSystem with a low entropy_factor."""
+    services = ServiceContainer.create()
+    try:
+        object.__setattr__(
+            services.defines,
+            "metabolism",
+            MetabolismDefines(entropy_factor=ENTROPY_FACTOR),
+        )
+
+        graph = build_graph()
+        MetabolismSystem().step(graph, services, TickContext(tick=1))
+
+        node = graph.get_node(SUBJECT_ID)
+        if node is None:
+            raise SystemExit(f"node {SUBJECT_ID} vanished during the tick")
+        a = node.attributes
+        print(f"entropy_factor = {ENTROPY_FACTOR!r}")
+        print("post-tick state:")
+        print(
+            f"  {SUBJECT_ID:<20} biocapacity={a['biocapacity']!r} "
+            f"max_biocapacity={a['max_biocapacity']!r}"
+        )
+    finally:
+        services.database.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/crates/babylon-tick/content/scenarios/metabolism_extreme_damage_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism_extreme_damage_conformance.py
@@ -1,0 +1,66 @@
+"""Conformance vector proving `metabolism/biocapacity-update`'s `new-max`
+floor clamp (`max(0.0, max_cap - damage)`) is REACHABLE and
+mutation-catchable (F4 fix round, adversarial review of PR #501).
+
+This script is the PROVENANCE of every number pinned in
+``rust/crates/babylon-tick/tests/metabolism_extreme_damage_conformance.rs``.
+
+See ``metabolism-extreme-damage-conformance.bscn`` for the full derivation
+of why ``damage > max_biocapacity`` is legal and reachable (no field this
+system reads has an upper bound that would forbid it), and why the
+mutation signal for this specific clamp lives in ``max_biocapacity``, not
+``biocapacity`` (which floors to ``0.0`` regardless, for an independent
+reason -- the ecological cost alone).
+
+Run it from the repository root, single process::
+
+    PYTHONPATH="$PWD/src" uv run python \\
+        rust/crates/babylon-tick/content/scenarios/metabolism_extreme_damage_conformance.py
+"""
+
+from __future__ import annotations
+
+from babylon.engine.context import TickContext
+from babylon.engine.services import ServiceContainer
+from babylon.engine.systems.metabolism import MetabolismSystem
+from babylon.models.enums import NodeType
+from babylon.topology.graph import BabylonGraph
+
+SUBJECT_ID = "extreme-county"
+SEED = {
+    "biocapacity": 100000.0,
+    "max_biocapacity": 100.0,
+    "extraction_intensity": 1.0,
+    "regeneration_rate": 0.02,
+}
+
+
+def build_graph() -> BabylonGraph:
+    """Build the one-territory world."""
+    graph = BabylonGraph()
+    graph.add_node(SUBJECT_ID, NodeType.TERRITORY, **SEED)
+    return graph
+
+
+def main() -> None:
+    """Run one tick of the frozen MetabolismSystem with an extreme biocapacity seed."""
+    services = ServiceContainer.create()
+    try:
+        graph = build_graph()
+        MetabolismSystem().step(graph, services, TickContext(tick=1))
+
+        node = graph.get_node(SUBJECT_ID)
+        if node is None:
+            raise SystemExit(f"node {SUBJECT_ID} vanished during the tick")
+        a = node.attributes
+        print("post-tick state:")
+        print(
+            f"  {SUBJECT_ID:<16} biocapacity={a['biocapacity']!r} "
+            f"max_biocapacity={a['max_biocapacity']!r}"
+        )
+    finally:
+        services.database.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/crates/babylon-tick/content/scenarios/metabolism_ratcheted_ceiling_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism_ratcheted_ceiling_conformance.py
@@ -1,0 +1,84 @@
+"""Conformance vector proving `metabolism/biocapacity-update`'s ceiling
+clamp binds against the RATCHETED ceiling (`new_max`), not the original
+`max_biocapacity` seed (F2 fix round, adversarial review of PR #501).
+
+This script is the PROVENANCE of every number pinned in
+``rust/crates/babylon-tick/tests/metabolism_ratcheted_ceiling_conformance.rs``.
+
+See ``metabolism-ratcheted-ceiling-conformance.bscn`` for the full
+derivation of why ``regeneration_rate=1.0``/``entropy_factor=1.005``/
+``hysteresis_rate=0.01`` (all pushed to their declared legal extremes,
+still ordinary ``MetabolismDefines``/``Territory`` construction, no
+Pydantic bypass needed) makes BOTH the hysteresis ratchet AND the ceiling
+clamp fire simultaneously for one territory -- the combination
+``metabolism_ceiling_conformance.py``'s earlier module docstring wrongly
+claimed was unreachable (it fixed ``entropy_factor``/``hysteresis_rate`` at
+their production defaults while reasoning about reachability, missing that
+both are ALSO per-scenario coefficients).
+
+Run it from the repository root, single process::
+
+    PYTHONPATH="$PWD/src" uv run python \\
+        rust/crates/babylon-tick/content/scenarios/metabolism_ratcheted_ceiling_conformance.py
+"""
+
+from __future__ import annotations
+
+from babylon.config.defines import MetabolismDefines
+from babylon.engine.context import TickContext
+from babylon.engine.services import ServiceContainer
+from babylon.engine.systems.metabolism import MetabolismSystem
+from babylon.models.enums import NodeType
+from babylon.topology.graph import BabylonGraph
+
+SUBJECT_ID = "ratcheted-ceiling-county"
+SEED = {
+    "biocapacity": 50.0,
+    "max_biocapacity": 100.0,
+    "extraction_intensity": 1.0,
+    # Legal maximum (Territory.regeneration_rate: Field(ge=0.0, le=1.0)).
+    "regeneration_rate": 1.0,
+}
+#: Barely above the declared floor (MetabolismDefines.entropy_factor:
+#: Field(gt=1.0, le=3.0)) -- legal, ordinary construction.
+ENTROPY_FACTOR = 1.005
+#: Legal maximum (MetabolismDefines.hysteresis_rate: Field(ge=0.001, le=0.01)).
+HYSTERESIS_RATE = 0.01
+
+
+def build_graph() -> BabylonGraph:
+    """Build the one-territory world."""
+    graph = BabylonGraph()
+    graph.add_node(SUBJECT_ID, NodeType.TERRITORY, **SEED)
+    return graph
+
+
+def main() -> None:
+    """Run one tick of the frozen MetabolismSystem with boosted coefficients."""
+    services = ServiceContainer.create()
+    try:
+        object.__setattr__(
+            services.defines,
+            "metabolism",
+            MetabolismDefines(entropy_factor=ENTROPY_FACTOR, hysteresis_rate=HYSTERESIS_RATE),
+        )
+
+        graph = build_graph()
+        MetabolismSystem().step(graph, services, TickContext(tick=1))
+
+        node = graph.get_node(SUBJECT_ID)
+        if node is None:
+            raise SystemExit(f"node {SUBJECT_ID} vanished during the tick")
+        a = node.attributes
+        print(f"entropy_factor = {ENTROPY_FACTOR!r}, hysteresis_rate = {HYSTERESIS_RATE!r}")
+        print("post-tick state:")
+        print(
+            f"  {SUBJECT_ID:<24} biocapacity={a['biocapacity']!r} "
+            f"max_biocapacity={a['max_biocapacity']!r}"
+        )
+    finally:
+        services.database.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/crates/babylon-tick/content/scenarios/metabolism_rounding_divergence_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism_rounding_divergence_conformance.py
@@ -82,7 +82,7 @@ def bsl_biocapacity_update(
     """
     regeneration_raw = regeneration_rate * max_cap
     regeneration = 0.0 if current >= max_cap else regeneration_raw
-    raw_extraction = (extraction_intensity * current) + 0.0
+    raw_extraction = extraction_intensity * current
     ecological_cost_scaled = raw_extraction * entropy_factor_x1e6
     ecological_cost = ecological_cost_scaled / 1_000_000
     delta = regeneration - ecological_cost

--- a/rust/crates/babylon-tick/content/scenarios/metabolism_rounding_divergence_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism_rounding_divergence_conformance.py
@@ -1,0 +1,142 @@
+"""Conformance vector PINNING the D-1 scaled-`Int` workaround's numeric
+DEVIATION from the frozen engine (F1 fix round, adversarial review of PR
+#501). Earlier revisions of ``metabolism.bsl``'s D-1 claimed the workaround
+"preserves the formula's exact value ... for ANY legal (1.0, 3.0] modded
+value" -- FALSE, proven by execution: the frozen engine computes
+``raw_extraction * entropy_factor`` as ONE binary64 multiply; this pack
+computes ``(raw_extraction * entropy_factor_x1e6) / 1000000`` -- an exact
+integer multiply followed by a correctly-rounded division. These are the
+SAME real-valued function but DIFFERENT floating-point programs, and can
+round to adjacent doubles (double rounding). See ``metabolism.bsl``'s own
+(rewritten) D-1 for the full derivation of both error sources (grid
+quantization, dominant for an arbitrary modded value; double rounding, the
+residual even at zero quantization error).
+
+This script prints TWO values for the same territory:
+
+1. The FROZEN ENGINE's value -- ``MetabolismSystem().step()``, unmodified.
+2. This pack's value, computed by a PURE-PYTHON REPLICA of
+   ``metabolism.bsl``'s own binding chain (``bsl_biocapacity_update``
+   below) -- every binding, in the SAME order, on `float` (IEEE-754
+   binary64, identical to Rust's `f64`). Because both languages implement
+   IEEE-754 basic operations identically (`+ - * /`, correctly rounded --
+   ``bsl-language.rst`` §4.3), this replica's output is BIT-IDENTICAL to
+   what the real Rust engine computes for the same scenario -- confirmed
+   directly against ``rust/crates/babylon-tick``'s own build during
+   authoring (both print ``1.4`` / ``0x3ff6666666666666`` for
+   ``biocapacity``), which is why
+   ``metabolism_rounding_divergence_conformance.rs`` can pin the SAME
+   numbers this script prints without needing an FFI bridge into the Rust
+   engine.
+
+``biocapacity=3`` is the SMALLEST int-seedable ``TERRITORY.biocapacity``
+value (with ``extraction_intensity=1`` and the shipped default
+``entropy_factor=1.2``, so grid-quantization error is exactly ZERO here --
+`1200000 / 1e6 == 1.2` exactly as a real number) that demonstrates the
+double-rounding residual: the two engines diverge by exactly 2 ULP.
+
+Run it from the repository root, single process::
+
+    PYTHONPATH="$PWD/src" uv run python \\
+        rust/crates/babylon-tick/content/scenarios/metabolism_rounding_divergence_conformance.py
+"""
+
+from __future__ import annotations
+
+import struct
+
+from babylon.engine.context import TickContext
+from babylon.engine.services import ServiceContainer
+from babylon.engine.systems.metabolism import MetabolismSystem
+from babylon.models.enums import NodeType
+from babylon.topology.graph import BabylonGraph
+
+SUBJECT_ID = "divergent-county"
+SEED = {
+    "biocapacity": 3.0,
+    "max_biocapacity": 100.0,
+    "extraction_intensity": 1.0,
+    "regeneration_rate": 0.02,
+}
+#: The exact integer `metabolism.bsl`'s `entropy-factor-x1e6` const carries
+#: -- the shipped default `entropy_factor=1.2`, `x1,000,000`.
+ENTROPY_FACTOR_X1E6 = 1_200_000
+
+
+def hexf(value: float) -> str:
+    """Big-endian hex dump of a float64's bit pattern, matching Rust's `{:016x}`."""
+    return struct.pack(">d", value).hex()
+
+
+def bsl_biocapacity_update(
+    current: float,
+    max_cap: float,
+    extraction_intensity: float,
+    regeneration_rate: float,
+    entropy_factor_x1e6: int,
+    hysteresis_rate: float,
+) -> tuple[float, float]:
+    """A pure-Python replica of `metabolism.bsl`'s own binding chain, in
+    DECLARATION ORDER, on `float` (binary64) throughout -- see the module
+    docstring for why this is bit-identical to the real Rust engine.
+    """
+    regeneration_raw = regeneration_rate * max_cap
+    regeneration = 0.0 if current >= max_cap else regeneration_raw
+    raw_extraction = (extraction_intensity * current) + 0.0
+    ecological_cost_scaled = raw_extraction * entropy_factor_x1e6
+    ecological_cost = ecological_cost_scaled / 1_000_000
+    delta = regeneration - ecological_cost
+    damage = raw_extraction * hysteresis_rate
+    max_cap_minus_damage = max_cap - damage
+    new_max = max_cap_minus_damage if max_cap_minus_damage > 0 else 0.0
+    current_plus_delta = current + delta
+    capped_at_ceiling = current_plus_delta if current_plus_delta < new_max else new_max
+    new_biocapacity = capped_at_ceiling if capped_at_ceiling > 0 else 0.0
+    return new_biocapacity, new_max
+
+
+def build_graph() -> BabylonGraph:
+    """Build the one-territory world."""
+    graph = BabylonGraph()
+    graph.add_node(SUBJECT_ID, NodeType.TERRITORY, **SEED)
+    return graph
+
+
+def main() -> None:
+    """Run the frozen engine AND the pure-Python BSL replica, print both."""
+    services = ServiceContainer.create()
+    try:
+        graph = build_graph()
+        MetabolismSystem().step(graph, services, TickContext(tick=1))
+        node = graph.get_node(SUBJECT_ID)
+        if node is None:
+            raise SystemExit(f"node {SUBJECT_ID} vanished during the tick")
+        a = node.attributes
+        frozen_bio = float(a["biocapacity"])
+        frozen_max = float(a["max_biocapacity"])
+
+        bsl_bio, bsl_max = bsl_biocapacity_update(
+            SEED["biocapacity"],
+            SEED["max_biocapacity"],
+            SEED["extraction_intensity"],
+            SEED["regeneration_rate"],
+            ENTROPY_FACTOR_X1E6,
+            0.005,
+        )
+
+        print("frozen engine (MetabolismSystem.step, unmodified):")
+        print(f"  biocapacity     = {frozen_bio!r}  {hexf(frozen_bio)}")
+        print(f"  max_biocapacity = {frozen_max!r}  {hexf(frozen_max)}")
+        print()
+        print("this pack's value (pure-Python replica of metabolism.bsl):")
+        print(f"  biocapacity     = {bsl_bio!r}  {hexf(bsl_bio)}")
+        print(f"  max_biocapacity = {bsl_max!r}  {hexf(bsl_max)}")
+        print()
+        print(f"biocapacity equal:     {frozen_bio == bsl_bio}")
+        print(f"max_biocapacity equal: {frozen_max == bsl_max}")
+    finally:
+        services.database.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -150,6 +150,10 @@ pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
         // accumulation as value transfer) — same class of minimal
         // driver-scaffolding addition as "vitality"/"lifecycle" above.
         "dispossession".to_owned(),
+        // The metabolism/* rule pack (Material Base @13.0, the per-territory
+        // half of the metabolic rift) — same class of minimal
+        // driver-scaffolding addition as the three above.
+        "metabolism".to_owned(),
     ]);
 
     let ctx = LoadContext {

--- a/rust/crates/babylon-tick/tests/metabolism_ceiling_conformance.rs
+++ b/rust/crates/babylon-tick/tests/metabolism_ceiling_conformance.rs
@@ -1,0 +1,84 @@
+//! The CEILING-CLAMP conformance suite for `metabolism/biocapacity-update`
+//! — proves the `min(new_max, current + delta)` half of the frozen
+//! formula's double clamp actually binds.
+//!
+//! # Provenance
+//!
+//! ```text
+//! PYTHONPATH="$PWD/src" uv run python \
+//!     rust/crates/babylon-tick/content/scenarios/metabolism_ceiling_conformance.py
+//! ```
+//!
+//! Its output on 2026-08-11, verbatim:
+//!
+//! ```text
+//! post-tick state:
+//!   ceiling-county biocapacity=100.0 max_biocapacity=100.0 (seed biocapacity=50.0 seed max_biocapacity=100.0)
+//! ```
+//!
+//! See `content/scenarios/metabolism_ceiling_conformance.py`'s module
+//! docstring for the full algebra behind why `regeneration_rate` is boosted
+//! to `0.9` here (the production-default `0.02` can never push
+//! `current + delta` above `max_biocapacity` for either int-seedable
+//! `extraction_intensity` value), and for the proof that a node
+//! simultaneously exercising a STRICTLY RATCHETED ceiling (`damage > 0`)
+//! AND a binding ceiling clamp is unreachable with slice 1's int-only field
+//! seeding, given this formula's own algebra. The ratchet itself (`new_max`
+//! strictly below its seed) is proven separately by
+//! `metabolism_conformance.rs::heavy_extraction_permanently_damages_the_ceiling`.
+
+use babylon_graph::memory::MemoryGraph;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::{run_once, run_once_into};
+
+const SCENARIO: &str = include_str!("../content/scenarios/metabolism-ceiling-conformance.bscn");
+const RULE: &str = include_str!("../content/rules/metabolism.bsl");
+
+fn run() -> MemoryGraph {
+    let mut graph = MemoryGraph::new();
+    let mut sink = babylon_bsl::structural_verbs::CollectingSink::default();
+    run_once_into(SCENARIO, RULE, &mut graph, &mut sink).expect("the Metabolism pack must run");
+    graph
+}
+
+fn attribute(graph: &MemoryGraph, id: u64, field: &str) -> f64 {
+    graph
+        .node_attribute(NodeId(id), field)
+        .unwrap_or_else(|e| panic!("node {id} field {field}: {}", e.message))
+}
+
+/// With `regeneration_rate=0.9` and `extraction_intensity=0`,
+/// `current + delta = 50 + 90 = 140` — comfortably past
+/// `max_biocapacity = 100` — and the frozen formula's
+/// `max(0.0, min(new_max, current + delta))` clamps it back to EXACTLY
+/// `100.0`, not `140.0` and not some intermediate value.
+#[test]
+fn the_ceiling_clamp_binds_and_saturates_at_exactly_the_ceiling() {
+    let graph = run();
+    assert_eq!(attribute(&graph, 0, "territory/biocapacity"), 100.0);
+}
+
+/// `extraction_intensity = 0` here means `raw_extraction = 0`, so the
+/// hysteresis damage is exactly zero and the ceiling ITSELF is unratcheted
+/// — `max_biocapacity` ends the tick bit-identical to its seed, unlike the
+/// zero-floor-county vector in `metabolism_conformance.rs`, whose ceiling
+/// DOES ratchet. Mutation-verified: flipping `metabolism.bsl`'s
+/// `capped-at-ceiling` binding's comparator from `<` to `>` (so the clamp
+/// picks the LARGER of `current + delta`/`new-max` instead of the smaller)
+/// flips `the_ceiling_clamp_binds_and_saturates_at_exactly_the_ceiling`
+/// (`140.0` unclamped instead of `100.0`) while leaving this test green —
+/// confirmed by hand during authoring, reverted before commit.
+#[test]
+fn the_ceiling_is_unratcheted_when_extraction_is_zero() {
+    let graph = run();
+    assert_eq!(attribute(&graph, 0, "territory/max-biocapacity"), 100.0);
+}
+
+/// Byte-determinism.
+#[test]
+fn the_ceiling_scenario_tick_is_deterministic() {
+    let a = run_once(SCENARIO, RULE).expect("first run");
+    let b = run_once(SCENARIO, RULE).expect("second run");
+    assert_eq!(a.after, b.after);
+    assert_eq!(a.fired, 1);
+}

--- a/rust/crates/babylon-tick/tests/metabolism_ceiling_conformance.rs
+++ b/rust/crates/babylon-tick/tests/metabolism_ceiling_conformance.rs
@@ -17,15 +17,22 @@
 //! ```
 //!
 //! See `content/scenarios/metabolism_ceiling_conformance.py`'s module
-//! docstring for the full algebra behind why `regeneration_rate` is boosted
-//! to `0.9` here (the production-default `0.02` can never push
-//! `current + delta` above `max_biocapacity` for either int-seedable
-//! `extraction_intensity` value), and for the proof that a node
-//! simultaneously exercising a STRICTLY RATCHETED ceiling (`damage > 0`)
-//! AND a binding ceiling clamp is unreachable with slice 1's int-only field
-//! seeding, given this formula's own algebra. The ratchet itself (`new_max`
-//! strictly below its seed) is proven separately by
-//! `metabolism_conformance.rs::heavy_extraction_permanently_damages_the_ceiling`.
+//! docstring for why `regeneration_rate` is boosted to `0.9` here: the
+//! production-default `0.02` does NOT make the clamp unreachable in
+//! general (a `current` within ~2% of `max_biocapacity` already exceeds it
+//! even at the default), but the boost makes the clamp fire from an
+//! ORDINARY mid-range stock (`50`, not `99`) with a dramatic, unambiguous
+//! margin. This scenario deliberately keeps `extraction_intensity=0` so
+//! the ceiling clamp is isolated with NO hysteresis interaction — the
+//! ratchet is exactly zero here (`damage = 0`, `new_max = max_biocapacity`
+//! unchanged). **A node exercising BOTH a strictly ratcheted ceiling
+//! (`damage > 0`) AND a binding ceiling clamp against that ratcheted value
+//! is proven REACHABLE** by
+//! `metabolism_ratcheted_ceiling_conformance.rs` — an earlier claim here
+//! that the combination was "provably unreachable with int-seeded fields"
+//! was FALSE (it fixed `entropy_factor`/`hysteresis_rate` at their
+//! production defaults while reasoning about reachability, missing that
+//! both are ALSO per-scenario coefficients).
 
 use babylon_graph::memory::MemoryGraph;
 use babylon_graph::substrate::{GraphSubstrate, NodeId};

--- a/rust/crates/babylon-tick/tests/metabolism_ceiling_suppression_conformance.rs
+++ b/rust/crates/babylon-tick/tests/metabolism_ceiling_suppression_conformance.rs
@@ -1,0 +1,85 @@
+//! The AT-THE-CEILING conformance suite for `metabolism/biocapacity-update`
+//! — proves the `(>= current max-cap)` regeneration-suppression guard fires
+//! at the EXACT boundary `current == max-cap`, not just "close to it" (F3
+//! fix round, adversarial review of PR #501).
+//!
+//! # Why this suite exists
+//!
+//! `metabolism_conformance.rs::zero_extraction_leaves_hysteresis_completely_inert`
+//! and its sibling `heavy_extraction_at_the_ceiling_floors_biocapacity_at_exactly_zero`
+//! both use `zero-floor-county` (`biocapacity == max_biocapacity == 100`,
+//! `entropy_factor` at the production default `1.2`), whose discriminating
+//! case floors BOTH the correct branch's result (`-20`) AND the wrong
+//! branch's result (`-18`, if regeneration wrongly fired) to the identical
+//! `0.0` — the `max(0.0, ...)` clamp downstream masks the guard's boundary
+//! entirely. This scenario is built specifically so the two branches land
+//! on DIFFERENT sides of the floor.
+//!
+//! # Provenance
+//!
+//! ```text
+//! PYTHONPATH="$PWD/src" uv run python \
+//!     rust/crates/babylon-tick/content/scenarios/metabolism_ceiling_suppression_conformance.py
+//! ```
+//!
+//! Its output on 2026-08-11, verbatim:
+//!
+//! ```text
+//! entropy_factor = 1.005, hysteresis_rate = 0.01
+//! post-tick state:
+//!   at-ceiling-county    biocapacity=0.0 max_biocapacity=9.9
+//! ```
+
+use babylon_graph::memory::MemoryGraph;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::{run_once, run_once_into};
+
+const SCENARIO: &str =
+    include_str!("../content/scenarios/metabolism-ceiling-suppression-conformance.bscn");
+const RULE: &str = include_str!("../content/rules/metabolism.bsl");
+
+fn run() -> MemoryGraph {
+    let mut graph = MemoryGraph::new();
+    let mut sink = babylon_bsl::structural_verbs::CollectingSink::default();
+    run_once_into(SCENARIO, RULE, &mut graph, &mut sink).expect("the Metabolism pack must run");
+    graph
+}
+
+fn attribute(graph: &MemoryGraph, id: u64, field: &str) -> f64 {
+    graph
+        .node_attribute(NodeId(id), field)
+        .unwrap_or_else(|e| panic!("node {id} field {field}: {}", e.message))
+}
+
+/// At `current == max_cap` exactly, regeneration is suppressed
+/// (`regeneration = 0.0`), so `current + delta = 10 - 10.05 = -0.05`,
+/// which floors to exactly `0.0`. Mutation-verified (by hand during
+/// authoring, reverted before commit): flipping `metabolism.bsl`'s
+/// `regeneration` binding's guard from `(>= current max-cap)` to
+/// `(> current max-cap)` — so regeneration WRONGLY fires at this exact
+/// boundary — flips this test's result to `4.949999999999999` (the guard
+/// no longer suppresses the `regeneration_rate * max_cap = 5` term, which
+/// survives the floor untouched).
+#[test]
+fn regeneration_is_suppressed_exactly_at_the_ceiling_boundary() {
+    let graph = run();
+    assert_eq!(attribute(&graph, 0, "territory/biocapacity"), 0.0);
+}
+
+/// The hysteresis ratchet is unaffected by this guard — `max_biocapacity`
+/// ends at `9.9` regardless of which branch of the regeneration guard
+/// fires, since `damage` never depends on `regeneration`.
+#[test]
+fn the_ceiling_still_ratchets_regardless_of_the_regeneration_guard() {
+    let graph = run();
+    assert_eq!(attribute(&graph, 0, "territory/max-biocapacity"), 9.9);
+}
+
+/// Byte-determinism.
+#[test]
+fn the_ceiling_suppression_scenario_tick_is_deterministic() {
+    let a = run_once(SCENARIO, RULE).expect("first run");
+    let b = run_once(SCENARIO, RULE).expect("second run");
+    assert_eq!(a.after, b.after);
+    assert_eq!(a.fired, 1);
+}

--- a/rust/crates/babylon-tick/tests/metabolism_conformance.rs
+++ b/rust/crates/babylon-tick/tests/metabolism_conformance.rs
@@ -1,0 +1,191 @@
+//! Conformance vectors for `metabolism/biocapacity-update`, taken from the
+//! frozen Python engine's live behaviour.
+//!
+//! # Provenance
+//!
+//! Every state value below was printed by the frozen `MetabolismSystem`
+//! running one `step()` over a fixture that mirrors
+//! `content/scenarios/metabolism-conformance.bscn` node for node. The
+//! command, from the repository root:
+//!
+//! ```text
+//! PYTHONPATH="$PWD/src" uv run python \
+//!     rust/crates/babylon-tick/content/scenarios/metabolism_conformance.py
+//! ```
+//!
+//! Its output on 2026-08-11, verbatim:
+//!
+//! ```text
+//! defines (src/babylon/data/defines.yaml, metabolism: section):
+//!   metabolism.entropy_factor = 1.2
+//!   metabolism.overshoot_threshold = 1.0
+//!   metabolism.hysteresis_rate = 0.005
+//!   metabolism.max_overshoot_ratio = 999.0
+//!
+//! post-tick state:
+//!   nominal-county           biocapacity=1.0 max_biocapacity=99.975 (seed biocapacity=5.0 seed max_biocapacity=100.0)
+//!   hysteresis-inert-county  biocapacity=52.0 max_biocapacity=100.0 (seed biocapacity=50.0 seed max_biocapacity=100.0)
+//!   zero-floor-county        biocapacity=0.0 max_biocapacity=99.5 (seed biocapacity=100.0 seed max_biocapacity=100.0)
+//!
+//! events:
+//!   (none)
+//! ```
+//!
+//! This pack ports only Phase 1 of the frozen system (per-territory
+//! biocapacity delta + hysteresis ratchet + double clamp) — the spec-070
+//! sovereign pre-pass and Phases 2-3 (global overshoot) are BLOCKED, per
+//! `reports/metabolism-port-assessment-2026-08-11.md`. No event is ever
+//! emitted by this rule (the frozen Phase 1 loop publishes nothing).
+//!
+//! # Why exact equality and no tolerance
+//!
+//! Both sides run IEEE-754 basic operations on binary64 — `+ − × ÷` and
+//! comparison, correctly rounded, reproducing bit-exactly across
+//! implementations (`bsl-language.rst` §4.3). The decimals below are Python
+//! `repr` output — the shortest round-tripping decimal for each double —
+//! and Rust parses a float literal correctly rounded, so e.g. `99.975_f64`
+//! IS the double Python printed.
+
+use babylon_graph::memory::MemoryGraph;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::{run_once, run_once_into};
+
+const SCENARIO: &str = include_str!("../content/scenarios/metabolism-conformance.bscn");
+const RULE: &str = include_str!("../content/rules/metabolism.bsl");
+
+fn run() -> MemoryGraph {
+    let mut graph = MemoryGraph::new();
+    let mut sink = babylon_bsl::structural_verbs::CollectingSink::default();
+    run_once_into(SCENARIO, RULE, &mut graph, &mut sink).expect("the Metabolism pack must run");
+    graph
+}
+
+fn attribute(graph: &MemoryGraph, id: u64, field: &str) -> f64 {
+    graph
+        .node_attribute(NodeId(id), field)
+        .unwrap_or_else(|e| panic!("node {id} field {field}: {}", e.message))
+}
+
+/// The nominal territory: a small stock, full extraction, neither clamp
+/// binds. `biocapacity=1.0` (`5.0 + delta`, `delta = 2.0 (regeneration) -
+/// 6.0 (ecological cost) = -4.0`, `5.0 - 4.0 = 1.0`); `max_biocapacity =
+/// 99.975` (`100.0 - 0.025` damage — `raw_extraction = 1*5 = 5`,
+/// `damage = 5 * 0.005 = 0.025`).
+///
+/// Mutation-verified: changing `metabolism.bsl`'s D-1 descaling divisor
+/// from `1000000` to `100000` (a 10x scale bug in the `entropy_factor`
+/// workaround) flips this test's `biocapacity` from `1.0` to `0.0` — the
+/// same mutation also flips `metabolism_entropy_low_conformance.rs`'s own
+/// vector but NOT `metabolism_entropy_high_conformance.rs`'s (the floor
+/// already binds there at the true `entropy_factor = 3.0`, and stays bound
+/// at the mutated effective `30.0`) — verified by hand during authoring,
+/// reverted before commit.
+#[test]
+fn the_nominal_territory_matches_the_frozen_engine_exactly() {
+    let graph = run();
+    assert_eq!(attribute(&graph, 0, "territory/biocapacity"), 1.0);
+    assert_eq!(attribute(&graph, 0, "territory/max-biocapacity"), 99.975);
+}
+
+/// `extraction_intensity = 0`: `raw_extraction = 0`, so BOTH the ecological
+/// cost AND the hysteresis damage are exactly zero — pure regeneration
+/// (`biocapacity = 50 + 0.02*100 = 52.0`), and `max_biocapacity` is
+/// UNCHANGED bit for bit from its seed (`100.0`), proving the hysteresis
+/// ratchet is genuinely inert here, not merely small.
+#[test]
+fn zero_extraction_leaves_hysteresis_completely_inert() {
+    let graph = run();
+    assert_eq!(attribute(&graph, 1, "territory/biocapacity"), 52.0);
+    assert_eq!(
+        attribute(&graph, 1, "territory/max-biocapacity"),
+        100.0,
+        "max_biocapacity must be bit-identical to its seed when extraction_intensity is 0"
+    );
+}
+
+/// The territory at its own ceiling (`biocapacity == max_biocapacity`, so
+/// the frozen formula's `if current_biocapacity >= max_biocapacity:
+/// regeneration = 0.0` suppresses regeneration entirely) with full
+/// extraction: the ecological cost alone drives `current + delta` deeply
+/// negative (`100 - 120 = -20`), and `max(0.0, ...)` floors it to EXACTLY
+/// `0.0` — not merely close to zero, not negative.
+///
+/// Mutation-verified (twice, by hand during authoring, reverted before
+/// commit): flipping `metabolism.bsl`'s `new-biocapacity` binding's
+/// comparator from `>` to `<` (so the floor clamp picks the unclamped
+/// negative value instead of `0.0`) flips this test to `-20.0`, and also
+/// flips `the_nominal_territory_matches_the_frozen_engine_exactly` and
+/// `zero_extraction_leaves_hysteresis_completely_inert`. Separately,
+/// flipping the `regeneration` binding's `>= current max-cap` guard to
+/// `< current max-cap` (so regeneration fires AT the ceiling instead of
+/// being suppressed there) does NOT flip this specific test — both
+/// mutated and original regeneration values are still deeply negative
+/// once floored — but DOES flip `the_nominal_territory_matches_the_frozen_
+/// engine_exactly` and `zero_extraction_leaves_hysteresis_completely_
+/// inert`, so the branch is still covered by this suite as a whole.
+#[test]
+fn heavy_extraction_at_the_ceiling_floors_biocapacity_at_exactly_zero() {
+    let graph = run();
+    assert_eq!(attribute(&graph, 2, "territory/biocapacity"), 0.0);
+}
+
+/// The SAME territory's `max_biocapacity` strictly decreases from its seed
+/// (`100.0` -> `99.5`) — proving the hysteresis ratchet
+/// (`new_max = max(0.0, max_cap - damage)`) is live and non-trivial,
+/// independent of whether the floor or ceiling clamp binds for
+/// `biocapacity` itself.
+#[test]
+fn heavy_extraction_permanently_damages_the_ceiling() {
+    let graph = run();
+    let max_biocapacity = attribute(&graph, 2, "territory/max-biocapacity");
+    assert_eq!(max_biocapacity, 99.5);
+    assert!(
+        max_biocapacity < 100.0,
+        "the ratchet must strictly lower the ceiling below its seed"
+    );
+}
+
+/// Byte-determinism: the same content twice is the same post-state hash,
+/// and the tick moved state at all.
+#[test]
+fn the_metabolism_tick_is_deterministic() {
+    let a = run_once(SCENARIO, RULE).expect("first run");
+    let b = run_once(SCENARIO, RULE).expect("second run");
+    assert_eq!(a.after, b.after, "two runs, one post-state");
+    assert_ne!(a.before, a.after, "the pack must move state");
+    assert_eq!(
+        a.fired, 3,
+        "all three territories are unconditional (no when guard)"
+    );
+}
+
+/// No event fires — the frozen Phase 1 loop publishes nothing (unlike
+/// Dispossession's two emits); Phases 2-3 (`ECOLOGICAL_OVERSHOOT`) are
+/// BLOCKED and not ported (see the module doc and this pack's D-4).
+#[test]
+fn no_event_fires() {
+    let mut graph = MemoryGraph::new();
+    let mut sink = babylon_bsl::structural_verbs::CollectingSink::default();
+    run_once_into(SCENARIO, RULE, &mut graph, &mut sink).expect("the pack must run");
+    assert!(sink.events.is_empty(), "Phase 1 publishes no event");
+}
+
+/// A rule reading a coefficient the scenario never declared fails at LOAD,
+/// with the coefficient named — the same discipline every other landed
+/// pack's own conformance suite pins.
+#[test]
+fn a_rule_reading_an_undeclared_coefficient_is_refused_at_load() {
+    let rule = "(rule metabolism/typo \
+                :material-basis \"a territory has a biocapacity\" :fuel 32 \
+                (bindings \
+                  (binding current :field territory/biocapacity) \
+                  (binding rate :const metabolism/regeneration-rat)) \
+                (effects (update-node self territory/biocapacity (set (* rate current)))))";
+    let Err(err) = run_once(SCENARIO, rule) else {
+        panic!("a mistyped coefficient must not load");
+    };
+    assert!(
+        err.contains("metabolism/regeneration-rat"),
+        "the rejection must name the coefficient: {err}"
+    );
+}

--- a/rust/crates/babylon-tick/tests/metabolism_conformance.rs
+++ b/rust/crates/babylon-tick/tests/metabolism_conformance.rs
@@ -37,14 +37,33 @@
 //! `reports/metabolism-port-assessment-2026-08-11.md`. No event is ever
 //! emitted by this rule (the frozen Phase 1 loop publishes nothing).
 //!
-//! # Why exact equality and no tolerance
+//! # Why exact equality and no tolerance — and where that claim STOPS
+//! applying
 //!
 //! Both sides run IEEE-754 basic operations on binary64 — `+ − × ÷` and
 //! comparison, correctly rounded, reproducing bit-exactly across
-//! implementations (`bsl-language.rst` §4.3). The decimals below are Python
-//! `repr` output — the shortest round-tripping decimal for each double —
-//! and Rust parses a float literal correctly rounded, so e.g. `99.975_f64`
-//! IS the double Python printed.
+//! implementations for any term where BOTH engines perform the SAME
+//! operation sequence (`bsl-language.rst` §4.3): the decimals below are
+//! Python `repr` output — the shortest round-tripping decimal for each
+//! double — and Rust parses a float literal correctly rounded, so e.g.
+//! `99.975_f64` IS the double Python printed. `regeneration`, `damage`
+//! (the hysteresis path), and both clamps hold to this exactly, because
+//! this pack's binding chain performs the IDENTICAL sequence of `+ − × ÷`
+//! the frozen formulas do for those terms.
+//!
+//! **This does NOT extend to `ecological-cost`.** The frozen engine
+//! computes `raw_extraction * entropy_factor` as ONE multiply; this pack's
+//! D-1 workaround computes `(raw_extraction * entropy_factor_x1e6) /
+//! 1000000` — a DIFFERENT operation sequence for the same real-valued
+//! function, which can double-round to an adjacent double (see
+//! `metabolism.bsl`'s own D-1 and
+//! `metabolism_rounding_divergence_conformance.rs`, which PINS a case
+//! where this happens). The vectors in THIS file's fixture
+//! (`nominal-county`'s `raw_extraction=5`, `entropy_factor=1.2`) happen to
+//! land on a value where the two operation sequences agree bit for bit —
+//! confirmed by execution, not assumed — but that agreement is a property
+//! of these SPECIFIC inputs, not a general guarantee this pack's D-1
+//! workaround provides.
 
 use babylon_graph::memory::MemoryGraph;
 use babylon_graph::substrate::{GraphSubstrate, NodeId};

--- a/rust/crates/babylon-tick/tests/metabolism_entropy_high_conformance.rs
+++ b/rust/crates/babylon-tick/tests/metabolism_entropy_high_conformance.rs
@@ -1,0 +1,78 @@
+//! The other half of the mutation-verification pair for D-1's scaled-`Int`
+//! workaround: `entropy_factor` AT its declared cap (`3.0`, inclusive,
+//! domain `(1.0, 3.0]`). See `metabolism_entropy_low_conformance.rs` for
+//! the companion — the IDENTICAL territory, differing only in
+//! `entropy_factor`.
+//!
+//! # Provenance
+//!
+//! ```text
+//! PYTHONPATH="$PWD/src" uv run python \
+//!     rust/crates/babylon-tick/content/scenarios/metabolism_entropy_high_conformance.py
+//! ```
+//!
+//! Its output on 2026-08-11, verbatim:
+//!
+//! ```text
+//! entropy_factor = 3.0
+//! post-tick state:
+//!   high-entropy-county  biocapacity=0.0 max_biocapacity=99.95
+//! ```
+
+use babylon_graph::memory::MemoryGraph;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::{run_once, run_once_into};
+
+const SCENARIO: &str =
+    include_str!("../content/scenarios/metabolism-entropy-high-conformance.bscn");
+const RULE: &str = include_str!("../content/rules/metabolism.bsl");
+
+fn run() -> MemoryGraph {
+    let mut graph = MemoryGraph::new();
+    let mut sink = babylon_bsl::structural_verbs::CollectingSink::default();
+    run_once_into(SCENARIO, RULE, &mut graph, &mut sink).expect("the Metabolism pack must run");
+    graph
+}
+
+fn attribute(graph: &MemoryGraph, id: u64, field: &str) -> f64 {
+    graph
+        .node_attribute(NodeId(id), field)
+        .unwrap_or_else(|e| panic!("node {id} field {field}: {}", e.message))
+}
+
+/// At `entropy_factor = 3.0` (the declared cap): `raw_extraction = 1*10 =
+/// 10`, `ecological_cost = 10 * 3.0 = 30`, `delta = 2 - 30 = -28`,
+/// `current + delta = 10 - 28 = -18` — the `max(0.0, ...)` floor binds at
+/// EXACTLY `0.0`. Contrast the low-entropy companion
+/// (`metabolism_entropy_low_conformance.rs`), the IDENTICAL territory at
+/// `entropy_factor = 1.01`, where the floor does NOT bind (`1.9`) — this
+/// swing, driven by nothing but `entropy_factor`, is the clearest possible
+/// proof the D-1 scaled-`Int` workaround (`entropy-factor-x1e6`, divided
+/// back out by `1000000`) carries the coefficient's effect end to end: an
+/// off-by-a-factor-of-ten bug in the descaling would make this vector
+/// diverge sharply from `0.0` (or the low-entropy vector diverge from
+/// `1.9`).
+#[test]
+fn a_high_entropy_factor_at_the_cap_floors_biocapacity_at_exactly_zero() {
+    let graph = run();
+    assert_eq!(attribute(&graph, 0, "territory/biocapacity"), 0.0);
+}
+
+/// `damage = raw_extraction * hysteresis_rate = 10 * 0.005 = 0.05`,
+/// unaffected by `entropy_factor` — identical to the low-entropy
+/// companion's own `max_biocapacity`, confirming the D-1 workaround only
+/// touches the ecological-cost term.
+#[test]
+fn the_hysteresis_damage_is_unaffected_by_entropy_factor() {
+    let graph = run();
+    assert_eq!(attribute(&graph, 0, "territory/max-biocapacity"), 99.95);
+}
+
+/// Byte-determinism.
+#[test]
+fn the_high_entropy_scenario_tick_is_deterministic() {
+    let a = run_once(SCENARIO, RULE).expect("first run");
+    let b = run_once(SCENARIO, RULE).expect("second run");
+    assert_eq!(a.after, b.after);
+    assert_eq!(a.fired, 1);
+}

--- a/rust/crates/babylon-tick/tests/metabolism_entropy_low_conformance.rs
+++ b/rust/crates/babylon-tick/tests/metabolism_entropy_low_conformance.rs
@@ -1,0 +1,82 @@
+//! One half of the mutation-verification pair for D-1's scaled-`Int`
+//! workaround (`metabolism.bsl`'s own D-1;
+//! `reports/metabolism-port-assessment-2026-08-11.md` §3):
+//! `entropy_factor` NEAR its declared floor (`1.01`, domain `(1.0, 3.0]`).
+//! See `metabolism_entropy_high_conformance.rs` for the companion at the
+//! declared cap — the SAME territory, differing only in `entropy_factor`.
+//!
+//! # Provenance
+//!
+//! ```text
+//! PYTHONPATH="$PWD/src" uv run python \
+//!     rust/crates/babylon-tick/content/scenarios/metabolism_entropy_low_conformance.py
+//! ```
+//!
+//! Its output on 2026-08-11, verbatim:
+//!
+//! ```text
+//! entropy_factor = 1.01
+//! post-tick state:
+//!   low-entropy-county   biocapacity=1.9000000000000004 max_biocapacity=99.95
+//! ```
+
+use babylon_graph::memory::MemoryGraph;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::{run_once, run_once_into};
+
+const SCENARIO: &str = include_str!("../content/scenarios/metabolism-entropy-low-conformance.bscn");
+const RULE: &str = include_str!("../content/rules/metabolism.bsl");
+
+fn run() -> MemoryGraph {
+    let mut graph = MemoryGraph::new();
+    let mut sink = babylon_bsl::structural_verbs::CollectingSink::default();
+    run_once_into(SCENARIO, RULE, &mut graph, &mut sink).expect("the Metabolism pack must run");
+    graph
+}
+
+fn attribute(graph: &MemoryGraph, id: u64, field: &str) -> f64 {
+    graph
+        .node_attribute(NodeId(id), field)
+        .unwrap_or_else(|e| panic!("node {id} field {field}: {}", e.message))
+}
+
+/// At `entropy_factor = 1.01`: `raw_extraction = 1*10 = 10`,
+/// `ecological_cost = 10 * 1.01 = 10.1`, `delta = 2 - 10.1 = -8.1`,
+/// `current + delta = 10 - 8.1 = 1.9` — the floor does NOT bind (contrast
+/// `metabolism_entropy_high_conformance.rs`, the IDENTICAL territory at
+/// `entropy_factor = 3.0`, where it does). Exact IEEE-754 float, not a
+/// rounded `1.9`.
+/// Mutation-verified: changing `metabolism.bsl`'s D-1 descaling divisor
+/// from `1000000` to `100000` (a 10x scale bug — the effective
+/// `entropy_factor` becomes `10.1` instead of `1.01`) flips this test's
+/// `biocapacity` from `1.9000000000000004` to `0.0` — verified by hand
+/// during authoring, reverted before commit.
+#[test]
+fn a_low_entropy_factor_leaves_the_floor_inert() {
+    let graph = run();
+    assert_eq!(
+        attribute(&graph, 0, "territory/biocapacity"),
+        1.900_000_000_000_000_4
+    );
+}
+
+/// `damage = raw_extraction * hysteresis_rate = 10 * 0.005 = 0.05`,
+/// unaffected by `entropy_factor` — `max_biocapacity = 100 - 0.05 = 99.95`,
+/// identical to the high-entropy companion's own `max_biocapacity` (proving
+/// the D-1 workaround affects ONLY the ecological-cost term, not the
+/// hysteresis damage, exactly as the frozen formulas keep the two
+/// independent).
+#[test]
+fn the_hysteresis_damage_is_unaffected_by_entropy_factor() {
+    let graph = run();
+    assert_eq!(attribute(&graph, 0, "territory/max-biocapacity"), 99.95);
+}
+
+/// Byte-determinism.
+#[test]
+fn the_low_entropy_scenario_tick_is_deterministic() {
+    let a = run_once(SCENARIO, RULE).expect("first run");
+    let b = run_once(SCENARIO, RULE).expect("second run");
+    assert_eq!(a.after, b.after);
+    assert_eq!(a.fired, 1);
+}

--- a/rust/crates/babylon-tick/tests/metabolism_extreme_damage_conformance.rs
+++ b/rust/crates/babylon-tick/tests/metabolism_extreme_damage_conformance.rs
@@ -1,0 +1,79 @@
+//! The EXTREME-DAMAGE conformance suite for `metabolism/biocapacity-update`
+//! — proves the `new-max` floor clamp (`max(0.0, max_cap - damage)`) is
+//! reachable and mutation-catchable (F4 fix round, adversarial review of
+//! PR #501: this clamp was never exercised by any prior fixture — deleting
+//! it left all 16 tests green).
+//!
+//! # Provenance
+//!
+//! ```text
+//! PYTHONPATH="$PWD/src" uv run python \
+//!     rust/crates/babylon-tick/content/scenarios/metabolism_extreme_damage_conformance.py
+//! ```
+//!
+//! Its output on 2026-08-11, verbatim:
+//!
+//! ```text
+//! post-tick state:
+//!   extreme-county   biocapacity=0.0 max_biocapacity=0.0
+//! ```
+//!
+//! See `metabolism-extreme-damage-conformance.bscn` for why
+//! `damage > max_biocapacity` is legal and reachable, and why this clamp's
+//! mutation signal lives entirely in `max_biocapacity` (`biocapacity`
+//! floors to `0.0` regardless, for the independent reason that the
+//! ecological cost alone drives `current + delta` far more negative than
+//! `max_cap - damage`).
+
+use babylon_graph::memory::MemoryGraph;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::{run_once, run_once_into};
+
+const SCENARIO: &str =
+    include_str!("../content/scenarios/metabolism-extreme-damage-conformance.bscn");
+const RULE: &str = include_str!("../content/rules/metabolism.bsl");
+
+fn run() -> MemoryGraph {
+    let mut graph = MemoryGraph::new();
+    let mut sink = babylon_bsl::structural_verbs::CollectingSink::default();
+    run_once_into(SCENARIO, RULE, &mut graph, &mut sink).expect("the Metabolism pack must run");
+    graph
+}
+
+fn attribute(graph: &MemoryGraph, id: u64, field: &str) -> f64 {
+    graph
+        .node_attribute(NodeId(id), field)
+        .unwrap_or_else(|e| panic!("node {id} field {field}: {}", e.message))
+}
+
+/// `max_cap - damage = 100 - 500 = -400`; the `max(0.0, ...)` floor must
+/// clamp `new-max` to EXACTLY `0.0`, not leave it negative. Mutation-
+/// verified (by hand during authoring, reverted before commit): deleting
+/// `metabolism.bsl`'s `new-max` floor clamp (using `max-cap-minus-damage`
+/// directly instead of the `if`-guarded floored version) flips this test
+/// from `0.0` to `-400.0`.
+#[test]
+fn the_new_max_floor_clamp_binds_at_exactly_zero() {
+    let graph = run();
+    assert_eq!(attribute(&graph, 0, "territory/max-biocapacity"), 0.0);
+}
+
+/// `biocapacity` also floors to `0.0`, but for the INDEPENDENT reason that
+/// the ecological cost alone (`raw_extraction * entropy_factor =
+/// 100000 * 1.2 = 120000`) drives `current + delta` far below zero — this
+/// does NOT discriminate the `new-max` floor clamp (see the module doc);
+/// asserted here only for completeness of the post-tick state.
+#[test]
+fn biocapacity_also_floors_at_exactly_zero() {
+    let graph = run();
+    assert_eq!(attribute(&graph, 0, "territory/biocapacity"), 0.0);
+}
+
+/// Byte-determinism.
+#[test]
+fn the_extreme_damage_scenario_tick_is_deterministic() {
+    let a = run_once(SCENARIO, RULE).expect("first run");
+    let b = run_once(SCENARIO, RULE).expect("second run");
+    assert_eq!(a.after, b.after);
+    assert_eq!(a.fired, 1);
+}

--- a/rust/crates/babylon-tick/tests/metabolism_ratcheted_ceiling_conformance.rs
+++ b/rust/crates/babylon-tick/tests/metabolism_ratcheted_ceiling_conformance.rs
@@ -1,0 +1,93 @@
+//! The RATCHETED-CEILING conformance suite for
+//! `metabolism/biocapacity-update` — proves the ceiling clamp
+//! (`capped-at-ceiling`) binds against the RATCHETED value (`new-max`),
+//! not the original `max-biocapacity` seed (F2 fix round, adversarial
+//! review of PR #501).
+//!
+//! # Why this suite exists
+//!
+//! `metabolism_ceiling_conformance.rs`'s own scenario uses
+//! `extraction_intensity=0`, so its hysteresis damage is exactly zero and
+//! its `new-max` binding equals the seed exactly — the ceiling clamp binds
+//! there, but against an UNRATCHETED ceiling. That left the
+//! `capped-at-ceiling` binding's SECOND operand
+//! (`(if (< current-plus-delta new-max) current-plus-delta new-max)`)
+//! mutation-dead: swapping `new-max` for `max-cap` in that `if` form
+//! changed nothing observable, because in every prior scenario the two
+//! values were either equal (damage zero) or the clamp never bound at all.
+//!
+//! # Provenance
+//!
+//! ```text
+//! PYTHONPATH="$PWD/src" uv run python \
+//!     rust/crates/babylon-tick/content/scenarios/metabolism_ratcheted_ceiling_conformance.py
+//! ```
+//!
+//! Its output on 2026-08-11, verbatim:
+//!
+//! ```text
+//! entropy_factor = 1.005, hysteresis_rate = 0.01
+//! post-tick state:
+//!   ratcheted-ceiling-county biocapacity=99.5 max_biocapacity=99.5
+//! ```
+//!
+//! See `metabolism-ratcheted-ceiling-conformance.bscn` for the derivation:
+//! `regeneration_rate=1.0`/`entropy_factor=1.005`/`hysteresis_rate=0.01`
+//! (all legal, at their declared extremes) make `current + delta = 99.75`
+//! exceed the RATCHETED `new_max = 99.5` (`damage = 50 * 0.01 = 0.5`) —
+//! the correct clamp result is `99.5`; a rule comparing against the
+//! UNRATCHETED `max_biocapacity = 100` instead would wrongly leave
+//! `biocapacity` at `99.75`.
+
+use babylon_graph::memory::MemoryGraph;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::{run_once, run_once_into};
+
+const SCENARIO: &str =
+    include_str!("../content/scenarios/metabolism-ratcheted-ceiling-conformance.bscn");
+const RULE: &str = include_str!("../content/rules/metabolism.bsl");
+
+fn run() -> MemoryGraph {
+    let mut graph = MemoryGraph::new();
+    let mut sink = babylon_bsl::structural_verbs::CollectingSink::default();
+    run_once_into(SCENARIO, RULE, &mut graph, &mut sink).expect("the Metabolism pack must run");
+    graph
+}
+
+fn attribute(graph: &MemoryGraph, id: u64, field: &str) -> f64 {
+    graph
+        .node_attribute(NodeId(id), field)
+        .unwrap_or_else(|e| panic!("node {id} field {field}: {}", e.message))
+}
+
+/// The clamp binds against the RATCHETED ceiling (`99.5`), not the
+/// unratcheted seed (`100.0`) and not the unclamped `current + delta`
+/// (`99.75`). Mutation-verified (by hand during authoring, reverted before
+/// commit): swapping `metabolism.bsl`'s `capped-at-ceiling` binding's
+/// second/third operand from `new-max` to `max-cap` flips this test from
+/// `99.5` to `99.75` — the exact "clamps against the wrong ceiling"
+/// mutation this vector exists to catch.
+#[test]
+fn the_ceiling_clamp_binds_against_the_ratcheted_ceiling_not_the_original() {
+    let graph = run();
+    assert_eq!(attribute(&graph, 0, "territory/biocapacity"), 99.5);
+}
+
+/// The ratchet itself: `max_biocapacity` ends the tick at `99.5`, strictly
+/// below its `100.0` seed.
+#[test]
+fn the_ceiling_is_strictly_ratcheted() {
+    let graph = run();
+    let max = attribute(&graph, 0, "territory/max-biocapacity");
+    assert_eq!(max, 99.5);
+    assert!(max < 100.0);
+}
+
+/// Byte-determinism.
+#[test]
+fn the_ratcheted_ceiling_scenario_tick_is_deterministic() {
+    let a = run_once(SCENARIO, RULE).expect("first run");
+    let b = run_once(SCENARIO, RULE).expect("second run");
+    assert_eq!(a.after, b.after);
+    assert_eq!(a.fired, 1);
+}

--- a/rust/crates/babylon-tick/tests/metabolism_rounding_divergence_conformance.rs
+++ b/rust/crates/babylon-tick/tests/metabolism_rounding_divergence_conformance.rs
@@ -1,0 +1,112 @@
+//! PINS the D-1 scaled-`Int` workaround's numeric DEVIATION from the frozen
+//! engine (F1 fix round, adversarial review of PR #501). An earlier
+//! revision of `metabolism.bsl`'s D-1 claimed the workaround "preserves the
+//! formula's exact value ... for ANY legal (1.0, 3.0] modded value" —
+//! FALSE, disproved by execution. This suite asserts what the engine
+//! ACTUALLY computes, including the exact bit pattern where it diverges
+//! from the frozen Python.
+//!
+//! # Provenance
+//!
+//! ```text
+//! PYTHONPATH="$PWD/src" uv run python \
+//!     rust/crates/babylon-tick/content/scenarios/metabolism_rounding_divergence_conformance.py
+//! ```
+//!
+//! Its output on 2026-08-11, verbatim:
+//!
+//! ```text
+//! frozen engine (MetabolismSystem.step, unmodified):
+//!   biocapacity     = 1.4000000000000004  3ff6666666666668
+//!   max_biocapacity = 99.985  4058ff0a3d70a3d7
+//!
+//! this pack's value (pure-Python replica of metabolism.bsl):
+//!   biocapacity     = 1.4  3ff6666666666666
+//!   max_biocapacity = 99.985  4058ff0a3d70a3d7
+//!
+//! biocapacity equal:     False
+//! max_biocapacity equal: True
+//! ```
+//!
+//! # Why `biocapacity` diverges and `max_biocapacity` does not
+//!
+//! `biocapacity`'s computation routes through `ecological-cost`, which
+//! uses the D-1 workaround (`(raw-extraction * entropy-factor-x1e6) /
+//! 1000000` — an exact integer multiply then a correctly-rounded division)
+//! where the frozen engine performs ONE binary64 multiply
+//! (`raw_extraction * entropy_factor`) instead. `max_biocapacity`'s
+//! computation (the hysteresis damage) never touches `entropy_factor` at
+//! all — `damage = raw_extraction * hysteresis_rate`, a plain multiply on
+//! both sides — so it is bit-identical.
+//!
+//! `0x3ff6666666666666` (this pack) versus `0x3ff6666666666668` (frozen
+//! Python) differ by exactly `2` in the raw bit pattern — 2 ULP, for a
+//! `biocapacity=3` seed where `entropy_factor` is at the shipped default
+//! `1.2` (grid-quantization error is exactly ZERO here — `1200000 / 1e6
+//! == 1.2` exactly as a real number, so this is purely the double-rounding
+//! residual `metabolism.bsl`'s D-1 derives).
+
+use babylon_graph::memory::MemoryGraph;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::{run_once, run_once_into};
+
+const SCENARIO: &str =
+    include_str!("../content/scenarios/metabolism-rounding-divergence-conformance.bscn");
+const RULE: &str = include_str!("../content/rules/metabolism.bsl");
+
+fn run() -> MemoryGraph {
+    let mut graph = MemoryGraph::new();
+    let mut sink = babylon_bsl::structural_verbs::CollectingSink::default();
+    run_once_into(SCENARIO, RULE, &mut graph, &mut sink).expect("the Metabolism pack must run");
+    graph
+}
+
+fn attribute(graph: &MemoryGraph, id: u64, field: &str) -> f64 {
+    graph
+        .node_attribute(NodeId(id), field)
+        .unwrap_or_else(|e| panic!("node {id} field {field}: {}", e.message))
+}
+
+/// `biocapacity` is `1.4` exactly (`0x3ff6666666666666`) — NOT the frozen
+/// engine's `1.4000000000000004` (`0x3ff6666666666668`). Asserted on the
+/// raw bit pattern, not just the decimal `==`, so a future accidental
+/// "fix" that happens to print the same short decimal cannot silently pass.
+#[test]
+fn biocapacity_is_this_packs_value_not_the_frozen_engines() {
+    let graph = run();
+    let bio = attribute(&graph, 0, "territory/biocapacity");
+    assert_eq!(bio, 1.4);
+    assert_eq!(
+        bio.to_bits(),
+        0x3ff6_6666_6666_6666,
+        "this pack's value, exactly 2 ULP below the frozen engine's 0x3ff6666666666668"
+    );
+    assert_ne!(
+        bio.to_bits(),
+        0x3ff6_6666_6666_6668,
+        "must NOT match the frozen engine's bit pattern — that would mean the double-rounding \
+         deviation stopped reproducing, which is worth investigating, not silently accepting"
+    );
+}
+
+/// `max_biocapacity` — the hysteresis damage path — never touches
+/// `entropy_factor` and so is bit-identical to the frozen engine's
+/// `99.985`, confirming the D-1 workaround's deviation is confined to the
+/// ecological-cost term exactly as derived.
+#[test]
+fn max_biocapacity_matches_the_frozen_engine_exactly() {
+    let graph = run();
+    let max = attribute(&graph, 0, "territory/max-biocapacity");
+    assert_eq!(max, 99.985);
+    assert_eq!(max.to_bits(), 0x4058_ff0a_3d70_a3d7);
+}
+
+/// Byte-determinism: the deviation is reproducible, which is what III.7
+/// actually requires — not bit-parity with the frozen Python reference.
+#[test]
+fn the_rounding_divergence_scenario_tick_is_deterministic() {
+    let a = run_once(SCENARIO, RULE).expect("first run");
+    let b = run_once(SCENARIO, RULE).expect("second run");
+    assert_eq!(a.after, b.after);
+    assert_eq!(a.fired, 1);
+}


### PR DESCRIPTION
## Summary

Ports Phase 1 of the frozen `MetabolismSystem` (Material Base @13.0, the metabolic rift between extraction and regeneration) to a `metabolism/biocapacity-update` BSL rule pack, following the Dispossession port's (PR #498) assessment-gate → provenance → rule-pack → conformance-test discipline exactly.

**Full assessment**: `reports/metabolism-port-assessment-2026-08-11.md`.

**This PR went through two adversarial-review rounds** after the initial port landed. Round 1 (three independent Opus lenses, BLOCK) found the port's original D-1 exactness claim false and three conformance vectors mutation-dead. Round 2 (independent re-verification of round 1's own fix) found round 1's D-1 restatement bounded the WRONG quantity and introduced two further false claims while retracting the first one. Both rounds' findings are folded in below; nothing is presented as settled that a later check could re-open.

### Per-block disposition

| Block | Disposition |
|---|---|
| Spec-070 sovereign pre-pass (`habitability` += `persistent_data["balkanization.metabolic_impact_by_territory"]`) | **BLOCKED** (D-3) — no BSL `<bind-src>` reads `context.persistent_data`. |
| Phase 1 — per-territory biocapacity/hysteresis | **PORTED**, with one workaround-plus-D-record (D-1) and one deliberate divergence (D-5) |
| Phase 2 — global aggregates (Σ biocapacity, Σ weighted consumption) | **BLOCKED** (D-4) |
| Phase 3 — overshoot check + `ECOLOGICAL_OVERSHOOT` emit | **BLOCKED** (D-4, same root cause as Phase 2) |

Phase 2/3's BLOCKED disposition is confirmed **at the execution-engine level**: `tick.rs::run_tick` never reads `loaded.domain` at all, even though `(domain :graph)` is fully implemented at load time; `babylon-tick` registers zero metrics; no scenario/rule/test anywhere exercises `(domain :graph)` or `fold` end to end.

### D-1: the entropy_factor workaround's numeric deviation — the full, twice-corrected story

The port needed a scaled bare-`Int` `:const` workaround for `entropy_factor` (`Ratio`'s only operator is `Currency × Ratio`, and this formula's multiplicand is necessarily `Real`, never `Currency`). Getting the workaround's own honesty right took two rounds:

- **Original claim (wrong)**: "preserves the formula's exact value ... for ANY legal `(1.0, 3.0]` modded value." Disproved: `biocapacity=3` at the shipped default diverges by 2 ULP (`0x…666` vs frozen `0x…668`).
- **Round-1 fix (also wrong, in a new way)**: correctly derived a ≤2 ULP bound over the `ecological-cost` *term*, then reported the same bound for `biocapacity` — the *output*. That doesn't hold: the term is subtracted from a comparable quantity under **cancellation**, then clamped. Verified counterexamples: seed A (`bio=149,max=150,extraction=1,regen=0.005,entropy=1.005`) diverges by **32768 ULP** (`0x3f747ae147ae8000` vs `0x3f747ae147ae0000`); seed B (`bio=1,max=10,extraction=3,regen=0.26,entropy=1.2` — the shipped default) lands the two engines on **opposite sides of the `max(0.0,…)` floor** (`4.44e-16` vs `0.0`). A broader sweep found 305 such floor-branch splits.
- **Round-1 also introduced**: a wrong exactness justification (product's significand must fit 2^53, not the operands'; only true on tick 1 with fresh int seeds — verified the two engines already disagree by tick 3 for a `biocapacity=5` seed), and a new false universal ("NOT bit-exact ... for ANY input, including the shipped default") that this pack's own `nominal-county` vector (bit-identical at the shipped default) already contradicted.
- **Round-2 (current state)**: the `ecological-cost` *term*'s own bound is real and re-confirmed (≤2 ULP derivable, ≤1 ULP measured over an exhaustive 4-billion-combination sweep: int `raw_extraction` 1–2000 × the full 6-digit `entropy_factor` grid in `(1.0,3.0]`). The rule's *output* is **not** ULP-bounded — deterministic, documented, and accepted under ADR183 §5.4 (frozen engine = structure/ordering contract, not a bit-exact oracle) and III.7 (this engine's own determinism is constitutional, not Python bit-parity) — not silently denied either direction. Also disclosed: the same bare-Int bypass that enables the workaround admits an out-of-domain or negative `entropy_factor` with **no refusal at all** (verified directly). En-masse retirement of this workaround class is chartered as **workstream 3 of the post-port refactor program** (#502).

A separate contradiction, also flagged in round 1: the D-record numbering the original task brief pointed at (`bsl-language.rst`'s Draft-Ruling Register, D97-D99) is language-spec-level and unrelated to the port-content `D-1`.. convention `dispossession.bsl`/`lifecycle.bsl` actually use (file-local, restarting at D-1). This port follows the real precedent — file-local `D-1`..`D-5`.

### Round-1 fix round: three mutation-dead clamps/guards found and closed

- **F2**: the ceiling clamp's operand choice (`new-max` vs `max-cap`) was mutation-dead. Fixed with `metabolism-ratcheted-ceiling-conformance.bscn`; mutation-verified (swap flips `99.5` → `99.75`).
- **F3**: the `(>= current max-cap)` regeneration-suppression guard's boundary was mutation-dead. Fixed with `metabolism-ceiling-suppression-conformance.bscn`; mutation-verified (flip → `0.0` vs `4.949999999999999`).
- **F4**: the `new-max` floor clamp had zero coverage. Fixed with `metabolism-extreme-damage-conformance.bscn`; mutation-verified (flip → `0.0` vs `-400.0`).
- **F5**: hygiene — a false "Int × Int" claim in a comment (field reads are unconditionally `Value::Real`), a new D-5 record for the four Python `.get(attr, default)` fallbacks (now loud failures, a deliberate III.11-favoring divergence), a corrected `rg -rn`→`rg -n` citation.

### Defaulted-attribute sweep

- `extraction_intensity`, `biocapacity`, `max_biocapacity` → `:field` (genuinely live/varying per-territory).
- `regeneration_rate` → `:const` (grep-verified uniform `0.02` everywhere).

### Conformance test inventory (28 tests, 8 scenarios, 8 Rust test files)

| Scenario | Tests | Proves |
|---|---|---|
| `metabolism-conformance.bscn` | 7 | nominal trajectory, hysteresis fully inert, zero floor + hysteresis ratchet |
| `metabolism-ceiling-conformance.bscn` | 3 | ceiling clamp binds, unratcheted |
| `metabolism-ratcheted-ceiling-conformance.bscn` (F2) | 3 | ceiling clamp binds against the RATCHETED value |
| `metabolism-ceiling-suppression-conformance.bscn` (F3) | 3 | regeneration suppressed exactly at `current == max_cap` |
| `metabolism-extreme-damage-conformance.bscn` (F4) | 3 | `new-max` floor clamp binds |
| `metabolism-entropy-low-conformance.bscn` | 3 | D-1 workaround carries the coefficient's magnitude (near floor) |
| `metabolism-entropy-high-conformance.bscn` | 3 | D-1 workaround carries the coefficient's magnitude (at cap) |
| `metabolism-rounding-divergence-conformance.bscn` (F1) | 3 | D-1's bit-level deviation, pinned not denied |

### Mutation-verification statement

Performed by hand during authoring (each perturbation reverted before commit): D-1 descaling divisor, ceiling-clamp comparator, floor-clamp comparator, general regeneration-suppression guard, F2's ratcheted-ceiling operand, F3's suppression-boundary comparator, F4's floor-clamp removal — each flips a specific, named test to a specific, verified value.

### Gate evidence (all green, from `rust/`, re-run after both review rounds)

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p babylon-tick` — **23 test binaries plus the Doc-tests section**, all green (corrected from an earlier "24 test binaries" miscount), including 28 metabolism-specific tests across 8 files — and `-p babylon-bsl` (457 tests, untouched)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- Repo-side: `mise run check:quick` green; all 8 Python provenance scripts pass `ruff check`/`ruff format --check`/`mypy` directly

## Test plan

- [x] `cargo test -p babylon-tick` — 23 binaries + Doc-tests section, all green, including all 8 metabolism suites (28 tests)
- [x] `cargo test -p babylon-bsl` — 457 tests, unaffected
- [x] `cargo fmt --all --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo doc` gate
- [x] Every Rust-pinned value independently cross-checked against the frozen `MetabolismSystem`'s own provenance script output (or a pure-Python replica confirmed bit-identical to the real Rust engine)
- [x] Mutation-verified every load-bearing clamp/guard by hand, both review rounds
- [x] D-1's numeric-deviation claims independently re-derived and re-verified against both engines (counterexamples A/B, the 4-billion-combination term sweep, the multi-tick replay, the out-of-domain load check)
- [x] `mise run check:quick` green
- [x] Working tree confirmed clean of stray/scratch files at every commit boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)