### PR TITLE
test(bsl): §6.2 families 14/15/17 + the aggregation corpus execute for real (query-eval group 4)

### DIFF
--- a/rust/crates/babylon-bsl/tests/conformance_corpus.rs
+++ b/rust/crates/babylon-bsl/tests/conformance_corpus.rs
@@ -8,11 +8,25 @@
 //! per-function disposition table is
 //! `reports/p27-conformance-corpus-transcription.md`.
 //!
-//! Phase-1 scope note (recorded in the ledger, not silent): fold/query
-//! EXECUTION needs the Phase-2 query evaluator, so aggregation vectors pin
-//! load-time verdicts (parse, resolve, §3.4 typecheck, §3.7 bound) here
-//! and their runtime values ride the Phase-2 vector re-run. Everything
-//! expressible in the Task 14 expression core executes for real.
+//! **PR 4, Task 14 (2026-08-11): the Phase-2 scope note retires for the
+//! node-set-shaped estate.** The former note read: "fold/query EXECUTION
+//! needs the Phase-2 query evaluator, so aggregation vectors pin load-time
+//! verdicts (parse, resolve, §3.4 typecheck, §3.7 bound) here and their
+//! runtime values ride the Phase-2 vector re-run." That evaluator has now
+//! landed (the BSL query-evaluation plan's slice 1). Every aggregation
+//! vector whose query is `(nodes …)` executes for real below —
+//! `event_node_condition.bsl` (`exists`), `event_forall.bsl` (`forall`)
+//! and `event_wealth_aggregates.bsl` (`sum`/`max`/`min`/weighted `mean`) —
+//! against a real `MemoryGraph`, asserting the RAISED/returned value and a
+//! `:fuel-used` figure (§6.1), not merely that the fixture loads and
+//! bounds. `event_edge_count.bsl` is the one exception: its query is
+//! `(edges …)`, which slice 1 does not serve (slice 2's dyadic edge lane)
+//! — it stays pinned at load only, and evaluating it anyway is asserted to
+//! refuse LOUDLY, naming slice 2 by name (Constraint 4), never a silent
+//! skip. `event_bifurcation.bsl` and `event_metric_conditions.bsl` needed
+//! no query at all and already executed for real before this task (see
+//! `bifurcation_routes_by_solidarity_density` and
+//! `metric_conditions_load_and_evaluate` below) — unchanged.
 #![allow(clippy::doc_markdown)] // doc comments cite Python test names and file paths verbatim
 
 use babylon_bsl::evaluator::{evaluate, EvalEnv, Value};
@@ -157,6 +171,26 @@ fn load(source: &str, rule_file: &str) -> Result<LoadedRule, LoadError> {
     load_rule(source, &ctx)
 }
 
+/// The `<when>` clause of a loaded rule — shared by `eval_when` and its
+/// graph-bearing twin `eval_when_over_graph` (PR 4, Task 14), plus the
+/// slice-2-refusal vector for `event_edge_count.bsl`.
+fn when_clause(rule: &LoadedRule) -> &babylon_bsl::SExpr {
+    let babylon_bsl::SExpr::List(items) = &rule.rule else {
+        unreachable!()
+    };
+    items
+        .iter()
+        .find_map(|child| match child {
+            babylon_bsl::SExpr::List(inner)
+                if matches!(inner.first(), Some(babylon_bsl::SExpr::Atom(babylon_bsl::Atom::Symbol(h))) if h == "when") =>
+            {
+                inner.get(1)
+            }
+            _ => None,
+        })
+        .expect("fixture has a when clause")
+}
+
 /// Load a fixture and evaluate its `<when>` condition against supplied
 /// binding values — the trap-DSL calling convention
 /// (`evaluate_trap_condition(expr, env, coeffs)`) reconstructed from the
@@ -170,22 +204,38 @@ fn eval_when(rule: &LoadedRule, supplied: &HashMap<String, Value>) -> bool {
         graph: None,
         elements: Vec::new(),
     };
-    let babylon_bsl::SExpr::List(items) = &rule.rule else {
-        unreachable!()
-    };
-    let cond = items
-        .iter()
-        .find_map(|child| match child {
-            babylon_bsl::SExpr::List(inner)
-                if matches!(inner.first(), Some(babylon_bsl::SExpr::Atom(babylon_bsl::Atom::Symbol(h))) if h == "when") =>
-            {
-                inner.get(1)
-            }
-            _ => None,
-        })
-        .expect("fixture has a when clause");
     let mut fuel = 10_000;
