### PR TITLE
docs(claude): Workflow args-stringification gotcha — guard-first rule (four-times-bitten)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,9 +359,13 @@ system backstop). Owner ruling 2026-07-14:
   so the rule is now positional: **the guard is the FIRST code in every workflow script, written
   before `meta`'s body is even filled in, with hard absolute fallbacks whenever values are knowable**:
   ```js
-  const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+  let A = {}
+  try { A = typeof args === 'string' ? JSON.parse(args) : (args || {}) } catch {}
   const X = A.x || '/known/absolute/fallback'   // degrade to correct, not to crash
   ```
+  The `try/catch` covers a third arrival shape (non-JSON string). It is right ONLY because hard
+  fallbacks follow — when a value has no knowable fallback, drop the catch and shape-check loudly
+  instead: a line-1 throw beats a runaway fan-out acting on `undefined`.
   Bites 1–2 dispatched agents per *character* of the stringified array toward the 1000-agent cap;
   bites 2 and 4 were saved only by a fanned-out agent refusing to act on an all-`undefined` spec and
   messaging the controller — never count on that.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,20 @@ system backstop). Owner ruling 2026-07-14:
   run`) resolves `babylon` to whichever checkout's venv is active, not necessarily this worktree's —
   prefix with `PYTHONPATH="$PWD/src"` or use the `mise run check:vocabulary` task, which sets it
   correctly.
+- **Workflow `args` arrives stringified or absent — FOUR times bitten (2026-07-22 ×2, 2026-07-29,
+  2026-08-11).** The orchestration harness can deliver a Workflow script's `args` as a JSON *string*
+  (so `args.field` is `undefined`, and prompts interpolate `"the PDF at undefined"` into every
+  fanned-out agent), and `resumeFromRunId` passes no args at all (bare `args.x` throws before the
+  cache engages). The memory file existed for bites 2–4 and was skipped at authoring time each time,
+  so the rule is now positional: **the guard is the FIRST code in every workflow script, written
+  before `meta`'s body is even filled in, with hard absolute fallbacks whenever values are knowable**:
+  ```js
+  const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+  const X = A.x || '/known/absolute/fallback'   // degrade to correct, not to crash
+  ```
+  Bites 1–2 dispatched agents per *character* of the stringified array toward the 1000-agent cap;
+  bites 2 and 4 were saved only by a fanned-out agent refusing to act on an all-`undefined` spec and
+  messaging the controller — never count on that.
 
 ## Maintaining this file
 


### PR DESCRIPTION
Director directive (live session, 2026-08-11): the Workflow args-stringification failure mode has now bitten four times (2026-07-22 ×2, 2026-07-29, 2026-08-11 — the latest sent all ten readers of a PDF-review fan-out after "the PDF at undefined"). The memory file recording the guard was skipped at authoring time on three of the four. Remedy: promote it to a CLAUDE.md gotcha so it is ALWAYS in context, with the rule made positional — the parse-guard + hard-fallback snippet is the first code in every workflow script, written before `meta`'s body is filled in.

One-file docs change; no code, no gates affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)