### PR TITLE
docs(bsl): enum deffield row + defenum/defvocabulary + the vocabulary-ceremony ADRs (org foundation Group A)

### DIFF
--- a/ai/decisions/ADR195_enum_deffield_row.yaml
+++ b/ai/decisions/ADR195_enum_deffield_row.yaml
@@ -1,0 +1,200 @@
+ADR195_enum_deffield_row:
+  status: "accepted"
+  date: "2026-08-11"
+  title: "The enum deffield row — Director ruling (Organization-as-game-object spec §1 Q12, 2026-08-11, approved twice): a seventh <type-name> row, `enum`, joins the six D94 sealed — a content-declared closed enum's member, stored as the declared-order ordinal in the existing binary64 attribute lane, surfaced ONLY as an EnumRef (never a bare number, in either direction); explicitly SUPERSEDES D94's six-row closure rather than silently reopening it"
+  context: |
+    ADR176 (34) had already retired five dead `EdgeType` members with the
+    intent to re-mint a graph vocabulary under BSL "in Phase 2 with their
+    own vocabulary ceremony". The Organization-as-game-object design work
+    (`docs/superpowers/specs/2026-08-11-organization-game-object-design.md`,
+    Director-approved 2026-08-11) needed exactly that ceremony for its Q1
+    ruling — "Content-declared kinds. One kernel `NodeType/ORGANIZATION`;
+    the four kinds (state / capital / party / civil-society) are a
+    content-declared enum field" — and for its Q15 founding-edge
+    vocabulary. Both needed a way to WRITE a closed enum's member into a
+    field at all, and the language had none: `bsl-language.rst` §3.1's
+    `<type-name>` table was sealed at six rows exactly one review earlier,
+    the same session, by D94 (`ADR191 R4`) — "no `<type-name>` position can
+    name" a seventh kind, ruled after the Phase-1 review's own two-repair
+    disposition. `Enum<T>` existed as a *typechecker* classification (the
+    static type of an `<enum-ref>` expression, `NodeType/SOCIAL_CLASS`
+    e.g.) but explicitly "Not storable" — nothing a `deffield` could
+    declare turned an enum reference into field STATE.
+
+    The Director ruled Q12 knowingly against that closure, in the same
+    session: "Mint the `enum` deffield row — a seventh type: declared
+    value set, validated symbol, canonical hashing. Language change,
+    chartered; first consumer is Q1's kind field." The question put to
+    her named the collision directly ("sealed twice this month"), and she
+    approved minting the seventh row twice — once live in the
+    brainstorming session, once again reviewing the written spec — rather
+    than treating D94 as an oversight to route around silently. This ADR
+    and its sibling D101/D102 register rows are the record that the
+    supersession was explicit, per the Organization foundation
+    implementation plan's Global Constraint 6
+    (`docs/superpowers/plans/2026-08-11-organization-foundation-plan.md`).
+
+    This ADR covers Task 1 of that plan only — the LANGUAGE CHANGE (spec
+    text: the type-table row, the widened `deffield` production, the
+    `defenum`/`defvocabulary` declaration forms, the error-code taxonomy,
+    the ebnf mirror). No Rust source is touched by this ADR; the reference
+    implementation (`EnumRegistry`, the `.bscn` loader, the runtime write/
+    read paths, vocabulary enforcement) is Tasks 3-10 of the same plan, a
+    separate cargo-gated lane not yet landed (the plan's Constraint 7:
+    Rust tasks wait on the query-evaluation slice-1 train having merged,
+    which it has, per PR #514, but the Rust work itself is future PRs).
+  decision: |
+    THE SEVENTH ROW (`bsl-language.rst` §3.1): `enum` — "one member of a
+    content-declared closed `defenum` type" — joins `int`/`bool`/
+    `currency`/`probability`/`intensity`/`coefficient` as a type a
+    `deffield` or `metric` may write after `:type`. The sealing paragraph
+    is REWRITTEN, not silently contradicted: it now reads "the seven rows
+    above", names all seven, and states explicitly that the seventh was
+    "minted afterward by the Director's own ruling... a knowing
+    supersession of D94's closure, not a silent reopening." D94 itself is
+    left unedited (Immutability of History — it captured what was true
+    through that review) and stands beside the new paragraph as the
+    historical record of the prior state.
+
+    ORDINAL STORAGE, ENUMREF SURFACE (the load-bearing law, spec §1 Q12's
+    "Architecture" framing, "Half-1 argument"): the enum's value is stored
+    as the member's DECLARED-ORDER ordinal in the SAME binary64 attribute
+    lane every other scalar field already uses — zero bytes of any
+    existing golden move, because an enum field's stored value is an
+    ordinary `§0x02` f64 row exactly like a `Probability` or `Coefficient`
+    field's. The ordinal is NEVER a surface value in either direction: a
+    `.bscn` body seeds the field with `<EnumType>/<MEMBER>` only (a bare
+    number is a load error), a structural-verb write accepts only a
+    matching `EnumRef` (a bare `Real` is an eval error), and a read
+    renders the stored ordinal back to its member as `Value::Enum` (never
+    a bare number a rule author could mistake for magnitude). Declaration
+    order is normative — it IS the ordinal — which is why the new
+    `EnumRegistry` construct (Task 3, not built by this ADR) must never
+    reuse the existing `ClosedVocabulary` machinery: that registry sorts
+    and deduplicates its members by design (no ordinal to preserve),
+    exactly wrong for a type whose member order the storage layer depends
+    on.
+
+    TWO REGISTRIES, NEVER ONE. The existing closed-vocabulary machinery
+    (`bsl-language.rst` §3.6, `vocabulary.rs`'s `ClosedVocabulary`) governs
+    the four STRUCTURAL kinds (`NodeType`/`EdgeType`/`HyperedgeType`/
+    `EventType`) and already carries its own error codes (`E-LOAD-030`/
+    `E-LOAD-031`/`E-LOAD-032`/`E-LOAD-033`/`E-LOAD-023`). Q12's `enum` row
+    is a SEPARATE, content-declared registry (`defenum`, new §2.13) for
+    field VALUES, not graph-element kinds. Which registry an `<enum-ref>`
+    checks against is a property of WHERE it sits (a §2.6 class-rule
+    operand vs. an `:enum-type`-declared field's value position), never a
+    guessed fallback between the two.
+
+    NEW DECLARATION FORMS (new §2.13, "Declaring enums and the graph
+    vocabulary"): `defenum` (mints a content-declared enum type and its
+    member ordinals) and `defvocabulary` (populates the EXISTING closed
+    graph vocabulary registry — §3.6's, unchanged in kind, just no longer
+    permanently empty). Both are `<top-form>`s, both hashed exactly as
+    `deffield`/`manifest`/`metric` already are (no new sibling digest, no
+    change to any existing form's encoding — proved in the appendix by the
+    same "§5.6's 421 bytes and both digests remain correct as written"
+    argument every prior additive §5.2 extension carries).
+
+    NO AGGREGATION KIND: `deffield`'s `:kind` slot widens to an
+    exclusive-or with a new `:enum-type` keyword — every `:type` but
+    `enum` still requires `:kind` and forbids `:enum-type`; `:type enum`
+    requires `:enum-type` (naming a `defenum`-declared type) and forbids
+    `:kind`. This is not a special case bolted onto the aggregation-law
+    table (§3.4): `Enum<T>` supports no arithmetic operation beyond `=`/
+    `!=` (§3.1), so an enum-typed value structurally never reaches a fold
+    with a kind to check.
+
+    ERROR CODES, contiguous with the existing sequences (§4.6, grep-
+    verified next-free at execution time: `E-LOAD` max was `052`, `E-EVAL`
+    max was `041` — no collision, no in-flight PR minting adjacent
+    numbers): `E-LOAD-053` (the `:kind`/`:enum-type` shape exclusivity
+    violation), `E-LOAD-054` (an `:enum-type` naming an unregistered
+    `defenum` type), `E-LOAD-055` (an `<enum-ref>` naming a member its
+    resolved type does not declare), `E-LOAD-056` (a non-`<enum-ref>`
+    value seeding an `:enum-type`-declared field at content-load time),
+    `E-EVAL-042` (the same law's runtime re-check on a structural-verb
+    write). `defvocabulary` membership violations deliberately do NOT get
+    parallel codes — they reuse `E-LOAD-030`/`E-LOAD-031`, the codes §3.6
+    already carries, now reachable from a real declaration rather than a
+    permanently-`None` registry; minting synonyms for an identical check
+    against a different populated instance of the same registry kind would
+    be exactly the hygiene defect D75 already rules against.
+
+    FIELD-OF DEFERRAL: §2.10's `field-of` accessor is NOT extended to
+    `:enum-type`-declared fields by this ruling — such a field is read
+    only through a `:field` binding (§2.5). The gap is named, not silently
+    left: D102 records it as deferred (an enum-declared EDGE or HYPEREDGE
+    field is not ruled out and would need exactly this accessor), owed to
+    whichever later revision first needs one.
+  consequences: |
+    `bsl-language.rst` gains its seventh normative `<type-name>` row and a
+    new §2.13. `bsl.ebnf` mirrors it: `top-form` widens with `defenum`/
+    `defvocabulary`, `deffield` widens with the `:enum-type` alternative,
+    and the two new productions reuse the EXISTING `enum-type`/`enum-
+    member` productions (§1.4) rather than inventing parallel ones. The
+    Draft-Ruling Register gains D101 (the row + explicit D94 supersession)
+    and D102 (the field-of deferral), both next-free against the register
+    at execution time (highest prior row was D100).
+
+    Discovered while writing the ebnf mirror: the CURRENT tree-sitter
+    tooling (`tools/tree-sitter-bsl`, a derived, non-normative editor-
+    tooling artifact) tokenizes an enum type name and its member as ONE
+    fused `enum_ref` atom (`Type/MEMBER`), with no way to lex either half
+    standalone — which `defenum`'s bare `<enum-type-name>` operand needs.
+    A scratch `tree-sitter parse` against `(defenum OrgKind (...))`
+    confirmed this produces a parse ERROR under the unmodified grammar.
+    Minimal, precedent-following additions (two new bare tokens, two new
+    rules shaped exactly like `manifest`/`ceiling`) were added rather than
+    leave a known-broken corpus case; `tree-sitter generate && tree-sitter
+    test` is 31/31 green with the new case included. This is JS tooling
+    work, not the babylon-bsl/babylon-tick cargo workspace, so it did not
+    touch the cargo lane the query-evaluation train (PR #514, merged) and
+    Tasks 3-10 of this plan share.
+
+    NOT YET DONE (Tasks 3-10 of the Organization foundation plan, cargo-
+    gated, a separate future PR lane): `EnumRegistry`/`EnumTypeId` in
+    `babylon-bsl`'s `types.rs`; the `.bscn` `defenum`/enum-`deffield`/
+    `defvocabulary` loader in `scenario.rs`; the runtime write path in
+    `structural_verbs.rs`; the read path in `tick.rs`; vocabulary
+    enforcement at the three producers `rule_pipeline.rs`/`scenario.rs`/
+    `structural_verbs.rs`; and `organization/kind`'s actual seeding in the
+    `organization-foundation.bscn` golden. `organization/kind` is this
+    row's DESIGNATED first consumer per Q12's own text, not yet a working
+    one — no Rust code reads this ADR's spec text yet.
+  verification: |
+    `mise run test:q -- tests/unit/reference/test_bsl_grammar_sync.py`:
+    32/32 green, including the new `TestTheEnumRowStaysInSync` class (4
+    tests). Red phase confirmed first: all 4 failed for the stated reasons
+    (no seventh type-table row; "seven rows"/"no <type-name> position can
+    name" absent from the sealing paragraph; "defenum"/"defvocabulary"
+    absent from bsl.ebnf; no "supersed... D94" citation in the register).
+    One of the plan's own given test bodies was corrected during the red
+    phase: an unscoped `re.search(r"^\s+\* - ``enum``", rst_text)` passes
+    vacuously against §5.2's PRE-EXISTING, unrelated CAS atom-kind row
+    (`enum` / `ASCII <EnumType>/<MEMBER_IDENTIFIER>`) — scoped to §3.1's
+    own list-table before the assertion was trustworthy.
+
+    `uv run pre-commit run rstcheck --files docs/reference/bsl-language.rst`
+    and `... run doc8 --files docs/reference/bsl-language.rst`: both
+    Passed. `mise run bsl:grammar-test`
+    (`tree-sitter generate && tree-sitter test` over
+    `tools/tree-sitter-bsl`): 31/31 parses green, including the new
+    corpus case.
+
+    Rust `tick_goldens` byte-identity is preserved TRIVIALLY, not by an
+    active cargo run: this ADR's diff touches zero Rust source (`rst`/
+    `ebnf`/one Python test file/JS tree-sitter tooling only), so there is
+    no encoder, no `state_hash.rs`, and no existing golden in scope to
+    move. The plan's Constraint 3 byte-identity proof is owed by Tasks
+    3-10, which implement the encoder-adjacent Rust paths this ADR only
+    specifies.
+  references:
+    - "docs/superpowers/specs/2026-08-11-organization-game-object-design.md (§1 Q12, Q1, Q15 — the ruling this ADR records)"
+    - "docs/superpowers/plans/2026-08-11-organization-foundation-plan.md (Task 1; Global Constraints 5/6 this ADR discharges)"
+    - "ADR191_director_rulings_batch_2026_08_11.yaml (R4, D94 — the six-row closure this ADR explicitly supersedes)"
+    - "ADR194_director_rulings_batch2_2026_08_11.yaml (R2, D99 — the prior precedent for a Phase-1-review addendum to §3.1 that does not reopen D94)"
+    - "docs/reference/bsl-language.rst (§3.1, §2.9, §2.13, §4.6, §5.2, Draft-Ruling Register D101/D102 — the edited text)"
+    - "docs/reference/bsl.ebnf (top-form, deffield, defenum, defvocabulary, the type-name D101 addendum)"
+    - "tests/unit/reference/test_bsl_grammar_sync.py::TestTheEnumRowStaysInSync"
+    - "tools/tree-sitter-bsl/grammar.js, tools/tree-sitter-bsl/test/corpus/declarations.txt (the derived-tooling repair this ADR's discovery required)"

--- a/ai/decisions/ADR196_org_vocabulary_ceremony.yaml
+++ b/ai/decisions/ADR196_org_vocabulary_ceremony.yaml
@@ -1,0 +1,132 @@
+ADR196_org_vocabulary_ceremony:
+  status: "accepted"
+  date: "2026-08-11"
+  title: "The Phase-2 BSL vocabulary ceremony (Organization-as-game-object spec §1 Q1/Q15) — ONE mint-and-retire record per ADR176 (34) + ADR187 OQ-7: mints NodeType/ORGANIZATION, EdgeType/{MEMBERSHIP, PRESENCE, COMMAND, TRANSACTIONAL, SOLIDARISTIC, SOLIDARITY}, and enum type OrgKind {STATE_APPARATUS, BUSINESS, POLITICAL_FACTION, CIVIL_SOCIETY} into the Rust closed BSL vocabulary (ADR195's registries); records TARGETS/OWNED_BY/JURISDICTION/RECRUITMENT/EMPLOYMENT and ActionType.STRIKE's dead member + eligibility row + base_cost_strike RETIRED — never to enter that vocabulary — leaving the frozen Python enums unedited"
+  context: |
+    Two prior rulings had already named a Phase 2 vocabulary ceremony
+    without holding it. ADR176 (34) (2026-07-29, the Game Design Standard
+    disposition batch): "The five dead edge types RETIRE (TARGETS,
+    OWNED_BY, JURISDICTION, RECRUITMENT, EMPLOYMENT); re-mint under BSL in
+    Phase 2 with their own vocabulary ceremony." ADR187 OQ-7 (2026-08-10,
+    the Article V 3x3 ratification): "RATIFIED (fold): ActionType.STRIKE's
+    dead enum member, its eligibility row and base_cost_strike retire
+    inside the Phase 2 BSL vocabulary ceremony alongside the five dead
+    edge types ADR176 (34) already retires — one ceremony, one record."
+    Both explicitly deferred to a single future ceremony rather than
+    disposing their items piecemeal.
+
+    The Organization-as-game-object design (Director-approved 2026-08-11)
+    supplied that ceremony's positive content. Q1 ("Content-declared
+    kinds"): one kernel `NodeType/ORGANIZATION`; the four kinds are a
+    content-declared `OrgKind` enum field, consuming ADR195's `enum`
+    deffield row. Q15 ("Founding edge vocabulary, sharpened"): MEMBERSHIP,
+    PRESENCE, COMMAND, TRANSACTIONAL, SOLIDARISTIC, and an org↔org usage
+    of the existing SOLIDARITY edge type — with RECRUITMENT/EMPLOYMENT
+    named explicitly as staying retired by ADR176 (34), "still present in
+    the frozen Python `EdgeType` enum, never re-minted in the Rust
+    vocabulary; every further edge earns its ceremony."
+
+    VERIFIED (not assumed) before writing this record: every mint-side
+    name already exists, by string value, in the frozen Python
+    `src/babylon/models/enums/topology.py` — `NodeType.ORGANIZATION =
+    "organization"` (line 63), `EdgeType.SOLIDARITY = "solidarity"` (line
+    100), `EdgeType.MEMBERSHIP`/`COMMAND`/`PRESENCE`/`TRANSACTIONAL`/
+    `SOLIDARISTIC` (lines 109-116). This ceremony does not invent new
+    English words; it mints them into the SEPARATE, currently-empty Rust
+    `ClosedVocabulary` registry (`babylon-bsl`'s `vocabulary.rs`, wired by
+    `defvocabulary`, ADR195/§2.13) that governs the BSL content the Rust
+    engine actually runs — a distinct namespace from the frozen Python
+    estate, which this ceremony does not touch. Likewise verified: the
+    retirement targets exist exactly where the two source rulings said —
+    `EdgeType.TARGETS`/`OWNED_BY`/`JURISDICTION` (topology.py lines
+    119-121) and `EdgeType.RECRUITMENT`/`EMPLOYMENT` (lines 110-111);
+    `ActionType.STRIKE = "strike"` (`models/enums/actions.py:75`);
+    `base_cost_strike: int = Field(default=3, ...)`
+    (`config/defines/ooda.py:302`, read at line 443); the eligibility row
+    ("STRIKE: PoliticalFaction and CivilSociety only",
+    `ooda/action_eligibility.py:56`).
+  decision: |
+    ONE CEREMONY, ONE RECORD, per both source rulings' own instruction.
+
+    MINTED — into the Rust closed BSL vocabulary (populated via
+    `defvocabulary`, ADR195/§2.13; NOT a Python code change):
+
+    - `NodeType/ORGANIZATION` (spec §1 Q1: "One kind of body... Churches,
+      parties, unions, newspapers, firms, police departments: all one
+      node type, distinguished by fields and edges, never by kernel
+      kind").
+    - `EdgeType/MEMBERSHIP`, `EdgeType/PRESENCE`, `EdgeType/COMMAND`,
+      `EdgeType/TRANSACTIONAL`, `EdgeType/SOLIDARISTIC` (spec §1 Q15's
+      founding five).
+    - `EdgeType/SOLIDARITY`, WITH AN EXPLICIT USAGE NOTE: this member
+      already exists in the vocabulary for `social_class`-to-`social_class`
+      solidarity (its long-standing use); Q15 extends its LEGAL ENDPOINT
+      pair to org↔org as well ("the Q15/Q18 edge", spec §1 Q15/Q18,
+      §2's "org↔org SOLIDARITY edge is deliberate: it is the Q15/Q18
+      edge, present from the first golden so the win-gate repair train
+      has a seeded instance to count"). This is not a new edge TYPE — the
+      `defvocabulary` declaration mints the type name once, as it already
+      would for the class-to-class usage; the ceremony's contribution is
+      recording, constitutionally, that an org↔org instance of it is
+      licensed, not a kernel-level restriction to one endpoint-type pair.
+    - Enum type `OrgKind {STATE_APPARATUS, BUSINESS, POLITICAL_FACTION,
+      CIVIL_SOCIETY}` (spec §1 Q1), declared via ADR195's `defenum` — the
+      Rust `EnumRegistry`'s first content-declared type, member order as
+      given (the declaration order IS the storage ordinal, ADR195). This
+      is `organization/kind`'s declared enum type — the field itself is
+      seeded and read by Task 10's `organization-foundation.bscn` golden
+      and `organization.bsl` probe rule (Rust lane, not this ADR).
+
+    RETIRED — recorded here as NEVER to enter the Rust closed BSL
+    vocabulary, discharging ADR176 (34) and ADR187 OQ-7 in full:
+
+    - `EdgeType`: `TARGETS`, `OWNED_BY`, `JURISDICTION`, `RECRUITMENT`,
+      `EMPLOYMENT` (ADR176 (34)). `RECRUITMENT`/`EMPLOYMENT` were the two
+      candidates the Organization spec itself considered and rejected for
+      the org↔class membership relation, which `MEMBERSHIP` (weighted by
+      population, spec §4's "social base" stratum) now covers instead.
+    - `ActionType.STRIKE`'s dead enum member, its
+      `ooda/action_eligibility.py` eligibility row ("STRIKE: PoliticalFaction
+      and CivilSociety only"), and `OODADefines.base_cost_strike`
+      (ADR187 OQ-7) — the STRIKE verb's frozen-estate remnants, superseded
+      by the Article V ratified grid's `mobilize:strike` sub-mode
+      (ADR176 (11)-(13), ADR177).
+
+    THE PYTHON ENUMS ARE FROZEN-ESTATE AND UNEDITED. This decision is
+    entirely a fact about the Rust `ClosedVocabulary`/`EnumRegistry`
+    registries this ADR authorizes `defvocabulary`/`defenum` content to
+    populate (ADR195). `src/babylon/models/enums/topology.py`,
+    `actions.py`, and `config/defines/ooda.py` are NOT touched by this
+    ADR — per the Constitution AE Python-engine-freeze ruling, the frozen
+    Python engine is reference-only, and "retiring" a member from a Rust
+    vocabulary that has never contained it is not a Python code change at
+    all. A reader of the frozen Python source will still find
+    `EdgeType.TARGETS` etc. defined there; what this ADR fixes is that
+    the RUST content-authoring surface will never be able to name them.
+  consequences: |
+    `ai/decisions/index.yaml` gains this ADR and ADR195. `defvocabulary
+    NodeType (... ORGANIZATION ...)` and `defvocabulary EdgeType (MEMBERSHIP
+    PRESENCE COMMAND TRANSACTIONAL SOLIDARISTIC SOLIDARITY)` and `defenum
+    OrgKind (STATE_APPARATUS BUSINESS POLITICAL_FACTION CIVIL_SOCIETY)` are
+    now the CONSTITUTIONALLY AUTHORIZED forms Task 10's
+    `organization-foundation.bscn` golden is licensed to declare — this
+    ADR is that scenario's ceremony citation, not its implementation.
+    ADR176 (34) and ADR187 OQ-7 both CLOSE with this ADR cited as their
+    disposition; neither issue needed further Director attention on the
+    vocabulary question.
+
+    NOT YET DONE: the actual Rust `defvocabulary`/`defenum` content
+    (Task 10, cargo-gated, not yet landed) and vocabulary ENFORCEMENT
+    (Task 8 — until it lands, a typo'd `EdgeType/TARGETS` in real content
+    still silently mints today, exactly the Scout-3-verified defect this
+    plan's Task 8 exists to close; this ADR authorizes the vocabulary's
+    CONTENT, not its enforcement, which is a separate typed motion). The
+    I.16 amendment motion the Organization spec's §3/§9 gestures toward
+    (institutionality, the apparatus hyperedge) is explicitly OUT of this
+    ceremony's scope, per the spec's own "NOT this plan" list.
+  supersedes: []
+  related:
+    - ADR195_enum_deffield_row
+    - ADR176_director_rulings_batch_gds_dispositions
+    - ADR187_article_v_3x3_ratified
+    - ADR189_amendment_ag_attributed_membership_lattice_instances

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -885,3 +885,13 @@ decisions:
     status: accepted
     date: '2026-08-11'
     file: ADR194_director_rulings_batch2_2026_08_11.yaml
+  ADR195_enum_deffield_row:
+    title: 'The enum deffield row — Director ruling (Organization-as-game-object spec §1 Q12, 2026-08-11, approved twice): a seventh <type-name> row, `enum`, joins the six D94 sealed — a content-declared closed enum''s member, stored as the declared-order ordinal in the existing binary64 attribute lane, surfaced ONLY as an EnumRef (never a bare number, in either direction); explicitly SUPERSEDES D94''s six-row closure rather than silently reopening it'
+    status: accepted
+    date: '2026-08-11'
+    file: ADR195_enum_deffield_row.yaml
+  ADR196_org_vocabulary_ceremony:
+    title: 'The Phase-2 BSL vocabulary ceremony (Organization-as-game-object spec §1 Q1/Q15) — ONE mint-and-retire record per ADR176 (34) + ADR187 OQ-7: mints NodeType/ORGANIZATION, EdgeType/{MEMBERSHIP, PRESENCE, COMMAND, TRANSACTIONAL, SOLIDARISTIC, SOLIDARITY}, and enum type OrgKind {STATE_APPARATUS, BUSINESS, POLITICAL_FACTION, CIVIL_SOCIETY} into the Rust closed BSL vocabulary (ADR195''s registries); records TARGETS/OWNED_BY/JURISDICTION/RECRUITMENT/EMPLOYMENT and ActionType.STRIKE''s dead member + eligibility row + base_cost_strike RETIRED — never to enter that vocabulary — leaving the frozen Python enums unedited'
+    status: accepted
+    date: '2026-08-11'
+    file: ADR196_org_vocabulary_ceremony.yaml

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -460,10 +460,21 @@ is no string concatenation, comparison, or interpolation in the language — the
 ``${var}`` substitution of today's ``TemplateEffect``/``EventEmission`` does
 **not** carry over (its job is done by binding references).
 
-**Enum member references.** The enum type name must be a member of the closed
-vocabulary registry (§3.6) and the member must exist in it; both checks are
-load-time (``E-LOAD-030``, ``E-LOAD-031``). There is no "unknown enum member
-reads as default" behavior anywhere in the language.
+**Enum member references.** An ``<enum-ref>``'s type name must be registered
+and its member must exist in that registration; both checks are load-time.
+There is no "unknown enum member reads as default" behavior anywhere in the
+language. **Which registry checks it is a property of where the
+``<enum-ref>`` sits, never a guess between two candidates** (§2.13 states
+this fully): in a §2.6 class-rule operand position (a query head, ``the``,
+a structural verb's type operand, ``emit``) it is checked against the
+**closed graph vocabulary** (§3.6, populated by ``defvocabulary`` —
+``E-LOAD-030``/``E-LOAD-031``); in an ``:enum-type``-declared field's value
+position (§2.9, §2.13) it is checked against that field's declared
+**content-declared enum type** (populated by ``defenum`` — ``E-LOAD-054``/
+``E-LOAD-055``). The two registries are never interchangeable: §3.6 sorts
+and deduplicates its members, while a ``defenum`` type's member order is
+the field's storage ordinal (§3.1's ``enum`` row) and must never be
+reordered.
 
 1.6 Keywords
 ~~~~~~~~~~~~~~
@@ -1623,7 +1634,8 @@ the combinatorial object Anti-Pattern VIII.9 bans has no BSL representation
 
    <deffield> ::= "(" "deffield" <qname>
                       ":type" <type-name>
-                      ":kind" ( "intensive" | "extensive" )
+                      ( ":kind" ( "intensive" | "extensive" )
+                      | ":enum-type" <enum-type-name> )
                       ( ":member" <enum-ref> )?
                   ")"
 
@@ -1772,6 +1784,23 @@ The rules, all decidable at load:
 - Kernel agreement is ``E-LOAD-022``, as for any other ``deffield``: the type,
   the kind and the member half are all checked against the kernel's
   registration of the attributed-membership object.
+
+**[Director ruling 2026-08-11, Organization-as-game-object spec §1 Q12]**
+*The* ``:kind`` *slot widens to an exclusive-or with* ``:enum-type``, *not
+an additional option.* Every ``deffield`` before this ruling carried a
+mandatory ``:kind``; an ``enum``-typed field carries none, because there is
+no meaningful extensive-or-intensive reading of a member identity — an
+aggregation *kind* answers "how does this quantity add up across a
+population", and a member has no such answer. §3.4's aggregation-law table
+is never even consulted for one: ``Enum<T>`` supports no operation beyond
+``=``/``!=`` (§3.1), so an enum-typed value never reaches a fold with an
+arithmetic kind to check in the first place — the refusal is structural,
+not a special case bolted onto §3.4. The two slots are therefore mutually
+exclusive and jointly exhaustive against ``:type``: any ``:type`` other
+than ``enum`` requires ``:kind`` and forbids ``:enum-type`` (unchanged from
+before this ruling); ``:type enum`` requires ``:enum-type`` — naming a
+type ``defenum`` has declared (§2.13) — and forbids ``:kind``. Either
+violation is ``E-LOAD-053``. Full declaration and read/write law: §2.13.
 
 2.10 Element accessors
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2128,6 +2157,127 @@ The kind law bites on membership payload exactly as it bites on node and edge
 fields — which is what "typed exactly like node/edge fields" costs, and the
 reason the amendment wrote it that way.
 
+2.13 Declaring enums and the graph vocabulary
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**[Director ruling 2026-08-11, Organization-as-game-object spec §1 Q12 —
+approved twice: the live brainstorming popup and the written spec review]**
+§3.1's seventh ``<type-name>`` row needed a declaration form and a
+governing law of its own; this section is that form. It is also, because
+the same ruling's Q1/Q15 consumers needed the graph vocabulary populated
+rather than left permanently empty (§3.6's own text: that registry "today
+has zero production call sites"), the closed graph vocabulary's own
+declaration form. **This section's** ``enum`` **row explicitly supersedes D94's
+exclusion** — D94 sealed §3.1's table at six rows and wrote, in its own
+words, that "no ``<type-name>`` position can name" a seventh kind.
+Recorded, with the supersession named explicitly, as D101 below.
+
+.. code-block:: text
+
+   <defenum>       ::= "(" "defenum" <enum-type-name>
+                            "(" <enum-member>+ ")" ")"
+   <defvocabulary> ::= "(" "defvocabulary" <enum-type-name>
+                            "(" <enum-member>+ ")" ")"
+
+Both are ``<top-form>``\ s (§2.2), parsed and validated at content load
+like ``deffield``/``manifest``/``metric``. ``<enum-type-name>`` is §1.4's
+existing ``<enum-type>`` production (an uppercase-initial identifier — the
+reader's existing ``<enum-ref>`` lexing, unchanged by this section) and
+``<enum-member>`` is §1.4's existing ``<enum-member>`` production, also
+unchanged. ``defvocabulary``'s type-name operand is additionally
+**semantically** restricted to §3.6's own closed set — ``NodeType`` /
+``EdgeType`` / ``HyperedgeType`` / ``EventType`` — which needs no dedicated
+grammar production: the restriction is a load-time check
+(``E-LOAD-030`` if the name is not one of the four, the same code §3.6
+already uses for an unregistered ``<enum-ref>`` type name), not a lexical
+one, exactly as a ``ceiling`` row's ``<enum-ref>`` operand is syntactically
+any enum-ref but semantically restricted to a registered graph-element
+type (§2.9). A duplicate ``defenum`` type name, or two ``defvocabulary``
+forms naming the same ``<enum-kind>``, is ``E-LOAD-001`` like any other
+duplicate declaration; **member order inside a** ``defenum`` **is
+normative** — it is the ordinal §3.1's ``enum`` row stores — while member
+order inside a ``defvocabulary`` is not (§3.6's registry has never had an
+ordinal; membership is the only fact it carries).
+
+**Two registries, one lexical production, never a guess between them.**
+An ``<enum-ref>`` (§1.4, ``Type/MEMBER``) is checked against exactly one
+of two registries, and *where the reference sits* — never a fallback
+search — decides which:
+
+- In a §2.6 class-rule operand position (D74) — a query head, ``the``, a
+  structural verb's type operand, ``emit`` — the type name is checked
+  against the **closed graph vocabulary** (§3.6), populated by
+  ``defvocabulary``. Unknown-type and unknown-member there stay
+  ``E-LOAD-030`` / ``E-LOAD-031``, exactly as §3.6 already states; a
+  content set that declares no ``defvocabulary`` for a kind leaves that
+  kind's checking exactly as inert as it is today, which is what makes
+  this section's arrival backward-compatible with every existing content
+  set (none of them declares one).
+- In an ``:enum-type``-declared field's value position (§2.9) — a
+  ``.bscn`` node/edge body seeding it, or a structural-verb write to it —
+  the type name is checked against the **content-declared**
+  ``EnumRegistry`` type ``defenum`` names, resolved at the field's own
+  ``:enum-type`` declaration. Unknown type there is ``E-LOAD-054``;
+  unknown member is ``E-LOAD-055``.
+
+The two registries are deliberately not one, and reusing one for the
+other's job would break a real invariant each way: ``ClosedVocabulary``
+(§3.6) sorts and deduplicates its members by design, which is correct for
+a set with no ordinal to preserve and wrong for one where declaration
+order IS the stored value; an ``EnumRegistry`` type's member order is
+that ordinal (§3.1's ``enum`` row) and must never be reordered. Forcing
+the structural kinds through an ordinal-preserving registry would gain
+them nothing; forcing a ``defenum`` type through the sort-and-dedup
+registry would silently corrupt whatever field values its ordinals
+already back.
+
+**The write/read law.** An ``:enum-type``-declared field is written and
+read **only** as an ``<enum-ref>`` of its declared type, in every
+direction, with no fallback and no default member:
+
+- A ``.bscn`` node or edge body seeding such a field with anything other
+  than a matching ``<enum-ref>`` — a bare number, an ``<enum-ref>`` of a
+  different declared type, any other atom — is ``E-LOAD-056``. The
+  ordinal is never a surface value; there is no "seed it as a number and
+  let the engine resolve the member" path, the same "a name outside the
+  registry is a load error, never a fallback" law §3.6 already states for
+  the structural kinds (D31's own module doc).
+- A structural-verb write (``update-node`` and its siblings, §2.8) to
+  such a field, evaluating to anything other than a matching
+  ``<enum-ref>`` — most concretely a bare ``Real``, the eval-time form of
+  the same mistake — is ``E-EVAL-042``. This is the same law re-checked
+  at the one boundary content cannot be checked once and for all at
+  load, the same two-site pattern the store boundary and range checks
+  already use (§3.7, §4.3).
+- A read of such a field (via a ``:field`` binding, §2.5) renders the
+  stored ordinal back to its member as a ``Value::Enum`` — never a bare
+  number, so a ``when`` guard or any other comparison always compares
+  members, never ordinals a rule author could confuse for magnitude. A
+  stored value that fails to round-trip against the field's declared
+  type — non-integral, or outside ``[0, member-count)`` — is a loud
+  integrity failure at the read boundary, never a clamp and never a
+  silently-substituted default member: Constitution III.11 binds a
+  corrupted store exactly as it binds a malformed load.
+
+**No aggregation kind.** §2.9's widened ``<deffield>`` production
+structurally omits ``:kind`` for the ``enum`` branch; the full statement
+of why — ``Enum<T>`` supports no arithmetic, so an enum-typed value never
+reaches §3.4's aggregation-law table with a kind to check — is recorded
+there, beside the production it explains, rather than repeated here.
+
+**The** ``field-of`` **deferral.** An ``:enum-type``-declared field is
+read through a ``:field`` binding exactly as any other node field is
+(§2.5); this section does **not** extend §2.10's ``field-of`` accessor —
+the edge/hyperedge equivalent — to enum-declared fields. A ``field-of``
+naming one refuses, loudly, citing this paragraph and D102 below. The gap
+is deferred, not forbidden: an enum-declared *edge* or *hyperedge* field
+is not ruled out by anything in this section, and such a field would need
+exactly this accessor, for exactly the reason §2.10 exists at all — it
+has no single owning body to bind a ``:field`` against. Building that
+path is left to whichever later revision first needs one; this row's job
+is only to make sure that revision does not have to rediscover the gap
+as an unexplained refusal.
+
 3. Static semantics
 ---------------------
 
@@ -2163,6 +2313,18 @@ degraded mode, and no rule that loads "partially".
    * - ``coefficient``
      - ``binary64``, ``[0.0, 1.0]``
      - Kernel scalar.
+   * - ``enum``
+     - one member of a content-declared closed ``defenum`` type
+     - **§2.13 addendum** (Director ruling 2026-08-11, Organization-as-
+       game-object spec §1 Q12 — approved twice, live popup and written
+       spec): the declared-order ordinal of the member, stored in the
+       existing binary64 attribute lane (§5.2's ``0x02`` atom row —
+       zero bytes of any existing golden move). The ordinal is never a
+       surface value: written and read ONLY as ``<EnumType>/<MEMBER>``
+       (an ``<enum-ref>``, §1.4); comparable with ``=``/``!=`` only, and
+       only to the same declared type; carries no aggregation ``:kind``
+       (§2.9, §3.4). Supersedes D94's exclusion of a declarable
+       closed-enum row — see D101 in the register below.
    * - ``Real``
      - ``binary64``, finite
      - The **unbounded intermediate** type (§3.3). Not storable.
@@ -2200,21 +2362,39 @@ degraded mode, and no rule that loads "partially".
 There are no type variables, no subtyping, no coercions, and no user-defined
 types. Every expression has exactly one static type, computed bottom-up.
 
-**[Director ruling 2026-08-11, ADR191 R4]** *A* ``<type-name>`` *is a
-lowercase* ``symbol``, and the six rows above that name one are its whole
-vocabulary. The first six rows are the types a ``deffield`` or a ``metric``
-may write after ``:type``; they are spelled here exactly as §1.4 lexes them,
-which the capitalized spellings this table used to carry were not — no
-capitalized run matches any §1.4 atom class, so that spelling was unlexable
-as written. The remaining rows — ``Real``, ``Enum<T>``, the three reference
-kinds, the three set kinds and ``Str`` — are **typechecker types that no**
-``<type-name>`` **position can name**: ``Real`` is the unbounded intermediate
-and is not storable (§3.3), the reference and set kinds are produced by
-expressions and never declared, and ``Str`` appears only at
+**[Director ruling 2026-08-11, ADR191 R4; the seventh row minted the same
+day by a separate, later ruling — see below]** *A* ``<type-name>`` *is a
+lowercase* ``symbol``, and the seven rows above that name one are its whole
+vocabulary. The first seven rows — ``int``, ``bool``, ``currency``,
+``probability``, ``intensity``, ``coefficient``, and ``enum`` — are the
+types a ``deffield`` or a ``metric`` may write after ``:type``; the first
+six are spelled here exactly as §1.4 lexes them, which the capitalized
+spellings this table used to carry were not — no capitalized run matches
+any §1.4 atom class, so that spelling was unlexable as written. That
+six-row closure was recorded as D94, and its own text sealed the table by
+name: no ``<type-name>`` position can name a seventh kind. **The seventh
+row, ``enum``, was minted afterward by the Director's own ruling** (the
+Organization-as-game-object spec, §1 Q12, 2026-08-11 — approved twice,
+once live in the brainstorming session and once again reviewing the
+written spec, "sealed twice this month" being the question put to her
+directly) — a knowing supersession of D94's closure, not a silent
+reopening. §2.13 is the row's declaration form and full law; D101 in the
+register below records the supersession explicitly, by name, so a reader
+of D94 alone is never left believing the table is still six rows.
+``Enum<T>`` (the next row) is unaffected: it remains the *typechecker*
+classification of an ``<enum-ref>`` expression's static type, while
+``enum`` is what a ``deffield`` declares to make a field HOLD one member —
+two different jobs that happen to share a root word, not one construct
+under two names. The remaining rows — ``Real``, ``Enum<T>``, the three
+reference kinds, the three set kinds and ``Str`` — are typechecker types
+that no ``<type-name>`` position can name: ``Real`` is the unbounded
+intermediate and is not storable (§3.3), the reference and set kinds are
+produced by expressions and never declared, and ``Str`` appears only at
 ``:material-basis`` and in vector ids. They keep their capitalized names
-because those names are this document's, not tokens; nothing lexes them, so
-nothing needed re-spelling. Recorded as D94, closing the first of the two
-repairs §7 deferred to this review.
+because those names are this document's, not tokens; nothing lexes them,
+so nothing needed re-spelling. D94 itself is left unedited (Immutability
+of History: it captured what was true through that review), and this
+paragraph is the current-law correction sitting beside it.
 
 ``Ratio`` (added by the §1.5/§3.2 addendum below, #492/ADR194 — recorded as
 D99, not a re-opening of D94) joins this same non-storable category for the
@@ -3400,7 +3580,11 @@ two times at which an error can occur.
        ``:invariant``, an intensive adjunction with no weight, and an
        adjunction that does not fit the schema at its declared rung; and, from
        the §3.2 addendum (#492/ADR194), a ``defconst``'s own ``Ratio`` value
-       exceeding its declared ``:cap`` ceiling.
+       exceeding its declared ``:cap`` ceiling; and, from §2.13 (Organization
+       spec §1 Q12), a ``:type enum``/``:enum-type`` shape violation, a
+       ``defenum``-registry type or member an ``:enum-type`` or ``<enum-ref>``
+       does not resolve, and a non-``<enum-ref>`` value seeding an
+       ``:enum-type``-declared field in a ``.bscn`` body.
    * - Evaluation
      - ``E-EVAL-0xx``
      - During a tick — checked-arithmetic failure, range violation at a store,
@@ -3412,7 +3596,10 @@ two times at which an error can occur.
        or a value the provider did not produce; and, from the Amendment AG
        sections, a named *(hyperedge, member)* pair that is not a membership;
        and, from the §3.2 addendum (#492/ADR194), a ``Currency × Ratio``
-       operand exceeding its declared domain ceiling.
+       operand exceeding its declared domain ceiling; and, from §2.13
+       (Organization spec §1 Q12), a non-``<enum-ref>`` value (or a
+       cross-type ``<enum-ref>``) reaching an ``:enum-type``-declared
+       field's write path at runtime.
 
 **Every code the R9 chapters add continues an existing sequence, and no code
 that existed before this revision is renumbered.** The new codes are
@@ -3436,9 +3623,9 @@ defect D75 ruled against.
 
 Sequence continuation is meant literally, and is checkable by inspection: every
 decade block of every family is **contiguous**, with no reserved and no
-skipped number — ``E-LOAD`` 001–004, 010–013, 020–025, 030–033, 040–052;
+skipped number — ``E-LOAD`` 001–004, 010–013, 020–025, 030–033, 040–056;
 ``E-PARSE`` 010–015, 020–022, 030–033, 040–042; ``E-TYPE`` 010–017, 020, 030,
-040–043; ``E-EVAL`` 010–014, 020–021, 030–041; ``E-LEX`` 001–003,
+040–043; ``E-EVAL`` 010–014, 020–021, 030–042; ``E-LEX`` 001–003,
 010–011, 020–027. The ``E-LOAD`` 040 block now runs past its own decade, and
 deliberately: opening a fresh block at 050 for the Amendment AG codes would
 have **reserved** 046–049, and a reserved number is precisely what the rule
@@ -3456,6 +3643,26 @@ The R9 chapters allocated per chapter and left two holes in
 the ``E-TYPE`` sequence; they were closed by renumbering the two offending
 **new** codes before any implementation pinned them, which is a liberty
 available exactly once and only to codes this revision minted.
+
+**§2.13 (Organization spec §1 Q12) continues the same sequences a third
+time.** It adds four ``E-LOAD-0xx`` codes — ``E-LOAD-053`` (the
+``:kind``/``:enum-type`` shape exclusivity), ``E-LOAD-054`` (an
+``:enum-type`` naming an unregistered ``defenum`` type), ``E-LOAD-055``
+(an ``<enum-ref>`` naming a member its resolved type does not declare),
+``E-LOAD-056`` (a non-``<enum-ref>`` value seeding an ``:enum-type``-declared
+field at content-load time) — and one ``E-EVAL-0xx``, ``E-EVAL-042`` (the
+same law's runtime re-check, §3.7/§4.3's two-site pattern), continuing the
+same overrun ``E-LOAD`` block past 052 for the same reason the §3.2
+addendum did: a fresh 060 block would reserve 057–059 for nothing. It
+mints **no** ``E-LEX``, ``E-PARSE`` or ``E-TYPE`` code: a ``defvocabulary``
+membership violation is not a new failure class at all — it reuses
+``E-LOAD-030``/``E-LOAD-031``, the codes §3.6's ``ClosedVocabulary``
+already carries, activated at three producers rather than left
+unreachable (Task 8 of the Organization foundation plan); minting
+parallel numbers for an identical check against a different registry
+would be exactly the hygiene defect D75 ruled against, the same reasoning
+the Amendment AG sections' paragraph above already applies to its own
+parse- and type-class reuse.
 
 **Load-time errors** report the offending file, line, column, form, and code,
 and reject the whole content set — there is no partial load and no "skip the
@@ -3603,8 +3810,9 @@ AST — a property implementations should exercise as a round-trip property test
 ``add-hyperedge``, ``update-hyperedge``, ``remove-hyperedge``, ``members``,
 ``member``, ``membership-field-of``, ``update-membership``,
 ``emit``, ``add``, ``sub``, ``set``, ``scale``, ``anchor``, ``deffield``,
-``intrinsic``, ``manifest``, ``ceiling``, ``rung``, ``adjunction``), plus the
-synthetic tag ``opt`` for a keyword option.
+``intrinsic``, ``manifest``, ``ceiling``, ``rung``, ``adjunction``,
+``defenum``, ``defvocabulary``), plus the synthetic tag ``opt`` for a
+keyword option.
 
 The six tags the Amendment D revision added — ``hyperedges``, ``members-of``,
 ``hyperedges-of``, ``add-hyperedge``, ``remove-hyperedge``, ``members`` — obey
@@ -3638,6 +3846,20 @@ a form that already has a digest** (§5.5's ``manifest``), so a manifest that
 declares no lattice encodes byte-for-byte as it did. None of these appears in
 §5.6's example, and no previously-optional child of ``rule`` becomes mandatory
 — **§5.6's 421 bytes and both digests remain correct as written**.
+
+**The Organization contract's Q12 tags obey it a fourth time.** ``defenum``
+and ``defvocabulary`` (§2.13) are their own head symbols, needing no
+registry entry, no numeric id and no new atom kind — the ``<enum-ref>``
+values they govern already encode with the existing atom kind the table
+above names for that lexical class, regardless of which registry checks
+them. ``deffield`` gains one more **optional** alternative in an existing
+keyword slot (``:enum-type`` beside ``:kind``, §2.9), not a new child
+position, so no existing ``deffield`` encoding moves. None of these forms
+appears in §5.6's example, and neither ``deffield`` nor any other form
+gains a newly *mandatory* child — **§5.6's 421 bytes and both digests
+remain correct as
+written**, the same proof of additivity every prior extension in this
+section carries.
 
 A keyword option is encoded as a two-child form:
 
@@ -5398,6 +5620,45 @@ consequences are the ordinary kind of review item.
        ``canonical_ast::rule_id`` (widened to ``pub(crate)``),
        ``lib::prepare_rules`` (Program 28 B2, ``docs/superpowers/plans/
        2026-08-11-b2-tick-loop-plan.md`` Phase A Tasks 2–4).
+   * - D101
+     - §2.13, §3.1
+     - **The** ``enum`` ``<type-name>`` **row and its declaration form**
+       (Director ruling 2026-08-11, Organization-as-game-object spec §1
+       Q12 — approved twice, live brainstorm popup and written spec
+       review). A seventh ``<type-name>`` row — the declared-order
+       ordinal of a content-declared closed enum, stored in the existing
+       binary64 attribute lane and surfaced only as an ``<enum-ref>`` —
+       joins the six D94 sealed. **This row explicitly supersedes D94's
+       exclusion**: D94 read "no ``<type-name>`` position can name" a
+       seventh kind, ruled the same review that closed the table at six;
+       Q12 is the Director's own later ruling minting a seventh, made
+       knowingly (the question put to her named "sealed twice this
+       month"). D94 itself is left unedited (Immutability of History: it
+       captured what was true through that review) and its six-row
+       reading stands as a record of what was true before Q12; §3.1's
+       table and the sealing paragraph beside it now state the current,
+       seven-row law. ``Enum<T>`` (§3.1's next row, the *typechecker*
+       classification of an ``<enum-ref>`` expression) is unchanged — Q12
+       mints a **storage** row, not a new expression type.
+       ``defenum``/``defvocabulary`` (§2.13), the widened ``<deffield>``
+       production (§2.9), and error codes ``E-LOAD-053`` through
+       ``E-LOAD-056`` and ``E-EVAL-042`` (§4.6) are this ruling's
+       consequences. First consumer: ``organization/kind`` (spec §1 Q1),
+       landing with the Phase-2 vocabulary-ceremony ADR.
+   * - D102
+     - §2.13, §2.10
+     - ``field-of`` (§2.10) is **not** extended to ``:enum-type``-declared
+       fields by D101 — such a field is read via a ``:field`` binding
+       only (§2.5). A ``field-of`` naming one refuses loudly, citing this
+       row. Deferred, not forbidden: an enum-declared EDGE or HYPEREDGE
+       field (this document does not rule one out) would need
+       ``field-of`` access precisely because it has no single owning
+       body to bind a ``:field`` against — the same reason §2.10 exists
+       for dyadic and hyperedge fields at all — and building that
+       accessor is left to whichever revision first has such a field to
+       read. This row names the gap so a future implementer does not
+       have to rediscover it as a silent "the enum-ref case must have
+       been an oversight" bug.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -1635,7 +1635,7 @@ the combinatorial object Anti-Pattern VIII.9 bans has no BSL representation
    <deffield> ::= "(" "deffield" <qname>
                       ":type" <type-name>
                       ( ":kind" ( "intensive" | "extensive" )
-                      | ":enum-type" <enum-type-name> )
+                      | ":enum-type" <enum-type> )
                       ( ":member" <enum-ref> )?
                   ")"
 
@@ -2174,14 +2174,14 @@ Recorded, with the supersession named explicitly, as D101 below.
 
 .. code-block:: text
 
-   <defenum>       ::= "(" "defenum" <enum-type-name>
+   <defenum>       ::= "(" "defenum" <enum-type>
                             "(" <enum-member>+ ")" ")"
-   <defvocabulary> ::= "(" "defvocabulary" <enum-type-name>
+   <defvocabulary> ::= "(" "defvocabulary" <enum-type>
                             "(" <enum-member>+ ")" ")"
 
 Both are ``<top-form>``\ s (§2.2), parsed and validated at content load
-like ``deffield``/``manifest``/``metric``. ``<enum-type-name>`` is §1.4's
-existing ``<enum-type>`` production (an uppercase-initial identifier — the
+like ``deffield``/``manifest``/``metric``. ``<enum-type>`` is §1.4's
+existing production (an uppercase-initial identifier — the
 reader's existing ``<enum-ref>`` lexing, unchanged by this section) and
 ``<enum-member>`` is §1.4's existing ``<enum-member>`` production, also
 unchanged. ``defvocabulary``'s type-name operand is additionally

--- a/docs/reference/bsl.ebnf
+++ b/docs/reference/bsl.ebnf
@@ -244,7 +244,19 @@ type-name   ::= symbol                                        /* §3.1 */
                    used to name. §3.1's remaining rows (`Real`, `Enum<T>`,
                    the reference and set kinds, `Str`) are typechecker
                    types no <type-name> position can reach, so nothing
-                   lexes them and nothing needed re-spelling. */
+                   lexes them and nothing needed re-spelling.
+
+                   ADDENDUM (Director ruling 2026-08-11, Organization spec
+                   §1 Q12 — a LATER ruling than D94 above, recorded as
+                   D101 and explicitly superseding D94's six-row closure,
+                   never a silent reopening of it): a seventh lowercase
+                   symbol, `enum`, joins this production's whole
+                   vocabulary. Its storage/read law lives in §3.1 and the
+                   `defenum`/`defvocabulary` declaration forms live at
+                   §2.13, below §2.11 in this file — this comment block is
+                   left otherwise unedited (D94's own record stands for
+                   what was true through that review) rather than
+                   rewritten to read as if it always said seven. */
 
 intrinsic-type-name ::= type-name | "real"                    /* §2.7 */
                 /* D98 (workforce draft ruling, Phase 1 review). Widens
@@ -273,12 +285,15 @@ intrinsic-type-name ::= type-name | "real"                    /* §2.7 */
 file        ::= top-form*                                     /* §2.2 */
 
 top-form    ::= rule | deffield | intrinsic-decl              /* §2.2 */
-              | manifest | metric-decl
+              | manifest | metric-decl | defenum | defvocabulary
                 /* File boundaries and file names carry NO semantics: the
                    same forms split across different files produce the
                    same rules_hash (§5.5). Duplicate rule ids, field,
                    intrinsic, rung or adjunction names across the content
-                   set are E-LOAD-001. */
+                   set are E-LOAD-001. `defenum`/`defvocabulary` (§2.13,
+                   D101, Organization spec §1 Q12) join this list without
+                   moving any existing form's encoding — see §5.2's
+                   fourth "obeys it" paragraph. */
 
 /* --- 2.3 Rules ------------------------------------------------------ */
 
@@ -526,7 +541,8 @@ payload-item ::= "(" symbol expr ")"                          /* §2.8 */
 
 deffield    ::= "(" "deffield" qname                          /* §2.9 */
                     ":type" type-name
-                    ":kind" ( "intensive" | "extensive" )
+                    ( ":kind" ( "intensive" | "extensive" )
+                    | ":enum-type" enum-type )
                     ( ":member" enum-ref )?
                 ")"
                 /* The qname's first segment names the OWNING element
@@ -537,6 +553,12 @@ deffield    ::= "(" "deffield" qname                          /* §2.9 */
                    MEMBERSHIP-payload declaration (D79): its operand is a
                    NodeType member and its qname's first segment must
                    render a HyperedgeType (E-LOAD-048 otherwise).
+                   `:kind`/`:enum-type` are mutually exclusive and jointly
+                   exhaustive against `:type` (§2.13, D101, Organization
+                   spec §1 Q12): every `:type` but `enum` requires `:kind`
+                   and forbids `:enum-type`; `:type enum` requires
+                   `:enum-type` (naming a `defenum`-declared type) and
+                   forbids `:kind` — violating either side is E-LOAD-053.
                    Every EdgeType additionally carries one IMPLICITLY
                    declared field, <edge-type>/strength, `:type
                    Coefficient` `:kind extensive` — re-declaring it is
@@ -614,6 +636,32 @@ metric-decl ::= "(" "metric" symbol                           /* §2.11 */
                    E-LOAD-025, an unregistered name E-LOAD-011, and
                    reading one through the wrong form for its declared
                    domain is E-LOAD-012. */
+
+/* --- 2.13 Declaring enums and the graph vocabulary ------------------- */
+
+defenum       ::= "(" "defenum" enum-type                     /* §2.13 */
+                       "(" enum-member+ ")"
+                   ")"
+                /* Director ruling 2026-08-11, Organization spec §1 Q12 —
+                   supersedes D94's exclusion, recorded as D101. Member
+                   order is NORMATIVE: it is the declared-order ordinal
+                   §3.1's `enum` row stores. A duplicate type name, or a
+                   duplicate member within one declaration, is
+                   E-LOAD-001. Reused (not reinvented) productions:
+                   `enum-type` and `enum-member` are §1.4's, unchanged. */
+
+defvocabulary ::= "(" "defvocabulary" enum-type                /* §2.13 */
+                       "(" enum-member+ ")"
+                   ")"
+                /* The operand is syntactically an `enum-type` but
+                   SEMANTICALLY restricted to §3.6's own closed set —
+                   NodeType / EdgeType / HyperedgeType / EventType — an
+                   unknown one is E-LOAD-030, the same code an unknown
+                   `<enum-ref>` type name already uses there. Populates
+                   the closed graph vocabulary (§3.6) `defenum` never
+                   touches; member order carries no ordinal and is not
+                   normative. Two `defvocabulary` forms for one
+                   `<enum-kind>` is E-LOAD-001. */
 
 
 /* =====================================================================

--- a/tests/unit/reference/test_bsl_grammar_sync.py
+++ b/tests/unit/reference/test_bsl_grammar_sync.py
@@ -589,3 +589,47 @@ class TestTheDraftRulingRegisterHasNoDuplicateRowNumbers:
             "— two rows claiming the same D-number, exactly the collision "
             "class a concurrently-drafted PR can introduce"
         )
+
+
+class TestTheEnumRowStaysInSync:
+    """The enum deffield row (spec §1 Q12 of the Organization contract) —
+    RHS-grain checks so the row cannot silently lose its way to be written.
+
+    This is a Task-1 red/green pair, not a D99-pattern RHS-grain guard over
+    an already-landed production: it exists to force the four textual
+    moves Q12 requires (the seventh type-table row, the sealing-paragraph
+    rewrite, the ebnf mirror, and the explicit D94-supersession record)
+    into existence in one commit, the same way ``TestTheRatioLiteralStaysInSync``
+    forced D99's four moves.
+    """
+
+    def test_the_rst_type_table_has_an_enum_row(self) -> None:
+        # Scoped to §3.1's own list-table: an unscoped scan over the whole
+        # document is satisfied vacuously by §5.2's UNRELATED CAS atom-kind
+        # row (`* - ``enum`` / ASCII <EnumType>/<MEMBER_IDENTIFIER>``), which
+        # names the same word for a different reason and exists already.
+        body = _read(RST)
+        start = body.index("3.1 Types")
+        end = body.index("3.2 Currency operator", start)
+        section = body[start:end]
+        assert re.search(r"^\s+\* - ``enum``", section, re.MULTILINE), (
+            "the <type-name> table must carry the enum row (spec §1 Q12)"
+        )
+
+    def test_the_sealing_paragraph_counts_seven(self) -> None:
+        body = _read(RST)
+        assert "seven rows" in body and "no ``<type-name>`` position can name" in body, (
+            "D94's sealing paragraph must be rewritten to seven rows with the "
+            "Q12 supersession recorded, not silently contradicted"
+        )
+
+    def test_the_ebnf_has_defenum_and_defvocabulary(self) -> None:
+        body = _ebnf_text()
+        assert "defenum" in body and "defvocabulary" in body
+
+    def test_the_supersession_d_row_is_recorded(self) -> None:
+        # Resolve the number at PR-open; the row must cite Q12 and D94 by name.
+        assert re.search(r"supersed\w+ D94", _read(RST)), (
+            "the register row must record that the enum row supersedes D94's "
+            "exclusion by Director ruling (spec §1 Q12), never silently"
+        )

--- a/tools/tree-sitter-bsl/grammar.js
+++ b/tools/tree-sitter-bsl/grammar.js
@@ -64,7 +64,8 @@
  * can accept them all and `generic_form` can reject them all. */
 const RESERVED_WORDS = [
   'add', 'add-edge', 'add-hyperedge', 'add-node', 'adjunction', 'anchor',
-  'and', 'binding', 'bindings', 'ceiling', 'deffield', 'domain',
+  'and', 'binding', 'bindings', 'ceiling', 'deffield', 'defenum',
+  'defvocabulary', 'domain',
   'edge-between', 'edges', 'effects', 'emit', 'exists', 'field-of', 'fold',
   'for-each', 'forall', 'guard', 'hyperedges', 'hyperedges-of', 'if',
   'intrinsic', 'manifest', 'member', 'members', 'members-of',
@@ -98,6 +99,8 @@ module.exports = grammar({
         $.intrinsic_decl,
         $.manifest,
         $.metric_decl,
+        $.defenum,
+        $.defvocabulary,
         $.generic_form,
       ),
 
@@ -414,6 +417,25 @@ module.exports = grammar({
         ')',
       ),
 
+    /* §2.13 (Organization spec §1 Q12, D101). */
+    defenum: ($) =>
+      seq(
+        '(',
+        'defenum',
+        $.enum_type,
+        seq('(', repeat1($.enum_member), ')'),
+        ')',
+      ),
+
+    defvocabulary: ($) =>
+      seq(
+        '(',
+        'defvocabulary',
+        $.enum_type,
+        seq('(', repeat1($.enum_member), ')'),
+        ')',
+      ),
+
     /* --- the fallback (see the file header, departure 1) ----------------- */
 
     generic_form: ($) =>
@@ -448,6 +470,16 @@ module.exports = grammar({
     qname: (_$) => token(/[a-z][a-z0-9-]*(\/[a-z][a-z0-9-]*)+/),
 
     enum_ref: (_$) => token(/[A-Z][A-Za-z0-9]*\/[A-Z][A-Z0-9_]*/),
+
+    /* §2.13 (Organization spec §1 Q12, D101): `defenum`'s type name and
+     * `defvocabulary`'s <enum-kind> operand are bare — no `/MEMBER` — so
+     * they need their own tokens rather than reusing `enum_ref`, whose
+     * regex is the whole `Type/MEMBER` pair as ONE atomic token. These
+     * two mirror `enum_ref`'s two halves exactly (bsl.ebnf's `enum-type`
+     * and `enum-member` productions, §1.4), split apart because §2.13 is
+     * the first construct that needs either half standalone. */
+    enum_type: (_$) => token(/[A-Z][A-Za-z0-9]*/),
+    enum_member: (_$) => token(/[A-Z][A-Z0-9_]*/),
 
     bool_lit: (_$) => choice('#t', '#f'),
 

--- a/tools/tree-sitter-bsl/test/corpus/declarations.txt
+++ b/tools/tree-sitter-bsl/test/corpus/declarations.txt
@@ -136,3 +136,25 @@ Manifest with a substrate rung and two adjunctions (§3.9 worked example)
       (qname)
       (symbol)
       (qname))))
+
+==================================================
+defenum and defvocabulary (§2.13, D101, Organization spec §1 Q12)
+==================================================
+
+(defenum OrgKind (STATE_APPARATUS BUSINESS POLITICAL_FACTION CIVIL_SOCIETY))
+(defvocabulary NodeType (SOCIAL_CLASS TERRITORY ORGANIZATION))
+
+---
+
+(source_file
+  (defenum
+    (enum_type)
+    (enum_member)
+    (enum_member)
+    (enum_member)
+    (enum_member))
+  (defvocabulary
+    (enum_type)
+    (enum_member)
+    (enum_member)
+    (enum_member)))


### PR DESCRIPTION
## Summary

PR Group A (Tasks 1–2) of the Organization foundation plan (`docs/superpowers/plans/2026-08-11-organization-foundation-plan.md`, merged #516; spec #515, issue #513).

**Task 1 — the spec text** (`9218bba2`): §3.1 gains its seventh `<type-name>` row (`enum`), the sealing paragraph is REWRITTEN to record the Q12↔D94 supersession explicitly (Director ruling, Organization spec §1 Q12, approved twice on 2026-08-11 — D94 itself left unedited per Immutability of History), new §2.13 defines `defenum`/`defvocabulary` with full load/runtime refusal law, `bsl.ebnf` mirrors the productions, and `TestTheEnumRowStaysInSync` (4 sync tests) keeps rst/ebnf/register in lockstep. D-rows **D101** (the supersession record) and **D102** minted; error codes **E-LOAD-053/054/055/056** and **E-EVAL-042** minted (grep-verified next-free); `defvocabulary` membership violations deliberately reuse §3.6's E-LOAD-030/031.

**Task 2 — the two ADRs** (`e6ee4e7c`): **ADR195** (the enum deffield row language change) + **ADR196** (the Phase-2 vocabulary ceremony — ONE mint-and-retire record per ADR176 (34) + ADR187 OQ-7: mints `NodeType/ORGANIZATION`, the six founding edges incl. org↔org SOLIDARITY, `OrgKind`; records TARGETS/OWNED_BY/JURISDICTION/RECRUITMENT/EMPLOYMENT + ActionType.STRIKE's estate RETIRED, frozen Python enums unedited). Numbers re-verified next-free against dev at execution per Global Constraint 5.

## Deviations from the plan (each recorded in the commit bodies)

- The plan's own literal sync-test regex was vacuous (matched a pre-existing CAS atom-kind row also spelled `enum`) — scoped to §3.1's table.
- New declaration law placed as §2.13 (purely additive) instead of a mid-chapter splice that would renumber every later §2.x citation across 5,433 lines.
- `tools/tree-sitter-bsl` (JS tooling, not the cargo workspace) gained minimal `defenum`/`defvocabulary` support because the existing corpus-coverage test pulls in every §5.2 form tag — verified by scratch parse that the unmodified grammar ERRORs on the new forms.

## Testing

- `mise run test:q -- tests/unit/reference/test_bsl_grammar_sync.py` — 32/32 (red phase observed first: 4 failures for the stated reasons).
- `mise run bsl:grammar-test` — 31/31 tree-sitter corpus.
- rstcheck / doc8 / yamllint / check-yaml pre-commit hooks green; ADR YAML `yaml.safe_load`-validated + index cross-checked.
- No cargo commands run (cargo lane owned by the query-eval train).

🤖 Generated with [Claude Code](https://claude.com/claude-code)