### PR TITLE
feat(bsl): the enum language change — EnumRegistry, .bscn defenum/defvocabulary, EnumRef-only field law (org foundation Group C)

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -5944,9 +5944,10 @@ consequences are the ordinary kind of review item.
        prove the discriminator is load-bearing, not merely byte-distinct by
        accident.
    * - D118
-     - §2.13, §4.6
-     - **Resolved (#528 fix round, MAJOR item 2) — a declared class
-       widened, not a new one minted.** ``E-EVAL-042`` is the code
+     - §2.13, §3, §4.6
+     - **Resolved (#528 fix round, MAJOR item 2 + MINOR item 3) — a
+       declared class widened, then the SAME law moved earlier, neither
+       move minting a new code.** ``E-EVAL-042`` is the code
        ``structural_verbs.rs::refuse_arithmetic_on_enum_field``
        (``c268b83b``) has reported for an ``add``/``sub``/``scale``
        update-op targeting an ``:enum-type``-declared field since the
@@ -5962,9 +5963,20 @@ consequences are the ordinary kind of review item.
        write-path violation of the identical law would be exactly the
        hygiene defect D75 ruled against. The refusal itself reaches all
        three sites a write can originate from (defense in depth,
-       unchanged by this row): ``update_node``'s immediate execute path,
+       unchanged by this move): ``update_node``'s immediate execute path,
        ``collect_update_node``'s collect path, and
        ``apply_pending_write``'s independent re-check at apply time.
+       **Second half — the law is statically decidable, so it now ALSO
+       runs at load** (§3's own law: "every check in this chapter runs
+       at content load"), matching D102's own precedent for §2.13's
+       sibling ``field-of`` deferral: ``typecheck.rs::
+       check_no_arithmetic_on_enum_field``, wired into
+       ``rule_pipeline.rs`` beside the D102 gate, refuses an
+       ``add``/``sub``/``scale`` ``update-op`` targeting an
+       ``:enum-type``-declared field at load, citing this row — the
+       three eval-time sites above STAY, unchanged, as defense in depth,
+       exactly as D102's own load-time gate left its eval-time siblings
+       standing.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -2248,7 +2248,12 @@ direction, with no fallback and no default member:
   the same mistake — is ``E-EVAL-042``. This is the same law re-checked
   at the one boundary content cannot be checked once and for all at
   load, the same two-site pattern the store boundary and range checks
-  already use (§3.7, §4.3).
+  already use (§3.7, §4.3). ``E-EVAL-042`` also covers an ``add``/
+  ``sub``/``scale`` update-op targeting such a field (D118): ``Enum<T>``
+  supports no arithmetic (the "No aggregation kind" paragraph below
+  states the same fact for folds), so combining a stored ordinal with an
+  operand's is never a coherent write against this field's declared type
+  — the same write-shape law, not a special case bolted onto it.
 - A read of such a field (via a ``:field`` binding, §2.5) renders the
   stored ordinal back to its member as a ``Value::Enum`` — never a bare
   number, so a ``when`` guard or any other comparison always compares
@@ -3599,7 +3604,9 @@ two times at which an error can occur.
        operand exceeding its declared domain ceiling; and, from §2.13
        (Organization spec §1 Q12), a non-``<enum-ref>`` value (or a
        cross-type ``<enum-ref>``) reaching an ``:enum-type``-declared
-       field's write path at runtime.
+       field's write path at runtime, and an ``add``/``sub``/``scale``
+       update-op targeting such a field (D118) — ``Enum<T>`` supports no
+       arithmetic.
 
 **Every code the R9 chapters add continues an existing sequence, and no code
 that existed before this revision is renumbered.** The new codes are
@@ -5936,6 +5943,28 @@ consequences are the ordinary kind of review item.
        reconstructs ATOMS (not just kind+payload bytes) from both shapes to
        prove the discriminator is load-bearing, not merely byte-distinct by
        accident.
+   * - D118
+     - §2.13, §4.6
+     - **Resolved (#528 fix round, MAJOR item 2) — a declared class
+       widened, not a new one minted.** ``E-EVAL-042`` is the code
+       ``structural_verbs.rs::refuse_arithmetic_on_enum_field``
+       (``c268b83b``) has reported for an ``add``/``sub``/``scale``
+       update-op targeting an ``:enum-type``-declared field since the
+       enum write law landed, but neither §2.13's own E-EVAL-042 bullet
+       nor the §4.6 class table row named that refusal — both scoped the
+       code strictly to the write-SHAPE law (a non-``<enum-ref>`` value,
+       or a cross-type one, reaching the write path), even though
+       ``Enum<T>`` supporting no arithmetic is already stated, uncoded,
+       at this section's own "No aggregation kind" paragraph and at
+       §2.9's ruling. **Resolved by declaring, not inventing**: both
+       citing passages now name the arithmetic refusal explicitly under
+       the SAME code — minting a second E-EVAL number for another
+       write-path violation of the identical law would be exactly the
+       hygiene defect D75 ruled against. The refusal itself reaches all
+       three sites a write can originate from (defense in depth,
+       unchanged by this row): ``update_node``'s immediate execute path,
+       ``collect_update_node``'s collect path, and
+       ``apply_pending_write``'s independent re-check at apply time.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -3794,7 +3794,16 @@ AST — a property implementations should exercise as a round-trip property test
    * - ``kw``
      - ASCII keyword name **without** the leading ``:``
    * - ``enum``
-     - ASCII ``<EnumType>/<MEMBER_IDENTIFIER>``
+     - ASCII ``<EnumType>/<MEMBER_IDENTIFIER>`` (an ``<enum-ref>`` value,
+       §1.4) **or**, for ``defenum``/``defvocabulary``'s own BARE
+       operands (§2.13's type-name operand and member-list items — never
+       ``<enum-ref>`` pairs), the bare identifier alone with no ``/``.
+       Collision-free by construction: an ``<enum-ref>`` payload always
+       contains exactly one ``/`` (§1.4's ``enum-type``/``enum-member``
+       charsets exclude it), a bare operand's payload never does, so the
+       PRESENCE of exactly one ``/`` is the discriminator a decoder reads
+       the payload back with — no numeric flag or second kind tag needed
+       (D117).
    * - ``str``
      - UTF-8 bytes after escape processing, NFC
 
@@ -3847,17 +3856,30 @@ declares no lattice encodes byte-for-byte as it did. None of these appears in
 §5.6's example, and no previously-optional child of ``rule`` becomes mandatory
 — **§5.6's 421 bytes and both digests remain correct as written**.
 
-**The Organization contract's Q12 tags obey it a fourth time.** ``defenum``
-and ``defvocabulary`` (§2.13) are their own head symbols, needing no
-registry entry, no numeric id and no new atom kind — the ``<enum-ref>``
-values they govern already encode with the existing atom kind the table
-above names for that lexical class, regardless of which registry checks
-them. ``deffield`` gains one more **optional** alternative in an existing
-keyword slot (``:enum-type`` beside ``:kind``, §2.9), not a new child
-position, so no existing ``deffield`` encoding moves. None of these forms
-appears in §5.6's example, and neither ``deffield`` nor any other form
-gains a newly *mandatory* child — **§5.6's 421 bytes and both digests
-remain correct as
+**The Organization contract's Q12 tags obey it a fourth time — with one
+payload-shape correction, D117 (#528 fix round, adversarial-verifier
+found).** ``defenum`` and ``defvocabulary`` (§2.13) are their own head
+symbols, needing no registry entry and no numeric id. **"No new atom
+kind" is still true — the kind tag stays the SAME "enum" string — but an
+earlier revision of this paragraph overstated WHY**, claiming "the ``<enum-ref>``
+values they govern already encode with the existing atom kind", as though
+only values these forms GOVERN were ever encoded. That is true of an
+``:enum-type``-declared field's own stored value (a genuine ``<enum-ref>``
+pair, unchanged), but false of ``defenum``/``defvocabulary``'s OWN
+operands: the type-name operand and each member-list item are BARE
+``<enum-type>``/``<enum-member>`` atoms (§2.13's own EBNF — no ``/`` at
+all), not ``<enum-ref>`` pairs, so encoding them at all requires that
+SAME kind's payload to admit a SECOND shape — declared above in the
+atom-kind/payload table, discriminated by the presence of exactly one
+``/``. The correction is additive, not a new kind tag: every existing
+``<enum-ref>`` payload is byte-identical to before, and the bare shape is
+new bytes for a construct (``defenum``/``defvocabulary``) that did not
+exist before Q12 either. ``deffield`` gains one more **optional**
+alternative in an existing keyword slot (``:enum-type`` beside ``:kind``,
+§2.9), not a new child position, so no existing ``deffield`` encoding
+moves. None of these forms appears in §5.6's example, and neither
+``deffield`` nor any other form gains a newly *mandatory* child —
+**§5.6's 421 bytes and both digests remain correct as
 written**, the same proof of additivity every prior extension in this
 section carries.
 
@@ -5881,6 +5903,39 @@ consequences are the ordinary kind of review item.
        train. Until then, ``lib.rs``/``session.rs``'s own doc comments
        state the in-place cross-rule order as a RECORDED GAP citing this
        row, never as "the frozen engine's semantics, inherited for free."
+   * - D117
+     - §5.2
+     - **Resolved (#528 fix round, PR #528's own adversarial-verifier
+       finding — the CAS resolution for ``defenum``/``defvocabulary``'s
+       bare atom).** §5.2's own Q12 paragraph stated "no new atom kind"
+       needed for ``defenum``/``defvocabulary`` because "the
+       ``<enum-ref>`` values they govern already encode with the existing
+       atom kind" — a premise that is FALSE for these two forms' own
+       operands: the type-name operand and each member-list item (§2.13's
+       own EBNF: ``defenum ::= "(" "defenum" enum-type "(" enum-member+
+       ")" ")"``) are BARE ``<enum-type>``/``<enum-member>`` atoms, never
+       ``<enum-ref>`` ``Type/MEMBER`` pairs — the document contradicted
+       itself the moment a reader takes ``defenum``'s own grammar literally.
+       **Resolved by declaring, not inventing**: the SAME "enum" CAS kind
+       tag (unchanged — still no NEW tag) widens to admit a SECOND payload
+       shape, the bare identifier with no ``/``, discriminated from the
+       existing ``<EnumType>/<MEMBER_IDENTIFIER>`` shape by the presence
+       of exactly one ``/`` — collision-free because §1.4's
+       ``enum-type``/``enum-member`` charsets exclude ``/`` entirely, so
+       an ``<enum-ref>`` payload always contains exactly one and a bare
+       operand's payload never does. §5.2's atom-kind/payload table and
+       its own Q12 paragraph are both corrected to state this explicitly
+       rather than the false single-shape premise. Reference
+       implementation: ``rust/crates/babylon-bsl/src/reader.rs``'s
+       ``Atom::BareUpperIdent`` (renamed from ``EnumTypeName``, which
+       under-described what it now carries — see that variant's own doc)
+       and ``canonical_ast.rs``'s ``encode_atom`` match arm, which already
+       encoded exactly this discriminated-union shape before this row
+       existed to declare it; the round-trip test
+       (``canonical_ast.rs::tests::the_enum_atom_kind_round_trips_both_
+       payload_shapes_without_confusion``) reconstructs ATOMS (not just
+       kind+payload bytes) from both shapes to prove the discriminator is
+       load-bearing, not merely byte-distinct by accident.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -5932,10 +5932,10 @@ consequences are the ordinary kind of review item.
        and ``canonical_ast.rs``'s ``encode_atom`` match arm, which already
        encoded exactly this discriminated-union shape before this row
        existed to declare it; the round-trip test
-       (``canonical_ast.rs::tests::the_enum_atom_kind_round_trips_both_
-       payload_shapes_without_confusion``) reconstructs ATOMS (not just
-       kind+payload bytes) from both shapes to prove the discriminator is
-       load-bearing, not merely byte-distinct by accident.
+       (``canonical_ast.rs::tests::the_enum_atom_kind_round_trips_both_payload_shapes_without_confusion``)
+       reconstructs ATOMS (not just kind+payload bytes) from both shapes to
+       prove the discriminator is load-bearing, not merely byte-distinct by
+       accident.
 
 See Also
 ----------

--- a/rust/crates/babylon-bsl/src/bound_checker.rs
+++ b/rust/crates/babylon-bsl/src/bound_checker.rs
@@ -295,10 +295,15 @@ pub fn expr_cost(
 /// `cost(field path | enum-ref) = 0`.
 fn atom_cost(atom: &Atom) -> Result<u64, BoundError> {
     match atom {
-        Atom::Int(_) | Atom::Currency(_) | Atom::Scaled(_) | Atom::Bool(_) | Atom::Str(_) => {
-            Ok(cost::LITERAL)
-        }
-        Atom::QName(_) | Atom::EnumRef { .. } | Atom::Keyword(_) => Ok(cost::LITERAL),
+        Atom::Int(_)
+        | Atom::Currency(_)
+        | Atom::Scaled(_)
+        | Atom::Bool(_)
+        | Atom::Str(_)
+        | Atom::QName(_)
+        | Atom::EnumRef { .. }
+        | Atom::Keyword(_)
+        | Atom::EnumTypeName(_) => Ok(cost::LITERAL),
         Atom::Symbol(_) => Ok(cost::VARIABLE_REF),
         Atom::Operator(op) => Err(malformed(format!(
             "operator {op} is valid only in form-head position"

--- a/rust/crates/babylon-bsl/src/bound_checker.rs
+++ b/rust/crates/babylon-bsl/src/bound_checker.rs
@@ -303,7 +303,7 @@ fn atom_cost(atom: &Atom) -> Result<u64, BoundError> {
         | Atom::QName(_)
         | Atom::EnumRef { .. }
         | Atom::Keyword(_)
-        | Atom::EnumTypeName(_) => Ok(cost::LITERAL),
+        | Atom::BareUpperIdent(_) => Ok(cost::LITERAL),
         Atom::Symbol(_) => Ok(cost::VARIABLE_REF),
         Atom::Operator(op) => Err(malformed(format!(
             "operator {op} is valid only in form-head position"

--- a/rust/crates/babylon-bsl/src/canonical_ast.rs
+++ b/rust/crates/babylon-bsl/src/canonical_ast.rs
@@ -695,6 +695,90 @@ mod tests {
         assert!(rules_hash_of(&forms).is_ok());
     }
 
+    /// The reconstructed logical value of an `"enum"`-kind CAS atom (D117):
+    /// either payload shape the kind admits, discriminated by the presence
+    /// of exactly one `/` — an `<enum-ref>` payload always has one (§1.4's
+    /// `enum-type`/`enum-member` charsets exclude `/`), a bare
+    /// `defenum`/`defvocabulary` operand's payload never does.
+    #[derive(Debug, PartialEq, Eq)]
+    enum DecodedEnumAtom {
+        EnumRef { enum_type: String, member: String },
+        BareUpperIdent(String),
+    }
+
+    /// Reconstruct an `"enum"`-kind atom's LOGICAL value from its payload
+    /// bytes — past the byte level `decode`/`reencode` above stop at
+    /// (they never interpret a payload, only re-transcribe it). This is
+    /// the round-trip the D117 register row cites: a decoder that only
+    /// proved byte-for-byte re-encoding, never a payload-to-atom mapping,
+    /// could not actually detect an `EnumRef`/`BareUpperIdent` confusion —
+    /// two different logical atoms whose bytes happened to collide would
+    /// still re-encode identically.
+    fn decode_enum_atom(payload: &[u8]) -> DecodedEnumAtom {
+        let text = std::str::from_utf8(payload).expect("an enum payload must be ASCII/UTF-8");
+        match text.split_once('/') {
+            Some((enum_type, member)) => DecodedEnumAtom::EnumRef {
+                enum_type: enum_type.to_owned(),
+                member: member.to_owned(),
+            },
+            None => DecodedEnumAtom::BareUpperIdent(text.to_owned()),
+        }
+    }
+
+    /// D117's own round-trip proof: both payload shapes the `enum` CAS
+    /// kind now admits decode back to the RIGHT logical atom, not just
+    /// identical bytes — an `<enum-ref>` value (one `/`), a
+    /// `defenum`/`defvocabulary` bare type-name operand (no `/`, mixed
+    /// case), and a bare MEMBER-LIST item (no `/`, all-uppercase-plus-
+    /// underscore — the #528 fix round's own corpus case,
+    /// `test/corpus/declarations.txt:144`).
+    #[test]
+    fn the_enum_atom_kind_round_trips_both_payload_shapes_without_confusion() {
+        let enum_ref_bytes = canonical_bytes(&read("NodeType/SOCIAL_CLASS").unwrap().0).unwrap();
+        let (node, consumed) = decode(&enum_ref_bytes);
+        assert_eq!(consumed, enum_ref_bytes.len());
+        let CasNode::Atom { kind, payload } = &node else {
+            panic!("expected an atom node")
+        };
+        assert_eq!(kind.as_slice(), b"enum");
+        assert_eq!(
+            decode_enum_atom(payload),
+            DecodedEnumAtom::EnumRef {
+                enum_type: "NodeType".into(),
+                member: "SOCIAL_CLASS".into(),
+            },
+            "an <enum-ref> payload (one '/') must decode as EnumRef, never BareUpperIdent"
+        );
+
+        let bare_type_bytes = canonical_bytes(&read("OrgKind").unwrap().0).unwrap();
+        let (node, consumed) = decode(&bare_type_bytes);
+        assert_eq!(consumed, bare_type_bytes.len());
+        let CasNode::Atom { kind, payload } = &node else {
+            panic!("expected an atom node")
+        };
+        assert_eq!(kind.as_slice(), b"enum");
+        assert_eq!(
+            decode_enum_atom(payload),
+            DecodedEnumAtom::BareUpperIdent("OrgKind".into()),
+            "a bare defenum type-name operand (no '/') must decode as \
+             BareUpperIdent, never EnumRef"
+        );
+
+        let bare_member_bytes = canonical_bytes(&read("STATE_APPARATUS").unwrap().0).unwrap();
+        let (node, consumed) = decode(&bare_member_bytes);
+        assert_eq!(consumed, bare_member_bytes.len());
+        let CasNode::Atom { kind, payload } = &node else {
+            panic!("expected an atom node")
+        };
+        assert_eq!(kind.as_slice(), b"enum");
+        assert_eq!(
+            decode_enum_atom(payload),
+            DecodedEnumAtom::BareUpperIdent("STATE_APPARATUS".into()),
+            "a bare defenum MEMBER-list item (no '/', underscore) must also \
+             decode as BareUpperIdent"
+        );
+    }
+
     /// Minimal independent decoder for the self-delimitation test only.
     enum CasNode {
         Atom {

--- a/rust/crates/babylon-bsl/src/canonical_ast.rs
+++ b/rust/crates/babylon-bsl/src/canonical_ast.rs
@@ -120,10 +120,12 @@ fn encode_atom(atom: &Atom, out: &mut Vec<u8>) -> Result<(), CasError> {
         }
         // §2.13 (Organization contract, Q12): reuses the EXISTING "enum"
         // CAS kind tag rather than minting a new one (bsl-language.rst's
-        // own §5.5 note: "needing... no new atom kind"). No collision with
-        // an `EnumRef` payload is possible — that payload always contains
-        // `/`, this one never does.
-        Atom::EnumTypeName(name) => ("enum", name.clone().into_bytes()),
+        // own §5.2 note: "needing... no new atom kind" — D117 corrects
+        // that note's premise for THIS payload shape, which is not an
+        // `<enum-ref>` value; the kind tag itself still doesn't move). No
+        // collision with an `EnumRef` payload is possible — that payload
+        // always contains exactly one `/`, this one never does (D117).
+        Atom::BareUpperIdent(name) => ("enum", name.clone().into_bytes()),
         Atom::Str(s) => ("str", s.clone().into_bytes()),
         Atom::Operator(op) => {
             return Err(CasError {

--- a/rust/crates/babylon-bsl/src/canonical_ast.rs
+++ b/rust/crates/babylon-bsl/src/canonical_ast.rs
@@ -118,6 +118,12 @@ fn encode_atom(atom: &Atom, out: &mut Vec<u8>) -> Result<(), CasError> {
         Atom::EnumRef { enum_type, member } => {
             ("enum", format!("{enum_type}/{member}").into_bytes())
         }
+        // §2.13 (Organization contract, Q12): reuses the EXISTING "enum"
+        // CAS kind tag rather than minting a new one (bsl-language.rst's
+        // own §5.5 note: "needing... no new atom kind"). No collision with
+        // an `EnumRef` payload is possible — that payload always contains
+        // `/`, this one never does.
+        Atom::EnumTypeName(name) => ("enum", name.clone().into_bytes()),
         Atom::Str(s) => ("str", s.clone().into_bytes()),
         Atom::Operator(op) => {
             return Err(CasError {

--- a/rust/crates/babylon-bsl/src/declarations.rs
+++ b/rust/crates/babylon-bsl/src/declarations.rs
@@ -284,6 +284,24 @@ pub struct OwnedFieldDecl {
 }
 
 /// Every declared field of a content set, keyed by qname.
+///
+/// **Dormant — declared, not wired (ADR109's declared-not-wired
+/// discipline; #528 fix round, MINOR item 5).** This type, its
+/// [`Self::declare`] (the only minting path for `E-LOAD-053`/`E-LOAD-054`'s
+/// `EnumKindShapeViolation`/`UnknownEnumRegistryType` in production shape)
+/// and [`Self::with_implicit_edge_strength`] have no production caller
+/// today: every reference outside this module's own `#[cfg(test)]` tests
+/// and `tests/r9_chapters.rs` is zero. Production builds its `TypeEnv`
+/// straight from a loaded scenario's own `deffield` forms instead —
+/// `babylon_tick::run_once`'s `TypeEnv { fields: scenario.fields.clone(),
+/// .. }` (`rust/crates/babylon-tick/src/lib.rs`), whose own comment names
+/// the same gap from the other side: "the scenario's `deffield` forms ARE
+/// the registries for slice 1. When Phase 2's content registries land they
+/// replace this wholesale." This type IS that Phase-2 registry, waiting on
+/// its consumer: rule-side `deffield` CONTENT PACKS (fields declared
+/// alongside `.bsl` rule content rather than re-declared per scenario) are
+/// what will wire it in — until then it stays fully built, fully tested,
+/// and correctly unreferenced from any live tick.
 #[derive(Debug, Clone, Default)]
 pub struct FieldRegistry {
     fields: HashMap<String, OwnedFieldDecl>,

--- a/rust/crates/babylon-bsl/src/declarations.rs
+++ b/rust/crates/babylon-bsl/src/declarations.rs
@@ -20,7 +20,7 @@
 //!   reserves it.
 
 use crate::reader::{Atom, SExpr};
-use crate::types::{BslType, FieldDecl, FieldKind};
+use crate::types::{BslType, EnumRegistry, EnumRegistryError, EnumTypeId, FieldDecl, FieldKind};
 use crate::vocabulary::{render_member, ClosedVocabulary, EnumKind, VocabularyError};
 use std::collections::HashMap;
 
@@ -161,6 +161,30 @@ pub enum DeclError {
         /// What was expected, and what was found.
         message: String,
     },
+    /// `E-LOAD-053` (§2.13, D101) — a `:type enum` `deffield` missing
+    /// `:enum-type`, carrying a `:kind` it structurally forbids, or a
+    /// non-enum `deffield` carrying `:enum-type`. The two slots are
+    /// mutually exclusive and jointly exhaustive against `:type`.
+    EnumKindShapeViolation {
+        /// The offending field.
+        field: String,
+        /// Which half of the exclusivity rule was violated.
+        detail: &'static str,
+    },
+    /// `E-LOAD-054` (§2.13, D101) — an `:enum-type` naming a `defenum`
+    /// type the registry does not carry.
+    UnknownEnumRegistryType {
+        /// The offending field.
+        field: String,
+        /// The unresolved type name.
+        enum_type: String,
+    },
+    /// A `defenum` declaration's own construction failure — `E-LOAD-001`
+    /// for a duplicate type/member (§2.13: "like any other duplicate
+    /// declaration"), uncoded for an empty member list (the grammar's
+    /// `<enum-member>+` is one-or-more, never zero — a shape violation,
+    /// not a semantic duplicate).
+    Enum(EnumRegistryError),
 }
 
 impl DeclError {
@@ -168,12 +192,17 @@ impl DeclError {
     #[must_use]
     pub fn spec_code(&self) -> Option<&'static str> {
         match self {
-            Self::Duplicate { .. } => Some("E-LOAD-001"),
+            Self::Duplicate { .. }
+            | Self::Enum(
+                EnumRegistryError::DuplicateType { .. } | EnumRegistryError::DuplicateMember { .. },
+            ) => Some("E-LOAD-001"),
             Self::KernelDisagreement { .. } => Some("E-LOAD-022"),
             Self::Vocabulary(e) => Some(e.spec_code()),
             Self::ReservedIntrinsicName { .. } => Some("E-LOAD-024"),
             Self::SignatureMismatch { .. } => Some("E-LOAD-020"),
-            Self::Malformed { .. } => None,
+            Self::Malformed { .. } | Self::Enum(EnumRegistryError::EmptyMemberList { .. }) => None,
+            Self::EnumKindShapeViolation { .. } => Some("E-LOAD-053"),
+            Self::UnknownEnumRegistryType { .. } => Some("E-LOAD-054"),
         }
     }
 }
@@ -200,6 +229,21 @@ impl std::fmt::Display for DeclError {
                  registration: {detail}"
             ),
             Self::Malformed { message } => write!(f, "malformed declaration: {message}"),
+            Self::EnumKindShapeViolation { field, detail } => {
+                write!(f, "E-LOAD-053: deffield {field}: {detail}")
+            }
+            Self::UnknownEnumRegistryType { field, enum_type } => write!(
+                f,
+                "E-LOAD-054: deffield {field}: :enum-type {enum_type} is not a \
+                 registered defenum type (§2.13)"
+            ),
+            Self::Enum(
+                e @ (EnumRegistryError::DuplicateType { .. }
+                | EnumRegistryError::DuplicateMember { .. }),
+            ) => {
+                write!(f, "E-LOAD-001: {e}")
+            }
+            Self::Enum(e @ EnumRegistryError::EmptyMemberList { .. }) => write!(f, "{e}"),
         }
     }
 }
@@ -209,6 +253,12 @@ impl std::error::Error for DeclError {}
 impl From<VocabularyError> for DeclError {
     fn from(e: VocabularyError) -> Self {
         Self::Vocabulary(e)
+    }
+}
+
+impl From<EnumRegistryError> for DeclError {
+    fn from(e: EnumRegistryError) -> Self {
+        Self::Enum(e)
     }
 }
 
@@ -274,13 +324,16 @@ impl FieldRegistry {
     /// [`DeclError::Vocabulary`] (`E-LOAD-023`) for an unregistered owning
     /// segment; [`DeclError::Duplicate`] (`E-LOAD-001`) for a second
     /// declaration of one field — including a re-declaration of an implicit
-    /// `<edge-type>/strength`; [`DeclError::Malformed`] off the grammar.
+    /// `<edge-type>/strength`; [`DeclError::Malformed`] off the grammar;
+    /// §2.13's `E-LOAD-053`/`E-LOAD-054` for a `:type enum` shape violation
+    /// or an unresolved `:enum-type` (see this module's own `parse_deffield`).
     pub fn declare(
         &mut self,
         form: &SExpr,
         vocabulary: &ClosedVocabulary,
+        enums: &EnumRegistry,
     ) -> Result<(), DeclError> {
-        let (qname, ty, kind) = parse_deffield(form)?;
+        let (qname, ty, kind) = parse_deffield(form, enums)?;
         let (owner_kind, owner_member) = vocabulary.owner_of_field(&qname)?;
         if let Some(existing) = self.fields.get(&qname) {
             let what = if existing.implicit {
@@ -361,8 +414,17 @@ impl FieldRegistry {
     }
 }
 
-/// Destructure `(deffield <qname> :type <type-name> :kind intensive|extensive)`.
-fn parse_deffield(form: &SExpr) -> Result<(String, BslType, FieldKind), DeclError> {
+/// Destructure `(deffield <qname> :type <type-name> :kind
+/// intensive|extensive)`, or — since §2.13 (D101, Organization spec §1
+/// Q12) — `(deffield <qname> :type enum :enum-type <EnumTypeName>)`. The
+/// two shapes are mutually exclusive and jointly exhaustive against
+/// `:type` (`E-LOAD-053` either way): every `:type` but `enum` requires
+/// `:kind` and forbids `:enum-type`; `:type enum` requires `:enum-type`
+/// (naming a type `enums` carries) and forbids `:kind`.
+fn parse_deffield(
+    form: &SExpr,
+    enums: &EnumRegistry,
+) -> Result<(String, BslType, FieldKind), DeclError> {
     let SExpr::List(items) = form else {
         return Err(malformed("a deffield must be a form"));
     };
@@ -378,13 +440,14 @@ fn parse_deffield(form: &SExpr) -> Result<(String, BslType, FieldKind), DeclErro
             "expected (deffield …), found ({head} …)"
         )));
     }
-    let mut ty: Option<BslType> = None;
+    let mut ty_name: Option<&str> = None;
     let mut kind: Option<FieldKind> = None;
+    let mut enum_type_name: Option<&str> = None;
     let mut cursor = options;
     while let [SExpr::Atom(Atom::Keyword(kw)), tail @ ..] = cursor {
         match (kw.as_str(), tail) {
             ("type", [SExpr::Atom(Atom::Symbol(name)), rest @ ..]) => {
-                ty = Some(parse_type_name(name)?);
+                ty_name = Some(name.as_str());
                 cursor = rest;
             }
             ("kind", [SExpr::Atom(Atom::Symbol(name)), rest @ ..]) => {
@@ -399,9 +462,13 @@ fn parse_deffield(form: &SExpr) -> Result<(String, BslType, FieldKind), DeclErro
                 });
                 cursor = rest;
             }
+            ("enum-type", [SExpr::Atom(Atom::EnumTypeName(name)), rest @ ..]) => {
+                enum_type_name = Some(name.as_str());
+                cursor = rest;
+            }
             (other, _) => {
                 return Err(malformed(format!(
-                    "a deffield takes :type and :kind, found :{other}"
+                    "a deffield takes :type, :kind and :enum-type, found :{other}"
                 )))
             }
         }
@@ -411,10 +478,117 @@ fn parse_deffield(form: &SExpr) -> Result<(String, BslType, FieldKind), DeclErro
             "unexpected trailing items in a deffield: {cursor:?}"
         )));
     }
-    match (ty, kind) {
-        (Some(ty), Some(kind)) => Ok((qname.clone(), ty, kind)),
-        _ => Err(malformed("a deffield declares both :type and :kind (§2.9)")),
+    let Some(ty_name) = ty_name else {
+        return Err(malformed("a deffield declares :type (§2.9)"));
+    };
+    if ty_name == "enum" {
+        return parse_enum_deffield(qname, kind, enum_type_name, enums);
     }
+    if enum_type_name.is_some() {
+        return Err(DeclError::EnumKindShapeViolation {
+            field: qname.clone(),
+            detail: ":enum-type is legal only alongside :type enum (§2.13)",
+        });
+    }
+    let ty = parse_type_name(ty_name)?;
+    match kind {
+        Some(kind) => Ok((qname.clone(), ty, kind)),
+        None => Err(malformed("a deffield declares both :type and :kind (§2.9)")),
+    }
+}
+
+/// The `:type enum` half of [`parse_deffield`] — split out because its own
+/// exclusivity checks (`E-LOAD-053`) and registry resolution
+/// (`E-LOAD-054`) are unrelated to the six-row concrete-type path.
+fn parse_enum_deffield(
+    qname: &str,
+    kind: Option<FieldKind>,
+    enum_type_name: Option<&str>,
+    enums: &EnumRegistry,
+) -> Result<(String, BslType, FieldKind), DeclError> {
+    if kind.is_some() {
+        return Err(DeclError::EnumKindShapeViolation {
+            field: qname.to_owned(),
+            detail: ":type enum forbids :kind — an enum-typed field carries \
+                     no aggregation kind, there being no meaningful \
+                     extensive-or-intensive reading of a member identity \
+                     (§2.13)",
+        });
+    }
+    let Some(enum_type_name) = enum_type_name else {
+        return Err(DeclError::EnumKindShapeViolation {
+            field: qname.to_owned(),
+            detail: ":type enum requires :enum-type naming a defenum-declared \
+                     type (§2.13)",
+        });
+    };
+    let Some(id) = enums.resolve(enum_type_name) else {
+        return Err(DeclError::UnknownEnumRegistryType {
+            field: qname.to_owned(),
+            enum_type: enum_type_name.to_owned(),
+        });
+    };
+    Ok((
+        qname.to_owned(),
+        BslType::Enum(id),
+        FieldKind::NotApplicable,
+    ))
+}
+
+/// `(defenum <EnumTypeName> (<member>+))` (§2.13, D101). Member order is
+/// **normative** — it is the declared-order ordinal §3.1's `enum` row
+/// stores (delegated to [`EnumRegistry::declare`], which preserves it).
+///
+/// **Members are written as full enum-refs repeating the declaring type**
+/// (`OrgKind/BUSINESS`, not a bare `BUSINESS`) — a deliberate reading of
+/// §2.13's EBNF, recorded here because the EBNF's own pretty-printed
+/// grammar shows a bare `<enum-member>+`. No atom class exists for a
+/// standalone `<enum-member>` distinct from a standalone `<enum-type>`:
+/// the two productions' character classes overlap (`BUSINESS` fits both
+/// `UPPER (UPPER|LOWER|DIGIT)*` and `UPPER (UPPER|DIGIT|"_")*`), so a
+/// position-free bare-member class would be lexically ambiguous with
+/// [`Atom::EnumTypeName`]. bsl-language.rst §5.5's own CAS note — "`defenum`
+/// and `defvocabulary` … needing … no new atom kind — the `<enum-ref>`
+/// values they govern already encode with the existing atom kind" —
+/// confirms the intended reading is the EXISTING `<enum-ref>` shape, not a
+/// new bare-token class, so that is what this parser accepts.
+///
+/// # Errors
+///
+/// [`DeclError::Enum`] for a duplicate type/member (`E-LOAD-001`) or an
+/// empty member list; [`DeclError::Malformed`] off the grammar, including a
+/// member whose type prefix does not match the type being declared.
+pub fn parse_defenum(form: &SExpr, registry: &mut EnumRegistry) -> Result<EnumTypeId, DeclError> {
+    let SExpr::List(items) = form else {
+        return Err(malformed("a defenum must be a form"));
+    };
+    let [SExpr::Atom(Atom::Symbol(head)), SExpr::Atom(Atom::EnumTypeName(name)), SExpr::List(member_items)] =
+        items.as_slice()
+    else {
+        return Err(malformed(
+            "(defenum <EnumTypeName> (<member>+)) — unrecognized shape",
+        ));
+    };
+    if head != "defenum" {
+        return Err(malformed(format!("expected (defenum …), found ({head} …)")));
+    }
+    let mut members = Vec::with_capacity(member_items.len());
+    for item in member_items {
+        let SExpr::Atom(Atom::EnumRef { enum_type, member }) = item else {
+            return Err(malformed(format!(
+                "defenum {name}: member {item:?} must be written {name}/<MEMBER>, \
+                 repeating the declaring type (§2.13)"
+            )));
+        };
+        if enum_type != name {
+            return Err(malformed(format!(
+                "defenum {name}: member {enum_type}/{member} names a \
+                 different type than the one being declared ({name})"
+            )));
+        }
+        members.push(member.clone());
+    }
+    registry.declare(name, &members).map_err(DeclError::from)
 }
 
 /// The §3.1 type names, as they are spelled in `:type` / `:returns`.
@@ -444,6 +618,22 @@ pub fn parse_type_name(name: &str) -> Result<BslType, DeclError> {
         "probability" => Ok(BslType::Probability),
         "intensity" => Ok(BslType::Intensity),
         "coefficient" => Ok(BslType::Coefficient),
+        // §2.13 (D101): `enum` IS one of §3.1's seven type names now, but
+        // this function only ever receives the bare name string — it
+        // cannot resolve a companion `:enum-type` operand, which lives in
+        // a DIFFERENT keyword slot a caller must have already read. A
+        // deffield's own keyword scan special-cases `:type enum` BEFORE
+        // reaching here (`parse_enum_deffield`); a metric declaration
+        // (§2.11) has no `:enum-type` slot in its grammar at all, so this
+        // arm is metrics' own refusal too — deferred, not silently
+        // widened.
+        "enum" => Err(malformed(
+            "'enum' needs a companion :enum-type naming a defenum-declared \
+             type (§2.13) that this function was not given — a deffield's \
+             own keyword scan resolves :type enum before calling this \
+             function, and a metric declaration (§2.11) does not support \
+             enum-typed metrics in this slice",
+        )),
         other => Err(malformed(format!(
             "'{other}' is not one of §3.1's type names (lowercase — D94 \
              rules type names lowercase symbols)"
@@ -787,9 +977,15 @@ mod tests {
         RESERVED_FORM_TAGS,
     };
     use crate::reader::{read, SExpr};
-    use crate::types::{BslType, FieldDecl, FieldKind};
+    use crate::types::{BslType, EnumRegistry, EnumRegistryError, FieldDecl, FieldKind};
     use crate::vocabulary::{ClosedVocabulary, EnumKind};
     use std::collections::HashMap;
+
+    /// No content in this module's tests declares an enum-typed field —
+    /// an empty registry is the honest "no `defenum`s in scope" input.
+    fn enums() -> EnumRegistry {
+        EnumRegistry::default()
+    }
 
     fn vocabulary() -> ClosedVocabulary {
         ClosedVocabulary::new([
@@ -832,6 +1028,7 @@ mod tests {
             .declare(
                 &form("(deffield solidarity/strength :type coefficient :kind extensive)"),
                 &vocabulary(),
+                &enums(),
             )
             .unwrap_err();
         assert_eq!(err.spec_code(), Some("E-LOAD-001"));
@@ -846,7 +1043,7 @@ mod tests {
             "(deffield exploitation/tension :type intensity :kind intensive)",
             "(deffield economic-sector/output :type currency :kind extensive)",
         ] {
-            registry.declare(&form(source), &v).expect(source);
+            registry.declare(&form(source), &v, &enums()).expect(source);
         }
         assert_eq!(
             registry.get("exploitation/tension").unwrap().owner_kind,
@@ -865,6 +1062,7 @@ mod tests {
             .declare(
                 &form("(deffield imperium/rent :type currency :kind extensive)"),
                 &vocabulary(),
+                &enums(),
             )
             .unwrap_err();
         assert_eq!(err.spec_code(), Some("E-LOAD-023"));
@@ -875,9 +1073,12 @@ mod tests {
         let v = vocabulary();
         let mut registry = FieldRegistry::default();
         let source = "(deffield social-class/wealth :type currency :kind extensive)";
-        registry.declare(&form(source), &v).unwrap();
+        registry.declare(&form(source), &v, &enums()).unwrap();
         assert_eq!(
-            registry.declare(&form(source), &v).unwrap_err().spec_code(),
+            registry
+                .declare(&form(source), &v, &enums())
+                .unwrap_err()
+                .spec_code(),
             Some("E-LOAD-001")
         );
     }
@@ -890,6 +1091,7 @@ mod tests {
             .declare(
                 &form("(deffield social-class/wealth :type currency :kind extensive)"),
                 &v,
+                &enums(),
             )
             .unwrap();
         let kernel = HashMap::from([(
@@ -1096,5 +1298,132 @@ mod tests {
         assert_eq!(decls.len(), 2);
         assert_eq!(decls["floor"].cost, 5);
         assert_eq!(decls["exp"].cost, 40);
+    }
+
+    // ---- §2.13 (Organization contract, Q12, D101): `defenum` and the
+    // `:type enum :enum-type` deffield shape ----
+
+    fn org_kind() -> super::EnumRegistry {
+        let mut registry = super::EnumRegistry::default();
+        super::parse_defenum(
+            &form(
+                "(defenum OrgKind (OrgKind/STATE_APPARATUS OrgKind/BUSINESS \
+                 OrgKind/POLITICAL_FACTION OrgKind/CIVIL_SOCIETY))",
+            ),
+            &mut registry,
+        )
+        .expect("OrgKind declares");
+        registry
+    }
+
+    #[test]
+    fn defenum_preserves_declaration_order_as_the_ordinal() {
+        let registry = org_kind();
+        let ty = registry.resolve("OrgKind").expect("OrgKind is declared");
+        assert_eq!(registry.ordinal(ty, "STATE_APPARATUS"), Some(0));
+        assert_eq!(registry.ordinal(ty, "BUSINESS"), Some(1));
+        assert_eq!(registry.ordinal(ty, "POLITICAL_FACTION"), Some(2));
+        assert_eq!(registry.ordinal(ty, "CIVIL_SOCIETY"), Some(3));
+    }
+
+    #[test]
+    fn defenum_refuses_a_member_naming_a_different_type() {
+        let mut registry = super::EnumRegistry::default();
+        let err = super::parse_defenum(
+            &form("(defenum OrgKind (NodeType/SOCIAL_CLASS))"),
+            &mut registry,
+        )
+        .unwrap_err();
+        assert!(matches!(err, DeclError::Malformed { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn defenum_refuses_an_empty_member_list_as_e_load_001_family() {
+        // The grammar's <enum-member>+ is one-or-more; an empty list is a
+        // shape violation the registry reports as EmptyMemberList (uncoded
+        // — never a duplicate-declaration lie).
+        let mut registry = super::EnumRegistry::default();
+        let err = super::parse_defenum(&form("(defenum OrgKind ())"), &mut registry).unwrap_err();
+        assert_eq!(err.spec_code(), None);
+        assert!(matches!(
+            err,
+            DeclError::Enum(EnumRegistryError::EmptyMemberList { .. })
+        ));
+    }
+
+    #[test]
+    fn a_duplicate_defenum_type_name_is_e_load_001() {
+        let mut registry = super::EnumRegistry::default();
+        super::parse_defenum(&form("(defenum OrgKind (OrgKind/BUSINESS))"), &mut registry).unwrap();
+        let err = super::parse_defenum(
+            &form("(defenum OrgKind (OrgKind/CIVIL_SOCIETY))"),
+            &mut registry,
+        )
+        .unwrap_err();
+        assert_eq!(err.spec_code(), Some("E-LOAD-001"));
+    }
+
+    #[test]
+    fn deffield_type_enum_requires_enum_type_and_resolves_it() {
+        let registry = org_kind();
+        let (qname, ty, kind) = super::parse_deffield(
+            &form("(deffield organization/kind :type enum :enum-type OrgKind)"),
+            &registry,
+        )
+        .expect("well-formed enum deffield");
+        assert_eq!(qname, "organization/kind");
+        assert_eq!(kind, FieldKind::NotApplicable);
+        let BslType::Enum(id) = ty else {
+            panic!("expected BslType::Enum, got {ty:?}")
+        };
+        assert_eq!(id, registry.resolve("OrgKind").unwrap());
+    }
+
+    #[test]
+    fn deffield_type_enum_without_enum_type_is_e_load_053() {
+        let registry = org_kind();
+        let err =
+            super::parse_deffield(&form("(deffield organization/kind :type enum)"), &registry)
+                .unwrap_err();
+        assert_eq!(err.spec_code(), Some("E-LOAD-053"));
+    }
+
+    #[test]
+    fn deffield_type_enum_with_kind_is_e_load_053() {
+        let registry = org_kind();
+        let err = super::parse_deffield(
+            &form(
+                "(deffield organization/kind :type enum :enum-type OrgKind \
+                 :kind extensive)",
+            ),
+            &registry,
+        )
+        .unwrap_err();
+        assert_eq!(err.spec_code(), Some("E-LOAD-053"));
+    }
+
+    #[test]
+    fn enum_type_keyword_on_a_non_enum_type_is_e_load_053() {
+        let registry = org_kind();
+        let err = super::parse_deffield(
+            &form(
+                "(deffield organization/budget :type currency :kind extensive \
+                 :enum-type OrgKind)",
+            ),
+            &registry,
+        )
+        .unwrap_err();
+        assert_eq!(err.spec_code(), Some("E-LOAD-053"));
+    }
+
+    #[test]
+    fn deffield_type_enum_naming_an_unregistered_type_is_e_load_054() {
+        let registry = super::EnumRegistry::default();
+        let err = super::parse_deffield(
+            &form("(deffield organization/kind :type enum :enum-type Nowhere)"),
+            &registry,
+        )
+        .unwrap_err();
+        assert_eq!(err.spec_code(), Some("E-LOAD-054"));
     }
 }

--- a/rust/crates/babylon-bsl/src/declarations.rs
+++ b/rust/crates/babylon-bsl/src/declarations.rs
@@ -462,7 +462,7 @@ fn parse_deffield(
                 });
                 cursor = rest;
             }
-            ("enum-type", [SExpr::Atom(Atom::EnumTypeName(name)), rest @ ..]) => {
+            ("enum-type", [SExpr::Atom(Atom::BareUpperIdent(name)), rest @ ..]) => {
                 enum_type_name = Some(name.as_str());
                 cursor = rest;
             }
@@ -535,55 +535,70 @@ fn parse_enum_deffield(
     ))
 }
 
-/// `(defenum <EnumTypeName> (<member>+))` (§2.13, D101). Member order is
+/// `(defenum <enum-type> (<enum-member>+))` (§2.13, D101;
+/// `bsl.ebnf`: `defenum ::= "(" "defenum" enum-type "(" enum-member+ ")"
+/// ")"`, `enum-type`/`enum-member` "§1.4's, unchanged"). Member order is
 /// **normative** — it is the declared-order ordinal §3.1's `enum` row
 /// stores (delegated to [`EnumRegistry::declare`], which preserves it).
 ///
-/// **Members are written as full enum-refs repeating the declaring type**
-/// (`OrgKind/BUSINESS`, not a bare `BUSINESS`) — a deliberate reading of
-/// §2.13's EBNF, recorded here because the EBNF's own pretty-printed
-/// grammar shows a bare `<enum-member>+`. No atom class exists for a
-/// standalone `<enum-member>` distinct from a standalone `<enum-type>`:
-/// the two productions' character classes overlap (`BUSINESS` fits both
-/// `UPPER (UPPER|LOWER|DIGIT)*` and `UPPER (UPPER|DIGIT|"_")*`), so a
-/// position-free bare-member class would be lexically ambiguous with
-/// [`Atom::EnumTypeName`]. bsl-language.rst §5.5's own CAS note — "`defenum`
-/// and `defvocabulary` … needing … no new atom kind — the `<enum-ref>`
-/// values they govern already encode with the existing atom kind" —
-/// confirms the intended reading is the EXISTING `<enum-ref>` shape, not a
-/// new bare-token class, so that is what this parser accepts.
+/// **Members are written BARE** (`STATE_APPARATUS`, not `OrgKind/
+/// STATE_APPARATUS`) — §2.13's own EBNF says so directly, and
+/// `tools/tree-sitter-bsl/test/corpus/declarations.txt`'s own worked
+/// example pins exactly this shape.
+///
+/// **#528 fix round, corrected reading.** An earlier version of this
+/// function required a full `<enum-type>/<enum-member>` ref repeating the
+/// declaring type instead, reasoning that no atom class existed for a
+/// standalone `<enum-member>` because `<enum-type>`'s and `<enum-member>`'s
+/// charsets overlap (`BUSINESS` fits both). That reasoning was the bug:
+/// neither production CONTAINS the other (`OrgKind` has lowercase,
+/// `STATE_APPARATUS` has `_`), so [`Atom::BareUpperIdent`] (see its own
+/// doc) admits their UNION at lex time and this function disambiguates
+/// POSITIONALLY — the type-name operand against
+/// [`crate::reader::is_enum_type_shape`], each member against
+/// [`crate::reader::is_enum_member_shape`]. A member written as a full
+/// enum-ref (with a `/`) is grammar-nonconforming and refuses loudly:
+/// grammar conformance cuts both ways.
 ///
 /// # Errors
 ///
 /// [`DeclError::Enum`] for a duplicate type/member (`E-LOAD-001`) or an
 /// empty member list; [`DeclError::Malformed`] off the grammar, including a
-/// member whose type prefix does not match the type being declared.
+/// declared type name not shaped like `<enum-type>`, a member not shaped
+/// like `<enum-member>`, or a member written as a full enum-ref.
 pub fn parse_defenum(form: &SExpr, registry: &mut EnumRegistry) -> Result<EnumTypeId, DeclError> {
     let SExpr::List(items) = form else {
         return Err(malformed("a defenum must be a form"));
     };
-    let [SExpr::Atom(Atom::Symbol(head)), SExpr::Atom(Atom::EnumTypeName(name)), SExpr::List(member_items)] =
+    let [SExpr::Atom(Atom::Symbol(head)), SExpr::Atom(Atom::BareUpperIdent(name)), SExpr::List(member_items)] =
         items.as_slice()
     else {
         return Err(malformed(
-            "(defenum <EnumTypeName> (<member>+)) — unrecognized shape",
+            "(defenum <enum-type> (<enum-member>+)) — unrecognized shape",
         ));
     };
     if head != "defenum" {
         return Err(malformed(format!("expected (defenum …), found ({head} …)")));
     }
+    if !crate::reader::is_enum_type_shape(name) {
+        return Err(malformed(format!(
+            "defenum {name}: the declared type name is not a valid \
+             <enum-type> (§1.4: UPPER (UPPER|LOWER|DIGIT)* — no underscore)"
+        )));
+    }
     let mut members = Vec::with_capacity(member_items.len());
     for item in member_items {
-        let SExpr::Atom(Atom::EnumRef { enum_type, member }) = item else {
+        let SExpr::Atom(Atom::BareUpperIdent(member)) = item else {
             return Err(malformed(format!(
-                "defenum {name}: member {item:?} must be written {name}/<MEMBER>, \
-                 repeating the declaring type (§2.13)"
+                "defenum {name}: member {item:?} must be a bare <enum-member> \
+                 (§2.13, §1.4) — e.g. `STATE_APPARATUS`, never a full \
+                 `{name}/<MEMBER>` enum-ref"
             )));
         };
-        if enum_type != name {
+        if !crate::reader::is_enum_member_shape(member) {
             return Err(malformed(format!(
-                "defenum {name}: member {enum_type}/{member} names a \
-                 different type than the one being declared ({name})"
+                "defenum {name}: member `{member}` is not a valid \
+                 <enum-member> (§1.4: UPPER (UPPER|DIGIT|\"_\")* — no lowercase)"
             )));
         }
         members.push(member.clone());
@@ -1307,13 +1322,30 @@ mod tests {
         let mut registry = super::EnumRegistry::default();
         super::parse_defenum(
             &form(
-                "(defenum OrgKind (OrgKind/STATE_APPARATUS OrgKind/BUSINESS \
-                 OrgKind/POLITICAL_FACTION OrgKind/CIVIL_SOCIETY))",
+                "(defenum OrgKind (STATE_APPARATUS BUSINESS \
+                 POLITICAL_FACTION CIVIL_SOCIETY))",
             ),
             &mut registry,
         )
         .expect("OrgKind declares");
         registry
+    }
+
+    /// The tree-sitter corpus's own worked example
+    /// (`test/corpus/declarations.txt:144`) — bare `<enum-member>` items,
+    /// never full `Type/MEMBER` refs (#528 fix round).
+    #[test]
+    fn parse_defenum_accepts_the_corpus_line_verbatim() {
+        let mut registry = super::EnumRegistry::default();
+        let ty = super::parse_defenum(
+            &form("(defenum OrgKind (STATE_APPARATUS BUSINESS POLITICAL_FACTION CIVIL_SOCIETY))"),
+            &mut registry,
+        )
+        .expect("the corpus's own bare-member shape must load");
+        assert_eq!(registry.ordinal(ty, "STATE_APPARATUS"), Some(0));
+        assert_eq!(registry.ordinal(ty, "BUSINESS"), Some(1));
+        assert_eq!(registry.ordinal(ty, "POLITICAL_FACTION"), Some(2));
+        assert_eq!(registry.ordinal(ty, "CIVIL_SOCIETY"), Some(3));
     }
 
     #[test]
@@ -1326,14 +1358,41 @@ mod tests {
         assert_eq!(registry.ordinal(ty, "CIVIL_SOCIETY"), Some(3));
     }
 
+    /// #528 fix round: repurposed from `defenum_refuses_a_member_naming_a_
+    /// different_type` — under the bare-member reading a member carries no
+    /// type prefix to mismatch AT ALL (that whole error class is now
+    /// structurally unreachable), so the meaningful sibling check is the
+    /// grammar-conformance direction: a member written as a full enum-ref
+    /// (even one naming a plausible-looking different type) still refuses.
     #[test]
-    fn defenum_refuses_a_member_naming_a_different_type() {
+    fn defenum_refuses_a_member_written_as_a_full_enum_ref() {
         let mut registry = super::EnumRegistry::default();
         let err = super::parse_defenum(
             &form("(defenum OrgKind (NodeType/SOCIAL_CLASS))"),
             &mut registry,
         )
         .unwrap_err();
+        assert!(matches!(err, DeclError::Malformed { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn defenum_refuses_a_type_name_shaped_like_an_enum_member() {
+        // Org_Kind lexes fine (Atom::BareUpperIdent admits the union
+        // charset) but is not a valid <enum-type> (underscore) — the
+        // parser, not the reader, must catch this.
+        let mut registry = super::EnumRegistry::default();
+        let err = super::parse_defenum(&form("(defenum Org_Kind (BUSINESS))"), &mut registry)
+            .unwrap_err();
+        assert!(matches!(err, DeclError::Malformed { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn defenum_refuses_a_member_shaped_like_an_enum_type() {
+        // `Business` lexes fine but is not a valid <enum-member>
+        // (lowercase) — same split, the other direction.
+        let mut registry = super::EnumRegistry::default();
+        let err =
+            super::parse_defenum(&form("(defenum OrgKind (Business))"), &mut registry).unwrap_err();
         assert!(matches!(err, DeclError::Malformed { .. }), "{err:?}");
     }
 
@@ -1354,12 +1413,9 @@ mod tests {
     #[test]
     fn a_duplicate_defenum_type_name_is_e_load_001() {
         let mut registry = super::EnumRegistry::default();
-        super::parse_defenum(&form("(defenum OrgKind (OrgKind/BUSINESS))"), &mut registry).unwrap();
-        let err = super::parse_defenum(
-            &form("(defenum OrgKind (OrgKind/CIVIL_SOCIETY))"),
-            &mut registry,
-        )
-        .unwrap_err();
+        super::parse_defenum(&form("(defenum OrgKind (BUSINESS))"), &mut registry).unwrap();
+        let err = super::parse_defenum(&form("(defenum OrgKind (CIVIL_SOCIETY))"), &mut registry)
+            .unwrap_err();
         assert_eq!(err.spec_code(), Some("E-LOAD-001"));
     }
 

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -175,6 +175,15 @@ pub enum EvalCode {
     /// for the disputed (negative) domain floor/trunc diverge on — a loud
     /// failure instead (III.11).
     DemotionOutOfDomain,
+    /// `E-EVAL-042` (§2.13, D101) — a structural-verb write (`update-node`
+    /// and siblings) to an `:enum-type`-declared field, evaluating to
+    /// anything other than a matching `<enum-ref>` of that exact declared
+    /// type. The load-time law (`E-LOAD-056`, `scenario.rs::
+    /// attribute_value_enum`) re-checked at the ONE boundary content
+    /// cannot be checked once and for all at load — the same two-site
+    /// pattern the store boundary (`E-EVAL-020`) and range checks
+    /// (`E-EVAL-041`) already use.
+    EnumWriteShapeViolation,
 }
 
 impl EvalCode {
@@ -199,6 +208,7 @@ impl EvalCode {
             Self::MetricValueAbsent => "E-EVAL-037",
             Self::FuelExhausted => "E-EVAL-040",
             Self::DemotionOutOfDomain => "E-EVAL-039",
+            Self::EnumWriteShapeViolation => "E-EVAL-042",
         }
     }
 }
@@ -2142,6 +2152,7 @@ mod tests {
     fn refusal_messages_name_their_slice() {
         use crate::structural_verbs::{CollectingSink, EffectExecutor};
         use crate::typecheck::TypeEnv;
+        use crate::types::EnumRegistry;
         use babylon_graph::memory::MemoryGraph;
         use babylon_graph::substrate::GraphSubstrate;
 
@@ -2193,7 +2204,8 @@ mod tests {
             fields: HashMap::new(),
             exemptions: &[],
         };
-        let mut executor = EffectExecutor::new(&types);
+        let enums = EnumRegistry::default();
+        let mut executor = EffectExecutor::new(&types, &enums);
         let mut sink = CollectingSink::default();
         let costs = costs();
         let effect_env = EvalEnv {

--- a/rust/crates/babylon-bsl/src/grammar.rs
+++ b/rust/crates/babylon-bsl/src/grammar.rs
@@ -266,7 +266,7 @@ pub fn check_enum_ref_kinds(expr: &SExpr) -> Result<(), GrammarError> {
 const MINTING_TYPE_OPERAND_HEADS: [&str; 3] = ["emit", "add-node", "add-edge"];
 
 /// Walk a form tree and refuse a non-`<enum-ref>` child at
-/// [`MINTING_TYPE_OPERAND_HEADS`]'s one typed position (operand 1) —
+/// `MINTING_TYPE_OPERAND_HEADS`'s one typed position (operand 1) —
 /// mirrors `bound_checker::enum_ref_key`'s own refusal for the sibling
 /// positions it already gates (the six §2.6 query heads, `add-hyperedge`);
 /// see that const's own doc for why these three specifically need a

--- a/rust/crates/babylon-bsl/src/grammar.rs
+++ b/rust/crates/babylon-bsl/src/grammar.rs
@@ -238,6 +238,71 @@ pub fn check_enum_ref_kinds(expr: &SExpr) -> Result<(), GrammarError> {
     Ok(())
 }
 
+/// The type-operand position (operand 1) of `emit`/`add-node`/`add-edge`
+/// — unlike the six §2.6 query heads and `add-hyperedge`, whose own type
+/// operand IS extracted and validated at load by
+/// `bound_checker::enum_ref_key` (`bound_checker.rs:189-196`), these
+/// three verbs' type operand is folded into the §3.7 static cost pass's
+/// generic per-operand sum (`bound_checker::verb_cost`/`atom_cost`),
+/// which prices a `BareUpperIdent` atom identically to an `<enum-ref>`
+/// (cost 0) — so a `Type_MEMBER` typo (slash typo'd as underscore,
+/// lexing as `Atom::BareUpperIdent` since the §2.13 lexer widening,
+/// D101) survives every load-time check and dies mid-tick, uncoded, at
+/// `structural_verbs.rs`'s own `enum_member` (#528 fix round Item D).
+///
+/// `add-node`/`add-edge` are ALSO two of the six graph-shape verbs
+/// `structural_verbs::check_no_deferred_shape_verbs` refuses
+/// unconditionally at load (§4.2 chapter C4's collect-then-apply gap,
+/// #519 fix round) — every rule using either verb is refused there
+/// regardless of this gate, so in `rule_pipeline::load_rule_form`'s full
+/// pipeline THIS check changes no observable outcome for them today. It
+/// still earns its place: it runs EARLIER in that pipeline (naming the
+/// actual shape defect rather than the unrelated deferred-verb gap when
+/// a rule happens to carry both), it is the only gate at all for a
+/// caller that drives this module's checks directly (as this module's
+/// own tests do), and it stops being redundant the day `add-node`/
+/// `add-edge` gain collect-then-apply support. `emit` carries no such
+/// second gate — this is its ONLY load-time shape check.
+const MINTING_TYPE_OPERAND_HEADS: [&str; 3] = ["emit", "add-node", "add-edge"];
+
+/// Walk a form tree and refuse a non-`<enum-ref>` child at
+/// [`MINTING_TYPE_OPERAND_HEADS`]'s one typed position (operand 1) —
+/// mirrors `bound_checker::enum_ref_key`'s own refusal for the sibling
+/// positions it already gates (the six §2.6 query heads, `add-hyperedge`);
+/// see that const's own doc for why these three specifically need a
+/// SEPARATE gate rather than reuse of that one.
+///
+/// # Errors
+///
+/// A plain message naming the form and what was found — uncoded, the
+/// same "no §2 production reserves a number for this" precedent a
+/// content-composition rejection already sets elsewhere in this crate,
+/// and the same uncoded vocabulary `bound_checker::enum_ref_key` itself
+/// uses for its sibling refusal ("expected an enum-ref where the grammar
+/// requires one").
+pub fn check_minting_type_operands_are_enum_refs(expr: &SExpr) -> Result<(), String> {
+    if let SExpr::List(items) = expr {
+        if let Some(SExpr::Atom(Atom::Symbol(head))) = items.first() {
+            if MINTING_TYPE_OPERAND_HEADS.contains(&head.as_str()) {
+                match items.get(1) {
+                    Some(SExpr::Atom(Atom::EnumRef { .. })) => {}
+                    other => {
+                        return Err(format!(
+                            "({head} …) operand 1 must be an <enum-ref> — expected an \
+                             enum-ref where the grammar requires one, found {other:?} \
+                             (#528 fix round Item D)"
+                        ));
+                    }
+                }
+            }
+        }
+        for child in items {
+            check_minting_type_operands_are_enum_refs(child)?;
+        }
+    }
+    Ok(())
+}
+
 /// The three minting verbs whose element type is an operand, so D37's
 /// field-init owner check is **static** there (§2.8).
 const MINTING_VERBS: [&str; 3] = ["add-node", "add-edge", "add-hyperedge"];
@@ -273,7 +338,20 @@ fn check_one_verbs_field_inits(
     vocabulary: &ClosedVocabulary,
 ) -> Result<(), GrammarError> {
     let Some(SExpr::Atom(Atom::EnumRef { enum_type, member })) = items.get(1) else {
-        return Ok(()); // a mis-shaped verb is the bound checker's rejection
+        // A mis-shaped `add-hyperedge` type-operand is the bound checker's
+        // rejection (`bound_checker::check_member_lists`, via
+        // `enum_ref_key`). `add-node`/`add-edge`'s is
+        // `check_minting_type_operands_are_enum_refs`, THIS module's own
+        // sibling gate — reached earlier in `rule_pipeline::
+        // load_rule_form`'s pipeline than this function ever runs (it is
+        // only called when `head` is a `MINTING_VERBS` member, gated by
+        // `check_field_init_owners`, itself after `check_enum_ref_kinds`
+        // wires `check_minting_type_operands_are_enum_refs` alongside it —
+        // #528 fix round Item D). Refusing `Ok(())` here too is not
+        // reachable through that pipeline for a mis-shaped operand, but
+        // stays correct — and honest — for any caller that drives this
+        // function directly, bypassing the earlier gate.
+        return Ok(());
     };
     let verb_type = format!("{enum_type}/{member}");
     for child in &items[2..] {
@@ -598,6 +676,64 @@ mod tests {
     fn an_enum_ref_in_an_untyped_position_is_a_value_not_a_mis_kinded_operand() {
         // §3.1's `Enum<T>` compares with =/!=; that position types nothing.
         assert!(check_enum_ref_kinds(&e("(= NodeType/POLITY NodeType/POLITY)")).is_ok());
+    }
+
+    // ---- the minting/emitting type-operand shape gate (#528 fix round
+    // Item D) — `check_enum_ref_kinds` above only checks the KIND of an
+    // enum-ref that is already there; this is the sibling check that the
+    // operand IS one in the first place, for the three positions
+    // `bound_checker::enum_ref_key` does not itself reach. ----
+
+    #[test]
+    fn a_bare_upper_ident_at_the_minting_type_operand_position_is_refused() {
+        // `Type_MEMBER` (slash typo'd as underscore) lexes as
+        // `Atom::BareUpperIdent` (D101's lexer widening) — exactly the
+        // shape this gate exists to catch.
+        for source in [
+            "(emit NodeType_SOCIAL_CLASS)",
+            "(add-node NodeType_SOCIAL_CLASS n1)",
+            "(add-edge EdgeType_SOLIDARITY a b :strength 0.5c)",
+        ] {
+            assert!(
+                super::check_minting_type_operands_are_enum_refs(&e(source)).is_err(),
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_correctly_shaped_enum_ref_at_the_minting_type_operand_position_is_untouched() {
+        for source in [
+            "(emit EventType/RUPTURE)",
+            "(add-node NodeType/SOCIAL_CLASS n1)",
+            "(add-edge EdgeType/SOLIDARITY a b :strength 0.5c)",
+        ] {
+            assert!(
+                super::check_minting_type_operands_are_enum_refs(&e(source)).is_ok(),
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_non_minting_head_with_a_bare_upper_ident_operand_is_untouched() {
+        // Query heads and `add-hyperedge` are gated elsewhere
+        // (`bound_checker::enum_ref_key`) — this function must not
+        // overreach into their positions.
+        assert!(super::check_minting_type_operands_are_enum_refs(&e(
+            "(nodes NodeType_SOCIAL_CLASS)"
+        ))
+        .is_ok());
+    }
+
+    #[test]
+    fn a_bare_upper_ident_nested_inside_a_guard_still_refuses() {
+        // The walk must recurse into (guard/…) bodies, not just the
+        // top-level form.
+        assert!(super::check_minting_type_operands_are_enum_refs(&e(
+            "(guard #t (emit NodeType_SOCIAL_CLASS))"
+        ))
+        .is_err());
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/reader.rs
+++ b/rust/crates/babylon-bsl/src/reader.rs
@@ -669,28 +669,45 @@ fn classify_bare_upper_ident(run: &str, start: usize) -> Result<Atom, ReadError>
     }
 }
 
-/// Whether `s` — already lexed as [`Atom::BareUpperIdent`] — conforms to
-/// §1.4's own `<enum-type>` production (`UPPER (UPPER|LOWER|DIGIT)*`, no
-/// underscore). The first character is uppercase by construction (the
-/// lexer already checked it); this validates the rest of the union
-/// charset narrows correctly. Used positionally by
-/// `crate::declarations::parse_defenum`/`crate::scenario::
-/// load_defvocabulary` to validate their own type-name operand — never by
-/// the reader itself, which stays lex-only (§2.13).
+/// Whether `s` conforms to §1.4's own `<enum-type>` production (`UPPER
+/// (UPPER|LOWER|DIGIT)*`, no underscore) — non-empty, first character
+/// ASCII uppercase, every character ASCII alphanumeric. Self-contained
+/// (#528 fix round Item E): every in-crate caller already runs this
+/// against a string lexed as [`Atom::BareUpperIdent`] (first character
+/// uppercase by construction), but this function is `pub` (via `pub mod
+/// reader`) and must not assume that precondition standing alone — the
+/// pre-fix version returned `true` for `""` (`.all()` on an empty
+/// iterator is vacuously `true`) and for a lowercase-initial string like
+/// `"orgkind"` (`is_ascii_alphanumeric` does not distinguish case).
+/// Used positionally by `crate::declarations::parse_defenum`/
+/// `crate::scenario::load_defvocabulary` to validate their own type-name
+/// operand — never by the reader itself, which stays lex-only (§2.13).
 #[must_use]
 pub fn is_enum_type_shape(s: &str) -> bool {
-    s.chars().all(|c| c.is_ascii_alphanumeric())
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_uppercase() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric())
 }
 
-/// Whether `s` — already lexed as [`Atom::BareUpperIdent`] — conforms to
-/// §1.4's own `<enum-member>` production (`UPPER (UPPER|DIGIT|"_")*`, no
-/// lowercase). Used positionally by `crate::declarations::parse_defenum`/
-/// `crate::scenario::load_defvocabulary` to validate their own member-list
-/// items.
+/// Whether `s` conforms to §1.4's own `<enum-member>` production (`UPPER
+/// (UPPER|DIGIT|"_")*`, no lowercase) — non-empty, first character ASCII
+/// uppercase, every character ASCII uppercase, digit, or underscore.
+/// Self-contained for the same reason [`is_enum_type_shape`] is (#528 fix
+/// round Item E): the pre-fix version returned `true` for `""` and for a
+/// digit-/underscore-initial string like `"_STATE"`. Used positionally by
+/// `crate::declarations::parse_defenum`/`crate::scenario::
+/// load_defvocabulary` to validate their own member-list items.
 #[must_use]
 pub fn is_enum_member_shape(s: &str) -> bool {
-    s.chars()
-        .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_uppercase() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
 }
 
 /// Validate a `digits` group (`DIGIT ( "_"? DIGIT )*`): underscores only
@@ -1522,6 +1539,19 @@ mod tests {
         assert!(super::is_enum_type_shape("HexResolution2"));
         assert!(!super::is_enum_type_shape("Org_Kind"));
         assert!(!super::is_enum_type_shape("STATE_APPARATUS"));
+        // #528 fix round Item E: both predicates are `pub` (via `pub mod
+        // reader`), so they must be self-contained rather than trusting a
+        // caller already ran them through the lexer — "" and a
+        // lowercase-initial string are the two shapes only the
+        // already-lexed precondition ruled out.
+        assert!(
+            !super::is_enum_type_shape(""),
+            "empty string is not a shape"
+        );
+        assert!(
+            !super::is_enum_type_shape("orgkind"),
+            "a lowercase-initial string is not a shape, even if every char is alphanumeric"
+        );
     }
 
     #[test]
@@ -1530,5 +1560,14 @@ mod tests {
         assert!(super::is_enum_member_shape("BUSINESS"));
         assert!(!super::is_enum_member_shape("OrgKind"));
         assert!(!super::is_enum_member_shape("HexResolution2"));
+        // #528 fix round Item E: same self-containment repair.
+        assert!(
+            !super::is_enum_member_shape(""),
+            "empty string is not a shape"
+        );
+        assert!(
+            !super::is_enum_member_shape("_STATE"),
+            "an underscore-initial string is not a shape — the first char must be UPPER"
+        );
     }
 }

--- a/rust/crates/babylon-bsl/src/reader.rs
+++ b/rust/crates/babylon-bsl/src/reader.rs
@@ -50,6 +50,29 @@ pub enum Atom {
         /// The member identifier, e.g. `SOCIAL_CLASS`.
         member: String,
     },
+    /// `enum-type` — a bare uppercase-initial identifier with **no** `/`,
+    /// e.g. `OrgKind` or `NodeType`. §1.4's `<enum-type>` production
+    /// already existed as the LHS half of `<enum-ref>` (`enum-ref ::=
+    /// enum-type "/" enum-member`), but no atom class carried it standing
+    /// alone — every position that named a type needed a member alongside
+    /// it. §2.13 (the Organization contract's Q12 ruling) introduces THREE
+    /// positions that do not: `defenum`/`defvocabulary`'s own type-name
+    /// operand and `deffield`'s `:enum-type` keyword operand (§2.9). All
+    /// three read a name with no member component, so `classify_enum_ref`
+    /// unconditionally requiring a `/` left them unlexable as written —
+    /// **spec repair, recorded** (mirrors D94's own precedent, this
+    /// module's header): `classify` now tries the `/`-split first and
+    /// falls through to this class when none is present, rather than
+    /// erroring. `<enum-member>` (the member half) is unaffected — a
+    /// `defenum`/`defvocabulary` member list is written as full
+    /// `<enum-type>/<enum-member>` pairs, repeating the declaring type,
+    /// which is why no SEPARATE bare-member atom class exists: the two
+    /// productions' character classes overlap (`BUSINESS` fits both), so a
+    /// standalone bare-member class would be lexically ambiguous with this
+    /// one — see `crate::scenario::load_defenum` and
+    /// `crate::declarations::parse_defenum`'s own docs for the concrete
+    /// written form this resolves to.
+    EnumTypeName(String),
     /// `bool-lit` — `#t` / `#f`. `true`/`false` are ordinary symbols.
     Bool(bool),
     /// One of the ten operator tokens `< <= > >= = != + - * /` — the §2
@@ -573,8 +596,11 @@ fn classify_name(run: &str, start: usize) -> Result<Atom, ReadError> {
     Ok(Atom::QName(run.to_string()))
 }
 
-/// Classify an uppercase-initial run as `enum-ref` (`EnumType/MEMBER`).
-/// Registry membership is load-time (`E-LOAD-030/031`), not checked here.
+/// Classify an uppercase-initial run as `enum-ref` (`EnumType/MEMBER`) or,
+/// with no `/` present, as a bare `enum-type` (`Atom::EnumTypeName` —
+/// §2.13, see its own doc for why this fallback exists rather than an
+/// error). Registry membership is load-time (`E-LOAD-030/031`), not
+/// checked here.
 fn classify_enum_ref(run: &str, start: usize) -> Result<Atom, ReadError> {
     let unclassifiable = || {
         lex_error(
@@ -584,7 +610,7 @@ fn classify_enum_ref(run: &str, start: usize) -> Result<Atom, ReadError> {
         )
     };
     let Some((enum_type, member)) = run.split_once('/') else {
-        return Err(unclassifiable());
+        return classify_enum_type_name(run, start);
     };
     let type_ok = enum_type
         .chars()
@@ -606,6 +632,23 @@ fn classify_enum_ref(run: &str, start: usize) -> Result<Atom, ReadError> {
         enum_type: enum_type.to_string(),
         member: member.to_string(),
     })
+}
+
+/// Classify a `/`-free uppercase-initial run as `<enum-type>` (§1.4:
+/// `UPPER (UPPER | LOWER | DIGIT)*`) — `Atom::EnumTypeName`, see its doc.
+fn classify_enum_type_name(run: &str, start: usize) -> Result<Atom, ReadError> {
+    let ok = run.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+        && run.chars().all(|c| c.is_ascii_alphanumeric())
+        && run.is_ascii();
+    if ok {
+        Ok(Atom::EnumTypeName(run.to_string()))
+    } else {
+        Err(lex_error(
+            LexCode::UnclassifiableToken,
+            format!("'{run}' matches no atom class"),
+            start,
+        ))
+    }
 }
 
 /// Validate a `digits` group (`DIGIT ( "_"? DIGIT )*`): underscores only
@@ -1342,5 +1385,33 @@ mod tests {
             LexCode::UnclassifiableToken
         );
         assert_eq!(lex_err("foo/Bar"), LexCode::UnclassifiableToken);
+    }
+
+    // ---- §2.13 bare enum-type names (Organization contract, Q12) ----
+
+    #[test]
+    fn a_bare_uppercase_run_with_no_slash_is_an_enum_type_name() {
+        assert_eq!(atom("OrgKind"), Atom::EnumTypeName("OrgKind".into()));
+        assert_eq!(atom("NodeType"), Atom::EnumTypeName("NodeType".into()));
+    }
+
+    #[test]
+    fn an_enum_type_name_permits_lowercase_but_not_underscore() {
+        // §1.4's <enum-type> ::= UPPER (UPPER | LOWER | DIGIT)* — the
+        // charset that distinguishes it from <enum-member> (no underscore).
+        assert_eq!(
+            atom("HexResolution2"),
+            Atom::EnumTypeName("HexResolution2".into())
+        );
+        assert_eq!(lex_err("Org_Kind"), LexCode::UnclassifiableToken);
+    }
+
+    #[test]
+    fn a_slash_terminated_or_double_slash_run_still_refuses() {
+        // The fallback only fires for a TRULY slash-free run; a malformed
+        // enum-ref (trailing/empty segments) must still be unclassifiable,
+        // never silently reread as an enum-type-name.
+        assert_eq!(lex_err("OrgKind/"), LexCode::UnclassifiableToken);
+        assert_eq!(lex_err("/BUSINESS"), LexCode::UnclassifiableToken);
     }
 }

--- a/rust/crates/babylon-bsl/src/reader.rs
+++ b/rust/crates/babylon-bsl/src/reader.rs
@@ -50,29 +50,45 @@ pub enum Atom {
         /// The member identifier, e.g. `SOCIAL_CLASS`.
         member: String,
     },
-    /// `enum-type` — a bare uppercase-initial identifier with **no** `/`,
-    /// e.g. `OrgKind` or `NodeType`. §1.4's `<enum-type>` production
+    /// A bare uppercase-initial run with **no** `/` — the lexical UNION of
+    /// §1.4's `<enum-type>` (`UPPER (UPPER|LOWER|DIGIT)*`) and
+    /// `<enum-member>` (`UPPER (UPPER|DIGIT|"_")*`) charsets:
+    /// `UPPER (UPPER|LOWER|DIGIT|"_")*`. §1.4's `<enum-type>` production
     /// already existed as the LHS half of `<enum-ref>` (`enum-ref ::=
     /// enum-type "/" enum-member`), but no atom class carried it standing
     /// alone — every position that named a type needed a member alongside
-    /// it. §2.13 (the Organization contract's Q12 ruling) introduces THREE
+    /// it. §2.13 (the Organization contract's Q12 ruling) introduces
     /// positions that do not: `defenum`/`defvocabulary`'s own type-name
-    /// operand and `deffield`'s `:enum-type` keyword operand (§2.9). All
-    /// three read a name with no member component, so `classify_enum_ref`
-    /// unconditionally requiring a `/` left them unlexable as written —
-    /// **spec repair, recorded** (mirrors D94's own precedent, this
-    /// module's header): `classify` now tries the `/`-split first and
-    /// falls through to this class when none is present, rather than
-    /// erroring. `<enum-member>` (the member half) is unaffected — a
-    /// `defenum`/`defvocabulary` member list is written as full
-    /// `<enum-type>/<enum-member>` pairs, repeating the declaring type,
-    /// which is why no SEPARATE bare-member atom class exists: the two
-    /// productions' character classes overlap (`BUSINESS` fits both), so a
-    /// standalone bare-member class would be lexically ambiguous with this
-    /// one — see `crate::scenario::load_defenum` and
-    /// `crate::declarations::parse_defenum`'s own docs for the concrete
-    /// written form this resolves to.
-    EnumTypeName(String),
+    /// operand, `deffield`'s `:enum-type` keyword operand (§2.9), and —
+    /// per §2.13's own EBNF (`<defenum> ::= "(" "defenum" <enum-type> "("
+    /// <enum-member>+ ")" ")"`) — `defenum`/`defvocabulary`'s MEMBER LIST
+    /// itself: the list holds bare `<enum-member>` atoms
+    /// (`STATE_APPARATUS`), never full `<enum-type>/<enum-member>` pairs.
+    ///
+    /// **#528 fix round, corrected reading.** An earlier version of this
+    /// doc read the member list as full enum-refs, reasoning that
+    /// `<enum-type>`'s and `<enum-member>`'s overlapping charsets
+    /// (`BUSINESS` fits both) made a standalone bare-member class
+    /// "lexically ambiguous" with this one — that reasoning was the bug:
+    /// neither production contains the other (`OrgKind` has lowercase,
+    /// `STATE_APPARATUS` has `_`), so admitting their UNION at lex time and
+    /// disambiguating POSITIONALLY, at the parser, is unambiguous and is
+    /// what the tree-sitter grammar (`tools/tree-sitter-bsl/grammar.js`'s
+    /// own `enum_type`/`enum_member` split) and its corpus
+    /// (`test/corpus/declarations.txt:144-145`) already assumed. This
+    /// variant (renamed from `EnumTypeName`, which no longer describes
+    /// what it carries) is that union; [`is_enum_type_shape`] and
+    /// [`is_enum_member_shape`], both in this module, are the two
+    /// narrower positional checks — `defenum`/`defvocabulary`'s type-name
+    /// operand against the former, their member-list items against the
+    /// latter — a full enum-ref written where a bare member belongs is
+    /// grammar-nonconforming and refuses loudly (see `crate::declarations::
+    /// parse_defenum` and `crate::scenario::load_defvocabulary`'s own
+    /// docs for the concrete written forms this resolves to). `deffield`'s
+    /// `:enum-type` operand needs no separate shape check: it is a
+    /// REFERENCE resolved through `crate::types::EnumRegistry::resolve`,
+    /// which only ever holds names `parse_defenum` already shape-checked.
+    BareUpperIdent(String),
     /// `bool-lit` — `#t` / `#f`. `true`/`false` are ordinary symbols.
     Bool(bool),
     /// One of the ten operator tokens `< <= > >= = != + - * /` — the §2
@@ -597,7 +613,7 @@ fn classify_name(run: &str, start: usize) -> Result<Atom, ReadError> {
 }
 
 /// Classify an uppercase-initial run as `enum-ref` (`EnumType/MEMBER`) or,
-/// with no `/` present, as a bare `enum-type` (`Atom::EnumTypeName` —
+/// with no `/` present, as a bare identifier (`Atom::BareUpperIdent` —
 /// §2.13, see its own doc for why this fallback exists rather than an
 /// error). Registry membership is load-time (`E-LOAD-030/031`), not
 /// checked here.
@@ -610,7 +626,7 @@ fn classify_enum_ref(run: &str, start: usize) -> Result<Atom, ReadError> {
         )
     };
     let Some((enum_type, member)) = run.split_once('/') else {
-        return classify_enum_type_name(run, start);
+        return classify_bare_upper_ident(run, start);
     };
     let type_ok = enum_type
         .chars()
@@ -634,14 +650,16 @@ fn classify_enum_ref(run: &str, start: usize) -> Result<Atom, ReadError> {
     })
 }
 
-/// Classify a `/`-free uppercase-initial run as `<enum-type>` (§1.4:
-/// `UPPER (UPPER | LOWER | DIGIT)*`) — `Atom::EnumTypeName`, see its doc.
-fn classify_enum_type_name(run: &str, start: usize) -> Result<Atom, ReadError> {
+/// Classify a `/`-free uppercase-initial run as the UNION of §1.4's
+/// `<enum-type>` and `<enum-member>` charsets (`UPPER (UPPER | LOWER |
+/// DIGIT | "_")*`) — `Atom::BareUpperIdent`, see its own doc for why the
+/// union is lexed here and split positionally downstream.
+fn classify_bare_upper_ident(run: &str, start: usize) -> Result<Atom, ReadError> {
     let ok = run.chars().next().is_some_and(|c| c.is_ascii_uppercase())
-        && run.chars().all(|c| c.is_ascii_alphanumeric())
+        && run.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
         && run.is_ascii();
     if ok {
-        Ok(Atom::EnumTypeName(run.to_string()))
+        Ok(Atom::BareUpperIdent(run.to_string()))
     } else {
         Err(lex_error(
             LexCode::UnclassifiableToken,
@@ -649,6 +667,30 @@ fn classify_enum_type_name(run: &str, start: usize) -> Result<Atom, ReadError> {
             start,
         ))
     }
+}
+
+/// Whether `s` — already lexed as [`Atom::BareUpperIdent`] — conforms to
+/// §1.4's own `<enum-type>` production (`UPPER (UPPER|LOWER|DIGIT)*`, no
+/// underscore). The first character is uppercase by construction (the
+/// lexer already checked it); this validates the rest of the union
+/// charset narrows correctly. Used positionally by
+/// `crate::declarations::parse_defenum`/`crate::scenario::
+/// load_defvocabulary` to validate their own type-name operand — never by
+/// the reader itself, which stays lex-only (§2.13).
+#[must_use]
+pub fn is_enum_type_shape(s: &str) -> bool {
+    s.chars().all(|c| c.is_ascii_alphanumeric())
+}
+
+/// Whether `s` — already lexed as [`Atom::BareUpperIdent`] — conforms to
+/// §1.4's own `<enum-member>` production (`UPPER (UPPER|DIGIT|"_")*`, no
+/// lowercase). Used positionally by `crate::declarations::parse_defenum`/
+/// `crate::scenario::load_defvocabulary` to validate their own member-list
+/// items.
+#[must_use]
+pub fn is_enum_member_shape(s: &str) -> bool {
+    s.chars()
+        .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
 }
 
 /// Validate a `digits` group (`DIGIT ( "_"? DIGIT )*`): underscores only
@@ -1387,31 +1429,106 @@ mod tests {
         assert_eq!(lex_err("foo/Bar"), LexCode::UnclassifiableToken);
     }
 
-    // ---- §2.13 bare enum-type names (Organization contract, Q12) ----
+    // ---- §2.13 bare uppercase identifiers (Organization contract, Q12)
+    // ---- and #528's own fix round (the bare-<enum-member> repair) -------
 
     #[test]
-    fn a_bare_uppercase_run_with_no_slash_is_an_enum_type_name() {
-        assert_eq!(atom("OrgKind"), Atom::EnumTypeName("OrgKind".into()));
-        assert_eq!(atom("NodeType"), Atom::EnumTypeName("NodeType".into()));
+    fn a_bare_uppercase_run_with_no_slash_is_a_bare_upper_ident() {
+        assert_eq!(atom("OrgKind"), Atom::BareUpperIdent("OrgKind".into()));
+        assert_eq!(atom("NodeType"), Atom::BareUpperIdent("NodeType".into()));
     }
 
     #[test]
-    fn an_enum_type_name_permits_lowercase_but_not_underscore() {
-        // §1.4's <enum-type> ::= UPPER (UPPER | LOWER | DIGIT)* — the
-        // charset that distinguishes it from <enum-member> (no underscore).
+    fn a_bare_upper_ident_admits_the_union_of_enum_type_and_enum_member_charsets() {
+        // §1.4's <enum-type> ::= UPPER (UPPER|LOWER|DIGIT)* permits
+        // lowercase but not underscore; <enum-member> ::=
+        // UPPER (UPPER|DIGIT|"_")* is the mirror (underscore, no
+        // lowercase). The READER lexes the UNION of both — shape
+        // conformance to one production or the other is the PARSER's job
+        // (`is_enum_type_shape`/`is_enum_member_shape`, exercised in
+        // `declarations.rs`/`scenario.rs`), never the lexer's.
         assert_eq!(
             atom("HexResolution2"),
-            Atom::EnumTypeName("HexResolution2".into())
+            Atom::BareUpperIdent("HexResolution2".into())
         );
-        assert_eq!(lex_err("Org_Kind"), LexCode::UnclassifiableToken);
+        assert_eq!(
+            atom("Org_Kind"),
+            Atom::BareUpperIdent("Org_Kind".into()),
+            "a lexer-level charset union admits underscore even though \
+             <enum-type> alone would not — the parser rejects this as a \
+             type-name operand, not the reader"
+        );
+        assert_eq!(
+            atom("STATE_APPARATUS"),
+            Atom::BareUpperIdent("STATE_APPARATUS".into())
+        );
     }
 
     #[test]
     fn a_slash_terminated_or_double_slash_run_still_refuses() {
         // The fallback only fires for a TRULY slash-free run; a malformed
         // enum-ref (trailing/empty segments) must still be unclassifiable,
-        // never silently reread as an enum-type-name.
+        // never silently reread as a bare identifier.
         assert_eq!(lex_err("OrgKind/"), LexCode::UnclassifiableToken);
         assert_eq!(lex_err("/BUSINESS"), LexCode::UnclassifiableToken);
+    }
+
+    // ---- #528 fix round: the two tree-sitter corpus lines, verbatim
+    // (test/corpus/declarations.txt:144-145). Before the fix,
+    // `STATE_APPARATUS` failed to lex at all (E-LEX-003): the pre-fix
+    // `classify_enum_type_name` refused underscore, because this crate had
+    // read a `defenum`/`defvocabulary` member list as full `Type/MEMBER`
+    // refs rather than the bare `<enum-member>`s §2.13's own EBNF
+    // declares.
+
+    #[test]
+    fn every_member_of_the_defenum_corpus_line_lexes() {
+        // (defenum OrgKind (STATE_APPARATUS BUSINESS POLITICAL_FACTION
+        //  CIVIL_SOCIETY)) — test/corpus/declarations.txt:144.
+        for member in [
+            "OrgKind",
+            "STATE_APPARATUS",
+            "BUSINESS",
+            "POLITICAL_FACTION",
+            "CIVIL_SOCIETY",
+        ] {
+            assert_eq!(
+                atom(member),
+                Atom::BareUpperIdent(member.into()),
+                "{member} must lex as a bare uppercase identifier"
+            );
+        }
+    }
+
+    #[test]
+    fn every_member_of_the_defvocabulary_corpus_line_lexes() {
+        // (defvocabulary NodeType (SOCIAL_CLASS TERRITORY ORGANIZATION)) —
+        // test/corpus/declarations.txt:145.
+        for member in ["NodeType", "SOCIAL_CLASS", "TERRITORY", "ORGANIZATION"] {
+            assert_eq!(
+                atom(member),
+                Atom::BareUpperIdent(member.into()),
+                "{member} must lex as a bare uppercase identifier"
+            );
+        }
+    }
+
+    // ---- is_enum_type_shape / is_enum_member_shape (the parser-level
+    // positional split a bare-upper-ident's two consumers need) ----------
+
+    #[test]
+    fn is_enum_type_shape_accepts_lowercase_and_rejects_underscore() {
+        assert!(super::is_enum_type_shape("OrgKind"));
+        assert!(super::is_enum_type_shape("HexResolution2"));
+        assert!(!super::is_enum_type_shape("Org_Kind"));
+        assert!(!super::is_enum_type_shape("STATE_APPARATUS"));
+    }
+
+    #[test]
+    fn is_enum_member_shape_accepts_underscore_and_rejects_lowercase() {
+        assert!(super::is_enum_member_shape("STATE_APPARATUS"));
+        assert!(super::is_enum_member_shape("BUSINESS"));
+        assert!(!super::is_enum_member_shape("OrgKind"));
+        assert!(!super::is_enum_member_shape("HexResolution2"));
     }
 }

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -47,7 +47,8 @@ use crate::scope::{
 };
 use crate::structural_verbs::check_no_deferred_shape_verbs;
 use crate::typecheck::{
-    check_reference_comparisons, check_selection_scores, typecheck_aggregation, TypeEnv, TypeError,
+    check_no_field_of_on_enum_field, check_reference_comparisons, check_selection_scores,
+    typecheck_aggregation, TypeEnv, TypeError,
 };
 use std::collections::{HashMap, HashSet};
 
@@ -256,6 +257,11 @@ pub fn load_rule_form(rule: SExpr, ctx: &LoadContext<'_>) -> Result<LoadedRule, 
     typecheck_rule_folds(&rule, ctx.types, &bindings).map_err(LoadError::Type)?;
     check_selection_scores(&rule, ctx.types, &bindings).map_err(LoadError::Type)?;
     check_reference_comparisons(&rule, ctx.types, &bindings).map_err(LoadError::Type)?;
+    // §2.13 (D101/D102): field-of is not extended to enum-declared fields —
+    // a static, content-only fact, so this is a load-time gate like its
+    // two siblings above, not a runtime surprise on the first admitted
+    // subject.
+    check_no_field_of_on_enum_field(&rule, ctx.types).map_err(LoadError::Type)?;
     let anchor = check_anchor(&rule, ctx.systems).map_err(LoadError::Anchor)?;
     resolve_bindings(&bindings, ctx.vocabulary).map_err(LoadError::Binding)?;
     check_free_variables(&rule, &bindings, &declared_element_names(&rule))

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -36,7 +36,8 @@ use crate::evaluator::{evaluate, EvalEnv, Value};
 use crate::fuel::{CardinalityCeilings, IntrinsicCosts};
 use crate::grammar::{
     check_arities_and_closed_sets, check_enum_ref_kinds, check_field_init_owners,
-    check_graph_flag_placement, check_string_positions, GrammarError,
+    check_graph_flag_placement, check_minting_type_operands_are_enum_refs, check_string_positions,
+    GrammarError,
 };
 use crate::material_basis::{check_rule_surface, SurfaceError};
 use crate::mod_anchors::{check_anchor, AnchorDecl, AnchorError};
@@ -143,6 +144,14 @@ pub enum LoadError {
     /// `check_no_deferred_shape_verbs`'s own composition limit, not a
     /// grammar violation (#519 fix round, fix 4).
     DeferredShapeVerb(String),
+    /// No numbered code, same precedent as [`Self::Content`]: a non-
+    /// `<enum-ref>` child at the type-operand position of `emit`/
+    /// `add-node`/`add-edge` is a shape defect the §3.7 static cost pass
+    /// does not itself catch (unlike its sibling positions,
+    /// `bound_checker::enum_ref_key` — see
+    /// [`crate::grammar::check_minting_type_operands_are_enum_refs`]'s own
+    /// doc); #528 fix round Item D.
+    MintingTypeOperand(String),
 }
 
 impl LoadError {
@@ -164,7 +173,7 @@ impl LoadError {
             Self::ElementName(e) => Some(e.spec_code()),
             Self::Bound(e) => e.spec_code(),
             Self::Intrinsic(e) => e.spec_code(),
-            Self::Content(_) | Self::DeferredShapeVerb(_) => None,
+            Self::Content(_) | Self::DeferredShapeVerb(_) | Self::MintingTypeOperand(_) => None,
         }
     }
 }
@@ -183,7 +192,9 @@ impl std::fmt::Display for LoadError {
             Self::ElementName(e) => write!(f, "{e}"),
             Self::Bound(e) => write!(f, "{e}"),
             Self::Intrinsic(e) => write!(f, "{e}"),
-            Self::Content(message) | Self::DeferredShapeVerb(message) => write!(f, "{message}"),
+            Self::Content(message)
+            | Self::DeferredShapeVerb(message)
+            | Self::MintingTypeOperand(message) => write!(f, "{message}"),
         }
     }
 }
@@ -233,6 +244,12 @@ pub fn load_rule_form(rule: SExpr, ctx: &LoadContext<'_>) -> Result<LoadedRule, 
     check_arities_and_closed_sets(&rule).map_err(LoadError::Grammar)?;
     check_string_positions(&rule).map_err(LoadError::Grammar)?;
     check_enum_ref_kinds(&rule).map_err(LoadError::Grammar)?;
+    // The type-operand position of emit/add-node/add-edge is the one
+    // §2.6 class-rule position `check_enum_ref_kinds` does not itself
+    // enforce as MANDATORY-enum-ref (it only checks the KIND of an
+    // enum-ref that is already there) — #528 fix round Item D, see this
+    // function's own doc for why these three specifically need it.
+    check_minting_type_operands_are_enum_refs(&rule).map_err(LoadError::MintingTypeOperand)?;
     check_graph_flag_placement(&rule).map_err(LoadError::Grammar)?;
     // #519 fix round, fix 4: a rule using one of the six graph-shape verbs
     // Task 12's collect-then-apply split cannot yet defer must be refused

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -47,8 +47,8 @@ use crate::scope::{
 };
 use crate::structural_verbs::check_no_deferred_shape_verbs;
 use crate::typecheck::{
-    check_no_field_of_on_enum_field, check_reference_comparisons, check_selection_scores,
-    typecheck_aggregation, TypeEnv, TypeError,
+    check_no_arithmetic_on_enum_field, check_no_field_of_on_enum_field,
+    check_reference_comparisons, check_selection_scores, typecheck_aggregation, TypeEnv, TypeError,
 };
 use std::collections::{HashMap, HashSet};
 
@@ -262,6 +262,12 @@ pub fn load_rule_form(rule: SExpr, ctx: &LoadContext<'_>) -> Result<LoadedRule, 
     // two siblings above, not a runtime surprise on the first admitted
     // subject.
     check_no_field_of_on_enum_field(&rule, ctx.types).map_err(LoadError::Type)?;
+    // §2.13's no-arithmetic law (D101), the static half (D118, #528 fix
+    // round Item C) — statically decidable from the field's declared
+    // type and the update-op's own symbol, so it belongs at load beside
+    // its sibling D102 gate above, not left to the three eval-time
+    // guards alone (which stay, as defense in depth).
+    check_no_arithmetic_on_enum_field(&rule, ctx.types).map_err(LoadError::Type)?;
     let anchor = check_anchor(&rule, ctx.systems).map_err(LoadError::Anchor)?;
     resolve_bindings(&bindings, ctx.vocabulary).map_err(LoadError::Binding)?;
     check_free_variables(&rule, &bindings, &declared_element_names(&rule))

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -1054,7 +1054,7 @@ fn load_edge(
 
 #[cfg(test)]
 mod tests {
-    use super::{load_scenario, BslType, FieldDecl, FieldKind};
+    use super::{load_scenario, BslType, EnumRegistry, FieldDecl, FieldKind};
     use crate::bindings::BindingVocabulary;
     use crate::fuel::{CardinalityCeilings, IntrinsicCosts};
     use crate::intrinsic_host::EmptyIntrinsicHost;
@@ -1344,9 +1344,11 @@ mod tests {
             let loaded =
                 load_rule(&rule, &ctx).unwrap_or_else(|e| panic!("{literal}: rule must load: {e}"));
             let mut sink = CollectingSink::default();
+            let enums = EnumRegistry::default();
             run_tick(
                 &loaded,
                 &types,
+                &enums,
                 &EmptyIntrinsicHost,
                 &mut graph,
                 &mut sink,

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -60,6 +60,7 @@
 use crate::evaluator::Value;
 use crate::reader::{read_all, Atom, ReadError, SExpr, ScaledKind};
 use crate::types::{BslType, EnumRegistry, EnumTypeId, FieldDecl, FieldKind};
+use crate::vocabulary::{ClosedVocabulary, EnumKind};
 use babylon_graph::substrate::{GraphError, GraphSubstrate, NodeId};
 use babylon_kernel::Ratio;
 use std::collections::{HashMap, HashSet};
@@ -179,6 +180,14 @@ pub struct LoadedScenario {
     /// is §2.13's own new construct, not a stand-in for a Phase-2 content
     /// registry that predates it.
     pub enums: EnumRegistry,
+    /// **§2.13 addendum (D101), §3.6.** The closed graph vocabulary this
+    /// scenario declared via `defvocabulary`, or `None` for a scenario
+    /// declaring none — opt-in per scenario, so every EXISTING content set
+    /// (which declares no `defvocabulary` at all) is unaffected (Task 7's
+    /// own backward-compatibility proof). Enforcement against this
+    /// registry (Task 8 of the Organization foundation plan) is out of
+    /// this train's scope; this field only carries what was declared.
+    pub vocabulary: Option<ClosedVocabulary>,
 }
 
 /// Read `source` and populate `graph` with it.
@@ -228,6 +237,16 @@ pub fn load_scenario(
     // AT THAT POINT, the same "declaration must precede use" discipline
     // `named`/`fields` already enforce for nodes and node-attribute reads.
     let mut enums: EnumRegistry = EnumRegistry::default();
+    // §2.13/§3.6: the closed graph vocabulary this scenario declares, per
+    // kind — collected across the load and fed to `ClosedVocabulary::new`
+    // ONCE at the end, since that constructor runs the whole-vocabulary
+    // rendering-disjointness check (`E-LOAD-032`) over every kind at once.
+    // `vocabulary_kinds_declared` is the "one form per kind" guard
+    // (`E-LOAD-001`) — `ClosedVocabulary::new` itself MERGES same-kind
+    // entries via `.extend` rather than rejecting a second one, so that
+    // check has to live here, before the merge ever happens.
+    let mut vocabulary_members: HashMap<EnumKind, Vec<String>> = HashMap::new();
+    let mut vocabulary_kinds_declared: HashSet<EnumKind> = HashSet::new();
     // §3.9 clause 5 (D73): hydration may not seed two dyadic edges sharing
     // one `(source-id, target-id, edge-type)` triple. This set is what
     // makes the triple a KEY rather than a sort field — without it §2.6's
@@ -244,6 +263,13 @@ pub fn load_scenario(
         match parts.first() {
             Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "defenum" => {
                 load_defenum(form, &mut enums)?;
+            }
+            Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "defvocabulary" => {
+                load_defvocabulary(
+                    form,
+                    &mut vocabulary_members,
+                    &mut vocabulary_kinds_declared,
+                )?;
             }
             Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "deffield" => {
                 load_deffield(parts, &mut fields, &enums)?;
@@ -263,12 +289,26 @@ pub fn load_scenario(
             }
             _ => {
                 return Err(err(
-                    "a scenario body form must begin with `defenum`, `deffield`, \
-                     `defconst`, `node` or `edge`",
+                    "a scenario body form must begin with `defenum`, `defvocabulary`, \
+                     `deffield`, `defconst`, `node` or `edge`",
                 ))
             }
         }
     }
+
+    // Opt-in per scenario (Task 7): no `defvocabulary` forms at all yields
+    // `None`, which is what keeps every scenario predating this section
+    // loading exactly as it did before it.
+    let vocabulary = if vocabulary_members.is_empty() {
+        None
+    } else {
+        Some(
+            ClosedVocabulary::new(vocabulary_members).map_err(|e| ScenarioError {
+                code: Some(e.spec_code()),
+                message: e.to_string(),
+            })?,
+        )
+    };
 
     Ok(LoadedScenario {
         id,
@@ -279,6 +319,7 @@ pub fn load_scenario(
         fields,
         consts,
         enums,
+        vocabulary,
     })
 }
 
@@ -599,6 +640,85 @@ fn load_defenum(form: &SExpr, enums: &mut EnumRegistry) -> Result<(), ScenarioEr
             code: e.spec_code(),
             message: e.to_string(),
         })
+}
+
+/// `(defvocabulary <EnumKind> (<member>+))` — §2.13, D101; §3.6's own
+/// closed graph vocabulary, populated **explicitly**, never inferred from
+/// what a scenario happens to seed. `<EnumKind>` is syntactically an
+/// `<enum-type>` (a bare, slash-free `Atom::EnumTypeName` — see that
+/// variant's doc for why the reader lexes it that way) but SEMANTICALLY
+/// restricted to `NodeType` / `EdgeType` / `HyperedgeType` / `EventType` —
+/// an unknown name is `E-LOAD-030`, the same code §3.6 already uses for an
+/// unregistered `<enum-ref>` type name (this is a load-time check, not a
+/// lexical one, exactly as `enum-type`'s own `defenum` doc reasons for its
+/// sibling). Members are written as full `<EnumKind>/<MEMBER>` enum-refs
+/// repeating the declaring kind — the SAME convention `load_defenum` uses,
+/// for the SAME reason (no bare-member atom class exists; see that
+/// function's doc).
+///
+/// Only inserts into `collected`/`declared` — `ClosedVocabulary::new` (the
+/// caller, once at end-of-load) runs the whole-vocabulary
+/// rendering-disjointness check over every kind together.
+///
+/// # Errors
+///
+/// `E-LOAD-030` for an unregistered `<enum-kind>`; `E-LOAD-001` for a
+/// second `defvocabulary` naming a kind already declared; an uncoded
+/// [`ScenarioError`] off the grammar, including a member whose kind prefix
+/// does not match the kind being declared.
+fn load_defvocabulary(
+    form: &SExpr,
+    collected: &mut HashMap<EnumKind, Vec<String>>,
+    declared: &mut HashSet<EnumKind>,
+) -> Result<(), ScenarioError> {
+    let SExpr::List(items) = form else {
+        return Err(err("a defvocabulary must be a form"));
+    };
+    let [SExpr::Atom(Atom::Symbol(head)), SExpr::Atom(Atom::EnumTypeName(kind_name)), SExpr::List(member_items)] =
+        items.as_slice()
+    else {
+        return Err(err("expected (defvocabulary <EnumKind> (<member>+))"));
+    };
+    if head != "defvocabulary" {
+        return Err(err(format!("expected (defvocabulary …), found ({head} …)")));
+    }
+    let Some(kind) = EnumKind::from_type_name(kind_name) else {
+        return Err(coded_err(
+            "E-LOAD-030",
+            format!(
+                "defvocabulary: `{kind_name}` is not one of NodeType / \
+                 EdgeType / HyperedgeType / EventType (§3.6)"
+            ),
+        ));
+    };
+    if !declared.insert(kind) {
+        return Err(coded_err(
+            "E-LOAD-001",
+            format!(
+                "duplicate defvocabulary for {kind_name} — a kind's \
+                 vocabulary is declared once (§2.13)"
+            ),
+        ));
+    }
+    let mut members = Vec::with_capacity(member_items.len());
+    for item in member_items {
+        let SExpr::Atom(Atom::EnumRef { enum_type, member }) = item else {
+            return Err(err(format!(
+                "defvocabulary {kind_name}: member {item:?} must be written \
+                 {kind_name}/<MEMBER>, repeating the declaring kind (§2.13)"
+            )));
+        };
+        if enum_type != kind_name {
+            return Err(err(format!(
+                "defvocabulary {kind_name}: member {enum_type}/{member} \
+                 names a different kind than the one being declared \
+                 ({kind_name})"
+            )));
+        }
+        members.push(member.clone());
+    }
+    collected.entry(kind).or_default().extend(members);
+    Ok(())
 }
 
 /// `(deffield <qname> <type-symbol> <kind-symbol>)`, or — since §2.13
@@ -1054,7 +1174,7 @@ fn load_edge(
 
 #[cfg(test)]
 mod tests {
-    use super::{load_scenario, BslType, EnumRegistry, FieldDecl, FieldKind};
+    use super::{load_scenario, BslType, EnumKind, EnumRegistry, FieldDecl, FieldKind};
     use crate::bindings::BindingVocabulary;
     use crate::fuel::{CardinalityCeilings, IntrinsicCosts};
     use crate::intrinsic_host::EmptyIntrinsicHost;
@@ -2035,5 +2155,94 @@ mod tests {
         assert_eq!(first.state_hash().unwrap(), second.state_hash().unwrap());
         assert_eq!(a.node_count, 2);
         assert_eq!(b.node_count, 2);
+    }
+
+    // ---- §2.13/§3.6 `defvocabulary`: the closed graph vocabulary is
+    // declared, never inferred (Task 7) ----
+
+    #[test]
+    fn a_scenario_declaring_the_vocabulary_loads_and_is_some() {
+        let source = r"
+(scenario org/vocab
+  (defvocabulary NodeType (NodeType/SOCIAL_CLASS NodeType/TERRITORY NodeType/ORGANIZATION))
+  (defvocabulary EdgeType
+    (EdgeType/MEMBERSHIP EdgeType/PRESENCE EdgeType/COMMAND
+     EdgeType/TRANSACTIONAL EdgeType/SOLIDARISTIC EdgeType/SOLIDARITY))
+  (node acme NodeType/ORGANIZATION))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph).expect("loads");
+        let vocabulary = loaded.vocabulary.expect("a declared vocabulary is Some");
+        assert_eq!(
+            vocabulary
+                .check_enum_ref("NodeType", "ORGANIZATION")
+                .unwrap(),
+            EnumKind::NodeType
+        );
+        assert_eq!(
+            vocabulary.check_enum_ref("EdgeType", "SOLIDARITY").unwrap(),
+            EnumKind::EdgeType
+        );
+    }
+
+    #[test]
+    fn a_scenario_with_no_defvocabulary_forms_yields_none() {
+        // Backward compatibility: existing content (this test module's own
+        // TWO_CLASSES fixture, and every scenario predating §2.13) declares
+        // no `defvocabulary` at all — enforcement stays exactly as inert
+        // as it is today.
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(TWO_CLASSES, &mut graph).expect("loads");
+        assert!(loaded.vocabulary.is_none());
+    }
+
+    #[test]
+    fn closed_vocabularys_own_rendering_collision_propagates_as_e_load_032() {
+        // TENANCY under two structural kinds — §2.9's disjointness
+        // obligation, `ClosedVocabulary::new`'s own check, reached through
+        // `load_defvocabulary`'s collected map rather than reinvented here.
+        let source = r"
+(scenario org/collision
+  (defvocabulary NodeType (NodeType/TENANCY))
+  (defvocabulary EdgeType (EdgeType/TENANCY))
+  (node acme NodeType/TENANCY))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-032"));
+    }
+
+    #[test]
+    fn an_unknown_enum_kind_symbol_refuses() {
+        let source = r"
+(scenario org/badkind
+  (defvocabulary SovereignType (SovereignType/USA)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-030"));
+    }
+
+    #[test]
+    fn two_defvocabulary_forms_for_one_kind_is_e_load_001() {
+        let source = r"
+(scenario org/twice
+  (defvocabulary NodeType (NodeType/SOCIAL_CLASS))
+  (defvocabulary NodeType (NodeType/TERRITORY)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-001"));
+    }
+
+    #[test]
+    fn a_defvocabulary_member_naming_a_different_kind_refuses() {
+        let source = r"
+(scenario org/mismatched
+  (defvocabulary NodeType (EdgeType/SOLIDARITY)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(err.message.contains("different kind"), "{}", err.message);
     }
 }

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -59,7 +59,7 @@
 
 use crate::evaluator::Value;
 use crate::reader::{read_all, Atom, ReadError, SExpr, ScaledKind};
-use crate::types::{BslType, FieldDecl, FieldKind};
+use crate::types::{BslType, EnumRegistry, EnumTypeId, FieldDecl, FieldKind};
 use babylon_graph::substrate::{GraphError, GraphSubstrate, NodeId};
 use babylon_kernel::Ratio;
 use std::collections::{HashMap, HashSet};
@@ -170,6 +170,15 @@ pub struct LoadedScenario {
     /// coefficient discipline forbids — so the scenario declares it and
     /// cites the `defines.yaml` line it was taken from.
     pub consts: HashMap<String, Value>,
+    /// **§2.13 addendum (D101, Organization spec §1 Q12).** Every
+    /// `defenum` type the scenario declared — the registry `enum`-typed
+    /// `deffield`s resolve against, and the read path (`tick.rs::
+    /// bind_subject`) renders stored ordinals back through. Empty for a
+    /// scenario with no `defenum` forms — unlike `fields`/`consts`, there
+    /// is no "the scenario is the only registry" claim here: `EnumRegistry`
+    /// is §2.13's own new construct, not a stand-in for a Phase-2 content
+    /// registry that predates it.
+    pub enums: EnumRegistry,
 }
 
 /// Read `source` and populate `graph` with it.
@@ -214,6 +223,11 @@ pub fn load_scenario(
     let mut edge_types: HashMap<String, u64> = HashMap::new();
     let mut node_count = 0_usize;
     let mut edge_count = 0_usize;
+    // §2.13 (D101): every `defenum` type this scenario declares, top to
+    // bottom — a `deffield ... enum <Type>` resolves against this AS IT IS
+    // AT THAT POINT, the same "declaration must precede use" discipline
+    // `named`/`fields` already enforce for nodes and node-attribute reads.
+    let mut enums: EnumRegistry = EnumRegistry::default();
     // §3.9 clause 5 (D73): hydration may not seed two dyadic edges sharing
     // one `(source-id, target-id, edge-type)` triple. This set is what
     // makes the triple a KEY rather than a sort field — without it §2.6's
@@ -228,14 +242,17 @@ pub fn load_scenario(
             ));
         };
         match parts.first() {
+            Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "defenum" => {
+                load_defenum(form, &mut enums)?;
+            }
             Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "deffield" => {
-                load_deffield(parts, &mut fields)?;
+                load_deffield(parts, &mut fields, &enums)?;
             }
             Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "defconst" => {
                 load_defconst(parts, &mut consts)?;
             }
             Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "node" => {
-                let minted = load_node(parts, graph, &mut named, &fields)?;
+                let minted = load_node(parts, graph, &mut named, &fields, &enums)?;
                 *node_types.entry(minted).or_insert(0) += 1;
                 node_count += 1;
             }
@@ -246,8 +263,8 @@ pub fn load_scenario(
             }
             _ => {
                 return Err(err(
-                    "a scenario body form must begin with `deffield`, `defconst`, \
-                     `node` or `edge`",
+                    "a scenario body form must begin with `defenum`, `deffield`, \
+                     `defconst`, `node` or `edge`",
                 ))
             }
         }
@@ -261,6 +278,7 @@ pub fn load_scenario(
         edge_types,
         fields,
         consts,
+        enums,
     })
 }
 
@@ -563,7 +581,34 @@ fn ratio_from_scaled(
     })
 }
 
-/// `(deffield <qname> <type-symbol> <kind-symbol>)`
+/// `(defenum <EnumTypeName> (<member>+))` — §2.13, D101. Delegates to
+/// `declarations::parse_defenum`, the SAME parser `.bsl` rule content uses
+/// (D93's own dialect split is about `defconst`/`node`/`edge`/`scenario`,
+/// which the RST grammar disclaims; `defenum` is an RST `<top-form>`, so
+/// there is exactly one grammar for it and no reason for a second reader).
+///
+/// # Errors
+///
+/// A [`ScenarioError`] wrapping the underlying [`crate::declarations::DeclError`]
+/// — `E-LOAD-001` for a duplicate type/member, uncoded for an empty member
+/// list or a malformed shape.
+fn load_defenum(form: &SExpr, enums: &mut EnumRegistry) -> Result<(), ScenarioError> {
+    crate::declarations::parse_defenum(form, enums)
+        .map(|_| ())
+        .map_err(|e| ScenarioError {
+            code: e.spec_code(),
+            message: e.to_string(),
+        })
+}
+
+/// `(deffield <qname> <type-symbol> <kind-symbol>)`, or — since §2.13
+/// (D101, Organization spec §1 Q12) — `(deffield <qname> enum
+/// <EnumTypeName>)`: the 4th slot holds the enum type name instead of a
+/// kind symbol, because an enum-typed field carries no aggregation kind
+/// at all (there is no `intensive`/`extensive` reading of a member
+/// identity) — this dialect has no separate `:enum-type` keyword the way
+/// the `.bsl` `deffield` production does; the type-symbol slot itself
+/// being `enum` is what selects the 4th slot's alternate meaning.
 ///
 /// The `deffield` registry in miniature. A field's TYPE and INTENSIVITY KIND
 /// cannot be inferred from a stored value — `120` is an `Int` whether it is a
@@ -572,42 +617,70 @@ fn ratio_from_scaled(
 fn load_deffield(
     parts: &[SExpr],
     fields: &mut HashMap<String, FieldDecl>,
+    enums: &EnumRegistry,
 ) -> Result<(), ScenarioError> {
-    let [_, SExpr::Atom(Atom::QName(qname)), SExpr::Atom(Atom::Symbol(ty)), SExpr::Atom(Atom::Symbol(kind))] =
-        parts
-    else {
+    let [_, SExpr::Atom(Atom::QName(qname)), SExpr::Atom(Atom::Symbol(ty)), fourth] = parts else {
         return Err(err(
-            "expected (deffield <field-qname> <type> <intensive|extensive>)",
+            "expected (deffield <field-qname> <type> <intensive|extensive>) or \
+             (deffield <field-qname> enum <EnumTypeName>)",
         ));
     };
-    let ty = match ty.as_str() {
-        "int" => BslType::Int,
-        "probability" => BslType::Probability,
-        "intensity" => BslType::Intensity,
-        "coefficient" => BslType::Coefficient,
-        "currency" => BslType::Currency,
-        other => {
+    let decl = if ty == "enum" {
+        let SExpr::Atom(Atom::EnumTypeName(type_name)) = fourth else {
             return Err(err(format!(
-                "deffield `{qname}`: unknown type `{other}` — one of \
-                 int / probability / intensity / coefficient / currency"
-            )))
+                "deffield `{qname}`: an enum-typed field's 4th slot is the \
+                 declared enum type name — (deffield {qname} enum \
+                 <EnumTypeName>), found {fourth:?}"
+            )));
+        };
+        let Some(id) = enums.resolve(type_name) else {
+            return Err(coded_err(
+                "E-LOAD-054",
+                format!(
+                    "deffield `{qname}`: enum type `{type_name}` was never \
+                     declared — add a (defenum {type_name} (…)) form ABOVE \
+                     this deffield"
+                ),
+            ));
+        };
+        FieldDecl {
+            ty: BslType::Enum(id),
+            kind: FieldKind::NotApplicable,
         }
-    };
-    let kind = match kind.as_str() {
-        "intensive" => FieldKind::Intensive,
-        "extensive" => FieldKind::Extensive,
-        other => {
+    } else {
+        let SExpr::Atom(Atom::Symbol(kind)) = fourth else {
             return Err(err(format!(
-                "deffield `{qname}`: unknown kind `{other}` — intensive or extensive. \
-                 An intensive field averaged without an extensive weight is the \
-                 variance error §3.4 exists to catch, so this is not optional"
-            )))
-        }
+                "deffield `{qname}`: expected an intensive|extensive kind \
+                 symbol, found {fourth:?}"
+            )));
+        };
+        let ty = match ty.as_str() {
+            "int" => BslType::Int,
+            "probability" => BslType::Probability,
+            "intensity" => BslType::Intensity,
+            "coefficient" => BslType::Coefficient,
+            "currency" => BslType::Currency,
+            other => {
+                return Err(err(format!(
+                    "deffield `{qname}`: unknown type `{other}` — one of \
+                     int / probability / intensity / coefficient / currency / enum"
+                )))
+            }
+        };
+        let kind = match kind.as_str() {
+            "intensive" => FieldKind::Intensive,
+            "extensive" => FieldKind::Extensive,
+            other => {
+                return Err(err(format!(
+                    "deffield `{qname}`: unknown kind `{other}` — intensive or extensive. \
+                     An intensive field averaged without an extensive weight is the \
+                     variance error §3.4 exists to catch, so this is not optional"
+                )))
+            }
+        };
+        FieldDecl { ty, kind }
     };
-    if fields
-        .insert(qname.clone(), FieldDecl { ty, kind })
-        .is_some()
-    {
+    if fields.insert(qname.clone(), decl).is_some() {
         return Err(err(format!(
             "duplicate deffield `{qname}` — a field has one declared type and kind"
         )));
@@ -621,6 +694,7 @@ fn load_node(
     graph: &mut dyn GraphSubstrate,
     named: &mut HashMap<String, NodeId>,
     declared: &HashMap<String, FieldDecl>,
+    enums: &EnumRegistry,
 ) -> Result<String, ScenarioError> {
     let [_, SExpr::Atom(Atom::Symbol(local)), SExpr::Atom(Atom::EnumRef { member, .. }), attrs @ ..] =
         parts
@@ -664,7 +738,11 @@ fn load_node(
                  (deffield {field} <type> <intensive|extensive>) form ABOVE this node"
             )));
         };
-        graph.update_node(id, field, attribute_value(value, local, field, decl)?)?;
+        graph.update_node(
+            id,
+            field,
+            attribute_value(value, local, field, decl, enums)?,
+        )?;
     }
     Ok(member.clone())
 }
@@ -694,6 +772,7 @@ fn attribute_value(
     local: &str,
     field: &str,
     decl: &FieldDecl,
+    enums: &EnumRegistry,
 ) -> Result<f64, ScenarioError> {
     match &decl.ty {
         BslType::Int => attribute_value_int(atom, local, field),
@@ -701,24 +780,79 @@ fn attribute_value(
             attribute_value_unit_interval(atom, local, field, &decl.ty)
         }
         BslType::Currency => Err(err(currency_refusal_message(local, field))),
+        BslType::Enum(ty) => attribute_value_enum(atom, local, field, *ty, enums),
         // Defense in depth, not a reachable content error: `load_deffield`
         // is the SOLE populator of the `declared` map `attribute_value` is
         // called against, and its own match on the type symbol admits only
-        // int/probability/intensity/coefficient/currency (anything else is
-        // refused AT DECLARATION, before a `node` form naming the field can
-        // even be read). Reaching here is a wiring bug in the deffield
+        // int/probability/intensity/coefficient/currency/enum (anything else
+        // is refused AT DECLARATION, before a `node` form naming the field
+        // can even be read). Reaching here is a wiring bug in the deffield
         // parser, not a content error — kept anyway because `BslType` is
         // not a closed match the compiler can prove exhaustive against this
         // function's actual call graph, and a silent `unreachable!()` would
         // panic rather than name the field that triggered it.
         other => Err(err(format!(
             "node `{local}`: field `{field}` is declared {other:?}, and the scenario \
-             loader stores only `int`, `probability`, `intensity` or `coefficient`-declared \
-             node attributes (currency is refused separately, deferred to typed storage's \
-             first consumer) — {other:?} has no representation as a GraphSubstrate f64 \
-             attribute at all"
+             loader stores only `int`, `probability`, `intensity`, `coefficient` or \
+             `enum`-declared node attributes (currency is refused separately, deferred \
+             to typed storage's first consumer) — {other:?} has no representation as a \
+             GraphSubstrate f64 attribute at all"
         ))),
     }
+}
+
+/// `enum`-declared fields (§2.13, D101 — the Q12 enum row's own lane in the
+/// Half-1 typed-attribute-seeding design). Accepts **only** a matching
+/// `<enum-ref>` atom, resolves its member through `enums`, and stores
+/// `ordinal as f64` — the SAME binary64 attribute lane every other declared
+/// type here already uses (zero bytes of any existing golden move: no
+/// existing scenario declares an enum field). The ordinal is never a
+/// surface value: a bare number, an `<enum-ref>` of a different declared
+/// type, or any other atom is `E-LOAD-056`; an `<enum-ref>` of the RIGHT
+/// type naming a member that type does not declare is `E-LOAD-055` — there
+/// is no "seed it as a number and let the engine resolve the member" path
+/// and no default member (§3.6's own "a name outside the registry is a
+/// load error, never a fallback" law, restated here for the content-declared
+/// registry).
+fn attribute_value_enum(
+    atom: &Atom,
+    local: &str,
+    field: &str,
+    ty: EnumTypeId,
+    enums: &EnumRegistry,
+) -> Result<f64, ScenarioError> {
+    let Atom::EnumRef { enum_type, member } = atom else {
+        return Err(coded_err(
+            "E-LOAD-056",
+            format!(
+                "node `{local}` field `{field}`: an enum-typed field is seeded \
+                 ONLY as <EnumType>/<MEMBER> — the ordinal is never a surface \
+                 value; found {atom:?}"
+            ),
+        ));
+    };
+    let declared_type = enums.name(ty);
+    if enum_type != declared_type {
+        return Err(coded_err(
+            "E-LOAD-056",
+            format!(
+                "node `{local}` field `{field}`: declared enum type is \
+                 {declared_type}, found {enum_type}/{member} — an <enum-ref> \
+                 of a different declared type is exactly as illegal as a bare \
+                 number here"
+            ),
+        ));
+    }
+    let Some(ordinal) = enums.ordinal(ty, member) else {
+        return Err(coded_err(
+            "E-LOAD-055",
+            format!(
+                "node `{local}` field `{field}`: {declared_type} has no \
+                 member {member} — never a default"
+            ),
+        ));
+    };
+    Ok(f64::from(ordinal))
 }
 
 /// `int`-declared fields — unchanged behavior, Half 1 does not touch this arm.
@@ -1800,5 +1934,104 @@ mod tests {
         let mut graph = MemoryGraph::new();
         let err = load_scenario(source, &mut graph).unwrap_err();
         assert!(err.message.contains("exactly one"), "{}", err.message);
+    }
+
+    // ---- §2.13 `.bscn` dialect: defenum, enum deffield, EnumRef-only
+    // seeding (Organization spec §1 Q12, D101) ----
+
+    const ORG_KIND_SOURCE: &str = r"
+(scenario org/t
+  (defenum OrgKind (OrgKind/STATE_APPARATUS OrgKind/BUSINESS
+                     OrgKind/POLITICAL_FACTION OrgKind/CIVIL_SOCIETY))
+  (deffield organization/kind enum OrgKind)
+  (node acme NodeType/ORGANIZATION (organization/kind OrgKind/BUSINESS)))
+";
+
+    #[test]
+    fn an_enum_field_seeds_by_member_ref_and_stores_the_declared_ordinal() {
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(ORG_KIND_SOURCE, &mut graph).expect("loads");
+        assert_eq!(loaded.node_count, 1);
+        let id = graph.nodes("ORGANIZATION")[0];
+        let stored = graph.node_attribute(id, "organization/kind").unwrap();
+        assert!(
+            (stored - 1.0).abs() < 1e-12,
+            "BUSINESS is declaration-order index 1, stored: {stored}"
+        );
+        assert!(loaded.enums.resolve("OrgKind").is_some());
+    }
+
+    #[test]
+    fn a_bare_number_into_an_enum_field_refuses_naming_the_law() {
+        let source = r"
+(scenario org/t
+  (defenum OrgKind (OrgKind/STATE_APPARATUS OrgKind/BUSINESS))
+  (deffield organization/kind enum OrgKind)
+  (node acme NodeType/ORGANIZATION (organization/kind 1)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-056"));
+        assert!(
+            err.message.contains("<EnumType>/<MEMBER>") && err.message.contains("never"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn a_wrong_enum_type_member_refuses() {
+        let source = r"
+(scenario org/t
+  (defenum OrgKind (OrgKind/STATE_APPARATUS OrgKind/BUSINESS))
+  (deffield organization/kind enum OrgKind)
+  (node acme NodeType/ORGANIZATION (organization/kind NodeType/SOCIAL_CLASS)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-056"));
+        assert!(err.message.contains("OrgKind"), "{}", err.message);
+    }
+
+    #[test]
+    fn an_undeclared_member_refuses() {
+        let source = r"
+(scenario org/t
+  (defenum OrgKind (OrgKind/STATE_APPARATUS OrgKind/BUSINESS))
+  (deffield organization/kind enum OrgKind)
+  (node acme NodeType/ORGANIZATION (organization/kind OrgKind/NOWHERE)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-055"));
+        assert!(err.message.contains("NOWHERE"), "{}", err.message);
+    }
+
+    #[test]
+    fn an_enum_deffield_naming_an_undeclared_type_is_e_load_054() {
+        let source = r"
+(scenario org/t
+  (deffield organization/kind enum Nowhere)
+  (node acme NodeType/ORGANIZATION))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-054"));
+    }
+
+    #[test]
+    fn enum_seeding_moves_no_existing_golden_bytes() {
+        // A scenario with NO defenum/enum-deffield forms loads exactly as
+        // it did before this train — an untouched, empty `EnumRegistry`.
+        // `tick_goldens.rs` re-proves this at the byte level for
+        // vitality-conformance.bscn on every run; this is the same claim
+        // at the unit level, for the fixture this test module already uses.
+        let mut first = MemoryGraph::new();
+        let mut second = MemoryGraph::new();
+        let a = load_scenario(TWO_CLASSES, &mut first).unwrap();
+        let b = load_scenario(TWO_CLASSES, &mut second).unwrap();
+        assert_eq!(first.state_hash().unwrap(), second.state_hash().unwrap());
+        assert_eq!(a.node_count, 2);
+        assert_eq!(b.node_count, 2);
     }
 }

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -622,11 +622,13 @@ fn ratio_from_scaled(
     })
 }
 
-/// `(defenum <EnumTypeName> (<member>+))` — §2.13, D101. Delegates to
+/// `(defenum <enum-type> (<enum-member>+))` — §2.13, D101. Delegates to
 /// `declarations::parse_defenum`, the SAME parser `.bsl` rule content uses
 /// (D93's own dialect split is about `defconst`/`node`/`edge`/`scenario`,
 /// which the RST grammar disclaims; `defenum` is an RST `<top-form>`, so
 /// there is exactly one grammar for it and no reason for a second reader).
+/// Members are written BARE (`STATE_APPARATUS`) — see that function's own
+/// doc for the #528 fix round's corrected reading.
 ///
 /// # Errors
 ///
@@ -642,19 +644,29 @@ fn load_defenum(form: &SExpr, enums: &mut EnumRegistry) -> Result<(), ScenarioEr
         })
 }
 
-/// `(defvocabulary <EnumKind> (<member>+))` — §2.13, D101; §3.6's own
+/// `(defvocabulary <enum-kind> (<enum-member>+))` — §2.13, D101; §3.6's own
 /// closed graph vocabulary, populated **explicitly**, never inferred from
-/// what a scenario happens to seed. `<EnumKind>` is syntactically an
-/// `<enum-type>` (a bare, slash-free `Atom::EnumTypeName` — see that
+/// what a scenario happens to seed. `<enum-kind>` is syntactically an
+/// `<enum-type>` (a bare, slash-free [`Atom::BareUpperIdent`] — see that
 /// variant's doc for why the reader lexes it that way) but SEMANTICALLY
 /// restricted to `NodeType` / `EdgeType` / `HyperedgeType` / `EventType` —
 /// an unknown name is `E-LOAD-030`, the same code §3.6 already uses for an
 /// unregistered `<enum-ref>` type name (this is a load-time check, not a
-/// lexical one, exactly as `enum-type`'s own `defenum` doc reasons for its
-/// sibling). Members are written as full `<EnumKind>/<MEMBER>` enum-refs
-/// repeating the declaring kind — the SAME convention `load_defenum` uses,
-/// for the SAME reason (no bare-member atom class exists; see that
-/// function's doc).
+/// lexical one). That closed-set check already subsumes a separate
+/// `<enum-type>`-shape check on the kind-name operand: none of the four
+/// valid kind names contains `_`, so a shape-invalid name (`Node_Type`)
+/// fails `EnumKind::from_type_name` on its own — a redundant
+/// `is_enum_type_shape` check here would only pre-empt that existing,
+/// already-coded `E-LOAD-030` with a less specific uncoded one, so this
+/// function does not add one (contrast `declarations::parse_defenum`,
+/// which mints a NEW type name with nothing to check it against and so
+/// DOES need the direct shape check).
+///
+/// **Members are written BARE** (`SOCIAL_CLASS`, not `NodeType/
+/// SOCIAL_CLASS`) — the SAME reading `load_defenum`/`parse_defenum` takes,
+/// for the same reason (§2.13's own EBNF; see that function's doc for the
+/// #528 fix round's corrected reading). A member written as a full
+/// enum-ref is grammar-nonconforming and refuses loudly.
 ///
 /// Only inserts into `collected`/`declared` — `ClosedVocabulary::new` (the
 /// caller, once at end-of-load) runs the whole-vocabulary
@@ -664,8 +676,8 @@ fn load_defenum(form: &SExpr, enums: &mut EnumRegistry) -> Result<(), ScenarioEr
 ///
 /// `E-LOAD-030` for an unregistered `<enum-kind>`; `E-LOAD-001` for a
 /// second `defvocabulary` naming a kind already declared; an uncoded
-/// [`ScenarioError`] off the grammar, including a member whose kind prefix
-/// does not match the kind being declared.
+/// [`ScenarioError`] off the grammar, including a member not shaped like
+/// `<enum-member>` or written as a full enum-ref.
 fn load_defvocabulary(
     form: &SExpr,
     collected: &mut HashMap<EnumKind, Vec<String>>,
@@ -674,10 +686,10 @@ fn load_defvocabulary(
     let SExpr::List(items) = form else {
         return Err(err("a defvocabulary must be a form"));
     };
-    let [SExpr::Atom(Atom::Symbol(head)), SExpr::Atom(Atom::EnumTypeName(kind_name)), SExpr::List(member_items)] =
+    let [SExpr::Atom(Atom::Symbol(head)), SExpr::Atom(Atom::BareUpperIdent(kind_name)), SExpr::List(member_items)] =
         items.as_slice()
     else {
-        return Err(err("expected (defvocabulary <EnumKind> (<member>+))"));
+        return Err(err("expected (defvocabulary <enum-kind> (<enum-member>+))"));
     };
     if head != "defvocabulary" {
         return Err(err(format!("expected (defvocabulary …), found ({head} …)")));
@@ -702,17 +714,17 @@ fn load_defvocabulary(
     }
     let mut members = Vec::with_capacity(member_items.len());
     for item in member_items {
-        let SExpr::Atom(Atom::EnumRef { enum_type, member }) = item else {
+        let SExpr::Atom(Atom::BareUpperIdent(member)) = item else {
             return Err(err(format!(
-                "defvocabulary {kind_name}: member {item:?} must be written \
-                 {kind_name}/<MEMBER>, repeating the declaring kind (§2.13)"
+                "defvocabulary {kind_name}: member {item:?} must be a bare \
+                 <enum-member> (§2.13, §1.4) — never a full \
+                 `{kind_name}/<MEMBER>` enum-ref"
             )));
         };
-        if enum_type != kind_name {
+        if !crate::reader::is_enum_member_shape(member) {
             return Err(err(format!(
-                "defvocabulary {kind_name}: member {enum_type}/{member} \
-                 names a different kind than the one being declared \
-                 ({kind_name})"
+                "defvocabulary {kind_name}: member `{member}` is not a valid \
+                 <enum-member> (§1.4: UPPER (UPPER|DIGIT|\"_\")* — no lowercase)"
             )));
         }
         members.push(member.clone());
@@ -746,7 +758,7 @@ fn load_deffield(
         ));
     };
     let decl = if ty == "enum" {
-        let SExpr::Atom(Atom::EnumTypeName(type_name)) = fourth else {
+        let SExpr::Atom(Atom::BareUpperIdent(type_name)) = fourth else {
             return Err(err(format!(
                 "deffield `{qname}`: an enum-typed field's 4th slot is the \
                  declared enum type name — (deffield {qname} enum \
@@ -2063,8 +2075,8 @@ mod tests {
 
     const ORG_KIND_SOURCE: &str = r"
 (scenario org/t
-  (defenum OrgKind (OrgKind/STATE_APPARATUS OrgKind/BUSINESS
-                     OrgKind/POLITICAL_FACTION OrgKind/CIVIL_SOCIETY))
+  (defenum OrgKind (STATE_APPARATUS BUSINESS
+                     POLITICAL_FACTION CIVIL_SOCIETY))
   (deffield organization/kind enum OrgKind)
   (node acme NodeType/ORGANIZATION (organization/kind OrgKind/BUSINESS)))
 ";
@@ -2087,7 +2099,7 @@ mod tests {
     fn a_bare_number_into_an_enum_field_refuses_naming_the_law() {
         let source = r"
 (scenario org/t
-  (defenum OrgKind (OrgKind/STATE_APPARATUS OrgKind/BUSINESS))
+  (defenum OrgKind (STATE_APPARATUS BUSINESS))
   (deffield organization/kind enum OrgKind)
   (node acme NodeType/ORGANIZATION (organization/kind 1)))
 ";
@@ -2105,7 +2117,7 @@ mod tests {
     fn a_wrong_enum_type_member_refuses() {
         let source = r"
 (scenario org/t
-  (defenum OrgKind (OrgKind/STATE_APPARATUS OrgKind/BUSINESS))
+  (defenum OrgKind (STATE_APPARATUS BUSINESS))
   (deffield organization/kind enum OrgKind)
   (node acme NodeType/ORGANIZATION (organization/kind NodeType/SOCIAL_CLASS)))
 ";
@@ -2119,7 +2131,7 @@ mod tests {
     fn an_undeclared_member_refuses() {
         let source = r"
 (scenario org/t
-  (defenum OrgKind (OrgKind/STATE_APPARATUS OrgKind/BUSINESS))
+  (defenum OrgKind (STATE_APPARATUS BUSINESS))
   (deffield organization/kind enum OrgKind)
   (node acme NodeType/ORGANIZATION (organization/kind OrgKind/NOWHERE)))
 ";
@@ -2160,14 +2172,38 @@ mod tests {
     // ---- §2.13/§3.6 `defvocabulary`: the closed graph vocabulary is
     // declared, never inferred (Task 7) ----
 
+    /// #528 fix round, RED before the fix: the tree-sitter corpus's own
+    /// worked example (`test/corpus/declarations.txt:145`) — bare
+    /// `<enum-member>` items, never full `Type/MEMBER` refs. Today's
+    /// `load_defvocabulary` requires the latter, so this fails with an
+    /// uncoded "must be written {kind_name}/<MEMBER>" error before the fix.
+    #[test]
+    fn defvocabulary_accepts_the_corpus_line_verbatim() {
+        let source = r"
+(scenario org/vocab-corpus
+  (defvocabulary NodeType (SOCIAL_CLASS TERRITORY ORGANIZATION))
+  (node acme NodeType/ORGANIZATION))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph)
+            .expect("the corpus's own bare-member shape must load");
+        let vocabulary = loaded.vocabulary.expect("a declared vocabulary is Some");
+        assert_eq!(
+            vocabulary
+                .check_enum_ref("NodeType", "SOCIAL_CLASS")
+                .unwrap(),
+            EnumKind::NodeType
+        );
+    }
+
     #[test]
     fn a_scenario_declaring_the_vocabulary_loads_and_is_some() {
         let source = r"
 (scenario org/vocab
-  (defvocabulary NodeType (NodeType/SOCIAL_CLASS NodeType/TERRITORY NodeType/ORGANIZATION))
+  (defvocabulary NodeType (SOCIAL_CLASS TERRITORY ORGANIZATION))
   (defvocabulary EdgeType
-    (EdgeType/MEMBERSHIP EdgeType/PRESENCE EdgeType/COMMAND
-     EdgeType/TRANSACTIONAL EdgeType/SOLIDARISTIC EdgeType/SOLIDARITY))
+    (MEMBERSHIP PRESENCE COMMAND
+     TRANSACTIONAL SOLIDARISTIC SOLIDARITY))
   (node acme NodeType/ORGANIZATION))
 ";
         let mut graph = MemoryGraph::new();
@@ -2203,8 +2239,8 @@ mod tests {
         // `load_defvocabulary`'s collected map rather than reinvented here.
         let source = r"
 (scenario org/collision
-  (defvocabulary NodeType (NodeType/TENANCY))
-  (defvocabulary EdgeType (EdgeType/TENANCY))
+  (defvocabulary NodeType (TENANCY))
+  (defvocabulary EdgeType (TENANCY))
   (node acme NodeType/TENANCY))
 ";
         let mut graph = MemoryGraph::new();
@@ -2216,7 +2252,7 @@ mod tests {
     fn an_unknown_enum_kind_symbol_refuses() {
         let source = r"
 (scenario org/badkind
-  (defvocabulary SovereignType (SovereignType/USA)))
+  (defvocabulary SovereignType (USA)))
 ";
         let mut graph = MemoryGraph::new();
         let err = load_scenario(source, &mut graph).unwrap_err();
@@ -2227,22 +2263,59 @@ mod tests {
     fn two_defvocabulary_forms_for_one_kind_is_e_load_001() {
         let source = r"
 (scenario org/twice
-  (defvocabulary NodeType (NodeType/SOCIAL_CLASS))
-  (defvocabulary NodeType (NodeType/TERRITORY)))
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (defvocabulary NodeType (TERRITORY)))
 ";
         let mut graph = MemoryGraph::new();
         let err = load_scenario(source, &mut graph).unwrap_err();
         assert_eq!(err.code, Some("E-LOAD-001"));
     }
 
+    /// #528 fix round: repurposed from `a_defvocabulary_member_naming_a_
+    /// different_kind_refuses` — under the bare-member reading a member
+    /// carries no kind prefix to mismatch AT ALL (that whole error class is
+    /// now structurally unreachable), so the meaningful sibling check is
+    /// the grammar-conformance direction: a member written as a full
+    /// enum-ref (even one that LOOKS like a plausible different kind, the
+    /// way `EdgeType/SOLIDARITY` does here) still refuses.
     #[test]
-    fn a_defvocabulary_member_naming_a_different_kind_refuses() {
+    fn a_defvocabulary_member_written_as_a_full_enum_ref_refuses() {
         let source = r"
 (scenario org/mismatched
   (defvocabulary NodeType (EdgeType/SOLIDARITY)))
 ";
         let mut graph = MemoryGraph::new();
         let err = load_scenario(source, &mut graph).unwrap_err();
-        assert!(err.message.contains("different kind"), "{}", err.message);
+        assert!(err.message.contains("bare"), "{}", err.message);
+    }
+
+    #[test]
+    fn a_defvocabulary_kind_name_shaped_like_an_enum_member_refuses() {
+        // Node_Type lexes fine (Atom::BareUpperIdent admits the union
+        // charset) but is not one of the closed four kind names — the
+        // EXISTING E-LOAD-030 check catches it (see `load_defvocabulary`'s
+        // own doc for why no separate shape check is added here).
+        let source = r"
+(scenario org/badkind-shape
+  (defvocabulary Node_Type (SOCIAL_CLASS)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-030"));
+    }
+
+    #[test]
+    fn a_defvocabulary_member_shaped_like_an_enum_type_refuses() {
+        // `SocialClass` has lowercase letters and no slash: it lexes fine
+        // as Atom::BareUpperIdent, but is not a valid <enum-member> (which
+        // permits no lowercase at all) — the parser must catch this, not
+        // the reader.
+        let source = r"
+(scenario org/badmember-shape
+  (defvocabulary NodeType (SocialClass)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(err.message.contains("enum-member"), "{}", err.message);
     }
 }

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -2176,7 +2176,7 @@ mod tests {
     /// worked example (`test/corpus/declarations.txt:145`) — bare
     /// `<enum-member>` items, never full `Type/MEMBER` refs. Today's
     /// `load_defvocabulary` requires the latter, so this fails with an
-    /// uncoded "must be written {kind_name}/<MEMBER>" error before the fix.
+    /// uncoded "must be written `{kind_name}`/<MEMBER>" error before the fix.
     #[test]
     fn defvocabulary_accepts_the_corpus_line_verbatim() {
         let source = r"

--- a/rust/crates/babylon-bsl/src/score_class.rs
+++ b/rust/crates/babylon-bsl/src/score_class.rs
@@ -118,8 +118,15 @@ fn classify_atom(atom: &Atom, env: &ClassEnv<'_>) -> ScoreClass {
         Atom::Str(_) => ScoreClass::Str,
         Atom::Symbol(name) => classify_symbol(name, env),
         // A qname is a static field path and a keyword an option marker;
-        // neither is an expression (§1.6 rejects both by position).
-        Atom::QName(_) | Atom::Keyword(_) | Atom::Operator(_) => ScoreClass::Unknown,
+        // neither is an expression (§1.6 rejects both by position). A bare
+        // `enum-type` name (§2.13) is a declaration-only construct — it
+        // never appears in `<when>`/`<effects>` expression position, only
+        // in `defenum`/`defvocabulary`'s own operand and `deffield`'s
+        // `:enum-type` keyword, both consumed by their own parsers before
+        // this classifier ever runs — so it is unclassified here too.
+        Atom::QName(_) | Atom::Keyword(_) | Atom::Operator(_) | Atom::EnumTypeName(_) => {
+            ScoreClass::Unknown
+        }
     }
 }
 

--- a/rust/crates/babylon-bsl/src/score_class.rs
+++ b/rust/crates/babylon-bsl/src/score_class.rs
@@ -124,7 +124,7 @@ fn classify_atom(atom: &Atom, env: &ClassEnv<'_>) -> ScoreClass {
         // in `defenum`/`defvocabulary`'s own operand and `deffield`'s
         // `:enum-type` keyword, both consumed by their own parsers before
         // this classifier ever runs — so it is unclassified here too.
-        Atom::QName(_) | Atom::Keyword(_) | Atom::Operator(_) | Atom::EnumTypeName(_) => {
+        Atom::QName(_) | Atom::Keyword(_) | Atom::Operator(_) | Atom::BareUpperIdent(_) => {
             ScoreClass::Unknown
         }
     }

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -501,6 +501,7 @@ impl<'a> EffectExecutor<'a> {
         let (new_value, previous) = match op.as_str() {
             "set" => (operand_value, self.probe_previous(&*graph, id, field)),
             "add" | "sub" | "scale" => {
+                self.refuse_arithmetic_on_enum_field(field)?;
                 let current = graph.node_attribute(id, field).map_err(from_graph)?;
                 let combined = match op.as_str() {
                     "add" => current + operand_value,
@@ -713,9 +714,18 @@ impl<'a> EffectExecutor<'a> {
         let operand_value = self.numeric_write_value(operand, env, host, fuel, field)?;
         let update_op = match op.as_str() {
             "set" => UpdateOp::Set,
-            "add" => UpdateOp::Add,
-            "sub" => UpdateOp::Sub,
-            "scale" => UpdateOp::Scale,
+            "add" => {
+                self.refuse_arithmetic_on_enum_field(field)?;
+                UpdateOp::Add
+            }
+            "sub" => {
+                self.refuse_arithmetic_on_enum_field(field)?;
+                UpdateOp::Sub
+            }
+            "scale" => {
+                self.refuse_arithmetic_on_enum_field(field)?;
+                UpdateOp::Scale
+            }
             other => {
                 return Err(plain(format!(
                     "unknown update-op ({other} …) — the set is add|sub|set|scale (§2.8)"
@@ -755,6 +765,7 @@ impl<'a> EffectExecutor<'a> {
                 self.probe_previous(&*graph, write.id, &write.field),
             ),
             UpdateOp::Add | UpdateOp::Sub | UpdateOp::Scale => {
+                self.refuse_arithmetic_on_enum_field(&write.field)?;
                 let current = graph
                     .node_attribute(write.id, &write.field)
                     .map_err(from_graph)?;
@@ -1199,6 +1210,41 @@ impl<'a> EffectExecutor<'a> {
             ));
         };
         Ok(f64::from(ordinal))
+    }
+
+    /// `E-EVAL-042` (§2.13, D101 — "no aggregation kind": `Enum<T>`
+    /// supports no arithmetic) — the `add`/`sub`/`scale` half of the write
+    /// law [`Self::enum_write_value`] does not itself cover. Reading the
+    /// stored ordinal, combining it with an operand's ordinal, and writing
+    /// the result back would silently reinterpret the combination as
+    /// whatever DIFFERENT member happens to share that ordinal (`add`), or
+    /// write a value with NO member at all — `store_range_check` (§3.3)
+    /// bounds only the three unit-interval types, so an enum field's
+    /// ordinal is otherwise unchecked at the store boundary (`sub`,
+    /// `scale`). `set` is the only coherent op and is unaffected: it never
+    /// reads the current value.
+    ///
+    /// Called from all THREE sites that would otherwise perform this
+    /// combine: [`Self::update_node`]'s immediate execute path,
+    /// [`Self::collect_update_node`]'s collect path (`run_tick`'s own —
+    /// refusing here means the write never even reaches
+    /// [`Self::apply_pending_write`]), and apply itself, which guards
+    /// independently as defense in depth (the same two-site discipline
+    /// `numeric_write_value`'s own doc names for the load-time/eval-time
+    /// enum-shape check) — and, if a storage-bearing `update-edge` is ever
+    /// built, would reuse this exact combine shape too.
+    fn refuse_arithmetic_on_enum_field(&self, field: &str) -> Result<(), EvalError> {
+        if let Some(BslType::Enum(_)) = self.types.fields.get(field).map(|decl| &decl.ty) {
+            return Err(EvalError::coded(
+                EvalCode::EnumWriteShapeViolation,
+                format!(
+                    "update-node {field}: add/sub/scale is not a coherent \
+                     operation on an enum-typed field — Enum<T> supports no \
+                     arithmetic (§2.13); only `set` may write it"
+                ),
+            ));
+        }
+        Ok(())
     }
 
     /// §3.3's one range check, at the store boundary: a value outside the
@@ -2026,6 +2072,39 @@ mod tests {
         Ok(sink.events)
     }
 
+    /// `collect_then_apply`'s COLLECT-ONLY half — stops before
+    /// `apply_pending_write` ever runs, never merely stopping at the first
+    /// error `collect_then_apply` would ALSO have surfaced. This is the one
+    /// way to isolate a collect-site guard from an apply-site one when both
+    /// exist as independent defense-in-depth checks (#528 fix round,
+    /// blocker 2's mutation-testing finding): `collect_then_apply` cannot
+    /// tell the caller which of the two sites actually produced a given
+    /// error, so a test built on it that MEANS to pin the collect site
+    /// stays green even with that site's own guard deleted, masked by the
+    /// apply site's identical backstop.
+    fn collect_only(
+        graph: &MemoryGraph,
+        types: &TypeEnv,
+        enums: &EnumRegistry,
+        bindings: HashMap<String, Value>,
+        effects_source: &str,
+        fuel: &mut u64,
+    ) -> Result<Vec<PendingWrite>, EvalError> {
+        let (form, _) = read(effects_source).expect("effects source must parse");
+        let SExpr::List(items) = form else {
+            unreachable!()
+        };
+        let mut sink = CollectingSink::default();
+        let env = EvalEnv {
+            bindings,
+            intrinsic_costs: &IntrinsicCosts::default(),
+            graph: Some(graph as &dyn GraphSubstrate),
+            elements: Vec::new(),
+        };
+        let mut collector = EffectExecutor::new(types, enums);
+        collector.collect_effects(&items[1..], &env, &EmptyIntrinsicHost, &mut sink, fuel)
+    }
+
     #[test]
     fn for_each_over_an_empty_query_applies_nothing_and_does_not_error() {
         // No ORGANIZATION node exists, so (nodes NodeType/ORGANIZATION)
@@ -2569,6 +2648,187 @@ mod tests {
         .unwrap_err();
         assert_eq!(err.code, Some(EvalCode::EnumWriteShapeViolation));
         assert!(err.message.contains("NOWHERE"), "{}", err.message);
+    }
+
+    // ==================================================== #528 fix round,
+    // blocker 2: `add`/`sub`/`scale` are refused on a `BslType::Enum`
+    // field (E-EVAL-042) — `Enum<T>` supports no arithmetic (§2.13's own
+    // "no aggregation kind" law). Driven through `collect_then_apply`
+    // exactly like the D101 tests above — the collect-path guard (inside
+    // `collect_update_node`) refuses before `apply_pending_write` ever
+    // runs, so these ALSO exercise the collect site the verifier named
+    // invisible to every pre-#528 unit test.
+
+    /// Isolated to the COLLECT site via `collect_only` (never
+    /// `collect_then_apply`): `apply_pending_write` guards the SAME class
+    /// independently (defense in depth), so a test built on
+    /// `collect_then_apply` cannot tell collect's own guard apart from
+    /// apply's — proven by mutation testing this fix round's own review
+    /// caught (deleting `collect_update_node`'s guard alone left a
+    /// `collect_then_apply`-based version of this test green, masked by
+    /// apply's identical backstop).
+    #[test]
+    fn add_on_an_enum_field_is_e_eval_042_at_the_collect_site() {
+        let mut graph = MemoryGraph::new();
+        let id = graph.add_node("ORGANIZATION").unwrap();
+        let (types, enums) = org_kind_types_and_enums();
+        graph.update_node(id, "organization/kind", 0.0).unwrap(); // STATE_APPARATUS
+        let mut fuel = 64;
+        let err = collect_only(
+            &graph,
+            &types,
+            &enums,
+            HashMap::from([("self".to_owned(), Value::NodeRef(id))]),
+            "(effects (update-node self organization/kind (add OrgKind/BUSINESS)))",
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::EnumWriteShapeViolation));
+        assert_eq!(err.code.map(EvalCode::spec_code), Some("E-EVAL-042"));
+        // No PendingWrite was ever built, let alone applied — the graph is
+        // observably untouched (never re-read `organization/kind` here on
+        // purpose: this test's whole point is that apply NEVER RAN).
+        let stored = graph.node_attribute(id, "organization/kind").unwrap();
+        assert!(
+            (stored - 0.0).abs() < 1e-12,
+            "the refused write must not have landed: {stored}"
+        );
+    }
+
+    /// [`Self::update_node`]'s IMMEDIATE execute path — `execute_effects`,
+    /// production's abandoned path since Task 12 but still this crate's own
+    /// unit-test harness (see that method's doc) — guards independently of
+    /// the collect/apply pair above.
+    #[test]
+    fn add_on_an_enum_field_is_e_eval_042_at_the_execute_site() {
+        let mut graph = MemoryGraph::new();
+        let id = graph.add_node("ORGANIZATION").unwrap();
+        let (types, enums) = org_kind_types_and_enums();
+        graph.update_node(id, "organization/kind", 0.0).unwrap(); // STATE_APPARATUS
+        let mut fuel = 64;
+        let (form, _) =
+            read("(effects (update-node self organization/kind (add OrgKind/BUSINESS)))")
+                .expect("effects source must parse");
+        let SExpr::List(items) = form else {
+            unreachable!()
+        };
+        let env = EvalEnv {
+            bindings: HashMap::from([("self".to_owned(), Value::NodeRef(id))]),
+            intrinsic_costs: &IntrinsicCosts::default(),
+            graph: None,
+            elements: Vec::new(),
+        };
+        let mut sink = CollectingSink::default();
+        let mut executor = EffectExecutor::new(&types, &enums);
+        let err = executor
+            .execute_effects(
+                &items[1..],
+                &env,
+                &EmptyIntrinsicHost,
+                &mut graph,
+                &mut sink,
+                &mut fuel,
+            )
+            .unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::EnumWriteShapeViolation));
+        let stored = graph.node_attribute(id, "organization/kind").unwrap();
+        assert!(
+            (stored - 0.0).abs() < 1e-12,
+            "the refused write must not have landed: {stored}"
+        );
+    }
+
+    #[test]
+    fn sub_on_an_enum_field_is_e_eval_042_before_it_corrupts_the_store() {
+        // The worst case: STATE_APPARATUS (ordinal 0) minus BUSINESS's
+        // ordinal (1) would write -1.0 — no range check bounds an enum
+        // field's ordinal at the store boundary (§3.3's unit-interval
+        // check does not cover BslType::Enum), so this is the "corrupts
+        // the store into a next-tick read error at the wrong site" case
+        // the fix round names.
+        let mut graph = MemoryGraph::new();
+        let id = graph.add_node("ORGANIZATION").unwrap();
+        let (types, enums) = org_kind_types_and_enums();
+        graph.update_node(id, "organization/kind", 0.0).unwrap(); // STATE_APPARATUS
+        let mut fuel = 64;
+        let err = collect_only(
+            &graph,
+            &types,
+            &enums,
+            HashMap::from([("self".to_owned(), Value::NodeRef(id))]),
+            "(effects (update-node self organization/kind (sub OrgKind/BUSINESS)))",
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::EnumWriteShapeViolation));
+        let stored = graph.node_attribute(id, "organization/kind").unwrap();
+        assert!(
+            (stored - 0.0).abs() < 1e-12,
+            "the refused write must never reach -1.0 (no such member): {stored}"
+        );
+    }
+
+    #[test]
+    fn scale_on_an_enum_field_is_e_eval_042_at_the_collect_site() {
+        let mut graph = MemoryGraph::new();
+        let id = graph.add_node("ORGANIZATION").unwrap();
+        let (types, enums) = org_kind_types_and_enums();
+        graph.update_node(id, "organization/kind", 0.0).unwrap();
+        let mut fuel = 64;
+        let err = collect_only(
+            &graph,
+            &types,
+            &enums,
+            HashMap::from([("self".to_owned(), Value::NodeRef(id))]),
+            "(effects (update-node self organization/kind (scale OrgKind/BUSINESS)))",
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::EnumWriteShapeViolation));
+    }
+
+    /// `apply_pending_write` guards independently of `collect_update_node`
+    /// (defense in depth, matching `numeric_write_value`'s own "the one
+    /// funnel every write value crosses" discipline) — proven by building a
+    /// `PendingWrite` DIRECTLY, bypassing collect entirely, the only way to
+    /// isolate the apply-site guard from the collect-site one.
+    #[test]
+    fn apply_pending_write_refuses_arithmetic_on_an_enum_field_even_bypassing_collect() {
+        let mut graph = MemoryGraph::new();
+        let id = graph.add_node("ORGANIZATION").unwrap();
+        let (types, enums) = org_kind_types_and_enums();
+        graph.update_node(id, "organization/kind", 0.0).unwrap();
+        let write = PendingWrite {
+            id,
+            field: "organization/kind".to_owned(),
+            op: UpdateOp::Add,
+            operand: 1.0,
+        };
+        let mut applier = EffectExecutor::new(&types, &enums);
+        let err = applier.apply_pending_write(&write, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::EnumWriteShapeViolation));
+        let stored = graph.node_attribute(id, "organization/kind").unwrap();
+        assert!((stored - 0.0).abs() < 1e-12);
+    }
+
+    /// `set` remains the coherent op on an enum field — the guard is scoped
+    /// to `add`/`sub`/`scale` only, never widened to refuse the legitimate
+    /// write path.
+    #[test]
+    fn set_on_an_enum_field_is_unaffected_by_the_arithmetic_guard() {
+        let mut graph = MemoryGraph::new();
+        let id = graph.add_node("ORGANIZATION").unwrap();
+        let (types, enums) = org_kind_types_and_enums();
+        let mut fuel = 64;
+        collect_then_apply(
+            &mut graph,
+            &types,
+            &enums,
+            HashMap::from([("self".to_owned(), Value::NodeRef(id))]),
+            "(effects (update-node self organization/kind (set OrgKind/BUSINESS)))",
+            &mut fuel,
+        )
+        .expect("set is the coherent op on an enum field");
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -55,7 +55,7 @@ use crate::fuel::cost;
 use crate::intrinsic_host::IntrinsicHost;
 use crate::reader::{Atom, SExpr};
 use crate::typecheck::TypeEnv;
-use crate::types::BslType;
+use crate::types::{BslType, EnumRegistry, EnumTypeId};
 use crate::write_log::{Write, WriteObserver, WriteRecord};
 use babylon_graph::substrate::{GraphError, GraphSubstrate, HyperedgeId, NodeId};
 use std::collections::HashMap;
@@ -146,6 +146,16 @@ fn from_graph(e: GraphError) -> EvalError {
 /// effect-list-scoped names `add-node`/`add-hyperedge` introduce.
 pub struct EffectExecutor<'a> {
     types: &'a TypeEnv,
+    /// **§2.13 addendum (D101).** The content-declared closed-enum
+    /// registry — `numeric_write_value`'s enum branch resolves a written
+    /// `<enum-ref>`'s ordinal through this, exactly as `bind_subject`
+    /// (`tick.rs`) resolves the read-path inverse. An empty registry
+    /// (`EnumRegistry::default()`) is the honest "no `defenum`s in scope"
+    /// input for content with none — every enum-typed `store_range_check`/
+    /// `numeric_write_value` site is unreachable without a
+    /// `BslType::Enum`-declared field in `types` first, so an empty
+    /// registry never silently under-serves real content.
+    enums: &'a EnumRegistry,
     declared_nodes: HashMap<String, NodeId>,
     declared_hyperedges: HashMap<String, HyperedgeId>,
     /// The ADR182 R1 interception point. `None` is the unobserved path and
@@ -160,11 +170,14 @@ pub struct EffectExecutor<'a> {
 
 impl<'a> EffectExecutor<'a> {
     /// A fresh executor for one effect list. `types` supplies the declared
-    /// field types the §3.3 store-boundary range check needs.
+    /// field types the §3.3 store-boundary range check needs; `enums`
+    /// supplies the §2.13 enum-ordinal registry a `BslType::Enum`-declared
+    /// field's write path resolves against.
     #[must_use]
-    pub fn new(types: &'a TypeEnv) -> Self {
+    pub fn new(types: &'a TypeEnv, enums: &'a EnumRegistry) -> Self {
         Self {
             types,
+            enums,
             declared_nodes: HashMap::new(),
             declared_hyperedges: HashMap::new(),
             observer: None,
@@ -184,11 +197,13 @@ impl<'a> EffectExecutor<'a> {
     #[must_use]
     pub fn observed(
         types: &'a TypeEnv,
+        enums: &'a EnumRegistry,
         rule: impl Into<String>,
         observer: &'a mut dyn WriteObserver,
     ) -> Self {
         Self {
             types,
+            enums,
             declared_nodes: HashMap::new(),
             declared_hyperedges: HashMap::new(),
             observer: Some(observer),
@@ -478,7 +493,7 @@ impl<'a> EffectExecutor<'a> {
             return Err(plain("update-op must be (add|sub|set|scale <expr>)"));
         };
         charge(fuel, cost::UPDATE_OP_BASE)?;
-        let operand_value = Self::numeric_write_value(operand, env, host, fuel, field)?;
+        let operand_value = self.numeric_write_value(operand, env, host, fuel, field)?;
         // `previous` is for the write log only. `set` does not otherwise read
         // the field, so it PROBES (a never-written field is `None`, not an
         // error — write_log discipline 3); the read-modify-write ops already
@@ -695,7 +710,7 @@ impl<'a> EffectExecutor<'a> {
             return Err(plain("update-op must be (add|sub|set|scale <expr>)"));
         };
         charge(fuel, cost::UPDATE_OP_BASE)?;
-        let operand_value = Self::numeric_write_value(operand, env, host, fuel, field)?;
+        let operand_value = self.numeric_write_value(operand, env, host, fuel, field)?;
         let update_op = match op.as_str() {
             "set" => UpdateOp::Set,
             "add" => UpdateOp::Add,
@@ -805,7 +820,7 @@ impl<'a> EffectExecutor<'a> {
                     "a field-init must be (<qname> <expr>), found {pair:?}"
                 )));
             };
-            let value = Self::numeric_write_value(value_expr, env, host, fuel, field)?;
+            let value = self.numeric_write_value(value_expr, env, host, fuel, field)?;
             self.store_range_check(field, value)?;
             // A field-init on a freshly minted node normally has no prior
             // value; probing rather than assuming keeps a repeated init
@@ -1090,14 +1105,28 @@ impl<'a> EffectExecutor<'a> {
     /// attribute), never a lossy cast — typed Currency storage is DEFERRED
     /// TO ITS FIRST CONSUMER (Director ruling, 2026-08-11 popup), not to a
     /// fixed phase boundary.
+    ///
+    /// **§2.13 addendum (D101).** When `field` is declared `BslType::Enum`
+    /// (`self.types`), the write funnels through [`Self::enum_write_value`]
+    /// instead: the ordinal is never a surface value, so a bare `Real`/`Int`
+    /// here is exactly as illegal as it is at load
+    /// (`scenario.rs::attribute_value_enum`, `E-LOAD-056`'s runtime
+    /// re-check, `E-EVAL-042`). For every OTHER field this arm is a no-op —
+    /// the existing catch-all below still refuses `Value::Enum` reaching a
+    /// non-enum field with its ORIGINAL message, unchanged.
     fn numeric_write_value(
+        &self,
         expr: &SExpr,
         env: &EvalEnv<'_>,
         host: &dyn IntrinsicHost,
         fuel: &mut u64,
         field: &str,
     ) -> Result<f64, EvalError> {
-        match evaluate(expr, env, host, fuel)? {
+        let value = evaluate(expr, env, host, fuel)?;
+        if let Some(BslType::Enum(ty)) = self.types.fields.get(field).map(|decl| &decl.ty) {
+            return self.enum_write_value(value, field, *ty);
+        }
+        match value {
             // The evaluator guards its own arithmetic (E-EVAL-014), but a
             // value can reach the store boundary without passing through it
             // — an intrinsic host's return is the trait's named
@@ -1124,6 +1153,52 @@ impl<'a> EffectExecutor<'a> {
                 "cannot store {other:?} as a numeric node attribute"
             ))),
         }
+    }
+
+    /// The `:enum-type`-declared half of [`Self::numeric_write_value`]
+    /// (§2.13, D101): accepts ONLY a `Value::Enum` of the field's exact
+    /// declared type, resolves its ordinal through `self.enums`, and
+    /// returns `ordinal as f64` — the SAME binary64 lane every other
+    /// declared type's write already uses. Everything else — a bare
+    /// `Value::Real`/`Value::Int` (the eval-time form of the load-time
+    /// bare-number mistake), a `Value::Enum` of a DIFFERENT declared type,
+    /// or any other value — is `E-EVAL-042`.
+    fn enum_write_value(
+        &self,
+        value: Value,
+        field: &str,
+        ty: EnumTypeId,
+    ) -> Result<f64, EvalError> {
+        let Value::Enum { enum_type, member } = value else {
+            return Err(EvalError::coded(
+                EvalCode::EnumWriteShapeViolation,
+                format!(
+                    "update-node {field}: an enum-typed field is written \
+                     ONLY as <EnumType>/<MEMBER> — the ordinal is never a \
+                     surface value; found {value:?} (§2.13)"
+                ),
+            ));
+        };
+        let declared_type = self.enums.name(ty);
+        if enum_type != declared_type {
+            return Err(EvalError::coded(
+                EvalCode::EnumWriteShapeViolation,
+                format!(
+                    "update-node {field}: declared enum type is \
+                     {declared_type}, found {enum_type}/{member} (§2.13)"
+                ),
+            ));
+        }
+        let Some(ordinal) = self.enums.ordinal(ty, &member) else {
+            return Err(EvalError::coded(
+                EvalCode::EnumWriteShapeViolation,
+                format!(
+                    "update-node {field}: {declared_type} has no member \
+                     {member} — never a default (§2.13)"
+                ),
+            ));
+        };
+        Ok(f64::from(ordinal))
     }
 
     /// §3.3's one range check, at the store boundary: a value outside the
@@ -1267,6 +1342,15 @@ mod tests {
         }
     }
 
+    /// The `types()` fixture above declares no enum-typed field — an empty
+    /// registry is the honest "no `defenum`s in scope" input for every
+    /// test in this module that does not build its own (the enum-write
+    /// tests below build `organization_types()`/an `OrgKind` registry
+    /// instead).
+    fn enums() -> EnumRegistry {
+        EnumRegistry::default()
+    }
+
     struct Fixture {
         graph: MemoryGraph,
         self_id: NodeId,
@@ -1306,7 +1390,8 @@ mod tests {
                 elements: Vec::new(),
             };
             let types = types();
-            let mut executor = EffectExecutor::new(&types);
+            let enums = enums();
+            let mut executor = EffectExecutor::new(&types, &enums);
             let mut sink = CollectingSink::default();
             executor.execute_effects(
                 &items[1..],
@@ -1339,10 +1424,12 @@ mod tests {
                 elements: Vec::new(),
             };
             let types = types();
+            let enums = enums();
             let mut log = CollectingWriteLog::new();
             let mut sink = CollectingSink::default();
             let result = {
-                let mut executor = EffectExecutor::observed(&types, "hunger/agitate", &mut log);
+                let mut executor =
+                    EffectExecutor::observed(&types, &enums, "hunger/agitate", &mut log);
                 executor.execute_effects(
                     &items[1..],
                     &env,
@@ -1696,7 +1783,8 @@ mod tests {
                 elements: Vec::new(),
             };
             let types = types();
-            let mut executor = EffectExecutor::new(&types);
+            let enums = enums();
+            let mut executor = EffectExecutor::new(&types, &enums);
             let mut sink = CollectingSink::default();
             let err = executor
                 .execute_effects(
@@ -1911,6 +1999,7 @@ mod tests {
     fn collect_then_apply(
         graph: &mut MemoryGraph,
         types: &TypeEnv,
+        enums: &EnumRegistry,
         bindings: HashMap<String, Value>,
         effects_source: &str,
         fuel: &mut u64,
@@ -1927,10 +2016,10 @@ mod tests {
                 graph: Some(&*graph as &dyn GraphSubstrate),
                 elements: Vec::new(),
             };
-            let mut collector = EffectExecutor::new(types);
+            let mut collector = EffectExecutor::new(types, enums);
             collector.collect_effects(&items[1..], &env, &EmptyIntrinsicHost, &mut sink, fuel)?
         };
-        let mut applier = EffectExecutor::new(types);
+        let mut applier = EffectExecutor::new(types, enums);
         for write in &pending {
             applier.apply_pending_write(write, &mut *graph)?;
         }
@@ -1957,6 +2046,7 @@ mod tests {
         let events = collect_then_apply(
             &mut graph,
             &types,
+            &enums(),
             HashMap::from([("self".to_owned(), Value::NodeRef(self_id))]),
             "(effects (for-each (nodes NodeType/ORGANIZATION) \
                (update-node self social-class/agitation (set 0.99i))))",
@@ -1986,6 +2076,7 @@ mod tests {
         let events = collect_then_apply(
             &mut graph,
             &types,
+            &enums(),
             HashMap::new(),
             "(effects (for-each (nodes NodeType/SOCIAL_CLASS) \
                (emit EventType/RUPTURE (who it))))",
@@ -2032,7 +2123,8 @@ mod tests {
             elements: Vec::new(),
         };
         let types = types();
-        let mut executor = EffectExecutor::new(&types);
+        let enums = enums();
+        let mut executor = EffectExecutor::new(&types, &enums);
         let mut sink = CollectingSink::default();
         let mut fuel = 256;
         let (form, _) = read(
@@ -2079,6 +2171,7 @@ mod tests {
         let events = collect_then_apply(
             &mut graph,
             &types,
+            &enums(),
             HashMap::new(),
             "(effects \
                (for-each (nodes NodeType/SOCIAL_CLASS) :as outer-elem \
@@ -2151,6 +2244,7 @@ mod tests {
         let err = collect_then_apply(
             &mut graph,
             &types,
+            &enums(),
             HashMap::from([("self".to_owned(), Value::NodeRef(self_id))]),
             "(effects (add-node NodeType/SOCIAL_CLASS recruit))",
             &mut fuel,
@@ -2175,6 +2269,7 @@ mod tests {
         let err = collect_then_apply(
             &mut graph,
             &types,
+            &enums(),
             HashMap::from([("self".to_owned(), Value::NodeRef(self_id))]),
             "(effects (guard 3 (emit event/rupture)))",
             &mut fuel,
@@ -2229,7 +2324,8 @@ mod tests {
             elements: Vec::new(),
         };
         let types = organization_types();
-        let mut executor = EffectExecutor::new(&types);
+        let enums = enums();
+        let mut executor = EffectExecutor::new(&types, &enums);
         let mut sink = CollectingSink::default();
         let mut fuel = 256;
         let (form, _) = read(
@@ -2295,6 +2391,7 @@ mod tests {
         let err = collect_then_apply(
             &mut graph,
             &types,
+            &enums(),
             HashMap::from([("self".to_owned(), Value::NodeRef(subject))]),
             "(effects (update-node self territory/population (set 5)))",
             &mut fuel,
@@ -2330,5 +2427,174 @@ mod tests {
                 "observe={observe} must not change the verdict"
             );
         }
+    }
+
+    // ==================================================== §2.13 (D101):
+    // the runtime enum write path — `update-node` on an `enum`-typed
+    // field. Driven through `collect_then_apply` (the SAME two-call
+    // sequence — `collect_effects` then `apply_pending_write` — that
+    // `tick.rs::run_tick` runs in production; see that helper's own doc),
+    // never `execute_effects` (test-harness-only since Task 12).
+
+    /// `OrgKind` in declaration order: `STATE_APPARATUS`=0, `BUSINESS`=1,
+    /// `POLITICAL_FACTION`=2, `CIVIL_SOCIETY`=3 — matching the spec's own
+    /// worked example (Organization spec §1 Q1/Q15). One `organization/kind`
+    /// field declared `BslType::Enum`, `FieldKind::NotApplicable`.
+    fn org_kind_types_and_enums() -> (TypeEnv, EnumRegistry) {
+        let mut enums = EnumRegistry::default();
+        let ty = enums
+            .declare(
+                "OrgKind",
+                &[
+                    "STATE_APPARATUS".to_owned(),
+                    "BUSINESS".to_owned(),
+                    "POLITICAL_FACTION".to_owned(),
+                    "CIVIL_SOCIETY".to_owned(),
+                ],
+            )
+            .unwrap();
+        let types = TypeEnv {
+            fields: HashMap::from([(
+                "organization/kind".to_owned(),
+                FieldDecl {
+                    ty: BslType::Enum(ty),
+                    kind: FieldKind::NotApplicable,
+                },
+            )]),
+            exemptions: &[],
+        };
+        (types, enums)
+    }
+
+    #[test]
+    fn update_node_writes_an_enum_ref_and_stores_the_declared_ordinal() {
+        let mut graph = MemoryGraph::new();
+        let id = graph.add_node("ORGANIZATION").unwrap();
+        let (types, enums) = org_kind_types_and_enums();
+        let mut fuel = 64;
+        collect_then_apply(
+            &mut graph,
+            &types,
+            &enums,
+            HashMap::from([("self".to_owned(), Value::NodeRef(id))]),
+            "(effects (update-node self organization/kind (set OrgKind/POLITICAL_FACTION)))",
+            &mut fuel,
+        )
+        .expect("a matching enum-ref write must succeed");
+        let stored = graph.node_attribute(id, "organization/kind").unwrap();
+        assert!(
+            (stored - 2.0).abs() < 1e-12,
+            "POLITICAL_FACTION is declaration-order ordinal 2, stored: {stored}"
+        );
+    }
+
+    #[test]
+    fn a_bare_real_write_into_an_enum_field_is_e_eval_042() {
+        // The eval-time form of the load-time bare-number mistake
+        // (`scenario.rs::attribute_value_enum`, E-LOAD-056) — the ordinal
+        // is never a surface value, checked again HERE because content
+        // cannot be checked once and for all at load (§3.7/§4.3's
+        // two-site pattern).
+        let mut graph = MemoryGraph::new();
+        let id = graph.add_node("ORGANIZATION").unwrap();
+        let (types, enums) = org_kind_types_and_enums();
+        let mut fuel = 64;
+        let err = collect_then_apply(
+            &mut graph,
+            &types,
+            &enums,
+            HashMap::from([("self".to_owned(), Value::NodeRef(id))]),
+            "(effects (update-node self organization/kind (set 2)))",
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::EnumWriteShapeViolation));
+        assert_eq!(err.code.map(EvalCode::spec_code), Some("E-EVAL-042"));
+    }
+
+    #[test]
+    fn a_cross_enum_type_write_is_e_eval_042() {
+        // NodeType/BUSINESS is a perfectly legal <enum-ref> — of the WRONG
+        // declared type for this field, but with a MEMBER NAME that
+        // collides with a real OrgKind member (BUSINESS, ordinal 1) —
+        // deliberately, so a mutant that skipped the type comparison and
+        // fell through to the member lookup would find "BUSINESS" and
+        // WRONGLY succeed with ordinal 1, rather than failing for a
+        // different, equally-plausible-looking reason (an earlier version
+        // of this test used SOCIAL_CLASS, whose absence from OrgKind's
+        // member list made the member-lookup branch ALSO refuse — masking
+        // whether the type check itself ran; caught by mutation testing).
+        // No load-time gate catches this either way (update-node's write
+        // operand is not one of `grammar.rs`'s typed ENUM_REF_POSITIONS),
+        // so this proves the runtime check is load-bearing on its own.
+        let mut graph = MemoryGraph::new();
+        let id = graph.add_node("ORGANIZATION").unwrap();
+        let (types, enums) = org_kind_types_and_enums();
+        let mut fuel = 64;
+        let err = collect_then_apply(
+            &mut graph,
+            &types,
+            &enums,
+            HashMap::from([("self".to_owned(), Value::NodeRef(id))]),
+            "(effects (update-node self organization/kind (set NodeType/BUSINESS)))",
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::EnumWriteShapeViolation));
+        assert!(
+            err.message.contains("declared enum type is OrgKind"),
+            "{}",
+            err.message
+        );
+        assert!(err.message.contains("NodeType/BUSINESS"), "{}", err.message);
+    }
+
+    #[test]
+    fn an_undeclared_member_of_the_right_type_is_e_eval_042() {
+        // OrgKind/NOWHERE lexes and type-checks fine (the reader never
+        // validates enum-ref MEMBERSHIP, only shape) — the registry lookup
+        // at write time is what catches it.
+        let mut graph = MemoryGraph::new();
+        let id = graph.add_node("ORGANIZATION").unwrap();
+        let (types, enums) = org_kind_types_and_enums();
+        let mut fuel = 64;
+        let err = collect_then_apply(
+            &mut graph,
+            &types,
+            &enums,
+            HashMap::from([("self".to_owned(), Value::NodeRef(id))]),
+            "(effects (update-node self organization/kind (set OrgKind/NOWHERE)))",
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::EnumWriteShapeViolation));
+        assert!(err.message.contains("NOWHERE"), "{}", err.message);
+    }
+
+    #[test]
+    fn an_enum_ref_write_into_a_non_enum_field_refuses_via_the_original_catchall() {
+        // The EXISTING catch-all in `numeric_write_value` — unchanged
+        // message — still fires for a non-enum field, proving the new
+        // branch is scoped to enum-declared fields only (`store field`
+        // has no enum in `types` here at all).
+        let mut graph = MemoryGraph::new();
+        let id = graph.add_node("SOCIAL_CLASS").unwrap();
+        let types = types();
+        let enums = enums();
+        let mut fuel = 64;
+        let err = collect_then_apply(
+            &mut graph,
+            &types,
+            &enums,
+            HashMap::from([("self".to_owned(), Value::NodeRef(id))]),
+            "(effects (update-node self social-class/head-count (set OrgKind/BUSINESS)))",
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("cannot store"),
+            "the ORIGINAL non-enum catch-all message must be unchanged: {}",
+            err.message
+        );
     }
 }

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -1253,4 +1253,35 @@ mod tests {
         assert!(message.contains("D102"), "{message}");
         assert!(message.contains("organization/kind"), "{message}");
     }
+
+    #[test]
+    fn arithmetic_on_an_enum_field_is_refused_at_load_not_left_to_die_mid_tick() {
+        // §2.13's no-arithmetic law is statically decidable (D118, #528
+        // fix round Item C) — before this task the only guards were the
+        // three EVAL-time ones (`structural_verbs.rs::
+        // refuse_arithmetic_on_enum_field`, c268b83b), so this exact rule
+        // shape loaded clean and died mid-tick, uncoded, on the first
+        // admitted subject. Drives `rule_pipeline::load_rule` (via
+        // `Fixture::try_load`), the actual production entry point — not
+        // `typecheck::check_no_arithmetic_on_enum_field` in isolation —
+        // proving the D118 load-time gate is REACHABLE, not merely
+        // correct, the same discipline the D102 test above uses for its
+        // sibling gap.
+        let fixture = org_kind_fixture();
+        let err = fixture
+            .try_load(
+                r#"(rule organization/kind-arithmetic-probe
+  :material-basis "add/sub/scale on an :enum-type-declared field is statically decidable and refused at load (D118), never left to die mid-tick"
+  :fuel 256
+  (bindings
+    (binding kind :field organization/kind))
+  (when #t)
+  (effects (update-node self organization/kind (add 1))))"#,
+                "organization/kind-arithmetic-probe.bsl",
+            )
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("D118"), "{message}");
+        assert!(message.contains("organization/kind"), "{message}");
+    }
 }

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -1284,4 +1284,39 @@ mod tests {
         assert!(message.contains("D118"), "{message}");
         assert!(message.contains("organization/kind"), "{message}");
     }
+
+    #[test]
+    fn a_slash_typo_in_emits_type_operand_is_refused_at_load_not_left_to_die_mid_tick() {
+        // `EventType_RUPTURE` (slash typo'd as underscore) lexes as
+        // `Atom::BareUpperIdent` since the §2.13 lexer widening (D101) —
+        // no load-time check enforced `emit`'s type-operand SHAPE before
+        // this task (#528 fix round Item D): the §3.7 static cost pass
+        // treats a `BareUpperIdent` atom identically to an `<enum-ref>`
+        // (cost 0, `bound_checker::atom_cost`), and `check_enum_ref_kinds`
+        // only checks the KIND of an enum-ref that is already there, so
+        // this exact rule loaded clean and died mid-tick, uncoded, at
+        // `structural_verbs.rs`'s own `enum_member`. `add-node`/
+        // `add-edge`'s SAME typo is separately caught in the full
+        // pipeline by `check_no_deferred_shape_verbs` (every rule using
+        // either verb is refused there regardless, #519 fix round) —
+        // `emit` carries no such second net, which is why it is the head
+        // this test drives through the real production pipeline
+        // (`rule_pipeline::load_rule`, via `Fixture::try_load`) rather
+        // than `add-node`/`add-edge`.
+        let fixture = org_kind_fixture();
+        let err = fixture
+            .try_load(
+                r#"(rule organization/emit-typo-probe
+  :material-basis "a slash typo in emit's type operand must refuse at load, not mid-tick (#528 fix round Item D)"
+  :fuel 64
+  (bindings)
+  (when #t)
+  (effects (emit EventType_RUPTURE (probe 1))))"#,
+                "organization/emit-typo-probe.bsl",
+            )
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("emit"), "{message}");
+        assert!(message.contains("BareUpperIdent"), "{message}");
+    }
 }

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -87,6 +87,7 @@ use crate::reader::{Atom, SExpr};
 use crate::rule_pipeline::LoadedRule;
 use crate::structural_verbs::{EffectExecutor, EventSink};
 use crate::typecheck::TypeEnv;
+use crate::types::EnumRegistry;
 use babylon_graph::substrate::{GraphSubstrate, NodeId};
 use std::collections::HashMap;
 
@@ -438,6 +439,7 @@ fn check_sources_servable(bindings: &[BindingDecl], defines: &DefinesEnv) -> Res
 pub fn run_tick(
     loaded: &LoadedRule,
     types: &TypeEnv,
+    enums: &EnumRegistry,
     host: &dyn IntrinsicHost,
     graph: &mut dyn GraphSubstrate,
     sink: &mut dyn EventSink,
@@ -506,7 +508,7 @@ pub fn run_tick(
             }
         }
 
-        let mut executor = EffectExecutor::new(types);
+        let mut executor = EffectExecutor::new(types, enums);
         let pending = executor.collect_effects(effects, &env, host, sink, &mut fuel)?;
         all_pending.extend(pending);
         fired += 1;
@@ -515,7 +517,7 @@ pub fn run_tick(
     // ---- Pass 2: apply, in the order collected (subject order outer,
     // source order inner) — `graph` is mutable again, the Pass-1 immutable
     // borrow having already ended. ----
-    let mut applier = EffectExecutor::new(types);
+    let mut applier = EffectExecutor::new(types, enums);
     for write in &all_pending {
         applier.apply_pending_write(write, graph)?;
     }
@@ -532,6 +534,7 @@ mod tests {
     use super::{check_sources_servable, run_tick, subject_type_of, DefinesEnv};
     use crate::bindings::{BindSource, BindingDecl};
     use crate::evaluator::Value;
+    use crate::types::EnumRegistry;
     use std::collections::HashMap;
     fn field(name: &str, qname: &str) -> BindingDecl {
         BindingDecl {
@@ -646,6 +649,10 @@ mod tests {
         ceilings: crate::fuel::CardinalityCeilings,
         intrinsics: crate::fuel::IntrinsicCosts,
         systems: std::collections::HashSet<String>,
+        /// No fixture in this module declares an enum-typed field — an
+        /// empty registry is the honest "no `defenum`s in scope" input to
+        /// `run_tick`.
+        enums: EnumRegistry,
     }
 
     impl Fixture {
@@ -668,6 +675,7 @@ mod tests {
                 ceilings: crate::fuel::CardinalityCeilings::new(edge_ceilings, HashMap::new()),
                 intrinsics: crate::fuel::IntrinsicCosts::default(),
                 systems: std::collections::HashSet::from(["geography".to_owned()]),
+                enums: EnumRegistry::default(),
             }
         }
 
@@ -747,6 +755,7 @@ mod tests {
         run_tick(
             &loaded,
             &fixture.types,
+            &fixture.enums,
             &crate::intrinsic_host::EmptyIntrinsicHost,
             &mut graph,
             &mut sink,
@@ -850,6 +859,7 @@ mod tests {
         let outcome = run_tick(
             &loaded,
             &fixture.types,
+            &fixture.enums,
             &crate::intrinsic_host::EmptyIntrinsicHost,
             &mut graph,
             &mut sink,

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -334,8 +334,30 @@ fn bind_field_value(
              (§2.13)"
         )));
     }
+    let member_count = enums.member_count(ty);
+    if member_count == 0 {
+        // `EnumRegistry::declare` refuses an empty member list
+        // (types.rs:126), so `member_count == 0` can only mean `ty` was
+        // never minted by THIS registry — a driver wiring bug (e.g. a
+        // `TypeEnv` resolved against one registry, handed to this
+        // function alongside a DIFFERENT one), never a legitimately empty
+        // `defenum`. Caught HERE, before the range check below folds it
+        // into `member_count as f64`: `stored >= 0.0` is true for every
+        // non-negative stored value already accepted above, so every one
+        // of them would otherwise silently reach the range-error branch's
+        // `enums.name(ty)` call — an out-of-bounds index PANIC for a `ty`
+        // this registry never minted (`EnumRegistry::name`'s own doc
+        // names this exact caller-bug shape). #528 fix round Item A
+        // (Copilot finding, confirmed real).
+        return Err(err(format!(
+            "field {qname}: enum type id {} was not minted by the \
+             executing registry — a driver wiring bug, not a content \
+             error (§2.13)",
+            ty.0
+        )));
+    }
     #[allow(clippy::cast_precision_loss)]
-    let member_count = enums.member_count(ty) as f64;
+    let member_count = member_count as f64;
     if stored >= member_count {
         return Err(err(format!(
             "field {qname}: the stored ordinal {stored} is outside \
@@ -602,7 +624,7 @@ pub fn run_tick(
 
 #[cfg(test)]
 mod tests {
-    use super::{check_sources_servable, run_tick, subject_type_of, DefinesEnv};
+    use super::{bind_field_value, check_sources_servable, run_tick, subject_type_of, DefinesEnv};
     use crate::bindings::{BindSource, BindingDecl};
     use crate::evaluator::Value;
     use crate::types::EnumRegistry;
@@ -1161,6 +1183,50 @@ mod tests {
             err.to_string().contains('2'),
             "must name the [0, member_count) bound: {err}"
         );
+    }
+
+    #[test]
+    fn an_enum_type_id_not_minted_by_the_executing_registry_is_a_loud_error_not_a_panic() {
+        // Copilot finding, confirmed real (#528 fix round Item A). Two
+        // INDEPENDENT registries: `home` mints `OrgKind` (its only entry,
+        // index 0); `stranger` is empty. A `ty` resolved against `home`,
+        // handed to `bind_field_value` alongside `stranger` — a driver
+        // wiring bug, e.g. a `TypeEnv` built against one content set's
+        // registry paired with a DIFFERENT tick's `EnumRegistry` — is
+        // exactly the mismatch this test proves loud: `EnumRegistry::
+        // declare` refuses an empty member list (types.rs:126), so
+        // `stranger.member_count(ty) == 0` can only mean "ty was never
+        // minted by this registry", never a legitimately empty `defenum`.
+        // Pre-fix, `member_count == 0` let ANY non-negative stored ordinal
+        // (0.0 here) satisfy `stored >= member_count` and reach
+        // `stranger.name(ty)` — an out-of-bounds index PANIC
+        // (`EnumRegistry::name`'s own doc names this exact caller-bug
+        // shape). Post-fix this is a loud `TickError` instead.
+        let mut home = EnumRegistry::default();
+        let ty = home
+            .declare(
+                "OrgKind",
+                &["STATE_APPARATUS".to_owned(), "BUSINESS".to_owned()],
+            )
+            .unwrap();
+        let stranger = EnumRegistry::default();
+
+        let types = crate::typecheck::TypeEnv {
+            fields: HashMap::from([(
+                "organization/kind".to_owned(),
+                crate::types::FieldDecl {
+                    ty: crate::types::BslType::Enum(ty),
+                    kind: crate::types::FieldKind::NotApplicable,
+                },
+            )]),
+            exemptions: &[],
+        };
+
+        let err = bind_field_value("organization/kind", 0.0, &types, &stranger).expect_err(
+            "a ty not minted by the executing registry must refuse loudly, never panic",
+        );
+        assert!(err.message.contains("not minted"), "{}", err.message);
+        assert!(err.message.contains("organization/kind"), "{}", err.message);
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -87,7 +87,7 @@ use crate::reader::{Atom, SExpr};
 use crate::rule_pipeline::LoadedRule;
 use crate::structural_verbs::{EffectExecutor, EventSink};
 use crate::typecheck::TypeEnv;
-use crate::types::EnumRegistry;
+use crate::types::{BslType, EnumRegistry};
 use babylon_graph::substrate::{GraphSubstrate, NodeId};
 use std::collections::HashMap;
 
@@ -221,6 +221,8 @@ fn bind_subject(
     graph: &dyn GraphSubstrate,
     defines: &DefinesEnv,
     tick: i64,
+    types: &TypeEnv,
+    enums: &EnumRegistry,
 ) -> Result<HashMap<String, Value>, TickError> {
     let mut env = HashMap::from([("self".to_owned(), Value::NodeRef(subject))]);
     for binding in bindings {
@@ -274,7 +276,7 @@ fn bind_subject(
             }
         };
         let value = match graph.node_attribute(subject, qname) {
-            Ok(value) => Value::Real(value),
+            Ok(value) => bind_field_value(qname, value, types, enums)?,
             Err(graph_err) => {
                 let Some(default) = binding.default.as_ref().filter(|_| binding.optional) else {
                     return Err(err(format!("subject {subject:?}: {}", graph_err.message)));
@@ -290,6 +292,67 @@ fn bind_subject(
         env.insert(binding.name.clone(), value);
     }
     Ok(env)
+}
+
+/// **§2.13 addendum (D101).** Render one stored field value through its
+/// declared type. Every non-enum field is unchanged: `Value::Real(stored)`,
+/// exactly as before this section existed. An `enum`-declared field's
+/// stored ordinal is rendered back to its member as a `Value::Enum` — the
+/// write/read law's read half (§2.13): a `when` guard or any other
+/// comparison always compares members, never an ordinal a rule author
+/// could confuse for magnitude.
+///
+/// A stored value that fails to round-trip against the field's declared
+/// type — non-integral, negative, or `>=` the type's member count — is a
+/// LOUD integrity failure, never a clamp and never a silently-substituted
+/// default member (Constitution III.11 binds a corrupted store exactly as
+/// it binds a malformed load). This is the one place a write bug elsewhere
+/// (or a hand-corrupted store, exercised by this task's own mutation-style
+/// integrity test) would surface.
+fn bind_field_value(
+    qname: &str,
+    stored: f64,
+    types: &TypeEnv,
+    enums: &EnumRegistry,
+) -> Result<Value, TickError> {
+    let Some(decl) = types.fields.get(qname) else {
+        // Unregistered field: unchanged behavior. `resolve_bindings`
+        // already rejects an unknown qname at load (E-LOAD-010); reaching
+        // here with one is a driver wiring bug, not content's fault — the
+        // SAME "defense in depth, not a reachable content error" shape
+        // `scenario.rs::attribute_value`'s own catch-all documents.
+        return Ok(Value::Real(stored));
+    };
+    let BslType::Enum(ty) = decl.ty else {
+        return Ok(Value::Real(stored));
+    };
+    if !stored.is_finite() || stored.fract() != 0.0 || stored < 0.0 {
+        return Err(err(format!(
+            "field {qname}: the stored value {stored} is not a valid enum \
+             ordinal (non-integral or negative) — a loud integrity failure, \
+             never a clamp and never a silently-substituted default member \
+             (§2.13)"
+        )));
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let member_count = enums.member_count(ty) as f64;
+    if stored >= member_count {
+        return Err(err(format!(
+            "field {qname}: the stored ordinal {stored} is outside \
+             {}'s [0, {member_count}) member range — a loud integrity \
+             failure, never a clamp (§2.13)",
+            enums.name(ty)
+        )));
+    }
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let ordinal = stored as u32;
+    let member = enums
+        .member(ty, ordinal)
+        .expect("range-checked against enums' own member_count above");
+    Ok(Value::Enum {
+        enum_type: enums.name(ty).to_owned(),
+        member: member.to_owned(),
+    })
 }
 
 fn atom_to_value(atom: &Atom) -> Option<Value> {
@@ -457,7 +520,15 @@ pub fn run_tick(
     // ---- Pass 1: collect, against the SAME pre-tick state for every
     // subject (`graph` is never mutated in this loop). ----
     for subject in &subjects {
-        let mut values = bind_subject(*subject, &loaded.bindings, &*graph, defines, tick)?;
+        let mut values = bind_subject(
+            *subject,
+            &loaded.bindings,
+            &*graph,
+            defines,
+            tick,
+            types,
+            enums,
+        )?;
         // Per-subject budget, from the rule's DECLARED `:fuel` — not from
         // `static_bound`, which is the load-time proof that the rule fits
         // rather than the allowance it runs under. Metering on the computed
@@ -680,6 +751,20 @@ mod tests {
         }
 
         fn load(&self, rule_source: &str, rule_file: &str) -> crate::rule_pipeline::LoadedRule {
+            self.try_load(rule_source, rule_file)
+                .expect("the rule must pass every load gate")
+        }
+
+        /// The non-panicking half of [`Self::load`] — for a test proving a
+        /// rule is REFUSED at load (§2.13's `field-of` deferral, D102),
+        /// driving the actual production entry point
+        /// (`rule_pipeline::load_rule`), not `check_no_field_of_on_enum_field`
+        /// in isolation.
+        fn try_load(
+            &self,
+            rule_source: &str,
+            rule_file: &str,
+        ) -> Result<crate::rule_pipeline::LoadedRule, crate::rule_pipeline::LoadError> {
             let ctx = crate::rule_pipeline::LoadContext {
                 vocabulary: &self.vocabulary,
                 types: &self.types,
@@ -690,7 +775,6 @@ mod tests {
                 rule_file,
             };
             crate::rule_pipeline::load_rule(rule_source, &ctx)
-                .expect("the rule must pass every load gate")
         }
     }
 
@@ -886,5 +970,221 @@ mod tests {
              distinguishes this triple from the symmetric one it replaces, \
              got {pool}"
         );
+    }
+
+    // ================================================== §2.13 (D101): the
+    // read path — `bind_subject` renders the stored ordinal back to its
+    // member (Task 6, Organization foundation plan).
+
+    /// A two-member `OrgKind` registry plus the matching `TypeEnv`/`Fixture`.
+    /// `Fixture::new` always seeds an EMPTY `EnumRegistry` (no fixture in
+    /// this module needs one before this section) — overwritten here with
+    /// the populated one, and `systems` widened to `"organization"` so the
+    /// probe rule's anchor default resolves.
+    fn org_kind_fixture() -> Fixture {
+        let mut enums = EnumRegistry::default();
+        let ty = enums
+            .declare(
+                "OrgKind",
+                &["STATE_APPARATUS".to_owned(), "BUSINESS".to_owned()],
+            )
+            .unwrap();
+        let mut fixture = Fixture::new(
+            HashMap::from([(
+                "organization/kind".to_owned(),
+                crate::types::FieldDecl {
+                    ty: crate::types::BslType::Enum(ty),
+                    kind: crate::types::FieldKind::NotApplicable,
+                },
+            )]),
+            HashMap::from([("NodeType/ORGANIZATION".to_owned(), 100)]),
+        );
+        fixture.enums = enums;
+        fixture.systems = std::collections::HashSet::from(["organization".to_owned()]);
+        fixture
+    }
+
+    #[test]
+    fn a_when_guard_comparing_the_bound_enum_field_fires_only_for_the_matching_member() {
+        use babylon_graph::memory::MemoryGraph;
+        use babylon_graph::substrate::GraphSubstrate;
+
+        let mut graph = MemoryGraph::new();
+        // Declaration-order ordinals: STATE_APPARATUS=0, BUSINESS=1.
+        let state_org = graph.add_node("ORGANIZATION").unwrap();
+        graph
+            .update_node(state_org, "organization/kind", 0.0)
+            .unwrap();
+        let biz_org = graph.add_node("ORGANIZATION").unwrap();
+        graph
+            .update_node(biz_org, "organization/kind", 1.0)
+            .unwrap();
+
+        let fixture = org_kind_fixture();
+        let loaded = fixture.load(
+            r#"
+(rule organization/kind-probe
+  :material-basis "the state's coercive organs are a distinct material kind; content can see the difference (spec Q1)"
+  :fuel 64
+  (bindings
+    (binding kind :field organization/kind))
+  (when (= kind OrgKind/STATE_APPARATUS))
+  (effects
+    (emit EventType/RUPTURE (probe 1))))
+"#,
+            "organization/kind-probe.bsl",
+        );
+
+        let mut sink = crate::structural_verbs::CollectingSink::default();
+        let outcome = run_tick(
+            &loaded,
+            &fixture.types,
+            &fixture.enums,
+            &crate::intrinsic_host::EmptyIntrinsicHost,
+            &mut graph,
+            &mut sink,
+            &fixture.intrinsics,
+            &DefinesEnv::new(),
+            1,
+        )
+        .expect("the tick must run");
+        assert_eq!(outcome.considered, 2, "both organizations are subjects");
+        assert_eq!(
+            outcome.fired, 1,
+            "the guard must discriminate — only the STATE_APPARATUS org matches"
+        );
+        assert_eq!(sink.events.len(), 1);
+    }
+
+    #[test]
+    fn ordering_on_a_bound_enum_field_refuses_naming_the_law() {
+        // Proves no `Real` leaks through the read path. Deliberately
+        // compares against a BARE NUMBER, not another enum-ref: comparing
+        // to `OrgKind/BUSINESS` would hit `apply_ordering`'s generic
+        // fallback (its message never depends on the LHS's actual runtime
+        // type) whether `kind` rendered as `Real` or `Enum` — a mutation
+        // check caught this the first time this test was written (see the
+        // Task-6 commit body). `Int` DOES promote into the binary64 lane
+        // (§3.3), so if `bind_subject` still rendered `Value::Real(0.0)`
+        // this comparison would SILENTLY SUCCEED (0.0 < 5) instead of
+        // refusing — the exact confusion §2.13's write/read law exists to
+        // prevent ("never an ordinal a rule author could confuse for
+        // magnitude"). Only the correct `Value::Enum` rendering makes this
+        // load-bearing-ly refuse.
+        use babylon_graph::memory::MemoryGraph;
+        use babylon_graph::substrate::GraphSubstrate;
+
+        let mut graph = MemoryGraph::new();
+        let org = graph.add_node("ORGANIZATION").unwrap();
+        graph.update_node(org, "organization/kind", 0.0).unwrap();
+
+        let fixture = org_kind_fixture();
+        let loaded = fixture.load(
+            r#"
+(rule organization/kind-ordering-probe
+  :material-basis "an enum has no ordering — this rule must never load-succeed AND run-succeed"
+  :fuel 64
+  (bindings
+    (binding kind :field organization/kind))
+  (when (< kind 5))
+  (effects
+    (emit EventType/RUPTURE (probe 1))))
+"#,
+            "organization/kind-ordering-probe.bsl",
+        );
+
+        let mut sink = crate::structural_verbs::CollectingSink::default();
+        let err = run_tick(
+            &loaded,
+            &fixture.types,
+            &fixture.enums,
+            &crate::intrinsic_host::EmptyIntrinsicHost,
+            &mut graph,
+            &mut sink,
+            &fixture.intrinsics,
+            &DefinesEnv::new(),
+            1,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Enum and Bool compare with =/!= alone"),
+            "the EXISTING apply_ordering message must fire unchanged: {err}"
+        );
+    }
+
+    #[test]
+    fn a_corrupted_stored_ordinal_is_a_loud_integrity_error_naming_the_field_and_member_count() {
+        // A hand-corrupted store (never reachable through the enum write
+        // path Task 5 built) — the read boundary's own defense, never a
+        // clamp and never a silently-substituted default member (III.11).
+        use babylon_graph::memory::MemoryGraph;
+        use babylon_graph::substrate::GraphSubstrate;
+
+        let mut graph = MemoryGraph::new();
+        let org = graph.add_node("ORGANIZATION").unwrap();
+        // OrgKind here declares only 2 members (ordinals 0, 1) — 7.0 is
+        // corrupt no matter which write path could have produced it.
+        graph.update_node(org, "organization/kind", 7.0).unwrap();
+
+        let fixture = org_kind_fixture();
+        let loaded = fixture.load(
+            r#"
+(rule organization/kind-integrity-probe
+  :material-basis "a corrupted store is a loud read-boundary failure, never a clamp"
+  :fuel 64
+  (bindings
+    (binding kind :field organization/kind))
+  (when #t)
+  (effects
+    (emit EventType/RUPTURE (probe 1))))
+"#,
+            "organization/kind-integrity-probe.bsl",
+        );
+
+        let mut sink = crate::structural_verbs::CollectingSink::default();
+        let err = run_tick(
+            &loaded,
+            &fixture.types,
+            &fixture.enums,
+            &crate::intrinsic_host::EmptyIntrinsicHost,
+            &mut graph,
+            &mut sink,
+            &fixture.intrinsics,
+            &DefinesEnv::new(),
+            1,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("organization/kind"), "{err}");
+        assert!(err.to_string().contains('7'), "{err}");
+        assert!(
+            err.to_string().contains('2'),
+            "must name the [0, member_count) bound: {err}"
+        );
+    }
+
+    #[test]
+    fn a_rule_using_field_of_over_an_enum_field_is_refused_at_load_by_the_real_pipeline() {
+        // Drives `rule_pipeline::load_rule` — the actual production entry
+        // point (`Fixture::try_load`) — not `typecheck::
+        // check_no_field_of_on_enum_field` in isolation (that function has
+        // its own focused unit tests in typecheck.rs). Proves the D102
+        // gate wired into `load_rule_form` is REACHABLE, not merely
+        // correct.
+        let fixture = org_kind_fixture();
+        let err = fixture
+            .try_load(
+                r#"(rule organization/field-of-probe
+  :material-basis "field-of is not extended to enum-declared fields (D102)"
+  :fuel 64
+  (bindings)
+  (when (= (field-of self organization/kind) OrgKind/BUSINESS))
+  (effects (emit EventType/RUPTURE (probe 1))))"#,
+                "organization/field-of-probe.bsl",
+            )
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("D102"), "{message}");
+        assert!(message.contains("organization/kind"), "{message}");
     }
 }

--- a/rust/crates/babylon-bsl/src/typecheck.rs
+++ b/rust/crates/babylon-bsl/src/typecheck.rs
@@ -225,6 +225,58 @@ pub fn check_reference_comparisons(
     walk_typed(expr, env, bindings, &HashMap::new(), Check::References)
 }
 
+/// **§2.13's `field-of` deferral (D101/D102, Organization spec §1 Q12).**
+/// An `:enum-type`-declared field is read through a `:field` binding
+/// exactly as any other node field is (§2.5); this is NOT extended to
+/// §2.10's `field-of` accessor. A `field-of` naming an enum-declared field
+/// refuses, loudly, citing D102 — deferred, not forbidden: an
+/// enum-declared EDGE or HYPEREDGE field (this document does not rule one
+/// out) would need `field-of` access precisely because it has no single
+/// owning body to bind a `:field` against, and building that accessor is
+/// left to whichever revision first has one.
+///
+/// This is a LOAD-time check (unlike Task 5's runtime write re-check):
+/// whether a `qname` is enum-declared is a static, content-only fact, so
+/// catching this before any tick executes matches §3's own law ("every
+/// check in this chapter runs at content load") rather than deferring an
+/// always-wrong construct to a runtime surprise on the first admitted
+/// subject.
+///
+/// # Errors
+///
+/// A structural [`TypeError`] (`code: None` — D102 mints no error code;
+/// this is a deferred gap, not a new failure class with its own number).
+pub fn check_no_field_of_on_enum_field(expr: &SExpr, env: &TypeEnv) -> Result<(), TypeError> {
+    if let SExpr::List(items) = expr {
+        if let [SExpr::Atom(Atom::Symbol(head)), _referent, SExpr::Atom(Atom::QName(qname))] =
+            items.as_slice()
+        {
+            if head == "field-of" {
+                if let Some(decl) = env.fields.get(qname) {
+                    if matches!(decl.ty, BslType::Enum(_)) {
+                        return Err(TypeError {
+                            code: None,
+                            message: format!(
+                                "field-of {qname}: an :enum-type-declared field is read \
+                                 via a :field binding only (§2.5) — field-of is not \
+                                 extended to enum-declared fields (§2.13, D102). The gap \
+                                 is deferred, not forbidden: an enum-declared edge or \
+                                 hyperedge field would need field-of for exactly the \
+                                 reason §2.10 exists, and building that path is left to \
+                                 whichever revision first has one"
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+        for child in items {
+            check_no_field_of_on_enum_field(child, env)?;
+        }
+    }
+    Ok(())
+}
+
 /// Which §2 rule the shared walker is applying. Both need the same thing —
 /// the classes of the element names in scope at each node — and computing
 /// that twice in two walkers is how the empty-map defect survived.
@@ -556,5 +608,60 @@ mod tests {
         assert!(check("wealth", &env()).is_err());
         assert!(check("(mean)", &env()).is_err());
         assert!(check("(mean wealth-share :weight)", &env()).is_err());
+    }
+
+    // ---- §2.13's field-of deferral (D101/D102, Organization spec §1 Q12) ----
+
+    fn org_env() -> TypeEnv {
+        let mut registry = crate::types::EnumRegistry::default();
+        let ty = registry
+            .declare(
+                "OrgKind",
+                &["STATE_APPARATUS".to_owned(), "BUSINESS".to_owned()],
+            )
+            .unwrap();
+        TypeEnv {
+            fields: HashMap::from([
+                (
+                    "organization/kind".to_owned(),
+                    FieldDecl {
+                        ty: BslType::Enum(ty),
+                        kind: FieldKind::NotApplicable,
+                    },
+                ),
+                (
+                    "organization/budget".to_owned(),
+                    FieldDecl {
+                        ty: BslType::Currency,
+                        kind: FieldKind::Extensive,
+                    },
+                ),
+            ]),
+            exemptions: &[],
+        }
+    }
+
+    #[test]
+    fn field_of_over_an_enum_declared_field_refuses_citing_d102() {
+        let (expr, _) = read("(field-of self organization/kind)").expect("must parse");
+        let err = super::check_no_field_of_on_enum_field(&expr, &org_env()).unwrap_err();
+        assert_eq!(err.code, None, "D102 mints no error code");
+        assert!(err.message.contains("D102"), "{}", err.message);
+        assert!(err.message.contains("organization/kind"), "{}", err.message);
+    }
+
+    #[test]
+    fn field_of_over_a_non_enum_field_is_untouched() {
+        let (expr, _) = read("(field-of self organization/budget)").expect("must parse");
+        assert!(super::check_no_field_of_on_enum_field(&expr, &org_env()).is_ok());
+    }
+
+    #[test]
+    fn field_of_over_an_enum_field_nested_inside_another_form_still_refuses() {
+        // The walk must recurse into (and/if/fold/…) bodies, not just the
+        // top-level form.
+        let (expr, _) = read("(and #t (= (field-of self organization/kind) OrgKind/BUSINESS))")
+            .expect("must parse");
+        assert!(super::check_no_field_of_on_enum_field(&expr, &org_env()).is_err());
     }
 }

--- a/rust/crates/babylon-bsl/src/typecheck.rs
+++ b/rust/crates/babylon-bsl/src/typecheck.rs
@@ -277,6 +277,70 @@ pub fn check_no_field_of_on_enum_field(expr: &SExpr, env: &TypeEnv) -> Result<()
     Ok(())
 }
 
+/// **§2.13's no-arithmetic law (D101), the static half (D118, #528 fix
+/// round Item C).** `Enum<T>` supports no arithmetic (§2.13, §3.1) — an
+/// `add`/`sub`/`scale` `update-op` targeting an `:enum-type`-declared
+/// field is a coherence violation the field's declared type and the
+/// op's own symbol already decide, in full, from content alone. Before
+/// this function the only guards were THREE eval-time ones
+/// (`structural_verbs.rs::refuse_arithmetic_on_enum_field`, `c268b83b`),
+/// so a rule shaped exactly like this check's own red-test content
+/// loaded clean and died mid-tick on the first admitted subject — the
+/// same "always-wrong construct deferred to a runtime surprise" shape
+/// [`check_no_field_of_on_enum_field`]'s own doc names for its sibling
+/// gap, and the same static-decidability argument as `rule_pipeline.rs`
+/// D102 wiring: §3's own law is "every check in this chapter runs at
+/// content load, before any tick executes."
+///
+/// The three eval-time guards STAY, unchanged, as defense in depth
+/// (the same two-site discipline `refuse_arithmetic_on_enum_field`'s own
+/// doc already names for its three call sites) — this function only
+/// moves the FIRST catch earlier, from the first admitted subject to
+/// load.
+///
+/// # Errors
+///
+/// A structural [`TypeError`] (`code: None` — same precedent
+/// [`check_no_field_of_on_enum_field`] already sets: E-EVAL-042 already
+/// covers this refusal at evaluation, D118, so this is a
+/// static-decidability repair, not a new failure class).
+pub fn check_no_arithmetic_on_enum_field(expr: &SExpr, env: &TypeEnv) -> Result<(), TypeError> {
+    if let SExpr::List(items) = expr {
+        if let [SExpr::Atom(Atom::Symbol(head)), _node, SExpr::Atom(Atom::QName(qname)), SExpr::List(op_items)] =
+            items.as_slice()
+        {
+            if head == "update-node" {
+                if let [SExpr::Atom(Atom::Symbol(op)), _operand] = op_items.as_slice() {
+                    if matches!(op.as_str(), "add" | "sub" | "scale") {
+                        if let Some(decl) = env.fields.get(qname) {
+                            if matches!(decl.ty, BslType::Enum(_)) {
+                                return Err(TypeError {
+                                    code: None,
+                                    message: format!(
+                                        "update-node {qname}: ({op} …) is not a coherent \
+                                         operation on an enum-typed field — Enum<T> \
+                                         supports no arithmetic (§2.13, D118); only `set` \
+                                         may write it. Statically decidable from the \
+                                         field's declared type and this op's own symbol \
+                                         — refused here, at load, rather than left to die \
+                                         mid-tick on the first admitted subject (§3's own \
+                                         law: every check in this chapter runs at content \
+                                         load)"
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        for child in items {
+            check_no_arithmetic_on_enum_field(child, env)?;
+        }
+    }
+    Ok(())
+}
+
 /// Which §2 rule the shared walker is applying. Both need the same thing —
 /// the classes of the element names in scope at each node — and computing
 /// that twice in two walkers is how the empty-map defect survived.
@@ -663,5 +727,57 @@ mod tests {
         let (expr, _) = read("(and #t (= (field-of self organization/kind) OrgKind/BUSINESS))")
             .expect("must parse");
         assert!(super::check_no_field_of_on_enum_field(&expr, &org_env()).is_err());
+    }
+
+    // ---- §2.13's no-arithmetic law, the static half (D118, #528 fix
+    // round Item C) ----
+
+    #[test]
+    fn add_on_an_enum_declared_field_refuses_citing_d118() {
+        let (expr, _) = read("(update-node self organization/kind (add 1))").expect("must parse");
+        let err = super::check_no_arithmetic_on_enum_field(&expr, &org_env()).unwrap_err();
+        assert_eq!(
+            err.code, None,
+            "D118 mints no error code — E-EVAL-042 already covers it"
+        );
+        assert!(err.message.contains("D118"), "{}", err.message);
+        assert!(err.message.contains("organization/kind"), "{}", err.message);
+    }
+
+    #[test]
+    fn sub_and_scale_on_an_enum_declared_field_both_refuse() {
+        for op in ["sub", "scale"] {
+            let source = format!("(update-node self organization/kind ({op} 1))");
+            let (expr, _) = read(&source).expect("must parse");
+            assert!(
+                super::check_no_arithmetic_on_enum_field(&expr, &org_env()).is_err(),
+                "{op} must refuse"
+            );
+        }
+    }
+
+    #[test]
+    fn set_on_an_enum_declared_field_is_untouched() {
+        // `set` is the ONE coherent op on an enum field (§2.13) — the
+        // guard must never widen to refuse it.
+        let (expr, _) = read("(update-node self organization/kind (set OrgKind/BUSINESS))")
+            .expect("must parse");
+        assert!(super::check_no_arithmetic_on_enum_field(&expr, &org_env()).is_ok());
+    }
+
+    #[test]
+    fn add_on_a_non_enum_field_is_untouched() {
+        let (expr, _) =
+            read("(update-node self organization/budget (add 5$))").expect("must parse");
+        assert!(super::check_no_arithmetic_on_enum_field(&expr, &org_env()).is_ok());
+    }
+
+    #[test]
+    fn add_on_an_enum_field_nested_inside_a_guard_still_refuses() {
+        // The walk must recurse into (guard/for-each/…) effect bodies, not
+        // just the top-level effect item.
+        let (expr, _) =
+            read("(guard #t (update-node self organization/kind (add 1)))").expect("must parse");
+        assert!(super::check_no_arithmetic_on_enum_field(&expr, &org_env()).is_err());
     }
 }

--- a/rust/crates/babylon-bsl/src/types.rs
+++ b/rust/crates/babylon-bsl/src/types.rs
@@ -6,6 +6,208 @@
 //! (Intensity) is intensive, and no type makes that decidable. `FieldKind`
 //! therefore travels alongside a field's `BslType`, and the typechecker
 //! (not the type) enforces the aggregation law.
+//!
+//! **§2.13 addendum (Director ruling 2026-08-11, Organization-as-game-object
+//! spec §1 Q12 — approved twice, live popup and written spec review; D101).**
+//! `BslType::Enum` widens from a bare `&'static str` name to an
+//! [`EnumTypeId`] — a content-declared closed `defenum` type, stored as the
+//! declared-order ordinal in the existing binary64 attribute lane. The
+//! ordinal is never a surface value: written and read only as an
+//! `<EnumType>/<MEMBER>` enum-ref (§1.4), comparable with `=`/`!=` only.
+//! [`EnumRegistry`] is the registry backing it — deliberately NOT
+//! [`crate::vocabulary::ClosedVocabulary`], which sorts-and-dedups its
+//! members by design (`vocabulary.rs`): correct for a set with no ordinal
+//! to preserve, and wrong for one where declaration order IS the stored
+//! value (bsl-language.rst §2.13).
+
+/// A closed `defenum` type's identity within one [`EnumRegistry`] — the
+/// registry's own index, `Copy` so it travels through `BslType`/`FieldDecl`
+/// exactly as freely as any other scalar type tag.
+///
+/// An `EnumTypeId` is only ever meaningful against the [`EnumRegistry`]
+/// that minted it (`EnumRegistry::declare`'s return value) — using one
+/// against a DIFFERENT registry instance is a caller bug, the same
+/// out-of-band-identity risk `babylon_graph`'s own id newtypes (`NodeId`,
+/// …) already carry and document there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EnumTypeId(pub u32);
+
+/// One `defenum` declaration: its type name and its members, in the
+/// **declaration order** that is normative (bsl-language.rst §2.13: "member
+/// order inside a `defenum` is normative — it is the ordinal §3.1's `enum`
+/// row stores").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnumDecl {
+    /// The `defenum` type name, e.g. `"OrgKind"`.
+    pub name: String,
+    /// The declared members, in declaration order — index `i` IS ordinal
+    /// `i` (§3.1's `enum` row).
+    pub members: Vec<String>,
+}
+
+/// A `defenum` declaration-time rejection (§2.13). Reused, not reinvented:
+/// wrapped by [`crate::declarations::DeclError`] via `From`, which is what
+/// assigns the spec code — this type carries no code of its own, matching
+/// [`crate::vocabulary::VocabularyError`]'s own layering (a lower-layer
+/// module states WHAT went wrong; the higher-layer caller states which
+/// spec code that is, since the same underlying shape can serve different
+/// codes at different call sites).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnumRegistryError {
+    /// A `defenum` type name declared twice in one content set.
+    DuplicateType {
+        /// The offending type name.
+        name: String,
+    },
+    /// A member repeated within one `defenum` declaration.
+    DuplicateMember {
+        /// The declaring type name.
+        name: String,
+        /// The repeated member.
+        member: String,
+    },
+    /// A `defenum` with zero members — the grammar's `<enum-member>+`
+    /// (bsl.ebnf, §2.13) is one-or-more, never zero.
+    EmptyMemberList {
+        /// The offending type name.
+        name: String,
+    },
+}
+
+impl std::fmt::Display for EnumRegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DuplicateType { name } => {
+                write!(f, "duplicate defenum type name: {name}")
+            }
+            Self::DuplicateMember { name, member } => {
+                write!(f, "defenum {name}: member {member} declared twice")
+            }
+            Self::EmptyMemberList { name } => write!(
+                f,
+                "defenum {name}: at least one member is required (§2.13's \
+                 <enum-member>+ is one-or-more, never zero)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EnumRegistryError {}
+
+/// The content-declared closed-enum registry (§2.13, D101) — every
+/// `defenum` type one content set declared, keyed by [`EnumTypeId`].
+///
+/// A plain `Vec`, deliberately: declaration order IS the storage (the
+/// registry's own index doubles as the ordinal §3.1's `enum` row persists),
+/// so nothing here may reorder or deduplicate-by-sort the way
+/// [`crate::vocabulary::ClosedVocabulary`] does for the structural kinds —
+/// see this module's own header. Member lookup is a linear scan; a
+/// `defenum`'s member count is a handful by construction (four for
+/// `OrgKind`'s worked example), so this is not a hot path.
+#[derive(Debug, Clone, Default)]
+pub struct EnumRegistry {
+    types: Vec<EnumDecl>,
+}
+
+impl EnumRegistry {
+    /// Declare one `defenum` type. Rejects a duplicate type name, a
+    /// duplicate member within the same declaration, and an empty member
+    /// list — never silently drops or reorders.
+    ///
+    /// # Errors
+    ///
+    /// [`EnumRegistryError::EmptyMemberList`] / [`EnumRegistryError::DuplicateType`]
+    /// / [`EnumRegistryError::DuplicateMember`].
+    pub fn declare(
+        &mut self,
+        name: &str,
+        members: &[String],
+    ) -> Result<EnumTypeId, EnumRegistryError> {
+        if members.is_empty() {
+            return Err(EnumRegistryError::EmptyMemberList {
+                name: name.to_owned(),
+            });
+        }
+        if self.types.iter().any(|d| d.name == name) {
+            return Err(EnumRegistryError::DuplicateType {
+                name: name.to_owned(),
+            });
+        }
+        let mut seen: Vec<&str> = Vec::with_capacity(members.len());
+        for member in members {
+            if seen.contains(&member.as_str()) {
+                return Err(EnumRegistryError::DuplicateMember {
+                    name: name.to_owned(),
+                    member: member.clone(),
+                });
+            }
+            seen.push(member.as_str());
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        let id = EnumTypeId(self.types.len() as u32);
+        self.types.push(EnumDecl {
+            name: name.to_owned(),
+            members: members.to_vec(),
+        });
+        Ok(id)
+    }
+
+    /// Resolve a `defenum` type name to its id.
+    #[must_use]
+    pub fn resolve(&self, name: &str) -> Option<EnumTypeId> {
+        self.types.iter().position(|d| d.name == name).map(|i| {
+            #[allow(clippy::cast_possible_truncation)]
+            let id = i as u32;
+            EnumTypeId(id)
+        })
+    }
+
+    /// The declared-order ordinal of `member` within `ty` — the value
+    /// §3.1's `enum` row stores in the binary64 attribute lane.
+    #[must_use]
+    pub fn ordinal(&self, ty: EnumTypeId, member: &str) -> Option<u32> {
+        let decl = self.types.get(ty.0 as usize)?;
+        decl.members.iter().position(|m| m == member).map(|i| {
+            #[allow(clippy::cast_possible_truncation)]
+            let ordinal = i as u32;
+            ordinal
+        })
+    }
+
+    /// The member name at `ordinal` within `ty` — the read-path inverse of
+    /// [`Self::ordinal`], rendering a stored ordinal back to its member
+    /// (§2.13's write/read law: a read renders the member, never a bare
+    /// number).
+    #[must_use]
+    pub fn member(&self, ty: EnumTypeId, ordinal: u32) -> Option<&str> {
+        self.types
+            .get(ty.0 as usize)?
+            .members
+            .get(ordinal as usize)
+            .map(String::as_str)
+    }
+
+    /// How many members `ty` declares — the read-path integrity check's
+    /// upper bound (a stored ordinal outside `[0, member_count)` is a loud
+    /// integrity failure, §2.13).
+    #[must_use]
+    pub fn member_count(&self, ty: EnumTypeId) -> usize {
+        self.types.get(ty.0 as usize).map_or(0, |d| d.members.len())
+    }
+
+    /// The type name of `ty`.
+    ///
+    /// # Panics
+    ///
+    /// If `ty` was not minted by THIS registry (see [`EnumTypeId`]'s own
+    /// doc) — a caller bug, not a content error; every legitimate `ty` in
+    /// circulation was resolved through [`Self::resolve`]/[`Self::declare`]
+    /// against this same registry.
+    #[must_use]
+    pub fn name(&self, ty: EnumTypeId) -> &str {
+        &self.types[ty.0 as usize].name
+    }
+}
 
 /// A BSL static type.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,8 +224,12 @@ pub enum BslType {
     Int,
     /// `#t` / `#f`.
     Bool,
-    /// A closed enum, by its registered type name (e.g. `"DoctrineTag"`).
-    Enum(&'static str),
+    /// A member of a content-declared closed `defenum` type (§2.13, D101)
+    /// — the declared-order ordinal, stored in the binary64 attribute lane,
+    /// surfaced only as an `<EnumType>/<MEMBER>` enum-ref. Comparable with
+    /// `=`/`!=` only, and only to the same [`EnumTypeId`]; carries no
+    /// aggregation kind (§2.9, §3.4).
+    Enum(EnumTypeId),
     /// A typed node-set reference, by `NodeType` name.
     NodeSet(&'static str),
     /// A typed edge-set reference, by `EdgeType` name.
@@ -37,6 +243,14 @@ pub enum FieldKind {
     Intensive,
     /// Sums meaningfully over a population or region.
     Extensive,
+    /// **§2.13 addendum (D101).** An `enum`-typed field's kind — there is
+    /// no meaningful extensive-or-intensive reading of a member identity,
+    /// so `:kind` is structurally forbidden on an `enum`-typed `deffield`
+    /// (`E-LOAD-053`, §2.9). This variant exists so [`FieldDecl::kind`]
+    /// never has to hold a fabricated `Intensive`/`Extensive` value for a
+    /// field the grammar itself declares kindless — a stored lie is worse
+    /// than an honest third case.
+    NotApplicable,
 }
 
 /// A model field's declared type + kind — the typechecker's environment
@@ -47,4 +261,92 @@ pub struct FieldDecl {
     pub ty: BslType,
     /// The field's declared intensivity kind.
     pub kind: FieldKind,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EnumRegistry, EnumRegistryError};
+
+    #[test]
+    fn declaration_order_is_the_ordinal_order_and_is_preserved() {
+        let mut r = EnumRegistry::default();
+        let ty = r
+            .declare(
+                "OrgKind",
+                &[
+                    "STATE_APPARATUS".into(),
+                    "BUSINESS".into(),
+                    "POLITICAL_FACTION".into(),
+                    "CIVIL_SOCIETY".into(),
+                ],
+            )
+            .unwrap();
+        assert_eq!(r.ordinal(ty, "STATE_APPARATUS"), Some(0));
+        assert_eq!(r.ordinal(ty, "CIVIL_SOCIETY"), Some(3));
+        assert_eq!(r.member(ty, 1), Some("BUSINESS"));
+        assert_eq!(r.ordinal(ty, "NOWHERE"), None);
+        assert_eq!(r.member_count(ty), 4);
+        assert_eq!(r.name(ty), "OrgKind");
+    }
+
+    #[test]
+    fn a_second_declare_call_gets_a_distinct_later_id() {
+        // Two types in one registry must not collide — the second type's
+        // ordinals live in their OWN member list, never mixed with the
+        // first's.
+        let mut r = EnumRegistry::default();
+        let a = r.declare("A", &["X".into()]).unwrap();
+        let b = r.declare("B", &["Y".into(), "Z".into()]).unwrap();
+        assert_ne!(a, b);
+        assert_eq!(r.ordinal(a, "X"), Some(0));
+        assert_eq!(r.ordinal(b, "Z"), Some(1));
+        assert_eq!(r.ordinal(a, "Y"), None, "Y belongs to B, not A");
+    }
+
+    #[test]
+    fn an_empty_member_list_refuses_loudly() {
+        let mut r = EnumRegistry::default();
+        assert_eq!(
+            r.declare("K", &[]).unwrap_err(),
+            EnumRegistryError::EmptyMemberList { name: "K".into() }
+        );
+    }
+
+    #[test]
+    fn a_duplicate_member_within_one_declaration_refuses_loudly() {
+        let mut r = EnumRegistry::default();
+        assert_eq!(
+            r.declare("K", &["A".into(), "A".into()]).unwrap_err(),
+            EnumRegistryError::DuplicateMember {
+                name: "K".into(),
+                member: "A".into()
+            }
+        );
+    }
+
+    #[test]
+    fn a_duplicate_type_name_refuses_loudly() {
+        let mut r = EnumRegistry::default();
+        r.declare("K", &["A".into()]).unwrap();
+        assert_eq!(
+            r.declare("K", &["B".into()]).unwrap_err(),
+            EnumRegistryError::DuplicateType { name: "K".into() }
+        );
+    }
+
+    #[test]
+    fn resolve_finds_a_declared_type_and_refuses_an_unknown_one() {
+        let mut r = EnumRegistry::default();
+        let ty = r.declare("OrgKind", &["BUSINESS".into()]).unwrap();
+        assert_eq!(r.resolve("OrgKind"), Some(ty));
+        assert_eq!(r.resolve("Nowhere"), None);
+    }
+
+    #[test]
+    fn member_and_ordinal_refuse_an_out_of_range_query() {
+        let mut r = EnumRegistry::default();
+        let ty = r.declare("OrgKind", &["BUSINESS".into()]).unwrap();
+        assert_eq!(r.member(ty, 5), None);
+        assert_eq!(r.ordinal(ty, "NOWHERE"), None);
+    }
 }

--- a/rust/crates/babylon-bsl/tests/conformance_corpus.rs
+++ b/rust/crates/babylon-bsl/tests/conformance_corpus.rs
@@ -429,8 +429,16 @@ fn malformed_conditions_fail_loud() {
     // "MASS_LINK 0" — missing comparison: the head is an undeclared call.
     let err = eval_cond_err("(ml 0)", &[("ml", Value::Int(0))]);
     assert!(err.message.contains("E-LOAD-021"), "{err}");
-    // "UNKNOWN_TAG <= 0" — SCREAMING_SNAKE is no BSL atom class at all.
-    assert!(read("(<= UNKNOWN_TAG 0)").is_err());
+    // "UNKNOWN_TAG <= 0" — SCREAMING_SNAKE now lexes fine (#528 fix round:
+    // a bare uppercase-with-underscore run is a legal <enum-member>-shaped
+    // atom, §2.13's own EBNF for a defenum/defvocabulary member list), but
+    // it is not a value in comparison/expression position — the refusal
+    // moves from the reader (E-LEX-003) to evaluation.
+    let err = eval_cond_err("(<= UNKNOWN_TAG 0)", &[]);
+    assert!(
+        err.message.contains("not a value in expression position"),
+        "{err}"
+    );
     // "MASS_LINK <= zero" — a non-literal RHS is a free variable: load error.
     let with_free = ADVENTURISM.replace("(<= mass-link 0)", "(<= mass-link zero)");
     assert_eq!(

--- a/rust/crates/babylon-bsl/tests/conformance_corpus.rs
+++ b/rust/crates/babylon-bsl/tests/conformance_corpus.rs
@@ -36,7 +36,7 @@ use babylon_bsl::reader::read;
 use babylon_bsl::rule_pipeline::{bind_environment, load_rule, LoadContext, LoadError, LoadedRule};
 use babylon_bsl::structural_verbs::{CollectingSink, EffectExecutor};
 use babylon_bsl::typecheck::TypeEnv;
-use babylon_bsl::types::{BslType, FieldDecl, FieldKind};
+use babylon_bsl::types::{BslType, EnumRegistry, FieldDecl, FieldKind};
 use babylon_bsl::BindingVocabulary;
 use babylon_graph::memory::MemoryGraph;
 use babylon_graph::substrate::GraphSubstrate;
@@ -145,6 +145,9 @@ struct Registries {
     ceilings: CardinalityCeilings,
     intrinsics: IntrinsicCosts,
     systems: HashSet<String>,
+    /// No fixture in this corpus declares an enum-typed field — an empty
+    /// registry is the honest "no `defenum`s in scope" input.
+    enums: EnumRegistry,
 }
 
 fn registries() -> Registries {
@@ -154,6 +157,7 @@ fn registries() -> Registries {
         ceilings: ceilings(),
         intrinsics: IntrinsicCosts::default(),
         systems: HashSet::from(["doctrine".to_owned(), "event".to_owned()]),
+        enums: EnumRegistry::default(),
     }
 }
 
@@ -909,7 +913,7 @@ fn bifurcation_routes_by_solidarity_density() {
             })
             .unwrap();
         let registries = registries();
-        let mut executor = EffectExecutor::new(&registries.types);
+        let mut executor = EffectExecutor::new(&registries.types, &registries.enums);
         let mut sink = CollectingSink::default();
         let mut fuel = 512;
         executor

--- a/rust/crates/babylon-bsl/tests/fundamental_theorem_tick.rs
+++ b/rust/crates/babylon-bsl/tests/fundamental_theorem_tick.rs
@@ -35,7 +35,7 @@ use babylon_bsl::scenario::load_scenario;
 use babylon_bsl::structural_verbs::CollectingSink;
 use babylon_bsl::tick::{run_tick, DefinesEnv};
 use babylon_bsl::typecheck::TypeEnv;
-use babylon_bsl::types::{BslType, FieldDecl, FieldKind};
+use babylon_bsl::types::{BslType, EnumRegistry, FieldDecl, FieldKind};
 use babylon_bsl::BindingVocabulary;
 use babylon_graph::memory::MemoryGraph;
 use babylon_graph::state_hash::CanonicalState;
@@ -97,6 +97,9 @@ struct Registries {
     ceilings: CardinalityCeilings,
     intrinsics: IntrinsicCosts,
     systems: HashSet<String>,
+    /// This file's fixture declares no enum-typed field — an empty
+    /// registry is the honest "no `defenum`s in scope" input.
+    enums: EnumRegistry,
 }
 
 fn registries() -> Registries {
@@ -114,6 +117,7 @@ fn registries() -> Registries {
         ),
         intrinsics: IntrinsicCosts::default(),
         systems: HashSet::from(["economics".to_owned()]),
+        enums: EnumRegistry::default(),
     }
 }
 
@@ -138,6 +142,7 @@ fn run_one_tick() -> (MemoryGraph, usize, usize) {
     let outcome = run_tick(
         &loaded,
         &r.types,
+        &r.enums,
         &EmptyIntrinsicHost,
         &mut graph,
         &mut sink,
@@ -247,6 +252,7 @@ fn a_changed_scenario_changes_the_hash() {
     run_tick(
         &loaded,
         &r.types,
+        &r.enums,
         &EmptyIntrinsicHost,
         &mut richer,
         &mut sink,
@@ -333,6 +339,7 @@ fn expr_registries() -> Registries {
         ),
         intrinsics: IntrinsicCosts::default(),
         systems: HashSet::from(["economics".to_owned()]),
+        enums: EnumRegistry::default(),
     }
 }
 
@@ -355,6 +362,7 @@ fn run_expr_tick(rule: &str) -> Result<(MemoryGraph, usize), String> {
     let outcome = run_tick(
         &loaded,
         &r.types,
+        &r.enums,
         &EmptyIntrinsicHost,
         &mut graph,
         &mut sink,

--- a/rust/crates/babylon-bsl/tests/r9_chapters.rs
+++ b/rust/crates/babylon-bsl/tests/r9_chapters.rs
@@ -34,6 +34,7 @@ use babylon_bsl::reader::{read, SExpr};
 use babylon_bsl::rule_pipeline::{load_rule, LoadContext};
 use babylon_bsl::scope::check_foreign_field_scoping;
 use babylon_bsl::typecheck::{typecheck_aggregation, TypeCode, TypeEnv};
+use babylon_bsl::types::EnumRegistry;
 use babylon_bsl::vocabulary::{ClosedVocabulary, EnumKind};
 use std::collections::{HashMap, HashSet};
 
@@ -99,6 +100,12 @@ fn bound(source: &str) -> Result<u64, BoundError> {
     rule_bound(&e(source), &ceilings(), &IntrinsicCosts::default())
 }
 
+/// No family in this file declares an enum-typed field — an empty registry
+/// is the honest "no `defenum`s in scope" input to `FieldRegistry::declare`.
+fn enums() -> EnumRegistry {
+    EnumRegistry::default()
+}
+
 /// The §3.4 environment: the implicit `<edge-type>/strength` rows (D32) plus
 /// the authored fields these families read.
 fn type_env() -> TypeEnv {
@@ -115,7 +122,7 @@ fn type_env() -> TypeEnv {
         "(deffield territory/wage-bill :type currency :kind extensive)",
         "(deffield polity/imperial-rent-pool :type currency :kind extensive)",
     ] {
-        registry.declare(&e(source), &v).expect(source);
+        registry.declare(&e(source), &v, &enums()).expect(source);
     }
     TypeEnv {
         fields: registry.type_env_fields(),
@@ -187,7 +194,7 @@ fn rule(body: &str) -> String {
 // below; their raise sites arrive with the Phase-2 evaluator.
 mod c1_edge_and_hyperedge_attributes {
     use super::{
-        aggregation_code, bound, check_foreign_field_scoping, check_intrinsic_name, cost, e,
+        aggregation_code, bound, check_foreign_field_scoping, check_intrinsic_name, cost, e, enums,
         vocabulary, ClosedVocabulary, EnumKind, EvalCode, FieldRegistry, TypeCode,
     };
     use babylon_bsl::bindings::parse_bindings;
@@ -250,6 +257,7 @@ mod c1_edge_and_hyperedge_attributes {
             .declare(
                 &e("(deffield exploitation/strength :type coefficient :kind extensive)"),
                 &v,
+                &enums(),
             )
             .unwrap_err();
         assert_eq!(err.spec_code(), Some("E-LOAD-001"));
@@ -265,6 +273,7 @@ mod c1_edge_and_hyperedge_attributes {
             .declare(
                 &e("(deffield imperium/rent :type currency :kind extensive)"),
                 &v,
+                &enums(),
             )
             .unwrap_err();
         assert_eq!(err.spec_code(), Some("E-LOAD-023"));

--- a/rust/crates/babylon-bsl/tests/r9_chapters.rs
+++ b/rust/crates/babylon-bsl/tests/r9_chapters.rs
@@ -993,7 +993,7 @@ mod c13_calendar_bindings {
 // silent skip. The result-type rule, the `E-TYPE-016` score rule and the
 // §3.7 cost row stay load-time static, exactly as before.
 mod c5_element_selection {
-    use super::{cost, e, type_env};
+    use super::{cost, e, enums, type_env};
     use babylon_bsl::bindings::parse_bindings;
     use babylon_bsl::evaluator::{evaluate, EvalCode, EvalEnv, EvalError, Value};
     use babylon_bsl::fuel::IntrinsicCosts;
@@ -1352,7 +1352,8 @@ mod c5_element_selection {
             elements: Vec::new(),
         };
         let types = type_env();
-        let mut executor = EffectExecutor::new(&types);
+        let enum_registry = enums();
+        let mut executor = EffectExecutor::new(&types, &enum_registry);
         let mut sink = CollectingSink::default();
         let mut fuel2 = 1_000;
         let pending = executor
@@ -1367,7 +1368,7 @@ mod c5_element_selection {
         // Pass 2 uses a FRESH executor, exactly as `tick.rs::run_tick`
         // does — the apply half must not depend on any state the
         // collecting executor accumulated (Copilot harvest, #520).
-        let mut apply_executor = EffectExecutor::new(&types);
+        let mut apply_executor = EffectExecutor::new(&types, &enum_registry);
         for write in &pending {
             apply_executor
                 .apply_pending_write(write, &mut graph)
@@ -1405,7 +1406,7 @@ mod c5_element_selection {
 // unchanged. The grammar, the arity, the static bound and the
 // `E-LOAD-040` interaction stay pinned exactly as before.
 mod c6_effect_position_iteration {
-    use super::{bound, cost, type_env};
+    use super::{bound, cost, enums, type_env};
     use babylon_bsl::evaluator::{EvalEnv, EvalError, Value};
     use babylon_bsl::fuel::IntrinsicCosts;
     use babylon_bsl::intrinsic_host::EmptyIntrinsicHost;
@@ -1526,6 +1527,7 @@ mod c6_effect_position_iteration {
             unreachable!()
         };
         let types = type_env();
+        let enum_registry = enums();
         let mut sink = CollectingSink::default();
         let pending = {
             let env = EvalEnv {
@@ -1534,10 +1536,10 @@ mod c6_effect_position_iteration {
                 graph: Some(&*graph as &dyn GraphSubstrate),
                 elements: Vec::new(),
             };
-            let mut collector = EffectExecutor::new(&types);
+            let mut collector = EffectExecutor::new(&types, &enum_registry);
             collector.collect_effects(&items[1..], &env, &EmptyIntrinsicHost, &mut sink, fuel)?
         };
-        let mut applier = EffectExecutor::new(&types);
+        let mut applier = EffectExecutor::new(&types, &enum_registry);
         for write in &pending {
             applier.apply_pending_write(write, &mut *graph)?;
         }

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -13,6 +13,7 @@ use babylon_bsl::scenario::load_scenario;
 use babylon_bsl::structural_verbs::CollectingSink;
 use babylon_bsl::tick::run_tick;
 use babylon_bsl::typecheck::TypeEnv;
+use babylon_bsl::types::EnumRegistry;
 use babylon_bsl::BindingVocabulary;
 use babylon_graph::hypergraph_store::HypergraphStore;
 use babylon_graph::state_hash::CanonicalState;
@@ -89,6 +90,11 @@ pub(crate) struct PreparedRules {
     pub types: TypeEnv,
     pub intrinsics: IntrinsicCosts,
     pub consts: HashMap<String, Value>,
+    /// **§2.13 addendum (D101).** The scenario's `defenum` registry —
+    /// `run_tick`'s write path (`update-node` on an enum-typed field) and
+    /// read path (`bind_subject` rendering a stored ordinal back to its
+    /// member) both resolve against this.
+    pub enums: EnumRegistry,
 }
 
 pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
@@ -233,6 +239,7 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
         types,
         intrinsics,
         consts: scenario.consts,
+        enums: scenario.enums,
     })
 }
 
@@ -291,6 +298,7 @@ pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
         let outcome = run_tick(
             loaded,
             &prepared.types,
+            &prepared.enums,
             &KernelIntrinsicHost,
             graph,
             sink,

--- a/rust/crates/babylon-tick/src/session.rs
+++ b/rust/crates/babylon-tick/src/session.rs
@@ -81,6 +81,7 @@ impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
             let outcome = run_tick(
                 loaded,
                 &self.prepared.types,
+                &self.prepared.enums,
                 &KernelIntrinsicHost,
                 &mut self.graph,
                 sink,

--- a/rust/crates/babylon-tick/tests/enum_arithmetic_e2e.rs
+++ b/rust/crates/babylon-tick/tests/enum_arithmetic_e2e.rs
@@ -1,0 +1,91 @@
+//! §2.13's "no aggregation kind" law (D101), proven through `run_once` — the
+//! SAME entry point production uses (`main.rs`'s CLI driver,
+//! `babylon-client`'s engine link) — not just the `babylon-bsl` unit-level
+//! `collect_then_apply` harness.
+//!
+//! **#528 fix round, blocker 2.** Before this fix, `(add OrgKind/BUSINESS)`
+//! on an `organization/kind` field seeded `OrgKind/STATE_APPARATUS` silently
+//! reduced to `current + operand` — declaration-order ORDINAL arithmetic
+//! (`0.0 + 1.0 = 1.0`) that happens to land on a DIFFERENT real member
+//! (`BUSINESS`) rather than refusing. `sub`/`scale` are worse: nothing in
+//! the store-boundary range check (`store_range_check`, §3.3) bounds an
+//! enum field's ordinal, so `(sub OrgKind/BUSINESS)` on `STATE_APPARATUS`
+//! (ordinal 0) writes `-1.0` completely unchecked — a stored value with no
+//! member at all, caught only later, by a DIFFERENT site, the next time
+//! something reads it back (`tick.rs`'s own corrupted-ordinal integrity
+//! check). `set` is the only coherent op on an `Enum<T>` field (§2.13: "no
+//! aggregation kind ... `Enum<T>` supports no arithmetic"); this file proves
+//! `add`/`sub`/`scale` are refused loudly, at the WRITE site, through the
+//! full `run_once` seam — not just the `babylon-bsl` unit-level harness the
+//! adversarial review found this whole class invisible to.
+
+use babylon_tick::run_once;
+
+const ORG_SCENARIO: &str = r#"
+(scenario enum-arithmetic-e2e/one-org
+  (defenum OrgKind (STATE_APPARATUS BUSINESS POLITICAL_FACTION CIVIL_SOCIETY))
+  (deffield organization/kind enum OrgKind)
+  (node acme NodeType/ORGANIZATION (organization/kind OrgKind/STATE_APPARATUS)))
+"#;
+
+fn enum_op_rule(op: &str) -> String {
+    format!(
+        r#"
+(rule vitality/enum-arithmetic-e2e-{op}
+  :material-basis "prove {op} on an enum field is a loud E-EVAL-042 tick error"
+  :fuel 64
+  (bindings
+    (binding kind :field organization/kind))
+  (effects
+    (update-node self organization/kind ({op} OrgKind/BUSINESS))))
+"#
+    )
+}
+
+#[test]
+fn add_on_a_seeded_enum_field_is_a_loud_e_eval_042_tick_error() {
+    let err = run_once(ORG_SCENARIO, &enum_op_rule("add")).unwrap_err();
+    assert!(
+        err.contains("E-EVAL-042"),
+        "add on an enum field must refuse as E-EVAL-042, not silently \
+         reinterpret the ordinal as a different member: {err}"
+    );
+}
+
+#[test]
+fn sub_on_a_seeded_enum_field_is_a_loud_e_eval_042_tick_error() {
+    // The task's own worst case: STATE_APPARATUS (ordinal 0) minus
+    // BUSINESS's ordinal (1) would write -1.0 completely unchecked — no
+    // member, and no range check on an enum field catches it at the store
+    // boundary (§3.3's unit-interval check does not cover BslType::Enum).
+    let err = run_once(ORG_SCENARIO, &enum_op_rule("sub")).unwrap_err();
+    assert!(
+        err.contains("E-EVAL-042"),
+        "sub on an enum field must refuse as E-EVAL-042 BEFORE it corrupts \
+         the store into an out-of-range ordinal: {err}"
+    );
+}
+
+#[test]
+fn scale_on_a_seeded_enum_field_is_a_loud_e_eval_042_tick_error() {
+    let err = run_once(ORG_SCENARIO, &enum_op_rule("scale")).unwrap_err();
+    assert!(err.contains("E-EVAL-042"), "{err}");
+}
+
+/// The green path is unaffected: `set` is the coherent op on an enum field
+/// and must still clear the full `run_once` seam.
+#[test]
+fn set_on_a_seeded_enum_field_still_succeeds_through_run_once() {
+    const SET_RULE: &str = r#"
+(rule vitality/enum-arithmetic-e2e-set
+  :material-basis "set remains the coherent op on an enum field"
+  :fuel 64
+  (bindings
+    (binding kind :field organization/kind))
+  (effects
+    (update-node self organization/kind (set OrgKind/BUSINESS))))
+"#;
+    let report = run_once(ORG_SCENARIO, SET_RULE)
+        .expect("set on an enum field must still succeed through the full seam");
+    assert_eq!(report.fired, 1);
+}

--- a/rust/crates/babylon-tick/tests/enum_arithmetic_e2e.rs
+++ b/rust/crates/babylon-tick/tests/enum_arithmetic_e2e.rs
@@ -3,7 +3,7 @@
 //! `babylon-client`'s engine link) — not just the `babylon-bsl` unit-level
 //! `collect_then_apply` harness.
 //!
-//! **#528 fix round, blocker 2.** Before this fix, `(add OrgKind/BUSINESS)`
+//! **#528 fix round, blocker 2.** Before that fix, `(add OrgKind/BUSINESS)`
 //! on an `organization/kind` field seeded `OrgKind/STATE_APPARATUS` silently
 //! reduced to `current + operand` — declaration-order ORDINAL arithmetic
 //! (`0.0 + 1.0 = 1.0`) that happens to land on a DIFFERENT real member
@@ -14,10 +14,26 @@
 //! member at all, caught only later, by a DIFFERENT site, the next time
 //! something reads it back (`tick.rs`'s own corrupted-ordinal integrity
 //! check). `set` is the only coherent op on an `Enum<T>` field (§2.13: "no
-//! aggregation kind ... `Enum<T>` supports no arithmetic"); this file proves
+//! aggregation kind ... `Enum<T>` supports no arithmetic"); that fix proved
 //! `add`/`sub`/`scale` are refused loudly, at the WRITE site, through the
 //! full `run_once` seam — not just the `babylon-bsl` unit-level harness the
 //! adversarial review found this whole class invisible to.
+//!
+//! **#528 fix round, second round Item C — the refusal moved earlier.**
+//! `typecheck::check_no_arithmetic_on_enum_field` (D118) now refuses this
+//! exact shape at LOAD, before `run_once` ever reaches a tick: the field's
+//! declared type and the update-op's own symbol are both static, content-only
+//! facts, so the eval-time `E-EVAL-042` guards this file originally proved
+//! are no longer the FIRST thing `run_once` hits for `add`/`sub`/`scale` on a
+//! declared-enum field — they stay, unchanged, as defense in depth
+//! (`structural_verbs.rs::refuse_arithmetic_on_enum_field`'s own three call
+//! sites), but this file's own three refusal tests now assert on the earlier
+//! LOAD rejection (`prepare_rules`'s "rule … rejected: …" wrapping, citing
+//! D118) rather than a tick-time `E-EVAL-042` `TickError`, because that is
+//! the honest first-failure `run_once` now reports. There is no scenario
+//! shape that reaches the eval-time guards through this full production seam
+//! any more — `add`/`sub`/`scale` on a declared-enum field is unconditionally
+//! decidable from content alone.
 
 use babylon_tick::run_once;
 
@@ -32,7 +48,7 @@ fn enum_op_rule(op: &str) -> String {
     format!(
         r#"
 (rule vitality/enum-arithmetic-e2e-{op}
-  :material-basis "prove {op} on an enum field is a loud E-EVAL-042 tick error"
+  :material-basis "prove {op} on an enum field is a loud load-time refusal (D118)"
   :fuel 64
   (bindings
     (binding kind :field organization/kind))
@@ -43,33 +59,41 @@ fn enum_op_rule(op: &str) -> String {
 }
 
 #[test]
-fn add_on_a_seeded_enum_field_is_a_loud_e_eval_042_tick_error() {
+fn add_on_a_seeded_enum_field_is_a_loud_load_time_refusal() {
     let err = run_once(ORG_SCENARIO, &enum_op_rule("add")).unwrap_err();
     assert!(
-        err.contains("E-EVAL-042"),
-        "add on an enum field must refuse as E-EVAL-042, not silently \
+        err.contains("D118"),
+        "add on an enum field must refuse at load (D118), not silently \
          reinterpret the ordinal as a different member: {err}"
+    );
+    assert!(
+        err.contains("rejected"),
+        "must be the LOAD rejection (prepare_rules's own wrapping), not a \
+         tick-time error: {err}"
     );
 }
 
 #[test]
-fn sub_on_a_seeded_enum_field_is_a_loud_e_eval_042_tick_error() {
+fn sub_on_a_seeded_enum_field_is_a_loud_load_time_refusal() {
     // The task's own worst case: STATE_APPARATUS (ordinal 0) minus
     // BUSINESS's ordinal (1) would write -1.0 completely unchecked — no
     // member, and no range check on an enum field catches it at the store
     // boundary (§3.3's unit-interval check does not cover BslType::Enum).
+    // D118 refuses this BEFORE the rule ever loads, let alone runs.
     let err = run_once(ORG_SCENARIO, &enum_op_rule("sub")).unwrap_err();
     assert!(
-        err.contains("E-EVAL-042"),
-        "sub on an enum field must refuse as E-EVAL-042 BEFORE it corrupts \
-         the store into an out-of-range ordinal: {err}"
+        err.contains("D118"),
+        "sub on an enum field must refuse at load (D118), before it could \
+         ever corrupt the store into an out-of-range ordinal: {err}"
     );
+    assert!(err.contains("rejected"), "{err}");
 }
 
 #[test]
-fn scale_on_a_seeded_enum_field_is_a_loud_e_eval_042_tick_error() {
+fn scale_on_a_seeded_enum_field_is_a_loud_load_time_refusal() {
     let err = run_once(ORG_SCENARIO, &enum_op_rule("scale")).unwrap_err();
-    assert!(err.contains("E-EVAL-042"), "{err}");
+    assert!(err.contains("D118"), "{err}");
+    assert!(err.contains("rejected"), "{err}");
 }
 
 /// The green path is unaffected: `set` is the coherent op on an enum field

--- a/tests/unit/reference/test_bsl_grammar_sync.py
+++ b/tests/unit/reference/test_bsl_grammar_sync.py
@@ -682,10 +682,15 @@ class TestTheEnumArithmeticRefusalIsDeclaredInTheRegistry:
         end = body.index("\nSee Also\n", start)
         section = body[start:end]
         d118_start = section.index("D118")
-        d118_row = section[d118_start : d118_start + 2000]
+        d118_row = section[d118_start : d118_start + 3000]
         assert "E-EVAL-042" in d118_row
         assert "add" in d118_row and "sub" in d118_row and "scale" in d118_row, (
             "D118's own row text must name the add/sub/scale refusal it resolves"
+        )
+        assert "check_no_arithmetic_on_enum_field" in d118_row, (
+            "D118's own row text must also record the load-time half (#528 "
+            "fix round Item C) — the same law moved earlier, not a second "
+            "decision"
         )
 
 

--- a/tests/unit/reference/test_bsl_grammar_sync.py
+++ b/tests/unit/reference/test_bsl_grammar_sync.py
@@ -635,6 +635,60 @@ class TestTheEnumCasPayloadShapeStaysInSync:
         )
 
 
+class TestTheEnumArithmeticRefusalIsDeclaredInTheRegistry:
+    """The write-boundary law's own drift class (#528 fix round, MAJOR
+    item 2). ``structural_verbs.rs::refuse_arithmetic_on_enum_field``
+    (``c268b83b``) has reported ``E-EVAL-042`` for an ``add``/``sub``/
+    ``scale`` update-op targeting an ``:enum-type``-declared field since
+    the enum write law landed, but §2.13's own E-EVAL-042 bullet and the
+    §4.6 class table row both scoped the code strictly to the
+    write-SHAPE law (a non-``<enum-ref>`` value reaching the write path)
+    — never naming the arithmetic refusal at all. RHS-grain checks, the
+    same class ``TestTheEnumCasPayloadShapeStaysInSync`` guards, so the
+    widening cannot silently regress to the narrower reading.
+    """
+
+    def test_the_213_write_read_law_names_the_arithmetic_refusal(self) -> None:
+        body = _read(RST)
+        start = body.index("**The write/read law.**")
+        end = body.index("**No aggregation kind.**", start)
+        section = body[start:end]
+        assert "E-EVAL-042" in section
+        assert "add" in section and "sub" in section and "scale" in section, (
+            "the §2.13 write/read law's E-EVAL-042 bullet must name the "
+            "add/sub/scale arithmetic refusal (#528 fix round Item B), not "
+            "just the write-shape law"
+        )
+
+    def test_the_46_class_table_names_the_arithmetic_refusal_too(self) -> None:
+        body = _read(RST)
+        start = body.index("   * - Evaluation")
+        end = body.index("**Every code the R9 chapters add", start)
+        section = body[start:end]
+        assert "field's write path at runtime" in section
+        assert "add" in section and "sub" in section and "scale" in section, (
+            "the §4.6 Evaluation class-table row must ALSO name the "
+            "add/sub/scale arithmetic refusal (#528 fix round Item B), not "
+            "just the write-shape violation"
+        )
+
+    def test_d118_is_recorded_in_the_register(self) -> None:
+        body = _read(RST)
+        assert re.search(r"^\s+\* - D118$", body, re.MULTILINE), (
+            "the E-EVAL-042 arithmetic-refusal widening is a decision and "
+            "owes a Draft-Ruling Register row (#528 fix round)"
+        )
+        start = body.index("\nDraft-Ruling Register\n")
+        end = body.index("\nSee Also\n", start)
+        section = body[start:end]
+        d118_start = section.index("D118")
+        d118_row = section[d118_start : d118_start + 2000]
+        assert "E-EVAL-042" in d118_row
+        assert "add" in d118_row and "sub" in d118_row and "scale" in d118_row, (
+            "D118's own row text must name the add/sub/scale refusal it resolves"
+        )
+
+
 class TestTheDraftRulingRegisterHasNoDuplicateRowNumbers:
     """A second row naming a D-number already in use passes every
     existence-only check above — each of D94/D95/D98/D99's own tests just

--- a/tests/unit/reference/test_bsl_grammar_sync.py
+++ b/tests/unit/reference/test_bsl_grammar_sync.py
@@ -562,6 +562,79 @@ class TestTheRatioLiteralStaysInSync:
         )
 
 
+class TestTheEnumCasPayloadShapeStaysInSync:
+    """D117's own drift class (#528 fix round, blocker item 3) — the §5.2
+    payload table's own self-contradiction, adversarial-verifier-found.
+    The Q12 paragraph claimed ``defenum``/``defvocabulary`` need "no new
+    atom kind" because "the ``<enum-ref>`` values they govern already
+    encode with the existing atom kind" — true of an ``:enum-type``
+    field's stored VALUES, false of ``defenum``/``defvocabulary``'s own
+    operands (the type-name operand, the member-list items), which are
+    bare ``<enum-type>``/``<enum-member>`` atoms, never ``<enum-ref>``
+    pairs. RHS-grain checks, the same class ``TestTheRatioLiteralStaysInSync``
+    and ``TestTheEnumRowStaysInSync`` guard, so the correction cannot
+    silently regress to the old, self-contradictory single-shape reading.
+    """
+
+    def test_the_enum_payload_row_admits_both_shapes(self) -> None:
+        # Scoped to §5.2's own list-table (the same scoping
+        # TestTheEnumRowStaysInSync uses to avoid the unrelated §3.1 row).
+        body = _read(RST)
+        start = body.index("**Atom kinds and payloads:**")
+        end = body.index("**Form tags**", start)
+        section = body[start:end]
+        assert re.search(r"^\s+\* - ``enum``", section, re.MULTILINE), (
+            "the CAS atom-kind/payload table must still carry the enum row"
+        )
+        assert "<enum-ref>" in section, (
+            "the enum row must still document the <enum-ref> (Type/MEMBER) payload shape"
+        )
+        assert "bare" in section.lower(), (
+            "the enum row must ALSO document the bare defenum/defvocabulary "
+            "operand payload shape (D117) — a single-shape table entry is "
+            "the very premise the fix round found false"
+        )
+        assert "discrimin" in section.lower(), (
+            "the enum row must name the discriminator (exactly one `/`) "
+            "that keeps the two payload shapes collision-free (D117)"
+        )
+
+    def test_the_q12_paragraph_no_longer_states_the_false_premise(self) -> None:
+        body = _read(RST)
+        start = body.index("The Organization contract's Q12 tags obey it a fourth time")
+        end = body.index("A keyword option is encoded as a two-child form", start)
+        section = body[start:end]
+        assert "defenum" in section and "defvocabulary" in section
+        # The corrected text must acknowledge the bare-operand payload
+        # shape explicitly, not just repeat the old "<enum-ref> values
+        # they govern" sentence unmodified.
+        assert "bare" in section.lower(), (
+            "the Q12 CAS paragraph must be corrected to acknowledge "
+            "defenum/defvocabulary's own BARE operand payload shape — the "
+            "premise that only <enum-ref> VALUES are involved is false "
+            "for these two forms' own operands (D117)"
+        )
+        assert "D117" in section, (
+            "the corrected Q12 CAS paragraph must cite D117, the register "
+            "row recording this resolution"
+        )
+
+    def test_d117_is_recorded_in_the_register(self) -> None:
+        body = _read(RST)
+        assert re.search(r"^\s+\* - D117$", body, re.MULTILINE), (
+            "the enum CAS payload-shape correction is a decision and owes "
+            "a Draft-Ruling Register row (#528 fix round)"
+        )
+        start = body.index("\nDraft-Ruling Register\n")
+        end = body.index("\nSee Also\n", start)
+        section = body[start:end]
+        d117_start = section.index("D117")
+        d117_row = section[d117_start : d117_start + 2000]
+        assert "defenum" in d117_row or "defvocabulary" in d117_row, (
+            "D117's own row text must name defenum/defvocabulary"
+        )
+
+
 class TestTheDraftRulingRegisterHasNoDuplicateRowNumbers:
     """A second row naming a D-number already in use passes every
     existence-only check above — each of D94/D95/D98/D99's own tests just


### PR DESCRIPTION
## Summary

PR Group C (Tasks 3–7) of the Organization foundation plan (#516; spec #515, issue #513) — the seventh `<type-name>` row implemented end to end, exactly as the merged spec text (#517) rules it.

- **Task 3** (`6ae29d23`): `EnumRegistry` (Vec-backed — **declaration order IS the ordinal**, never sorted; mutation-verified), `EnumTypeId`, `BslType::Enum(EnumTypeId)`, `deffield :type enum :enum-type <Name>` with E-LOAD-053/054.
- **Task 4** (`0dcb5452`): `.bscn` gains `defenum` + the enum `deffield` arm + `attribute_value_enum` — EnumRef-only seeding, E-LOAD-055/056 (bare numbers refuse in both directions).
- **Task 5** (`120474bd`): runtime writes — EnumRef in, ordinal stored in the existing f64 lane, `E-EVAL-042` for everything else; `EnumRegistry` threaded through `run_once_into`/`TickSession::advance` into production; tests drive the composed `collect_effects`+`apply_pending_write` path (the #519 lesson, applied from the start).
- **Task 6** (`e76f2c73`): reads render `Value::Enum` via `bind_field_value` (loud integrity failure on a non-round-tripping stored value); `field-of` on an enum field refuses at LOAD.
- **Task 7** (`fc63db7e`): `defvocabulary` — the closed graph vocabulary is DECLARED, never inferred; duplicate-kind guard proven load-bearing by mutation.

## Two judgment calls, flagged for review

1. **`Atom::EnumTypeName` (new lexer atom class):** the merged spec's grammar makes `defenum`/`defvocabulary`/`:enum-type` take §1.4's bare `<enum-type>` production, but `reader.rs::classify_enum_ref` unconditionally required a `/` — the merged keyword was unwritable. Resolved additively rather than deferred; member lists inside `defenum` use full `<Type>/<MEMBER>` refs (recorded reconciliation).
2. **`field-of`'s enum deferral is a load-time gate** (`check_no_field_of_on_enum_field` in the rule pipeline), not the plan's runtime sketch — eligibility is a static fact and §3's law says load-time; cites the already-merged **D102** rather than minting a parallel row (register re-checked, still ends at D116).

## Testing

- TDD per task; mutation checks each task (ordinal-sort flip, bare-number acceptance flip, type-check-skip flip — round 2 caught its own test-precision gap and fixed the fixture to a real OrgKind member so the mutation discriminates).
- Full 4-leg gate green at EVERY commit; `tick_goldens` 3/3 byte-identical after every task; 423 babylon-bsl tests by the end, workspace zero failures.

Adversarial verification pass running pre-merge per branch standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)