### PR TITLE
feat(bsl): Half-1 typed-attribute seeding — fractional lanes into f64 storage (P27 port lane)

### DIFF
--- a/reports/typed-attribute-seeding-design-2026-08-11.md
+++ b/reports/typed-attribute-seeding-design-2026-08-11.md
@@ -1,0 +1,489 @@
+# Typed-Attribute Scenario Seeding — Design (Program 27 Phase 2)
+
+**Date.** 2026-08-11. **Author.** Design engineer, typed-attribute seeding train (read-only
+survey against dev tip `94533b77`, no branch cut). **Purpose.** The declared Phase-2 trait
+revision `docs/reference/phase-1-exit-checklist.md`'s DEFERRED table names ("Typed attribute
+storage (Currency i128 exactness on node fields) | Phase 2 trait revision | `f64` attributes
+cannot hold i128; Currency writes are LOUD errors today, never lossy casts") — scoped here to
+what actually blocks the port lane: the scenario **loader**'s refusal to seed any field-value
+combination except an integer literal into an `int`-declared field
+(`rust/crates/babylon-bsl/src/scenario.rs::attribute_value`, line 653).
+
+**Headline finding the task brief's framing gets wrong in one place.** The brief says this
+train "retires the D-1 `:const` workarounds across Dispossession/Lifecycle/Metabolism" as if
+uniform. It is not. Dispossession's D-1 (five rate fields) and Lifecycle's D-1/D-2 (eleven
+fields) are exactly what this design retires — they are fractional-seeding gaps, full stop.
+**Metabolism's own D-1 (`entropy_factor`, `content/rules/metabolism.bsl` lines 21–207) is a
+different gap this design does not touch**: even with a `Ratio`-typed `defconst` (D99/ADR194),
+the only legal `Ratio` operator is `Currency × Ratio`, and `entropy_factor`'s multiplicand is
+`Real` (both factors are `:field` reads, always `Value::Real` — see §D below) — there is no
+`Real × Ratio` operator on the language surface at all. That gap is explicitly chartered as
+"workstream 3 of the post-port refactor program" (metabolism.bsl lines 178–183, GitHub issue #502)
+and is **out of scope here**, exactly as edge/hyperedge field storage (ADR192) is out of scope
+here. What this design DOES retire from Metabolism is its **D-2** — `biocapacity`/
+`max-biocapacity`/`extraction-intensity`, already `:field`-bound but seeded today as
+workaround `int`-declared fields (`metabolism-conformance.bscn` lines 25–27) standing in for
+what the source-of-truth Pydantic model declares `Currency`/`float [0,1]`
+(`src/babylon/models/entities/territory.py:155–172`).
+
+Second correction, smaller: the brief cites "Territory's STOP record (blocker 2: heat/
+organization fixtures need fractional seeds)" as an existing artifact to read. No such file
+exists in the tree today — there is no Territory BSL port-assessment or plan document yet
+(unlike Dispossession's, Lifecycle's, and Metabolism's, all of which landed one before their
+`.bsl`). The underlying claim is independently true and verified below (`Territory.heat:
+Intensity`, `territory.py:130–132`; `Organization.heat: Probability`, `organization.py:184`;
+`bsl-gap-analysis-2026-08-10.md` row 2.0 names "heat dynamics, camp decay, heat spillover" as
+Territory's three blocked families) — but it is a claim this design corroborates from source,
+not a citation this design found.
+
+---
+
+## 0. Scope
+
+**In scope.** Widening the scenario loader (`scenario.rs::attribute_value`) and, for Currency,
+the substrate storage layer, so a `.bscn` file can seed a fractional or Currency value into a
+node field of the field's own declared type, instead of every non-`int` field being an
+unconditional load refusal.
+
+**Out of scope, named so a later reader does not re-derive the boundary:**
+
+- **Edge/hyperedge field storage** — ADR192's lane. That ruling already grants "dyadic edges
+  and hyperedges MAY carry declared, typed, hash-covered fields" as machinery, with its own
+  Aleksandrov-per-field gate and its own `CanonicalState` widening. This design's Half 2 (§B)
+  reuses ADR192's *pattern* (additive widening, ceremony on first declaration) for **node**
+  attributes, but does not touch edges or hyperedges at all.
+- **`Real × Ratio` / the scaled-Int workaround class** — issue #502 workstream 3. Typed
+  attribute storage does not create a `Real × Ratio` operator; Metabolism's D-1 stays exactly
+  as workaround'd as it is today after this design lands.
+- **Per-territory reference-data hydration** (§3.9's hydration contract — FRED-derived
+  foreclosure rates, real Census legitimation data) — that is a data-build-pipeline seam
+  (`docs/reference/bsl-language.rst` §3.9 clause 4), and this design only widens what the
+  **scenario loader** can legally seed. Whether the eventual hydration pipeline writes through
+  the same `attribute_value`-equivalent path or a different one is that seam's own decision.
+- **Currency's sign domain.** `babylon_kernel::Currency` is deliberately left signed at the
+  type level (`currency.rs` lines 4–12, "OPEN — flagged in the Phase-1 plan's open
+  questions") even though the BSL spec table declares Currency's domain `[0, ∞)`
+  (`bsl-language.rst` lines 2154–2155). §B recommends enforcing `[0, ∞)` at the typed-attribute store
+  boundary, matching the spec table, but does not resolve the kernel type's own open flag.
+
+---
+
+## A. The two-half split
+
+### Half 1 — fractional f64-representable lanes (Probability / Intensity / Coefficient / Real)
+
+**Claim: seedable with no trait revision, by widening `attribute_value` alone. Verified true
+at three independent levels:**
+
+1. **The storage layer already holds arbitrary `f64`.** `GraphSubstrate::update_node`/
+   `node_attribute` are `f64` in and out today (`rust/crates/babylon-graph/src/substrate.rs`
+   lines 133, 142) — nothing about the trait, `MemoryGraph`, or `HypergraphStore`
+   (`hypergraph_store.rs` line 77: `attributes: HashMap<(NodeId, String), f64>`) restricts
+   values to integers. The restriction is **entirely** in the scenario loader's
+   `attribute_value` function, which the refusal's own doc names precisely: "slice 1 stores
+   only `int`-declared fields ... the scaled and Currency lanes need typed attribute storage"
+   (`scenario.rs` lines 659–666). That sentence conflates two different gaps under one
+   refusal; Half 1 is the half that needs no typed storage at all.
+2. **The runtime write path already enforces exactly the domain check Half 1 needs, and Half
+   1 should mirror it verbatim.** `structural_verbs.rs::store_range_check` (lines 707–728)
+   already refuses a runtime `update-node` write outside `[0,1]` for a Probability/Intensity/
+   Coefficient-declared field, loud, `E-EVAL-020`, never a clamp. Widening `attribute_value`
+   to accept these three types should apply the **identical predicate**
+   (`matches!(decl.ty, BslType::Probability | BslType::Intensity | BslType::Coefficient)` then
+   `(0.0..=1.0).contains(&value)`) at load time — not a new invented rule, the same rule the
+   runtime store boundary already lives by, just checked one call frame earlier. `Real` gets no
+   range check at either boundary today (§3.3: "the unbounded intermediate type"; not
+   independently storable per §3.1's table — a `deffield` cannot declare `real` as a type at
+   all, confirmed against the table's six `<type-name>` rows, `bsl-language.rst` lines 2148–2165)
+   — so `Real` is not actually a fourth seedable *declared* type, only the runtime lane every
+   arithmetic result promotes into (§3.3).
+3. **`CanonicalState`/`state_hash.rs` is untouched.** The canonical byte layout's attribute
+   section (`0x02`) is already `u64 id ‖ str name ‖ u64 value-bits` over an `f64`
+   (`state_hash.rs` lines 20–21, 141–152) regardless of what BSL-level type declared the field.
+   A `0.358` seeded into a `coefficient`-declared field and a `0.358` seeded into a
+   (hypothetically legal) `int`-declared field hash **byte-identically** — the section's shape
+   does not depend on `BslType` at all, only on the stored `f64`. Widening `attribute_value`'s
+   accepted `(value, decl.ty)` combinations therefore changes **zero** bytes of the encoding
+   for any existing scenario (every existing `.bscn` seeds only `int` fields, and the `int`
+   arm of `attribute_value` is untouched) — Half 1 is provably additive at the hash level,
+   with no ceremony, no golden move, and no `qa:regression`/vault consequence.
+
+**The quantization contract, precisely, correcting an assumption in the task brief.** The
+brief frames this as "a decimal literal like `0.358` must enter storage as the exact same
+f64 the evaluator's 1e-6-grid lanes would produce." Verified against the actual code: **there
+is no 1e-6-grid lane in the BSL evaluator today.** `babylon_kernel::grid::quantize` (the
+`(value * 1e6 + 0.5).floor() / 1e6` half-up law, `grid.rs` lines 17–32) is invoked in exactly
+one place in the entire `babylon-bsl` crate: `reader.rs`'s `Ratio`-literal legality check
+(does an `r`-suffixed literal quantize to zero, `E-LEX-027`). It is **not** invoked when a
+`p`/`i`/`c` literal is lexed (`reader.rs::classify_unit_interval`, lines 761–806, is a plain
+`[0,1]` range check over up to 9 exact fractional digits, no grid snap), **not** invoked when
+a scaled literal becomes a `Value::Real` (`tick.rs::atom_to_value` line 264 and
+`scenario.rs::load_defconst` line 311 both compute `unscaled as f64 / 10f64.powi(scale)` —
+one IEEE-754 division, nothing else), and **not** invoked at the runtime store boundary
+(`numeric_write_value`/`store_range_check`, `structural_verbs.rs` lines 668–728, check
+finiteness and `[0,1]` range only). The 1e-6 grid is exclusively a `babylon_kernel` **scalar
+newtype** invariant (`scalars.rs`'s `Probability::new`/`Intensity::new`/`Coefficient::new`/
+`Ratio::new`, each calling `quantize` on construction) — a code path nothing in
+`babylon-bsl` currently reaches, because nothing in the BSL crates constructs a kernel scalar
+newtype from a graph-read `f64`; the evaluator's binary64 lane is raw `f64` (`Value::Real`)
+end to end.
+
+**Recommendation: do not invent a grid-snap for the seed path alone.** Doing so would create
+exactly the asymmetry it is trying to prevent — a value entering storage via
+`(update-node self field (+ x y))` during a tick is not grid-quantized today, so if the seed
+path alone snapped to the grid, a rule-loaded-then-written value and a scenario-seeded value
+of the identical field would follow two different rules for the same declared type. **The
+seed-path contract Half 1 should state is the one that already governs every other BSL
+numeric literal**: the stored value is the single, correctly-rounded IEEE-754 result of
+`unscaled / 10^scale` (up to 9 fractional digits, `ScaledLit`'s own bound, `reader.rs` line
+107), identical byte-for-byte to what a `:const`/`:default` binding of the same literal
+already produces via `Value::Real`. That conversion is a **basic IEEE-754 operation** (a
+single division of two exactly-representable operands — `unscaled` as an integer, `10^scale`
+exact in `f64` for `scale ≤ 22`), which reproduces bit-identically across conforming
+implementations (the same class of guarantee `grid.rs`'s own cross-language conformance
+vector relies on, and the class CLAUDE.md's Tests-as-Behavioral-Contracts principle 4 already
+names as safe: "basic IEEE-754 ops reproduce across languages"). No new rule is minted; the
+existing rule is extended verbatim to the node-attribute seed path. **Watch item, not a
+blocker**: if a future intrinsic host or native Rust system ever constructs a
+`babylon_kernel::Intensity`/`Probability`/`Coefficient` directly from a graph-read attribute,
+that construction's own `quantize()` call could silently re-round a value seeded with more
+than 6 significant fractional digits, diverging from the hashed value. Flagged for whoever
+builds that bridge (mirroring `E-EVAL-041`'s own "defense in depth... re-check at the point of
+use" discipline) — unreachable today, so not this design's problem to solve.
+
+### Half 2 — Currency (i128 micro-units)
+
+**Genuinely needs typed storage — not an extension of Half 1's fix.** Two independent reasons,
+both grounded in code already in the tree:
+
+1. **Exactness.** `Currency` is `i128` micro-units (`currency.rs` line 36); `f64` is exact
+   only to `2^53` (≈9.007×10¹⁵), which bounds exact-integer *micro-units* to about $9.007
+   billion — inside county-scale headroom today, but the exactness argument
+   `attribute_value`'s own `Int` arm already makes for `i64` (lines 670–672: "Exact in f64 to
+   2^53; past that the stored value would differ from the declared one, which is a lie the
+   state hash would faithfully record") applies with a **narrower** headroom to `i128`.
+2. **Rounding semantics, the deeper reason.** Every `Currency`-mixed operation in §3.2's table
+   is pinned to a specific rounding law — half-even, at a specific intermediate width (`i256`
+   for `Currency ÷ Currency`) — that a raw `f64` round-trip cannot preserve once a value has
+   passed through even one arithmetic step: IEEE-754 binary rounding and the spec's
+   half-even-on-the-micro-unit-grid rounding are not the same rounding, and they diverge after
+   composition even when they agree on the first operation. This is why `attribute_value`
+   refuses Currency outright today (line 681) rather than merely widening its integer-exactness
+   check — the gap is not "we haven't raised the exactness ceiling yet," it is "an `f64` cannot
+   carry the operator table's own guarantees across a write/read round trip."
+
+**No candidate shape stores Currency as two f64 halves — rejected, per the prompt's own
+instruction to reject it loudly.** A hi/lo or dollars/micro-remainder split reintroduces the
+identical `2^53`-exactness ceiling on whichever half carries the larger magnitude (a
+dollars-component past ~9 quadrillion micro-units is exactly the failure this design exists to
+retire, just relocated), and it invents a **second, un-normative cross-language contract**
+(how the two halves recombine into one `i128`) duplicating the work of specifying `i128`
+storage directly, with strictly more surface for a bug. Rejected without further analysis.
+
+---
+
+## B. The trait-revision shape for Half 2
+
+Two candidate shapes, plus the rejected third from §A:
+
+### Shape 1 (recommended) — a parallel typed-attribute surface on `GraphSubstrate`
+
+Two new trait methods, additive to the existing 14 (`substrate.rs`'s own module doc already
+counts them as 14):
+
+```rust
+fn update_node_currency(&mut self, id: NodeId, attribute: &str, value: Currency)
+    -> Result<(), GraphError>;
+fn node_attribute_currency(&self, id: NodeId, attribute: &str)
+    -> Result<Currency, GraphError>;
+```
+
+backed by a second map per store (`HashMap<(NodeId, String), Currency>`, sitting alongside
+`attributes: HashMap<(NodeId, String), f64>` unchanged in both `MemoryGraph` and
+`HypergraphStore`). `CanonicalState` gains a **fifth** section, `0x05`, `u64 id ‖ str name ‖
+i128 value (16 bytes, big-endian)`, sorted `(id, name)` exactly as section `0x02` is, emitted
+after `0x04` so existing readers' section-tag dispatch is untouched. **Existing content
+(nothing declares a `currency`-typed field today) encodes with an empty `0x05` section — four
+bytes, `u32 count = 0` — appended after today's four sections.** That is a **byte-shape
+change to every existing golden** (the trailing `0x05 00000000` is new bytes even for zero
+Currency attributes), which is the one place this shape is NOT free — see the ceremony note
+below.
+
+**`encode_state`'s provided default keeps doing all the sorting**, exactly as it already does
+for the other four sections (`state_hash.rs` lines 257–283) — a fifth `write_currency_attributes`
+call added to the same provided method, no new per-store logic beyond the two new listing
+methods (`all_currency_attributes`, mirroring `all_attributes`).
+
+### Shape 2 (rejected as this train's shape, correct as a LATER shape) — widen the attribute value to an enum
+
+Replace `f64` with `AttributeValue { F64(f64), Currency(Currency) }` across the trait's two
+existing methods (`update_node`, `node_attribute`). This is not additive: it changes the
+signature of two methods every existing caller uses (`scenario.rs`, `structural_verbs.rs`,
+`tick.rs::bind_subject`), forces every implementor (`MemoryGraph`, `HypergraphStore`, any
+future store) to re-type its attribute map, and — because the *shape* of every attribute row
+changes (a tag byte minimum, even for a plain `f64`) — re-encodes **every existing attribute
+row in section `0x02`**, not just adds a new empty section. Every stored golden hash moves,
+not just gains four trailing bytes. Reject for this train: strictly more blast radius than
+Shape 1 for the identical behavioral outcome, and it forecloses ever giving Currency its own
+section-level ceremony discipline the way ADR192 gives edge/hyperedge fields theirs. (It could
+still be the right shape for a hypothetical *third* typed lane arriving later, if the
+per-lane-parallel-map pattern stops scaling — not a call this design needs to make.)
+
+### Which goldens move, and under what ceremony
+
+Shape 1 moves **every existing golden hash** the moment it lands, even though no content
+declares a Currency field yet — because the empty `0x05` section is still four new bytes in
+the encoding. This is the one place Half 2 is **not** free, unlike Half 1. The repo's own
+`test(baselines): …` ceremony (CLAUDE.md "Definition of done," `Baselines: blessed(<slug>)`
+trailer, `tools/generate_ceremony_message.py`) is the mechanism — this is a **mechanical**
+drift (every cell's hash changes, none of its *value*), so the ceremony's drift table will
+read as "every baseline moved, zero semantic deltas," which the ceremony format already
+supports (it records attribution, and "new empty section" is a one-line attribution repeated
+identically across every scenario). **Recommendation: land Shape 1's trait/encoding change
+and its baseline ceremony as its own PR, separate from and before the first Currency-typed
+`deffield`** — isolating "the encoding widened" from "content started using it" mirrors
+ADR192's own clause 3 verbatim ("content declaring no relation fields encodes byte-identically
+... the ceremony fires when content FIRST DECLARES such a field, not when the machinery
+lands") *except* that ADR192's edge/hyperedge widening achieves TRUE zero-golden-movement
+(a new section only appears once a hyperedge or edge actually carries a field), while Shape 1
+here cannot: an *empty* `0x05` section still writes four bytes for every scenario, because
+`CanonicalState::encode_state`'s four-then-five-section shape is unconditional. If literal
+byte-parity with ADR192's discipline is wanted, the alternative is to make section `0x05`
+**conditionally emitted** — omitted entirely when a store's Currency-attribute set is empty —
+which restores true zero-movement for every currently-Currency-free scenario at the cost of a
+single `if !currency_attrs.is_empty()` branch in `encode_state`. **Recommended over the
+unconditional variant above** for exactly this reason: it makes Half 2's landing PR truly
+byte-free until content opts in, matching the precedent this design is explicitly modeling
+itself on.
+
+---
+
+## C. What is Director-gated
+
+One item rises to a genuine reserved-line decision; everything else below it is settled
+engineering under an existing ruling, cited.
+
+### Gated — sequencing: does Half 2 land now, unconsumed, or wait for its first real consumer?
+
+Even with the conditional-section fix (§B), Half 2 is real, non-trivial surface (a second
+per-store map, two new trait methods, a fifth `CanonicalState` section, a `bind_subject`
+plumbing change — §D) landing with **no BSL content that uses it**, since nothing in
+`content/rules/*.bsl` declares a `currency` field today (every pack currently fakes Currency
+fields as `int`). This sits directly against two standing, previously-ruled positions that
+pull opposite ways:
+
+- *For landing it now:* `feedback_full_vision_no_mvps.md` — "never propose MVP/Phase-1
+  splits of fully-specced features" — and the Phase-1 exit checklist already scoped "Typed
+  attribute storage" as one Phase-2 item, not two.
+- *For deferring it:* the D99/#492 addendum's own precedent — "Porting these five rules to
+  BSL is explicitly OUT of scope for the change that adds this addendum — it lands the
+  machinery only, in its own right-sized, reviewable unit; each consumer ports in its own
+  train" (`bsl-language.rst` line 2293) — landed the OPERATOR unconsumed, deliberately, in
+  living memory, one session before this design.
+
+This is presented as an open question rather than resolved by citation, because the two
+precedents disagree and neither is more authoritative than the other:
+
+**AskUserQuestion-ready:**
+
+> Typed Currency-attribute storage (Half 2) can land two ways. Which do you want?
+>
+> - **Option A (recommended): sequence it.** Ship Half 1 alone in this train — it unblocks
+>   Territory immediately and is byte-free (§A). Charter Half 2 as its own follow-on train,
+>   opened by whichever port first needs a real Currency field (Dispossession's
+>   `territory/wealth`, Lifecycle's `wealth-d-prime`, or Metabolism's `biocapacity`/
+>   `max-biocapacity` are the three live candidates — all three are `Currency`-typed in the
+>   frozen Pydantic source and all three are seeded as `int` workarounds today). Mirrors the
+>   D99/#492 precedent exactly.
+> - **Option B: land both halves together, now.** Keeps the "declared Phase-2 trait revision"
+>   as one delivered unit matching the exit checklist's single line item, and gets the
+>   ceremony-movement pain (§B) over in one PR instead of two. Costs: a second train's worth of
+>   surface (new trait methods, new store map, new `CanonicalState` section, `bind_subject`
+>   plumbing) ships with zero consumers to prove it against beyond hand-written tests.
+
+### Settled — everything else, cited
+
+- **Half 1's shape needs no ruling.** It is provably additive at the hash level (§A, point 3),
+  it is exactly what Dispossession's and Lifecycle's own D-1 records already anticipated
+  verbatim ("these five become genuine per-territory `:field` reads with NO OTHER CHANGE...
+  When real per-county hydration lands (Phase 2's Currency/Probability-typed field storage)",
+  `dispossession.bsl` lines 41–44), and it mints no new primitive, no new algebra, no new
+  BSL grammar.
+- **Half 2's SHAPE choice (Shape 1 over Shape 2) needs no ruling.** Phase-1 exit checklist's
+  own words on the sibling storage-pick decision apply verbatim: "The trait is the insulation
+  layer; a storage pick is an engineering choice under a settled shape" (line 41). ADR191 R8
+  ruled the identical class of question — "NO constitutional text required for hypergraph-rs
+  engine-storage adoption" — for the hyperedge-storage pick; the same reasoning covers the
+  Currency-storage pick.
+- **Widening the canonical carrier set at all needs no NEW ruling — ADR192 already ruled the
+  general pattern**, one relation-carrier lane over: "dyadic edges and hyperedges MAY carry
+  declared, typed, hash-covered fields, widening the canonical carrier set beyond {node,
+  node-attr, edge-strength, hyperedge-members}" (ADR192 decision clause 1), on the warrant that
+  the addition "mints no new mathematics and no new primitive." A sixth canonical carrier
+  (`{node, node-attr, edge-strength, hyperedge-members, [edge-attr, hyperedge-attr — ADR192],
+  node-currency-attr — this design}`) is the same class of move ADR192 already licensed, not
+  a new one. This design treats ADR192 as the standing precedent for "how a canonical-carrier
+  widening gets ceremonied," not as literal authority over node attributes (ADR192's text is
+  scoped to edges/hyperedges) — flagged so a reviewer can independently judge whether that
+  extension-by-analogy is sound, rather than this document asserting it is self-evidently
+  covered.
+- **Enforcing `[0, ∞)` at the Currency-attribute store boundary needs no ruling.** It is a
+  direct application of the BSL spec's own declared domain for the type (`bsl-language.rst`
+  table row: `currency | i128 micro-units, [0, ∞)`, lines 2154–2155), mirroring
+  `store_range_check`'s existing precedent for the three unit-interval types
+  (`structural_verbs.rs` lines 707–728). Recommended, not gated.
+
+---
+
+## D. The read path
+
+**What Value lane a `:field` read enters today, verified against `tick.rs`, not assumed.**
+`bind_subject` (`tick.rs` lines 179–254) resolves a `BindSource::Field(qname)` binding at line
+237: `graph.node_attribute(subject, qname).map(Value::Real)` — **every** field read is wrapped
+`Value::Real`, unconditionally. `bind_subject`'s signature takes no `TypeEnv` at all (line
+180–184: `subject, bindings, graph, defines, tick` — no `types` parameter), so it is
+**structurally incapable** of consulting a field's declared `BslType` even if it wanted to.
+This is true for a field declared `int` too — `social-class/wages` is `int`-declared in every
+existing scenario, and a `:field wages` binding still reads back as `Value::Real`, never
+`Value::Int`. Confirmed directly in the test suite's own assumption (`dispossession.bsl`'s
+comment at lines 280–290, on why its D-4 clamp binding adds `(- 0 0c)` rather than returning a
+bare `:const`: "readable correctly by `real_lane` either way" — the code already treats
+`Value::Real` as the field-read lane's universal, type-blind output).
+
+### Verifying the D-1 claim: "they slot into the SAME positions... with NO OTHER CHANGE"
+
+**True for Half 1, with one caveat; false as stated for two named conformance-fixture classes.**
+
+For an **in-domain** value, the claim holds exactly, and Half 1 needs zero `tick.rs` changes:
+a `:const` binding of a scaled `c`/`p`/`i` literal already produces `Value::Real` via
+`atom_to_value` (line 264); a `:field` binding of the same value, once Half 1 lands, produces
+`Value::Real` via `bind_subject` line 238. Same runtime lane, same downstream arithmetic —
+the swap really is a one-line binding-source edit, exactly as claimed.
+
+**The caveat: bare, unsuffixed `Int` `:const` literals used as deliberate domain-check
+bypasses cannot make the same swap.** Dispossession's own D-2/D-4 records document, correctly,
+that a bare `Int` `:const` "carries NO domain check at all" (`E-LEX-024` bounds only
+suffixed literals) — and four of its own conformance scenarios exploit exactly that gap on
+purpose: `dispossession-ceiling-matrix-conformance.bscn` (`eviction-rate 6`,
+`displacement-rate 8`, `concentrated-ownership 9`, `absentee-landlord-share 4`) and
+`dispossession-negative-input-conformance.bscn` (`foreclosure-rate 5`, `eviction-rate -3`,
+`displacement-rate -8`, `concentrated-ownership -2`, `absentee-landlord-share -9`) — deliberately
+out-of-`[0,1]`-domain values, seeded specifically to prove the rule's own in-body clamps
+(D-2/D-3/D-4) actually fire. §A's Half 1 recommendation is to mirror `store_range_check`'s
+`[0,1]` enforcement at seed time — which means, once Half 1 lands, a properly `probability`-
+or `intensity`-declared field **cannot** be seeded with `6`, `-3`, or any other out-of-domain
+probe value; the loader would refuse it (a new load-time error, analogous to `E-LOAD-052`'s
+Ratio-bound check, not yet numbered — `E-LOAD-053` is next-free at time of writing per a
+sweep of every `E-LOAD-0xx` code currently in the tree). **This is correct and desired**
+(domain-typed storage should refuse an out-of-domain seed — that is the whole point of
+declaring the type), but it means these four adversarial scenarios must **keep** using
+`:const`'s domain-blind escape hatch even after Half 1 lands, permanently, by design — they
+cannot "become genuine per-territory `:field` reads" the way the D-1 header's general
+aspiration describes, because what they are testing is specifically unreachable through a
+properly-typed field. A later reader migrating Dispossession's `:const` bindings to `:field`
+should keep these two scenarios' five rate consts as `:const`, and migrate only the
+in-domain scenarios (`dispossession-conformance.bscn`, `dispossession-zero-rate-conformance.bscn`,
+`dispossession-single-rate-conformance.bscn`, `dispossession-saturation-conformance.bscn`,
+`dispossession-negative-weight-conformance.bscn`) — five of the pack's seven conformance
+scenarios, not all seven. (The header's own count of "four more, added in the adversarial-review
+fix round" names four scenarios total in that round — `saturation`, `negative-input`,
+`ceiling-matrix`, `negative-weight` — of which only `negative-input` and `ceiling-matrix` are
+actually out-of-`[0,1]`-domain; `saturation` and `negative-weight` probe the domain's own
+closed boundary (`1c`/`0c`) and stay legally in-range.)
+
+### Half 2's consequence for the read path — a real plumbing change, not a no-op
+
+For Currency, the "no other change" claim does not hold even in the best case, because
+`bind_subject` cannot dispatch to `node_attribute_currency` vs `node_attribute` without
+knowing the field's declared type — and it currently has no access to one at all. The fix is
+small and mostly already in place: `run_tick` (`tick.rs` line 356) **already receives**
+`types: &TypeEnv` as a parameter (used today only to construct `EffectExecutor::new(types)` at
+line 415) but does not forward it to `bind_subject`'s call at line 373. Threading `types`
+through `bind_subject` and switching on `types.fields.get(qname).map(|d| &d.ty)` to choose
+`node_attribute` (wrap `Value::Real`) vs `node_attribute_currency` (wrap `Value::Currency`) is
+the whole change — no new parameter needs to be invented at the `run_tick`/`run_once_into`
+call sites, since `prepared.types` (`babylon-tick/src/lib.rs` line 209) is already constructed
+and already flows to `run_tick` today.
+
+---
+
+## E. Sequencing
+
+Plan-ready granularity, assuming §C Option A (Half 1 now, Half 2 deferred):
+
+1. **Widen `attribute_value`** (`scenario.rs`) to accept `Probability`/`Intensity`/
+   `Coefficient`-declared fields, applying the `[0,1]` domain check mirrored from
+   `store_range_check`. `Int`'s existing arm is untouched (no behavior change for any field
+   declared `int`). Currency's refusal arm is untouched (still refused, same message).
+   *Proves*: the existing test `a_currency_attribute_is_refused_not_cast`
+   (`scenario.rs` line 849) still passes unmodified — Currency's refusal must survive Half 1
+   verbatim, since Half 2 is deferred.
+2. **New unit tests, mirroring the existing `attribute_value` suite's own style**: a `p`/`i`/
+   `c` literal seeds correctly into a matching-typed field; an out-of-`[0,1]` literal (bare
+   unsuffixed `Int`, or an in-range-suffix-but-wrong-magnitude case — there is no
+   out-of-range-suffixed case, `E-LEX-024` already refuses that at lex time) into a
+   Probability/Intensity/Coefficient field is refused at load, loud, naming the field; a
+   `Real`-typed `deffield` is impossible to write at all (confirms §A point 2's finding that
+   `Real` is not a legal `<type-name>`, so this is a grammar-level refusal already covered by
+   existing `deffield` type-name tests, not new).
+3. **Byte-identity regression, the "provably additive" claim made concrete.** A test that
+   loads a scenario seeding one `int` field and one new `coefficient` field, computes
+   `state_hash()`, and separately hand-constructs the expected `0x02` section bytes for both
+   rows via `StateEncoder` directly (mirroring `state_hash.rs`'s own
+   `the_canonical_encoding_is_pinned_byte_for_byte` test) — proving no format branch was
+   introduced by field type. A second test re-runs every EXISTING scenario fixture
+   (`dispossession-*.bscn`, `lifecycle-*.bscn`, `metabolism-*.bscn`, `vitality-*.bscn`) and
+   asserts each `state_hash()` is unchanged from its pre-change value — the actual
+   "provably additive" proof for real content, not just a synthetic fixture. This is the gate
+   that should block the PR if it fails; per §A's analysis it should pass trivially (no
+   existing scenario seeds anything but `int`), which is itself the point of running it.
+4. **Migrate Lifecycle's eleven D-1/D-2 `:const` bindings to `:field`**, five of Dispossession's
+   seven `:const` conformance-scenario declarations (the in-domain ones — §D), and Metabolism's
+   D-2 three
+   fields (`biocapacity`/`max-biocapacity`/`extraction-intensity` — note `biocapacity`/
+   `max-biocapacity` are `Currency`-typed in the source model and can only become properly
+   typed with Half 2; **this step upgrades their `deffield` declaration from `int` to
+   `intensity`/`coefficient` where the field is genuinely unit-interval
+   (`extraction-intensity`), and leaves `biocapacity`/`max-biocapacity` as `int` workarounds
+   still, pending Half 2** — a partial win, stated as such, not oversold). Each migration is
+   its own small PR per pack (three packs, three PRs), each re-running that pack's full
+   conformance suite and asserting unchanged output — the migration is a storage-representation
+   change only; the D-1/D-2 header comments retire in the same PR that migrates their fields
+   (the record no longer describes current behavior once the field is genuinely per-node).
+5. **Territory port re-enters here.** Once step 1 lands, Territory's `heat` (`Intensity`,
+   confirmed `territory.py:130–132`) and any per-territory Probability/Intensity/Coefficient
+   fields the eventual Territory BSL plan needs are seedable. This design does not write that
+   plan — the gap-analysis row (2.0, `bsl-gap-analysis-2026-08-10.md`) still names three
+   blocked families (heat dynamics, camp decay, heat spillover) and "eviction routing has no
+   expressible form" as **separate**, unresolved blockers this train does not touch; typed
+   seeding removes exactly one blocking dependency (fractional field storage), not all of
+   them. A Territory port-assessment document, matching the Dispossession/Lifecycle/Metabolism
+   convention, is the correct next artifact before any Territory `.bsl` is written — outside
+   this design's scope to produce.
+6. **(Deferred, per §C Option A) Half 2's own train**, opened by whichever of
+   `territory/wealth`, `lifecycle/wealth-d-prime`, or `metabolism/biocapacity` +
+   `max-biocapacity` first needs real Currency fidelity — landing the trait methods, the
+   second per-store map, the conditionally-emitted `0x05` `CanonicalState` section (§B), the
+   `bind_subject` type-aware dispatch (§D), its own baseline ceremony (empty-section
+   byte-movement, even with zero consumers, per §B's analysis), and only then migrating its
+   one triggering field.
+
+---
+
+## What this document does not cover, restated
+
+Edge/hyperedge field storage (ADR192's own lane, untouched); the `Real × Ratio` operator gap
+(issue #502 WS3, untouched — Metabolism's D-1 is not retired by this design); per-territory
+reference-data hydration's own bind-src/pipeline question (§3.9's seam, a Phase-2/3 content
+question independent of what the loader can legally store); Territory's own port plan (named
+as the next artifact, not written here); Currency's kernel-level sign-domain openness
+(`currency.rs`'s own flagged question, orthogonal to whether the BSL store boundary enforces
+`[0,∞)`, which this design does recommend).
+
+---
+
+## Rulings postscript
+
+Director ruling 2026-08-11 (popup): Half 2 Currency i128 typed storage DEFERRED TO FIRST
+CONSUMER — Half 1 proceeds as settled engineering; both halves remain fully specced in this
+document; this is train sequencing, not scope reduction.

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -664,10 +664,11 @@ fn load_node(
 /// micro-units were promised — both are the store lying about what it holds.
 ///
 /// **Half 1 needs no new typed storage.** `GraphSubstrate` attributes are
-/// already `f64` in and out (`babylon-graph/src/substrate.rs`); nothing
-/// about the trait restricts values to integers, and `CanonicalState`'s
-/// section `0x02` (`state_hash.rs`) is a bare `f64` regardless of which
-/// `BslType` declared the field — a `0.358` seeded into a
+/// already `f64` in and out (`rust/crates/babylon-graph/src/substrate.rs`);
+/// nothing about the trait restricts values to integers, and
+/// `CanonicalState`'s section `0x02`
+/// (`rust/crates/babylon-graph/src/state_hash.rs`) is a bare `f64`
+/// regardless of which `BslType` declared the field — a `0.358` seeded into a
 /// `coefficient`-declared field and one seeded into an (illegally)
 /// `int`-declared field hash byte-identically. The restriction lived
 /// entirely in this function; widening it changes zero bytes for any
@@ -1388,7 +1389,8 @@ mod tests {
         // `attribute_value`'s widening introduced no format branch keyed on
         // `BslType`. `CanonicalState`'s section 0x02 is a bare
         // `u64 id ‖ str name ‖ u64 value-bits` regardless of which BSL type
-        // declared the field (`state_hash.rs` module docs).
+        // declared the field (`rust/crates/babylon-graph/src/state_hash.rs`
+        // module docs).
         let source = r"
 (scenario ft/mixed-types
   (deffield social-class/population int extensive)

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -39,11 +39,18 @@
 //!
 //! - **No `Currency` attributes.** `GraphSubstrate` attributes are `f64`,
 //!   which cannot hold `Currency`'s i128 micro-units; the verb layer already
-//!   refuses such a write loudly rather than casting lossily. Values here are
-//!   integer literals, exact in `f64` to 2^53. Typed attribute storage is a
-//!   declared Phase-2 trait revision (`docs/reference/phase-1-exit-checklist.md`),
-//!   and the Fundamental Theorem will want it — wages and value produced are
-//!   properly money. Slice 1 states the simplification rather than hiding it.
+//!   refuses such a write loudly rather than casting lossily. Typed
+//!   attribute storage (Half 2 of the typed-attribute-seeding design,
+//!   `reports/typed-attribute-seeding-design-2026-08-11.md`) is DEFERRED TO
+//!   ITS FIRST CONSUMER (Director ruling, 2026-08-11 popup) — not to a fixed
+//!   phase boundary — and the Fundamental Theorem will want it once it
+//!   lands: wages and value produced are properly money. This module states
+//!   the gap rather than hiding it.
+//! - **`int`- and fractional-typed attributes only (Half 1).** An
+//!   `int`-declared field takes an integer literal, exact in `f64` to 2^53.
+//!   A `probability`/`intensity`/`coefficient`-declared field takes any
+//!   literal that widens to `[0, 1]` — see `attribute_value` (private, this
+//!   module) for the conversion contract and its determinism argument.
 //! - **No hyperedges yet.** The grammar has room for them; nothing in slice 1
 //!   needs one, and an unused form is an untested form.
 //! - **No defaults.** A node with no attributes gets no attributes. An
@@ -643,28 +650,49 @@ fn load_node(
     Ok(member.clone())
 }
 
-/// Slice-1 attribute values: integer literals into `int`-declared fields.
+/// Attribute values: `int` literals into `int`-declared fields (unchanged
+/// since slice 1), and — Half 1 of the typed-attribute-seeding design
+/// (`reports/typed-attribute-seeding-design-2026-08-11.md`) — a fractional
+/// literal into a `probability`/`intensity`/`coefficient`-declared field.
 ///
 /// The declaration is checked, not just consulted. A `120` written into a
-/// field declared `intensity` would be out of that type's `[0, 1]` domain,
-/// and one written into a `currency` field would silently become an f64
-/// where i128 micro-units were promised — both are the store lying about
-/// what it holds.
+/// field declared `intensity` is out of that type's `[0, 1]` domain, and one
+/// written into a `currency` field would silently become an f64 where i128
+/// micro-units were promised — both are the store lying about what it holds.
+///
+/// **Half 1 needs no new typed storage.** `GraphSubstrate` attributes are
+/// already `f64` in and out (`babylon-graph/src/substrate.rs`); nothing
+/// about the trait restricts values to integers, and `CanonicalState`'s
+/// section `0x02` (`state_hash.rs`) is a bare `f64` regardless of which
+/// `BslType` declared the field — a `0.358` seeded into a
+/// `coefficient`-declared field and one seeded into an (illegally)
+/// `int`-declared field hash byte-identically. The restriction lived
+/// entirely in this function; widening it changes zero bytes for any
+/// existing scenario, since every one seeds only `int` fields today.
 fn attribute_value(
     atom: &Atom,
     local: &str,
     field: &str,
     decl: &FieldDecl,
 ) -> Result<f64, ScenarioError> {
-    if !matches!(decl.ty, BslType::Int) {
-        return Err(err(format!(
-            "node `{local}`: field `{field}` is declared {:?}, and slice 1 stores only \
-             `int`-declared fields — the scaled and Currency lanes need typed attribute \
-             storage (a declared Phase-2 trait revision), so this refuses rather than \
-             widening a value into a type it was not declared as",
-            decl.ty
-        )));
+    match &decl.ty {
+        BslType::Int => attribute_value_int(atom, local, field),
+        BslType::Probability | BslType::Intensity | BslType::Coefficient => {
+            attribute_value_unit_interval(atom, local, field, &decl.ty)
+        }
+        BslType::Currency => Err(err(currency_refusal_message(local, field))),
+        other => Err(err(format!(
+            "node `{local}`: field `{field}` is declared {other:?}, and the scenario \
+             loader stores only `int`, `probability`, `intensity` or `coefficient`-declared \
+             node attributes (currency is refused separately, deferred to typed storage's \
+             first consumer) — {other:?} has no representation as a GraphSubstrate f64 \
+             attribute at all"
+        ))),
     }
+}
+
+/// `int`-declared fields — unchanged behavior, Half 1 does not touch this arm.
+fn attribute_value_int(atom: &Atom, local: &str, field: &str) -> Result<f64, ScenarioError> {
     match atom {
         Atom::Int(value) => {
             // Exact in f64 to 2^53; past that the stored value would differ
@@ -678,15 +706,125 @@ fn attribute_value(
             #[allow(clippy::cast_precision_loss)]
             Ok(*value as f64)
         }
-        Atom::Currency(_) => Err(err(format!(
-            "node `{local}` field `{field}`: Currency attributes need typed attribute \
-             storage (a declared Phase-2 trait revision) — f64 cannot hold i128 \
-             micro-units, and slice 1 refuses rather than casting lossily"
-        ))),
+        Atom::Currency(_) => Err(err(currency_refusal_message(local, field))),
         other => Err(err(format!(
             "node `{local}` field `{field}`: expected an integer literal, found {other:?}"
         ))),
     }
+}
+
+/// `probability`/`intensity`/`coefficient`-declared fields (Half 1).
+///
+/// Mirrors `structural_verbs.rs::store_range_check`'s runtime predicate
+/// VERBATIM, one call frame earlier — not a new invented rule, the same
+/// `[0,1]` rule the runtime write boundary already lives by:
+/// `matches!(decl.ty, Probability | Intensity | Coefficient)` then
+/// `(0.0..=1.0).contains(&value)`. That runtime check is itself kind-blind
+/// among the three unit-interval types — `Value::Real` carries no `p`/`i`/`c`
+/// tag once evaluated, so a rule computing a value for a `coefficient` field
+/// is checked by the exact same predicate as one for a `probability` field —
+/// so this load-time mirror is equally kind-blind: an `Int` literal or any
+/// `p`/`i`/`c`-suffixed literal is accepted for ANY of the three declared
+/// types, provided its magnitude is in range. `Ratio` (`r`-suffixed) is
+/// EXCLUDED even though its value may numerically fall in `[0,1]` for a
+/// given literal — `Ratio` is a genuinely distinct runtime `Value` variant
+/// with its own `(0, ∞)` domain and its own restricted operator
+/// (`Currency × Ratio` only, §3.2 addendum); a field read can never legally
+/// produce one (`bind_subject` wraps every `:field` read `Value::Real`,
+/// never `Value::Ratio`), so admitting one here would store a value under a
+/// type the read path cannot represent.
+///
+/// # The conversion contract, and why it is NOT `babylon_kernel::grid::quantize`
+///
+/// A scaled (`p`/`i`/`c`) literal converts as `unscaled / 10^scale` — one
+/// IEEE-754 division of two exactly-representable operands (`unscaled` as an
+/// integer, `10^scale` exact in `f64` for `scale <= 9`, the literal's own
+/// bound) — the SAME arithmetic `tick.rs::atom_to_value` and
+/// `scenario.rs::load_defconst` already perform for a `:default`/`:const`
+/// literal of the same value. This is deliberate, not an oversight: `grid.rs`'s
+/// `(value * 1e6 + 0.5).floor() / 1e6` half-up quantization is a
+/// `babylon_kernel` **scalar newtype** invariant
+/// (`Probability::new`/`Intensity::new`/`Coefficient::new` call it on
+/// construction) that nothing in `babylon-bsl` reaches today — the
+/// evaluator's binary64 lane is raw `f64` (`Value::Real`) end to end, and a
+/// value entering storage via `(update-node self field (+ x y))` during a
+/// tick is not grid-quantized either. Snapping only the seed path to the
+/// grid would create exactly the asymmetry it would be trying to prevent: a
+/// rule-computed write and a scenario-seeded value of the identical field
+/// would then follow two different rounding rules for the same declared
+/// type. A single correctly-rounded IEEE-754 division is a "basic IEEE-754
+/// op" — it reproduces bit-identically across conforming implementations,
+/// the same guarantee class CLAUDE.md's Tests-as-Behavioral-Contracts
+/// principle 4 names as safe ("basic IEEE-754 ops reproduce across
+/// languages") — so no new rule is minted; the existing rule is extended
+/// verbatim to the node-attribute seed path.
+fn attribute_value_unit_interval(
+    atom: &Atom,
+    local: &str,
+    field: &str,
+    ty: &BslType,
+) -> Result<f64, ScenarioError> {
+    let value = match atom {
+        Atom::Int(value) => {
+            // Bare Int literals carry NO domain check at lex time
+            // (`E-LEX-024` bounds only `p`/`i`/`c`-suffixed literals) — the
+            // `[0,1]` check below is this arm's ONLY domain enforcement, and
+            // it is load-bearing: an out-of-range bare Int (e.g. `6`) must
+            // still be refused here.
+            #[allow(clippy::cast_precision_loss)]
+            let widened = *value as f64;
+            widened
+        }
+        Atom::Scaled(scaled) if scaled.kind == ScaledKind::Ratio => {
+            return Err(err(format!(
+                "node `{local}` field `{field}`: a Ratio (r-suffixed) literal is not a \
+                 legal {ty:?} attribute value — Ratio is its own runtime type with domain \
+                 (0, ∞), and a :field read can never legally produce one"
+            )));
+        }
+        Atom::Scaled(scaled) => {
+            // See this function's doc comment for the conversion contract
+            // and why it is not `grid::quantize`.
+            #[allow(clippy::cast_precision_loss)]
+            let numerator = scaled.unscaled as f64;
+            numerator / 10_f64.powi(i32::from(scaled.scale))
+        }
+        Atom::Currency(_) => return Err(err(currency_refusal_message(local, field))),
+        other => {
+            return Err(err(format!(
+                "node `{local}` field `{field}`: expected an int or scaled (p/i/c) \
+                 literal, found {other:?}"
+            )))
+        }
+    };
+    if !(0.0..=1.0).contains(&value) {
+        return Err(err(format!(
+            "node `{local}` field `{field}`: storing {value} leaves its declared \
+             {ty:?} [0,1] domain — a loud failure, never a clamp (mirrors \
+             structural_verbs.rs::store_range_check's runtime rule, checked one \
+             call frame earlier)"
+        )));
+    }
+    Ok(value)
+}
+
+/// Currency's refusal, worded identically at every site it fires — the
+/// Half-2 typed-storage gap this train (Half 1) explicitly does not close.
+///
+/// Wording note (typed-attribute-seeding train, 2026-08-11): earlier
+/// revisions of this message cited "a declared Phase-2 trait revision"
+/// pending on the Phase-1 exit checklist's own DEFERRED row. The Director's
+/// 2026-08-11 popup ruling supersedes that framing: Half 2 (Currency i128
+/// typed storage) is DEFERRED TO ITS FIRST CONSUMER — whichever port first
+/// needs a real Currency field — not to a fixed phase boundary, so the
+/// message cites the ruling directly rather than a phase number.
+fn currency_refusal_message(local: &str, field: &str) -> String {
+    format!(
+        "node `{local}` field `{field}`: Currency attributes need typed attribute \
+         storage — the Director ruled (2026-08-11) that this lands with Currency's \
+         first real consumer, not this train — f64 cannot hold i128 micro-units, and \
+         this refuses rather than casting lossily"
+    )
 }
 
 /// `(edge <enum-ref> <local-name> <local-name> <int>)`
@@ -749,7 +887,7 @@ fn load_edge(
 mod tests {
     use super::load_scenario;
     use babylon_graph::memory::MemoryGraph;
-    use babylon_graph::state_hash::CanonicalState;
+    use babylon_graph::state_hash::{CanonicalState, StateEncoder};
     use babylon_graph::substrate::{Direction, GraphSubstrate, NodeId};
 
     const TWO_CLASSES: &str = r"
@@ -882,6 +1020,15 @@ mod tests {
     fn an_int_into_a_non_int_declared_field_is_refused() {
         // 120 in a field declared `intensity` is outside that type's [0,1]
         // domain — storing it would make the store lie about what it holds.
+        //
+        // Half 1 (typed-attribute seeding) note: this is now the SAME code
+        // path `attribute_value_unit_interval`'s bare-Int arm takes — 120 is
+        // syntactically admissible for an `intensity`-declared field (bare
+        // Int literals carry no lex-time domain check), and refused because
+        // it leaves [0,1], not because its literal kind is illegal. This
+        // test's assertion (`"declared"`) is unmodified from before Half 1
+        // and continues to pass unchanged, which is itself part of the
+        // additivity proof: existing behavior at this exact boundary held.
         let source = r"
 (scenario ft/mistyped
   (deffield social-class/agitation intensity intensive)
@@ -890,6 +1037,231 @@ mod tests {
         let mut graph = MemoryGraph::new();
         let err = load_scenario(source, &mut graph).unwrap_err();
         assert!(err.message.contains("declared"), "{}", err.message);
+    }
+
+    // ---- Half 1 (typed-attribute seeding, P27 Phase 2) ----
+    // `reports/typed-attribute-seeding-design-2026-08-11.md` §A/§E.
+
+    #[test]
+    fn a_scaled_literal_seeds_correctly_into_each_unit_interval_type() {
+        for (ty, literal, expected) in [
+            ("probability", "0.75p", 0.75),
+            ("intensity", "0.5i", 0.5),
+            ("coefficient", "0.358c", 0.358),
+        ] {
+            let source = format!(
+                "(scenario ft/unit-interval\n  \
+                 (deffield social-class/x {ty} intensive)\n  \
+                 (node core NodeType/SOCIAL_CLASS (social-class/x {literal})))"
+            );
+            let mut graph = MemoryGraph::new();
+            load_scenario(&source, &mut graph).unwrap();
+            let value = graph.node_attribute(NodeId(0), "social-class/x").unwrap();
+            assert!((value - expected).abs() < 1e-12, "{ty}: got {value}");
+        }
+    }
+
+    #[test]
+    fn unit_interval_literal_acceptance_is_kind_blind_among_p_i_c() {
+        // `store_range_check`'s own runtime predicate does not distinguish
+        // Probability/Intensity/Coefficient from one another — `Value::Real`
+        // carries no p/i/c tag once a literal is evaluated. This load-time
+        // mirror does not either: a `p`-suffixed literal is legal for a
+        // `coefficient`-declared field.
+        let source = r"
+(scenario ft/kind-blind
+  (deffield social-class/agitation coefficient intensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/agitation 0.5p)))
+";
+        let mut graph = MemoryGraph::new();
+        load_scenario(source, &mut graph).unwrap();
+        let value = graph
+            .node_attribute(NodeId(0), "social-class/agitation")
+            .unwrap();
+        assert!((value - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn a_bare_int_within_0_1_seeds_a_unit_interval_field() {
+        // Bare Int literals carry no lex-time domain check, so an IN-range
+        // one (unlike `an_int_into_a_non_int_declared_field_is_refused`'s
+        // 120) must be accepted, exactly as `store_range_check` would accept
+        // a rule-computed `Value::Int` widened to the same f64 at runtime.
+        let source = r"
+(scenario ft/bare-int-in-range
+  (deffield social-class/agitation intensity intensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/agitation 1)))
+";
+        let mut graph = MemoryGraph::new();
+        load_scenario(source, &mut graph).unwrap();
+        let value = graph
+            .node_attribute(NodeId(0), "social-class/agitation")
+            .unwrap();
+        assert!((value - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn a_negative_bare_int_into_a_unit_interval_field_is_refused() {
+        // The mirrored predicate's message, pinned precisely: mentions the
+        // [0,1] domain and states the never-a-clamp discipline, matching
+        // `store_range_check`'s own wording family (`E-EVAL-020`).
+        let source = r"
+(scenario ft/negative-bare-int
+  (deffield social-class/agitation probability intensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/agitation -3)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(err.message.contains("[0,1]"), "{}", err.message);
+        assert!(err.message.contains("never a clamp"), "{}", err.message);
+    }
+
+    #[test]
+    fn a_ratio_literal_is_refused_for_a_unit_interval_field_even_in_range() {
+        // 0.5r numerically falls in [0,1], but Ratio is a distinct runtime
+        // `Value` variant with its own (0, ∞) domain, and a `:field` read
+        // can never legally produce one (`bind_subject` wraps every field
+        // read `Value::Real`) — a kind refusal, not a range violation.
+        let source = r"
+(scenario ft/ratio-into-coefficient
+  (deffield social-class/agitation coefficient intensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/agitation 0.5r)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(err.message.contains("Ratio"), "{}", err.message);
+    }
+
+    #[test]
+    fn an_int_exceeding_f64_exact_range_is_refused() {
+        // The 2^53 guard, unchanged by Half 1 — still lives in
+        // `attribute_value_int`, still fires for an `int`-declared field.
+        let source = format!(
+            "(scenario ft/too-big\n  (deffield social-class/population int extensive)\n  \
+             (node core NodeType/SOCIAL_CLASS (social-class/population {})))",
+            (1_i64 << 53) + 1
+        );
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(&source, &mut graph).unwrap_err();
+        assert!(
+            err.message.contains("exceeds f64's exact integer range"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn an_int_at_exactly_2_pow_53_still_loads() {
+        // The boundary is inclusive — exact in f64 up to and including 2^53.
+        let source = format!(
+            "(scenario ft/at-boundary\n  (deffield social-class/population int extensive)\n  \
+             (node core NodeType/SOCIAL_CLASS (social-class/population {})))",
+            1_i64 << 53
+        );
+        let mut graph = MemoryGraph::new();
+        load_scenario(&source, &mut graph).unwrap();
+    }
+
+    #[test]
+    fn the_currency_refusal_cites_the_directors_defer_to_first_consumer_ruling() {
+        // Wording update (typed-attribute-seeding train, 2026-08-11): the
+        // refusal used to cite "a declared Phase-2 trait revision"; the
+        // Director's popup ruling supersedes that framing.
+        let source = r"
+(scenario ft/money-ruling
+  (deffield social-class/wages currency extensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/wages 120$)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(
+            err.message.contains("typed attribute storage"),
+            "{}",
+            err.message
+        );
+        assert!(
+            err.message.contains("first real consumer"),
+            "{}",
+            err.message
+        );
+        assert!(err.message.contains("2026-08-11"), "{}", err.message);
+    }
+
+    #[test]
+    fn a_currency_literal_into_an_int_declared_field_is_refused() {
+        // The OTHER Currency-refusal site: the field is legally declared
+        // `int`, but the literal itself is `$`-suffixed.
+        let source = r"
+(scenario ft/currency-into-int
+  (deffield social-class/wages int extensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/wages 120$)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(
+            err.message.contains("typed attribute storage"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn a_currency_literal_into_a_unit_interval_field_is_refused() {
+        let source = r"
+(scenario ft/currency-into-coefficient
+  (deffield social-class/agitation coefficient intensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/agitation 120$)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(
+            err.message.contains("typed attribute storage"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn a_coefficient_attribute_hashes_identically_to_the_same_f64_as_an_int() {
+        // The "provably additive" claim, made concrete at the byte level:
+        // seeding a `coefficient`-declared field with `0.358c` must produce
+        // the EXACT same section-0x02 row shape `StateEncoder` would produce
+        // for an `int`-declared field holding the same f64 — proving
+        // `attribute_value`'s widening introduced no format branch keyed on
+        // `BslType`. `CanonicalState`'s section 0x02 is a bare
+        // `u64 id ‖ str name ‖ u64 value-bits` regardless of which BSL type
+        // declared the field (`state_hash.rs` module docs).
+        let source = r"
+(scenario ft/mixed-types
+  (deffield social-class/population int extensive)
+  (deffield social-class/agitation coefficient intensive)
+  (node core NodeType/SOCIAL_CLASS
+    (social-class/population 120)
+    (social-class/agitation 0.358c)))
+";
+        let mut graph = MemoryGraph::new();
+        load_scenario(source, &mut graph).unwrap();
+        let hash = graph.state_hash().unwrap();
+
+        // Hand-built via StateEncoder directly, bypassing attribute_value
+        // (and the whole scenario loader) entirely — a second, independent
+        // encoding of the identical facts, attributes sorted by name
+        // ascending ("social-class/agitation" < "social-class/population").
+        let mut enc = StateEncoder::new();
+        enc.write_nodes(&[(NodeId(0), "SOCIAL_CLASS".to_owned())])
+            .unwrap();
+        enc.write_attributes(&[
+            (
+                NodeId(0),
+                "social-class/agitation".to_owned(),
+                358.0 / 1000.0,
+            ),
+            (NodeId(0), "social-class/population".to_owned(), 120.0),
+        ])
+        .unwrap();
+        enc.write_edges(&[]).unwrap();
+        enc.write_hyperedges(&[]).unwrap();
+        assert_eq!(hash, enc.finish());
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -327,12 +327,15 @@ fn load_defconst(
         // micro-units. Accepting one HERE would make the same literal legal
         // through one door and rejected through the others — the entry point
         // deciding the type system, which is the drift the sibling refusals
-        // exist to prevent. Currency coefficients arrive with typed attribute
-        // storage (a declared Phase-2 trait revision), not before.
+        // exist to prevent. Currency coefficients arrive with typed
+        // attribute storage once it lands — DEFERRED TO ITS FIRST CONSUMER
+        // (Director ruling, 2026-08-11 popup), not to a fixed phase
+        // boundary — not before.
         Atom::Currency(_) => {
             return Err(err(format!(
                 "defconst `{qname}`: a Currency coefficient needs typed \
-                 attribute storage (a declared Phase-2 trait revision) — the \
+                 attribute storage — the Director ruled (2026-08-11) that \
+                 this lands with Currency's first real consumer — the \
                  `:default` and node-attribute paths refuse one for the same \
                  reason, and admitting it here alone would make the literal's \
                  legality depend on which form it was written in"
@@ -681,6 +684,16 @@ fn attribute_value(
             attribute_value_unit_interval(atom, local, field, &decl.ty)
         }
         BslType::Currency => Err(err(currency_refusal_message(local, field))),
+        // Defense in depth, not a reachable content error: `load_deffield`
+        // is the SOLE populator of the `declared` map `attribute_value` is
+        // called against, and its own match on the type symbol admits only
+        // int/probability/intensity/coefficient/currency (anything else is
+        // refused AT DECLARATION, before a `node` form naming the field can
+        // even be read). Reaching here is a wiring bug in the deffield
+        // parser, not a content error — kept anyway because `BslType` is
+        // not a closed match the compiler can prove exhaustive against this
+        // function's actual call graph, and a silent `unreachable!()` would
+        // panic rather than name the field that triggered it.
         other => Err(err(format!(
             "node `{local}`: field `{field}` is declared {other:?}, and the scenario \
              loader stores only `int`, `probability`, `intensity` or `coefficient`-declared \
@@ -776,10 +789,13 @@ fn attribute_value_unit_interval(
             widened
         }
         Atom::Scaled(scaled) if scaled.kind == ScaledKind::Ratio => {
+            #[allow(clippy::cast_precision_loss)]
+            let numerator = scaled.unscaled as f64;
+            let value = numerator / 10_f64.powi(i32::from(scaled.scale));
             return Err(err(format!(
-                "node `{local}` field `{field}`: a Ratio (r-suffixed) literal is not a \
-                 legal {ty:?} attribute value — Ratio is its own runtime type with domain \
-                 (0, ∞), and a :field read can never legally produce one"
+                "node `{local}` field `{field}`: {value}r is a Ratio (r-suffixed) literal, \
+                 not a legal {ty:?} attribute value — Ratio is its own runtime type with \
+                 domain (0, ∞), and a :field read can never legally produce one"
             )));
         }
         Atom::Scaled(scaled) => {
@@ -885,10 +901,18 @@ fn load_edge(
 
 #[cfg(test)]
 mod tests {
-    use super::load_scenario;
+    use super::{load_scenario, BslType, FieldDecl, FieldKind};
+    use crate::bindings::BindingVocabulary;
+    use crate::fuel::{CardinalityCeilings, IntrinsicCosts};
+    use crate::intrinsic_host::EmptyIntrinsicHost;
+    use crate::rule_pipeline::{load_rule, LoadContext};
+    use crate::structural_verbs::CollectingSink;
+    use crate::tick::{run_tick, DefinesEnv};
+    use crate::typecheck::TypeEnv;
     use babylon_graph::memory::MemoryGraph;
     use babylon_graph::state_hash::{CanonicalState, StateEncoder};
     use babylon_graph::substrate::{Direction, GraphSubstrate, NodeId};
+    use std::collections::{HashMap, HashSet};
 
     const TWO_CLASSES: &str = r"
 (scenario ft/two-classes
@@ -1017,18 +1041,21 @@ mod tests {
     }
 
     #[test]
-    fn an_int_into_a_non_int_declared_field_is_refused() {
+    fn a_bare_int_above_1_into_a_unit_interval_field_is_refused() {
         // 120 in a field declared `intensity` is outside that type's [0,1]
         // domain — storing it would make the store lie about what it holds.
         //
-        // Half 1 (typed-attribute seeding) note: this is now the SAME code
-        // path `attribute_value_unit_interval`'s bare-Int arm takes — 120 is
-        // syntactically admissible for an `intensity`-declared field (bare
-        // Int literals carry no lex-time domain check), and refused because
-        // it leaves [0,1], not because its literal kind is illegal. This
-        // test's assertion (`"declared"`) is unmodified from before Half 1
-        // and continues to pass unchanged, which is itself part of the
-        // additivity proof: existing behavior at this exact boundary held.
+        // Renamed from `an_int_into_a_non_int_declared_field_is_refused`
+        // (F3, typed-attribute-seeding fix round): before Half 1, EVERY
+        // non-int-declared field refused EVERY value outright, so that name
+        // described the whole refusal. Half 1 legalized the field's type; a
+        // bare Int is now syntactically admissible for `intensity`
+        // (`attribute_value_unit_interval`'s bare-Int arm — no lex-time
+        // domain check on an unsuffixed literal) and refused ONLY because
+        // 120 leaves [0,1] — the name now says what's actually tested. The
+        // assertion (`"declared"`) is unmodified from before Half 1 and
+        // continues to pass unchanged: existing behavior at this exact
+        // boundary held, part of the additivity proof.
         let source = r"
 (scenario ft/mistyped
   (deffield social-class/agitation intensity intensive)
@@ -1044,10 +1071,31 @@ mod tests {
 
     #[test]
     fn a_scaled_literal_seeds_correctly_into_each_unit_interval_type() {
-        for (ty, literal, expected) in [
-            ("probability", "0.75p", 0.75),
-            ("intensity", "0.5i", 0.5),
-            ("coefficient", "0.358c", 0.358),
+        // Exact-bit pins, NOT a tolerance. A `< 1e-12` comparison here would
+        // hide exactly the transcription error it would appear to absorb —
+        // the repo's own rule (`vitality_conformance.rs`). The conversion
+        // CONTRACT `attribute_value_unit_interval`'s doc comment documents is
+        // bit-for-bit IEEE-754, not approximately-equal.
+        //
+        // Expected bits computed INDEPENDENTLY of this crate — Python's
+        // `struct.pack('>d', v)`, a different language's own correctly-
+        // rounded decimal-to-binary conversion — not by re-running this
+        // crate's own division and calling the result the oracle.
+        //
+        // `0.7c` and `0.123456789c` are DISCRIMINATING: `numerator *
+        // 10_f64.powi(-scale)` (a real, non-equivalent reciprocal-multiply
+        // substitution for the `/` this function actually uses) diverges
+        // from `numerator / 10_f64.powi(scale)` at exactly these values
+        // (`0.7c` seeds as `0x3fe6666666666667` under the mutation, against
+        // `0x3fe6666666666666` here) while AGREEING at 0.75/0.5/0.358 — a
+        // test using only the latter three is blind to that whole mutation
+        // class, which is exactly what the F1 fix round found.
+        for (ty, literal, expected_bits) in [
+            ("probability", "0.75p", 0x3fe8_0000_0000_0000_u64),
+            ("intensity", "0.5i", 0x3fe0_0000_0000_0000_u64),
+            ("coefficient", "0.358c", 0x3fd6_e978_d4fd_f3b6_u64),
+            ("coefficient", "0.7c", 0x3fe6_6666_6666_6666_u64),
+            ("coefficient", "0.123456789c", 0x3fbf_9add_3739_635f_u64),
         ] {
             let source = format!(
                 "(scenario ft/unit-interval\n  \
@@ -1057,7 +1105,117 @@ mod tests {
             let mut graph = MemoryGraph::new();
             load_scenario(&source, &mut graph).unwrap();
             let value = graph.node_attribute(NodeId(0), "social-class/x").unwrap();
-            assert!((value - expected).abs() < 1e-12, "{ty}: got {value}");
+            assert_eq!(
+                value.to_bits(),
+                expected_bits,
+                "{ty} {literal}: got 0x{:016x}, want 0x{expected_bits:016x}",
+                value.to_bits()
+            );
+        }
+    }
+
+    #[test]
+    fn a_seeded_literal_bit_matches_the_same_literal_written_by_a_rule() {
+        // F1 (typed-attribute-seeding fix round): the conversion contract
+        // pinned as the RELATION between the two paths, which is what
+        // `attribute_value_unit_interval`'s doc comment actually promises —
+        // not two independently-eyeballed numbers that happen to agree.
+        // Seeds a field via the scenario loader (`attribute_value`) with a
+        // literal, and separately has a rule write the IDENTICAL literal
+        // text to a parallel field via `(update-node self … (set …))` —
+        // the runtime path (`tick.rs::atom_to_value` /
+        // `structural_verbs.rs::numeric_write_value`) — then compares
+        // `to_bits()` off the live graph. Mutation-caught: the same
+        // reciprocal-multiply substitution the previous test's doc comment
+        // describes leaves this test's OTHER two literals agreeing but
+        // diverges `0.7c` between the two paths.
+        for literal in ["0.7c", "0.5c", "0.123456789c"] {
+            let source = format!(
+                "(scenario ft/bit-equality\n  \
+                 (deffield social-class/seeded coefficient extensive)\n  \
+                 (deffield social-class/written coefficient extensive)\n  \
+                 (node core NodeType/SOCIAL_CLASS (social-class/seeded {literal})))"
+            );
+            let mut graph = MemoryGraph::new();
+            load_scenario(&source, &mut graph).unwrap();
+
+            let types = TypeEnv {
+                fields: HashMap::from([
+                    (
+                        "social-class/seeded".to_owned(),
+                        FieldDecl {
+                            ty: BslType::Coefficient,
+                            kind: FieldKind::Extensive,
+                        },
+                    ),
+                    (
+                        "social-class/written".to_owned(),
+                        FieldDecl {
+                            ty: BslType::Coefficient,
+                            kind: FieldKind::Extensive,
+                        },
+                    ),
+                ]),
+                exemptions: &[],
+            };
+            let vocabulary = BindingVocabulary {
+                fields: types.fields.keys().cloned().collect(),
+                consts: HashSet::new(),
+                metrics: HashSet::new(),
+            };
+            let ceilings = CardinalityCeilings::new(
+                HashMap::from([("NodeType/SOCIAL_CLASS".to_owned(), 100)]),
+                HashMap::new(),
+            );
+            let intrinsics = IntrinsicCosts::default();
+            let systems = HashSet::from(["ft".to_owned()]);
+            let ctx = LoadContext {
+                vocabulary: &vocabulary,
+                types: &types,
+                ceilings: &ceilings,
+                intrinsics: &intrinsics,
+                systems: &systems,
+                vocabulary_registry: None,
+                rule_file: "ft/bit-equality.bsl",
+            };
+            let rule = format!(
+                "(rule ft/mirror\n  \
+                 :material-basis \"pins the seed path and the runtime write path to the \
+                 SAME conversion, as one relation rather than two independently-eyeballed \
+                 numbers\"\n  \
+                 :fuel 64\n  \
+                 (bindings (binding seeded :field social-class/seeded))\n  \
+                 (when (>= seeded 0.0c))\n  \
+                 (effects (update-node self social-class/written (set {literal}))))"
+            );
+            let loaded =
+                load_rule(&rule, &ctx).unwrap_or_else(|e| panic!("{literal}: rule must load: {e}"));
+            let mut sink = CollectingSink::default();
+            run_tick(
+                &loaded,
+                &types,
+                &EmptyIntrinsicHost,
+                &mut graph,
+                &mut sink,
+                &intrinsics,
+                &DefinesEnv::new(),
+                1,
+            )
+            .unwrap_or_else(|e| panic!("{literal}: tick must run: {e}"));
+
+            let seeded = graph
+                .node_attribute(NodeId(0), "social-class/seeded")
+                .unwrap();
+            let written = graph
+                .node_attribute(NodeId(0), "social-class/written")
+                .unwrap();
+            assert_eq!(
+                seeded.to_bits(),
+                written.to_bits(),
+                "{literal}: seed path 0x{:016x} != runtime path 0x{:016x}",
+                seeded.to_bits(),
+                written.to_bits()
+            );
         }
     }
 
@@ -1084,7 +1242,7 @@ mod tests {
     #[test]
     fn a_bare_int_within_0_1_seeds_a_unit_interval_field() {
         // Bare Int literals carry no lex-time domain check, so an IN-range
-        // one (unlike `an_int_into_a_non_int_declared_field_is_refused`'s
+        // one (unlike `a_bare_int_above_1_into_a_unit_interval_field_is_refused`'s
         // 120) must be accepted, exactly as `store_range_check` would accept
         // a rule-computed `Value::Int` widened to the same f64 at runtime.
         let source = r"

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -665,8 +665,10 @@ impl<'a> EffectExecutor<'a> {
 
     /// Evaluate a value that will be WRITTEN to `field`, in the binary64
     /// lane the trait's attribute storage carries. A Currency-typed value
-    /// is a loud declared Phase-2 gap (i128 exactness does not survive an
-    /// f64 attribute), never a lossy cast.
+    /// is a loud declared gap (i128 exactness does not survive an f64
+    /// attribute), never a lossy cast — typed Currency storage is DEFERRED
+    /// TO ITS FIRST CONSUMER (Director ruling, 2026-08-11 popup), not to a
+    /// fixed phase boundary.
     fn numeric_write_value(
         expr: &SExpr,
         env: &EvalEnv<'_>,
@@ -693,7 +695,9 @@ impl<'a> EffectExecutor<'a> {
             Value::Int(n) => Ok(n as f64),
             Value::Currency(_) => Err(plain(format!(
                 "writing a Currency value to {field} needs typed attribute \
-                 storage (Phase 2 gap, module doc) — refusing the lossy f64 cast"
+                 storage — the Director ruled (2026-08-11) that this lands \
+                 with Currency's first real consumer — refusing the lossy \
+                 f64 cast"
             ))),
             other => Err(plain(format!(
                 "cannot store {other:?} as a numeric node attribute"
@@ -1004,7 +1008,8 @@ mod tests {
                 &mut fuel,
             )
             .unwrap_err();
-        assert!(err.message.contains("Phase 2 gap"), "{err}");
+        assert!(err.message.contains("typed attribute storage"), "{err}");
+        assert!(err.message.contains("first real consumer"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements **Half 1 only** of `reports/typed-attribute-seeding-design-2026-08-11.md` (P27 Phase 2): widens `rust/crates/babylon-bsl/src/scenario.rs::attribute_value` so a `.bscn` scenario can seed a fractional literal into a `probability`/`intensity`/`coefficient`-declared node attribute, mirroring `structural_verbs.rs::store_range_check`'s runtime `[0,1]` predicate one call frame earlier. No new typed storage — `GraphSubstrate` attributes are already `f64`, so this closes a scenario-loader-only gap.

**Director ruling quoted (2026-08-11 popup):**

> Half 2 Currency i128 typed storage DEFERRED TO FIRST CONSUMER — Half 1 proceeds as settled engineering; both halves remain fully specced in this document; this is train sequencing, not scope reduction.

Half 2 (Currency i128 typed storage, `CanonicalState`'s fifth section, the `bind_subject` type-aware dispatch) is **not touched by this PR** — Currency stays a loud refusal, wording updated to cite the ruling above instead of "a declared Phase-2 trait revision."

## What changed

- `attribute_value` now dispatches on the field's declared `BslType` into three arms:
  - `attribute_value_int` — unchanged, byte-for-byte, from before this PR.
  - `attribute_value_unit_interval` (new) — accepts a bare `Int` or any `p`/`i`/`c`-suffixed literal that widens to `[0,1]`, for ANY of Probability/Intensity/Coefficient (kind-blind among the three, matching `store_range_check`'s own kind-blindness — `Value::Real` carries no p/i/c tag once evaluated). `Ratio` (`r`-suffixed) is explicitly refused even when its value numerically falls in `[0,1]`: it's a distinct runtime `Value` variant with its own `(0, ∞)` domain that a `:field` read can never legally produce, and the refusal names the offending value.
  - `Currency` — still refused, loud, message updated.
- The scaled-literal conversion is `unscaled / 10^scale` — deliberately **not** `babylon_kernel::grid::quantize`. The design's determinism argument (why grid-snapping only the seed path would create the asymmetry it's trying to prevent, and why a single correctly-rounded IEEE-754 division is a "basic IEEE-754 op" safe under CLAUDE.md's Tests-as-Behavioral-Contracts principle 4) is transcribed verbatim into `attribute_value_unit_interval`'s doc comment.
- Currency's refusal message updated at every site it fires — `attribute_value`'s two Currency arms, `load_defconst`'s Currency arm, and `structural_verbs.rs::numeric_write_value`'s Currency arm — to cite the Director's ruling instead of "a declared Phase-2 trait revision" / "Phase 2 gap, module doc".
- Module-level doc comment updated to describe the widened surface.

## Fix round (adversarial verification, same day)

An adversarial verifier confirmed the implementation correct (bit-equality between the seed and runtime write paths proven by execution, kind-blindness mirror verified true at the store boundary, all original mutations flip their named tests, additivity green, all judgment calls sound) but **blocked on one finding**: the conversion contract was right but unpinned.

**F1 (blocker) — the conversion contract, pinned to exact bits.** Mutation evidence: substituting `numerator * 10_f64.powi(-scale)` for the `/` division `attribute_value_unit_interval` actually uses is a real, non-equivalent change that left the ENTIRE estate green while diverging the seed path from the runtime path — `0.7c` seeds as `0x3fe6666666666667` under the mutation against the correct `0x3fe6666666666666`, flowing straight into `CanonicalState` section `0x02` and the tick hash. Three reasons the original estate was blind to this: (a) `< 1e-12` tolerance assertions — the repo's own rule (`vitality_conformance.rs`) is "a tolerance here would hide exactly the transcription error it would appear to absorb"; (b) the hash-identity test's oracle was hand-computed `358.0/1000.0` — the same arithmetic production runs, tautological for the conversion; (c) every literal originally used (0.358, 0.5, 0.75) is one where divide and multiply-by-reciprocal agree bit-for-bit anyway. Fixed in two layers:
1. `a_scaled_literal_seeds_correctly_into_each_unit_interval_type`'s three tolerance assertions replaced with `to_bits()` exact-bit pins, expected values computed independently via Python's `struct.pack('>d', v)` (a different language's own correctly-rounded decimal-to-binary conversion, not this crate's own division computing its own oracle). Adds two DISCRIMINATING literals the mutation actually moves: `0.7c` → `0x3fe6666666666666` and `0.123456789c` → `0x3fbf9add3739635f` (both independently verified).
2. New test `a_seeded_literal_bit_matches_the_same_literal_written_by_a_rule` — the sharpest form: seeds a field via the scenario loader, has a rule write the IDENTICAL literal text to a parallel field via `(update-node self … (set …))` (the runtime path), and asserts `to_bits()` equality off the live graph — pinning the contract as the RELATION between the two paths, which is what the doc comment actually promises. Covers `0.7c`, `0.5c`, `0.123456789c`.

Mutation-verified: re-applied the reciprocal-multiply substitution; both new tests flipped red with the EXACT predicted bits (`assertion left == right failed: 0.7c: got/seed path 0x3fe6666666666667, want/runtime path 0x3fe6666666666666`); reverted, diffed byte-identical to pre-mutation.

**Advisory findings, all addressed:**
- **F2** — harmonized the Currency-deferral framing. `load_defconst`'s Currency refusal and `numeric_write_value`'s Currency refusal both still said "a declared Phase-2 trait revision" / "Phase 2 gap, module doc" (stale framing a user actually sees), contradicting the ruling the module doc and `attribute_value`'s own refusal already cited. Both updated; `currency_writes_are_a_loud_declared_gap_never_a_lossy_cast` updated to match. The OTHER "Phase 2 gap" site (hyperedge field inits, a different and unrelated gap) is untouched.
- **F3** — renamed `an_int_into_a_non_int_declared_field_is_refused` → `a_bare_int_above_1_into_a_unit_interval_field_is_refused`: Half 1 legalized the field's type, so the old name described a refusal the code no longer has.
- **F4** — documented `attribute_value`'s unreachable `other` arm as a wiring-bug guard (`load_deffield` is the sole populator of the type registry and admits only 5 `BslType` variants), matching the repo's existing "reaching here is a wiring bug … not a content error" convention (`ratio_from_scaled`).
- **F5** — the Ratio-kind refusal now names the offending value (`{value}r`), matching the range-refusal's own standard.

## Per-behavior test inventory + mutation evidence

12 new tests across `scenario.rs` and `structural_verbs.rs`, all TDD'd against the pre-widening code and mutation-verified after:

| Behavior | Test | Mutation kill |
|---|---|---|
| p/i/c literal seeds each unit-interval type, exact bits | `a_scaled_literal_seeds_correctly_into_each_unit_interval_type` | independently-computed exact-bit pins (F1) |
| Seed path and runtime write path bit-match on the SAME literal | `a_seeded_literal_bit_matches_the_same_literal_written_by_a_rule` | reciprocal-multiply mutation → flips red on `0.7c`, exact predicted bits (F1) |
| Kind-blind among P/I/C | `unit_interval_literal_acceptance_is_kind_blind_among_p_i_c` | — |
| In-range bare `Int` accepted | `a_bare_int_within_0_1_seeds_a_unit_interval_field` | — |
| Out-of-range bare `Int` refused, loud | `a_negative_bare_int_into_a_unit_interval_field_is_refused` | lower bound widened to `-10.0` → flips red |
| Pre-existing out-of-range case (120 into `intensity`) still refused | `a_bare_int_above_1_into_a_unit_interval_field_is_refused` (renamed, F3; assertion unmodified) | upper bound widened to `200.0` → flips red |
| `Ratio` refused even when in-range | `a_ratio_literal_is_refused_for_a_unit_interval_field_even_in_range` | guard disabled → flips red (re-verified after F5's edit to the same arm) |
| 2^53 exactness guard unchanged | `an_int_exceeding_f64_exact_range_is_refused` / `an_int_at_exactly_2_pow_53_still_loads` | bound widened to `1<<62` → flips red |
| Currency refusal cites the ruling | `the_currency_refusal_cites_the_directors_defer_to_first_consumer_ruling` | — |
| Currency literal into `int` field refused | `a_currency_literal_into_an_int_declared_field_is_refused` | — |
| Currency literal into unit-interval field refused | `a_currency_literal_into_a_unit_interval_field_is_refused` | — |
| Currency-declared field still refuses (pre-existing) | `a_currency_attribute_is_refused_not_cast` (unmodified) | — |
| Byte-shape proof: `coefficient` hashes identically to the same `f64` as `int` | `a_coefficient_attribute_hashes_identically_to_the_same_f64_as_an_int` | — |
| Runtime Currency-write refusal cites the ruling | `currency_writes_are_a_loud_declared_gap_never_a_lossy_cast` (updated assertion, F2) | — |

Each mutation was applied, confirmed the named test(s) flipped red, then reverted (file diffed byte-identical to pre-mutation after every revert).

## Additivity proof

- `CanonicalState`'s section `0x02` (`state_hash.rs`) is a bare `u64 id ‖ str name ‖ u64 value-bits` over an `f64`, regardless of which `BslType` declared the field — verified by the byte-shape test above, which hand-constructs the expected bytes via `StateEncoder` directly, bypassing `attribute_value` entirely.
- Every `.bscn` fixture currently in the tree declares only `int`-typed fields (swept with `rg` across every `deffield` in every `.bscn`) — so `attribute_value_int`'s untouched arm means every existing scenario's byte encoding is provably unaffected.
- `cargo test -p babylon-tick --test tick_goldens`: all 3 pinned pre/post-tick hash pairs (two-classes+fundamental-theorem, vitality-conformance+vitality, us-counties-lifecycle-demo) byte-identical, unmoved.
- `cargo test -p babylon-tick` (full, 29 binaries incl. every dispossession/lifecycle/metabolism/vitality conformance suite): green, unmodified.
- `cargo test -p babylon-bsl` (326+19+9+121 = 475 tests across lib + 3 integration suites): green.
- `cargo test -p babylon-graph -p babylon-kernel`: green (untouched crates, confirmed no incidental drift).
- `mise run qa:regression`: **11/11 byte-identical** + two-process determinism leg PASS (Python reference engine — untouched by this PR, confirms no cross-engine leakage).
- `mise run qa:vault-regression-ci`: golden-vault byte-gate PASS.
- `cargo fmt --all --check`: clean. `cargo clippy --workspace --all-targets -- -D warnings`: clean (full workspace, including the Bevy client). `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`: clean. `mise run check:quick`: clean (Python side untouched, doc touch only).

All legs re-run and re-confirmed green after the fix round. No drift anywhere — nothing to STOP on.

## What this unblocks

- Territory's port (its `heat: Intensity` field and other Probability/Intensity/Coefficient fields are now seedable — the gap-analysis's other named Territory blockers, e.g. eviction routing's missing expressible form, are unrelated and untouched).
- D-1 `:const` retirements for Dispossession (five in-domain conformance scenarios only — `ceiling-matrix` and `negative-input` stay `:const` **permanently**, per the design's own correction: they deliberately exploit bare-`Int`'s lack of a lex-time domain check to probe D-4's in-body clamps, which a properly-typed field would now refuse at load) and Lifecycle (eleven D-1/D-2 fields) — each its own follow-on PR per the design's §E step 4, **not done here**.
- Metabolism's D-2 (`extraction-intensity`, the genuinely unit-interval field) — also a follow-on PR. Metabolism's `entropy_factor` (D-1) is explicitly **not** unblocked by this PR — that gap is the `Real × Ratio` operator, issue #502 workstream 3, untouched by typed-attribute seeding entirely.

## Where the design document needed a judgment call (reported, not improvised around)

- **Kind-blindness among Probability/Intensity/Coefficient.** The design's own text ("an in-range-suffix-but-wrong-magnitude case") reads ambiguously on whether a `p`-suffixed literal should be legal for a `coefficient`-declared field. Resolved by first-principles: `store_range_check` (the runtime rule this is mirroring) is itself completely kind-blind among the three — `Value::Real` carries no p/i/c tag once a literal is evaluated, so there is no way for the runtime write boundary to enforce a kind match even if it wanted to. Implemented as kind-blind, pinned by a dedicated test, and documented in the doc comment. The adversarial verifier independently confirmed this resolution sound.
- **`Ratio` literals.** Not addressed anywhere in the design (Ratio only appears in the `defconst :floor`/`:cap` context, a different feature). Explicitly refused rather than silently folded into the `[0,1]` check, since `Ratio` is a genuinely distinct `Value` variant a `:field` read can never produce — flagged as a considered addition beyond the design's literal text, not a silent invention.
- **`E-LOAD-053`.** The design's §D speculates this is "next-free" for a new load-time domain-violation code, by analogy to the `defconst` Ratio-bound pair (`E-LOAD-052`/`E-EVAL-041`). Per the literal instruction to check design §E (Sequencing) specifically — which does not call for a new coded error or an RST edit — and per `attribute_value`'s existing convention (every sibling refusal in this function is an uncoded `ScenarioError`), I left the new domain refusal **uncoded**, matching precedent. No automated "register sync-guard" test exists in the tree today for `bsl-language.rst`'s error-taxonomy contiguity claim (verified by search) — it's asserted as "checkable by inspection," not mechanically enforced — so nothing was at risk of going red either way. `E-LOAD-053` remains available if a future reviewer wants this promoted to a normative code.
- **`docs/reference/bsl-language.rst`.** Not edited. §7/D93 already rules that the `.bscn`-dialect constructs (`node`/`edge`/`defconst`/`scenario`) sit outside the consolidated grammar's normative scope, and design §E names no RST edit for this widening.
- **The conversion contract's exactness (F1, adversarial fix round).** Originally proven only by tolerance-bounded assertions and a tautological hand-computed oracle — the adversarial verifier's mutation evidence showed this was a genuine gap, not a false positive; fixed as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
