### PR TITLE
refactor(client): Bevy-native logging — LogPlugin owns the subscriber

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -184,12 +184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
 name = "approx"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,15 +199,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "arc-swap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -388,7 +373,6 @@ dependencies = [
  "bevy",
  "earcutr",
  "log",
- "log4rs",
 ]
 
 [[package]]
@@ -1983,17 +1967,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,30 +3055,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3412,32 +3361,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
-name = "log-mdc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
-
-[[package]]
-name = "log4rs"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e947bb896e702c711fccc2bf02ab2abb6072910693818d1d6b07ee2b9dfd86c"
-dependencies = [
- "anyhow",
- "arc-swap",
- "chrono",
- "derive_more",
- "fnv",
- "log",
- "log-mdc",
- "mock_instant",
- "parking_lot",
- "thiserror 2.0.20",
- "thread-id",
- "unicode-segmentation",
-]
-
-[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3519,12 +3442,6 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
-
-[[package]]
-name = "mock_instant"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb517913cfcfb9eeda59f36020269075a152701a01606c612f547e4890be399"
 
 [[package]]
 name = "moxcms"
@@ -5097,16 +5014,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "thread-id"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2010d27add3f3240c1fef7959f46c814487b216baee662af53be645ba7831c07"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/crates/babylon-client/Cargo.toml
+++ b/rust/crates/babylon-client/Cargo.toml
@@ -24,18 +24,10 @@ babylon-tick = { path = "../babylon-tick" }
 babylon-graph = { path = "../babylon-graph" }
 babylon-bsl = { path = "../babylon-bsl" }
 earcutr = "0.5"
-# Client logging estate (Director directive 2026-07-28): log4rs is the Rust
-# log4j — programmatic config, size-triggered rolling, fixed-window archive
-# caps. default-features off keeps the graph to exactly the pieces the
-# file-only sink uses (a console appender is the PR #318 frame-corruption
-# class; gzip would pull flate2 for nothing). Pure Rust — the client stays
-# C-toolchain-free (AA disclosure). Resurrected from the deleted
-# babylon-tui crate (B2 Task 16) — same crates, same feature set.
+# Client logging estate (Director directive 2026-07-28 for location +
+# rotation; Director-approved switch 2026-08-11, #503 item 7): the file
+# sink rides Bevy's own tracing stack via LogPlugin::custom_layer —
+# tracing-subscriber comes through bevy_log's re-export, no direct dep.
+# `log` stays: LogPlugin installs LogTracer, bridging this crate's
+# log:: call sites into tracing.
 log = "0.4"
-log4rs = { version = "1", default-features = false, features = [
-    "rolling_file_appender",
-    "compound_policy",
-    "size_trigger",
-    "fixed_window_roller",
-    "pattern_encoder",
-] }

--- a/rust/crates/babylon-client/src/logging.rs
+++ b/rust/crates/babylon-client/src/logging.rs
@@ -1,33 +1,34 @@
-//! File-only client logging (Director directive 2026-07-28; resurrected
-//! for the Bevy client at Program 28 B2, per CLAUDE.md: "the Bevy client's
-//! file sink lands at milestone B2"). Built on `log4rs` — the same crate
-//! and the same rotation policy the deleted Ratatui client's
-//! `babylon-tui::logging` used, transcribed here rather than reinvented.
+//! File logging through Bevy's own `tracing` stack (Director directive
+//! 2026-07-28 for the sink location + rotation; Director-approved switch
+//! 2026-08-11, #503 item 7: `LogPlugin` is the ONE global subscriber and
+//! the file sink attaches to it as a [`LogPlugin::custom_layer`], so
+//! Bevy's engine diagnostics land in the file alongside client events).
 //!
-//! **Independent of Bevy's own logging.** `bevy::log::LogPlugin` runs on
-//! `tracing` and keeps printing to stderr exactly as `DefaultPlugins`
-//! wires it — untouched by this module. `log4rs` listens on the separate
-//! `log` facade; this crate's OWN `log::debug!`/`log::info!` calls (never
-//! `bevy::log::info!`, which is `tracing`) are what land in the file.
+//! The B2 `log4rs` sink this replaces raced `LogPlugin` for the global
+//! logger slot — whoever initialized second failed (`bevy_log`'s
+//! `LogTracer::init()` is the losing line the Director's eyes-on session
+//! surfaced). With `log4rs` gone, `LogPlugin` installs `LogTracer`
+//! itself, so this crate's `log::debug!`/`log::info!` call sites bridge
+//! into `tracing` unchanged.
 //!
-//! **No wall-clock in client source.** Timestamps come from `log4rs`'s own
-//! pattern encoder inside the appender.
+//! **No wall-clock in client source.** Timestamps come from the fmt
+//! layer's own timer inside the subscriber, exactly as `log4rs`'s pattern
+//! encoder did before.
+//!
+//! [`LogPlugin::custom_layer`]: bevy::log::LogPlugin
 
-use std::path::Path;
-use std::sync::OnceLock;
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
 
-use log::LevelFilter;
-use log4rs::append::rolling_file::policy::compound::roll::fixed_window::FixedWindowRoller;
-use log4rs::append::rolling_file::policy::compound::trigger::size::SizeTrigger;
-use log4rs::append::rolling_file::policy::compound::CompoundPolicy;
-use log4rs::append::rolling_file::RollingFileAppender;
-use log4rs::config::{Appender, Config, Root};
-use log4rs::encode::pattern::PatternEncoder;
+use bevy::app::App;
+use bevy::log::tracing_subscriber;
+use bevy::log::{BoxedFmtLayer, BoxedLayer};
 
 const LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
 const LOG_ARCHIVES: u32 = 5;
-
-static INIT: OnceLock<()> = OnceLock::new();
+const LOG_FILE: &str = "babylon-client.log";
 
 /// `$XDG_DATA_HOME/babylon/logs` else `~/.local/share/babylon/logs` —
 /// mirrors `src/babylon/config/paths.py::player_data_dir()` /
@@ -35,10 +36,10 @@ static INIT: OnceLock<()> = OnceLock::new();
 /// re-derived (no PyO3 in the play path, Amendment AF, so this cannot call
 /// the Python function — it reproduces its two-line rule instead).
 #[must_use]
-pub fn log_dir() -> std::path::PathBuf {
+pub fn log_dir() -> PathBuf {
     log_dir_from(
-        std::env::var_os("XDG_DATA_HOME").map(std::path::PathBuf::from),
-        std::env::var_os("HOME").map(std::path::PathBuf::from),
+        std::env::var_os("XDG_DATA_HOME").map(PathBuf::from),
+        std::env::var_os("HOME").map(PathBuf::from),
     )
 }
 
@@ -46,96 +47,188 @@ pub fn log_dir() -> std::path::PathBuf {
 /// inputs injected — the test exercises this directly, so it never mutates
 /// process-global env vars (cargo runs tests in parallel; a `set_var` in
 /// one test races every other test's threads).
-fn log_dir_from(
-    xdg_data_home: Option<std::path::PathBuf>,
-    home: Option<std::path::PathBuf>,
-) -> std::path::PathBuf {
+fn log_dir_from(xdg_data_home: Option<PathBuf>, home: Option<PathBuf>) -> PathBuf {
     let base = xdg_data_home
         .unwrap_or_else(|| home.expect("HOME must be set").join(".local").join("share"));
     base.join("babylon").join("logs")
 }
 
-/// Install the rolling-file logger writing `babylon-client.log` under
-/// `log_dir`. `level` is one of `error|warn|info|debug|trace`.
-///
-/// # Errors
-/// A config defect (bad level, non-UTF-8 log dir, log4rs init failure).
-pub fn init_file_logging(log_dir: &Path, level: &str) -> Result<(), String> {
-    let level_filter = parse_level(level)?;
-    if INIT.get().is_some() {
-        return Ok(());
+/// A size-rotating file sink: `babylon-client.log` live, archives shifted
+/// to `babylon-client.{0..N-1}.log` (0 newest) when the live file would
+/// exceed the byte cap — the same naming and window the `log4rs`
+/// `FixedWindowRoller` used, so archives from before the switch stay
+/// coherent. `Clone` is cheap (shared state behind a mutex); the fmt
+/// layer's `MakeWriter` hands a clone to every event.
+#[derive(Clone)]
+pub struct RotatingSink {
+    inner: Arc<Mutex<SinkState>>,
+}
+
+struct SinkState {
+    dir: PathBuf,
+    max_bytes: u64,
+    archives: u32,
+    file: File,
+    written: u64,
+}
+
+impl RotatingSink {
+    /// Open (append) the live log file under `dir`, rotating at
+    /// `max_bytes` and keeping `archives` shifted archive files.
+    ///
+    /// # Errors
+    /// `archives` is zero, or the directory or live file cannot be
+    /// created/opened, or its size cannot be read.
+    pub fn open(dir: &Path, max_bytes: u64, archives: u32) -> Result<Self, String> {
+        if archives == 0 {
+            return Err("log rotation needs at least one archive slot".to_string());
+        }
+        std::fs::create_dir_all(dir).map_err(|e| format!("log dir {}: {e}", dir.display()))?;
+        let live = dir.join(LOG_FILE);
+        let file = open_live(&live)?;
+        let written = file
+            .metadata()
+            .map_err(|e| format!("log file size {}: {e}", live.display()))?
+            .len();
+        Ok(Self {
+            inner: Arc::new(Mutex::new(SinkState {
+                dir: dir.to_path_buf(),
+                max_bytes,
+                archives,
+                file,
+                written,
+            })),
+        })
     }
-    let roll_pattern = log_dir.join("babylon-client.{}.log");
-    let roller = FixedWindowRoller::builder()
-        .build(
-            roll_pattern
-                .to_str()
-                .ok_or_else(|| format!("log dir is not valid UTF-8: {}", log_dir.display()))?,
-            LOG_ARCHIVES,
-        )
-        .map_err(|e| format!("log roller config: {e}"))?;
-    let policy = CompoundPolicy::new(Box::new(SizeTrigger::new(LOG_MAX_BYTES)), Box::new(roller));
-    let appender = RollingFileAppender::builder()
-        .encoder(Box::new(PatternEncoder::new(
-            "{d(%Y-%m-%dT%H:%M:%S%.3f)} [{l}] {t} — {m}{n}",
-        )))
-        .build(log_dir.join("babylon-client.log"), Box::new(policy))
-        .map_err(|e| format!("log appender: {e}"))?;
-    let config = Config::builder()
-        .appender(Appender::builder().build("file", Box::new(appender)))
-        .build(Root::builder().appender("file").build(level_filter))
-        .map_err(|e| format!("log config: {e}"))?;
-    log4rs::init_config(config).map_err(|e| format!("log init: {e}"))?;
-    let _ = INIT.set(());
-    install_panic_hook();
+}
+
+fn open_live(live: &Path) -> Result<File, String> {
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(live)
+        .map_err(|e| format!("log file {}: {e}", live.display()))
+}
+
+fn archive_path(dir: &Path, index: u32) -> PathBuf {
+    dir.join(format!("babylon-client.{index}.log"))
+}
+
+/// Shift the fixed archive window one slot (oldest dropped, live becomes
+/// archive 0) and reopen a fresh live file — the same window the `log4rs`
+/// `FixedWindowRoller` kept, so pre-switch archives shift coherently.
+fn rotate(state: &mut SinkState) -> io::Result<()> {
+    let oldest = archive_path(&state.dir, state.archives - 1);
+    if oldest.exists() {
+        std::fs::remove_file(&oldest)?;
+    }
+    for index in (0..state.archives - 1).rev() {
+        let from = archive_path(&state.dir, index);
+        if from.exists() {
+            std::fs::rename(&from, archive_path(&state.dir, index + 1))?;
+        }
+    }
+    let live = state.dir.join(LOG_FILE);
+    std::fs::rename(&live, archive_path(&state.dir, 0))?;
+    state.file = open_live(&live).map_err(io::Error::other)?;
+    state.written = 0;
     Ok(())
 }
 
-fn parse_level(level: &str) -> Result<LevelFilter, String> {
-    match level {
-        "error" => Ok(LevelFilter::Error),
-        "warn" => Ok(LevelFilter::Warn),
-        "info" => Ok(LevelFilter::Info),
-        "debug" => Ok(LevelFilter::Debug),
-        "trace" => Ok(LevelFilter::Trace),
-        other => Err(format!(
-            "unknown log_level {other:?} (expected error|warn|info|debug|trace)"
-        )),
+impl io::Write for RotatingSink {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut state = self
+            .inner
+            .lock()
+            .map_err(|e| io::Error::other(format!("log sink mutex poisoned: {e}")))?;
+        let incoming = buf.len() as u64;
+        if state.written > 0 && state.written + incoming > state.max_bytes {
+            rotate(&mut state)?;
+        }
+        state.file.write_all(buf)?;
+        state.written += incoming;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut state = self
+            .inner
+            .lock()
+            .map_err(|e| io::Error::other(format!("log sink mutex poisoned: {e}")))?;
+        state.file.flush()
     }
 }
 
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for RotatingSink {
+    type Writer = RotatingSink;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// The file lane against an explicit directory — [`file_layer`] minus the
+/// environment resolution, so tests drive it at a temp dir and exercise
+/// the REAL production layer (never a copied pipeline).
+fn file_layer_in(dir: &Path) -> Option<BoxedLayer> {
+    match RotatingSink::open(dir, LOG_MAX_BYTES, LOG_ARCHIVES) {
+        Ok(sink) => {
+            install_panic_hook();
+            let layer = tracing_subscriber::fmt::Layer::default()
+                .with_ansi(false)
+                .with_writer(sink);
+            Some(Box::new(layer))
+        }
+        Err(e) => {
+            eprintln!("warning: client file logging did not start: {e}");
+            None
+        }
+    }
+}
+
+/// [`bevy::log::LogPlugin::custom_layer`] — the rolling-file lane. On any
+/// sink failure the game still runs: a stderr warning, no layer.
+#[must_use]
+pub fn file_layer(_app: &mut App) -> Option<BoxedLayer> {
+    file_layer_in(&log_dir())
+}
+
+/// [`bevy::log::LogPlugin::fmt_layer`] — the stderr lane, capped at INFO
+/// so the file's DEBUG traffic never spams the terminal (the pre-switch
+/// behavior: `log4rs` logged DEBUG to file only).
+#[must_use]
+pub fn stderr_fmt_layer(_app: &mut App) -> Option<BoxedFmtLayer> {
+    use bevy::log::tracing_subscriber::Layer as _;
+    let layer = tracing_subscriber::fmt::Layer::default()
+        .with_writer(std::io::stderr)
+        .with_filter(tracing_subscriber::filter::LevelFilter::INFO);
+    Some(Box::new(layer))
+}
+
 fn install_panic_hook() {
-    let previous = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |info| {
-        log::error!(target: "panic", "client panic: {info}");
-        log::logger().flush();
-        previous(info);
-    }));
+    static HOOK: OnceLock<()> = OnceLock::new();
+    HOOK.get_or_init(|| {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            log::error!(target: "panic", "client panic: {info}");
+            previous(info);
+        }));
+    });
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write as _;
 
-    #[test]
-    fn an_unknown_level_fails_loudly_even_after_init() {
-        let err = init_file_logging(Path::new("/nonexistent"), "loudest").unwrap_err();
-        assert!(err.contains("unknown log_level"));
-    }
-
-    #[test]
-    fn init_writes_the_sink_and_reinit_is_a_noop_success() {
-        let dir =
-            std::env::temp_dir().join(format!("babylon-client-logtest-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).expect("test log dir");
-        init_file_logging(&dir, "debug").expect("first init");
-        log::debug!(target: "test", "sink probe line");
-        log::logger().flush();
-        let sink = dir.join("babylon-client.log");
-        let written = std::fs::read_to_string(&sink).expect("sink exists");
-        assert!(written.contains("sink probe line"));
-        init_file_logging(&dir, "debug").expect("re-init is a no-op success");
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "babylon-client-logtest-{tag}-{}",
+            std::process::id()
+        ));
         std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).expect("test log dir");
+        dir
     }
 
     #[test]
@@ -143,12 +236,140 @@ mod tests {
         // Injected inputs, no env mutation — parallel-safe by construction
         // (the deleted TUI module's test set XDG_DATA_HOME process-globally
         // and leaned on a single-threaded assumption; not transcribed).
-        let xdg = log_dir_from(Some(std::path::PathBuf::from("/tmp/xdg-probe")), None);
-        assert_eq!(xdg, std::path::PathBuf::from("/tmp/xdg-probe/babylon/logs"));
-        let fallback = log_dir_from(None, Some(std::path::PathBuf::from("/home/probe")));
+        let xdg = log_dir_from(Some(PathBuf::from("/tmp/xdg-probe")), None);
+        assert_eq!(xdg, PathBuf::from("/tmp/xdg-probe/babylon/logs"));
+        let fallback = log_dir_from(None, Some(PathBuf::from("/home/probe")));
         assert_eq!(
             fallback,
-            std::path::PathBuf::from("/home/probe/.local/share/babylon/logs")
+            PathBuf::from("/home/probe/.local/share/babylon/logs")
+        );
+    }
+
+    #[test]
+    fn the_sink_appends_across_instances_never_truncates() {
+        let dir = temp_dir("append");
+        {
+            let mut sink = RotatingSink::open(&dir, 1024, 2).expect("first open");
+            sink.write_all(b"first line\n").expect("write");
+        }
+        let mut sink = RotatingSink::open(&dir, 1024, 2).expect("re-open");
+        sink.write_all(b"second line\n").expect("write");
+        let live = std::fs::read_to_string(dir.join(LOG_FILE)).expect("live file");
+        assert!(live.contains("first line"), "re-open truncated the log");
+        assert!(live.contains("second line"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn the_sink_rotates_at_the_cap_and_shifts_archives_zero_newest() {
+        let dir = temp_dir("rotate");
+        let mut sink = RotatingSink::open(&dir, 24, 2).expect("open");
+        sink.write_all(b"aaaaaaaaaaaaaaaaaaaa\n").expect("gen a"); // 21 bytes
+        sink.write_all(b"bbbbbbbbbbbbbbbbbbbb\n").expect("gen b"); // would exceed 24
+        sink.write_all(b"cccccccccccccccccccc\n").expect("gen c");
+        let live = std::fs::read_to_string(dir.join(LOG_FILE)).expect("live");
+        let arch0 = std::fs::read_to_string(dir.join("babylon-client.0.log")).expect("archive 0");
+        let arch1 = std::fs::read_to_string(dir.join("babylon-client.1.log")).expect("archive 1");
+        assert!(live.contains("ccc"), "live holds the newest generation");
+        assert!(
+            arch0.contains("bbb"),
+            "archive 0 is the previous generation"
+        );
+        assert!(arch1.contains("aaa"), "archive 1 is the oldest kept");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_three_deep_shift_preserves_generation_order() {
+        // A 2-archive window cannot tell a reversed shift loop from a
+        // forward one (both collapse to a single rename); three archives
+        // can — a forward loop clobbers the middle generation.
+        let dir = temp_dir("three-deep");
+        let mut sink = RotatingSink::open(&dir, 8, 3).expect("open");
+        for gen in [b"aaaaaaaa\n", b"bbbbbbbb\n", b"cccccccc\n", b"dddddddd\n"] {
+            sink.write_all(gen).expect("write generation");
+        }
+        let arch0 = std::fs::read_to_string(dir.join("babylon-client.0.log")).expect("archive 0");
+        let arch1 = std::fs::read_to_string(dir.join("babylon-client.1.log")).expect("archive 1");
+        let arch2 = std::fs::read_to_string(dir.join("babylon-client.2.log")).expect("archive 2");
+        assert!(arch0.contains("ccc"), "archive 0 is the newest archived");
+        assert!(arch1.contains("bbb"), "archive 1 is the middle generation");
+        assert!(arch2.contains("aaa"), "archive 2 is the oldest kept");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_single_write_larger_than_the_cap_lands_without_rotating() {
+        // An empty live file must never rotate: the oversized record lands,
+        // and rotation waits for the NEXT write (log4rs size-trigger
+        // semantics — the cap bounds the file, not the record).
+        let dir = temp_dir("oversize");
+        let mut sink = RotatingSink::open(&dir, 8, 2).expect("open");
+        sink.write_all(b"one oversized record\n").expect("write");
+        let live = std::fs::read_to_string(dir.join(LOG_FILE)).expect("live");
+        assert!(live.contains("one oversized record"));
+        assert!(
+            !dir.join("babylon-client.0.log").exists(),
+            "an empty live file must not be archived"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rotation_drops_the_oldest_archive_beyond_the_window() {
+        let dir = temp_dir("window");
+        let mut sink = RotatingSink::open(&dir, 8, 2).expect("open");
+        for gen in [b"aaaaaaaa\n", b"bbbbbbbb\n", b"cccccccc\n", b"dddddddd\n"] {
+            sink.write_all(gen).expect("write generation");
+        }
+        assert!(
+            !dir.join("babylon-client.2.log").exists(),
+            "window is 2 archives; a third index must never appear"
+        );
+        let arch1 = std::fs::read_to_string(dir.join("babylon-client.1.log")).expect("archive 1");
+        assert!(
+            arch1.contains("bbb"),
+            "the aaa generation fell off the window"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn the_production_file_layer_writes_events_to_the_live_file() {
+        use bevy::log::tracing_subscriber::layer::SubscriberExt as _;
+        // The REAL layer `file_layer` returns (via `file_layer_in`), driven
+        // through a registry exactly as `LogPlugin` composes it — not a
+        // rebuilt copy of the pipeline (the #504 test-vacuity lesson).
+        let dir = temp_dir("layer");
+        let layer = file_layer_in(&dir).expect("layer builds against a writable dir");
+        let subscriber = bevy::log::tracing_subscriber::registry().with(layer);
+        bevy::log::tracing::subscriber::with_default(subscriber, || {
+            bevy::log::info!(target: "probe", "file lane probe line");
+        });
+        let live = std::fs::read_to_string(dir.join(LOG_FILE)).expect("live file");
+        assert!(live.contains("file lane probe line"));
+        assert!(live.contains("probe"), "the event target is encoded");
+        assert!(
+            !live.contains("\u{1b}["),
+            "the file lane must carry no ANSI escapes"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_bad_directory_yields_no_layer_instead_of_a_panic() {
+        assert!(
+            file_layer_in(Path::new("/proc/definitely/not/writable")).is_none(),
+            "an unwritable dir degrades to no file lane, the game still runs"
+        );
+    }
+
+    #[test]
+    fn the_stderr_lane_exists() {
+        let mut app = App::new();
+        assert!(
+            stderr_fmt_layer(&mut app).is_some(),
+            "the INFO-capped stderr formatter replaces LogPlugin's default"
         );
     }
 }

--- a/rust/crates/babylon-client/src/logging.rs
+++ b/rust/crates/babylon-client/src/logging.rs
@@ -68,7 +68,9 @@ struct SinkState {
     dir: PathBuf,
     max_bytes: u64,
     archives: u32,
-    file: File,
+    /// `None` only after a failed rotation — every later write then fails
+    /// loudly instead of silently dropping records.
+    file: Option<File>,
     written: u64,
 }
 
@@ -95,7 +97,7 @@ impl RotatingSink {
                 dir: dir.to_path_buf(),
                 max_bytes,
                 archives,
-                file,
+                file: Some(file),
                 written,
             })),
         })
@@ -129,8 +131,12 @@ fn rotate(state: &mut SinkState) -> io::Result<()> {
         }
     }
     let live = state.dir.join(LOG_FILE);
+    // Drop the live handle BEFORE the rename: Unix renames an open file
+    // happily, Windows refuses (sharing violation) — Amendment AA makes
+    // Windows binding post-1.0, so the order is load-bearing, not style.
+    state.file = None;
     std::fs::rename(&live, archive_path(&state.dir, 0))?;
-    state.file = open_live(&live).map_err(io::Error::other)?;
+    state.file = Some(open_live(&live).map_err(io::Error::other)?);
     state.written = 0;
     Ok(())
 }
@@ -145,7 +151,10 @@ impl io::Write for RotatingSink {
         if state.written > 0 && state.written + incoming > state.max_bytes {
             rotate(&mut state)?;
         }
-        state.file.write_all(buf)?;
+        let file = state.file.as_mut().ok_or_else(|| {
+            io::Error::other("log sink has no live file (a prior rotation failed)")
+        })?;
+        file.write_all(buf)?;
         state.written += incoming;
         Ok(buf.len())
     }
@@ -155,7 +164,10 @@ impl io::Write for RotatingSink {
             .inner
             .lock()
             .map_err(|e| io::Error::other(format!("log sink mutex poisoned: {e}")))?;
-        state.file.flush()
+        match state.file.as_mut() {
+            Some(file) => file.flush(),
+            None => Ok(()),
+        }
     }
 }
 

--- a/rust/crates/babylon-client/src/main.rs
+++ b/rust/crates/babylon-client/src/main.rs
@@ -22,29 +22,39 @@
 //! `engine_link::engine_link_probe` itself is untouched (B0's own pinned
 //! test, `tests/engine_link.rs`, still exercises it directly).
 //!
-//! B2 Task 16 resurrects the `log4rs` file sink (`logging`) — independent
-//! of Bevy's own `tracing`-based `LogPlugin`, which keeps printing to the
-//! console exactly as `DefaultPlugins` already wires it.
+//! Logging rides Bevy's own `tracing` stack (Director-approved switch
+//! 2026-08-11, #503 item 7, replacing B2 Task 16's `log4rs` sink):
+//! `LogPlugin` is the ONE global subscriber, the rolling file sink
+//! attaches as its `custom_layer`, and the stderr formatter is capped at
+//! INFO so the file's DEBUG lane stays off the terminal. The filter
+//! grants this crate DEBUG on top of Bevy's default noise floor; the
+//! startup line moves AFTER `add_plugins` because nothing is listening
+//! before `LogPlugin::build` installs the subscriber.
 
-use babylon_client::{loop_ui, map, palette};
+use babylon_client::{logging, loop_ui, map, palette};
+use bevy::log::LogPlugin;
 use bevy::prelude::*;
 
 fn main() {
-    let log_dir = babylon_client::logging::log_dir();
-    std::fs::create_dir_all(&log_dir).ok();
-    if let Err(e) = babylon_client::logging::init_file_logging(&log_dir, "debug") {
-        eprintln!("warning: client file logging did not start: {e}");
-    }
-    log::info!("babylon-client starting (B2 tick loop)");
-    App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Babylon — The Fall of America".into(),
+    let mut app = App::new();
+    app.add_plugins(
+        DefaultPlugins
+            .set(LogPlugin {
+                filter: format!("{},babylon_client=debug", bevy::log::DEFAULT_FILTER),
+                custom_layer: logging::file_layer,
+                fmt_layer: logging::stderr_fmt_layer,
+                ..default()
+            })
+            .set(WindowPlugin {
+                primary_window: Some(Window {
+                    title: "Babylon — The Fall of America".into(),
+                    ..default()
+                }),
                 ..default()
             }),
-            ..default()
-        }))
-        .add_plugins(map::MapPlugin)
+    );
+    log::info!("babylon-client starting (B2 tick loop, Bevy-native logging)");
+    app.add_plugins(map::MapPlugin)
         .add_plugins(loop_ui::TickLoopPlugin)
         .insert_resource(ClearColor(palette::FIELD))
         .add_systems(Startup, spawn_title)


### PR DESCRIPTION
## What

Executes the Director-approved switch (2026-08-11, #503 item 7 re-scope): the client's file logging moves off `log4rs` and onto Bevy's own `tracing` stack. `LogPlugin` is now the ONE global subscriber; the rolling file sink attaches as its `custom_layer`; the stderr formatter is replaced by an INFO-capped `fmt_layer`.

## Why

The B2 `log4rs` sink raced `LogPlugin` for the global logger slot — `bevy_log`'s `LogTracer::init()` lost, producing the startup ERROR the Director's eyes-on session surfaced (`Could not set global logger as it is already set`). Disabling LogPlugin (the original #503 filing) would have kept Bevy's engine diagnostics orphaned on stderr; this way render/winit/asset warnings land in `~/.local/share/babylon/logs/babylon-client.log` alongside client events — exactly the log you want when a player reports a render glitch.

## How

- **`RotatingSink`** — size-rotating writer: 10 MB cap, 5-archive fixed window, `babylon-client.{n}.log` naming (0 newest) — the same window and naming the `log4rs` `FixedWindowRoller` used, so pre-switch archives shift coherently. `MakeWriter` hands a mutex-guarded clone per event; a record larger than the cap lands rather than rotating an empty file (log4rs size-trigger semantics: the cap bounds the file, not the record).
- **`file_layer`** (`custom_layer`) — ANSI-free fmt layer over the sink; on any sink failure the game still runs (stderr warning, no layer). Panic hook re-installed here.
- **`stderr_fmt_layer`** (`fmt_layer`) — INFO cap, so the file's DEBUG lane stays off the terminal (pre-switch behavior preserved).
- **Filter** — `DEFAULT_FILTER + babylon_client=debug`: our crate logs DEBUG to file; Bevy noise floor unchanged.
- **`log4rs` leaves the crate**; `tracing-subscriber` comes through `bevy_log`'s re-export (no new direct dependency); the `log` crate stays — `LogPlugin` installs `LogTracer`, bridging the existing `log::` call sites unchanged.
- **Startup line moves after `add_plugins`** — nothing is listening before `LogPlugin::build` installs the subscriber.

## Verification

- TDD: 6 red → green; 9 logging tests. The layer test drives the REAL production-returned layer through a registry (never a rebuilt pipeline — the #504 test-vacuity lesson).
- **Mutation-verified** (branch standard): M1 (shift loop reversed to forward) flips `a_three_deep_shift_preserves_generation_order` — that test exists precisely because a 2-archive window is direction-blind; M2 (empty-file guard dropped) flips `a_single_write_larger_than_the_cap_lands_without_rotating`. Both reverted byte-identical.
- Full local gate: `cargo fmt --check`, `clippy -D warnings`, 94 crate tests, `doc -D warnings` — all green.
- Honest limit: the composed `DefaultPlugins` startup (windowed) is not CI-testable headless; the structural cause of the ERROR line is removed by construction (log4rs no longer holds the slot `LogTracer::init` needs — `bevy_log-0.18.1/src/lib.rs:406`). Director's next `cargo run` confirms visually.

No engine/economics/defines surface touched — client crate only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)