### PR TITLE
feat(bsl): query-eval slice 1, PR group 1 — seam split, graph-bearing EvalEnv, node_type_of

### DIFF
--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -38,7 +38,9 @@
 
 use crate::fuel::{cost, IntrinsicCosts};
 use crate::intrinsic_host::IntrinsicHost;
+use crate::query::Element;
 use crate::reader::{Atom, SExpr, ScaledKind};
+use babylon_graph::substrate::GraphSubstrate;
 use babylon_kernel::{Coefficient, Currency, Ratio};
 use std::collections::HashMap;
 
@@ -244,15 +246,27 @@ impl std::fmt::Display for EvalError {
 
 impl std::error::Error for EvalError {}
 
-/// The evaluation environment (§4.2, the expression-core slice): resolved
-/// binding values and the declared intrinsic costs. The graph, tick and
-/// `self`/`it` references join with Task 16.
+/// The evaluation environment (§4.2): resolved binding values, the declared
+/// intrinsic costs, the graph a query-evaluating form reads, and the §2.6
+/// chapter C8 element stack `it`/`:as` resolve through.
 pub struct EvalEnv<'a> {
     /// Resolved rule bindings, name → value (binding resolution itself is
     /// the loader's job, §3.5 — unbound here means the loader failed).
+    /// `self` lives here, bound once per subject (`tick.rs::bind_subject`)
+    /// — distinct from `it`, which is never a binding (see `elements`).
     pub bindings: HashMap<String, Value>,
     /// Declared `:cost` per intrinsic (§2.7), for the §4.5 charge.
     pub intrinsic_costs: &'a IntrinsicCosts,
+    /// The graph a query-evaluating form reads. `None` for the
+    /// pure-expression callers (`:expr` binding resolution, the arithmetic
+    /// conformance vectors) — a query head reached with no graph is a LOUD
+    /// driver error (`require_graph`), never an empty set.
+    pub graph: Option<&'a dyn GraphSubstrate>,
+    /// The §2.6 chapter C8 element stack, innermost-last. `it` always reads
+    /// the last entry's element; a `:as` name reads by name (wired in a
+    /// later task) — the paired `Option<String>` is that declared name,
+    /// `None` for an iterating form with no `:as`.
+    pub elements: Vec<(Option<String>, Element)>,
 }
 
 /// Evaluate `expr`, decrementing `*fuel` per §4.5. Fuel exhaustion should
@@ -344,6 +358,28 @@ fn atom_value(atom: &Atom, env: &EvalEnv<'_>) -> Result<Value, EvalError> {
             enum_type: enum_type.clone(),
             member: member.clone(),
         }),
+        // §2.6 chapter C8: `it` denotes the element of the innermost
+        // enclosing iterating form — resolved through the element stack,
+        // NEVER through `env.bindings` (it is not a binding, and never has
+        // been one). `scope.rs::walk_names` already refuses a bare `it`
+        // outside a body at LOAD time (E-TYPE-012); reaching an empty
+        // element stack here is defense in depth, exactly like the unbound-
+        // variable arm below.
+        Atom::Symbol(name) if name == "it" => env
+            .elements
+            .last()
+            .map(|(_, element)| element.to_value())
+            .ok_or_else(|| {
+                EvalError::plain(
+                    "it — §2.6 chapter C8: it denotes the element of the \
+                     innermost enclosing iterating form, and the element \
+                     stack is empty here, so there is no such form. This \
+                     should already be refused at load time \
+                     (scope.rs::walk_names, E-TYPE-012); reaching it here is \
+                     defense in depth, never a stale or default read"
+                        .to_owned(),
+                )
+            }),
         Atom::Symbol(name) => env.bindings.get(name).cloned().ok_or_else(|| {
             EvalError::plain(format!(
                 "unbound variable: {name} — binding resolution is a load-time \
@@ -355,6 +391,37 @@ fn atom_value(atom: &Atom, env: &EvalEnv<'_>) -> Result<Value, EvalError> {
             "atom is not a value in expression position: {other:?}"
         ))),
     }
+}
+
+/// The graph a query-evaluating form needs (§4.2). `EvalEnv.graph` is
+/// `None` only for the pure-expression callers; a query head reached with
+/// no graph is a LOUD driver error — the caller built an environment with
+/// no graph for a form that needs one, which is not the same fact as "the
+/// query found nothing" and must never read as an empty set or a `0`. Every
+/// query head Task 4 onward dispatches charges through this one seam.
+///
+/// # Errors
+///
+/// A loud, uncoded [`EvalError`] naming `form` and the driver-error reading
+/// when `env.graph` is `None`.
+// Task 2 lands this seam; Task 4 onward (query.rs's `materialize()`, this
+// module's `fold`/`exists`/`forall`/`select-*`/`field-of` arms) is the
+// production caller. Genuinely unused within Tasks 1-3's own scope — this
+// crate has no precedent for a blanket allow, so the exemption is scoped to
+// exactly this function and reasoned here rather than silenced globally.
+#[allow(dead_code)]
+pub(crate) fn require_graph<'a>(
+    env: &EvalEnv<'a>,
+    form: &str,
+) -> Result<&'a dyn GraphSubstrate, EvalError> {
+    env.graph.ok_or_else(|| {
+        EvalError::plain(format!(
+            "({form} …) needs the graph substrate (§4.2) but this EvalEnv \
+             carries none — a driver error: the caller built an environment \
+             with no graph for a query-evaluating form, never an empty set \
+             and never a 0"
+        ))
+    })
 }
 
 /// Heads that are EFFECT-position verbs (§2.8) or update-op/grouping forms.