-    match evaluate(cond, &env, &EmptyIntrinsicHost, &mut fuel).expect("condition must evaluate") {
+    match evaluate(when_clause(rule), &env, &EmptyIntrinsicHost, &mut fuel)
+        .expect("condition must evaluate")
+    {
+        Value::Bool(b) => b,
+        other => panic!("a <cond> must be Bool, got {other:?}"),
+    }
+}
+
+/// `eval_when`'s graph-bearing twin (PR 4, Task 14): the same calling
+/// convention, but `env.graph = Some(graph)` — for fixtures whose
+/// `<when>` materializes a `<query>` (§2.6) rather than reading only
+/// rule-scope bindings. Takes the fuel meter BY REFERENCE, unlike
+/// `eval_when`, so a caller can assert `:fuel-used` (§6.1) on the vector
+/// that matters.
+fn eval_when_over_graph(
+    rule: &LoadedRule,
+    supplied: &HashMap<String, Value>,
+    graph: &dyn GraphSubstrate,
+    fuel: &mut u64,
+) -> bool {
+    let env_map = bind_environment(&rule.bindings, supplied).expect("environment must bind");
+    let costs = IntrinsicCosts::default();
+    let env = EvalEnv {
+        bindings: env_map,
+        intrinsic_costs: &costs,
+        graph: Some(graph),
+        elements: Vec::new(),
+    };
+    match evaluate(when_clause(rule), &env, &EmptyIntrinsicHost, fuel)
+        .expect("condition must evaluate")
+    {
         Value::Bool(b) => b,
         other => panic!("a <cond> must be Bool, got {other:?}"),
     }
@@ -499,8 +549,12 @@ fn nested_paths_are_qnames_and_absence_is_declared() {
 
 /// test_event_evaluator.py:182-214 + 244-323 — aggregations become folds:
 /// any -> exists, all -> forall, count/sum/max/min/weighted-mean load and
-/// bound against declared ceilings. Runtime fold values ride the Phase-2
-/// query evaluator (ledger row); the load verdicts pin here.
+/// bound against declared ceilings. The load verdict pins here for all
+/// four; three of the four ALSO execute for real below
+/// (`node_condition_exists_executes_over_a_real_graph`,
+/// `forall_executes_over_a_real_graph`,
+/// `wealth_aggregates_execute_over_a_real_graph`) — `EDGE_COUNT` is the
+/// one exception (`edges` is slice 2, `edge_count_stays_pinned_and_names_slice_2`).
 #[test]
 fn aggregation_fixtures_load_and_bound() {
     for (fixture, name) in [
@@ -512,6 +566,234 @@ fn aggregation_fixtures_load_and_bound() {
         let loaded = load(fixture, "x.bsl").unwrap_or_else(|e| panic!("{name}: {e}"));
         assert!(loaded.static_bound > 0, "{name} has a real bound");
     }
+}
+
+/// **PR 4, Task 14: EXECUTES.** `event_node_condition.bsl`'s `<when>` —
+/// `(exists (nodes NodeType/SOCIAL_CLASS) (>= agitation 0.6p))` —
+/// materializes `nodes` and runs `exists` over it, both served by slice 1.
+/// The predicate reads the RULE-SCOPE `agitation` binding (not a
+/// per-element field, exactly as the fixture is written), so a non-empty
+/// population's verdict is gated by `self`'s own agitation, and an EMPTY
+/// population is `#f` regardless of it — §4.4's exists-over-empty-is-false.
+#[test]
+fn node_condition_exists_executes_over_a_real_graph() {
+    let loaded = load(NODE_CONDITION, "x.bsl").unwrap();
+    let mut populated = MemoryGraph::new();
+    populated.add_node("SOCIAL_CLASS").unwrap();
+
+    let mut fuel = 10_000;
+    assert!(eval_when_over_graph(
+        &loaded,
+        &owned(vec![("agitation", real(0.7))]),
+        &populated,
+        &mut fuel,
+    ));
+    assert_eq!(
+        10_000 - fuel,
+        5,
+        ":fuel-used is a conformance-vector quantity (§6.1)"
+    );
+
+    let mut under = 10_000;
+    assert!(!eval_when_over_graph(
+        &loaded,
+        &owned(vec![("agitation", real(0.3))]),
+        &populated,
+        &mut under,
+    ));
+
+    let empty = MemoryGraph::new();
+    let mut on_empty = 10_000;
+    assert!(!eval_when_over_graph(
+        &loaded,
+        &owned(vec![("agitation", real(0.9))]),
+        &empty,
+        &mut on_empty,
+    ));
+}
+
+/// **PR 4, Task 14: EXECUTES.** `event_forall.bsl`'s `<when>` — `(forall
+/// (nodes NodeType/SOCIAL_CLASS) (>= agitation 0.5p))` — materializes
+/// `nodes` and runs `forall` over it. §4.4's forall-over-empty-is-TRUE is
+/// the dual of `exists`' empty case above: an EMPTY population fires
+/// regardless of agitation, because the condition holds VACUOUSLY.
+#[test]
+fn forall_executes_over_a_real_graph() {
+    let loaded = load(FORALL, "x.bsl").unwrap();
+    let mut populated = MemoryGraph::new();
+    populated.add_node("SOCIAL_CLASS").unwrap();
+
+    let mut fuel = 10_000;
+    assert!(eval_when_over_graph(
+        &loaded,
+        &owned(vec![("agitation", real(0.6))]),
+        &populated,
+        &mut fuel,
+    ));
+    assert_eq!(
+        10_000 - fuel,
+        5,
+        ":fuel-used is a conformance-vector quantity (§6.1)"
+    );
+
+    let mut under = 10_000;
+    assert!(!eval_when_over_graph(
+        &loaded,
+        &owned(vec![("agitation", real(0.2))]),
+        &populated,
+        &mut under,
+    ));
+
+    let empty = MemoryGraph::new();
+    let mut on_empty = 10_000;
+    assert!(eval_when_over_graph(
+        &loaded,
+        &owned(vec![("agitation", real(0.0))]),
+        &empty,
+        &mut on_empty,
+    ));
+}
+
+/// **PR 4, Task 14: EXECUTES.** `event_wealth_aggregates.bsl`'s `<when>`
+/// folds `sum`/`max`/`min` over `wealth` and a weighted `mean` over
+/// `agitation`/`population` — all four over `(nodes NodeType/SOCIAL_CLASS)`,
+/// served by slice 1. Every body is a RULE-SCOPE binding — constant across
+/// the fold's elements, exactly as the fixture is written (it is a
+/// transcription of an aggregation SHAPE, not a per-node reader) — so with
+/// N nodes: `sum = N × wealth`, `max = min = wealth`, and a weighted
+/// `mean` of a constant is that constant regardless of the weight.
+///
+/// **A real finding this executed vector surfaces that the load-only pin
+/// could not, recorded rather than silently patched:** the fixture's
+/// `wealth` binding is declared `Currency` (this file's own `types()`),
+/// but its three threshold literals — `550`, `500`, `50` — are bare `Int`
+/// atoms (no `$` suffix). §3.1 orders within ONE numeric lane only, so
+/// `(>= <Currency> 550)` is a loud, UNCODED lane-mismatch failure at
+/// EVALUATION, for every possible `wealth` value — not `#f`, and not the
+/// `E-TYPE-030` arithmetic-mix code (that family covers `+`/`-`/`*`/`/`,
+/// not `<`/`<=`/`>`/`>=`). This is exactly the class of defect Task 14's
+/// re-run exists to catch: invisible to the Phase-1 load-only pin (parse,
+/// resolve, §3.4 typecheck and §3.7 bound all accept the fixture as
+/// written — `aggregation_fixtures_load_and_bound` above still passes),
+/// visible the moment real evaluation runs. Repairing the fixture itself
+/// (`550` → `550$` etc.) is outside this task's file list — conformance
+/// corpus DATA, not `conformance_corpus.rs` — so it is filed here as a
+/// finding, not fixed blind. Each fold is verified on its own below,
+/// against its own exact value, and the compound clause's REAL raised
+/// error closes the vector.
+#[test]
+fn wealth_aggregates_execute_over_a_real_graph() {
+    let loaded = load(WEALTH_AGGREGATES, "x.bsl").unwrap();
+    let mut graph = MemoryGraph::new();
+    graph.add_node("SOCIAL_CLASS").unwrap();
+    graph.add_node("SOCIAL_CLASS").unwrap();
+
+    let bindings = owned(vec![
+        (
+            "wealth",
+            Value::Currency(babylon_kernel::Currency::from_micro_units(300_000_000)),
+        ),
+        ("agitation", real(0.4)),
+        ("population", int(10)),
+    ]);
+
+    // sum = 2 x 300 = 600.
+    let mut fuel = 10_000;
+    assert_eq!(
+        eval_value_over_graph(
+            "(fold sum (nodes NodeType/SOCIAL_CLASS) wealth)",
+            &bindings,
+            &graph,
+            &mut fuel,
+        ),
+        Value::Currency(babylon_kernel::Currency::from_micro_units(600_000_000)),
+    );
+    assert_eq!(
+        10_000 - fuel,
+        5,
+        ":fuel-used is a conformance-vector quantity (§6.1)"
+    );
+
+    // max = min = 300 — the constant-body finding stated in the doc above.
+    let mut fuel2 = 10_000;
+    assert_eq!(
+        eval_value_over_graph(
+            "(fold max (nodes NodeType/SOCIAL_CLASS) wealth)",
+            &bindings,
+            &graph,
+            &mut fuel2,
+        ),
+        Value::Currency(babylon_kernel::Currency::from_micro_units(300_000_000)),
+    );
+    let mut fuel3 = 10_000;
+    assert_eq!(
+        eval_value_over_graph(
+            "(fold min (nodes NodeType/SOCIAL_CLASS) wealth)",
+            &bindings,
+            &graph,
+            &mut fuel3,
+        ),
+        Value::Currency(babylon_kernel::Currency::from_micro_units(300_000_000)),
+    );
+
+    // The weighted mean of a constant is that constant, whatever N and
+    // whatever the (also-constant) weight — population cancels out of
+    // Σ(w·x)/Σw exactly.
+    let mut fuel4 = 10_000;
+    assert_eq!(
+        eval_value_over_graph(
+            "(fold mean (nodes NodeType/SOCIAL_CLASS) agitation :weight population)",
+            &bindings,
+            &graph,
+            &mut fuel4,
+        ),
+        Value::Real(0.4),
+    );
+
+    // The compound `<when>` raises a loud, UNCODED lane-mismatch error —
+    // the currency-vs-bare-Int defect stated in the doc above — built
+    // directly (not through `eval_when_over_graph`, which `.expect()`s
+    // success) so the failure is asserted, not panicked past.
+    let costs = IntrinsicCosts::default();
+    let env_map = bind_environment(&loaded.bindings, &bindings).unwrap();
+    let env = EvalEnv {
+        bindings: env_map,
+        intrinsic_costs: &costs,
+        graph: Some(&graph as &dyn GraphSubstrate),
+        elements: Vec::new(),
+    };
+    let mut fuel5 = 10_000;
+    let err = evaluate(when_clause(&loaded), &env, &EmptyIntrinsicHost, &mut fuel5).unwrap_err();
+    assert_eq!(err.code, None, "{err}");
+    assert!(
+        err.message.contains("one numeric lane"),
+        "expected the §3.1 lane-mismatch refusal, got: {err}"
+    );
+}
+
+/// **PR 4, Task 14: still pinned, named by its slice.** Unlike its three
+/// siblings above, `event_edge_count.bsl`'s `<when>` — `(>= (fold count
+/// (edges EdgeType/SOLIDARITY) it) 1)` — queries `edges`, which slice 1
+/// does not serve (it lands in slice 2, the dyadic edge lane). It stays
+/// pinned at LOAD only (`aggregation_fixtures_load_and_bound` above).
+/// Evaluating it anyway must refuse LOUDLY, naming the slice — never a
+/// silent skip (Constraint 4) and never `E-LOAD-021`'s misdiagnosis.
+#[test]
+fn edge_count_stays_pinned_and_names_slice_2() {
+    let loaded = load(EDGE_COUNT, "x.bsl").unwrap();
+    let graph = MemoryGraph::new();
+    let costs = IntrinsicCosts::default();
+    let env_map = bind_environment(&loaded.bindings, &HashMap::new())
+        .expect("EDGE_COUNT's bindings are empty — nothing to resolve");
+    let env = EvalEnv {
+        bindings: env_map,
+        intrinsic_costs: &costs,
+        graph: Some(&graph as &dyn GraphSubstrate),
+        elements: Vec::new(),
+    };
+    let mut fuel = 10_000;
+    let err = evaluate(when_clause(&loaded), &env, &EmptyIntrinsicHost, &mut fuel).unwrap_err();
+    assert!(err.message.contains("slice 2"), "{err}");
 }
 
 /// §3.4 catches what Python's aggregate_and_compare silently permitted:
@@ -728,6 +1010,26 @@ fn eval_value(source: &str, env_pairs: &[(&str, Value)]) -> Value {
     let (expr, _) = read(source).expect("vector source must parse");
     let mut fuel = 10_000;
     evaluate(&expr, &env, &EmptyIntrinsicHost, &mut fuel).expect("vector must evaluate")
+}
+
+/// `eval_value`'s graph-bearing twin (PR 4, Task 14): `env.graph =
+/// Some(graph)`, and the fuel meter is BY REFERENCE so a caller can
+/// assert `:fuel-used` (§6.1).
+fn eval_value_over_graph(
+    source: &str,
+    bindings: &HashMap<String, Value>,
+    graph: &dyn GraphSubstrate,
+    fuel: &mut u64,
+) -> Value {
+    let costs = IntrinsicCosts::default();
+    let env = EvalEnv {
+        bindings: bindings.clone(),
+        intrinsic_costs: &costs,
+        graph: Some(graph),
+        elements: Vec::new(),
+    };
+    let (expr, _) = read(source).expect("vector source must parse");
+    evaluate(&expr, &env, &EmptyIntrinsicHost, fuel).expect("vector must evaluate")
 }
 
 fn eval_cond(source: &str, env_pairs: &[(&str, Value)]) -> bool {

--- a/rust/crates/babylon-bsl/tests/r9_chapters.rs
+++ b/rust/crates/babylon-bsl/tests/r9_chapters.rs
@@ -993,7 +993,7 @@ mod c5_element_selection {
     use babylon_bsl::structural_verbs::{CollectingSink, EffectExecutor};
     use babylon_bsl::typecheck::{check_selection_scores, TypeCode};
     use babylon_graph::memory::MemoryGraph;
-    use babylon_graph::substrate::{GraphSubstrate, NodeId};
+    use babylon_graph::substrate::GraphSubstrate;
     use std::collections::HashMap;
 
     /// Evaluate one `<expr>` (a bare fragment, not a whole rule) against a
@@ -1181,7 +1181,12 @@ mod c5_element_selection {
     /// `E-LOAD-021` misdiagnosis.
     #[test]
     fn the_other_four_selection_heads_stay_pinned_named_by_their_slice() {
-        let graph = MemoryGraph::new();
+        // `self` binds to a REAL node: were it a dangling id, a future
+        // referent-validation pass could fire before the slice refusal
+        // and this vector would pin the wrong error (Copilot harvest,
+        // #520).
+        let mut graph = MemoryGraph::new();
+        let subject = graph.add_node("SOCIAL_CLASS").unwrap();
         for (query, slice) in [
             ("(edges EdgeType/SOLIDARITY)", "slice 2"),
             ("(hyperedges HyperedgeType/ECONOMIC_SECTOR)", "slice 3"),
@@ -1195,7 +1200,7 @@ mod c5_element_selection {
             let err = eval_expr(
                 &format!("(select-max {query} it)"),
                 &graph,
-                HashMap::from([("self".to_owned(), Value::NodeRef(NodeId(0)))]),
+                HashMap::from([("self".to_owned(), Value::NodeRef(subject))]),
                 &mut fuel,
             )
             .unwrap_err();
@@ -1350,8 +1355,14 @@ mod c5_element_selection {
                 &mut fuel2,
             )
             .unwrap();
+        // Pass 2 uses a FRESH executor, exactly as `tick.rs::run_tick`
+        // does — the apply half must not depend on any state the
+        // collecting executor accumulated (Copilot harvest, #520).
+        let mut apply_executor = EffectExecutor::new(&types);
         for write in &pending {
-            executor.apply_pending_write(write, &mut graph).unwrap();
+            apply_executor
+                .apply_pending_write(write, &mut graph)
+                .unwrap();
         }
         let selected = graph
             .node_attribute(high, "organization/claim-strength")

--- a/rust/crates/babylon-bsl/tests/r9_chapters.rs
+++ b/rust/crates/babylon-bsl/tests/r9_chapters.rs
@@ -3,16 +3,27 @@
 //! chapters were planned in (C1 → C13).
 //!
 //! **Scope honesty, recorded once here rather than per family.** §6.2's
-//! families mix load-time and evaluation-time obligations. The crate's
-//! evaluator is the §4 *expression core*: queries, folds, selections,
-//! accessors and effect-position iteration have no runtime yet (the
-//! `conformance_corpus.rs` header records the same boundary for the
-//! pre-R9 estate). Every vector below therefore pins the obligation at the
-//! time the language reference assigns it **and that this crate can
-//! observe**: the `E-LEX`/`E-PARSE`/`E-TYPE`/`E-LOAD` classes execute for
-//! real, and each `E-EVAL` row is pinned as its code's identity and
-//! discipline rather than as a raised value. Rows that need the query
-//! evaluator are named in the per-family notes, never silently skipped.
+//! families mix load-time and evaluation-time obligations. Through PR 3
+//! (the BSL query-evaluation plan's slice 1, Phase 2), the crate's
+//! evaluator served only the §4 *expression core*: queries, folds,
+//! selections, accessors and effect-position iteration had no runtime (the
+//! `conformance_corpus.rs` header recorded the same boundary for the
+//! pre-R9 estate). **PR 4, Task 13 (2026-08-11) retires that boundary for
+//! three families**: 14 (element selection), 15 (effect-position
+//! iteration) and 17 (typed neighbours and element naming) now EXECUTE —
+//! their `fold`/`exists`/`forall`/`select-max`/`select-min`/`field-of`/
+//! `for-each` vectors run the real query evaluator over a `MemoryGraph`
+//! fixture and assert the RAISED value or written state, not merely the
+//! code's identity. Every other family stays exactly as it was: the
+//! `E-LEX`/`E-PARSE`/`E-TYPE`/`E-LOAD` classes execute for real everywhere
+//! (unchanged, load-time), and an `E-EVAL` row outside families 14/15/17
+//! is still pinned as its code's identity and discipline rather than as a
+//! raised value — each remaining deferral is named in its own family's
+//! module doc with the slice that will serve it (2 for the dyadic edge
+//! lane — `edges`/`edge-between`/`the`; 3 for the hyperedge + metric lane
+//! — `hyperedges`/`members-of`/`hyperedges-of`/`metric-of`; 4 for
+//! attribute STORAGE — `update-edge`/`update-hyperedge`, Constitution
+//! III.7), never silently skipped.
 
 use babylon_bsl::bindings::BindingVocabulary;
 use babylon_bsl::bound_checker::{expr_cost, rule_bound, BoundError};
@@ -963,16 +974,48 @@ mod c13_calendar_bindings {
 // ====================================================== family 14 — C5
 // Element selection (§2.7's `select-max` / `select-min`).
 //
-// Runtime rows deferred: the tie vector, the `E-EVAL-021` empty query, and
-// a selection feeding `update-node`/`field-of` all need the query
-// evaluator. The result-type rule, the score rule and the cost row are
-// pinned statically, and the tiebreak is pinned as language text below.
+// **PR 4, Task 13 (2026-08-11): EXECUTES.** `select-max`/`select-min` over
+// the two heads slice 1 serves (`nodes`, `neighbors`) run for real below:
+// the tie vector, the `E-EVAL-021` empty-query RAISE (not merely the
+// code's identity), an intensive score's ranking, and a selection feeding
+// both `field-of` and `update-node`. The other four query heads (`edges`,
+// `hyperedges`, `members-of`, `hyperedges-of`) still refuse at evaluation,
+// each naming its own slice (2 or 3) — pinned as a real refusal, not a
+// silent skip. The result-type rule, the `E-TYPE-016` score rule and the
+// §3.7 cost row stay load-time static, exactly as before.
 mod c5_element_selection {
     use super::{cost, e, type_env};
     use babylon_bsl::bindings::parse_bindings;
-    use babylon_bsl::evaluator::EvalCode;
+    use babylon_bsl::evaluator::{evaluate, EvalCode, EvalEnv, EvalError, Value};
+    use babylon_bsl::fuel::IntrinsicCosts;
+    use babylon_bsl::intrinsic_host::EmptyIntrinsicHost;
     use babylon_bsl::score_class::{selection_result_class, ScoreClass};
+    use babylon_bsl::structural_verbs::{CollectingSink, EffectExecutor};
     use babylon_bsl::typecheck::{check_selection_scores, TypeCode};
+    use babylon_graph::memory::MemoryGraph;
+    use babylon_graph::substrate::{GraphSubstrate, NodeId};
+    use std::collections::HashMap;
+
+    /// Evaluate one `<expr>` (a bare fragment, not a whole rule) against a
+    /// graph and a supplied binding map — the shared seam every real
+    /// evaluation vector below drives through, mirroring the pattern
+    /// `evaluator.rs`'s own `#[cfg(test)]` module uses (`eval_over`) at
+    /// this conformance-family level instead of the implementation level.
+    fn eval_expr(
+        source: &str,
+        graph: &dyn GraphSubstrate,
+        bindings: HashMap<String, Value>,
+        fuel: &mut u64,
+    ) -> Result<Value, EvalError> {
+        let costs = IntrinsicCosts::default();
+        let env = EvalEnv {
+            bindings,
+            intrinsic_costs: &costs,
+            graph: Some(graph),
+            elements: Vec::new(),
+        };
+        evaluate(&e(source), &env, &EmptyIntrinsicHost, fuel)
+    }
 
     fn score_error(body: &str) -> Option<TypeCode> {
         let form = e(&super::rule(body));
@@ -1085,25 +1128,271 @@ mod c5_element_selection {
         );
     }
 
+    // -------------------------------------------------- PR 4 Task 13: EXECUTES
+
+    /// `select-max`/`select-min` run for real over BOTH heads slice 1
+    /// serves: `nodes` and `neighbors`. The `neighbors` case also proves
+    /// the D24 filter composes with a selection — only the annotated
+    /// `NodeType` is eligible to win.
+    #[test]
+    fn select_max_and_select_min_execute_over_nodes_and_neighbors() {
+        let mut graph = MemoryGraph::new();
+        let low = graph.add_node("ORGANIZATION").unwrap();
+        let high = graph.add_node("ORGANIZATION").unwrap();
+        graph
+            .update_node(low, "organization/claim-strength", 0.2)
+            .unwrap();
+        graph
+            .update_node(high, "organization/claim-strength", 0.9)
+            .unwrap();
+        let mut fuel = 1_000;
+        let result = eval_expr(
+            "(select-max (nodes NodeType/ORGANIZATION) \
+             (field-of it organization/claim-strength))",
+            &graph,
+            HashMap::new(),
+            &mut fuel,
+        )
+        .unwrap();
+        assert_eq!(result, Value::NodeRef(high));
+
+        // Over `neighbors`: `self` reaches both ORGANIZATION nodes via
+        // SOLIDARITY; the NodeType annotation is the only filter and both
+        // qualify, so the selection picks between them exactly as it did
+        // over the bare `nodes` query above.
+        let subject = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph.add_edge("SOLIDARITY", subject, low, 1.0).unwrap();
+        graph.add_edge("SOLIDARITY", subject, high, 1.0).unwrap();
+        let mut fuel2 = 1_000;
+        let result2 = eval_expr(
+            "(select-min (neighbors self EdgeType/SOLIDARITY :out NodeType/ORGANIZATION) \
+             (field-of it organization/claim-strength))",
+            &graph,
+            HashMap::from([("self".to_owned(), Value::NodeRef(subject))]),
+            &mut fuel2,
+        )
+        .unwrap();
+        assert_eq!(result2, Value::NodeRef(low));
+    }
+
+    /// The other four §2.6 query heads a selection could in principle run
+    /// over stay refused at EVALUATION, each naming the slice that will
+    /// serve it (Constraint 4) — never a silent skip and never an
+    /// `E-LOAD-021` misdiagnosis.
+    #[test]
+    fn the_other_four_selection_heads_stay_pinned_named_by_their_slice() {
+        let graph = MemoryGraph::new();
+        for (query, slice) in [
+            ("(edges EdgeType/SOLIDARITY)", "slice 2"),
+            ("(hyperedges HyperedgeType/ECONOMIC_SECTOR)", "slice 3"),
+            ("(members-of self HyperedgeType/ECONOMIC_SECTOR)", "slice 3"),
+            (
+                "(hyperedges-of self HyperedgeType/ECONOMIC_SECTOR)",
+                "slice 3",
+            ),
+        ] {
+            let mut fuel = 1_000;
+            let err = eval_expr(
+                &format!("(select-max {query} it)"),
+                &graph,
+                HashMap::from([("self".to_owned(), Value::NodeRef(NodeId(0)))]),
+                &mut fuel,
+            )
+            .unwrap_err();
+            assert!(err.message.contains(slice), "{query}: {err}");
+        }
+    }
+
     /// D45: the tiebreak is a property of the LANGUAGE, not of each rule —
     /// the first element in §2.6's ascending id byte order wins, for both
-    /// operators. Pinned here as the identity of the empty-query code and
-    /// re-proved as behaviour when the query evaluator lands.
+    /// operators, EXECUTED against two equally-scored elements.
     #[test]
-    fn an_empty_selection_shares_the_empty_aggregate_code() {
-        assert_eq!(EvalCode::EmptyAggregate.spec_code(), "E-EVAL-021");
+    fn the_tie_vector_breaks_to_the_smaller_id_for_both_operators() {
+        let mut graph = MemoryGraph::new();
+        let first = graph.add_node("ORGANIZATION").unwrap(); // id 0
+        let second = graph.add_node("ORGANIZATION").unwrap(); // id 1
+        graph
+            .update_node(first, "organization/claim-strength", 0.5)
+            .unwrap();
+        graph
+            .update_node(second, "organization/claim-strength", 0.5)
+            .unwrap();
+        for op in ["select-max", "select-min"] {
+            let mut fuel = 1_000;
+            let result = eval_expr(
+                &format!(
+                    "({op} (nodes NodeType/ORGANIZATION) \
+                     (field-of it organization/claim-strength))"
+                ),
+                &graph,
+                HashMap::new(),
+                &mut fuel,
+            )
+            .unwrap();
+            assert_eq!(
+                result,
+                Value::NodeRef(first),
+                "{op}: the smaller id wins a tie"
+            );
+        }
+    }
+
+    /// D45/§4.4: an empty query RAISES `E-EVAL-021` — not merely shares the
+    /// code's identity, as the retired pin only proved.
+    #[test]
+    fn selection_over_an_empty_query_raises_e_eval_021() {
+        let graph = MemoryGraph::new();
+        for op in ["select-max", "select-min"] {
+            let mut fuel = 1_000;
+            let err = eval_expr(
+                &format!(
+                    "({op} (nodes NodeType/ORGANIZATION) \
+                     (field-of it organization/claim-strength))"
+                ),
+                &graph,
+                HashMap::new(),
+                &mut fuel,
+            )
+            .unwrap_err();
+            assert_eq!(err.code, Some(EvalCode::EmptyAggregate), "{op}: {err}");
+            assert_eq!(err.code.unwrap().spec_code(), "E-EVAL-021");
+        }
+    }
+
+    /// D46's acceptance half, EXECUTED: an intensive score ranks correctly
+    /// at evaluation — there is no evaluator-level kind check to enforce
+    /// (no `TypeEnv` reaches this far), exactly as §2.7 says §3.4 polices
+    /// aggregation, never ordering.
+    #[test]
+    fn an_intensive_score_ranks_correctly_at_evaluation() {
+        let mut graph = MemoryGraph::new();
+        let mut ids = Vec::new();
+        for i in 0..4 {
+            let id = graph.add_node("ORGANIZATION").unwrap();
+            graph
+                .update_node(id, "organization/claim-strength", f64::from(i))
+                .unwrap();
+            ids.push(id);
+        }
+        let mut fuel = 1_000;
+        let result = eval_expr(
+            "(select-max (nodes NodeType/ORGANIZATION) \
+             (field-of it organization/claim-strength))",
+            &graph,
+            HashMap::new(),
+            &mut fuel,
+        )
+        .unwrap();
+        assert_eq!(result, Value::NodeRef(*ids.last().unwrap()));
+    }
+
+    /// A selection result feeds BOTH consumers §2.7 names: `field-of` (a
+    /// read) and `update-node` (a write, Task 11's own concern) — EXECUTED
+    /// through the production collect-then-apply path
+    /// (`EffectExecutor::collect_effects` + `apply_pending_write`), not
+    /// merely accepted at load.
+    #[test]
+    fn a_selection_feeds_field_of_and_update_node() {
+        let mut graph = MemoryGraph::new();
+        let low = graph.add_node("ORGANIZATION").unwrap();
+        let high = graph.add_node("ORGANIZATION").unwrap();
+        graph
+            .update_node(low, "organization/claim-strength", 0.2)
+            .unwrap();
+        graph
+            .update_node(high, "organization/claim-strength", 0.9)
+            .unwrap();
+
+        // field-of over the selection result — the §2.7 worked example's
+        // read half.
+        let mut fuel = 1_000;
+        let read_back = eval_expr(
+            "(field-of \
+               (select-max (nodes NodeType/ORGANIZATION) \
+                            (field-of it organization/claim-strength)) \
+               organization/claim-strength)",
+            &graph,
+            HashMap::new(),
+            &mut fuel,
+        )
+        .unwrap();
+        assert_eq!(read_back, Value::Real(0.9));
+
+        // update-node against the selection result — the write half,
+        // driven through the SAME collect-then-apply production path
+        // `tick.rs::run_tick` uses (Task 12).
+        let (form, _) = babylon_bsl::reader::read(
+            "(effects (update-node \
+               (select-max (nodes NodeType/ORGANIZATION) \
+                            (field-of it organization/claim-strength)) \
+               organization/claim-strength (set 0.5c)))",
+        )
+        .expect("must parse");
+        let babylon_bsl::reader::SExpr::List(items) = form else {
+            unreachable!()
+        };
+        let env = EvalEnv {
+            bindings: HashMap::new(),
+            intrinsic_costs: &IntrinsicCosts::default(),
+            graph: Some(&graph as &dyn GraphSubstrate),
+            elements: Vec::new(),
+        };
+        let types = type_env();
+        let mut executor = EffectExecutor::new(&types);
+        let mut sink = CollectingSink::default();
+        let mut fuel2 = 1_000;
+        let pending = executor
+            .collect_effects(
+                &items[1..],
+                &env,
+                &EmptyIntrinsicHost,
+                &mut sink,
+                &mut fuel2,
+            )
+            .unwrap();
+        for write in &pending {
+            executor.apply_pending_write(write, &mut graph).unwrap();
+        }
+        let selected = graph
+            .node_attribute(high, "organization/claim-strength")
+            .unwrap();
+        assert!(
+            (selected - 0.5).abs() < 1e-12,
+            "the SELECTED (higher-scoring) node was written"
+        );
+        let untouched = graph
+            .node_attribute(low, "organization/claim-strength")
+            .unwrap();
+        assert!(
+            (untouched - 0.2).abs() < 1e-12,
+            "the non-selected node was left alone"
+        );
     }
 }
 
 // ====================================================== family 15 — C6
 // Effect-position iteration (§2.8's `for-each`).
 //
-// Runtime rows deferred and named: the per-element `update-edge`/`emit`
-// results, the pre-state materialization proof, and the empty-query
-// no-op all need the query evaluator. The grammar, the arity, the static
-// bound and the `E-LOAD-040` interaction are pinned.
+// **PR 4, Task 13 (2026-08-11): EXECUTES.** `for-each` over `nodes`/
+// `neighbors` applies `update-node` and `emit` per element for real below,
+// through the SAME collect-then-apply production path `tick.rs::run_tick`
+// uses (Task 12): the pre-state materialization proof, the empty-query
+// quiet case, and a real nested `for-each`. `update-edge`'s per-element
+// results stay pinned — a DIFFERENT, orthogonal gap (C2's declared
+// substrate-storage refusal, Constitution III.7), not a query-evaluator
+// gap, so the three static cost vectors below (which only ever computed
+// §3.7's bound, never executed) keep `update-edge` in their body
+// unchanged. The grammar, the arity, the static bound and the
+// `E-LOAD-040` interaction stay pinned exactly as before.
 mod c6_effect_position_iteration {
-    use super::{bound, cost};
+    use super::{bound, cost, type_env};
+    use babylon_bsl::evaluator::{EvalEnv, EvalError, Value};
+    use babylon_bsl::fuel::IntrinsicCosts;
+    use babylon_bsl::intrinsic_host::EmptyIntrinsicHost;
+    use babylon_bsl::structural_verbs::{CollectingSink, EffectExecutor};
+    use babylon_graph::memory::MemoryGraph;
+    use babylon_graph::substrate::GraphSubstrate;
+    use std::collections::HashMap;
 
     /// §3.7's row: `2 + cost(query) + ceiling(query) × Σ cost(effect-items)`
     /// — charged exactly as `exists`/`forall` are, which is what keeps the
@@ -1194,6 +1483,251 @@ mod c6_effect_position_iteration {
             Ok(203)
         );
     }
+
+    // -------------------------------------------------- PR 4 Task 13: EXECUTES
+
+    /// Run one `(effects …)` list through the PRODUCTION path (Task 12):
+    /// collect against an immutable borrow of `graph`, then — after that
+    /// borrow ends — apply every collected write against a mutable one.
+    /// The SAME two passes `tick.rs::run_tick` runs, on one shared graph
+    /// object — the conformance-family mirror of `structural_verbs.rs`'s
+    /// own `collect_then_apply` test helper, built from public API since
+    /// this file is a separate integration-test crate.
+    #[allow(clippy::type_complexity)]
+    fn collect_then_apply(
+        graph: &mut MemoryGraph,
+        bindings: HashMap<String, Value>,
+        effects_source: &str,
+        fuel: &mut u64,
+    ) -> Result<Vec<(String, Vec<(String, Value)>)>, EvalError> {
+        let (form, _) =
+            babylon_bsl::reader::read(effects_source).expect("effects source must parse");
+        let babylon_bsl::reader::SExpr::List(items) = form else {
+            unreachable!()
+        };
+        let types = type_env();
+        let mut sink = CollectingSink::default();
+        let pending = {
+            let env = EvalEnv {
+                bindings,
+                intrinsic_costs: &IntrinsicCosts::default(),
+                graph: Some(&*graph as &dyn GraphSubstrate),
+                elements: Vec::new(),
+            };
+            let mut collector = EffectExecutor::new(&types);
+            collector.collect_effects(&items[1..], &env, &EmptyIntrinsicHost, &mut sink, fuel)?
+        };
+        let mut applier = EffectExecutor::new(&types);
+        for write in &pending {
+            applier.apply_pending_write(write, &mut *graph)?;
+        }
+        Ok(sink.events)
+    }
+
+    /// `for-each` over `nodes` applies `update-node` and `emit` once per
+    /// element, in §2.6 ascending-id order — the §2.8 worked shape,
+    /// EXECUTED.
+    #[test]
+    fn for_each_over_nodes_applies_update_node_and_emit_per_element_in_order() {
+        let mut graph = MemoryGraph::new();
+        let a = graph.add_node("SOCIAL_CLASS").unwrap();
+        let b = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph
+            .update_node(a, "social-class/agitation", 0.10)
+            .unwrap();
+        graph
+            .update_node(b, "social-class/agitation", 0.20)
+            .unwrap();
+        let mut fuel = 4_096;
+        let events = collect_then_apply(
+            &mut graph,
+            HashMap::new(),
+            "(effects (for-each (nodes NodeType/SOCIAL_CLASS) \
+               (update-node it social-class/agitation (set 0.5i)) \
+               (emit EventType/RUPTURE (who it))))",
+            &mut fuel,
+        )
+        .unwrap();
+        assert_eq!(
+            events,
+            vec![
+                (
+                    "RUPTURE".to_owned(),
+                    vec![("who".to_owned(), Value::NodeRef(a))]
+                ),
+                (
+                    "RUPTURE".to_owned(),
+                    vec![("who".to_owned(), Value::NodeRef(b))]
+                ),
+            ],
+            "once per element, in §2.6 ascending-id iteration order"
+        );
+        for id in [a, b] {
+            let stored = graph.node_attribute(id, "social-class/agitation").unwrap();
+            assert!((stored - 0.5).abs() < 1e-12, "{id:?}");
+        }
+    }
+
+    /// `for-each` over `neighbors` composes the same way — D24's type
+    /// filter narrows the population `for-each` iterates, EXECUTED.
+    #[test]
+    fn for_each_over_neighbors_applies_update_node_per_element() {
+        let mut graph = MemoryGraph::new();
+        let subject = graph.add_node("SOCIAL_CLASS").unwrap();
+        let tenant = graph.add_node("SOCIAL_CLASS").unwrap();
+        let other = graph.add_node("ORGANIZATION").unwrap();
+        graph
+            .update_node(tenant, "social-class/agitation", 0.10)
+            .unwrap();
+        graph.add_edge("SOLIDARITY", subject, tenant, 1.0).unwrap();
+        graph.add_edge("SOLIDARITY", subject, other, 1.0).unwrap();
+        let mut fuel = 4_096;
+        collect_then_apply(
+            &mut graph,
+            HashMap::from([("self".to_owned(), Value::NodeRef(subject))]),
+            "(effects (for-each (neighbors self EdgeType/SOLIDARITY :out NodeType/SOCIAL_CLASS) \
+               (update-node it social-class/agitation (set 0.9i))))",
+            &mut fuel,
+        )
+        .unwrap();
+        let stored = graph
+            .node_attribute(tenant, "social-class/agitation")
+            .unwrap();
+        assert!(
+            (stored - 0.9).abs() < 1e-12,
+            "the typed neighbor was written"
+        );
+    }
+
+    /// §2.8 chapter C6: an iteration is a COMMAND, and "do it to none" is
+    /// fully determined — the one place an empty set is quiet (unlike
+    /// mean/min/max/select-*, which must PRODUCE a value and have none to
+    /// produce, `E-EVAL-021`). EXECUTED, not merely asserted deferred.
+    #[test]
+    fn for_each_over_an_empty_query_applies_nothing_and_does_not_error() {
+        let mut graph = MemoryGraph::new();
+        let self_id = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph
+            .update_node(self_id, "social-class/agitation", 0.10)
+            .unwrap();
+        let mut fuel = 512;
+        let events = collect_then_apply(
+            &mut graph,
+            HashMap::from([("self".to_owned(), Value::NodeRef(self_id))]),
+            "(effects (for-each (nodes NodeType/ORGANIZATION) \
+               (update-node self social-class/agitation (set 0.99i))))",
+            &mut fuel,
+        )
+        .expect("an empty for-each is not an error");
+        assert!(events.is_empty());
+        let stored = graph
+            .node_attribute(self_id, "social-class/agitation")
+            .unwrap();
+        assert!(
+            (stored - 0.10).abs() < 1e-12,
+            "an empty for-each applies NOTHING — the body never ran"
+        );
+    }
+
+    /// The §6.2 family-15 pre-state vector. §2.8 chapter C6, quoted in the
+    /// module: "every expression anywhere in an effects list … is
+    /// evaluated against the pre-state". An EARLIER `update-node` in the
+    /// SAME effects list has not landed when the `for-each`'s query and
+    /// body evaluate — both read through `env.graph`, the collect-time
+    /// reborrow, and nothing applies until `collect_effects` returns.
+    #[test]
+    fn for_each_reads_the_pre_state_not_an_earlier_verbs_effect_in_the_same_list() {
+        let mut graph = MemoryGraph::new();
+        let subject = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph
+            .update_node(subject, "social-class/agitation", 0.10)
+            .unwrap();
+        let mut fuel = 1_024;
+        let events = collect_then_apply(
+            &mut graph,
+            HashMap::from([("self".to_owned(), Value::NodeRef(subject))]),
+            "(effects \
+               (update-node self social-class/agitation (set 0.90i)) \
+               (for-each (nodes NodeType/SOCIAL_CLASS) \
+                 (emit EventType/RUPTURE (agitation (field-of it social-class/agitation)))))",
+            &mut fuel,
+        )
+        .unwrap();
+        assert_eq!(
+            events,
+            vec![(
+                "RUPTURE".to_owned(),
+                vec![("agitation".to_owned(), Value::Real(0.10))]
+            )],
+            "for-each's query and body must read the PRE-state (0.10), never \
+             the earlier update-node's collected-but-not-yet-applied write \
+             (0.90) — §2.8 chapter C6"
+        );
+        // …and the earlier update-node's own effect DID land, once
+        // collect_effects returned and apply_pending_write ran.
+        let stored = graph
+            .node_attribute(subject, "social-class/agitation")
+            .unwrap();
+        assert!((stored - 0.90).abs() < 1e-12);
+    }
+
+    /// Nested `for-each` composes outer-iteration-then-inner-source-order,
+    /// EXECUTED — the real-evaluation twin of
+    /// `nested_for_each_multiplies_its_two_ceilings`'s static bound above.
+    #[test]
+    fn nested_for_each_composes_and_executes() {
+        let mut graph = MemoryGraph::new();
+        let sc1 = graph.add_node("SOCIAL_CLASS").unwrap();
+        let sc2 = graph.add_node("SOCIAL_CLASS").unwrap();
+        let org1 = graph.add_node("ORGANIZATION").unwrap();
+        let org2 = graph.add_node("ORGANIZATION").unwrap();
+        let mut fuel = 16_384;
+        let events = collect_then_apply(
+            &mut graph,
+            HashMap::new(),
+            "(effects \
+               (for-each (nodes NodeType/SOCIAL_CLASS) :as outer \
+                 (for-each (nodes NodeType/ORGANIZATION) \
+                   (emit EventType/PAIR (outer outer) (inner it)))))",
+            &mut fuel,
+        )
+        .unwrap();
+        assert_eq!(
+            events,
+            vec![
+                (
+                    "PAIR".to_owned(),
+                    vec![
+                        ("outer".to_owned(), Value::NodeRef(sc1)),
+                        ("inner".to_owned(), Value::NodeRef(org1))
+                    ]
+                ),
+                (
+                    "PAIR".to_owned(),
+                    vec![
+                        ("outer".to_owned(), Value::NodeRef(sc1)),
+                        ("inner".to_owned(), Value::NodeRef(org2))
+                    ]
+                ),
+                (
+                    "PAIR".to_owned(),
+                    vec![
+                        ("outer".to_owned(), Value::NodeRef(sc2)),
+                        ("inner".to_owned(), Value::NodeRef(org1))
+                    ]
+                ),
+                (
+                    "PAIR".to_owned(),
+                    vec![
+                        ("outer".to_owned(), Value::NodeRef(sc2)),
+                        ("inner".to_owned(), Value::NodeRef(org2))
+                    ]
+                ),
+            ],
+            "outer = iteration order, inner = source order — composed, not \
+             an unordered reduction anywhere (§2.8 chapter C6)"
+        );
+    }
 }
 
 // ====================================================== family 17 — C8
@@ -1205,13 +1739,28 @@ mod c6_effect_position_iteration {
 // exercised, and this crate's bound checker is the one place that carried
 // the pre-change spelling.
 //
-// Runtime row deferred: the **multiplicity vector** (two qualifying edges
-// reaching one node, whose `fold count` must be 1) is D72's set semantics,
-// which needs the query evaluator. It is named here, not skipped.
+// **PR 4, Task 13 (2026-08-11): EXECUTES.** The multiplicity vector (D72's
+// set semantics: two qualifying edges reaching one node count once, not
+// twice) and the filtering vector (D24: the annotated `NodeType` excludes
+// a wrong-typed neighbour) both run for real below, over `MemoryGraph`.
+// The three-operand `E-PARSE-042` arity check, the swapped-operand
+// `E-TYPE-011` check, and the lesser-of-two-ceilings static bound were
+// already real (all three are load-time static checks, unaffected by the
+// query evaluator) and stay as they were. The `:as`/`it` naming rows stay
+// load-time static too, EXCEPT the two-hop nested-query shape, which now
+// also runs for real (over `nodes`/`neighbors`, the two heads slice 1
+// serves — the spec's own worked example uses `hyperedges`/`members-of`,
+// slice 3, so its static accept-and-bound pin stays alongside).
 mod c8_typed_neighbours_and_naming {
     use super::{cost, e};
+    use babylon_bsl::evaluator::{evaluate, EvalEnv, Value};
+    use babylon_bsl::fuel::IntrinsicCosts;
     use babylon_bsl::grammar::{check_arities_and_closed_sets, check_enum_ref_kinds};
+    use babylon_bsl::intrinsic_host::EmptyIntrinsicHost;
     use babylon_bsl::scope::check_element_names;
+    use babylon_graph::memory::MemoryGraph;
+    use babylon_graph::substrate::GraphSubstrate;
+    use std::collections::HashMap;
 
     /// D51: the operand is **mandatory**, so the pre-C8 three-operand form
     /// is an arity error rather than a silently edge-type-only bound.
@@ -1331,6 +1880,113 @@ mod c8_typed_neighbours_and_naming {
         ));
         let err = check_element_names(&form, &[]).unwrap_err();
         assert_eq!(err.spec_code(), "E-TYPE-012");
+    }
+
+    // -------------------------------------------------- PR 4 Task 13: EXECUTES
+
+    fn eval_expr(
+        source: &str,
+        graph: &dyn GraphSubstrate,
+        bindings: HashMap<String, Value>,
+        fuel: &mut u64,
+    ) -> Value {
+        let costs = IntrinsicCosts::default();
+        let env = EvalEnv {
+            bindings,
+            intrinsic_costs: &costs,
+            graph: Some(graph),
+            elements: Vec::new(),
+        };
+        evaluate(&e(source), &env, &EmptyIntrinsicHost, fuel).expect("vector must evaluate")
+    }
+
+    /// The §6.2 family-17 multiplicity vector (D72), EXECUTED: two
+    /// qualifying edges (one `:out`, one `:in`) reaching one node under
+    /// `:any` yield it ONCE — `neighbors` is a set, not a multiset.
+    #[test]
+    fn neighbors_multiplicity_vector_counts_each_qualifying_node_once() {
+        let mut graph = MemoryGraph::new();
+        let subject = graph.add_node("SOCIAL_CLASS").unwrap();
+        let other = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph.add_edge("SOLIDARITY", subject, other, 1.0).unwrap();
+        graph.add_edge("SOLIDARITY", other, subject, 1.0).unwrap();
+        let mut fuel = 1_000;
+        let result = eval_expr(
+            "(fold count (neighbors self EdgeType/SOLIDARITY :any NodeType/SOCIAL_CLASS) it)",
+            &graph,
+            HashMap::from([("self".to_owned(), Value::NodeRef(subject))]),
+            &mut fuel,
+        );
+        assert_eq!(result, Value::Int(1), "one node, once, not twice (D72)");
+    }
+
+    /// The §6.2 family-17 filtering vector (D24), EXECUTED: a node reached
+    /// via the named edge type that is NOT of the annotated `NodeType` is
+    /// simply not in the result — the annotation filters, it does not
+    /// assert.
+    #[test]
+    fn neighbors_filtering_vector_excludes_the_wrong_node_type() {
+        let mut graph = MemoryGraph::new();
+        let subject = graph.add_node("SOCIAL_CLASS").unwrap();
+        let tenant = graph.add_node("SOCIAL_CLASS").unwrap();
+        let org = graph.add_node("ORGANIZATION").unwrap();
+        graph.add_edge("SOLIDARITY", tenant, subject, 1.0).unwrap();
+        graph.add_edge("SOLIDARITY", org, subject, 1.0).unwrap();
+        let mut fuel = 1_000;
+        let result = eval_expr(
+            "(fold count (neighbors self EdgeType/SOLIDARITY :in NodeType/SOCIAL_CLASS) it)",
+            &graph,
+            HashMap::from([("self".to_owned(), Value::NodeRef(subject))]),
+            &mut fuel,
+        );
+        assert_eq!(
+            result,
+            Value::Int(1),
+            "the ORGANIZATION neighbour is excluded by the annotation"
+        );
+    }
+
+    /// D53 + D54, EXECUTED: `it` denotes the INNERMOST element and `:as`
+    /// reaches the outer one, over `nodes`/`neighbors` — the two heads
+    /// slice 1 serves (the spec's own `hyperedges`/`members-of` worked
+    /// example stays the static accept-and-bound pin above, since slice 1
+    /// does not serve those heads).
+    #[test]
+    fn it_resolves_to_the_inner_element_and_the_as_name_to_the_outer() {
+        let mut graph = MemoryGraph::new();
+        let outer_a = graph.add_node("SOCIAL_CLASS").unwrap();
+        let inner_a = graph.add_node("ORGANIZATION").unwrap();
+        graph
+            .update_node(inner_a, "organization/claim-strength", 10.0)
+            .unwrap();
+        graph.add_edge("SOLIDARITY", outer_a, inner_a, 1.0).unwrap();
+
+        let outer_b = graph.add_node("SOCIAL_CLASS").unwrap();
+        let inner_b = graph.add_node("ORGANIZATION").unwrap();
+        graph
+            .update_node(inner_b, "organization/claim-strength", 20.0)
+            .unwrap();
+        graph.add_edge("SOLIDARITY", outer_b, inner_b, 1.0).unwrap();
+
+        let mut fuel = 10_000;
+        // The outer fold names its element `:as outer`; the inner fold's
+        // query reads `outer` (the OUTER element, via the neighbors source
+        // operand) while its body reads `it` (the INNER element) — both
+        // live on the element stack at once, and each name resolves to the
+        // right one.
+        let result = eval_expr(
+            "(fold sum (nodes NodeType/SOCIAL_CLASS) :as outer \
+               (fold sum (neighbors outer EdgeType/SOLIDARITY :out NodeType/ORGANIZATION) \
+                     (field-of it organization/claim-strength)))",
+            &graph,
+            HashMap::new(),
+            &mut fuel,
+        );
+        assert_eq!(
+            result,
+            Value::Real(30.0),
+            "10 (outer_a's neighbor) + 20 (outer_b's neighbor) = 30"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

⟨PR 4⟩ of the BSL query-evaluation plan (Tasks 13–14; groups 1–3 = #509/#514/#519). **Test-only** — zero production code changes; the r9_chapters header's honest boundary ("each E-EVAL row is pinned as its code's identity … rather than as a raised value") retires for three families.

**Task 13** (`f77b6d30`): families 14 (element selection), 15 (effect-position iteration), 17 (typed neighbours + `:as` naming) flip from load-time pins to real evaluation — 121→134 tests. Selections execute over `nodes`/`neighbors` with real D45 ties and a real `E-EVAL-021` raise; a selection feeds `field-of` AND `update-node` through the production `collect_effects`+`apply_pending_write` path; for-each applies per element for real incl. the §2.8 C6 pre-state vector; D72 multiplicity + D24 filtering execute; the unserved heads (`edges`/`hyperedges`/`members-of`/`hyperedges-of`) are asserted to still refuse naming their slice. `update-edge`'s static cost vectors stay pinned on purpose (C2 storage gap, III.7 — not a query-evaluator matter).

**Task 14** (`624e2ade`): conformance_corpus's "Phase-2 query evaluator" scope note retires; `exists`/`forall`/aggregation vectors execute over a real `MemoryGraph` with pinned `:fuel-used` values read from real failure output first (19→23 tests).

## Finding — pre-existing fixture defect, documented not patched

`event_wealth_aggregates.bsl` (untouched, outside scope) compares a `Currency`-typed fold against bare `Int` literals (`550`/`500`/`50`, no `$` suffix) — a loud §3.1 lane-mismatch at evaluation for EVERY wealth value, invisible to the Phase-1 load-only pin. Each sub-fold was verified individually against exact expected values (sum=600, max=min=300, weighted-mean=0.4 — the currency arithmetic is correct); the compound clause's real raised error is asserted as-is. Repair decision left to the next train, recorded in the test doc + commit body.

## Testing

- Full 4-leg gate green from `rust/`: fmt --check, clippy --workspace -D warnings, test --workspace --locked (0 failures), RUSTDOCFLAGS='-D warnings' cargo doc.
- `tick_goldens` 3/3 byte-identical before and after both commits.
- #519's post-plan facts honored: no vector routes shape verbs through load_rule; no guard vector needed the as_bool adjustment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)