### PR TITLE
test(tick): the four Territory-shaped e2e vectors + the Slice-1 handoff (query-eval group 5 — SLICE 1 COMPLETE)

### DIFF
--- a/ai/decisions/ADR197_bsl_query_evaluation_slice1_handoff.yaml
+++ b/ai/decisions/ADR197_bsl_query_evaluation_slice1_handoff.yaml
@@ -1,0 +1,178 @@
+ADR197_bsl_query_evaluation_slice1_handoff:
+  status: "accepted"
+  date: "2026-08-11"
+  title: "The BSL query-evaluation Slice-1 handoff (P27 Phase 2) — the four-slice cut, the III.7 read-only-widening rule, PR #464's supersession verdict, and the §4.2 chapter-C4 pre-state repair, all closed by ⟨PR 5⟩'s consumer-handoff evidence"
+  context: |
+    docs/superpowers/plans/2026-08-11-bsl-query-evaluation-plan.md served
+    the BSL graph-query surface (§2.6's six query heads, §2.7's fold/
+    exists/forall/select-*, §2.8's for-each, §2.10's field-of) so that
+    27 GRAPH_SEAM_HEADS could stop refusing at evaluation and the
+    Territory port train could start from evidence instead of optimism.
+    Five PR groups executed the plan's sixteen tasks:
+
+    - ⟨PR 1⟩ (Tasks 1-3, #509): seam-refusal hygiene (every unserved
+      head names its slice), EvalEnv gains the graph + the §2.6 element
+      stack, GraphSubstrate::node_type_of (the ONE read-only method
+      slice 1 adds).
+    - ⟨PR 2⟩ (Tasks 4-9, #514): query materialization (nodes, typed
+      neighbors), fold's five operators, exists/forall, select-max/
+      select-min with the language-level tiebreak, field-of over a
+      NodeRef, :as element naming.
+    - ⟨PR 3⟩ (Tasks 10-12, #519): for-each in effect position,
+      update-node against a computed NodeRef, and the §4.2 chapter-C4
+      pre-state repair (D-row Q1/D103 below).
+    - ⟨PR 4⟩ (Tasks 13-14, #520): the §6.2 conformance families and the
+      aggregation corpus flip from load-time pins to real evaluation
+      (test-only; landed independently of this record).
+    - ⟨PR 5⟩ (Tasks 15-16, this record): the four Territory-shaped
+      end-to-end vectors and this handoff.
+
+    This ADR is the consolidated record Task 16 charters: it does not
+    re-litigate any of the above, it CLOSES the loop by recording, in one
+    place, the four architectural facts the plan's own text scattered
+    across its Architecture/Substrate-widening/Prior-art sections plus
+    the pre-state repair PR 3 actually landed.
+  decision: |
+    **1. The four-slice cut stands, as designed.** Slice 1 (this train,
+    now complete) serves the node-set query lane: nodes/neighbors, fold,
+    exists/forall, select-max/select-min, field-of over a NodeRef,
+    for-each, update-node against a computed ref — everything the
+    Territory port's four blocked shapes needed, and nothing that needs
+    an EdgeRef, an edge attribute, or a hyperedge. Slices 2-4 remain
+    SCOPED, NOT BUILT: slice 2 (the dyadic edge lane — edges,
+    edge-between, field-of over an EdgeRef, the) needs a new Value::
+    EdgeRef/EdgeKey type and one read-only edge-attribute lookup, hash-
+    free; slice 3 (the hyperedge + metric lane — hyperedges, members-of,
+    hyperedges-of, metric-of) is likewise hash-free, a read-only walk of
+    existing CanonicalState sections; slice 4 (edge/hyperedge/membership
+    attribute STORAGE) is the one that widens CanonicalState and
+    ESCALATES to the Director under Constitution III.7 + Amendment AG —
+    it is not chartered by a plan, it needs an ADR of its own, and stays
+    DEFERRED TO ITS FIRST CONSUMER per the Director's third 2026-08-11
+    ruling (same pattern as the Currency-i128 ruling and ADR192's
+    additive sequencing). Every un-served query head keeps a LOUD
+    refusal naming the slice that will serve it (Task 1's
+    UNSERVED_EXPRESSION_HEADS / query.rs's UNSERVED_QUERY_HEADS tables)
+    — a head falling through to eval_intrinsic's generic E-LOAD-021
+    misdiagnosis would be the defect this cut exists to prevent.
+
+    **2. The III.7 read-only-widening rule, exercised exactly as
+    designed.** Slice 1 added ONE new GraphSubstrate method,
+    node_type_of — a read-only report of a fact CanonicalState's section
+    1 (all_nodes -> (NodeId, type)) already hashes, proven byte-invariant
+    by a dedicated fixture-hash test at Task 3's landing
+    (adding_a_read_only_query_method_does_not_move_the_state_hash).
+    Fourteen methods became fifteen; zero CanonicalState sections
+    changed; zero encoder bytes changed. This is the evidence obligation
+    Constraint 7 of the plan demanded of every substrate task, discharged
+    once, at the one substrate task slice 1 needed. Nothing in ⟨PR 5⟩
+    (Task 15's e2e vectors) needed a second substrate method — the four
+    Territory shapes run entirely on nodes/neighbors/field-of/fold/
+    select-max/for-each/update-node, all already served by group 2-3's
+    landing, confirming the plan's own "why this cut" claim empirically
+    rather than merely by design.
+
+    **3. PR #464 ("feat/p2-slice2-query-trait") — SUPERSEDED, verdict
+    ALREADY POSTED AND CLOSED.** The plan's "Prior-art disposition"
+    section ruled HARVEST THREE IDEAS, SUPERSEDE THE BRANCH: (a)
+    members_of(id, hyperedge_type)'s mandatory-type-operand shape,
+    harvested verbatim in reasoning for slice 3; (b) edge_strength's
+    two-distinguishable-error-case argument (dangling endpoint vs. absent
+    edge), harvested and widened for slice 2's general edge-attribute
+    read; (c) the stale neighbors doc-note repair ("contrast
+    hyperedges_of, whose infallible signature predates this ruling" —
+    false on dev since hyperedges_of already returns Result), harvested
+    verbatim at Task 3. Rationale, verified at the plan's writing and
+    unchanged since: #464 is 229 commits behind dev, its implementation
+    target (MemoryGraph) is no longer the production store (ADR179 T3 /
+    ADR193 swapped production to HypergraphStore), it predates the R9
+    spec chapters' four-operand neighbors form entirely, and it carries a
+    live doc-comment defect a merge would have shipped through
+    RUSTDOCFLAGS='-D warnings'. **Verified at THIS record's writing**
+    (2026-08-11, via `gh pr view 464`): the PR is CLOSED
+    (closedAt 2026-08-11T17:29:18Z), with the verdict posted verbatim,
+    citing this plan by path, by the Director herself — Task 16's own
+    checklist item ("post the #464 verdict on the PR and close it") was
+    therefore already discharged before this handoff record was written;
+    this ADR records that fact rather than re-performing the action.
+
+    **4. The §4.2 chapter-C4 pre-state repair — LANDED, Director-ruled to
+    land in this train.** tick.rs::run_tick's pre-Task-12 divergence (D-row
+    Q1, register row D103 in docs/reference/bsl-language.rst) — in-place
+    mutation as the subject loop walked, contradicting chapter C4's own
+    "all firings of one rule observe the same pre-state … applied in
+    that subject order" — is REPAIRED, not merely documented: run_tick now
+    collects every subject's effects against one shared pre-tick borrow,
+    then applies them in subject order (structural_verbs::PendingWrite,
+    EffectExecutor::{collect_effects, apply_pending_write}). Byte-neutral
+    for every rule pack that existed at the repair's landing (verified by
+    grep over every content/rules/*.bsl file: none reads another node's
+    field, so in-place and collect-then-apply were observationally
+    identical for all of them) and confirmed unmoved by tick_goldens.rs
+    (3/3, still byte-identical after ⟨PR 5⟩). ⟨PR 5⟩'s Task 15 is this
+    repair's first END-TO-END witness: query_lane_e2e.rs's
+    shape_a_heat_spillover_reads_pre_tick_neighbour_state test is a
+    four-subject, one-rule fold-sum-over-neighbors vector whose expected
+    values are DERIVED assuming every subject reads the tick's shared
+    pre-state — a regression to in-place mutation would silently produce
+    different, order-dependent numbers, caught by this vector through the
+    real run_once_into seam rather than only at tick.rs's own unit level.
+    The accumulating-read timing question the repair opened (D-row Q2,
+    register row D104) is ruled APPLY TIME, matching §4.2's own
+    accumulation clause. The repair's narrower, STILL-OPEN sibling — two
+    rules at one anchor position do not yet share pre-state, only
+    subjects within one rule do (D-row Q14, register row D116) — is
+    RECORDED, not fixed, deferred to its own train; every ⟨PR 5⟩ vector
+    stays clear of it by construction (one rule per tick, always).
+
+    **A fifth item, found during ⟨PR 5⟩ and recorded here for
+    completeness though it is not one of Task 16's four named topics:**
+    two small, additive, III.7-clean production fixes were prerequisite
+    to Task 15's vectors even existing — babylon-bsl's scenario.rs now
+    censuses EdgeType counts (LoadedScenario::edge_types, mirroring the
+    existing node_types census) and babylon-tick's lib.rs merges that
+    census into CardinalityCeilings, closing a latent gap where
+    run_once_into's driver could never load ANY rule using (neighbors …)
+    at all (neighbors_ceiling needs both a NodeType and an EdgeType
+    ceiling; the driver only ever supplied the former, unexercised until
+    a rule pack finally used neighbors through the scenario-driven path).
+    A second, GENUINE landed-code gap was found and left RECORDED, not
+    fixed, as out of ⟨PR 5⟩'s scope: rule_pipeline::resolve_expr_bindings
+    still passes graph: None unconditionally when resolving a :expr
+    binding — its own doc names this "P6" from the #514 fix round,
+    explicitly waiting on "the same collect-then-apply repair" this
+    record's item 4 confirms DID land, but the callsite itself was never
+    updated. A :expr binding containing a query form therefore still
+    fails loud through the real driver today; every ⟨PR 5⟩ vector routes
+    its query forms through guards/effects instead, both of which
+    already carry the real, graph-bearing environment.
+  consequences: |
+    Slice 1 of the BSL query-evaluation plan is COMPLETE: all sixteen
+    tasks landed across five PR groups, PR #464 is closed with its
+    verdict on record, and the Territory port train (reports/territory-
+    port-phase1-inventory-2026-08-11.md) can proceed from evidence — its
+    verdict section is updated by this same handoff to record the
+    blocking train's landing. Fourteen D-row register entries (D103-D116)
+    are filed in docs/reference/bsl-language.rst, transcribing the plan's
+    own Q1-Q14 table into the document's permanent record; D105 (Q3)
+    additionally documents a real numbering collision the plan's own
+    Task-16 discipline anticipated ("resolve the number when the PR
+    opens, never hard-code it") — E-EVAL-042, the plan's proposed next-
+    free number for Q3, was allocated to an unrelated ruling (D101, the
+    Organization spec's Q12 enum-field law) in the interim between the
+    plan's drafting and this filing; the row records E-EVAL-043 as the
+    actual next-free number as of this ADR, not 042.
+
+    OPEN, NAMED, NOT THIS TRAIN'S: slice 2 (dyadic edge lane), slice 3
+    (hyperedge + metric lane), slice 4 (attribute storage, Director-
+    escalation-gated); D-row Q9 (Territory's closed-enum field-storage
+    gap, restated named for the port's own D-record); D-row Q14 (the
+    cross-rule pre-state gap, deferred to its own collect-then-apply
+    train); the resolve_expr_bindings graph: None gap (item 5 above),
+    which the next slice touching a :expr-bound query form should close
+    before relying on it.
+  supersedes: []
+  related:
+    - ADR193_hypergraph_storage_swap
+    - ADR192_relation_state_delegated_ruling
+    - ADR189_amendment_ag_attributed_membership_lattice_instances

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -1,5 +1,5 @@
 meta:
-  version: 1.71.0
+  version: 1.72.0
   updated: '2026-08-11'
   description: Architecture Decision Records Index
   format: See individual ADR files in this directory
@@ -895,3 +895,8 @@ decisions:
     status: accepted
     date: '2026-08-11'
     file: ADR196_org_vocabulary_ceremony.yaml
+  ADR197_bsl_query_evaluation_slice1_handoff:
+    title: 'The BSL query-evaluation Slice-1 handoff (P27 Phase 2) — ⟨PR 5⟩''s Task 16 closes the loop on the four-slice cut (slice 1 complete: node-set query lane; slices 2-4 scoped not built, slice 4 Director-escalation-gated under III.7); the III.7 read-only-widening rule (GraphSubstrate::node_type_of, 14→15 methods, zero CanonicalState bytes moved, hash-invariance proven by fixture test); PR #464''s SUPERSEDED verdict (three ideas harvested — members_of''s mandatory-type operand, edge_strength''s two-error-case argument, the stale neighbors doc note — verified ALREADY posted and closed by the Director, citing this plan, before this record was written); and the §4.2 chapter-C4 pre-state repair (D-row Q1/register D103) LANDED and now witnessed end-to-end by Task 15''s query_lane_e2e.rs spillover vector, with its still-open cross-RULE sibling (D-row Q14/D116) recorded not fixed. Records a fifth, unscoped finding: two additive scenario.rs/lib.rs edge-type-census fixes were prerequisite to any (neighbors …) rule loading through run_once_into at all, and rule_pipeline::resolve_expr_bindings''s graph: None gap (never wired up after Task 12 landed, despite its own doc naming that dependency) is left recorded for the next :expr-bound-query consumer to close. Files fourteen D-row register rows D103-D116 in docs/reference/bsl-language.rst, transcribing the plan''s Q1-Q14 table; D105 (Q3) documents a real E-EVAL numbering collision (042 taken by D101 in the interim; next free is 043) as a worked instance of the plan''s own "resolve the number when the PR opens" discipline'
+    status: accepted
+    date: '2026-08-11'
+    file: ADR197_bsl_query_evaluation_slice1_handoff.yaml

--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -5,6 +5,54 @@ meta:
   version: "2.70.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
   updated: "2026-08-11"
   truth_status: |
+    (2026-08-11 BSL QUERY-EVALUATION PLAN ⟨PR 5⟩ — THE CONSUMER HANDOFF,
+    TASKS 15+16) The final PR group of docs/superpowers/plans/2026-08-11-
+    bsl-query-evaluation-plan.md (P27 Phase 2 Slice 1) landed on branch
+    feat/bsl-query-eval-group5 (worktree ../wt-query-eval), based on
+    origin/dev @ a60be38a — groups 1-3 (Tasks 1-12: seam hygiene, query
+    materialization, fold/exists/forall/select-*/field-of, for-each, the
+    section-4.2 chapter-C4 pre-state repair) merged via #509/#514/#519;
+    group 4 (Tasks 13-14, r9_chapters.rs + conformance_corpus.rs) landed
+    separately in CI as #520, untouched by this group. Task 15
+    (rust/crates/babylon-tick/tests/query_lane_e2e.rs,
+    content/scenarios/query-lane-e2e.bscn) proves all FOUR shapes
+    reports/territory-port-phase1-inventory-2026-08-11.md §6's blocker
+    table named are expressible and correct through the REAL
+    run_once_into seam, on a hand-built fixture (no Territory content
+    ships): select-max's section-2.7 tiebreak feeding update-node against
+    a computed NodeRef (sink selection + population transfer, with the
+    frozen _find_sink_node's OWN mode-ordered tiebreak left as a named
+    comparison the Territory port's D-record owes); fold sum over
+    neighbors reading PRE-tick state (heat spillover — the end-to-end
+    proof of the C4 pre-state law, through the real driver rather than
+    tick.rs's own unit tests); the exists-guarded fallback (no
+    E-EVAL-021 on an empty ADJACENCY neighbourhood); for-each writing a
+    TENANCY :in neighbour set (PENAL_COLONY organization suppression).
+    Two small, additive, III.7-clean production fixes were prerequisite
+    and are the one place this group touched code beyond the test estate:
+    scenario.rs's LoadedScenario now censuses edge types
+    (mirroring the existing node-type census) and lib.rs's prepare_rules
+    merges that census into CardinalityCeilings — without it, EVERY rule
+    using (neighbors ...) through the scenario-driven run_once_into path
+    was latently unloadable (neighbors_ceiling needs an EdgeType ceiling
+    the driver never supplied; unexercised because no rule pack before
+    this one used neighbors that way); lib.rs also registers "territory"
+    as a legal section-2.3 rule-id anchor namespace for these synthetic
+    vectors, explicitly NOT a Territory-port system. RECORDED, not fixed
+    (out of this task's scope, named for the next slice touching :expr
+    bindings): rule_pipeline::resolve_expr_bindings still passes
+    graph: None unconditionally to a :expr binding's EvalEnv — its own
+    doc names this "P6" from the #514 fix round, waiting on the SAME
+    Task-12 collect-then-apply repair that DID land, but the callsite was
+    never updated alongside it; a :expr binding containing a query form
+    still fails loud through the real driver today, so every vector here
+    routes its query forms through guards/effects instead (both DO carry
+    the real graph-bearing env). tick_goldens stayed 3/3 byte-identical
+    throughout; cargo test --workspace --locked green (zero Python files
+    touched, so qa:regression/qa:vault-regression-ci cannot move by
+    construction); the 4-leg gate (fmt/clippy -D warnings/test/doc -D
+    warnings) is green. NOT yet merged to dev.
+    PREVIOUS:
     (2026-08-11 DIRECTOR RULINGS BATCH 2, ADR194) Four director-gate items
     cleared in a second sitting the same day, each ruled by selecting the
     workforce's recommended option: #491 (audit Q3, within-class wealth

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -5659,6 +5659,228 @@ consequences are the ordinary kind of review item.
        read. This row names the gap so a future implementer does not
        have to rediscover it as a silent "the enum-ref case must have
        been an oversight" bug.
+   * - D103
+     - §4.2, §2.8
+     - **Resolved (query-evaluation plan Q1).** ``tick.rs::run_tick``'s
+       pre-Task-12 divergence — mutating the graph in place as it walked
+       subjects, so a later subject in one rule's firing order observed
+       an earlier subject's ALREADY-APPLIED effects — contradicted chapter
+       C4's own text ("all firings of one rule observe the same
+       pre-state … applied in that subject order") from the moment this
+       document ratified it; ``tick.rs``'s own module doc admitted the
+       gap rather than asserting it as a feature. **The spec's text is
+       followed, not amended**: ``run_tick`` now runs two passes —
+       collect every subject's effects against one shared, unmutated
+       pre-tick borrow, then apply the collected writes in subject order
+       — verified byte-neutral for every rule pack landed at the time of
+       the repair (``rust/crates/babylon-tick/tests/tick_goldens.rs``,
+       unmoved). Reference implementation: ``structural_verbs::
+       PendingWrite``, ``EffectExecutor::{collect_effects,
+       apply_pending_write}``, ``tick::run_tick``'s two-pass split.
+       Mutation-verified: reverting to inline per-subject application
+       flips ``all_firings_of_one_rule_observe_the_same_pre_state`` red
+       while ``tick_goldens`` stays green, proving the guard is a guard
+       and not merely a restatement of the fix. See also D116 (Q14), the
+       narrower, still-open sibling of this same divergence one anchor
+       level up.
+   * - D104
+     - §2.8, §4.2
+     - **Resolved (query-evaluation plan Q2).** Under D103's
+       collect-then-apply split, ``add``/``sub``/``scale`` read the
+       write target's CURRENT value at **apply** time, not at collect
+       time. Collect-time reads would be unsatisfiable against §4.2's own
+       accumulation clause: several subjects each contributing a slice to
+       one shared carrier node must reduce all of their contributions,
+       and a collect-time read would let a later subject's collected
+       write silently overwrite (not accumulate atop) an earlier one's,
+       losing every contribution but the last. Reference implementation:
+       ``PendingWrite``'s own doc comment states this explicitly as the
+       reason it carries an *operand*, never a pre-resolved target value;
+       ``EffectExecutor::apply_pending_write`` performs the read.
+       ``accumulation_into_a_shared_target_reduces_in_subject_order_and_
+       keeps_every_contribution`` (§6.2 family 12) is the vector.
+   * - D105
+     - §2.6, §2.10
+     - **Query-evaluation plan Q3, left deliberately uncoded.** A query
+       OPERAND naming no live element — a dangling ``NodeRef`` fed to
+       ``(neighbors <expr> …)`` — has no ``E-EVAL`` code of its own: §2.6
+       codes the *annotation* mismatch (``E-EVAL-032``) and §2.10 codes
+       *accessor referents* (``E-EVAL-033``), but neither covers a query
+       head's own source-element operand. The landed evaluator
+       (``query::materialize_neighbors``) raises a loud, UNCODED error
+       naming this row rather than inventing a number, per the crate's
+       standing "no invented codes" rule
+       (``neighbors_of_a_dangling_node_is_loud_not_empty`` asserts
+       ``err.code == None``). **Numbering note, itself an instance of the
+       collision this document's own Task-16 filing discipline warns
+       about:** the query-evaluation plan's draft text proposed
+       ``E-EVAL-042`` as "the next free number" at the time it was
+       written; D101 (§2.13, the Organization spec's Q12 enum-field
+       ruling) allocated ``E-EVAL-042`` to an unrelated law in the
+       interim, before this row was filed. Should this row ever graduate
+       from uncoded to coded, the number to allocate is whatever is next
+       free **at that time** — as of this row's own filing, that is
+       ``E-EVAL-043`` — never ``042``, and never hard-coded off this
+       row's own text without re-checking the register first.
+   * - D106
+     - §2.6
+     - **Query-evaluation plan Q4, recorded not ruled.** Whether a
+       self-loop edge places a node in its own ``neighbors … :any`` set
+       is unstated by this document; the substrate's current
+       implementation yields the node itself when such an edge exists.
+       No landed conformance vector or content rule exercises a
+       self-loop topology, so this is a silent, implementation-defined
+       answer of exactly the kind §2.6 exists to close — recorded here so
+       a future vector can pin it explicitly, either way, rather than
+       leave it accidental.
+   * - D107
+     - §2.7, §3.4, §4.2
+     - **Resolved (query-evaluation plan Q5).** Weighted ``mean``'s
+       reduction shape is ``Σ(wᵢ·xᵢ) ÷ Σwᵢ``, with both sums reduced in
+       §2.6 iteration order — not an incremental running-average update,
+       which would associate differently in binary64 and is therefore a
+       genuinely distinct computation, not a rewrite of the same one.
+       Pinned with exact bits:
+       ``weighted_mean_is_sum_of_products_over_sum_of_weights``
+       (``evaluator.rs``, Task 5).
+   * - D108
+     - §3.3, §4.3, §4.4
+     - **RULED (Director, 2026-08-11, query-evaluation plan Q6).**
+       ``fold mean`` over an ``Int``-typed body REFUSES LOUDLY, citing
+       this row — ``mean`` serves ``Real``-typed bodies only. §4.3 leaves
+       ``Int ÷ Int`` with "no pinned semantics" as a loud evaluation
+       error outside a binary64 expression, and whether ``mean``'s own
+       division counts as one was genuinely silent between §3.3 and
+       §4.3; the Director's ruling closes it by refusal rather than by
+       inventing a promote-then-divide reading nothing in this document
+       licensed. ``count``'s ``Int`` result (§3.4 row 6) and ``sum``'s
+       type-preserving result are untouched — this row narrows ``mean``
+       alone. Reference implementation:
+       ``mean_over_an_int_body_refuses_by_name`` (``evaluator.rs``,
+       Task 5), which comments this row's number rather than deciding
+       silently.
+   * - D109
+     - §3.2 addendum, §4.4
+     - **Resolved (query-evaluation plan Q7).** ``fold sum`` over an
+       empty ``Ratio``-typed body is an ILLEGAL fold-body type, not a
+       case needing an additive identity. §4.4's "additive identity of
+       the body type" predates the ``Ratio`` variant (§3.2 addendum,
+       #492/ADR194), whose only legal operator is ``Currency × Ratio``
+       and whose own domain is open at zero — minting an identity for it
+       would place a value outside the type's own declared domain, which
+       is precisely what the ``Ratio`` ruling exists to forbid elsewhere.
+   * - D110
+     - §2.7, §2.8
+     - **Resolved (query-evaluation plan Q8) — a misdiagnosis corrected,
+       not a spec gap filled.** ``(guard …)`` in expression position was
+       refused pre-Task-1 as an unimplemented Phase-2 seam, naming the
+       wrong reason: §2.7's ``<expr>`` production has no ``guard``
+       alternative at all, and §2.8 makes ``guard`` effect-position-only
+       by construction — the refusal the evaluator gave was never a
+       missing capability, only a wrong error message. Fixed by Task 1's
+       ``EFFECT_POSITION_ONLY``/``UNSERVED_EXPRESSION_HEADS`` split. This
+       row exists so a future implementer re-reading the old refusal text
+       does not re-derive "guard needs a Phase-2 query evaluator" as a
+       fact about the language.
+   * - D111
+     - §2.9, §2.13
+     - **Query-evaluation plan Q9, recorded not resolved — Territory-port
+       facing.** ``deffield`` has no representation for a SMALL CLOSED
+       field like the frozen Territory system's ``profile`` (2-valued) or
+       ``territory_type`` (5-valued), independent of D101/D102's later
+       ``enum`` ``<type-name>`` row (Organization spec §1 Q12, filed
+       above as D101): that row exists and could in principle serve this
+       case, but this plan makes no ruling connecting the two — it is
+       explicitly out of this train's scope (see this plan's "Explicitly
+       out of scope" section) and is restated here, numbered, so the
+       Territory port's own D-record inherits it named rather than
+       silently rediscovering it.
+   * - D112
+     - §3.7, §4.5
+     - **Resolved (query-evaluation plan Q10) — a property stated, not a
+       change made.** §3.7's ``cost(query) = 1`` charges query
+       MATERIALIZATION at a flat rate while the runtime work underneath
+       (a ``neighbors`` filter walking every incident edge) is
+       O(candidates); the implementation conforms to the letter of §3.7
+       and §4.5 as written. Fuel exists to guarantee TOTALITY and
+       DETERMINISM under declared cardinality ceilings, not to model
+       wall-clock cost — stated explicitly here so a future
+       national-scale profiling finding that disagrees becomes a
+       measured, vector-re-blessed change, never a silently edited
+       constant.
+   * - D113
+     - §2.7, §3.4
+     - **Resolved (query-evaluation plan Q11) — a fix-round finding,
+       corrected before this document's own text was checked against the
+       implementation.** §2.7's ``<fold>`` grammar admits an optional
+       ``:weight`` operand unconditionally on every ``<fold-op>``, but
+       §3.4's per-operator semantic table gives ``:weight`` a reading for
+       ``mean`` alone; the pre-fix evaluator silently evaluated and
+       discarded a ``:weight`` operand on ``sum``/``min``/``max``/
+       ``count``, which is a species of the "over-admitted at the
+       grammar layer, silently dropped at evaluation" defect this
+       document exists to prevent elsewhere. **Ruling: refuse loudly at
+       evaluation** for every non-``mean`` fold-op supplying ``:weight``,
+       naming the operator and citing this row — no grammar change (a
+       grammar admitting more than its semantics use is acceptable; an
+       evaluator silently discarding what it admits is not).
+   * - D114
+     - §2.7, §4.4
+     - **Resolved (query-evaluation plan Q12) — an implementation
+       boundary named, not a spec gap.** §4.4's empty-``fold-sum``
+       additive-identity rule says "the additive identity of the body
+       type" without saying every conforming implementation must be able
+       to COMPUTE that identity for every §2.7-legal body shape. The
+       landed classifier (``evaluator::static_additive_identity``) serves
+       literals, ``field-of`` reads, and homogeneous arithmetic over
+       them; a nested ``fold`` or a bare binding-symbol body are both
+       load-legal shapes it does not attempt. **Ruling: an unclassifiable
+       body shape refuses loudly, citing this row**, rather than guessing
+       an identity or widening the classifier speculatively ahead of a
+       real consumer needing it.
+   * - D115
+     - §3.4 row 6, §3.7, §4.5
+     - **Resolved (query-evaluation plan Q13).** ``fold count``'s §3.7
+       STATIC bound still charges ``ceiling(query) × (cost(body) +
+       cost(weight))`` like every other fold operator — the formula is
+       not special-cased — but §3.4 row 6 makes ``count``'s RESULT
+       independent of the body's VALUE, and the landed RUNTIME meter
+       (``evaluator::fold_count``) does not evaluate the body at all.
+       This is not a divergence: §4.5's runtime meter exists as a
+       backstop against the static bound being UNSOUND (charging too
+       LITTLE, letting a rule exceed its declared ``:fuel``), never
+       against it being merely conservative (charging too MUCH, which
+       every other static over-approximation in this document already
+       does). Under-charging ``count`` at the static-bound layer would be
+       unsound; charging it there while not charging it at runtime is the
+       safe direction and stays as implemented.
+   * - D116
+     - §4.2
+     - **Query-evaluation plan Q14, recorded not fixed — a second,
+       narrower instance of D103's same divergence, one anchor level up.**
+       D103 repaired the WITHIN-one-rule half of §4.2's own sentence
+       ("rules within one system position observe the same pre-state"):
+       every subject firing of ONE rule now observes that rule's shared
+       pre-tick state. The RULE-to-rule half is still open:
+       ``babylon-tick``'s ``run_once_into``/``TickSession::advance`` run
+       each rule in a content set to COMPLETION — collect and apply —
+       before the next rule starts, against the SAME mutable graph, so a
+       second rule at the same anchor position observes the FIRST rule's
+       already-applied writes from this tick, not the tick's shared
+       pre-state. Latent today: every landed rule pack keeps its system
+       position to exactly one rule (``vitality.bsl``'s own header
+       records the reasoning: a multi-rule decomposition would have to
+       restate the drain algebra across rules), so no shipped content
+       exercises the gap; ``query_lane_e2e.rs`` (Task 15) does not either
+       — every one of its four vectors loads exactly one rule per tick,
+       specifically to stay on the repaired side of D103 and clear of
+       this row. Re-scoping ``run_once_into``/``TickSession::advance`` to
+       collect-across-rules-then-apply is a second collect-then-apply
+       repair, structurally identical to D103's but one anchor level up,
+       carrying the same golden-baseline exposure — deferred to its own
+       train. Until then, ``lib.rs``/``session.rs``'s own doc comments
+       state the in-place cross-rule order as a RECORDED GAP citing this
+       row, never as "the frozen engine's semantics, inherited for free."
 
 See Also
 ----------

--- a/reports/territory-port-phase1-inventory-2026-08-11.md
+++ b/reports/territory-port-phase1-inventory-2026-08-11.md
@@ -5,6 +5,44 @@
 the Currency scale op and int-only seeding — are both resolved by PR #500 and PR #505;
 this inventory finds the deeper gap those blockers masked).
 
+**UPDATE (2026-08-11, later the same day) — the blocking train has landed.** The
+query-evaluation train this verdict's "Why DEFER beats an honest-partial pack" section
+named as the unblock is `docs/superpowers/plans/2026-08-11-bsl-query-evaluation-plan.md`
+(P27 Phase 2 Slice 1), and it now stands COMPLETE: sixteen tasks across five PR groups
+(⟨PR 1⟩ #509, ⟨PR 2⟩ #514, ⟨PR 3⟩ #519, ⟨PR 4⟩ #520, ⟨PR 5⟩ — branch
+`feat/bsl-query-eval-group5`, not yet merged to `dev` at the time of this update).
+⟨PR 5⟩'s Task 15 (`rust/crates/babylon-tick/tests/query_lane_e2e.rs`) is this
+inventory's own §6 blocker table, proved: `select-max` with the §2.7 language-level
+tiebreak feeding `update-node` against a computed reference (blocker rows 1-2 —
+`_find_sink_node`/the population transfer, `territory.py:139-194,259-267`); a
+pull-side `fold sum` over `neighbors` reading PRE-tick state (blocker row 3 —
+`_process_spillover`, `territory.py:269-316`, and the vector this inventory's own §5
+named "structurally dormant on every canonical scenario"); and `for-each` writing a
+`TENANCY`-incident subject set (blocker row 4 — `_suppress_organization`,
+`territory.py:353-378`) — all through the REAL `run_once_into` production seam, on a
+hand-built fixture, exactly as this inventory's §5 anticipated ("A port's conformance
+fixtures will need to be hand-built … not harvested from the canonical scenarios").
+The `exists` guard this verdict's parent plan derived (the "two further
+requirements … not in that table" note) proves out alongside it: an empty `ADJACENCY`
+neighbourhood takes the fallback branch, never `E-EVAL-021`. **Full record:**
+`ai/decisions/ADR197_bsl_query_evaluation_slice1_handoff.yaml`. **Prior art
+(§ "Prior art to reconcile," above): DISCHARGED** — PR #464 now stands closed, its
+verdict (SUPERSEDE, three ideas harvested) posted citing the plan by path.
+
+**What this update does NOT do.** No Territory content ships in ⟨PR 5⟩ or this update
+— the fixture is synthetic, not the frozen system transcribed. Every item this
+inventory filed OUT of scope for the eventual pack stays exactly as filed: the
+enum-field-storage gap (finding 4, now also register row D111/query-evaluation-plan
+Q9 in `docs/reference/bsl-language.rst`, restated named rather than resolved), the
+two-clamp inconsistency (Phase-1 `_write_clamped [0,1]` vs. Phase-3's upper-only
+`min(1.0, …)` — the port must transcribe both shapes faithfully, port-as-is, and
+Task 15's own spillover vector deliberately never needed the clamp, choosing seed
+heats that stay under it rather than expressing it), the `rent_spike_multiplier`
+scaled-Int workaround, and the #502 WS1 cross-system-channel ledger items. The
+Territory port train itself — an actual Director dossier, a real `.bscn`/`.bsl`
+transcription of `territory.py`, its own conformance oracle — has not started; this
+update closes the BLOCKING dependency, not the port.
+
 ## Adjudicated verdict
 
 The frozen `TerritorySystem` (378 lines, `src/babylon/engine/systems/territory.py`) was

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -137,6 +137,19 @@ pub struct LoadedScenario {
     /// the static bound is checked against a real number rather than an
     /// invented one.
     pub node_types: HashMap<String, u64>,
+    /// How many dyadic edges of each `EdgeType` member the scenario minted.
+    ///
+    /// The SAME argument as `node_types`, one axis over: `neighbors_ceiling`
+    /// (`bound_checker.rs`) bounds a `(neighbors …)` fold against the
+    /// **lesser** of the queried edge type's ceiling and the annotated
+    /// result `NodeType`'s — so a rule using `neighbors` needs an
+    /// `EdgeType/…` entry in `CardinalityCeilings` too, or `check_rule`
+    /// raises `MissingCeiling` for the edge axis specifically. Added by the
+    /// query-evaluation plan's Task 15 (P27 Phase 2 PR 5) — the FIRST
+    /// consumer of `neighbors` through the scenario-driven `run_once_into`
+    /// path (every rule pack landed before it read only `:field`s, never a
+    /// query), so this gap was latent, not exercised, until now.
+    pub edge_types: HashMap<String, u64>,
     /// The fields the scenario DECLARED, keyed by qname.
     ///
     /// This is the `deffield` registry in miniature: a rule's typechecker
@@ -198,6 +211,7 @@ pub fn load_scenario(
     let mut fields: HashMap<String, FieldDecl> = HashMap::new();
     let mut consts: HashMap<String, Value> = HashMap::new();
     let mut node_types: HashMap<String, u64> = HashMap::new();
+    let mut edge_types: HashMap<String, u64> = HashMap::new();
     let mut node_count = 0_usize;
     let mut edge_count = 0_usize;
     // §3.9 clause 5 (D73): hydration may not seed two dyadic edges sharing
@@ -226,7 +240,8 @@ pub fn load_scenario(
                 node_count += 1;
             }
             Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "edge" => {
-                load_edge(parts, graph, &named, &mut seeded_edges)?;
+                let minted = load_edge(parts, graph, &named, &mut seeded_edges)?;
+                *edge_types.entry(minted).or_insert(0) += 1;
                 edge_count += 1;
             }
             _ => {
@@ -243,6 +258,7 @@ pub fn load_scenario(
         node_count,
         edge_count,
         node_types,
+        edge_types,
         fields,
         consts,
     })
@@ -844,13 +860,15 @@ fn currency_refusal_message(local: &str, field: &str) -> String {
     )
 }
 
-/// `(edge <enum-ref> <local-name> <local-name> <int>)`
+/// `(edge <enum-ref> <local-name> <local-name> <int>)` — returns the minted
+/// `EdgeType` member (verbatim, matching `load_node`'s own return
+/// convention) so the caller can build the `edge_types` census.
 fn load_edge(
     parts: &[SExpr],
     graph: &mut dyn GraphSubstrate,
     named: &HashMap<String, NodeId>,
     seeded: &mut HashSet<(String, NodeId, NodeId)>,
-) -> Result<(), ScenarioError> {
+) -> Result<String, ScenarioError> {
     let [_, SExpr::Atom(Atom::EnumRef { member, .. }), SExpr::Atom(Atom::Symbol(from)), SExpr::Atom(Atom::Symbol(to)), SExpr::Atom(strength)] =
         parts
     else {
@@ -897,7 +915,7 @@ fn load_edge(
         ));
     }
     graph.add_edge(member, from_id, to_id, strength)?;
-    Ok(())
+    Ok(member.clone())
 }
 
 #[cfg(test)]

--- a/rust/crates/babylon-tick/content/scenarios/query-lane-e2e.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/query-lane-e2e.bscn
@@ -1,0 +1,98 @@
+; The four Territory-SHAPED query-lane fixtures (P27 Phase 2, BSL
+; query-evaluation plan, PR 5 / Task 15).
+;
+; **This is not Territory content.** `reports/territory-port-phase1-inventory
+; -2026-08-11.md` §6's blocker table names four shapes the query evaluator
+; had to serve before the real Territory port could start; this scenario
+; proves each one expressible and correct against a hand-built topology, the
+; way Metabolism's own fixtures were hand-built before Metabolism had a
+; canonical scenario. `rust/crates/babylon-tick/tests/query_lane_e2e.rs`
+; loads this ONE file four times (once per shape, a fresh graph each load)
+; and runs a DIFFERENT single-rule content set each time — so every rule
+; below needs to read safely across the WHOLE node population this file
+; declares, not just the nodes it is "about": `run_tick`'s subject loop
+; walks every node of the rule's derived TERRITORY type regardless of which
+; shape a given node belongs to (`territory/shape` exists for exactly this
+; reason — see below).
+;
+; Four node groups, in declaration order (fixes id assignment, scenario.rs's
+; own contract):
+;   0-3  t0..t3          Shape A — the heat-spillover chain (ADJACENCY)
+;   4-6  source-b/sink-a/sink-b  Shape B — tie-break sink selection + transfer
+;   7    isolated-c       Shape C — the exists-guarded fallback (no ADJACENCY)
+;   8    penal-colony-d    Shape D — TENANCY suppression source
+;   9-11 tenant-1/tenant-2/non-tenant  Shape D — the suppressed/untouched classes
+;
+; `territory/shape` is a discriminator this fixture invents (0..4, one per
+; group above) — NOT a Territory-port field. Each shape's rule guards on it
+; so that ONLY the nodes it means to touch actually fire; every rule still
+; declares `territory/shape` as its one `:field` binding (subject-type
+; derivation needs at least one, `tick.rs::subject_type_of`), which is why
+; EVERY territory node below carries it, even nodes another shape's rule
+; will never reach.
+;
+; `territory/heat`, `territory/priority` and `territory/population` are each
+; seeded ONLY on the nodes the relevant shape's QUERY or WRITE path actually
+; touches — never universally — because every rule's own query/accessor
+; forms are reached only from inside a GUARD-passed effect (§2.8), so a node
+; outside a shape's own guarded subgraph never needs that shape's fields at
+; all. `sink-b` deliberately carries NO `territory/population` — Shape B's
+; assertion that it stays untouched is that reading it after the tick still
+; errors "never written" (III.11), which is a stronger proof than a numeric
+; "unchanged" comparison would be.
+;
+; `territory/heat` is declared EXTENSIVE here so Shape A's
+; `(fold sum (neighbors …) (field-of it territory/heat))` typechecks
+; against §3.4's aggregation law (`E-TYPE-041`, "sum of intensive field").
+; Physically heat reads more like an intensive per-node level than a summed
+; extensive quantity; the REAL Territory port's eventual field-kind ruling
+; is a separate, later decision (D-row Q9 territory adjacent) this synthetic
+; fixture does not make — it only needs `sum` to typecheck the way the
+; frozen `_process_spillover`'s own inflow accumulation does.
+(scenario territory/query-lane-e2e
+  (deffield territory/shape int extensive)
+  (deffield territory/heat coefficient extensive)
+  (deffield territory/priority int extensive)
+  (deffield territory/population int extensive)
+  (deffield social-class/organization int extensive)
+
+  ; src/babylon/data/defines.yaml:240 — heat_spillover_rate: 0.05.
+  (defconst territory/heat-spillover-rate 0.05c)
+  ; src/babylon/data/defines.yaml:239 — displacement_rate: 0.1.
+  (defconst territory/displacement-rate 0.1c)
+
+  ; ---- Shape A: the heat-spillover chain (ids 0-3) ----
+  ; t0 - t1 - t2 - t3, heats chosen as exact binary fractions (1/4, 1/2,
+  ; 1/8, 3/8) so every INTERMEDIATE sum stays exact in binary64 and only the
+  ; single multiply-by-rate at the end carries real IEEE-754 rounding —
+  ; see query_lane_e2e.rs's derivation comment for the exact arithmetic.
+  (node t0 NodeType/TERRITORY (territory/shape 0) (territory/heat 0.25c))
+  (node t1 NodeType/TERRITORY (territory/shape 0) (territory/heat 0.5c))
+  (node t2 NodeType/TERRITORY (territory/shape 0) (territory/heat 0.125c))
+  (node t3 NodeType/TERRITORY (territory/shape 0) (territory/heat 0.375c))
+
+  ; ---- Shape B: tie-break sink selection + population transfer (ids 4-6) ----
+  ; source-b has two ADJACENCY :out neighbours scoring EQUAL priority (5) —
+  ; the §2.7 tiebreak must pick sink-a (the lower id), never sink-b.
+  (node source-b NodeType/TERRITORY (territory/shape 1) (territory/population 100))
+  (node sink-a NodeType/TERRITORY (territory/shape 2) (territory/priority 5) (territory/population 0))
+  (node sink-b NodeType/TERRITORY (territory/shape 2) (territory/priority 5))
+
+  ; ---- Shape C: the exists-guarded fallback (id 7) ----
+  ; No ADJACENCY edge at all — the empty-neighbourhood case Task 6 exists to
+  ; guard against raising E-EVAL-021.
+  (node isolated-c NodeType/TERRITORY (territory/shape 3))
+
+  ; ---- Shape D: PENAL_COLONY organization suppression (ids 8-11) ----
+  (node penal-colony-d NodeType/TERRITORY (territory/shape 4))
+  (node tenant-1 NodeType/SOCIAL_CLASS (social-class/organization 1))
+  (node tenant-2 NodeType/SOCIAL_CLASS (social-class/organization 1))
+  (node non-tenant NodeType/SOCIAL_CLASS (social-class/organization 1))
+
+  (edge EdgeType/ADJACENCY t0 t1 1)
+  (edge EdgeType/ADJACENCY t1 t2 1)
+  (edge EdgeType/ADJACENCY t2 t3 1)
+  (edge EdgeType/ADJACENCY source-b sink-a 1)
+  (edge EdgeType/ADJACENCY source-b sink-b 1)
+  (edge EdgeType/TENANCY tenant-1 penal-colony-d 1)
+  (edge EdgeType/TENANCY tenant-2 penal-colony-d 1))

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -141,11 +141,27 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
     // A type the scenario declared zero of still gets no ceiling — and that
     // is correct: a rule querying a population that does not exist should
     // fail loudly at load rather than quietly iterate nothing.
+    //
+    // Same for `EdgeType/MEMBER` (query-evaluation plan, Task 15, P27 Phase
+    // 2 PR 5): `bound_checker::neighbors_ceiling` bounds a `(neighbors …)`
+    // fold against the LESSER of the queried edge type's ceiling and the
+    // annotated result NodeType's, so a rule using `neighbors` needs an
+    // edge-type entry too, or the load fails `MissingCeiling` on the edge
+    // axis specifically. `scenario.node_types` and `scenario.edge_types`
+    // key disjoint namespaces (`NodeType/…` vs `EdgeType/…`), so merging
+    // them into one flat map — which is what `CardinalityCeilings` already
+    // is — cannot collide.
     let ceilings = CardinalityCeilings::new(
         scenario
             .node_types
             .iter()
             .map(|(member, count)| (format!("NodeType/{member}"), *count))
+            .chain(
+                scenario
+                    .edge_types
+                    .iter()
+                    .map(|(member, count)| (format!("EdgeType/{member}"), *count)),
+            )
             .collect(),
         HashMap::new(),
     );
@@ -165,6 +181,14 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
         // half of the metabolic rift) — same class of minimal
         // driver-scaffolding addition as the three above.
         "metabolism".to_owned(),
+        // NOT a Territory-port system (§2.3's anchor default names a real
+        // content pack; this train ships none — see the query-evaluation
+        // plan's Task 15, "this task ships no Territory content"). Added
+        // solely so `query_lane_e2e.rs`'s four synthetic, Territory-SHAPED
+        // vectors have a legal, honestly-named rule-id namespace to anchor
+        // under; same class of minimal driver-scaffolding addition as the
+        // four above.
+        "territory".to_owned(),
     ]);
 
     // ONE shared LoadContext for every rule in the content set — the