@@ -891,6 +958,8 @@ mod tests {
         let env = EvalEnv {
             bindings,
             intrinsic_costs: &costs,
+            graph: None,
+            elements: Vec::new(),
         };
         let (expr, _) = read(source).expect("test source must parse");
         evaluate(&expr, &env, &EmptyIntrinsicHost, fuel)
@@ -1239,6 +1308,54 @@ mod tests {
         assert!(err.message.contains("E-LOAD-010"), "{err}");
     }
 
+    /// Task 2 (§2.6 chapter C8): `it` always denotes the element of the
+    /// innermost enclosing iterating form, resolved through `EvalEnv`'s new
+    /// element stack — NEVER through `env.bindings`, and never a stale
+    /// read. `scope.rs::walk_names` already refuses a bare `it` at LOAD time
+    /// (`E-TYPE-012`, `NameOutsideItsBody`); this is the same discipline
+    /// held at evaluation, defense in depth, exactly as an unbound variable
+    /// is (the test above).
+    #[test]
+    fn it_outside_any_iterating_form_is_loud() {
+        let err = eval("it").unwrap_err();
+        assert!(err.message.contains("it"), "{err}");
+        assert!(err.message.contains("§2.6"), "{err}");
+    }
+
+    /// Task 2: `EvalEnv.graph` is `None` for the pure-expression callers
+    /// (every existing test in this module). A query-evaluating form
+    /// reached with no graph is a loud DRIVER error — the caller forgot to
+    /// supply one — never an empty set and never a `0`; `require_graph` is
+    /// the one seam every future query head (Task 4+) will call through.
+    ///
+    /// `fold`/`nodes` themselves still refuse as Task 1's unserved-head seam
+    /// (they are not dispatched to the graph yet — that lands with Task 4/5,
+    /// a later PR), so this pins `require_graph` directly rather than
+    /// through a full `(fold count (nodes NodeType/X) 1)` evaluation, which
+    /// would only exercise Task 1's message. See the final report for the
+    /// discrepancy this records against the plan's literal wording.
+    #[test]
+    fn a_query_with_no_graph_is_a_loud_driver_error() {
+        let costs = costs();
+        let env = EvalEnv {
+            bindings: HashMap::new(),
+            intrinsic_costs: &costs,
+            graph: None,
+            elements: Vec::new(),
+        };
+        // `Result::unwrap_err` needs `T: Debug`; `&dyn GraphSubstrate` isn't
+        // one, so the Ok arm is matched out by hand.
+        let Err(err) = require_graph(&env, "fold") else {
+            panic!("EvalEnv.graph is None; require_graph must refuse")
+        };
+        assert!(err.message.contains("driver"), "{err}");
+        assert!(err.message.contains("fold"), "{err}");
+        // Structural, not just textual: `require_graph` returns
+        // `Result<&dyn GraphSubstrate, EvalError>` — there is no code path
+        // by which its Err arm could be confused with a Value::Int(0) or a
+        // Value::Real(0.0); the type itself makes "yields 0" unreachable.
+    }
+
     #[test]
     fn fuel_exhaustion_at_the_exact_boundary_is_e_eval_040() {
         // (< wealth 1000.5$) consumes 2. A meter of 2 reaches zero on the
@@ -1269,6 +1386,8 @@ mod tests {
         let env = EvalEnv {
             bindings: HashMap::new(),
             intrinsic_costs: &costs,
+            graph: None,
+            elements: Vec::new(),
         };
         let (expr, _) = read("(double 5)").unwrap();
         let mut fuel = 100;
@@ -1294,6 +1413,8 @@ mod tests {
         let env = EvalEnv {
             bindings: HashMap::from([("x".to_owned(), Value::Real(7.8))]),
             intrinsic_costs: &costs,
+            graph: None,
+            elements: Vec::new(),
         };
         let (expr, _) = read("(floor x)").unwrap();
         let mut fuel = 100;
@@ -1311,6 +1432,8 @@ mod tests {
         let neg_env = EvalEnv {
             bindings: HashMap::from([("x".to_owned(), Value::Real(-2.5))]),
             intrinsic_costs: &costs,
+            graph: None,
+            elements: Vec::new(),
         };
         let mut fuel2 = 100;
         let err = evaluate(
@@ -1372,6 +1495,8 @@ mod tests {
         let effect_env = EvalEnv {
             bindings: HashMap::from([("self".to_owned(), Value::NodeRef(self_id))]),
             intrinsic_costs: &costs,
+            graph: None,
+            elements: Vec::new(),
         };
         let (form, _) =
             read("(effects (update-edge EdgeType/SOLIDARITY self self))").expect("must parse");

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -6,9 +6,12 @@
 //! Scope (Phase 1 Task 14): the **expression core** — literals, variable
 //! references, the two numeric lanes (§3.3), strictly binary arithmetic,
 //! comparison, `and`/`or`/`not`, `if`, and the [`crate::intrinsic_host`]
-//! boundary. Folds, queries, effects and `guard` need the graph substrate
-//! and land with Task 16; meeting one here is a loud error naming that
-//! seam, never a default.
+//! boundary. `guard` and the §2.8 effect verbs are grammar errors here
+//! (they are EFFECT-position only, and already served there by
+//! [`crate::structural_verbs`]); folds, queries, selections and accessors
+//! are a loud error naming the query-evaluation-plan slice that will serve
+//! them (P27 Phase 2 Task 1 — `EFFECT_POSITION_ONLY` /
+//! `UNSERVED_EXPRESSION_HEADS`), never a default.
 //!
 //! Semantics held to the letter of §4:
 //! - **§4.1**: strict, call-by-value, left to right; `and`/`or`
@@ -354,23 +357,16 @@ fn atom_value(atom: &Atom, env: &EvalEnv<'_>) -> Result<Value, EvalError> {
     }
 }
 
-/// Form heads the expression core deliberately does NOT evaluate — they
-/// need the graph substrate and land with Task 16.
-/// The R9 chapters' new heads (§2.7's selections, §2.8's `for-each` and the
-/// two new update verbs, §2.10's accessors) join the list rather than fall
-/// through to `eval_intrinsic`: an accessor treated as an undeclared
-/// intrinsic would report `E-LOAD-021`, which is the wrong diagnosis for a
-/// form the language *does* have.
-const GRAPH_SEAM_HEADS: [&str; 27] = [
-    "fold",
-    "exists",
-    "forall",
-    "nodes",
-    "edges",
-    "neighbors",
-    "hyperedges",
-    "members-of",
-    "hyperedges-of",
+/// Heads that are EFFECT-position verbs (§2.8) or update-op/grouping forms.
+/// Meeting one of these in EXPRESSION position (this module) is a grammar
+/// error, not an unimplemented seam — §2.7's `<expr>` production has no
+/// production for any of them; they are already served, in effect position,
+/// by [`crate::structural_verbs`]. The ten §2.8 verbs (`update-node`,
+/// `update-edge`, `update-hyperedge`, `add-node`, `remove-node`, `add-edge`,
+/// `remove-edge`, `add-hyperedge`, `remove-hyperedge`, `emit`) plus `guard`
+/// and `for-each` plus the four update-ops (`add`/`sub`/`set`/`scale`) plus
+/// the `members` list form — 17 in all.
+const EFFECT_POSITION_ONLY: [&str; 17] = [
     "guard",
     "for-each",
     "update-node",
@@ -383,12 +379,38 @@ const GRAPH_SEAM_HEADS: [&str; 27] = [
     "add-hyperedge",
     "remove-hyperedge",
     "emit",
-    "select-max",
-    "select-min",
-    "field-of",
-    "edge-between",
-    "the",
-    "metric-of",
+    "add",
+    "sub",
+    "set",
+    "scale",
+    "members",
+];
+
+/// Expression heads the query evaluator does not yet serve, each mapped to
+/// the slice of `docs/superpowers/plans/2026-08-11-bsl-query-evaluation-plan.md`
+/// that will: `nodes`/`neighbors`/`fold`/`exists`/`forall`/`select-max`/
+/// `select-min`/`field-of` (slice 1, THIS plan's remaining tasks);
+/// `edges`/`edge-between`/`the` (slice 2, the dyadic edge lane);
+/// `hyperedges`/`members-of`/`hyperedges-of`/`metric-of` (slice 3, the
+/// hyperedge + metric lane). Exhaustive over the pre-Task-1
+/// `GRAPH_SEAM_HEADS` set once [`EFFECT_POSITION_ONLY`] is subtracted from
+/// it: a head in neither table is `eval_intrinsic`'s.
+const UNSERVED_EXPRESSION_HEADS: [(&str, &str); 15] = [
+    ("fold", "slice 1"),
+    ("exists", "slice 1"),
+    ("forall", "slice 1"),
+    ("nodes", "slice 1"),
+    ("neighbors", "slice 1"),
+    ("select-max", "slice 1"),
+    ("select-min", "slice 1"),
+    ("field-of", "slice 1"),
+    ("edges", "slice 2"),
+    ("edge-between", "slice 2"),
+    ("the", "slice 2"),
+    ("hyperedges", "slice 3"),
+    ("members-of", "slice 3"),
+    ("hyperedges-of", "slice 3"),
+    ("metric-of", "slice 3"),
 ];
 
 fn eval_form(
@@ -418,17 +440,25 @@ fn eval_form(
             Ok(Value::Bool(!value))
         }
         "if" => eval_if(&items[1..], env, host, fuel),
-        h if GRAPH_SEAM_HEADS.contains(&h)
-            || matches!(h, "add" | "sub" | "set" | "scale" | "members") =>
-        {
-            Err(EvalError::plain(format!(
-                "({h} …) is outside the Task 14 expression core — folds, \
-                 queries, selections, accessors and effects evaluate against \
-                 the graph substrate (Task 16 / the Phase-2 query evaluator), \
-                 never as a default here"
-            )))
+        name => {
+            if EFFECT_POSITION_ONLY.contains(&name) {
+                return Err(EvalError::plain(format!(
+                    "({name} …) is an effect-position verb or grouping form \
+                     (§2.8) — using it in expression position is a grammar \
+                     error, not an unimplemented seam: §2.7's <expr> \
+                     production has no ({name} …) form; it is already \
+                     served, in effect position, by structural_verbs"
+                )));
+            }
+            if let Some((_, slice)) = UNSERVED_EXPRESSION_HEADS.iter().find(|(h, _)| *h == name) {
+                return Err(EvalError::plain(format!(
+                    "({name} …) is a query/selection/accessor form the \
+                     evaluator does not yet serve (§2.6/§2.7/§2.10) — it \
+                     lands with {slice}, never as a default here"
+                )));
+            }
+            eval_intrinsic(name, &items[1..], env, host, fuel)
         }
-        name => eval_intrinsic(name, &items[1..], env, host, fuel),
     }
 }
 
@@ -1294,16 +1324,123 @@ mod tests {
         assert_eq!(err.code.unwrap().spec_code(), "E-EVAL-039");
     }
 
+    /// Task 1: the old `GRAPH_SEAM_HEADS` conflation reported EVERY one of
+    /// these heads with the same "Task 16" misdiagnosis. After the split,
+    /// each refusal names what it actually is — an effect-position-only
+    /// verb/grouping form is a grammar error, never an unimplemented seam;
+    /// an unserved query/selection/accessor form names the slice that will
+    /// serve it. The `update-edge` case crosses into effect position
+    /// (`structural_verbs.rs`) to prove that refusal — already correct,
+    /// already citing Constitution III.7 — was untouched by this split.
     #[test]
-    fn graph_seam_forms_are_loud_task_16_errors_never_defaults() {
-        for source in [
-            "(fold sum (nodes NodeType/SOCIAL_CLASS) it)",
-            "(exists (nodes NodeType/SOCIAL_CLASS))",
-            "(update-node self social-class/agitation (add 0.05i))",
-            "(guard #t (emit EventType/RUPTURE))",
-        ] {
-            let err = eval(source).unwrap_err();
-            assert!(err.message.contains("Task 16"), "{source}: {err}");
+    fn refusal_messages_name_their_slice() {
+        use crate::structural_verbs::{CollectingSink, EffectExecutor};
+        use crate::typecheck::TypeEnv;
+        use babylon_graph::memory::MemoryGraph;
+        use babylon_graph::substrate::GraphSubstrate;
+
+        // `emit` is EFFECT-position only (§2.8): in expression position it
+        // is a grammar error, never "Task 16".
+        let emit_err = eval("(emit EventType/RUPTURE (severity 0.9c))").unwrap_err();
+        assert!(!emit_err.message.contains("Task 16"), "{emit_err}");
+        assert!(emit_err.message.contains("§2.8"), "{emit_err}");
+        assert!(emit_err.message.contains("effect position"), "{emit_err}");
+
+        // `edges` is unserved until slice 2.
+        let edges_err = eval("(edges EdgeType/SOLIDARITY)").unwrap_err();
+        assert!(edges_err.message.contains("slice 2"), "{edges_err}");
+
+        // `members-of` is unserved until slice 3.
+        let members_of_err = eval("(members-of self HyperedgeType/CELL)").unwrap_err();
+        assert!(
+            members_of_err.message.contains("slice 3"),
+            "{members_of_err}"
+        );
+
+        // `update-edge`'s EFFECT-position storage refusal
+        // (`structural_verbs.rs`, untouched by this task) still names
+        // Constitution III.7 — a regression guard, not a new behaviour.
+        let mut graph = MemoryGraph::new();
+        let self_id = graph.add_node("SOCIAL_CLASS").unwrap();
+        let types = TypeEnv {
+            fields: HashMap::new(),
+            exemptions: &[],
+        };
+        let mut executor = EffectExecutor::new(&types);
+        let mut sink = CollectingSink::default();
+        let costs = costs();
+        let effect_env = EvalEnv {
+            bindings: HashMap::from([("self".to_owned(), Value::NodeRef(self_id))]),
+            intrinsic_costs: &costs,
+        };
+        let (form, _) =
+            read("(effects (update-edge EdgeType/SOLIDARITY self self))").expect("must parse");
+        let SExpr::List(items) = form else {
+            unreachable!()
+        };
+        let mut fuel = 128;
+        let update_edge_err = executor
+            .execute_effects(
+                &items[1..],
+                &effect_env,
+                &EmptyIntrinsicHost,
+                &mut graph,
+                &mut sink,
+                &mut fuel,
+            )
+            .unwrap_err();
+        assert!(
+            update_edge_err.message.contains("Constitution III.7"),
+            "{update_edge_err}"
+        );
+    }
+
+    /// The sentinel Task 1 exists to install: every one of the 27 heads
+    /// `GRAPH_SEAM_HEADS` used to conflate is classified in EXACTLY ONE of
+    /// `EFFECT_POSITION_ONLY` / `UNSERVED_EXPRESSION_HEADS` — so a head can
+    /// never silently fall through to `eval_intrinsic` and report the wrong
+    /// diagnosis (`E-LOAD-021`, undeclared intrinsic) for a form the
+    /// language does have.
+    #[test]
+    fn every_seam_head_is_classified() {
+        const ORIGINAL_27_SEAM_HEADS: [&str; 27] = [
+            "fold",
+            "exists",
+            "forall",
+            "nodes",
+            "edges",
+            "neighbors",
+            "hyperedges",
+            "members-of",
+            "hyperedges-of",
+            "guard",
+            "for-each",
+            "update-node",
+            "update-edge",
+            "update-hyperedge",
+            "add-node",
+            "remove-node",
+            "add-edge",
+            "remove-edge",
+            "add-hyperedge",
+            "remove-hyperedge",
+            "emit",
+            "select-max",
+            "select-min",
+            "field-of",
+            "edge-between",
+            "the",
+            "metric-of",
+        ];
+        for head in ORIGINAL_27_SEAM_HEADS {
+            let in_effect_only = EFFECT_POSITION_ONLY.contains(&head);
+            let in_unserved = UNSERVED_EXPRESSION_HEADS.iter().any(|(h, _)| *h == head);
+            assert!(
+                in_effect_only ^ in_unserved,
+                "{head} must appear in exactly one of EFFECT_POSITION_ONLY / \
+                 UNSERVED_EXPRESSION_HEADS, found effect_only={in_effect_only} \
+                 unserved={in_unserved}"
+            );
         }
     }
 }

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -424,16 +424,23 @@ pub(crate) fn require_graph<'a>(
     })
 }
 
-/// Heads that are EFFECT-position verbs (§2.8) or update-op/grouping forms.
-/// Meeting one of these in EXPRESSION position (this module) is a grammar
-/// error, not an unimplemented seam — §2.7's `<expr>` production has no
-/// production for any of them; they are already served, in effect position,
-/// by [`crate::structural_verbs`]. The ten §2.8 verbs (`update-node`,
-/// `update-edge`, `update-hyperedge`, `add-node`, `remove-node`, `add-edge`,
-/// `remove-edge`, `add-hyperedge`, `remove-hyperedge`, `emit`) plus `guard`
-/// and `for-each` plus the four update-ops (`add`/`sub`/`set`/`scale`) plus
-/// the `members` list form — 17 in all.
-const EFFECT_POSITION_ONLY: [&str; 17] = [
+/// Heads whose grammatical home is EFFECT position (§2.8) or an update-op/
+/// grouping form. Meeting one in EXPRESSION position (this module) is a
+/// grammar error, not an unimplemented seam — §2.7's `<expr>` production has
+/// no production for any of them. (Whether the head is SERVED in effect
+/// position varies: most dispatch in [`crate::structural_verbs`]; `for-each`
+/// and `update-edge`/`update-hyperedge`/`update-membership` refuse there too,
+/// pending their own tasks/slices — the message below claims only the
+/// grammar, never service.) §2.8's `<verb>` production has ELEVEN
+/// alternatives: the ten structural verbs (`update-node`, `update-edge`,
+/// `update-hyperedge`, `update-membership`, `add-node`, `remove-node`,
+/// `add-edge`, `remove-edge`, `add-hyperedge`, `remove-hyperedge`) plus
+/// `emit`. Those eleven, plus `guard` and `for-each`, the four update-ops
+/// (`add`/`sub`/`set`/`scale`), and the two list forms (`members`,
+/// `member`) — 19 in all. (`update-membership`/`member` are Amendment-AG-era
+/// heads absent from `RESERVED_FORM_TAGS`; that reservation gap is a filed
+/// follow-up, not this table's concern.)
+const EFFECT_POSITION_ONLY: [&str; 19] = [
     "guard",
     "for-each",
     "update-node",
@@ -445,32 +452,57 @@ const EFFECT_POSITION_ONLY: [&str; 17] = [
     "remove-edge",
     "add-hyperedge",
     "remove-hyperedge",
+    "update-membership",
     "emit",
     "add",
     "sub",
     "set",
     "scale",
     "members",
+    "member",
 ];
 
 /// Expression heads the query evaluator does not yet serve, each mapped to
 /// the slice of `docs/superpowers/plans/2026-08-11-bsl-query-evaluation-plan.md`
-/// that will: `nodes`/`neighbors`/`fold`/`exists`/`forall`/`select-max`/
-/// `select-min`/`field-of` (slice 1, THIS plan's remaining tasks);
-/// `edges`/`edge-between`/`the` (slice 2, the dyadic edge lane);
-/// `hyperedges`/`members-of`/`hyperedges-of`/`metric-of` (slice 3, the
-/// hyperedge + metric lane). Exhaustive over the pre-Task-1
-/// `GRAPH_SEAM_HEADS` set once [`EFFECT_POSITION_ONLY`] is subtracted from
-/// it: a head in neither table is `eval_intrinsic`'s.
-const UNSERVED_EXPRESSION_HEADS: [(&str, &str); 15] = [
-    ("fold", "slice 1"),
-    ("exists", "slice 1"),
-    ("forall", "slice 1"),
+/// that will: `nodes`/`neighbors` and the node-set shapes of the polymorphic
+/// heads (slice 1, THIS plan's remaining tasks); `edges`/`edge-between`/`the`
+/// (slice 2, the dyadic edge lane); `hyperedges`/`members-of`/
+/// `hyperedges-of`/`metric-of` (slice 3, the hyperedge + metric lane);
+/// `membership-field-of` (slice 4, the CanonicalState-widening storage
+/// lane — Director-ruled deferred to first consumer). The polymorphic heads
+/// (`fold`/`exists`/`forall`/`select-max`/`select-min`/`field-of`) say so in
+/// their slice string: slice 1 serves their NODE-SET shapes; their edge/
+/// hyperedge shapes ride slices 2-3 with the query kinds they range over.
+/// Together with [`EFFECT_POSITION_ONLY`] this is exhaustive over the
+/// pre-Task-1 `GRAPH_SEAM_HEADS` set AND the grammar's §2.8/§2.10 heads:
+/// a head in neither table is `eval_intrinsic`'s.
+const UNSERVED_EXPRESSION_HEADS: [(&str, &str); 16] = [
+    (
+        "fold",
+        "slice 1 (node-set shapes; edge/hyperedge shapes ride slices 2-3)",
+    ),
+    (
+        "exists",
+        "slice 1 (node-set shapes; edge/hyperedge shapes ride slices 2-3)",
+    ),
+    (
+        "forall",
+        "slice 1 (node-set shapes; edge/hyperedge shapes ride slices 2-3)",
+    ),
     ("nodes", "slice 1"),
     ("neighbors", "slice 1"),
-    ("select-max", "slice 1"),
-    ("select-min", "slice 1"),
-    ("field-of", "slice 1"),
+    (
+        "select-max",
+        "slice 1 (node-set shapes; edge/hyperedge shapes ride slices 2-3)",
+    ),
+    (
+        "select-min",
+        "slice 1 (node-set shapes; edge/hyperedge shapes ride slices 2-3)",
+    ),
+    (
+        "field-of",
+        "slice 1 (node refs; edge refs ride slice 2, membership reads slice 4)",
+    ),
     ("edges", "slice 2"),
     ("edge-between", "slice 2"),
     ("the", "slice 2"),
@@ -478,6 +510,7 @@ const UNSERVED_EXPRESSION_HEADS: [(&str, &str); 15] = [
     ("members-of", "slice 3"),
     ("hyperedges-of", "slice 3"),
     ("metric-of", "slice 3"),
+    ("membership-field-of", "slice 4"),
 ];
 
 fn eval_form(
@@ -513,8 +546,8 @@ fn eval_form(
                     "({name} …) is an effect-position verb or grouping form \
                      (§2.8) — using it in expression position is a grammar \
                      error, not an unimplemented seam: §2.7's <expr> \
-                     production has no ({name} …) form; it is already \
-                     served, in effect position, by structural_verbs"
+                     production has no ({name} …) form; its grammatical home \
+                     is effect position (§2.8)"
                 )));
             }
             if let Some((_, slice)) = UNSERVED_EXPRESSION_HEADS.iter().find(|(h, _)| *h == name) {
@@ -1318,8 +1351,12 @@ mod tests {
     #[test]
     fn it_outside_any_iterating_form_is_loud() {
         let err = eval("it").unwrap_err();
-        assert!(err.message.contains("it"), "{err}");
+        // The load-bearing assertions pin the ELEMENT-STACK refusal
+        // specifically — `contains("it")` alone was vacuous (the verify
+        // round showed the unbound-variable fall-through also contains
+        // "it"), so the §2.6 citation and the stack wording carry the test.
         assert!(err.message.contains("§2.6"), "{err}");
+        assert!(err.message.contains("element stack is empty"), "{err}");
     }
 
     /// Task 2: `EvalEnv.graph` is `None` for the pure-expression callers
@@ -1480,6 +1517,27 @@ mod tests {
             "{members_of_err}"
         );
 
+        // `for-each` in expression position: a grammar error naming its
+        // §2.8 home — and NEVER a claim that it is already served in effect
+        // position (it refuses there too, pending Task 10; the verify round
+        // caught the earlier message asserting service that does not exist).
+        let for_each_err = eval("(for-each (nodes NodeType/X) (emit EventType/E))").unwrap_err();
+        assert!(for_each_err.message.contains("§2.8"), "{for_each_err}");
+        assert!(
+            !for_each_err.message.contains("already served"),
+            "the refusal must claim only the grammar, never service: {for_each_err}"
+        );
+
+        // `update-membership` (Amendment-AG-era §2.8 verb): same grammar
+        // refusal, not E-LOAD-021 "undeclared intrinsic".
+        let upd_mem_err = eval("(update-membership self self (set x/y 1))").unwrap_err();
+        assert!(upd_mem_err.message.contains("§2.8"), "{upd_mem_err}");
+        assert!(!upd_mem_err.message.contains("E-LOAD-021"), "{upd_mem_err}");
+
+        // `membership-field-of` (§2.10) is unserved until slice 4.
+        let mem_field_err = eval("(membership-field-of self self x/y)").unwrap_err();
+        assert!(mem_field_err.message.contains("slice 4"), "{mem_field_err}");
+
         // `update-edge`'s EFFECT-position storage refusal
         // (`structural_verbs.rs`, untouched by this task) still names
         // Constitution III.7 — a regression guard, not a new behaviour.
@@ -1520,51 +1578,64 @@ mod tests {
         );
     }
 
-    /// The sentinel Task 1 exists to install: every one of the 27 heads
-    /// `GRAPH_SEAM_HEADS` used to conflate is classified in EXACTLY ONE of
-    /// `EFFECT_POSITION_ONLY` / `UNSERVED_EXPRESSION_HEADS` — so a head can
-    /// never silently fall through to `eval_intrinsic` and report the wrong
-    /// diagnosis (`E-LOAD-021`, undeclared intrinsic) for a form the
-    /// language does have.
+    /// The sentinel Task 1 exists to install: a form the language HAS can
+    /// never fall through to `eval_intrinsic` and report the wrong
+    /// diagnosis (`E-LOAD-021`, undeclared intrinsic). Proven MECHANICALLY,
+    /// not against a hard-coded historical list (the verify round showed the
+    /// original 27-head copy could not catch an unclassified grammar head):
+    /// every entry of `declarations::RESERVED_FORM_TAGS` partitions into
+    /// exactly one of {evaluator-served, effect-position-only, unserved-
+    /// expression, declaration-level}, with no remainder — plus the three
+    /// Amendment-AG-era heads that predate their own `RESERVED_FORM_TAGS`
+    /// rows (a filed reservation-gap follow-up).
     #[test]
     fn every_seam_head_is_classified() {
-        const ORIGINAL_27_SEAM_HEADS: [&str; 27] = [
-            "fold",
-            "exists",
-            "forall",
-            "nodes",
-            "edges",
-            "neighbors",
-            "hyperedges",
-            "members-of",
-            "hyperedges-of",
-            "guard",
-            "for-each",
-            "update-node",
-            "update-edge",
-            "update-hyperedge",
-            "add-node",
-            "remove-node",
-            "add-edge",
-            "remove-edge",
-            "add-hyperedge",
-            "remove-hyperedge",
-            "emit",
-            "select-max",
-            "select-min",
-            "field-of",
-            "edge-between",
-            "the",
-            "metric-of",
+        const EVALUATOR_SERVED: [&str; 4] = ["and", "or", "not", "if"];
+        // Tags that are declaration/top-form/clause vocabulary, never
+        // expression-position heads — the load layer owns them.
+        const DECLARATION_LEVEL: [&str; 13] = [
+            "anchor",
+            "binding",
+            "bindings",
+            "ceiling",
+            "deffield",
+            "domain",
+            "effects",
+            "intrinsic",
+            "manifest",
+            "metric",
+            "opt",
+            "rule",
+            "when",
         ];
-        for head in ORIGINAL_27_SEAM_HEADS {
+        let mut unclassified = Vec::new();
+        for tag in crate::declarations::RESERVED_FORM_TAGS {
+            let buckets = [
+                EVALUATOR_SERVED.contains(&tag),
+                EFFECT_POSITION_ONLY.contains(&tag),
+                UNSERVED_EXPRESSION_HEADS.iter().any(|(h, _)| *h == tag),
+                DECLARATION_LEVEL.contains(&tag),
+            ];
+            match buckets.iter().filter(|b| **b).count() {
+                1 => {}
+                0 => unclassified.push(tag),
+                n => panic!("{tag} appears in {n} buckets — the partition must be exclusive"),
+            }
+        }
+        assert!(
+            unclassified.is_empty(),
+            "unclassified RESERVED_FORM_TAGS (each would misdiagnose as \
+             E-LOAD-021): {unclassified:?}"
+        );
+        // The AG-era heads are absent from RESERVED_FORM_TAGS (filed gap)
+        // but MUST still be classified here so they refuse with the right
+        // diagnosis today.
+        for head in ["update-membership", "member", "membership-field-of"] {
             let in_effect_only = EFFECT_POSITION_ONLY.contains(&head);
             let in_unserved = UNSERVED_EXPRESSION_HEADS.iter().any(|(h, _)| *h == head);
             assert!(
                 in_effect_only ^ in_unserved,
-                "{head} must appear in exactly one of EFFECT_POSITION_ONLY / \
-                 UNSERVED_EXPRESSION_HEADS, found effect_only={in_effect_only} \
-                 unserved={in_unserved}"
+                "AG-era head {head} must be classified in exactly one table"
             );
         }
     }

--- a/rust/crates/babylon-bsl/src/lib.rs
+++ b/rust/crates/babylon-bsl/src/lib.rs
@@ -18,6 +18,7 @@ pub mod manifest;
 pub mod material_basis;
 pub mod metrics;
 pub mod mod_anchors;
+pub mod query;
 pub mod reader;
 pub mod rule_pipeline;
 pub mod scenario;
@@ -54,6 +55,7 @@ pub use manifest::{check_rule_against_manifest, CeilingRow, Manifest, ManifestEr
 pub use material_basis::{check_rule_surface, SurfaceError, MAX_FUEL};
 pub use metrics::{MetricDecl, MetricDomain, MetricError, MetricRegistry};
 pub use mod_anchors::{check_anchor, AnchorDecl, AnchorError, AnchorPosition};
+pub use query::Element;
 pub use reader::{
     read, read_all, Atom, LexCode, ReadError, ReadErrorKind, SExpr, ScaledKind, ScaledLit,
 };

--- a/rust/crates/babylon-bsl/src/query.rs
+++ b/rust/crates/babylon-bsl/src/query.rs
@@ -1,0 +1,42 @@
+//! Query element materialization (`bsl-language.rst` §2.6).
+//!
+//! **Slice boundary, recorded honestly.** Task 2 of the BSL
+//! query-evaluation plan
+//! (`docs/superpowers/plans/2026-08-11-bsl-query-evaluation-plan.md`) adds
+//! this module a task early, so [`crate::evaluator::EvalEnv`]'s §2.6
+//! chapter C8 element stack has a type to hold before any query head
+//! actually produces one — the environment cannot express "the element the
+//! innermost enclosing iterating form bound" without it. Task 4 is the one
+//! that fills in `ElementSet` and `materialize()` (the six heads' dispatch,
+//! the §2.6 total order, the `neighbors` type filter); that work is **not**
+//! done here.
+//!
+//! Only [`Element::Node`] exists yet. `Edge(EdgeKey)` (slice 2 — `EdgeKey`
+//! is not a type this codebase has minted) and `Hyperedge(HyperedgeId)`
+//! (slice 3) are deliberately not added here: minting `EdgeKey` is slice 2's
+//! own scope, not Task 2's, and a variant nothing can construct would be
+//! dead weight, not forward-compatibility.
+
+use crate::evaluator::Value;
+use babylon_graph::substrate::NodeId;
+
+/// One materialized graph element (§2.6). See the module doc for why only
+/// `Node` exists yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Element {
+    /// A materialized node — the only element kind slice 1's node-set query
+    /// lane produces.
+    Node(NodeId),
+}
+
+impl Element {
+    /// This element's runtime value. An element reached through `it` or a
+    /// `:as` name is a reference of the appropriate kind (§2.6) — for
+    /// `Node`, exactly what `self`/`add-node` already produce.
+    #[must_use]
+    pub fn to_value(self) -> Value {
+        match self {
+            Self::Node(id) => Value::NodeRef(id),
+        }
+    }
+}

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -419,6 +419,11 @@ pub fn resolve_expr_bindings<S: std::hash::BuildHasher + Clone>(
         let scope = EvalEnv {
             bindings: env.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
             intrinsic_costs,
+            // A `:expr` binding is a pure-expression caller (§4.2) — it has
+            // no query/element context of its own (Task 2, P27 Phase 2
+            // Slice 1).
+            graph: None,
+            elements: Vec::new(),
         };
         let value = evaluate(expr, &scope, host, fuel)?;
         env.insert(decl.name.clone(), value);

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -800,6 +800,8 @@ mod tests {
             let env = EvalEnv {
                 bindings: HashMap::from([("self".to_owned(), Value::NodeRef(self.self_id))]),
                 intrinsic_costs: &self.costs,
+                graph: None,
+                elements: Vec::new(),
             };
             let types = types();
             let mut executor = EffectExecutor::new(&types);
@@ -831,6 +833,8 @@ mod tests {
             let env = EvalEnv {
                 bindings: HashMap::from([("self".to_owned(), Value::NodeRef(self.self_id))]),
                 intrinsic_costs: &self.costs,
+                graph: None,
+                elements: Vec::new(),
             };
             let types = types();
             let mut log = CollectingWriteLog::new();
@@ -1186,6 +1190,8 @@ mod tests {
             let env = EvalEnv {
                 bindings: HashMap::from([("self".to_owned(), Value::NodeRef(fixture.self_id))]),
                 intrinsic_costs: &costs,
+                graph: None,
+                elements: Vec::new(),
             };
             let types = types();
             let mut executor = EffectExecutor::new(&types);

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -398,6 +398,16 @@ pub fn run_tick(
         let env = EvalEnv {
             bindings: values,
             intrinsic_costs: costs,
+            // Task 2 (P27 Phase 2 Slice 1): the environment shape carries a
+            // graph now, but this driver keeps passing `None` here — `env`
+            // is still alive (borrowed by `evaluate` for the guard) at the
+            // point `execute_effects` below needs `graph: &mut dyn
+            // GraphSubstrate`; holding `Some(&*graph)` in `env` at the same
+            // time would alias a live `&mut`. Wiring a real graph reference
+            // through the guard is Task 4+'s query-dispatch work, on the
+            // far side of that aliasing question — not this task's.
+            graph: None,
+            elements: Vec::new(),
         };
 
         if let Some(guard) = guard {

--- a/rust/crates/babylon-bsl/tests/conformance_corpus.rs
+++ b/rust/crates/babylon-bsl/tests/conformance_corpus.rs
@@ -167,6 +167,8 @@ fn eval_when(rule: &LoadedRule, supplied: &HashMap<String, Value>) -> bool {
     let env = EvalEnv {
         bindings: env_map,
         intrinsic_costs: &costs,
+        graph: None,
+        elements: Vec::new(),
     };
     let babylon_bsl::SExpr::List(items) = &rule.rule else {
         unreachable!()
@@ -607,6 +609,8 @@ fn bifurcation_routes_by_solidarity_density() {
         let env = EvalEnv {
             bindings: env_map,
             intrinsic_costs: &costs,
+            graph: None,
+            elements: Vec::new(),
         };
         let babylon_bsl::SExpr::List(items) = &loaded.rule else {
             unreachable!()
@@ -718,6 +722,8 @@ fn eval_value(source: &str, env_pairs: &[(&str, Value)]) -> Value {
     let env = EvalEnv {
         bindings: owned(env_pairs.to_vec()),
         intrinsic_costs: &costs,
+        graph: None,
+        elements: Vec::new(),
     };
     let (expr, _) = read(source).expect("vector source must parse");
     let mut fuel = 10_000;
@@ -736,6 +742,8 @@ fn eval_cond_err(source: &str, env_pairs: &[(&str, Value)]) -> babylon_bsl::Eval
     let env = EvalEnv {
         bindings: owned(env_pairs.to_vec()),
         intrinsic_costs: &costs,
+        graph: None,
+        elements: Vec::new(),
     };
     let (expr, _) = read(source).expect("vector source must parse");
     let mut fuel = 10_000;

--- a/rust/crates/babylon-graph/src/conformance.rs
+++ b/rust/crates/babylon-graph/src/conformance.rs
@@ -41,6 +41,8 @@ where
     state_hash_is_stable_and_order_invariant_and_sensitive(&make);
     a_decade_boundary_orders_numerically_not_lexicographically(&make);
     declared_order_never_leaks_through_any_ranged_accessor(&make);
+    node_type_of_reports_the_declared_type(&make);
+    node_type_of_a_dangling_id_is_loud_not_untyped(&make);
 }
 
 /// ADR185 R2: removing a node takes its incident dyadic edges, its
@@ -477,6 +479,38 @@ where
         "hyperedges_of orders ascending HyperedgeId — mint order here, \
          since ids are assigned monotonically and cannot themselves be \
          declared out of order"
+    );
+}
+
+/// Task 3 (P27 Phase 2 Slice 1, `bsl-language.rst` §2.6 D24 / §2.10
+/// discipline 1): `node_type_of` reports the declared type a live node was
+/// minted under — the same fact `all_nodes`/`nodes(node_type)` already
+/// report, read through a keyed lookup instead of a ranged listing.
+fn node_type_of_reports_the_declared_type<G, F>(make: &F)
+where
+    G: GraphSubstrate + CanonicalState,
+    F: Fn() -> G,
+{
+    let mut graph = make();
+    let class = graph.add_node("SOCIAL_CLASS").unwrap();
+    let territory = graph.add_node("TERRITORY").unwrap();
+    assert_eq!(graph.node_type_of(class).unwrap(), "SOCIAL_CLASS");
+    assert_eq!(graph.node_type_of(territory).unwrap(), "TERRITORY");
+}
+
+/// A dangling [`NodeId`] must never read as an untyped node — the same
+/// honest-null discipline `node_attribute`/`neighbors` already hold
+/// (III.11): absence is a loud [`crate::substrate::GraphError`], never an
+/// empty string or a default.
+fn node_type_of_a_dangling_id_is_loud_not_untyped<G, F>(make: &F)
+where
+    G: GraphSubstrate + CanonicalState,
+    F: Fn() -> G,
+{
+    let graph = make();
+    assert!(
+        graph.node_type_of(NodeId(999_999)).is_err(),
+        "a dangling NodeId must be a loud error, never an untyped read"
     );
 }
 

--- a/rust/crates/babylon-graph/src/hypergraph_store.rs
+++ b/rust/crates/babylon-graph/src/hypergraph_store.rs
@@ -414,10 +414,13 @@ impl GraphSubstrate for HypergraphStore {
         Ok(found)
     }
 
-    fn node_type_of(&self, id: NodeId) -> Result<String, GraphError> {
-        self.nodes.get(&id).cloned().ok_or_else(|| GraphError {
-            message: format!("no such node: {id:?} — a dangling ref never reads as untyped"),
-        })
+    fn node_type_of(&self, id: NodeId) -> Result<&str, GraphError> {
+        self.nodes
+            .get(&id)
+            .map(String::as_str)
+            .ok_or_else(|| GraphError {
+                message: format!("no such node: {id:?} — a dangling ref never reads as untyped"),
+            })
     }
 }
 

--- a/rust/crates/babylon-graph/src/hypergraph_store.rs
+++ b/rust/crates/babylon-graph/src/hypergraph_store.rs
@@ -413,6 +413,12 @@ impl GraphSubstrate for HypergraphStore {
         found.sort_unstable();
         Ok(found)
     }
+
+    fn node_type_of(&self, id: NodeId) -> Result<String, GraphError> {
+        self.nodes.get(&id).cloned().ok_or_else(|| GraphError {
+            message: format!("no such node: {id:?} — a dangling ref never reads as untyped"),
+        })
+    }
 }
 
 impl CanonicalState for HypergraphStore {
@@ -480,9 +486,42 @@ impl CanonicalState for HypergraphStore {
 mod tests {
     use super::HypergraphStore;
     use crate::conformance::run_substrate_conformance;
+    use crate::state_hash::CanonicalState;
+    use crate::substrate::GraphSubstrate;
+    use std::fmt::Write as _;
 
     #[test]
     fn hypergraph_store_passes_the_conformance_suite() {
         run_substrate_conformance(HypergraphStore::new);
+    }
+
+    /// Task 3's III.7 evidence, not a claim (P27 Phase 2 Slice 1): the
+    /// literal below was captured from `dev` BEFORE `node_type_of` was
+    /// added — this fixture (3 nodes, 2 edges, 1 hyperedge, mixed
+    /// attributes) is the III.7 baseline, and this test is run again AFTER
+    /// the trait widens to prove the hash did not move.
+    #[test]
+    fn adding_a_read_only_query_method_does_not_move_the_state_hash() {
+        let mut graph = HypergraphStore::new();
+        let a = graph.add_node("SOCIAL_CLASS").unwrap();
+        let b = graph.add_node("SOCIAL_CLASS").unwrap();
+        let c = graph.add_node("TERRITORY").unwrap();
+        graph.update_node(a, "social-class/wages", 120.0).unwrap();
+        graph.update_node(a, "social-class/agitation", 0.3).unwrap();
+        graph.update_node(c, "territory/heat", 0.5).unwrap();
+        graph.add_edge("SOLIDARITY", a, b, 0.75).unwrap();
+        graph.add_edge("ADJACENCY", b, c, 1.0).unwrap();
+        graph.add_hyperedge("CELL", &[a, b, c]).unwrap();
+
+        let hash = graph.state_hash().unwrap();
+        let hex = hash.iter().fold(String::new(), |mut acc, byte| {
+            let _ = write!(acc, "{byte:02x}");
+            acc
+        });
+        assert_eq!(
+            hex, "9577d95124a7c4ed6faad2c4aca5980b435fb73e7b58813413500a5fdef798ed",
+            "state_hash moved — node_type_of must be III.7-clean (read-only, \
+             no new CanonicalState section, no byte moved)"
+        );
     }
 }

--- a/rust/crates/babylon-graph/src/memory.rs
+++ b/rust/crates/babylon-graph/src/memory.rs
@@ -325,6 +325,12 @@ impl GraphSubstrate for MemoryGraph {
         found.sort_unstable();
         Ok(found)
     }
+
+    fn node_type_of(&self, id: NodeId) -> Result<String, GraphError> {
+        self.nodes.get(&id).cloned().ok_or_else(|| GraphError {
+            message: format!("no such node: {id:?} — a dangling ref never reads as untyped"),
+        })
+    }
 }
 
 #[cfg(test)]

--- a/rust/crates/babylon-graph/src/memory.rs
+++ b/rust/crates/babylon-graph/src/memory.rs
@@ -326,10 +326,13 @@ impl GraphSubstrate for MemoryGraph {
         Ok(found)
     }
 
-    fn node_type_of(&self, id: NodeId) -> Result<String, GraphError> {
-        self.nodes.get(&id).cloned().ok_or_else(|| GraphError {
-            message: format!("no such node: {id:?} — a dangling ref never reads as untyped"),
-        })
+    fn node_type_of(&self, id: NodeId) -> Result<&str, GraphError> {
+        self.nodes
+            .get(&id)
+            .map(String::as_str)
+            .ok_or_else(|| GraphError {
+                message: format!("no such node: {id:?} — a dangling ref never reads as untyped"),
+            })
     }
 }
 

--- a/rust/crates/babylon-graph/src/substrate.rs
+++ b/rust/crates/babylon-graph/src/substrate.rs
@@ -172,8 +172,7 @@ pub trait GraphSubstrate {
     /// # Errors
     /// Returns [`GraphError`] if `node` does not exist — a dangling
     /// `NodeRef` must never read as an empty neighborhood (the honest-null
-    /// discipline; contrast `hyperedges_of`, whose infallible signature
-    /// predates this ruling and is flagged for Phase-2 review).
+    /// discipline).
     fn neighbors(
         &self,
         node: NodeId,
@@ -233,4 +232,18 @@ pub trait GraphSubstrate {
         node: NodeId,
         hyperedge_type: &str,
     ) -> Result<Vec<HyperedgeId>, GraphError>;
+
+    /// The declared type of a live node — `(neighbors … <NodeType>)`'s
+    /// filter (§2.6, D24: this operand FILTERS) and §2.10 discipline 1's
+    /// `E-EVAL-033` referent check both need it, and neither is expressible
+    /// without it.
+    ///
+    /// READ-ONLY: it reports a fact the substrate already stores to satisfy
+    /// [`Self::nodes`]. It adds no state, and `CanonicalState`'s four
+    /// sections are untouched.
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if `id` names no live node — a dangling
+    /// `NodeRef` never reads as an untyped node (III.11).
+    fn node_type_of(&self, id: NodeId) -> Result<String, GraphError>;
 }

--- a/rust/crates/babylon-graph/src/substrate.rs
+++ b/rust/crates/babylon-graph/src/substrate.rs
@@ -245,5 +245,5 @@ pub trait GraphSubstrate {
     /// # Errors
     /// Returns [`GraphError`] if `id` names no live node — a dangling
     /// `NodeRef` never reads as an untyped node (III.11).
-    fn node_type_of(&self, id: NodeId) -> Result<String, GraphError>;
+    fn node_type_of(&self, id: NodeId) -> Result<&str, GraphError>;
 }


### PR DESCRIPTION
## What

Tasks 1-3 of the merged query-evaluation plan (`docs/superpowers/plans/2026-08-11-bsl-query-evaluation-plan.md`) — the foundation PR group for slice 1.

- **Task 1** — `GRAPH_SEAM_HEADS` (27) splits into `EFFECT_POSITION_ONLY` (17, grammar-error message citing §2.8) and `UNSERVED_EXPRESSION_HEADS` (15, each refusal names the slice that will serve it: slice 1/2/3).
- **Task 2** — `EvalEnv` gains `graph: Option<&dyn GraphSubstrate>` + the §2.6 element stack; `it` resolves through the stack only (loud outside an iterating form, citing §2.6); `require_graph()` is the one seam every future query head calls.
- **Task 3** — `GraphSubstrate::node_type_of` (read-only, loud on dangling id), implemented on BOTH stores, proven through the shared conformance suite; **hash-invariance proof**: state-hash literal `9577d951…98ed` captured BEFORE the trait widening, pinned, unmoved after. #464's stale-doc harvest applied (the `hyperedges_of` infallible-signature note, verified already-stale on dev before deletion).

## Red→green evidence

Task 1: E0425 on the named consts → 32/32. Task 2: E0560/E0425 → 329/329. Task 3: E0599 ×3 call sites → 88/88 with the pinned hash literal unmoved. Full four-leg gate green (fmt / clippy `-D warnings` workspace / scoped tests 121+88 / doc `-D warnings`).

## Judgment calls (from the implementation report, for reviewers)

1. `query.rs` created one task early holding only `Element::Node` — Task 2's interface needs the type; `Edge`/`Hyperedge` variants wait for slice 2 (`EdgeKey` isn't minted yet). Documented for Task 4's executor.
2. The plan's literal red-phase test bodies for Task 2 would only have re-exercised Task 1's refusal seam (those heads dispatch in Task 4/5), so the tests pin Task 2's actual surface instead: `eval("it")` directly, and `require_graph` directly. Reasoning in-file.
3. `require_graph` carries a function-scoped `#[allow(dead_code)]` until Task 4 wires it into query dispatch.
4. `tick.rs` keeps `graph: None` in the guard-evaluation env — threading `Some(&*graph)` there would alias the live mutable borrow `execute_effects` needs; resolving that aliasing is Task 4's dispatch work, noted in-line.

Pre-existing, untouched: `babylon-graph/tests/storage_benchmark.rs` has a clippy-pedantic doc-backtick nit present on dev before this branch (babylon-graph is not held to pedantic in the sanctioned gate).

Adversarial verification runs before merge per branch standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Verification + fix round (pre-merge, per branch standard)

Opus adversarial verification: **no blockers; 2 MAJORs, 4 minors — all repaired or recorded in `8ca54443`**; 8 clean-passes with evidence, including: the pinned state-hash **independently reproduced in Python from the byte-layout spec alone** (proving the literal is spec-derived, not code-derived); both substituted tests proven non-vacuous by mutation (and the plan's literal test bodies proven WRONG — one false-green over dead code, one permanently red until Task 5); the old refused set shown to be 32 (27 + the 5-head `matches!` arm), split set-identically — no head added, dropped, or double-listed.

Repairs: refusal messages claim only the grammar (the 'already served by structural_verbs' tail was false for 3 of 17 heads); §2.8's eleven-verb enumeration corrected; the three AG-era heads (`update-membership`/`member`/`membership-field-of`) classified — they previously fell through to the E-LOAD-021 misdiagnosis this task exists to prevent; polymorphic heads' slice strings scoped; the `it`-test's vacuous assertion replaced with discriminating wording; `every_seam_head_is_classified` rewritten as a mechanical partition of all 49 `RESERVED_FORM_TAGS` (no remainder) instead of a hard-coded historical copy. The `RESERVED_FORM_TAGS` reservation gap for the AG-era heads is filed on #503 (item 8) for the slice-4/AG train.