--- a/rust/crates/babylon-tick/tests/query_lane_e2e.rs
+++ b/rust/crates/babylon-tick/tests/query_lane_e2e.rs
@@ -314,7 +314,9 @@ fn shape_c_empty_neighbourhood_takes_the_fallback_branch_never_e_eval_021() {
     );
     assert_eq!(report.fired, 1, "only isolated-c (shape=3) fires");
 
-    let priority = graph.node_attribute(ISOLATED_C, "territory/priority").unwrap();
+    let priority = graph
+        .node_attribute(ISOLATED_C, "territory/priority")
+        .unwrap();
     assert_eq!(
         priority, 1.0,
         "the update-node target resolved to self (isolated-c) via the \
@@ -356,7 +358,11 @@ fn shape_d_penal_colony_suppression_writes_only_tenant_classes() {
         .expect("the penal-colony rule must load and run through run_once_into");
     assert_eq!(report.fired, 1, "only penal-colony-d (shape=4) fires");
 
-    let organization = |id: NodeId| graph.node_attribute(id, "social-class/organization").unwrap();
+    let organization = |id: NodeId| {
+        graph
+            .node_attribute(id, "social-class/organization")
+            .unwrap()
+    };
     assert_eq!(organization(TENANT_1), 0.0, "tenant-1: zeroed via TENANCY");
     assert_eq!(organization(TENANT_2), 0.0, "tenant-2: zeroed via TENANCY");
     assert_eq!(

--- a/rust/crates/babylon-tick/tests/query_lane_e2e.rs
+++ b/rust/crates/babylon-tick/tests/query_lane_e2e.rs
@@ -1,0 +1,407 @@
+//! The four Territory-shaped end-to-end query-lane vectors (BSL
+//! query-evaluation plan, `docs/superpowers/plans/2026-08-11-bsl-query-
+//! evaluation-plan.md`, ⟨PR 5⟩ Task 15).
+//!
+//! **This ships no Territory content.** It proves the four shapes
+//! `reports/territory-port-phase1-inventory-2026-08-11.md` §6's blocker
+//! table named — sink selection with a tie, population transfer against a
+//! computed reference, heat spillover reading pre-tick neighbour state, and
+//! `for-each`-driven organization suppression — are now expressible and
+//! CORRECT through the real production entry point
+//! (`babylon_tick::run_once_into`, the same seam the CLI driver and
+//! `babylon-client`'s engine link both call), using a synthetic, hand-built
+//! fixture (`content/scenarios/query-lane-e2e.bscn`) rather than real
+//! Territory data — the same posture Metabolism's own fixtures took before
+//! Metabolism had a canonical scenario.
+//!
+//! Each shape below runs as its OWN single-rule content set, loaded fresh
+//! from the ONE shared scenario file each time (`run_once_into` loads the
+//! scenario into a NEW graph per call) — so no shape's tick can observe
+//! another shape's writes, and the cross-RULE pre-state gap (D-row **Q14**,
+//! `bsl-language.rst`'s register — `run_once_into`/`TickSession::advance`
+//! run each rule in a content set to completion before the next starts, so
+//! TWO rules at the same anchor position do not share pre-state) never
+//! applies here: nothing in this file ever loads more than one `(rule …)`
+//! form in the same `rule_src`.
+//!
+//! **Why every rule declares `territory/shape`.** `run_tick`'s subject loop
+//! (`tick.rs::run_tick`) walks EVERY node of a rule's derived subject type,
+//! and `bind_subject` reads every declared `:field` binding for every one
+//! of them BEFORE the guard runs — so a rule sharing the TERRITORY subject
+//! type with three other shapes' nodes needs a way to skip the ones it does
+//! not own. `territory/shape` is that discriminator (a fixture-only field,
+//! not a Territory-port one); see the scenario file's own header for the
+//! full reasoning, including why it is the ONLY field seeded on every
+//! territory node while `heat`/`priority`/`population` are seeded only
+//! where a shape's own guarded query or write path reaches.
+//!
+//! **A landed-code finding, recorded rather than fixed (out of this task's
+//! scope).** `rule_pipeline::resolve_expr_bindings` still unconditionally
+//! passes `graph: None` to the `EvalEnv` it builds for a `:expr` binding
+//! (its own doc comment names this "P6", flagged during the PR #514 fix
+//! round, waiting on "the same collect-then-apply repair" as `tick.rs`'s
+//! guard/effects environment) — but Task 12 (that repair) landed in group 3
+//! and this callsite was not updated alongside it. A `:expr` binding
+//! containing a query form (`fold`/`neighbors`/`select-max`/`exists`/…)
+//! therefore still fails loud today ("needs the graph substrate … this
+//! EvalEnv carries none") through the REAL `run_once_into` driver, even
+//! though the underlying evaluator serves every one of those heads. Every
+//! rule below routes around this by writing its query forms directly
+//! inline inside a `(when …)` guard or an `(effects …)` operand — both of
+//! which DO receive the real, graph-carrying `env` (`tick.rs::run_tick`
+//! constructs it after `resolve_expr_bindings` returns) — never inside an
+//! `:expr` binding. This is a real, narrow gap the next slice touching
+//! `:expr` bindings should close; Task 16's handoff record names it.
+//!
+//! # Provenance
+//!
+//! Every expected numeric value below is DERIVED in this file's own
+//! comments from `src/babylon/data/defines.yaml`'s coefficients
+//! (`heat_spillover_rate: 0.05`, `displacement_rate: 0.1`) and the
+//! scenario's own seeded literals, using the SAME IEEE-754 binary64
+//! arithmetic Rust and Python both perform on basic ops (`+ − × ÷`,
+//! correctly rounded) — never copied from this crate's own printed output.
+//! Where a value is not a "clean" finite decimal, its exact bit pattern is
+//! pinned via `to_bits()` rather than a tolerance comparison (CLAUDE.md's
+//! Tests-as-Behavioral-Contracts principle 4: basic IEEE-754 ops reproduce
+//! bit-exactly across languages, so a value independently computed in
+//! Python and asserted here as an exact `f64` literal is not a guess).
+
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::hypergraph_store::HypergraphStore;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::run_once_into;
+
+const SCENARIO: &str = include_str!("../content/scenarios/query-lane-e2e.bscn");
+
+// Node ids, fixed by the scenario's own declaration order (scenario.rs's
+// "declaration order is the id order" contract) — see the scenario file's
+// header comment for the full id map.
+const T0: NodeId = NodeId(0);
+const T1: NodeId = NodeId(1);
+const T2: NodeId = NodeId(2);
+const T3: NodeId = NodeId(3);
+#[allow(dead_code)] // named for documentation symmetry with the id map above
+const SOURCE_B: NodeId = NodeId(4);
+const SINK_A: NodeId = NodeId(5);
+const SINK_B: NodeId = NodeId(6);
+const ISOLATED_C: NodeId = NodeId(7);
+#[allow(dead_code)] // named for documentation symmetry with the id map above
+const PENAL_COLONY_D: NodeId = NodeId(8);
+const TENANT_1: NodeId = NodeId(9);
+const TENANT_2: NodeId = NodeId(10);
+const NON_TENANT: NodeId = NodeId(11);
+
+// ============================================================ Shape A
+
+/// Heat spillover: `(fold sum (neighbors self EdgeType/ADJACENCY :any
+/// NodeType/TERRITORY) (field-of it territory/heat))`, over the 4-territory
+/// chain `t0 - t1 - t2 - t3` — Territory blocker table row 3
+/// (`_process_spillover`, `territory.py:269-316`).
+///
+/// **The pre-state proof.** All four subjects fire under ONE rule, in
+/// ascending id order (`t0, t1, t2, t3`). Under the §4.2 chapter C4 law
+/// (Task 12, landed group 3), every firing's fold reads the SAME pre-tick
+/// heat values — so `t1`'s spillover reads `t0`'s ORIGINAL 0.25, never the
+/// 0.275 `t0`'s OWN firing (earlier in subject order) just wrote. If
+/// `run_tick` still mutated in place (the pre-Task-12 divergence, D-row Q1),
+/// `t1` would read `t0`'s ALREADY-SPILLED heat instead, and every assertion
+/// below would need a different, order-dependent number. This is the
+/// end-to-end analogue of `tick.rs`'s own unit-level pre-state tests, run
+/// through the REAL scenario/rule/driver seam rather than a hand-built
+/// `EvalEnv`.
+///
+/// # Derivation
+///
+/// `rate = 5.0 / 100.0` (the `0.05c` defconst's own conversion contract) —
+/// not exact in binary64; every number below carries the real rounding.
+///
+/// Seeded heats (each an exact binary64 value — `1/4`, `1/2`, `1/8`, `3/8`):
+/// `heat(t0)=0.25, heat(t1)=0.5, heat(t2)=0.125, heat(t3)=0.375`.
+///
+/// `neighbors(tk, ADJACENCY, :any)` ascending-id order (`nodes_materializes_
+/// in_ascending_id_order`'s own guarantee) gives, per subject:
+/// - `t0`: `{t1}` → `inflow = 0.5`
+/// - `t1`: `{t0, t2}` → `inflow = 0.25 + 0.125 = 0.375` (exact)
+/// - `t2`: `{t1, t3}` → `inflow = 0.5 + 0.375 = 0.875` (exact)
+/// - `t3`: `{t2}` → `inflow = 0.125`
+///
+/// `new_heat = heat + inflow * rate`, each term computed independently in
+/// Python (`repr()`/`struct.pack('>d', …)`, `python3` at the time of
+/// writing) and pinned here as the exact bits:
+/// - `t0`: `0.25 + 0.5*0.05 = 0.275` (`0x3fd199999999999a`)
+/// - `t1`: `0.5 + 0.375*0.05 = 0.51875` (`0x3fe099999999999a`)
+/// - `t2`: `0.125 + 0.875*0.05 = 0.16875` (`0x3fc599999999999a`)
+/// - `t3`: `0.375 + 0.125*0.05 = 0.38125` (`0x3fd8666666666666`)
+///
+/// All four are comfortably under the frozen system's `min(1.0, …)` ceiling
+/// (`territory.py:315`), so this vector never needs to express that clamp —
+/// a deliberate fixture choice, not an omission (this task ships no
+/// Territory content, and the clamp needs no query-lane capability this
+/// plan serves).
+const RULE_SPILLOVER: &str = r#"
+(rule territory/spillover-e2e
+  :material-basis "heat spillover via a pull-side fold reading pre-tick neighbour heat — Territory blocker table row 3 (_process_spillover, territory.py:269-316); proves the section-4.2 chapter-C4 pre-state law end to end through the real run_once_into seam"
+  :fuel 256
+  (bindings
+    (binding shape :field territory/shape)
+    (binding rate :const territory/heat-spillover-rate))
+  (when (= shape 0))
+  (effects
+    (update-node self territory/heat
+      (add (* (fold sum (neighbors self EdgeType/ADJACENCY :any NodeType/TERRITORY)
+                    (field-of it territory/heat))
+              rate)))))
+"#;
+
+#[test]
+fn shape_a_heat_spillover_reads_pre_tick_neighbour_state() {
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(SCENARIO, RULE_SPILLOVER, &mut graph, &mut sink)
+        .expect("the spillover rule must load and run through run_once_into");
+    assert_eq!(
+        report.fired, 4,
+        "exactly the four shape=0 chain territories fire"
+    );
+
+    let heat = |id: NodeId| graph.node_attribute(id, "territory/heat").unwrap();
+    assert_eq!(
+        heat(T0).to_bits(),
+        0.275_f64.to_bits(),
+        "t0: 0.25 + 0.5*0.05 = 0.275, read from t1's PRE-tick heat"
+    );
+    assert_eq!(
+        heat(T1).to_bits(),
+        0.51875_f64.to_bits(),
+        "t1: 0.5 + (0.25+0.125)*0.05 = 0.51875, reading t0's and t2's PRE-tick \
+         heat — NOT t0's already-updated 0.275"
+    );
+    assert_eq!(
+        heat(T2).to_bits(),
+        0.16875_f64.to_bits(),
+        "t2: 0.125 + (0.5+0.375)*0.05 = 0.16875"
+    );
+    assert_eq!(
+        heat(T3).to_bits(),
+        0.38125_f64.to_bits(),
+        "t3: 0.375 + 0.125*0.05 = 0.38125, reading t2's PRE-tick heat"
+    );
+}
+
+// ============================================================ Shape B
+
+/// Priority sink selection with a tie, plus the population transfer it
+/// feeds: `(select-max (neighbors self EdgeType/ADJACENCY :out
+/// NodeType/TERRITORY) (field-of it territory/priority))`, guarded by
+/// `exists` (Task 6's Territory `_find_sink_node` shape), then `update-node`
+/// against the COMPUTED reference — Territory blocker table rows 1-2
+/// (`_find_sink_node`, `territory.py:139-194`; the population transfer,
+/// `territory.py:259-267`).
+///
+/// `source-b` has two ADJACENCY `:out` neighbours, `sink-a` and `sink-b`,
+/// scored EQUAL (`territory/priority = 5` on both). §2.7's tiebreak (D45)
+/// says the FIRST element in ascending id byte order wins for `select-max`
+/// — `sink-a` (id 5) was declared before `sink-b` (id 6), so `sink-a` must
+/// be the one written. The frozen `_find_sink_node`
+/// (`territory.py:166-193`) carries its OWN mode-ordered tiebreak
+/// (`_PRIORITY_BY_MODE`, a fixed type-priority list scanned in order) — a
+/// DIFFERENT tiebreak rule from this language's "lowest id wins"; the
+/// Territory port's own D-record owes a comparison between the two, and
+/// this vector is the evidence that comparison will need.
+///
+/// # Derivation
+///
+/// `rate = 1.0 / 10.0` (the `0.1c` defconst). `source-b`'s own population is
+/// seeded `100` (an exact `int`). `transfer = 100.0 * 0.1`; computed
+/// independently in Python: `100 * 0.1 == 10.0` exactly (the rounding in
+/// `0.1`'s own binary64 representation happens to cancel against `100`'s
+/// power-of-2 factor here) — `sink_a.population = 0 + 10.0 = 10.0`.
+///
+/// `sink-b`'s `territory/population` is never seeded in the scenario, so a
+/// post-tick read of it failing with "never written" is stronger proof that
+/// it was NOT selected than a numeric "still 0" comparison would be — a
+/// bug that wrote the wrong constant to the wrong node would still read as
+/// "still 0" if `sink-b` happened to start at 0, but a bug that wrote to
+/// `sink-b` at all is caught unconditionally by the read failing to fail.
+const RULE_SINK_SELECTION: &str = r#"
+(rule territory/sink-selection-tiebreak-e2e
+  :material-basis "priority sink selection with the section-2.7 language-level tiebreak, guarded by exists (Task 6), feeding update-node against the computed reference — Territory blocker table rows 1-2 (_find_sink_node, territory.py:139-194; the population transfer, territory.py:259-267)"
+  :fuel 256
+  (bindings
+    (binding shape :field territory/shape)
+    (binding rate :const territory/displacement-rate))
+  (when (= shape 1))
+  (effects
+    (update-node
+      (if (exists (neighbors self EdgeType/ADJACENCY :out NodeType/TERRITORY) #t)
+          (select-max (neighbors self EdgeType/ADJACENCY :out NodeType/TERRITORY)
+                      (field-of it territory/priority))
+          self)
+      territory/population
+      (add (* (field-of self territory/population) rate)))))
+"#;
+
+#[test]
+fn shape_b_priority_sink_selection_with_a_tie() {
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(SCENARIO, RULE_SINK_SELECTION, &mut graph, &mut sink)
+        .expect("the sink-selection rule must load and run through run_once_into");
+    assert_eq!(report.fired, 1, "only source-b (shape=1) fires");
+
+    let sink_a_population = graph
+        .node_attribute(SINK_A, "territory/population")
+        .unwrap();
+    assert_eq!(
+        sink_a_population, 10.0,
+        "sink-a (the lower-id, tied-priority sink) received the transfer: \
+         0 + 100*0.1 = 10.0"
+    );
+
+    let sink_b_result = graph.node_attribute(SINK_B, "territory/population");
+    assert!(
+        sink_b_result.is_err(),
+        "sink-b was never selected, so its never-seeded population field \
+         must still read as unwritten (III.11) — a write to the wrong node \
+         would make this read succeed: {sink_b_result:?}"
+    );
+}
+
+// ============================================================ Shape C
+
+/// The `exists`-guarded fallback over a territory with NO `ADJACENCY`
+/// neighbour — the requirement the plan's own intro derives from
+/// `_process_eviction_pipeline`'s `sink_id is None` case ("exists earns its
+/// place, and slice 1 ships it"): without the guard, `select-max` over the
+/// empty query is `E-EVAL-021` (§4.4/D45), a TICK ABORT, where the frozen
+/// engine just skips the transfer.
+///
+/// `isolated-c` (shape=3) carries zero `ADJACENCY` edges. Its rule reuses
+/// the SAME `if`/`exists`/`select-max`/fallback shape Shape B's rule does,
+/// scored the same way — the only difference is the topology it runs
+/// against — so this vector is proof that the identical, reusable pattern
+/// takes the FALLBACK branch (`self`) rather than erroring, and that the
+/// selected reference really is the fallback: `update-node`'s target
+/// resolves to `self`, so `isolated-c`'s OWN `territory/priority` (never
+/// seeded) ends the tick holding the literal the effect sets — `1` — which
+/// could only happen if the target really was `isolated-c` itself.
+const RULE_FALLBACK: &str = r#"
+(rule territory/fallback-no-sink-e2e
+  :material-basis "the exists-guarded selection's fallback branch, never E-EVAL-021, when a territory has no ADJACENCY neighbour — the plan intro's exists requirement, over _process_eviction_pipeline's sink_id-is-None case"
+  :fuel 128
+  (bindings
+    (binding shape :field territory/shape))
+  (when (= shape 3))
+  (effects
+    (update-node
+      (if (exists (neighbors self EdgeType/ADJACENCY :out NodeType/TERRITORY) #t)
+          (select-max (neighbors self EdgeType/ADJACENCY :out NodeType/TERRITORY)
+                      (field-of it territory/priority))
+          self)
+      territory/priority
+      (set 1))))
+"#;
+
+#[test]
+fn shape_c_empty_neighbourhood_takes_the_fallback_branch_never_e_eval_021() {
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(SCENARIO, RULE_FALLBACK, &mut graph, &mut sink).expect(
+        "an empty ADJACENCY neighbourhood must take the fallback branch, \
+         never raise E-EVAL-021 — a returned Err here would be exactly \
+         that failure",
+    );
+    assert_eq!(report.fired, 1, "only isolated-c (shape=3) fires");
+
+    let priority = graph.node_attribute(ISOLATED_C, "territory/priority").unwrap();
+    assert_eq!(
+        priority, 1.0,
+        "the update-node target resolved to self (isolated-c) via the \
+         fallback branch — the ONLY way isolated-c's own never-seeded \
+         priority field ends the tick holding the literal the effect sets"
+    );
+}
+
+// ============================================================ Shape D
+
+/// `PENAL_COLONY` organization suppression via `for-each` writing the
+/// SOURCE node — Territory blocker table row 4 (`_suppress_organization`,
+/// `territory.py:353-378`): `(for-each (neighbors self EdgeType/TENANCY :in
+/// NodeType/SOCIAL_CLASS) (update-node it social-class/organization (set
+/// 0)))`.
+///
+/// `penal-colony-d` (shape=4) has two `TENANCY :in` neighbours, `tenant-1`
+/// and `tenant-2`, both seeded `social-class/organization = 1`; `non-tenant`
+/// carries no `TENANCY` edge to it at all — the frozen law
+/// `test_social_class_without_tenancy_edge_is_untouched` transcribed
+/// directly: every tenant zeroed, the non-tenant left alone.
+const RULE_PENAL_COLONY: &str = r#"
+(rule territory/penal-colony-suppression-e2e
+  :material-basis "PENAL_COLONY organization suppression via for-each writing the source node's TENANCY :in neighbours — Territory blocker table row 4 (_suppress_organization, territory.py:353-378)"
+  :fuel 128
+  (bindings
+    (binding shape :field territory/shape))
+  (when (= shape 4))
+  (effects
+    (for-each (neighbors self EdgeType/TENANCY :in NodeType/SOCIAL_CLASS)
+      (update-node it social-class/organization (set 0)))))
+"#;
+
+#[test]
+fn shape_d_penal_colony_suppression_writes_only_tenant_classes() {
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(SCENARIO, RULE_PENAL_COLONY, &mut graph, &mut sink)
+        .expect("the penal-colony rule must load and run through run_once_into");
+    assert_eq!(report.fired, 1, "only penal-colony-d (shape=4) fires");
+
+    let organization = |id: NodeId| graph.node_attribute(id, "social-class/organization").unwrap();
+    assert_eq!(organization(TENANT_1), 0.0, "tenant-1: zeroed via TENANCY");
+    assert_eq!(organization(TENANT_2), 0.0, "tenant-2: zeroed via TENANCY");
+    assert_eq!(
+        organization(NON_TENANT),
+        1.0,
+        "non-tenant carries no TENANCY edge to penal-colony-d and must be \
+         left exactly as seeded — test_social_class_without_tenancy_edge_\
+         is_untouched, transcribed"
+    );
+}
+
+// ============================================================ Determinism
+
+/// §6.2 family 8: every shape's tick, run twice in one process against
+/// independently-loaded graphs, must produce byte-identical `TickReport`s —
+/// not merely equal final attributes, the full report (hash, fired count).
+/// "Once in a fresh process" is proven by running this same binary via
+/// `cargo test` a second time (a fresh process by construction); nothing in
+/// these rules or this scenario reads process-local state (no wall clock, no
+/// `HashMap` iteration on a result path — Constraint 2), so the two legs
+/// are not expected to differ and do not.
+#[test]
+fn every_shape_is_deterministic_across_two_independent_runs() {
+    for (rule, label) in [
+        (RULE_SPILLOVER, "spillover"),
+        (RULE_SINK_SELECTION, "sink-selection"),
+        (RULE_FALLBACK, "fallback"),
+        (RULE_PENAL_COLONY, "penal-colony"),
+    ] {
+        let mut graph_a = HypergraphStore::new();
+        let mut sink_a = CollectingSink::default();
+        let report_a = run_once_into(SCENARIO, rule, &mut graph_a, &mut sink_a)
+            .unwrap_or_else(|e| panic!("{label}: first run: {e}"));
+
+        let mut graph_b = HypergraphStore::new();
+        let mut sink_b = CollectingSink::default();
+        let report_b = run_once_into(SCENARIO, rule, &mut graph_b, &mut sink_b)
+            .unwrap_or_else(|e| panic!("{label}: second run: {e}"));
+
+        assert_eq!(report_a.before, report_b.before, "{label}: before hash");
+        assert_eq!(report_a.after, report_b.after, "{label}: after hash");
+        assert_eq!(report_a.fired, report_b.fired, "{label}: fired count");
+        assert_eq!(
+            report_a.per_rule_fired, report_b.per_rule_fired,
+            "{label}: per_rule_fired"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

⟨PR 5⟩, the final group of the BSL query-evaluation plan (#508; groups 1–4 = #509/#514/#519/#520). **Slice 1 closes with this PR**: an author can now write the whole Territory port in BSL with no evaluation-time refusal in its path, and the evidence is executable.

**Task 15** (`c28c1f34`+`cb578edf`): `query_lane_e2e.rs` + `query-lane-e2e.bscn` — the four blocker-table shapes from the Territory Phase-1 inventory, end-to-end through `run_once_into`:
- **Shape A — heat spillover**: pull-side `fold sum` over a 4-territory chain proves the §4.2 C4 pre-state law end-to-end; expected values derived by an independent Python IEEE-754 oracle and asserted via `to_bits()`, no tolerance (t0=0.275 `0x3fd199999999999a`, t1=0.51875, t2=0.16875, t3=0.38125).
- **Shape B — sink selection**: `select-max` D45 tiebreak feeding `update-node` against the computed ref; the loser's never-written field still errors on read.
- **Shape C — empty neighbourhood**: the `exists`-guarded fallback pattern; no `E-EVAL-021` abort.
- **Shape D — PENAL_COLONY suppression**: `for-each` writes only TENANCY-linked classes.
- Plus a determinism vector: byte-identical `TickReport`s across independent runs per shape.

Red phases surfaced two LATENT driver gaps, fixed additively (III.7-clean, no CanonicalState change): the scenario census never supplied **EdgeType ceilings** (`MissingCeiling` on any `neighbors` rule through the driver — no prior pack used one), and `prepare_rules` had no `territory` anchor namespace (registered with an explicit not-a-port-system comment). A third finding was routed around and stays recorded: `resolve_expr_bindings` still passes `graph: None` (the #514 P6 note) — vectors put query forms inline in guards/effects, which carry the real graph.

**Task 16** (`c21c0f81`): the handoff record — **ADR197** (four-slice cut, the III.7 read-only-widening rule, the C4 repair, #464's verdict), **D103–D116** transcribing the plan's Q1–Q14 register into `bsl-language.rst` (D105 records a live E-code collision: the plan's proposed E-EVAL-042 was consumed by D101 in the interim — actual next-free E-EVAL-043, the plan's own resolve-at-PR-time caution firing), `ai/state.yaml` entry, and an UPDATE block on the Territory inventory (original DEFER verdict intact per Immutability of History; all four blocker rows now proven, port not yet started).

**Q14 note:** every vector loads exactly one rule per tick, so the recorded cross-rule pre-state gap never applies — stated in the module doc.

## Testing

- Full 4-leg gate green from `rust/`: fmt --check, clippy --workspace -D warnings, test --workspace --locked, RUSTDOCFLAGS='-D warnings' cargo doc.
- `tick_goldens` 3/3 byte-identical throughout.
- Python estate byte-neutral by construction (zero files under `src/babylon/` — verified by diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)