### PR TITLE
feat(bsl): org foundation Group D — closed-vocabulary enforcement live at all three producers

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -3604,7 +3604,9 @@ two times at which an error can occur.
        operand exceeding its declared domain ceiling; and, from §2.13
        (Organization spec §1 Q12), a non-``<enum-ref>`` value (or a
        cross-type ``<enum-ref>``) reaching an ``:enum-type``-declared
-       field's write path at runtime, and an ``add``/``sub``/``scale``
+       field's write path at runtime, an ``<enum-ref>`` of the right
+       declared type naming a member that type does not declare
+       (``E-LOAD-055``'s runtime twin), and an ``add``/``sub``/``scale``
        update-op targeting such a field (D118) — ``Enum<T>`` supports no
        arithmetic.
 

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -5979,6 +5979,33 @@ consequences are the ordinary kind of review item.
        three eval-time sites above STAY, unchanged, as defense in depth,
        exactly as D102's own load-time gate left its eval-time siblings
        standing.
+   * - D119
+     - §2.13, §3.6
+     - **Resolved (#534 fix round item 1, adversarial-panel finding,
+       mutation-reproduced).** ``ClosedVocabulary::check_enum_ref``
+       (``rust/crates/babylon-bsl/src/vocabulary.rs``) conflated two
+       distinct facts under one refusal: a kind ABSENT from the
+       vocabulary — no ``defvocabulary`` for it at all — and a DECLARED
+       kind whose members simply do not include the one written. Both
+       fell through the same ``self.members.get(&kind).is_some_and(…)``
+       lookup returning ``false``, so a scenario declaring ``NodeType``
+       and ``EdgeType`` but not ``EventType`` refused ``EventType/…`` at
+       ``E-LOAD-031`` — a kind it never opted into checking at all — which
+       is exactly the shape §2.13's own text above already rules against
+       ("a content set that declares no ``defvocabulary`` for a kind
+       leaves THAT KIND's checking exactly as inert as it is today").
+       **Resolved by reading the registry's OWN presence, not just
+       membership within it**: an absent kind returns ``Ok`` (inert,
+       unchanged from before this section existed); a declared kind —
+       including one declared with zero members — keeps enforcing
+       ``E-LOAD-031`` exactly as before. This is SCOPE, not a fallback:
+       §3.6's "a name that is not in the registry is a load error, never
+       a fallback" law binds a name checked AGAINST a registry that
+       exists for its kind; a kind with no registry at all is simply not
+       being checked, the same distinction §1.5 already draws between "no
+       default" and "no check". No test in the landing PR (#534's Group D
+       predecessor) pinned the all-or-nothing behavior this row corrects
+       — the gap was latent, not a regression of a prior guarantee.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -6007,7 +6007,7 @@ consequences are the ordinary kind of review item.
        predecessor) pinned the all-or-nothing behavior this row corrects
        — the gap was latent, not a regression of a prior guarantee.
        **Recorded, not changed, in the same fix round (F8, item 8):** at
-       one of the sixteen §2.6 class-rule operand positions this section
+       any of the sixteen §2.6 class-rule operand positions this section
        names, an UNKNOWN type name — not merely the wrong structural kind
        — is ``E-TYPE-011`` in the reference implementation
        (``grammar::check_enum_ref_kinds``, D74, which runs earlier and
@@ -6018,6 +6018,42 @@ consequences are the ordinary kind of review item.
        recorded only in ``check_enum_ref_membership``'s own Rust doc
        comment (grammar.rs) — folded into the register here so the
        divergence is honest at spec level too.
+
+       **Extended (G2, #534 fix round 2 item 2, mutation-reproduced).**
+       The SAME conflation this row already records for the sixteen §2.6
+       rule-form positions recurred, independently, at the SCENARIO
+       HYDRATION positions — a ``.bscn`` file's own ``node``/``edge``
+       forms. §3.9 clause 1 authorizes exactly this check, unconditionally
+       ("It creates elements of declared types and writes declared
+       fields, and nothing else. An undeclared field or type at hydration
+       is the same ``E-LOAD-0xx`` class as it would be in content —
+       hydration is not a back door into the closed vocabulary (§3.6)."):
+       a node/edge form's own type operand demands its position's kind
+       (``NodeType``/``EdgeType`` respectively) independent of whether
+       any ``defvocabulary`` was declared for it at all — mirroring the
+       sixteen rule-form positions' own unconditional reading, one level
+       down. The reference implementation's hydration-side producer,
+       ``scenario::demand_enum_kind`` (``rust/crates/babylon-bsl/src/
+       scenario.rs``), originally reported EVERY kind mismatch here as
+       ``E-LOAD-030`` — including a syntactically-real type at the wrong
+       position (``(node x EdgeType/SOLIDARITY)`` under a vocabulary that
+       registers both kinds), whose message ("EdgeType is not a
+       registered enum type") was false for exactly that case: ``EdgeType``
+       plainly IS a registered structural kind, just not this position's.
+       **Resolved the same way this row's own §2.6 half already is**: a
+       written type that is REAL — one of the four structural kinds, or a
+       type this scenario declared via ``defenum`` — but wrong for the
+       position is ``E-TYPE-011`` (``VocabularyError::WrongEnumKind``); a
+       written type that names nothing real at all, anywhere, stays
+       ``E-LOAD-030`` (``VocabularyError::UnknownEnumType``, whose message
+       is now true of every case it fires for). This split is POSITIONAL,
+       not vocabulary-gated, exactly as the unconditional §3.9 clause 1
+       reading demands: it holds whether or not the written kind was
+       itself ``defvocabulary``-declared in this scenario, and whether or
+       not ANY ``defvocabulary`` form appears in it at all — the SEPARATE
+       membership check a threaded ``ClosedVocabulary`` performs (this
+       row's own F1 half, above) is the only opt-in half of the hydration
+       path.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -6006,6 +6006,18 @@ consequences are the ordinary kind of review item.
        default" and "no check". No test in the landing PR (#534's Group D
        predecessor) pinned the all-or-nothing behavior this row corrects
        — the gap was latent, not a regression of a prior guarantee.
+       **Recorded, not changed, in the same fix round (F8, item 8):** at
+       one of the sixteen §2.6 class-rule operand positions this section
+       names, an UNKNOWN type name — not merely the wrong structural kind
+       — is ``E-TYPE-011`` in the reference implementation
+       (``grammar::check_enum_ref_kinds``, D74, which runs earlier and
+       unconditionally), never the ``E-LOAD-030`` this section's own text
+       above states; ``ClosedVocabulary::check_enum_ref``'s ``E-LOAD-030``
+       branch is unreachable at these specific sixteen positions for
+       exactly that reason. Pre-existing since D74 landed, previously
+       recorded only in ``check_enum_ref_membership``'s own Rust doc
+       comment (grammar.rs) — folded into the register here so the
+       divergence is honest at spec level too.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -6055,6 +6055,21 @@ consequences are the ordinary kind of review item.
        row's own F1 half, above) is the only opt-in half of the hydration
        path.
 
+       **Disclosed (H2, #534 fix round 3): the split is ALSO
+       registry-relative, not just positional.** A scenario-declared
+       ``defenum`` type participates in "is this a REAL type" only from
+       its OWN declaration point down — the same "declaration must
+       precede use" discipline ``deffield``/``defconst``/
+       ``defvocabulary`` already enforce, and consistent with
+       ``vocabulary_so_far``'s own running-snapshot reading (F1's half,
+       above). ``(defenum OrgKind (BUSINESS)) (node x OrgKind/BUSINESS)``
+       is ``E-TYPE-011`` (``OrgKind`` genuinely exists by the time the
+       node form runs); the SAME probe with the ``defenum`` moved AFTER
+       the ``node`` form is ``E-LOAD-030`` (``OrgKind`` genuinely names
+       nothing YET at that point in the load) — not a bug, the same
+       ordering sensitivity every other declared-registry lookup in this
+       loader already has, undisclosed until now.
+
 See Also
 ----------
 

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -2205,7 +2205,7 @@ mod tests {
             exemptions: &[],
         };
         let enums = EnumRegistry::default();
-        let mut executor = EffectExecutor::new(&types, &enums);
+        let mut executor = EffectExecutor::new(&types, &enums, None);
         let mut sink = CollectingSink::default();
         let costs = costs();
         let effect_env = EvalEnv {

--- a/rust/crates/babylon-bsl/src/grammar.rs
+++ b/rust/crates/babylon-bsl/src/grammar.rs
@@ -343,6 +343,30 @@ const TYPE_OPERAND_HEADS: [&str; 4] = ["emit", "add-node", "add-edge", "remove-e
 /// const's own doc for why these four specifically need a SEPARATE gate
 /// rather than reuse of that one.
 ///
+/// **Head-position-only** (#528 delta-verify rider R2). A matched head's
+/// own trailing operands are NOT recursed into — only a list whose OWN
+/// head did not match is walked further. Before this, the walk treated
+/// every child list's head as a fresh candidate, wherever it sat: `emit`'s
+/// `<payload-item>` label is an unconstrained `Atom::Symbol` (§2.8's
+/// `<payload-item> ::= (<symbol> <expr>)`), so a payload item happening
+/// to be labeled `emit` — a LABEL, never a nested verb invocation — was
+/// wrongly refused as if it were one:
+/// `(emit EventType/RUPTURE (emit 5) (severity 1))` errored although it
+/// is well-formed content. Stopping at a matched head is safe: a
+/// `<field-init>`'s own head is always an `Atom::QName` (never a
+/// `Atom::Symbol`, so it can never even reach the `Some(Atom::Symbol(_))`
+/// arm below), a `(members …)` list's elements are bare node
+/// expressions, and every legal EXPRESSION-position head (`field-of`,
+/// `fold`, the arithmetic/comparison operators, …) is drawn from a
+/// CLOSED keyword set disjoint from `TYPE_OPERAND_HEADS` — these four
+/// names are themselves reserved against the intrinsic namespace (D33,
+/// `declarations::RESERVED_FORM_TAGS`) — so nothing legally nested inside
+/// a matched verb's own operands could ever be a genuine further match.
+/// `guard`/`for-each` are unaffected: neither is in `TYPE_OPERAND_HEADS`,
+/// so a form headed by either still falls through to the unconditional
+/// recursion below, reaching any REAL verb nested in their bodies exactly
+/// as before.
+///
 /// # Errors
 ///
 /// A plain message naming the form and what was found — uncoded, the
@@ -366,6 +390,10 @@ pub fn check_type_operands_are_enum_refs(expr: &SExpr) -> Result<(), String> {
                         ));
                     }
                 }
+                // Head-position-only (R2): stop here — the rest of
+                // `items` is this verb's own operand list, never a
+                // sibling form to inspect.
+                return Ok(());
             }
         }
         for child in items {
@@ -817,6 +845,29 @@ mod tests {
     fn a_correctly_shaped_remove_edge_is_untouched() {
         assert!(super::check_type_operands_are_enum_refs(&e(
             "(remove-edge EdgeType/SOLIDARITY a b)"
+        ))
+        .is_ok());
+    }
+
+    #[test]
+    fn a_payload_item_labeled_like_a_type_operand_head_is_never_over_refused() {
+        // #528 delta-verify rider R2: a payload item's LABEL is an
+        // unconstrained `Atom::Symbol` (§2.8's `<payload-item> ::=
+        // (<symbol> <expr>)`) — nothing stops content from naming one
+        // `emit`, and that label is not a nested verb invocation. The
+        // buggy walk treated every child list's head as a fresh
+        // candidate and wrongly refused this exact form; the fix makes
+        // the check HEAD-POSITION-ONLY: once `emit`'s own type operand
+        // is confirmed, its trailing payload items are never descended
+        // into by this check at all.
+        assert!(super::check_type_operands_are_enum_refs(&e(
+            "(emit EventType/RUPTURE (emit 5) (severity 1))"
+        ))
+        .is_ok());
+        // The same shape with a different label was always Ok — proves
+        // the probe isolates the label collision, not some other cause.
+        assert!(super::check_type_operands_are_enum_refs(&e(
+            "(emit EventType/RUPTURE (foo 5) (severity 1))"
         ))
         .is_ok());
     }

--- a/rust/crates/babylon-bsl/src/grammar.rs
+++ b/rust/crates/babylon-bsl/src/grammar.rs
@@ -273,6 +273,35 @@ pub fn check_enum_ref_kinds(expr: &SExpr) -> Result<(), GrammarError> {
 /// ANY `defvocabulary` was declared anywhere in the scenario — coupling
 /// two registries that must stay independent.
 ///
+/// **Head-position-only at `emit`** (F5(a), #534 fix round item 5 —
+/// mirrors `check_type_operands_are_enum_refs`'s own R2 fix, #528
+/// delta-verify rider). `emit`'s `<payload-item>` label is an
+/// unconstrained `Atom::Symbol` (§2.8's `<payload-item> ::= (<symbol>
+/// <expr>)`) — nothing stops content from naming one `emit`, with a VALUE
+/// that happens to be a coincidentally well-kinded-but-unregistered
+/// `<enum-ref>`. Before this, the unconditional recursion below
+/// re-inspected such a payload item as a FRESH `emit` invocation and
+/// wrongly refused its "operand 1" — a value, not `emit`'s own type
+/// operand — under `E-LOAD-031`. Stopping once `emit`'s own operand-1
+/// check above has run loses no coverage: `emit` has exactly ONE typed
+/// position in [`ENUM_REF_POSITIONS`], already checked in the loop above.
+///
+/// **Several of the sixteen typed positions cannot fire through the
+/// production load pipeline in slice 1.** `add-node`, `add-edge`,
+/// `remove-edge` and `add-hyperedge` are four of [`ENUM_REF_POSITIONS`]'
+/// rows, but every rule using any of them is ALREADY refused, earlier and
+/// unconditionally, by [`crate::structural_verbs::
+/// check_no_deferred_shape_verbs`] (`rule_pipeline::load_rule_form` calls
+/// it before this function's own gating block even opens) — so a rule
+/// reaching this walk at all has none of the six graph-shape verbs
+/// anywhere in it, and these four rows' own membership checks are dead
+/// code in that pipeline (live only for this module's own direct unit
+/// tests, which drive `check_enum_ref_membership` without that earlier
+/// gate). The remaining twelve positions (`nodes`, `edges`, `neighbors`
+/// ×2, `hyperedges`, `members-of`, `hyperedges-of`, `the`,
+/// `edge-between`, `domain`, `emit`) carry no such earlier refusal and
+/// fire in production exactly as this doc otherwise describes.
+///
 /// # Errors
 ///
 /// [`GrammarError::Vocabulary`] wrapping [`VocabularyError::UnknownEnumMember`]
@@ -284,7 +313,9 @@ pub fn check_enum_ref_membership(
     let SExpr::List(items) = expr else {
         return Ok(());
     };
+    let mut head_is_emit = false;
     if let Some(SExpr::Atom(Atom::Symbol(head))) = items.first() {
+        head_is_emit = head == "emit";
         for (operand, child) in items.iter().enumerate().skip(1) {
             let SExpr::Atom(Atom::EnumRef { enum_type, member }) = child else {
                 continue;
@@ -296,6 +327,9 @@ pub fn check_enum_ref_membership(
                 .check_enum_ref(enum_type, member)
                 .map_err(GrammarError::Vocabulary)?;
         }
+    }
+    if head_is_emit {
+        return Ok(());
     }
     for child in items {
         check_enum_ref_membership(child, vocabulary)?;
@@ -1021,6 +1055,28 @@ mod tests {
             check_enum_ref_membership(&e("(guard #t (emit EventType/NOWHERE))"), &vocabulary())
                 .unwrap_err();
         assert_eq!(err.spec_code(), "E-LOAD-031");
+    }
+
+    #[test]
+    fn a_payload_item_labeled_like_emit_is_never_over_refused() {
+        // F5(a) (#534 fix round item 5, mirrors R2's exact fix for the
+        // sibling `check_type_operands_are_enum_refs` walk). `emit`'s
+        // `<payload-item>` label is an unconstrained `Atom::Symbol`
+        // (§2.8's `<payload-item> ::= (<symbol> <expr>)`) — nothing stops
+        // content from naming one `emit`, with a VALUE that happens to be
+        // a coincidentally well-kinded-but-unregistered `<enum-ref>`. The
+        // unconditional recursion used to re-inspect this nested list as
+        // a FRESH `emit` invocation and refuse its "operand 1" under
+        // E-LOAD-031 for a value that is not `emit`'s type operand at
+        // all. The regression pair — a GENUINE nested `emit` still
+        // getting caught — is already pinned by
+        // `membership_recurses_into_nested_forms` above (nested inside a
+        // `guard`, not inside `emit`'s own payload).
+        assert!(check_enum_ref_membership(
+            &e("(emit EventType/RUPTURE (emit EventType/NOWHERE))"),
+            &vocabulary(),
+        )
+        .is_ok());
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/grammar.rs
+++ b/rust/crates/babylon-bsl/src/grammar.rs
@@ -88,11 +88,11 @@ pub enum GrammarError {
     },
     /// `E-LOAD-023` / `E-LOAD-030` / `E-LOAD-031` (Task 8, Organization
     /// foundation plan) — a closed-vocabulary failure surfacing through
-    /// this module's own checks: [`check_one_verbs_field_inits`]'s
-    /// `owner_of` lookup (`E-LOAD-023`, previously silently skipped —
-    /// "the declaration reader's rejection" was true only for a field's
-    /// OWN `deffield`, never for a field-init naming a segment no
-    /// `deffield` ever declared) and [`check_enum_ref_membership`]
+    /// this module's own checks: `check_field_init_owners`'s `owner_of`
+    /// lookup (`E-LOAD-023`, previously silently skipped — "the
+    /// declaration reader's rejection" was true only for a field's OWN
+    /// `deffield`, never for a field-init naming a segment no `deffield`
+    /// ever declared) and [`check_enum_ref_membership`]
     /// (`E-LOAD-030`/`E-LOAD-031`).
     Vocabulary(VocabularyError),
 }

--- a/rust/crates/babylon-bsl/src/grammar.rs
+++ b/rust/crates/babylon-bsl/src/grammar.rs
@@ -315,27 +315,33 @@ pub fn check_enum_ref_membership(
 /// D101) survives every load-time check and dies mid-tick, uncoded, at
 /// `structural_verbs.rs`'s own `enum_member` (#528 fix round Item D).
 ///
-/// `add-node`/`add-edge` are ALSO two of the six graph-shape verbs
-/// `structural_verbs::check_no_deferred_shape_verbs` refuses
-/// unconditionally at load (§4.2 chapter C4's collect-then-apply gap,
-/// #519 fix round) — every rule using either verb is refused there
+/// **`remove-edge`** (#528 delta-verify rider R1) shares the exact same
+/// uncovered shape — its type operand is ALSO folded into the generic
+/// per-operand cost sum rather than extracted by `enum_ref_key` — even
+/// though it mints nothing (it is a REMOVAL verb); the const/function
+/// names below were widened, and renamed off "minting", accordingly.
+///
+/// `add-node`/`add-edge`/`remove-edge` are ALSO three of the six
+/// graph-shape verbs `structural_verbs::check_no_deferred_shape_verbs`
+/// refuses unconditionally at load (§4.2 chapter C4's collect-then-apply
+/// gap, #519 fix round) — every rule using any of them is refused there
 /// regardless of this gate, so in `rule_pipeline::load_rule_form`'s full
 /// pipeline THIS check changes no observable outcome for them today. It
 /// still earns its place: it runs EARLIER in that pipeline (naming the
 /// actual shape defect rather than the unrelated deferred-verb gap when
 /// a rule happens to carry both), it is the only gate at all for a
 /// caller that drives this module's checks directly (as this module's
-/// own tests do), and it stops being redundant the day `add-node`/
-/// `add-edge` gain collect-then-apply support. `emit` carries no such
-/// second gate — this is its ONLY load-time shape check.
-const MINTING_TYPE_OPERAND_HEADS: [&str; 3] = ["emit", "add-node", "add-edge"];
+/// own tests do), and it stops being redundant the day these verbs gain
+/// collect-then-apply support. `emit` carries no such second gate — this
+/// is its ONLY load-time shape check.
+const TYPE_OPERAND_HEADS: [&str; 4] = ["emit", "add-node", "add-edge", "remove-edge"];
 
 /// Walk a form tree and refuse a non-`<enum-ref>` child at
-/// `MINTING_TYPE_OPERAND_HEADS`'s one typed position (operand 1) —
-/// mirrors `bound_checker::enum_ref_key`'s own refusal for the sibling
-/// positions it already gates (the six §2.6 query heads, `add-hyperedge`);
-/// see that const's own doc for why these three specifically need a
-/// SEPARATE gate rather than reuse of that one.
+/// `TYPE_OPERAND_HEADS`'s one typed position (operand 1) — mirrors
+/// `bound_checker::enum_ref_key`'s own refusal for the sibling positions
+/// it already gates (the six §2.6 query heads, `add-hyperedge`); see that
+/// const's own doc for why these four specifically need a SEPARATE gate
+/// rather than reuse of that one.
 ///
 /// # Errors
 ///
@@ -345,24 +351,25 @@ const MINTING_TYPE_OPERAND_HEADS: [&str; 3] = ["emit", "add-node", "add-edge"];
 /// and the same uncoded vocabulary `bound_checker::enum_ref_key` itself
 /// uses for its sibling refusal ("expected an enum-ref where the grammar
 /// requires one").
-pub fn check_minting_type_operands_are_enum_refs(expr: &SExpr) -> Result<(), String> {
+pub fn check_type_operands_are_enum_refs(expr: &SExpr) -> Result<(), String> {
     if let SExpr::List(items) = expr {
         if let Some(SExpr::Atom(Atom::Symbol(head))) = items.first() {
-            if MINTING_TYPE_OPERAND_HEADS.contains(&head.as_str()) {
+            if TYPE_OPERAND_HEADS.contains(&head.as_str()) {
                 match items.get(1) {
                     Some(SExpr::Atom(Atom::EnumRef { .. })) => {}
                     other => {
                         return Err(format!(
                             "({head} …) operand 1 must be an <enum-ref> — expected an \
                              enum-ref where the grammar requires one, found {other:?} \
-                             (#528 fix round Item D)"
+                             (#528 fix round Item D; remove-edge added #528 delta-verify \
+                             rider R1)"
                         ));
                     }
                 }
             }
         }
         for child in items {
-            check_minting_type_operands_are_enum_refs(child)?;
+            check_type_operands_are_enum_refs(child)?;
         }
     }
     Ok(())
@@ -406,12 +413,12 @@ fn check_one_verbs_field_inits(
         // A mis-shaped `add-hyperedge` type-operand is the bound checker's
         // rejection (`bound_checker::check_member_lists`, via
         // `enum_ref_key`). `add-node`/`add-edge`'s is
-        // `check_minting_type_operands_are_enum_refs`, THIS module's own
+        // `check_type_operands_are_enum_refs`, THIS module's own
         // sibling gate — reached earlier in `rule_pipeline::
         // load_rule_form`'s pipeline than this function ever runs (it is
         // only called when `head` is a `MINTING_VERBS` member, gated by
         // `check_field_init_owners`, itself after `check_enum_ref_kinds`
-        // wires `check_minting_type_operands_are_enum_refs` alongside it —
+        // wires `check_type_operands_are_enum_refs` alongside it —
         // #528 fix round Item D). Refusing `Ok(())` here too is not
         // reachable through that pipeline for a mis-shaped operand, but
         // stays correct — and honest — for any caller that drives this
@@ -769,7 +776,7 @@ mod tests {
             "(add-edge EdgeType_SOLIDARITY a b :strength 0.5c)",
         ] {
             assert!(
-                super::check_minting_type_operands_are_enum_refs(&e(source)).is_err(),
+                super::check_type_operands_are_enum_refs(&e(source)).is_err(),
                 "{source}"
             );
         }
@@ -783,10 +790,35 @@ mod tests {
             "(add-edge EdgeType/SOLIDARITY a b :strength 0.5c)",
         ] {
             assert!(
-                super::check_minting_type_operands_are_enum_refs(&e(source)).is_ok(),
+                super::check_type_operands_are_enum_refs(&e(source)).is_ok(),
                 "{source}"
             );
         }
+    }
+
+    #[test]
+    fn a_bare_upper_ident_at_remove_edges_type_operand_position_is_refused() {
+        // #528 delta-verify rider R1: remove-edge shares the SAME
+        // uncovered type-operand shape as emit/add-node/add-edge — it
+        // mints nothing, but its type operand is folded into the same
+        // generic per-operand cost sum, so the same typo survives every
+        // load-time check the same way. Driven in isolation (this
+        // function directly), not through the full rule pipeline: a
+        // remove-edge rule is ALSO refused by
+        // `structural_verbs::check_no_deferred_shape_verbs` at load,
+        // which would mask this check entirely if driven end to end.
+        assert!(super::check_type_operands_are_enum_refs(&e(
+            "(remove-edge EdgeType_SOLIDARITY a b)"
+        ))
+        .is_err());
+    }
+
+    #[test]
+    fn a_correctly_shaped_remove_edge_is_untouched() {
+        assert!(super::check_type_operands_are_enum_refs(&e(
+            "(remove-edge EdgeType/SOLIDARITY a b)"
+        ))
+        .is_ok());
     }
 
     #[test]
@@ -794,17 +826,16 @@ mod tests {
         // Query heads and `add-hyperedge` are gated elsewhere
         // (`bound_checker::enum_ref_key`) — this function must not
         // overreach into their positions.
-        assert!(super::check_minting_type_operands_are_enum_refs(&e(
-            "(nodes NodeType_SOCIAL_CLASS)"
-        ))
-        .is_ok());
+        assert!(
+            super::check_type_operands_are_enum_refs(&e("(nodes NodeType_SOCIAL_CLASS)")).is_ok()
+        );
     }
 
     #[test]
     fn a_bare_upper_ident_nested_inside_a_guard_still_refuses() {
         // The walk must recurse into (guard/…) bodies, not just the
         // top-level form.
-        assert!(super::check_minting_type_operands_are_enum_refs(&e(
+        assert!(super::check_type_operands_are_enum_refs(&e(
             "(guard #t (emit NodeType_SOCIAL_CLASS))"
         ))
         .is_err());

--- a/rust/crates/babylon-bsl/src/grammar.rs
+++ b/rust/crates/babylon-bsl/src/grammar.rs
@@ -10,7 +10,7 @@
 //! ([`crate::vocabulary`]).
 
 use crate::reader::{Atom, SExpr};
-use crate::vocabulary::{ClosedVocabulary, EnumKind};
+use crate::vocabulary::{ClosedVocabulary, EnumKind, VocabularyError};
 
 /// A static shape rejection.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -86,6 +86,15 @@ pub enum GrammarError {
         /// The type the field owns off, as `EnumType/MEMBER`.
         owner: String,
     },
+    /// `E-LOAD-023` / `E-LOAD-030` / `E-LOAD-031` (Task 8, Organization
+    /// foundation plan) — a closed-vocabulary failure surfacing through
+    /// this module's own checks: [`check_one_verbs_field_inits`]'s
+    /// `owner_of` lookup (`E-LOAD-023`, previously silently skipped —
+    /// "the declaration reader's rejection" was true only for a field's
+    /// OWN `deffield`, never for a field-init naming a segment no
+    /// `deffield` ever declared) and [`check_enum_ref_membership`]
+    /// (`E-LOAD-030`/`E-LOAD-031`).
+    Vocabulary(VocabularyError),
 }
 
 impl GrammarError {
@@ -101,6 +110,7 @@ impl GrammarError {
             Self::GraphFlagOutsideDomain => "E-PARSE-013",
             Self::StrengthFieldInit { .. } => "E-PARSE-041",
             Self::FieldInitOwnerMismatch { .. } => "E-TYPE-014",
+            Self::Vocabulary(e) => e.spec_code(),
         }
     }
 }
@@ -166,6 +176,7 @@ impl std::fmt::Display for GrammarError {
                 "E-TYPE-014: field-init {field} owns off {owner}, but the verb \
                  mints a {verb_type} (§2.8)"
             ),
+            Self::Vocabulary(e) => write!(f, "{e}"),
         }
     }
 }
@@ -234,6 +245,60 @@ pub fn check_enum_ref_kinds(expr: &SExpr) -> Result<(), GrammarError> {
     }
     for child in items {
         check_enum_ref_kinds(child)?;
+    }
+    Ok(())
+}
+
+/// Task 8 (Organization foundation plan): the SIBLING pass to
+/// [`check_enum_ref_kinds`] over the SAME sixteen typed positions —
+/// [`check_enum_ref_kinds`] proves an already-present enum-ref names the
+/// right KIND for its position (D74); this proves it names a REGISTERED
+/// MEMBER of the scenario's declared closed vocabulary (§3.6). It runs
+/// only when a vocabulary was declared (`rule_pipeline::load_rule_form`
+/// gates the call on `ctx.vocabulary_registry`), and it runs AFTER
+/// [`check_enum_ref_kinds`] in that pipeline, so every enum-ref this walk
+/// inspects is already guaranteed kind-correct for its position —
+/// `ClosedVocabulary::check_enum_ref` can therefore only ever raise its
+/// MEMBER half here (`E-LOAD-031`); its type half (`E-LOAD-030`) is
+/// [`check_enum_ref_kinds`]'s own `WrongEnumKind`/`E-TYPE-011` failure
+/// mode for these positions, not unreachable by design — just refused
+/// earlier, under a different code.
+///
+/// Restricted to the SAME typed positions (not every enum-ref anywhere in
+/// the rule) on purpose: an untyped enum-ref may legitimately name a
+/// CONTENT-DECLARED custom enum type (`OrgKind`, [`crate::types::
+/// EnumRegistry`]'s own registry, Tasks 3–6) rather than one of the four
+/// structural kinds [`ClosedVocabulary`] governs. Walking every position
+/// indiscriminately would refuse `(= kind OrgKind/BUSINESS)` the moment
+/// ANY `defvocabulary` was declared anywhere in the scenario — coupling
+/// two registries that must stay independent.
+///
+/// # Errors
+///
+/// [`GrammarError::Vocabulary`] wrapping [`VocabularyError::UnknownEnumMember`]
+/// (`E-LOAD-031`) in practice at these positions.
+pub fn check_enum_ref_membership(
+    expr: &SExpr,
+    vocabulary: &ClosedVocabulary,
+) -> Result<(), GrammarError> {
+    let SExpr::List(items) = expr else {
+        return Ok(());
+    };
+    if let Some(SExpr::Atom(Atom::Symbol(head))) = items.first() {
+        for (operand, child) in items.iter().enumerate().skip(1) {
+            let SExpr::Atom(Atom::EnumRef { enum_type, member }) = child else {
+                continue;
+            };
+            if demanded_kind(head, operand).is_none() {
+                continue;
+            }
+            vocabulary
+                .check_enum_ref(enum_type, member)
+                .map_err(GrammarError::Vocabulary)?;
+        }
+    }
+    for child in items {
+        check_enum_ref_membership(child, vocabulary)?;
     }
     Ok(())
 }
@@ -366,9 +431,15 @@ fn check_one_verbs_field_inits(
                 field: field.clone(),
             });
         }
-        let Ok((owner_kind, owner_member)) = vocabulary.owner_of(segment) else {
-            continue; // E-LOAD-023 is the declaration reader's rejection
-        };
+        // Task 8 (Organization foundation plan): this used to `continue`
+        // here on the theory that "E-LOAD-023 is the declaration reader's
+        // rejection" — true only for a field's OWN `deffield` (§2.9's own
+        // check, `declarations.rs`), never for a field-init HERE naming a
+        // segment no `deffield` ever declared at all. That segment is a
+        // typo a rule can carry silently past every OTHER load-time gate;
+        // propagating makes it loud instead.
+        let (owner_kind, owner_member) =
+            vocabulary.owner_of(segment).map_err(GrammarError::Vocabulary)?;
         let owner = format!("{}/{owner_member}", owner_kind.type_name());
         if owner != verb_type {
             return Err(GrammarError::FieldInitOwnerMismatch {
@@ -616,9 +687,9 @@ pub fn check_graph_flag_placement(expr: &SExpr) -> Result<(), GrammarError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{check_enum_ref_kinds, check_field_init_owners};
+    use super::{check_enum_ref_kinds, check_enum_ref_membership, check_field_init_owners, GrammarError};
     use crate::reader::read;
-    use crate::vocabulary::{ClosedVocabulary, EnumKind};
+    use crate::vocabulary::{ClosedVocabulary, EnumKind, VocabularyError};
 
     fn vocabulary() -> ClosedVocabulary {
         ClosedVocabulary::new([
@@ -768,5 +839,87 @@ mod tests {
             &vocabulary(),
         )
         .is_ok());
+    }
+
+    // ---- Task 8 (Organization foundation plan): closed-vocabulary
+    // enforcement — `owner_of`'s Err now propagates (E-LOAD-023), and the
+    // new membership pass (E-LOAD-030/031) ----
+
+    #[test]
+    fn a_field_init_owning_off_an_unregistered_segment_is_e_load_023() {
+        // Before this task: silently `continue`d past — "E-LOAD-023 is the
+        // declaration reader's rejection" was true only for the field's OWN
+        // `deffield`, never for a field-init here naming a segment no
+        // `deffield` — nor any registered graph-element type — ever named.
+        let err = check_field_init_owners(
+            &e("(add-node NodeType/SOCIAL_CLASS n1 (imperium/rent 5$))"),
+            &vocabulary(),
+        )
+        .unwrap_err();
+        assert_eq!(err.spec_code(), "E-LOAD-023");
+        assert!(matches!(
+            err,
+            GrammarError::Vocabulary(VocabularyError::UnknownFieldOwner { segment }) if segment == "imperium"
+        ));
+    }
+
+    #[test]
+    fn an_unregistered_member_at_a_typed_position_is_e_load_031() {
+        for source in [
+            "(nodes NodeType/NOWHERE)",
+            "(edges EdgeType/NOWHERE)",
+            "(hyperedges HyperedgeType/NOWHERE)",
+            "(the NodeType/NOWHERE)",
+            "(domain NodeType/NOWHERE)",
+            "(emit EventType/NOWHERE)",
+            "(add-node NodeType/NOWHERE n1)",
+            "(add-edge EdgeType/NOWHERE a b)",
+            "(add-hyperedge HyperedgeType/NOWHERE h1 (members a b))",
+        ] {
+            let err = check_enum_ref_membership(&e(source), &vocabulary()).expect_err(source);
+            assert_eq!(err.spec_code(), "E-LOAD-031", "{source}");
+        }
+    }
+
+    #[test]
+    fn a_registered_member_at_a_typed_position_is_untouched() {
+        for source in [
+            "(nodes NodeType/SOCIAL_CLASS)",
+            "(emit EventType/RUPTURE)",
+            "(add-node NodeType/SOCIAL_CLASS n1)",
+            "(add-edge EdgeType/SOLIDARITY a b)",
+            "(add-hyperedge HyperedgeType/COMMUNITY h1 (members a b))",
+        ] {
+            assert!(
+                check_enum_ref_membership(&e(source), &vocabulary()).is_ok(),
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_enum_ref_at_an_untyped_position_is_never_checked_for_membership() {
+        // A comparison operand is not one of D74's sixteen typed
+        // positions — an unregistered member there is a value, not a
+        // mis-kinded or unregistered operand, and this pass must not
+        // overreach into it (a content-declared custom enum type, e.g.
+        // `OrgKind`, lives in a wholly different registry and must stay
+        // uncoupled from this one).
+        assert!(check_enum_ref_membership(
+            &e("(= NodeType/NOWHERE NodeType/NOWHERE)"),
+            &vocabulary(),
+        )
+        .is_ok());
+        assert!(check_enum_ref_membership(&e("(= kind OrgKind/BUSINESS)"), &vocabulary()).is_ok());
+    }
+
+    #[test]
+    fn membership_recurses_into_nested_forms() {
+        let err = check_enum_ref_membership(
+            &e("(guard #t (emit EventType/NOWHERE))"),
+            &vocabulary(),
+        )
+        .unwrap_err();
+        assert_eq!(err.spec_code(), "E-LOAD-031");
     }
 }

--- a/rust/crates/babylon-bsl/src/grammar.rs
+++ b/rust/crates/babylon-bsl/src/grammar.rs
@@ -94,7 +94,15 @@ pub enum GrammarError {
     /// `deffield`, never for a field-init naming a segment no `deffield`
     /// ever declared) and [`check_enum_ref_membership`]
     /// (`E-LOAD-030`/`E-LOAD-031`).
-    Vocabulary(VocabularyError),
+    Vocabulary {
+        /// The verb/form whose enum-ref or field-init failed (F6, #534 fix
+        /// round item 6) — §4.6's own house style ("load-time errors
+        /// report the offending form") for a class this crate did not
+        /// itself originate.
+        form: String,
+        /// The underlying vocabulary fact.
+        error: VocabularyError,
+    },
 }
 
 impl GrammarError {
@@ -110,7 +118,7 @@ impl GrammarError {
             Self::GraphFlagOutsideDomain => "E-PARSE-013",
             Self::StrengthFieldInit { .. } => "E-PARSE-041",
             Self::FieldInitOwnerMismatch { .. } => "E-TYPE-014",
-            Self::Vocabulary(e) => e.spec_code(),
+            Self::Vocabulary { error, .. } => error.spec_code(),
         }
     }
 }
@@ -176,7 +184,7 @@ impl std::fmt::Display for GrammarError {
                 "E-TYPE-014: field-init {field} owns off {owner}, but the verb \
                  mints a {verb_type} (§2.8)"
             ),
-            Self::Vocabulary(e) => write!(f, "{e}"),
+            Self::Vocabulary { form, error } => write!(f, "({form} …): {error}"),
         }
     }
 }
@@ -284,11 +292,11 @@ pub fn check_enum_ref_kinds(expr: &SExpr) -> Result<(), GrammarError> {
 /// wrongly refused its "operand 1" — a value, not `emit`'s own type
 /// operand — under `E-LOAD-031`. Stopping once `emit`'s own operand-1
 /// check above has run loses no coverage: `emit` has exactly ONE typed
-/// position in [`ENUM_REF_POSITIONS`], already checked in the loop above.
+/// position in `ENUM_REF_POSITIONS`, already checked in the loop above.
 ///
 /// **Several of the sixteen typed positions cannot fire through the
 /// production load pipeline in slice 1.** `add-node`, `add-edge`,
-/// `remove-edge` and `add-hyperedge` are four of [`ENUM_REF_POSITIONS`]'
+/// `remove-edge` and `add-hyperedge` are four of `ENUM_REF_POSITIONS`'
 /// rows, but every rule using any of them is ALREADY refused, earlier and
 /// unconditionally, by [`crate::structural_verbs::
 /// check_no_deferred_shape_verbs`] (`rule_pipeline::load_rule_form` calls
@@ -325,7 +333,10 @@ pub fn check_enum_ref_membership(
             }
             vocabulary
                 .check_enum_ref(enum_type, member)
-                .map_err(GrammarError::Vocabulary)?;
+                .map_err(|error| GrammarError::Vocabulary {
+                    form: head.clone(),
+                    error,
+                })?;
         }
     }
     if head_is_emit {
@@ -524,9 +535,13 @@ fn check_one_verbs_field_inits(
         // field_init_owners`'s unit tests below drive it with a
         // hand-built `ClosedVocabulary`), and for whenever that content
         // lands.
-        let (owner_kind, owner_member) = vocabulary
-            .owner_of(segment)
-            .map_err(GrammarError::Vocabulary)?;
+        let (owner_kind, owner_member) =
+            vocabulary
+                .owner_of(segment)
+                .map_err(|error| GrammarError::Vocabulary {
+                    form: head.to_owned(),
+                    error,
+                })?;
         let owner = format!("{}/{owner_member}", owner_kind.type_name());
         if owner != verb_type {
             return Err(GrammarError::FieldInitOwnerMismatch {
@@ -994,9 +1009,14 @@ mod tests {
         .unwrap_err();
         assert_eq!(err.spec_code(), "E-LOAD-023");
         assert!(matches!(
-            err,
-            GrammarError::Vocabulary(VocabularyError::UnknownFieldOwner { segment }) if segment == "imperium"
+            &err,
+            GrammarError::Vocabulary {
+                error: VocabularyError::UnknownFieldOwner { segment },
+                ..
+            } if segment == "imperium"
         ));
+        // F6 (#534 fix round item 6): the offending verb is named too.
+        assert!(err.to_string().contains("add-node"), "{err}");
     }
 
     #[test]
@@ -1055,6 +1075,17 @@ mod tests {
             check_enum_ref_membership(&e("(guard #t (emit EventType/NOWHERE))"), &vocabulary())
                 .unwrap_err();
         assert_eq!(err.spec_code(), "E-LOAD-031");
+    }
+
+    #[test]
+    fn the_membership_refusal_names_the_offending_verb() {
+        // F6 (#534 fix round item 6): §4.6 requires load-time errors to
+        // report the offending form — the raw `VocabularyError` alone
+        // names only the type/member, not which verb wrote it.
+        let err =
+            check_enum_ref_membership(&e("(emit EventType/NOWHERE)"), &vocabulary()).unwrap_err();
+        assert!(err.to_string().contains("emit"), "{err}");
+        assert!(err.to_string().contains("EventType/NOWHERE"), "{err}");
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/grammar.rs
+++ b/rust/crates/babylon-bsl/src/grammar.rs
@@ -1005,4 +1005,24 @@ mod tests {
                 .unwrap_err();
         assert_eq!(err.spec_code(), "E-LOAD-031");
     }
+
+    #[test]
+    fn an_undeclared_kind_under_a_partial_vocabulary_is_inert_at_the_rule_producer() {
+        // F1 (#534 fix round item 1): the plan's own Task-10 scenario shape
+        // (docs/superpowers/plans/2026-08-11-organization-foundation-plan.md
+        // Task 10, ~lines 443-480) declares `NodeType`/`EdgeType` but NOT
+        // `EventType`, then its probe rule emits
+        // `EventType/ORGANIZATION_SEEDED` — a member of a kind the scenario
+        // never declared at all. Before the fix, `check_enum_ref`'s
+        // ABSENT-kind case was indistinguishable from a DECLARED kind
+        // missing the member, so this load would have wrongly refused
+        // E-LOAD-031 for a kind that was never even opted into vocabulary
+        // checking.
+        let partial =
+            ClosedVocabulary::new([(EnumKind::NodeType, vec!["SOCIAL_CLASS".to_owned()])]).unwrap();
+        assert!(
+            check_enum_ref_membership(&e("(emit EventType/ANYTHING)"), &partial).is_ok(),
+            "EventType was never declared in this vocabulary — its checking must stay inert"
+        );
+    }
 }

--- a/rust/crates/babylon-bsl/src/grammar.rs
+++ b/rust/crates/babylon-bsl/src/grammar.rs
@@ -473,6 +473,23 @@ fn check_one_verbs_field_inits(
         // segment no `deffield` ever declared at all. That segment is a
         // typo a rule can carry silently past every OTHER load-time gate;
         // propagating makes it loud instead.
+        //
+        // **Not reachable through the production load pipeline in slice 1
+        // (F4, #534 fix round item 4)** — the same caveat
+        // `check_enum_ref_membership`'s own doc states for its sibling
+        // pass, undisclosed here until now. `check_field_init_owners`
+        // (this function's caller) only runs inside
+        // `rule_pipeline::load_rule_form`'s `ctx.vocabulary_registry`-gated
+        // block, and no shipped `.bscn` content set declares a
+        // `defvocabulary` yet — `prepare_rules` (`babylon-tick/src/
+        // lib.rs`) threads whatever the scenario declared, which today is
+        // always `None`. It becomes reachable the day a real content set
+        // opts in — Task 10's `organization-foundation.bscn` (the
+        // Organization foundation plan) is the first one that will. Live
+        // today for this crate's own direct callers (`check_
+        // field_init_owners`'s unit tests below drive it with a
+        // hand-built `ClosedVocabulary`), and for whenever that content
+        // lands.
         let (owner_kind, owner_member) = vocabulary
             .owner_of(segment)
             .map_err(GrammarError::Vocabulary)?;

--- a/rust/crates/babylon-bsl/src/grammar.rs
+++ b/rust/crates/babylon-bsl/src/grammar.rs
@@ -438,8 +438,9 @@ fn check_one_verbs_field_inits(
         // segment no `deffield` ever declared at all. That segment is a
         // typo a rule can carry silently past every OTHER load-time gate;
         // propagating makes it loud instead.
-        let (owner_kind, owner_member) =
-            vocabulary.owner_of(segment).map_err(GrammarError::Vocabulary)?;
+        let (owner_kind, owner_member) = vocabulary
+            .owner_of(segment)
+            .map_err(GrammarError::Vocabulary)?;
         let owner = format!("{}/{owner_member}", owner_kind.type_name());
         if owner != verb_type {
             return Err(GrammarError::FieldInitOwnerMismatch {
@@ -687,7 +688,9 @@ pub fn check_graph_flag_placement(expr: &SExpr) -> Result<(), GrammarError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{check_enum_ref_kinds, check_enum_ref_membership, check_field_init_owners, GrammarError};
+    use super::{
+        check_enum_ref_kinds, check_enum_ref_membership, check_field_init_owners, GrammarError,
+    };
     use crate::reader::read;
     use crate::vocabulary::{ClosedVocabulary, EnumKind, VocabularyError};
 
@@ -915,11 +918,9 @@ mod tests {
 
     #[test]
     fn membership_recurses_into_nested_forms() {
-        let err = check_enum_ref_membership(
-            &e("(guard #t (emit EventType/NOWHERE))"),
-            &vocabulary(),
-        )
-        .unwrap_err();
+        let err =
+            check_enum_ref_membership(&e("(guard #t (emit EventType/NOWHERE))"), &vocabulary())
+                .unwrap_err();
         assert_eq!(err.spec_code(), "E-LOAD-031");
     }
 }

--- a/rust/crates/babylon-bsl/src/grammar.rs
+++ b/rust/crates/babylon-bsl/src/grammar.rs
@@ -301,10 +301,33 @@ pub fn check_enum_ref_kinds(expr: &SExpr) -> Result<(), GrammarError> {
 /// NodeType/NOWHERE)`) escaped this walk too, silently. `emit` having
 /// exactly ONE typed position of its own (`ENUM_REF_POSITIONS`, checked in
 /// the loop above) bounds `emit`'s OWN operand list, not what a payload
-/// VALUE may nest. The corrected discipline: once `emit`'s own operand-1
-/// check has run, recurse into each payload item's element-1 VALUE ONLY —
-/// never treating the payload item itself as a form headed by its LABEL
-/// (element 0).
+/// VALUE may nest. The corrected discipline (G1): once `emit`'s own
+/// operand-1 check has run, recurse into each payload item's element-1
+/// VALUE ONLY — never treating the payload item itself as a form headed by
+/// its LABEL (element 0).
+///
+/// **G1's own fix still assumed two invariants no check here established
+/// (H1, #534 fix round 3 — one root cause with `structural_verbs::
+/// find_deferred_shape_verb`'s own sibling fix): that `items[1]` really is
+/// `emit`'s type operand (so `items[2..]` are genuinely payload items),
+/// and that a payload item has exactly two elements (so `pair.get(1)`
+/// finds its whole value).** Neither holds once a SECOND malformation is
+/// present. `(m (emit (the NodeType/NOWHERE)))` is a payload item whose
+/// value is a NESTED `emit` MISSING its own type operand — `items[1]`
+/// there is `(the NodeType/NOWHERE)` itself, not an `<enum-ref>`, and the
+/// old unconditional `skip(2)` silently treated it as "the confirmed type
+/// operand" and skipped it, so its own typed position never got checked.
+/// `(m 1 (the NodeType/NOWHERE))` is an OVER-ARITY payload item — three
+/// elements, not two — so `pair.get(1)` (the literal `1`) never reached
+/// `pair[2]`. Corrected: `items[1]` is only trusted as `emit`'s type
+/// operand when it is genuinely an `<enum-ref>` (`items[2..]` payload,
+/// `pair[1..]` every value); otherwise no positional assumption is safe
+/// once the type-operand slot itself is broken, so every item after the
+/// head is recursed into in full (`items[1..]`, ordinary recursion) —
+/// `check_type_operands_are_enum_refs` is the earlier load-time gate that
+/// refuses this exact malformed-nested-`emit` shape outright, but this
+/// function must not rely on that gate having run first (it is driven
+/// directly by this module's own tests, same as its two siblings).
 ///
 /// **Several of the sixteen typed positions cannot fire through the
 /// production load pipeline in slice 1.** `add-node`, `add-edge`,
@@ -352,14 +375,28 @@ pub fn check_enum_ref_membership(
         }
     }
     if head_is_emit {
-        // Payload-LABEL-only (G1): `items[2..]` are `emit`'s payload
-        // items, each `(<symbol> <expr>)`. Recurse into element 1 (the
-        // VALUE) only — element 0 (the LABEL) is never read as a head.
-        for payload_item in items.iter().skip(2) {
-            if let SExpr::List(pair) = payload_item {
-                if let Some(value_expr) = pair.get(1) {
-                    check_enum_ref_membership(value_expr, vocabulary)?;
+        // Payload-LABEL-only (G1), guarded (H1, #534 fix round 3):
+        // `items[1]` is emit's type operand ONLY when it is genuinely an
+        // `<enum-ref>` — a malformed nested emit (missing its own type
+        // operand) has no such guarantee when this function is driven
+        // directly. Well-formed: skip the confirmed type operand
+        // (`items[2..]`) and descend into every element AFTER each
+        // payload item's label (`pair[1..]`, not just `pair.get(1)` — an
+        // over-arity payload item has more than one value). Malformed:
+        // fall back to full recursion over every item after the head,
+        // since no positional assumption is safe once the type-operand
+        // slot itself is broken.
+        if matches!(items.get(1), Some(SExpr::Atom(Atom::EnumRef { .. }))) {
+            for payload_item in items.iter().skip(2) {
+                if let SExpr::List(pair) = payload_item {
+                    for value in pair.iter().skip(1) {
+                        check_enum_ref_membership(value, vocabulary)?;
+                    }
                 }
+            }
+        } else {
+            for item in items.iter().skip(1) {
+                check_enum_ref_membership(item, vocabulary)?;
             }
         }
         return Ok(());
@@ -410,29 +447,36 @@ const TYPE_OPERAND_HEADS: [&str; 4] = ["emit", "add-node", "add-edge", "remove-e
 /// const's own doc for why these four specifically need a SEPARATE gate
 /// rather than reuse of that one.
 ///
-/// **Head-position-only** (#528 delta-verify rider R2). A matched head's
-/// own trailing operands are NOT recursed into — only a list whose OWN
-/// head did not match is walked further. Before this, the walk treated
-/// every child list's head as a fresh candidate, wherever it sat: `emit`'s
-/// `<payload-item>` label is an unconstrained `Atom::Symbol` (§2.8's
-/// `<payload-item> ::= (<symbol> <expr>)`), so a payload item happening
-/// to be labeled `emit` — a LABEL, never a nested verb invocation — was
-/// wrongly refused as if it were one:
-/// `(emit EventType/RUPTURE (emit 5) (severity 1))` errored although it
-/// is well-formed content. Stopping at a matched head is safe: a
-/// `<field-init>`'s own head is always an `Atom::QName` (never a
-/// `Atom::Symbol`, so it can never even reach the `Some(Atom::Symbol(_))`
-/// arm below), a `(members …)` list's elements are bare node
-/// expressions, and every legal EXPRESSION-position head (`field-of`,
-/// `fold`, the arithmetic/comparison operators, …) is drawn from a
-/// CLOSED keyword set disjoint from `TYPE_OPERAND_HEADS` — these four
-/// names are themselves reserved against the intrinsic namespace (D33,
-/// `declarations::RESERVED_FORM_TAGS`) — so nothing legally nested inside
-/// a matched verb's own operands could ever be a genuine further match.
-/// `guard`/`for-each` are unaffected: neither is in `TYPE_OPERAND_HEADS`,
-/// so a form headed by either still falls through to the unconditional
-/// recursion below, reaching any REAL verb nested in their bodies exactly
-/// as before.
+/// **Payload-LABEL-only, corrected (H1, #534 fix round 3 — the third
+/// walker G1 (#534 fix round 2) should have fixed alongside its two
+/// siblings, `grammar::check_enum_ref_membership` and `structural_verbs::
+/// find_deferred_shape_verb`; supersedes the original R2 fix, #528
+/// delta-verify rider).** `emit`'s `<payload-item>` label is an
+/// unconstrained `Atom::Symbol` (§2.8's `<payload-item> ::= (<symbol>
+/// <expr>)`), so a payload item happening to be labeled `emit` — a LABEL,
+/// never a nested verb invocation — was wrongly refused as if it were one
+/// before R2: `(emit EventType/RUPTURE (emit 5) (severity 1))` errored
+/// although it is well-formed content.
+///
+/// R2's own fix over-corrected: stopping entirely once a matched head's
+/// own operand 1 is confirmed skipped the WHOLE rest of that head's
+/// subtree, not just the payload LABELS — so a payload item's VALUE (an
+/// arbitrary `<expr>` that may itself be headed by a `TYPE_OPERAND_HEADS`
+/// member, MISSING its own type operand) escaped this check too, silently
+/// — the exact malformation this function exists to refuse, just one
+/// level down: `(emit EventType/RUPTURE (m (emit (add-node
+/// NodeType/SOCIAL_CLASS 5))))`'s inner `(emit (add-node …))` has no
+/// `<enum-ref>` at its own operand 1, and R2's stop never reached it. The
+/// corrected discipline: once a matched head's own operand 1 is
+/// confirmed an `<enum-ref>` (so `items[2..]` are genuinely payload
+/// items, never this verb's own further operands), recurse into each
+/// payload item's element-1.. VALUES ONLY — never its element-0 LABEL,
+/// and never just element 1 alone (an over-arity payload item like
+/// `(m 1 (add-node …))` has more than one value to check — H1's own
+/// second escape). `guard`/`for-each` are unaffected: neither is in
+/// `TYPE_OPERAND_HEADS`, so a form headed by either still falls through
+/// to the unconditional recursion below, reaching any REAL verb nested in
+/// their bodies exactly as before.
 ///
 /// # Errors
 ///
@@ -457,9 +501,19 @@ pub fn check_type_operands_are_enum_refs(expr: &SExpr) -> Result<(), String> {
                         ));
                     }
                 }
-                // Head-position-only (R2): stop here — the rest of
-                // `items` is this verb's own operand list, never a
-                // sibling form to inspect.
+                // Payload-LABEL-only (H1): `items[1]` is now CONFIRMED an
+                // `<enum-ref>` by the match above, so `items[2..]` are
+                // genuinely payload items — recurse into each one's
+                // element-1.. VALUES (never its element-0 LABEL) so a
+                // NESTED occurrence of `TYPE_OPERAND_HEADS` lurking inside
+                // a payload value still gets its own arity checked.
+                for payload_item in items.iter().skip(2) {
+                    if let SExpr::List(pair) = payload_item {
+                        for value in pair.iter().skip(1) {
+                            check_type_operands_are_enum_refs(value)?;
+                        }
+                    }
+                }
                 return Ok(());
             }
         }
@@ -961,6 +1015,26 @@ mod tests {
     }
 
     #[test]
+    fn a_nested_emit_missing_its_own_type_operand_in_a_payload_value_still_refuses_type_operand() {
+        // H1 (#534 fix round 3, residual of G1 — one root cause with
+        // `structural_verbs::find_deferred_shape_verb`'s own sibling
+        // fix): R2's head-position-only stop (the test above) never
+        // recursed into a payload item's VALUE at all, so a SECOND
+        // malformation nested there — here, a payload item whose value is
+        // itself headed `emit` but MISSING its own type operand — escaped
+        // this check entirely. `(m (emit (add-node NodeType/SOCIAL_CLASS
+        // 5)))` is `emit`'s payload item labeled `m`, whose value
+        // `(emit (add-node NodeType/SOCIAL_CLASS 5))` is a NESTED `emit`
+        // invocation with no `<enum-ref>` at its own operand 1 — the
+        // exact shape this whole function exists to refuse, just one
+        // level down.
+        assert!(super::check_type_operands_are_enum_refs(&e(
+            "(emit EventType/RUPTURE (m (emit (add-node NodeType/SOCIAL_CLASS 5))))"
+        ))
+        .is_err());
+    }
+
+    #[test]
     fn a_non_minting_head_with_a_bare_upper_ident_operand_is_untouched() {
         // Query heads and `add-hyperedge` are gated elsewhere
         // (`bound_checker::enum_ref_key`) — this function must not
@@ -1205,5 +1279,46 @@ mod tests {
             &vocabulary(),
         )
         .is_ok());
+    }
+
+    // ---- H1 (#534 fix round 3, residual of G1 — one root cause with
+    // `structural_verbs::find_deferred_shape_verb`'s own sibling fix):
+    // the G1 descent assumed items[1] is emit's type operand (`skip(2)`)
+    // and that a payload item has exactly 2 elements (`pair.get(1)`).
+    // Neither invariant is established when this function is driven
+    // directly — a SECOND malformation (a type-operand-less nested emit,
+    // or an over-arity payload item) breaks both assumptions at once. ----
+
+    #[test]
+    fn a_nested_emit_missing_its_own_type_operand_inside_a_payload_value_still_refuses() {
+        // The `check_enum_ref_membership` twin of `check_type_operands_
+        // are_enum_refs`'s own escape-1 probe above: `(m (emit (the
+        // NodeType/NOWHERE)))` is a payload item whose value is a NESTED
+        // `emit` missing its own type operand — under the OLD `skip(2)`,
+        // this nested emit's `items[1]` (`(the NodeType/NOWHERE)`) was
+        // silently treated as "the confirmed type operand" and skipped,
+        // so the `NodeType/NOWHERE` typed position inside it never got
+        // checked. The fallback must fully recurse instead.
+        let err = check_enum_ref_membership(
+            &e("(emit EventType/RUPTURE (m (emit (the NodeType/NOWHERE))))"),
+            &vocabulary(),
+        )
+        .expect_err("a typed position behind a malformed nested emit must still be checked");
+        assert_eq!(err.spec_code(), "E-LOAD-031");
+    }
+
+    #[test]
+    fn an_over_arity_payload_item_still_checks_every_value_not_just_element_one() {
+        // `(m 1 (the NodeType/NOWHERE))` is an over-arity payload item —
+        // THREE elements, not the well-formed `(<symbol> <expr>)` two —
+        // so `pair.get(1)` alone (the literal `1`) never reached
+        // `pair[2]`, the `(the NodeType/NOWHERE)` typed position. The fix
+        // descends `pair[1..]`, every element after the label.
+        let err = check_enum_ref_membership(
+            &e("(emit EventType/RUPTURE (m 1 (the NodeType/NOWHERE)))"),
+            &vocabulary(),
+        )
+        .expect_err("every value after an over-arity payload item's label must still be checked");
+        assert_eq!(err.spec_code(), "E-LOAD-031");
     }
 }

--- a/rust/crates/babylon-bsl/src/grammar.rs
+++ b/rust/crates/babylon-bsl/src/grammar.rs
@@ -281,18 +281,30 @@ pub fn check_enum_ref_kinds(expr: &SExpr) -> Result<(), GrammarError> {
 /// ANY `defvocabulary` was declared anywhere in the scenario — coupling
 /// two registries that must stay independent.
 ///
-/// **Head-position-only at `emit`** (F5(a), #534 fix round item 5 —
-/// mirrors `check_type_operands_are_enum_refs`'s own R2 fix, #528
-/// delta-verify rider). `emit`'s `<payload-item>` label is an
+/// **Payload-LABEL-only at `emit`, corrected (G1, #534 fix round 2 — one
+/// root cause with the sibling fix in `structural_verbs::
+/// find_deferred_shape_verb`; supersedes F5(a), #534 fix round item 5,
+/// which itself mirrored `check_type_operands_are_enum_refs`'s R2 fix,
+/// #528 delta-verify rider).** `emit`'s `<payload-item>` label is an
 /// unconstrained `Atom::Symbol` (§2.8's `<payload-item> ::= (<symbol>
 /// <expr>)`) — nothing stops content from naming one `emit`, with a VALUE
 /// that happens to be a coincidentally well-kinded-but-unregistered
-/// `<enum-ref>`. Before this, the unconditional recursion below
+/// `<enum-ref>`. Before F5(a), the unconditional recursion below
 /// re-inspected such a payload item as a FRESH `emit` invocation and
 /// wrongly refused its "operand 1" — a value, not `emit`'s own type
-/// operand — under `E-LOAD-031`. Stopping once `emit`'s own operand-1
-/// check above has run loses no coverage: `emit` has exactly ONE typed
-/// position in `ENUM_REF_POSITIONS`, already checked in the loop above.
+/// operand — under `E-LOAD-031`.
+///
+/// F5(a)'s own fix over-corrected: returning `Ok(())` once `head_is_emit`
+/// skipped `emit`'s ENTIRE subtree, not just the payload LABELS — so a
+/// payload item's VALUE (element 1 of `(<symbol> <expr>)`, an arbitrary
+/// `<expr>` that may itself carry a typed position, e.g. `(the
+/// NodeType/NOWHERE)`) escaped this walk too, silently. `emit` having
+/// exactly ONE typed position of its own (`ENUM_REF_POSITIONS`, checked in
+/// the loop above) bounds `emit`'s OWN operand list, not what a payload
+/// VALUE may nest. The corrected discipline: once `emit`'s own operand-1
+/// check has run, recurse into each payload item's element-1 VALUE ONLY —
+/// never treating the payload item itself as a form headed by its LABEL
+/// (element 0).
 ///
 /// **Several of the sixteen typed positions cannot fire through the
 /// production load pipeline in slice 1.** `add-node`, `add-edge`,
@@ -340,6 +352,16 @@ pub fn check_enum_ref_membership(
         }
     }
     if head_is_emit {
+        // Payload-LABEL-only (G1): `items[2..]` are `emit`'s payload
+        // items, each `(<symbol> <expr>)`. Recurse into element 1 (the
+        // VALUE) only — element 0 (the LABEL) is never read as a head.
+        for payload_item in items.iter().skip(2) {
+            if let SExpr::List(pair) = payload_item {
+                if let Some(value_expr) = pair.get(1) {
+                    check_enum_ref_membership(value_expr, vocabulary)?;
+                }
+            }
+        }
         return Ok(());
     }
     for child in items {
@@ -1128,5 +1150,60 @@ mod tests {
             check_enum_ref_membership(&e("(emit EventType/ANYTHING)"), &partial).is_ok(),
             "EventType was never declared in this vocabulary — its checking must stay inert"
         );
+    }
+
+    // ---- G1 (#534 fix round 2, delta-verify MAJOR ×2 — one root cause):
+    // `a_payload_item_labeled_like_emit_is_never_over_refused` proved the
+    // over-refusal fix; these are its own over-CORRECTION. Stopping at
+    // `head_is_emit` skipped the whole subtree below `emit`, not just the
+    // payload LABELS — so a payload item's own VALUE (an arbitrary
+    // `<expr>` per §2.8's `<payload-item> ::= (<symbol> <expr>)`) escaped
+    // this walk entirely, including a typed position nested inside it. ----
+
+    #[test]
+    fn a_payload_values_own_typed_position_still_refuses_one_level_down() {
+        // `(m (the NodeType/NOWHERE))` is a payload item labeled `m` whose
+        // VALUE is `(the NodeType/NOWHERE)` — `the`'s own operand 1 is a
+        // typed NodeType position (D74), and NOWHERE is unregistered.
+        // Before the fix, `head_is_emit` returned `Ok(())` before the
+        // recursion ever reached this nested form at all.
+        let err = check_enum_ref_membership(
+            &e("(emit EventType/RUPTURE (m (the NodeType/NOWHERE)))"),
+            &vocabulary(),
+        )
+        .expect_err("a payload VALUE's own typed position must still be checked");
+        assert_eq!(err.spec_code(), "E-LOAD-031");
+    }
+
+    #[test]
+    fn a_payload_values_own_typed_position_still_refuses_nested_deeper() {
+        // The same discipline two levels down: the value is `(fold sum
+        // (nodes NodeType/NOWHERE) 1)` — `nodes`'s own operand 1 is still
+        // reachable by the ordinary recursive walk once inside the
+        // payload VALUE (never re-entering `emit`'s own head-position-only
+        // branch, since `fold`/`nodes` are neither `emit` nor a match for
+        // `demanded_kind`'s own head set at the wrong operand).
+        let err = check_enum_ref_membership(
+            &e("(emit EventType/RUPTURE (m (fold sum (nodes NodeType/NOWHERE) 1)))"),
+            &vocabulary(),
+        )
+        .expect_err("a typed position nested inside a payload value must still be checked");
+        assert_eq!(err.spec_code(), "E-LOAD-031");
+    }
+
+    #[test]
+    fn the_r2_over_refusal_fix_stays_green_after_the_g1_repair() {
+        // The CONSTRAINT G1 must not regress: a payload item's own LABEL
+        // is still never mistaken for a nested verb/typed-position head —
+        // `a_payload_item_labeled_like_emit_is_never_over_refused` above
+        // already pins the `(emit EventType/RUPTURE (emit
+        // EventType/NOWHERE))` shape; this is its sibling probe with a
+        // DIFFERENT label, isolating that the fix is about position
+        // (label vs. value), not about the specific label spelling.
+        assert!(check_enum_ref_membership(
+            &e("(emit EventType/RUPTURE (foo EventType/NOWHERE))"),
+            &vocabulary(),
+        )
+        .is_ok());
     }
 }

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -35,9 +35,9 @@ use crate::domain::{resolve_domain, DomainError, RuleDomain};
 use crate::evaluator::{evaluate, EvalEnv, Value};
 use crate::fuel::{CardinalityCeilings, IntrinsicCosts};
 use crate::grammar::{
-    check_arities_and_closed_sets, check_enum_ref_kinds, check_field_init_owners,
-    check_graph_flag_placement, check_minting_type_operands_are_enum_refs, check_string_positions,
-    GrammarError,
+    check_arities_and_closed_sets, check_enum_ref_kinds, check_enum_ref_membership,
+    check_field_init_owners, check_graph_flag_placement,
+    check_minting_type_operands_are_enum_refs, check_string_positions, GrammarError,
 };
 use crate::material_basis::{check_rule_surface, SurfaceError};
 use crate::mod_anchors::{check_anchor, AnchorDecl, AnchorError};
@@ -259,6 +259,13 @@ pub fn load_rule_form(rule: SExpr, ctx: &LoadContext<'_>) -> Result<LoadedRule, 
     check_no_deferred_shape_verbs(&rule).map_err(LoadError::DeferredShapeVerb)?;
     let mut domain = None;
     if let Some(vocabulary) = ctx.vocabulary_registry {
+        // Task 8 (Organization foundation plan): the closed-vocabulary
+        // MEMBERSHIP pass — sibling to `check_enum_ref_kinds` above, which
+        // is unconditional and already proved every typed enum-ref's KIND.
+        // Runs first in this block: it is the most basic fact about an
+        // enum-ref (does it even name something registered), and nothing
+        // below assumes it has run.
+        check_enum_ref_membership(&rule, vocabulary).map_err(LoadError::Grammar)?;
         check_field_init_owners(&rule, vocabulary).map_err(LoadError::Grammar)?;
         // The domain resolves BEFORE the scoping check, which needs the
         // subject node type to know which `:field` bindings are foreign.
@@ -907,5 +914,101 @@ mod deferred_shape_verb_tests {
             &ctx,
         )
         .expect("update-node must never trip the deferred-shape-verb gate");
+    }
+}
+
+#[cfg(test)]
+mod vocabulary_membership_tests {
+    // Task 8 (Organization foundation plan): the load-time half of
+    // closed-vocabulary enforcement, wired into `load_rule_form`'s
+    // `ctx.vocabulary_registry`-gated block. Exercised through `emit`
+    // rather than `add-node`/`add-edge`/`add-hyperedge`: those three are
+    // ALREADY refused, unconditionally, by `check_no_deferred_shape_verbs`
+    // (the six graph-shape verbs — see `deferred_shape_verb_tests` above
+    // and `structural_verbs.rs`'s own doc), so a rule using one would
+    // never reach this gate through the full pipeline regardless of
+    // vocabulary — `emit` is not one of the six, and its type operand is
+    // one of D74's own sixteen typed positions, so it is the one minting
+    // form that actually proves THIS gate, not an earlier one.
+    use super::{load_rule, LoadContext, LoadError};
+    use crate::bindings::BindingVocabulary;
+    use crate::fuel::{CardinalityCeilings, IntrinsicCosts};
+    use crate::grammar::GrammarError;
+    use crate::typecheck::TypeEnv;
+    use crate::vocabulary::{ClosedVocabulary, EnumKind, VocabularyError};
+    use std::collections::{HashMap, HashSet};
+
+    fn vocabulary() -> ClosedVocabulary {
+        ClosedVocabulary::new([(EnumKind::EventType, vec!["RUPTURE".to_owned()])]).unwrap()
+    }
+
+    fn load_ctx(vocabulary_registry: Option<&ClosedVocabulary>) -> LoadContext<'_> {
+        // Same leaking-fixture shape as `deferred_shape_verb_tests::load_ctx`
+        // above — this module needs no drop discipline either.
+        LoadContext {
+            vocabulary: Box::leak(Box::new(BindingVocabulary {
+                fields: HashSet::new(),
+                consts: HashSet::new(),
+                metrics: HashSet::new(),
+            })),
+            types: Box::leak(Box::new(TypeEnv {
+                fields: HashMap::new(),
+                exemptions: &[],
+            })),
+            ceilings: Box::leak(Box::new(CardinalityCeilings::new(
+                HashMap::new(),
+                HashMap::new(),
+            ))),
+            intrinsics: Box::leak(Box::new(IntrinsicCosts::default())),
+            systems: Box::leak(Box::new(HashSet::from(["probe".to_owned()]))),
+            vocabulary_registry,
+            rule_file: "x.bsl",
+        }
+    }
+
+    const RULE: &str = r#"(rule probe/vocab :material-basis "x" :fuel 64
+  (domain :graph)
+  (bindings)
+  (when #t)
+  (effects (emit EventType/RUPTURE)))"#;
+
+    const TYPO_RULE: &str = r#"(rule probe/vocab :material-basis "x" :fuel 64
+  (domain :graph)
+  (bindings)
+  (when #t)
+  (effects (emit EventType/NOWHERE)))"#;
+
+    #[test]
+    fn an_unregistered_enum_ref_in_a_rule_is_e_load_031_under_a_declared_vocabulary() {
+        let vocab = vocabulary();
+        let ctx = load_ctx(Some(&vocab));
+        let err = load_rule(TYPO_RULE, &ctx).unwrap_err();
+        assert_eq!(err.spec_code(), Some("E-LOAD-031"));
+        assert!(
+            matches!(
+                &err,
+                LoadError::Grammar(GrammarError::Vocabulary(
+                    VocabularyError::UnknownEnumMember { enum_type, member }
+                )) if enum_type == "EventType" && member == "NOWHERE"
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn a_registered_enum_ref_loads_clean_under_a_declared_vocabulary() {
+        let vocab = vocabulary();
+        let ctx = load_ctx(Some(&vocab));
+        load_rule(RULE, &ctx).expect("a registered EventType member must load");
+    }
+
+    #[test]
+    fn the_same_typo_source_loads_with_no_vocabulary_declared_backward_compat_pin() {
+        // The plan's own backward-compatibility proof: with NO declared
+        // vocabulary, `EventType/NOWHERE` is exactly as legal as it was
+        // before this task — membership is unchecked, opt-in per scenario.
+        let ctx = load_ctx(None);
+        load_rule(TYPO_RULE, &ctx)
+            .expect("no declared vocabulary means membership is unchecked (backward compat)");
     }
 }

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -907,6 +907,48 @@ mod deferred_shape_verb_tests {
         assert!(err.to_string().contains("remove-node"), "{err}");
     }
 
+    // ---- G1 (#534 fix round 2, delta-verify MAJOR ×2 — one root cause
+    // with the sibling fix in `grammar::check_enum_ref_membership`): the
+    // F5(b) over-refusal fix (`a_rule_using_remove_node_refuses_at_load_
+    // naming_the_verb` above stayed green throughout) itself
+    // over-corrected — stopping at a matched `emit` head skipped the
+    // WHOLE subtree, including a payload item's own VALUE, which is an
+    // arbitrary `<expr>` that may illegally spell a real deferred-shape
+    // verb invocation. Before this fix both probes below loaded clean and
+    // only died mid-tick, the exact "load-passes/execute-dies" shape this
+    // whole gate exists to prevent (this module's own header comment). ----
+
+    #[test]
+    fn a_deferred_shape_verb_inside_an_emit_payload_value_still_refuses_at_load() {
+        let ctx = load_ctx();
+        let err = load_rule(
+            r#"(rule geography/mint :material-basis "x" :fuel 64
+  (bindings)
+  (effects (emit EventType/RUPTURE (payload (add-node NodeType/SOCIAL_CLASS 5)))))"#,
+            &ctx,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, LoadError::DeferredShapeVerb(_)),
+            "expected LoadError::DeferredShapeVerb, got {err:?}"
+        );
+        assert!(err.to_string().contains("add-node"), "{err}");
+    }
+
+    #[test]
+    fn a_deferred_shape_verb_inside_an_emit_payload_value_nested_in_a_guard_still_refuses() {
+        let ctx = load_ctx();
+        let err = load_rule(
+            r#"(rule geography/mint :material-basis "x" :fuel 64
+  (bindings)
+  (effects (guard #t (emit EventType/RUPTURE (payload (remove-node self))))))"#,
+            &ctx,
+        )
+        .unwrap_err();
+        assert!(matches!(err, LoadError::DeferredShapeVerb(_)), "{err}");
+        assert!(err.to_string().contains("remove-node"), "{err}");
+    }
+
     #[test]
     fn a_rule_with_no_deferred_shape_verb_is_unaffected_by_the_gate() {
         // The regression guard: a rule that uses only update-node must not

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -36,8 +36,8 @@ use crate::evaluator::{evaluate, EvalEnv, Value};
 use crate::fuel::{CardinalityCeilings, IntrinsicCosts};
 use crate::grammar::{
     check_arities_and_closed_sets, check_enum_ref_kinds, check_enum_ref_membership,
-    check_field_init_owners, check_graph_flag_placement,
-    check_minting_type_operands_are_enum_refs, check_string_positions, GrammarError,
+    check_field_init_owners, check_graph_flag_placement, check_minting_type_operands_are_enum_refs,
+    check_string_positions, GrammarError,
 };
 use crate::material_basis::{check_rule_surface, SurfaceError};
 use crate::mod_anchors::{check_anchor, AnchorDecl, AnchorError};

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -991,12 +991,15 @@ mod vocabulary_membership_tests {
         assert!(
             matches!(
                 &err,
-                LoadError::Grammar(GrammarError::Vocabulary(
-                    VocabularyError::UnknownEnumMember { enum_type, member }
-                )) if enum_type == "EventType" && member == "NOWHERE"
+                LoadError::Grammar(GrammarError::Vocabulary {
+                    error: VocabularyError::UnknownEnumMember { enum_type, member, .. },
+                    ..
+                }) if enum_type == "EventType" && member == "NOWHERE"
             ),
             "{err:?}"
         );
+        // F6 (#534 fix round item 6): the offending verb is named too.
+        assert!(err.to_string().contains("emit"), "{err}");
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -114,7 +114,11 @@ pub enum LoadError {
     /// §3.4 aggregation law.
     Type(TypeError),
     /// §2's static shape rules — D74's enum-ref operand class rule and
-    /// D37's field-init owner rule.
+    /// D37's field-init owner rule — plus, since Task 8 (Organization
+    /// foundation plan, #534 fix round item 7), §3.6's closed-vocabulary
+    /// membership/field-owner rejections
+    /// (`GrammarError::Vocabulary`'s `E-LOAD-023`/`E-LOAD-030`/`E-LOAD-031`)
+    /// surfacing through this module's own checks.
     Grammar(GrammarError),
     /// §2.3 anchors.
     Anchor(AnchorError),
@@ -248,11 +252,12 @@ pub fn load_rule_form(rule: SExpr, ctx: &LoadContext<'_>) -> Result<LoadedRule, 
     check_arities_and_closed_sets(&rule).map_err(LoadError::Grammar)?;
     check_string_positions(&rule).map_err(LoadError::Grammar)?;
     check_enum_ref_kinds(&rule).map_err(LoadError::Grammar)?;
-    // The type-operand position of emit/add-node/add-edge is the one
-    // §2.6 class-rule position `check_enum_ref_kinds` does not itself
-    // enforce as MANDATORY-enum-ref (it only checks the KIND of an
-    // enum-ref that is already there) — #528 fix round Item D, see this
-    // function's own doc for why these three specifically need it.
+    // The type-operand position of emit/add-node/add-edge/remove-edge is
+    // the one §2.6 class-rule position `check_enum_ref_kinds` does not
+    // itself enforce as MANDATORY-enum-ref (it only checks the KIND of an
+    // enum-ref that is already there) — #528 fix round Item D
+    // (remove-edge added by #528 delta-verify rider R1), see this
+    // function's own doc for why these four specifically need it.
     check_type_operands_are_enum_refs(&rule).map_err(LoadError::MintingTypeOperand)?;
     check_graph_flag_placement(&rule).map_err(LoadError::Grammar)?;
     // #519 fix round, fix 4: a rule using one of the six graph-shape verbs

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -36,8 +36,8 @@ use crate::evaluator::{evaluate, EvalEnv, Value};
 use crate::fuel::{CardinalityCeilings, IntrinsicCosts};
 use crate::grammar::{
     check_arities_and_closed_sets, check_enum_ref_kinds, check_enum_ref_membership,
-    check_field_init_owners, check_graph_flag_placement, check_minting_type_operands_are_enum_refs,
-    check_string_positions, GrammarError,
+    check_field_init_owners, check_graph_flag_placement, check_string_positions,
+    check_type_operands_are_enum_refs, GrammarError,
 };
 use crate::material_basis::{check_rule_surface, SurfaceError};
 use crate::mod_anchors::{check_anchor, AnchorDecl, AnchorError};
@@ -146,11 +146,15 @@ pub enum LoadError {
     DeferredShapeVerb(String),
     /// No numbered code, same precedent as [`Self::Content`]: a non-
     /// `<enum-ref>` child at the type-operand position of `emit`/
-    /// `add-node`/`add-edge` is a shape defect the §3.7 static cost pass
-    /// does not itself catch (unlike its sibling positions,
-    /// `bound_checker::enum_ref_key` — see
-    /// [`crate::grammar::check_minting_type_operands_are_enum_refs`]'s own
-    /// doc); #528 fix round Item D.
+    /// `add-node`/`add-edge`/`remove-edge` is a shape defect the §3.7
+    /// static cost pass does not itself catch (unlike its sibling
+    /// positions, `bound_checker::enum_ref_key` — see
+    /// [`crate::grammar::check_type_operands_are_enum_refs`]'s own
+    /// doc); #528 fix round Item D (`remove-edge` added #528
+    /// delta-verify rider R1). Variant name kept as-is despite the
+    /// underlying check's rename — `remove-edge` doesn't mint, but this
+    /// error still names the class of defect the type-operand position
+    /// shares with the three minting verbs.
     MintingTypeOperand(String),
 }
 
@@ -249,7 +253,7 @@ pub fn load_rule_form(rule: SExpr, ctx: &LoadContext<'_>) -> Result<LoadedRule, 
     // enforce as MANDATORY-enum-ref (it only checks the KIND of an
     // enum-ref that is already there) — #528 fix round Item D, see this
     // function's own doc for why these three specifically need it.
-    check_minting_type_operands_are_enum_refs(&rule).map_err(LoadError::MintingTypeOperand)?;
+    check_type_operands_are_enum_refs(&rule).map_err(LoadError::MintingTypeOperand)?;
     check_graph_flag_placement(&rule).map_err(LoadError::Grammar)?;
     // #519 fix round, fix 4: a rule using one of the six graph-shape verbs
     // Task 12's collect-then-apply split cannot yet defer must be refused

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -902,7 +902,6 @@ fn load_deffield(
 }
 
 /// `(node <local-name> <enum-ref> (<qname> <int>)*)`
-#[allow(clippy::too_many_arguments)]
 fn load_node(
     parts: &[SExpr],
     graph: &mut dyn GraphSubstrate,
@@ -1234,7 +1233,6 @@ fn currency_refusal_message(local: &str, field: &str) -> String {
 /// `(edge <enum-ref> <local-name> <local-name> <int>)` — returns the minted
 /// `EdgeType` member (verbatim, matching `load_node`'s own return
 /// convention) so the caller can build the `edge_types` census.
-#[allow(clippy::too_many_arguments)]
 fn load_edge(
     parts: &[SExpr],
     graph: &mut dyn GraphSubstrate,

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -127,6 +127,35 @@ fn err(message: impl Into<String>) -> ScenarioError {
     }
 }
 
+/// F2 (#534 fix round item 2): demand that a `.bscn` node/edge form's
+/// `<enum-ref>` type-operand names the POSITION's own kind — a static fact
+/// about the WRITTEN type name, independent of whether any
+/// `defvocabulary` was declared for it at all (mirrors
+/// `grammar::check_enum_ref_kinds`'s D74 class rule for rules, which is
+/// also unconditional — it runs whether or not `ctx.vocabulary_registry`
+/// is `Some`). Without this, `load_node`/`load_edge` called
+/// `ClosedVocabulary::check_enum_ref` and discarded its returned
+/// [`EnumKind`], never comparing it against the position it came from, so
+/// e.g. `(node x EdgeType/SOLIDARITY)` minted a node silently typed
+/// SOLIDARITY under a declared vocabulary that registers
+/// `EdgeType/SOLIDARITY` (panel-proven, mutation-reproduced: hardcoding
+/// "`NodeType`" at the call site flipped zero tests before this).
+///
+/// # Errors
+///
+/// [`VocabularyError::UnknownEnumType`] (`E-LOAD-030`) — reused, not
+/// invented: from THIS position's own viewpoint, a syntactically-valid but
+/// wrong-kind type name is exactly as absent from the registry as an
+/// outright unregistered one (bsl-language.rst D119).
+fn demand_enum_kind(enum_type: &str, demanded: EnumKind) -> Result<(), VocabularyError> {
+    if EnumKind::from_type_name(enum_type) == Some(demanded) {
+        return Ok(());
+    }
+    Err(VocabularyError::UnknownEnumType {
+        enum_type: enum_type.to_owned(),
+    })
+}
+
 /// A hydration failure the reference gives a code (§3.9).
 fn coded_err(code: &'static str, message: impl Into<String>) -> ScenarioError {
     ScenarioError {
@@ -877,6 +906,16 @@ fn load_node(
              and silently rebinding it would make later edges ambiguous"
         )));
     }
+    // F2 (#534 fix round item 2): a node's own enum-ref position demands
+    // NodeType — a STATIC fact about the written type name, independent of
+    // whether any `defvocabulary` was declared at all (mirrors
+    // `grammar::check_enum_ref_kinds`'s D74 class rule for rules, which is
+    // ALSO unconditional). Without this, `(node x EdgeType/SOLIDARITY)`
+    // minted a node silently typed SOLIDARITY under a declared vocabulary
+    // that registers `EdgeType/SOLIDARITY` — `check_enum_ref`'s returned
+    // `EnumKind` was discarded and never compared against the position it
+    // came from (panel-proven, mutation-reproduced).
+    demand_enum_kind(enum_type, EnumKind::NodeType)?;
     // Task 8 (Organization foundation plan): the scenario-load half of
     // closed-vocabulary enforcement — checked BEFORE minting, so a typo'd
     // type never even reaches the substrate. `None` (no `defvocabulary`
@@ -1189,6 +1228,9 @@ fn load_edge(
             "expected (edge <EdgeType/MEMBER> <from-name> <to-name> <int>)",
         ));
     };
+    // F2 (#534 fix round item 2): see `load_node`'s identical comment —
+    // the edge position demands EdgeType, unconditionally.
+    demand_enum_kind(enum_type, EnumKind::EdgeType)?;
     // Task 8 (Organization foundation plan): see `load_node`'s identical
     // comment — the same check, before the substrate's own `add_edge`.
     if let Some(vocabulary) = vocabulary {
@@ -2421,6 +2463,137 @@ mod tests {
         let loaded = load_scenario(source, &mut graph).expect("registered members must load");
         assert_eq!(loaded.node_count, 2);
         assert_eq!(loaded.edge_count, 1);
+    }
+
+    // ---- F2 (#534 fix round item 2): `load_node`/`load_edge` demand the
+    // POSITION'S OWN kind — a node minted from `EdgeType/SOLIDARITY`
+    // silently typed itself "SOLIDARITY" before this (panel-proven:
+    // hardcoding "NodeType" at the call site flipped zero tests). ----
+
+    #[test]
+    fn load_node_demands_nodetype_regardless_of_what_is_declared() {
+        // The matrix: declared-right-kind, undeclared-kind (F1
+        // interaction — inert), wrong-kind — all three must enforce the
+        // node position's own kind identically.
+
+        // declared-right-kind: NodeType is declared, member is a typo.
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario org/matrix-declared-right-kind
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (node x NodeType/NOWHERE))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-031"), "{}", err.message);
+
+        // undeclared-kind: NodeType is never declared (only EdgeType is) —
+        // the KIND matches the node position, and F1 leaves NodeType's own
+        // membership inert, so this loads clean.
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(
+            r"
+(scenario org/matrix-undeclared-kind
+  (defvocabulary EdgeType (SOLIDARITY))
+  (node x NodeType/ANYTHING))
+",
+            &mut graph,
+        )
+        .expect("NodeType was never declared — position-kind matches, membership stays inert");
+        assert_eq!(loaded.node_count, 1);
+
+        // wrong-kind: NodeType IS declared, but the written ref names
+        // EdgeType — refused as a kind mismatch, never silently minted as
+        // a node typed "SOLIDARITY".
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario org/matrix-wrong-kind
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (defvocabulary EdgeType (SOLIDARITY))
+  (node x EdgeType/SOLIDARITY))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-030"), "{}", err.message);
+        assert_eq!(graph.nodes("SOLIDARITY").len(), 0);
+    }
+
+    #[test]
+    fn load_node_refuses_the_org_kind_business_probe_verbatim() {
+        // The panel's exact probe: `OrgKind` is not even a valid
+        // structural `EnumKind` name — the same E-LOAD-030 a bare typo'd
+        // kind name gets.
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario org/org-kind-probe
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (node x OrgKind/BUSINESS))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-030"), "{}", err.message);
+    }
+
+    #[test]
+    fn load_edge_demands_edgetype_regardless_of_what_is_declared() {
+        // The EdgeType-position mirror of
+        // `load_node_demands_nodetype_regardless_of_what_is_declared`.
+
+        // declared-right-kind: typo under a declared EdgeType.
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario org/edge-matrix-declared-right-kind
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (defvocabulary EdgeType (SOLIDARITY))
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (edge EdgeType/NOWHERE a b 1))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-031"), "{}", err.message);
+
+        // undeclared-kind: EdgeType never declared (only NodeType is) —
+        // kind matches the edge position, membership stays inert (F1).
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(
+            r"
+(scenario org/edge-matrix-undeclared-kind
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (edge EdgeType/ANYTHING a b 1))
+",
+            &mut graph,
+        )
+        .expect("EdgeType was never declared — position-kind matches, membership stays inert");
+        assert_eq!(loaded.edge_count, 1);
+
+        // wrong-kind: EdgeType IS declared, but the written ref names
+        // NodeType — refused as a kind mismatch.
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario org/edge-matrix-wrong-kind
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (defvocabulary EdgeType (SOLIDARITY))
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (edge NodeType/SOCIAL_CLASS a b 1))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-030"), "{}", err.message);
+        assert_eq!(graph.edge_count(), 0);
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -2424,6 +2424,27 @@ mod tests {
     }
 
     #[test]
+    fn an_edge_under_an_undeclared_edge_type_is_inert_not_e_load_031() {
+        // F1 (#534 fix round item 1): a vocabulary declaring ONLY NodeType
+        // must leave EdgeType's own membership checking inert — an
+        // undeclared MEMBER of an UNDECLARED kind must never be conflated
+        // with an undeclared member of a DECLARED kind (that stays
+        // E-LOAD-031, `an_unregistered_edge_member_under_a_declared_
+        // vocabulary_is_e_load_031` above).
+        let source = r"
+(scenario org/edge-type-undeclared
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (edge EdgeType/ANYTHING a b 1))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph)
+            .expect("EdgeType was never declared — its checking must stay inert");
+        assert_eq!(loaded.edge_count, 1);
+    }
+
+    #[test]
     fn the_same_typo_source_loads_with_no_defvocabulary_declared_backward_compat_pin() {
         // Task 8's own backward-compat pin: the SAME node-type typo, with
         // NO `defvocabulary` form at all, loads exactly as it did before

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -158,6 +158,19 @@ fn err(message: impl Into<String>) -> ScenarioError {
 /// membership check a threaded `ClosedVocabulary` performs (below, in
 /// `load_node`/`load_edge`) is the only opt-in half.
 ///
+/// **H2 (#534 fix round 3): the split is ALSO registry-relative, not just
+/// positional.** `enums` is `vocabulary_so_far`'s sibling — the running
+/// `defenum` registry as it stands at THIS point in the top-to-bottom
+/// load — so a scenario-declared type participates in "is this a REAL
+/// type" only from its OWN declaration point down, the same
+/// "declaration must precede use" discipline `deffield`/`defconst`/
+/// `defvocabulary` already enforce. `(defenum OrgKind (BUSINESS)) (node x
+/// OrgKind/BUSINESS)` is `E-TYPE-011` (`OrgKind` genuinely exists by the
+/// time the node form runs); `(node x OrgKind/BUSINESS) (defenum OrgKind
+/// (BUSINESS))` is `E-LOAD-030` (`OrgKind` genuinely names nothing YET at
+/// that point in the load) — not a bug, the same ordering sensitivity
+/// every other declared-registry lookup in this loader already has.
+///
 /// # Errors
 ///
 /// [`VocabularyError::WrongEnumKind`] (`E-TYPE-011`) for a real type at
@@ -2632,6 +2645,54 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err.code, Some("E-TYPE-011"), "{}", err.message);
+    }
+
+    #[test]
+    fn demand_enum_kinds_split_is_also_registry_relative_not_just_positional() {
+        // H2 (#534 fix round 3): disclosure pin — the E-TYPE-011/
+        // E-LOAD-030 split is POSITIONAL (G3(c) below: unconditional, not
+        // vocabulary-gated) AND REGISTRY-RELATIVE: a scenario-declared
+        // `defenum` type participates in "is this a REAL type" only from
+        // ITS OWN declaration point down, the same "declaration must
+        // precede use" discipline `deffield`/`defconst`/`defvocabulary`
+        // already enforce, consistent with `vocabulary_so_far`. The SAME
+        // `(node x OrgKind/BUSINESS)` probe, both orderings — that pair of
+        // facts IS the contract.
+        let mut declared_first = MemoryGraph::new();
+        let err_declared_first = load_scenario(
+            r"
+(scenario org/org-kind-order-declared-first
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (defenum OrgKind (BUSINESS))
+  (node x OrgKind/BUSINESS))
+",
+            &mut declared_first,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err_declared_first.code,
+            Some("E-TYPE-011"),
+            "OrgKind exists by the time the node form runs: {}",
+            err_declared_first.message
+        );
+
+        let mut declared_after = MemoryGraph::new();
+        let err_declared_after = load_scenario(
+            r"
+(scenario org/org-kind-order-declared-after
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (node x OrgKind/BUSINESS)
+  (defenum OrgKind (BUSINESS)))
+",
+            &mut declared_after,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err_declared_after.code,
+            Some("E-LOAD-030"),
+            "OrgKind names nothing YET at this point in the load — not a bug: {}",
+            err_declared_after.message
+        );
     }
 
     // ---- G3(c) (#534 fix round 2): F1×F2 interaction pins —

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -127,33 +127,59 @@ fn err(message: impl Into<String>) -> ScenarioError {
     }
 }
 
-/// F2 (#534 fix round item 2): demand that a `.bscn` node/edge form's
-/// `<enum-ref>` type-operand names the POSITION's own kind — a static fact
-/// about the WRITTEN type name, independent of whether any
-/// `defvocabulary` was declared for it at all (mirrors
-/// `grammar::check_enum_ref_kinds`'s D74 class rule for rules, which is
-/// also unconditional — it runs whether or not `ctx.vocabulary_registry`
-/// is `Some`). Without this, `load_node`/`load_edge` called
-/// `ClosedVocabulary::check_enum_ref` and discarded its returned
-/// [`EnumKind`], never comparing it against the position it came from, so
-/// e.g. `(node x EdgeType/SOLIDARITY)` minted a node silently typed
-/// SOLIDARITY under a declared vocabulary that registers
-/// `EdgeType/SOLIDARITY` (panel-proven, mutation-reproduced: hardcoding
-/// "`NodeType`" at the call site flipped zero tests before this).
+/// F2 (#534 fix round item 2), corrected by G2 (#534 fix round 2 item 2):
+/// demand that a `.bscn` node/edge form's `<enum-ref>` type-operand names
+/// the POSITION's own kind — a static fact about the WRITTEN type name,
+/// independent of whether any `defvocabulary` was declared for it at all
+/// (mirrors `grammar::check_enum_ref_kinds`'s D74 class rule for rules,
+/// which is also unconditional — it runs whether or not
+/// `ctx.vocabulary_registry` is `Some`; authority: §3.9 clause 1,
+/// "hydration is not a back door into the closed vocabulary"). Without
+/// this, `load_node`/`load_edge` called `ClosedVocabulary::check_enum_ref`
+/// and discarded its returned [`EnumKind`], never comparing it against the
+/// position it came from, so e.g. `(node x EdgeType/SOLIDARITY)` minted a
+/// node silently typed SOLIDARITY under a declared vocabulary that
+/// registers `EdgeType/SOLIDARITY` (panel-proven, mutation-reproduced:
+/// hardcoding "`NodeType`" at the call site flipped zero tests before
+/// this).
+///
+/// **G2's own correction.** §2.6's class rule (bsl-language.rst:972-974)
+/// splits two facts F2's original landing conflated under one code and one
+/// message: whether the WRITTEN kind is the position's own kind
+/// (`E-TYPE-011`) is independent of whether the type/member exist AT ALL
+/// (`E-LOAD-030`/`E-LOAD-031`). `enum_type` naming a REAL type — one of
+/// the four structural kinds, or a type this scenario declared via
+/// `defenum` (`enums`) — that simply is not the kind this position demands
+/// is `E-TYPE-011`; `enum_type` naming nothing real anywhere is the
+/// genuine `E-LOAD-030` case (bsl-language.rst D119). This split is
+/// POSITIONAL, not vocabulary-gated: it holds whether or not the WRITTEN
+/// kind was itself `defvocabulary`-declared in this scenario, and whether
+/// or not any `defvocabulary` form appears in it at all — the SEPARATE
+/// membership check a threaded `ClosedVocabulary` performs (below, in
+/// `load_node`/`load_edge`) is the only opt-in half.
 ///
 /// # Errors
 ///
-/// [`VocabularyError::UnknownEnumType`] (`E-LOAD-030`) — reused, not
-/// invented: from THIS position's own viewpoint, a syntactically-valid but
-/// wrong-kind type name is exactly as absent from the registry as an
-/// outright unregistered one (bsl-language.rst D119).
+/// [`VocabularyError::WrongEnumKind`] (`E-TYPE-011`) for a real type at
+/// the wrong position; [`VocabularyError::UnknownEnumType`] (`E-LOAD-030`)
+/// for a type name that is not registered anywhere at all.
 fn demand_enum_kind(
     enum_type: &str,
     member: &str,
     demanded: EnumKind,
+    enums: &EnumRegistry,
 ) -> Result<(), VocabularyError> {
     if EnumKind::from_type_name(enum_type) == Some(demanded) {
         return Ok(());
+    }
+    let is_real_type =
+        EnumKind::from_type_name(enum_type).is_some() || enums.resolve(enum_type).is_some();
+    if is_real_type {
+        return Err(VocabularyError::WrongEnumKind {
+            enum_type: enum_type.to_owned(),
+            member: member.to_owned(),
+            expected: demanded,
+        });
     }
     Err(VocabularyError::UnknownEnumType {
         enum_type: enum_type.to_owned(),
@@ -257,6 +283,15 @@ pub struct LoadedScenario {
 /// [`ScenarioError`] if the source does not read, the top-level form is not a
 /// single `scenario`, a node or edge form is malformed, a local name is
 /// duplicated or unknown, or the substrate refuses a write.
+// G2 (#534 fix round 2 item 2): threading `&enums` symmetrically into
+// `load_edge`'s call site (alongside `load_node`'s pre-existing one), so
+// `demand_enum_kind` can recognize a scenario-declared `defenum` type as a
+// REAL type — not just the four structural kinds — crosses the ~100-line
+// soft cap by exactly one line. Splitting this single, cohesive top-to-
+// bottom load loop (whose own doc states "declaration order is the id
+// order") into smaller pieces would trade that linear narrative for
+// indirection over a one-line breach; not worth it.
+#[allow(clippy::too_many_lines)]
 pub fn load_scenario(
     source: &str,
     graph: &mut dyn GraphSubstrate,
@@ -370,6 +405,7 @@ pub fn load_scenario(
                     graph,
                     &named,
                     &mut seeded_edges,
+                    &enums,
                     vocabulary_so_far.as_ref(),
                 )?;
                 *edge_types.entry(minted).or_insert(0) += 1;
@@ -932,7 +968,7 @@ fn load_node(
     // that registers `EdgeType/SOLIDARITY` — `check_enum_ref`'s returned
     // `EnumKind` was discarded and never compared against the position it
     // came from (panel-proven, mutation-reproduced).
-    demand_enum_kind(enum_type, member, EnumKind::NodeType)
+    demand_enum_kind(enum_type, member, EnumKind::NodeType, enums)
         .map_err(|e| vocab_err(format!("node `{local}`"), &e))?;
     // Task 8 (Organization foundation plan): the scenario-load half of
     // closed-vocabulary enforcement — checked BEFORE minting, so a typo'd
@@ -1238,6 +1274,7 @@ fn load_edge(
     graph: &mut dyn GraphSubstrate,
     named: &HashMap<String, NodeId>,
     seeded: &mut HashSet<(String, NodeId, NodeId)>,
+    enums: &EnumRegistry,
     vocabulary: Option<&ClosedVocabulary>,
 ) -> Result<String, ScenarioError> {
     let [_, SExpr::Atom(Atom::EnumRef { enum_type, member }), SExpr::Atom(Atom::Symbol(from)), SExpr::Atom(Atom::Symbol(to)), SExpr::Atom(strength)] =
@@ -1253,7 +1290,8 @@ fn load_edge(
     let form = format!("edge ({from} → {to})");
     // F2 (#534 fix round item 2): see `load_node`'s identical comment —
     // the edge position demands EdgeType, unconditionally.
-    demand_enum_kind(enum_type, member, EnumKind::EdgeType).map_err(|e| vocab_err(&form, &e))?;
+    demand_enum_kind(enum_type, member, EnumKind::EdgeType, enums)
+        .map_err(|e| vocab_err(&form, &e))?;
     // Task 8 (Organization foundation plan): see `load_node`'s identical
     // comment — the same check, before the substrate's own `add_edge`.
     if let Some(vocabulary) = vocabulary {
@@ -2531,7 +2569,10 @@ mod tests {
 
         // wrong-kind: NodeType IS declared, but the written ref names
         // EdgeType — refused as a kind mismatch, never silently minted as
-        // a node typed "SOLIDARITY".
+        // a node typed "SOLIDARITY". G2 (#534 fix round 2 item 2):
+        // EdgeType is a REAL structural kind, just the wrong one for a
+        // node's position — E-TYPE-011, never E-LOAD-030 (that code is now
+        // reserved for a type name registered nowhere at all).
         let mut graph = MemoryGraph::new();
         let err = load_scenario(
             r"
@@ -2543,15 +2584,19 @@ mod tests {
             &mut graph,
         )
         .unwrap_err();
-        assert_eq!(err.code, Some("E-LOAD-030"), "{}", err.message);
+        assert_eq!(err.code, Some("E-TYPE-011"), "{}", err.message);
         assert_eq!(graph.nodes("SOLIDARITY").len(), 0);
     }
 
     #[test]
     fn load_node_refuses_the_org_kind_business_probe_verbatim() {
-        // The panel's exact probe: `OrgKind` is not even a valid
-        // structural `EnumKind` name — the same E-LOAD-030 a bare typo'd
-        // kind name gets.
+        // The panel's exact probe: `OrgKind` is not declared ANYWHERE in
+        // this scenario — no `defvocabulary` (it is not a structural kind
+        // name to begin with) and no `defenum` either — so it names
+        // nothing real at all: the genuine E-LOAD-030 case. Contrast
+        // `load_node_refuses_the_org_kind_business_probe_when_orgkind_is_
+        // declared_too` below, the G2 sibling where OrgKind IS real (via
+        // `defenum`) but still wrong for a node's position (E-TYPE-011).
         let mut graph = MemoryGraph::new();
         let err = load_scenario(
             r"
@@ -2563,6 +2608,75 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err.code, Some("E-LOAD-030"), "{}", err.message);
+    }
+
+    #[test]
+    fn load_node_refuses_the_org_kind_business_probe_when_orgkind_is_declared_too() {
+        // G2's sibling probe (#534 fix round 2 item 2): the SAME `(node x
+        // OrgKind/BUSINESS)` shape, but `OrgKind` IS a real,
+        // scenario-declared `defenum` type this time — not nothing at
+        // all, just the wrong kind for a node's own position.
+        // `demand_enum_kind` must tell these two facts apart: E-LOAD-030
+        // above (OrgKind exists nowhere); E-TYPE-011 here (OrgKind exists,
+        // but a node's position demands NodeType, not a content-declared
+        // enum type).
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario org/org-kind-declared-probe
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (defenum OrgKind (BUSINESS))
+  (node x OrgKind/BUSINESS))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some("E-TYPE-011"), "{}", err.message);
+    }
+
+    // ---- G3(c) (#534 fix round 2): F1×F2 interaction pins —
+    // `demand_enum_kind`'s split is POSITIONAL, never vocabulary-gated. ----
+
+    #[test]
+    fn a_wrong_kind_ref_refuses_even_when_that_kind_was_never_declared_via_defvocabulary() {
+        // Only NodeType is declared here; EdgeType is not. Whether
+        // EdgeType itself was ever `defvocabulary`-declared in THIS
+        // scenario is irrelevant to whether it names a REAL structural
+        // kind — EdgeType/… at a node's position is still E-TYPE-011,
+        // never conflated with F1's own inertness rule (which governs
+        // MEMBERSHIP checking of a kind, a separate, opt-in concern from
+        // this KIND-position check).
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario org/wrong-kind-undeclared-vocab
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (node x EdgeType/SOLIDARITY))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some("E-TYPE-011"), "{}", err.message);
+    }
+
+    #[test]
+    fn a_wrong_kind_ref_refuses_even_with_no_defvocabulary_at_all() {
+        // The unconditional half of `demand_enum_kind`'s own doc: a wrong
+        // KIND at a node/edge's position is checked independent of
+        // whether ANY `defvocabulary` was declared — unlike the SEPARATE
+        // membership check a threaded `ClosedVocabulary` performs, this
+        // one is not opt-in (§3.9 clause 1: "hydration is not a back door
+        // into the closed vocabulary").
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario org/wrong-kind-no-vocab-at-all
+  (node x EdgeType/SOLIDARITY))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some("E-TYPE-011"), "{}", err.message);
     }
 
     #[test]
@@ -2603,7 +2717,9 @@ mod tests {
         assert_eq!(loaded.edge_count, 1);
 
         // wrong-kind: EdgeType IS declared, but the written ref names
-        // NodeType — refused as a kind mismatch.
+        // NodeType — refused as a kind mismatch. G2 (#534 fix round 2 item
+        // 2): NodeType is a REAL structural kind, just the wrong one for
+        // an edge's position — E-TYPE-011.
         let mut graph = MemoryGraph::new();
         let err = load_scenario(
             r"
@@ -2617,7 +2733,7 @@ mod tests {
             &mut graph,
         )
         .unwrap_err();
-        assert_eq!(err.code, Some("E-LOAD-030"), "{}", err.message);
+        assert_eq!(err.code, Some("E-TYPE-011"), "{}", err.message);
         assert_eq!(graph.edge_count(), 0);
     }
 

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -60,7 +60,7 @@
 use crate::evaluator::Value;
 use crate::reader::{read_all, Atom, ReadError, SExpr, ScaledKind};
 use crate::types::{BslType, EnumRegistry, EnumTypeId, FieldDecl, FieldKind};
-use crate::vocabulary::{ClosedVocabulary, EnumKind};
+use crate::vocabulary::{ClosedVocabulary, EnumKind, VocabularyError};
 use babylon_graph::substrate::{GraphError, GraphSubstrate, NodeId};
 use babylon_kernel::Ratio;
 use std::collections::{HashMap, HashSet};
@@ -103,6 +103,19 @@ impl From<GraphError> for ScenarioError {
         Self {
             message: format!("substrate refused the scenario: {}", err.message),
             code: None,
+        }
+    }
+}
+
+/// Task 8 (Organization foundation plan): a closed-vocabulary failure
+/// (`load_defvocabulary`'s own build, or `load_node`/`load_edge`'s
+/// membership check below) carries the same code/message shape §3.6
+/// already uses.
+impl From<VocabularyError> for ScenarioError {
+    fn from(err: VocabularyError) -> Self {
+        Self {
+            code: Some(err.spec_code()),
+            message: err.to_string(),
         }
     }
 }
@@ -247,6 +260,20 @@ pub fn load_scenario(
     // check has to live here, before the merge ever happens.
     let mut vocabulary_members: HashMap<EnumKind, Vec<String>> = HashMap::new();
     let mut vocabulary_kinds_declared: HashSet<EnumKind> = HashSet::new();
+    // Task 8 (Organization foundation plan): rebuilt after EVERY
+    // `defvocabulary` form (below), so `load_node`/`load_edge` can check
+    // membership BEFORE minting — the same "declaration must precede use"
+    // discipline this loader already applies to `deffield`/`defenum`/
+    // `defconst`. Cheap (a scenario vocabulary is a handful of members),
+    // and re-running `ClosedVocabulary::new`'s disjointness check against a
+    // growing snapshot can only detect a REAL collision earlier, never
+    // manufacture a false one — a later member cannot un-collide two that
+    // already collided. `None` for a scenario declaring no `defvocabulary`
+    // at all (Task 7's backward-compatibility proof), and — by construction
+    // — it equals exactly `ClosedVocabulary::new(vocabulary_members)` once
+    // the loop ends, so it doubles as the FINAL `LoadedScenario.vocabulary`
+    // value with no separate end-of-load construction needed.
+    let mut vocabulary_so_far: Option<ClosedVocabulary> = None;
     // §3.9 clause 5 (D73): hydration may not seed two dyadic edges sharing
     // one `(source-id, target-id, edge-type)` triple. This set is what
     // makes the triple a KEY rather than a sort field — without it §2.6's
@@ -270,6 +297,7 @@ pub fn load_scenario(
                     &mut vocabulary_members,
                     &mut vocabulary_kinds_declared,
                 )?;
+                vocabulary_so_far = Some(ClosedVocabulary::new(vocabulary_members.clone())?);
             }
             Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "deffield" => {
                 load_deffield(parts, &mut fields, &enums)?;
@@ -278,12 +306,25 @@ pub fn load_scenario(
                 load_defconst(parts, &mut consts)?;
             }
             Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "node" => {
-                let minted = load_node(parts, graph, &mut named, &fields, &enums)?;
+                let minted = load_node(
+                    parts,
+                    graph,
+                    &mut named,
+                    &fields,
+                    &enums,
+                    vocabulary_so_far.as_ref(),
+                )?;
                 *node_types.entry(minted).or_insert(0) += 1;
                 node_count += 1;
             }
             Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "edge" => {
-                let minted = load_edge(parts, graph, &named, &mut seeded_edges)?;
+                let minted = load_edge(
+                    parts,
+                    graph,
+                    &named,
+                    &mut seeded_edges,
+                    vocabulary_so_far.as_ref(),
+                )?;
                 *edge_types.entry(minted).or_insert(0) += 1;
                 edge_count += 1;
             }
@@ -296,19 +337,12 @@ pub fn load_scenario(
         }
     }
 
-    // Opt-in per scenario (Task 7): no `defvocabulary` forms at all yields
-    // `None`, which is what keeps every scenario predating this section
-    // loading exactly as it did before it.
-    let vocabulary = if vocabulary_members.is_empty() {
-        None
-    } else {
-        Some(
-            ClosedVocabulary::new(vocabulary_members).map_err(|e| ScenarioError {
-                code: Some(e.spec_code()),
-                message: e.to_string(),
-            })?,
-        )
-    };
+    // Opt-in per scenario (Task 7): no `defvocabulary` forms at all leaves
+    // `vocabulary_so_far` at its initial `None`, which is what keeps every
+    // scenario predating this section loading exactly as it did before it.
+    // Already fully built (`vocabulary_so_far` is rebuilt after EVERY
+    // `defvocabulary` form above, so by here it reflects all of them).
+    let vocabulary = vocabulary_so_far;
 
     Ok(LoadedScenario {
         id,
@@ -821,14 +855,16 @@ fn load_deffield(
 }
 
 /// `(node <local-name> <enum-ref> (<qname> <int>)*)`
+#[allow(clippy::too_many_arguments)]
 fn load_node(
     parts: &[SExpr],
     graph: &mut dyn GraphSubstrate,
     named: &mut HashMap<String, NodeId>,
     declared: &HashMap<String, FieldDecl>,
     enums: &EnumRegistry,
+    vocabulary: Option<&ClosedVocabulary>,
 ) -> Result<String, ScenarioError> {
-    let [_, SExpr::Atom(Atom::Symbol(local)), SExpr::Atom(Atom::EnumRef { member, .. }), attrs @ ..] =
+    let [_, SExpr::Atom(Atom::Symbol(local)), SExpr::Atom(Atom::EnumRef { enum_type, member }), attrs @ ..] =
         parts
     else {
         return Err(err(
@@ -840,6 +876,15 @@ fn load_node(
             "duplicate scenario name `{local}` — a local name denotes exactly one node, \
              and silently rebinding it would make later edges ambiguous"
         )));
+    }
+    // Task 8 (Organization foundation plan): the scenario-load half of
+    // closed-vocabulary enforcement — checked BEFORE minting, so a typo'd
+    // type never even reaches the substrate. `None` (no `defvocabulary`
+    // declared, or none declared YET — declaration must precede use, same
+    // as `deffield`/`defenum`/`defconst`) is exactly today's unchecked
+    // behavior (Task 7's backward-compatibility proof).
+    if let Some(vocabulary) = vocabulary {
+        vocabulary.check_enum_ref(enum_type, member)?;
     }
 
     // The node type string is the enum MEMBER verbatim, matching what
@@ -1129,19 +1174,26 @@ fn currency_refusal_message(local: &str, field: &str) -> String {
 /// `(edge <enum-ref> <local-name> <local-name> <int>)` — returns the minted
 /// `EdgeType` member (verbatim, matching `load_node`'s own return
 /// convention) so the caller can build the `edge_types` census.
+#[allow(clippy::too_many_arguments)]
 fn load_edge(
     parts: &[SExpr],
     graph: &mut dyn GraphSubstrate,
     named: &HashMap<String, NodeId>,
     seeded: &mut HashSet<(String, NodeId, NodeId)>,
+    vocabulary: Option<&ClosedVocabulary>,
 ) -> Result<String, ScenarioError> {
-    let [_, SExpr::Atom(Atom::EnumRef { member, .. }), SExpr::Atom(Atom::Symbol(from)), SExpr::Atom(Atom::Symbol(to)), SExpr::Atom(strength)] =
+    let [_, SExpr::Atom(Atom::EnumRef { enum_type, member }), SExpr::Atom(Atom::Symbol(from)), SExpr::Atom(Atom::Symbol(to)), SExpr::Atom(strength)] =
         parts
     else {
         return Err(err(
             "expected (edge <EdgeType/MEMBER> <from-name> <to-name> <int>)",
         ));
     };
+    // Task 8 (Organization foundation plan): see `load_node`'s identical
+    // comment — the same check, before the substrate's own `add_edge`.
+    if let Some(vocabulary) = vocabulary {
+        vocabulary.check_enum_ref(enum_type, member)?;
+    }
     let resolve = |name: &String| -> Result<NodeId, ScenarioError> {
         named.get(name).copied().ok_or_else(|| {
             err(format!(
@@ -2317,5 +2369,89 @@ mod tests {
         let mut graph = MemoryGraph::new();
         let err = load_scenario(source, &mut graph).unwrap_err();
         assert!(err.message.contains("enum-member"), "{}", err.message);
+    }
+
+    // ---- Task 8 (Organization foundation plan): closed-vocabulary
+    // enforcement at hydration — `load_node`/`load_edge` check membership
+    // BEFORE minting, when the scenario declared one ----
+
+    #[test]
+    fn an_unregistered_node_member_under_a_declared_vocabulary_is_e_load_031() {
+        let source = r"
+(scenario org/typo-node
+  (defvocabulary NodeType (SOCIAL_CLASS TERRITORY ORGANIZATION))
+  (node x NodeType/FOO))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-031"));
+        assert!(err.message.contains("FOO"), "{}", err.message);
+        // The node must never have minted — a loud refusal is not a
+        // best-effort partial hydration.
+        assert_eq!(graph.nodes("FOO").len(), 0);
+    }
+
+    #[test]
+    fn an_unregistered_edge_member_under_a_declared_vocabulary_is_e_load_031() {
+        let source = r"
+(scenario org/typo-edge
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (defvocabulary EdgeType (SOLIDARITY))
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (edge EdgeType/NOWHERE a b 1))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-031"));
+        assert!(err.message.contains("NOWHERE"), "{}", err.message);
+    }
+
+    #[test]
+    fn a_registered_node_and_edge_member_load_clean_under_a_declared_vocabulary() {
+        let source = r"
+(scenario org/vocab-clean
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (defvocabulary EdgeType (SOLIDARITY))
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (edge EdgeType/SOLIDARITY a b 1))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph).expect("registered members must load");
+        assert_eq!(loaded.node_count, 2);
+        assert_eq!(loaded.edge_count, 1);
+    }
+
+    #[test]
+    fn the_same_typo_source_loads_with_no_defvocabulary_declared_backward_compat_pin() {
+        // Task 8's own backward-compat pin: the SAME node-type typo, with
+        // NO `defvocabulary` form at all, loads exactly as it did before
+        // this task — membership is opt-in per scenario.
+        let source = r"
+(scenario org/typo-node-unchecked
+  (node x NodeType/FOO))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph)
+            .expect("with no declared vocabulary, membership is unchecked (backward compat)");
+        assert_eq!(loaded.node_count, 1);
+        assert!(loaded.vocabulary.is_none());
+    }
+
+    #[test]
+    fn a_node_before_any_defvocabulary_form_is_unchecked_declaration_precedes_use() {
+        // A vocabulary declared LATER in the file cannot retroactively
+        // check a node minted before it — same "declaration must precede
+        // use" discipline `deffield`/`defenum`/`defconst` already carry.
+        let source = r"
+(scenario org/vocab-after
+  (node x NodeType/FOO)
+  (defvocabulary NodeType (SOCIAL_CLASS)))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph)
+            .expect("a node minted before any defvocabulary form is unchecked");
+        assert_eq!(loaded.node_count, 1);
     }
 }

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -147,13 +147,31 @@ fn err(message: impl Into<String>) -> ScenarioError {
 /// invented: from THIS position's own viewpoint, a syntactically-valid but
 /// wrong-kind type name is exactly as absent from the registry as an
 /// outright unregistered one (bsl-language.rst D119).
-fn demand_enum_kind(enum_type: &str, demanded: EnumKind) -> Result<(), VocabularyError> {
+fn demand_enum_kind(
+    enum_type: &str,
+    member: &str,
+    demanded: EnumKind,
+) -> Result<(), VocabularyError> {
     if EnumKind::from_type_name(enum_type) == Some(demanded) {
         return Ok(());
     }
     Err(VocabularyError::UnknownEnumType {
         enum_type: enum_type.to_owned(),
+        member: member.to_owned(),
     })
+}
+
+/// F6 (#534 fix round item 6): wrap a [`VocabularyError`] with the
+/// offending form's identity — §4.6's own house style ("load-time errors
+/// report the offending file, line, column, form, and code"). A raw
+/// `VocabularyError` names the type/member but not WHICH node or edge
+/// form wrote it; this prefixes that, at the two scenario-hydration
+/// producers (`load_node`/`load_edge`).
+fn vocab_err(form: impl std::fmt::Display, error: &VocabularyError) -> ScenarioError {
+    ScenarioError {
+        code: Some(error.spec_code()),
+        message: format!("{form}: {error}"),
+    }
 }
 
 /// A hydration failure the reference gives a code (§3.9).
@@ -915,7 +933,8 @@ fn load_node(
     // that registers `EdgeType/SOLIDARITY` — `check_enum_ref`'s returned
     // `EnumKind` was discarded and never compared against the position it
     // came from (panel-proven, mutation-reproduced).
-    demand_enum_kind(enum_type, EnumKind::NodeType)?;
+    demand_enum_kind(enum_type, member, EnumKind::NodeType)
+        .map_err(|e| vocab_err(format!("node `{local}`"), &e))?;
     // Task 8 (Organization foundation plan): the scenario-load half of
     // closed-vocabulary enforcement — checked BEFORE minting, so a typo'd
     // type never even reaches the substrate. `None` (no `defvocabulary`
@@ -923,7 +942,9 @@ fn load_node(
     // as `deffield`/`defenum`/`defconst`) is exactly today's unchecked
     // behavior (Task 7's backward-compatibility proof).
     if let Some(vocabulary) = vocabulary {
-        vocabulary.check_enum_ref(enum_type, member)?;
+        vocabulary
+            .check_enum_ref(enum_type, member)
+            .map_err(|e| vocab_err(format!("node `{local}`"), &e))?;
     }
 
     // The node type string is the enum MEMBER verbatim, matching what
@@ -1228,13 +1249,19 @@ fn load_edge(
             "expected (edge <EdgeType/MEMBER> <from-name> <to-name> <int>)",
         ));
     };
+    // F6 (#534 fix round item 6): an edge form has no local name of its
+    // own (unlike a node) — its endpoints are what identifies it in a
+    // refusal message.
+    let form = format!("edge ({from} → {to})");
     // F2 (#534 fix round item 2): see `load_node`'s identical comment —
     // the edge position demands EdgeType, unconditionally.
-    demand_enum_kind(enum_type, EnumKind::EdgeType)?;
+    demand_enum_kind(enum_type, member, EnumKind::EdgeType).map_err(|e| vocab_err(&form, &e))?;
     // Task 8 (Organization foundation plan): see `load_node`'s identical
     // comment — the same check, before the substrate's own `add_edge`.
     if let Some(vocabulary) = vocabulary {
-        vocabulary.check_enum_ref(enum_type, member)?;
+        vocabulary
+            .check_enum_ref(enum_type, member)
+            .map_err(|e| vocab_err(&form, &e))?;
     }
     let resolve = |name: &String| -> Result<NodeId, ScenarioError> {
         named.get(name).copied().ok_or_else(|| {

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -56,6 +56,7 @@ use crate::intrinsic_host::IntrinsicHost;
 use crate::reader::{Atom, SExpr};
 use crate::typecheck::TypeEnv;
 use crate::types::{BslType, EnumRegistry, EnumTypeId};
+use crate::vocabulary::ClosedVocabulary;
 use crate::write_log::{Write, WriteObserver, WriteRecord};
 use babylon_graph::substrate::{GraphError, GraphSubstrate, HyperedgeId, NodeId};
 use std::collections::HashMap;
@@ -156,6 +157,20 @@ pub struct EffectExecutor<'a> {
     /// `BslType::Enum`-declared field in `types` first, so an empty
     /// registry never silently under-serves real content.
     enums: &'a EnumRegistry,
+    /// Task 8 (Organization foundation plan): the closed graph vocabulary,
+    /// threaded exactly as `enums` above (Task 5's precedent). `None` is
+    /// today's unchecked behavior for every EXISTING caller — and, in
+    /// production, for `tick.rs::run_tick`'s two construction sites
+    /// unconditionally: the three MINTING verbs this field gates
+    /// (`add_node`/`add_edge`/`add_hyperedge`, via
+    /// [`Self::enum_member_checked`]) are refused at LOAD TIME,
+    /// unconditionally, by `rule_pipeline::check_no_deferred_shape_verbs`
+    /// for every rule reaching `run_tick`, so no rule can ever exercise
+    /// this field there regardless of what it is threaded to. It exists
+    /// for the crate's own direct-execution callers
+    /// (`execute_effects`/`execute_item`, this module's unit tests,
+    /// `conformance_corpus.rs`) and for whenever that gate lifts.
+    vocabulary_registry: Option<&'a ClosedVocabulary>,
     declared_nodes: HashMap<String, NodeId>,
     declared_hyperedges: HashMap<String, HyperedgeId>,
     /// The ADR182 R1 interception point. `None` is the unobserved path and
@@ -172,12 +187,21 @@ impl<'a> EffectExecutor<'a> {
     /// A fresh executor for one effect list. `types` supplies the declared
     /// field types the §3.3 store-boundary range check needs; `enums`
     /// supplies the §2.13 enum-ordinal registry a `BslType::Enum`-declared
-    /// field's write path resolves against.
+    /// field's write path resolves against; `vocabulary_registry` is the
+    /// §3.6 closed graph vocabulary a minting verb's type-operand is
+    /// checked against, when one is threaded (Task 8, Organization
+    /// foundation plan — see this struct's own field doc for why `None`
+    /// changes nothing observable in production today).
     #[must_use]
-    pub fn new(types: &'a TypeEnv, enums: &'a EnumRegistry) -> Self {
+    pub fn new(
+        types: &'a TypeEnv,
+        enums: &'a EnumRegistry,
+        vocabulary_registry: Option<&'a ClosedVocabulary>,
+    ) -> Self {
         Self {
             types,
             enums,
+            vocabulary_registry,
             declared_nodes: HashMap::new(),
             declared_hyperedges: HashMap::new(),
             observer: None,
@@ -198,12 +222,14 @@ impl<'a> EffectExecutor<'a> {
     pub fn observed(
         types: &'a TypeEnv,
         enums: &'a EnumRegistry,
+        vocabulary_registry: Option<&'a ClosedVocabulary>,
         rule: impl Into<String>,
         observer: &'a mut dyn WriteObserver,
     ) -> Self {
         Self {
             types,
             enums,
+            vocabulary_registry,
             declared_nodes: HashMap::new(),
             declared_hyperedges: HashMap::new(),
             observer: Some(observer),
@@ -812,7 +838,7 @@ impl<'a> EffectExecutor<'a> {
                 "(add-node <enum-ref> <expr> <field-init>*) — too few operands",
             ));
         };
-        let node_type = Self::enum_member(type_ref)?;
+        let node_type = self.enum_member_checked(type_ref)?;
         let name = self.fresh_declared_name(id_expr, env)?;
         let id = graph.add_node(node_type).map_err(from_graph)?;
         self.declared_nodes.insert(name, id);
@@ -881,7 +907,7 @@ impl<'a> EffectExecutor<'a> {
                  substrate gap (R9 chapter C2), never silently dropped",
             ));
         }
-        let edge_type = Self::enum_member(type_ref)?;
+        let edge_type = self.enum_member_checked(type_ref)?;
         let from_id = self.resolve_node(from, env, host, fuel)?;
         let to_id = self.resolve_node(to, env, host, fuel)?;
         let strength = match evaluate(strength_expr, env, host, fuel)? {
@@ -958,7 +984,7 @@ impl<'a> EffectExecutor<'a> {
                  a declared Phase-2 gap (§2.8 draft ruling), never silently dropped",
             ));
         }
-        let hyperedge_type = Self::enum_member(type_ref)?;
+        let hyperedge_type = self.enum_member_checked(type_ref)?;
         let name = self.fresh_declared_name(id_expr, env)?;
         let SExpr::List(member_items) = members_form else {
             return Err(plain("expected a (members <expr>+) form"));
@@ -1038,6 +1064,29 @@ impl<'a> EffectExecutor<'a> {
                 "expected an enum-ref where the grammar requires one, found {other:?}"
             ))),
         }
+    }
+
+    /// [`Self::enum_member`] plus the runtime half of Task 8's (Organization
+    /// foundation plan) closed-vocabulary enforcement (§3.6): when a
+    /// registry is threaded, the member must be REGISTERED, not merely
+    /// well-shaped. Used only by the three MINTING verbs
+    /// (`add-node`/`add-edge`/`add-hyperedge`) — Scout 3's "three
+    /// producers" are the ones that mint a graph element the vocabulary is
+    /// closed over; the non-minting verbs (`remove-edge`, `emit`) are
+    /// unchanged by this task and keep calling [`Self::enum_member`]
+    /// directly.
+    fn enum_member_checked<'e>(&self, expr: &'e SExpr) -> Result<&'e str, EvalError> {
+        let SExpr::Atom(Atom::EnumRef { enum_type, member }) = expr else {
+            // Reuses `enum_member`'s exact refusal for a non-enum-ref
+            // operand — the same message either way.
+            return Self::enum_member(expr);
+        };
+        if let Some(vocabulary) = self.vocabulary_registry {
+            vocabulary
+                .check_enum_ref(enum_type, member)
+                .map_err(|e| plain(e.to_string()))?;
+        }
+        Ok(member)
     }
 
     /// The id operand of `add-node`/`add-hyperedge`: a symbol introducing a
@@ -1437,7 +1486,42 @@ mod tests {
             };
             let types = types();
             let enums = enums();
-            let mut executor = EffectExecutor::new(&types, &enums);
+            let mut executor = EffectExecutor::new(&types, &enums, None);
+            let mut sink = CollectingSink::default();
+            executor.execute_effects(
+                &items[1..],
+                &env,
+                &EmptyIntrinsicHost,
+                &mut self.graph,
+                &mut sink,
+                fuel,
+            )?;
+            Ok(sink.events)
+        }
+
+        /// [`Self::run`], with a closed vocabulary threaded (Task 8,
+        /// Organization foundation plan) — the runtime enforcement red/green
+        /// tests below drive this rather than duplicating `run`'s body.
+        #[allow(clippy::type_complexity)]
+        fn run_with_vocabulary(
+            &mut self,
+            effects_source: &str,
+            fuel: &mut u64,
+            vocabulary: &crate::vocabulary::ClosedVocabulary,
+        ) -> Result<Vec<(String, Vec<(String, Value)>)>, EvalError> {
+            let (form, _) = read(effects_source).expect("effects source must parse");
+            let SExpr::List(items) = form else {
+                unreachable!()
+            };
+            let env = EvalEnv {
+                bindings: HashMap::from([("self".to_owned(), Value::NodeRef(self.self_id))]),
+                intrinsic_costs: &self.costs,
+                graph: None,
+                elements: Vec::new(),
+            };
+            let types = types();
+            let enums = enums();
+            let mut executor = EffectExecutor::new(&types, &enums, Some(vocabulary));
             let mut sink = CollectingSink::default();
             executor.execute_effects(
                 &items[1..],
@@ -1475,7 +1559,7 @@ mod tests {
             let mut sink = CollectingSink::default();
             let result = {
                 let mut executor =
-                    EffectExecutor::observed(&types, &enums, "hunger/agitate", &mut log);
+                    EffectExecutor::observed(&types, &enums, None, "hunger/agitate", &mut log);
                 executor.execute_effects(
                     &items[1..],
                     &env,
@@ -1543,6 +1627,103 @@ mod tests {
             )
             .unwrap();
         assert_eq!(fixture.graph.edge_count(), 1);
+    }
+
+    // ---- Task 8 (Organization foundation plan): closed-vocabulary
+    // enforcement at verb execution — add-node/add-edge/add-hyperedge's
+    // type operand is checked when a registry is threaded ----
+
+    fn probe_vocabulary() -> crate::vocabulary::ClosedVocabulary {
+        crate::vocabulary::ClosedVocabulary::new([
+            (
+                crate::vocabulary::EnumKind::NodeType,
+                vec!["SOCIAL_CLASS".to_owned()],
+            ),
+            (
+                crate::vocabulary::EnumKind::EdgeType,
+                vec!["SOLIDARITY".to_owned()],
+            ),
+            (
+                crate::vocabulary::EnumKind::HyperedgeType,
+                vec!["CELL".to_owned()],
+            ),
+        ])
+        .unwrap()
+    }
+
+    #[test]
+    fn add_node_with_an_unregistered_type_is_a_loud_eval_error_under_a_declared_vocabulary() {
+        let mut fixture = Fixture::new();
+        let mut fuel = 128;
+        let vocabulary = probe_vocabulary();
+        let err = fixture
+            .run_with_vocabulary("(effects (add-node NodeType/FOO recruit))", &mut fuel, &vocabulary)
+            .unwrap_err();
+        assert!(err.message.contains("E-LOAD-031"), "{}", err.message);
+        assert!(err.message.contains("FOO"), "{}", err.message);
+        // The node must never have minted.
+        assert_eq!(fixture.graph.nodes("FOO").len(), 0);
+    }
+
+    #[test]
+    fn add_edge_with_an_unregistered_type_is_a_loud_eval_error_under_a_declared_vocabulary() {
+        let mut fixture = Fixture::new();
+        let mut fuel = 128;
+        let vocabulary = probe_vocabulary();
+        let err = fixture
+            .run_with_vocabulary(
+                "(effects (add-edge EdgeType/NOWHERE self self :strength 0.5c))",
+                &mut fuel,
+                &vocabulary,
+            )
+            .unwrap_err();
+        assert!(err.message.contains("E-LOAD-031"), "{}", err.message);
+        assert_eq!(fixture.graph.edge_count(), 0);
+    }
+
+    #[test]
+    fn add_hyperedge_with_an_unregistered_type_is_a_loud_eval_error_under_a_declared_vocabulary() {
+        let mut fixture = Fixture::new();
+        let mut fuel = 128;
+        let vocabulary = probe_vocabulary();
+        let err = fixture
+            .run_with_vocabulary(
+                "(effects (add-hyperedge HyperedgeType/NOWHERE nucleus (members self)))",
+                &mut fuel,
+                &vocabulary,
+            )
+            .unwrap_err();
+        assert!(err.message.contains("E-LOAD-031"), "{}", err.message);
+    }
+
+    #[test]
+    fn a_registered_type_mints_clean_under_a_declared_vocabulary() {
+        let mut fixture = Fixture::new();
+        let mut fuel = 128;
+        let vocabulary = probe_vocabulary();
+        fixture
+            .run_with_vocabulary(
+                "(effects \
+                   (add-node NodeType/SOCIAL_CLASS recruit) \
+                   (add-edge EdgeType/SOLIDARITY recruit self :strength 0.5c))",
+                &mut fuel,
+                &vocabulary,
+            )
+            .expect("a registered member must mint clean");
+        assert_eq!(fixture.graph.edge_count(), 1);
+    }
+
+    #[test]
+    fn the_same_typo_source_mints_with_no_vocabulary_threaded_backward_compat_pin() {
+        // The plan's own backward-compatibility proof, at the THIRD
+        // producer (verb execution): `Fixture::run` threads `None` — the
+        // same unchecked behavior as every EXISTING test in this module.
+        let mut fixture = Fixture::new();
+        let mut fuel = 128;
+        fixture
+            .run("(effects (add-node NodeType/FOO recruit))", &mut fuel)
+            .expect("with no threaded vocabulary, membership is unchecked (backward compat)");
+        assert_eq!(fixture.graph.nodes("FOO").len(), 1);
     }
 
     #[test]
@@ -1830,7 +2011,7 @@ mod tests {
             };
             let types = types();
             let enums = enums();
-            let mut executor = EffectExecutor::new(&types, &enums);
+            let mut executor = EffectExecutor::new(&types, &enums, None);
             let mut sink = CollectingSink::default();
             let err = executor
                 .execute_effects(
@@ -2062,10 +2243,10 @@ mod tests {
                 graph: Some(&*graph as &dyn GraphSubstrate),
                 elements: Vec::new(),
             };
-            let mut collector = EffectExecutor::new(types, enums);
+            let mut collector = EffectExecutor::new(types, enums, None);
             collector.collect_effects(&items[1..], &env, &EmptyIntrinsicHost, &mut sink, fuel)?
         };
-        let mut applier = EffectExecutor::new(types, enums);
+        let mut applier = EffectExecutor::new(types, enums, None);
         for write in &pending {
             applier.apply_pending_write(write, &mut *graph)?;
         }
@@ -2101,7 +2282,7 @@ mod tests {
             graph: Some(graph as &dyn GraphSubstrate),
             elements: Vec::new(),
         };
-        let mut collector = EffectExecutor::new(types, enums);
+        let mut collector = EffectExecutor::new(types, enums, None);
         collector.collect_effects(&items[1..], &env, &EmptyIntrinsicHost, &mut sink, fuel)
     }
 
@@ -2203,7 +2384,7 @@ mod tests {
         };
         let types = types();
         let enums = enums();
-        let mut executor = EffectExecutor::new(&types, &enums);
+        let mut executor = EffectExecutor::new(&types, &enums, None);
         let mut sink = CollectingSink::default();
         let mut fuel = 256;
         let (form, _) = read(
@@ -2404,7 +2585,7 @@ mod tests {
         };
         let types = organization_types();
         let enums = enums();
-        let mut executor = EffectExecutor::new(&types, &enums);
+        let mut executor = EffectExecutor::new(&types, &enums, None);
         let mut sink = CollectingSink::default();
         let mut fuel = 256;
         let (form, _) = read(
@@ -2719,7 +2900,7 @@ mod tests {
             elements: Vec::new(),
         };
         let mut sink = CollectingSink::default();
-        let mut executor = EffectExecutor::new(&types, &enums);
+        let mut executor = EffectExecutor::new(&types, &enums, None);
         let err = executor
             .execute_effects(
                 &items[1..],
@@ -2804,7 +2985,7 @@ mod tests {
             op: UpdateOp::Add,
             operand: 1.0,
         };
-        let mut applier = EffectExecutor::new(&types, &enums);
+        let mut applier = EffectExecutor::new(&types, &enums, None);
         let err = applier.apply_pending_write(&write, &mut graph).unwrap_err();
         assert_eq!(err.code, Some(EvalCode::EnumWriteShapeViolation));
         let stored = graph.node_attribute(id, "organization/kind").unwrap();

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -1392,25 +1392,41 @@ pub fn check_no_deferred_shape_verbs(rule: &SExpr) -> Result<(), String> {
 /// in `expr`. `Option<&str>` borrows the symbol straight out of the AST —
 /// no allocation for a check that runs on every rule at load.
 ///
-/// **Head-position-only at `emit`** (F5(b), #534 fix round item 5 — the
+/// **Payload-LABEL-only at `emit`, corrected (G1, #534 fix round 2 — one
+/// root cause with the sibling fix in `grammar::check_enum_ref_membership`;
+/// supersedes F5(b), #534 fix round item 5, which itself mirrored the
 /// same label-as-head misreading `grammar::check_type_operands_are_enum_
-/// refs` R2 already fixed, #528 delta-verify rider). `emit`'s own trailing
+/// refs` R2 fixed, #528 delta-verify rider).** `emit`'s own trailing
 /// operands are its type operand (an `<enum-ref>`, never a form) and zero
 /// or more `<payload-item>`s (`(<symbol> <expr>)`, §2.8) — a payload
 /// item's LABEL is an unconstrained `Atom::Symbol` that nothing stops
 /// content from spelling like one of `DEFERRED_SHAPE_VERBS` (`add-node`,
 /// `remove-edge`, …), even though it is a label, never a nested verb
-/// invocation. Before this, the unconditional recursion below treated
+/// invocation. Before F5(b), the unconditional recursion below treated
 /// every child list's head as a fresh candidate wherever it sat, so
 /// `(emit EventType/RUPTURE (add-node 5) (severity 1))` — a payload item
 /// merely LABELED `add-node` — was wrongly refused as if it invoked the
-/// verb. Stopping at `emit` is safe: none of `DEFERRED_SHAPE_VERBS` is
-/// legal in expression position (§2.4/§2.7 — they are effect-position-only,
-/// this const's own doc), so nothing genuinely nested inside `emit`'s own
-/// operands could ever be a real match. `guard`/`for-each` are unaffected:
-/// neither head matches here, so a form headed by either still falls
-/// through to the unconditional recursion, reaching any REAL deferred-shape
-/// verb nested in their bodies exactly as before.
+/// verb.
+///
+/// F5(b)'s own fix over-corrected: `return None` on a matched `emit` head
+/// skipped `emit`'s ENTIRE subtree, not just the payload LABELS. Its own
+/// justification — "none of `DEFERRED_SHAPE_VERBS` is legal in expression
+/// position, so nothing genuinely nested inside `emit`'s own operands
+/// could ever be a real match" — reasons about what content SHOULD look
+/// like, not what the reader will happily parse: nothing stops a payload
+/// item's VALUE from spelling `(add-node NodeType/SOCIAL_CLASS 5)`
+/// verbatim, and THIS is exactly the ILLEGAL-but-syntactically-present
+/// case [`check_no_deferred_shape_verbs`] exists to catch at load rather
+/// than let die mid-tick — stopping at `emit` silently let it back through
+/// (a rule loading clean and aborting the first tick whose guard admitted
+/// a subject, the exact shape this whole gate exists to prevent). The
+/// corrected discipline: once a matched `emit` head is confirmed, recurse
+/// into each payload item's element-1 VALUE ONLY — never treating the
+/// payload item itself as a form headed by its LABEL (element 0).
+/// `guard`/`for-each` are unaffected: neither head matches here, so a form
+/// headed by either still falls through to the unconditional recursion,
+/// reaching any REAL deferred-shape verb nested in their bodies exactly as
+/// before.
 fn find_deferred_shape_verb(expr: &SExpr) -> Option<&str> {
     let SExpr::List(items) = expr else {
         return None;
@@ -1420,6 +1436,19 @@ fn find_deferred_shape_verb(expr: &SExpr) -> Option<&str> {
             return Some(head.as_str());
         }
         if head == "emit" {
+            // Payload-LABEL-only (G1): `items[2..]` are `emit`'s payload
+            // items, each `(<symbol> <expr>)`. Recurse into element 1
+            // (the VALUE) only — element 0 (the LABEL) is never read as a
+            // head.
+            for payload_item in items.iter().skip(2) {
+                if let SExpr::List(pair) = payload_item {
+                    if let Some(value_expr) = pair.get(1) {
+                        if let Some(verb) = find_deferred_shape_verb(value_expr) {
+                            return Some(verb);
+                        }
+                    }
+                }
+            }
             return None;
         }
     }

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -838,7 +838,7 @@ impl<'a> EffectExecutor<'a> {
                 "(add-node <enum-ref> <expr> <field-init>*) — too few operands",
             ));
         };
-        let node_type = self.enum_member_checked(type_ref)?;
+        let node_type = self.enum_member_checked(type_ref, "add-node")?;
         let name = self.fresh_declared_name(id_expr, env)?;
         let id = graph.add_node(node_type).map_err(from_graph)?;
         self.declared_nodes.insert(name, id);
@@ -907,7 +907,7 @@ impl<'a> EffectExecutor<'a> {
                  substrate gap (R9 chapter C2), never silently dropped",
             ));
         }
-        let edge_type = self.enum_member_checked(type_ref)?;
+        let edge_type = self.enum_member_checked(type_ref, "add-edge")?;
         let from_id = self.resolve_node(from, env, host, fuel)?;
         let to_id = self.resolve_node(to, env, host, fuel)?;
         let strength = match evaluate(strength_expr, env, host, fuel)? {
@@ -984,7 +984,7 @@ impl<'a> EffectExecutor<'a> {
                  a declared Phase-2 gap (§2.8 draft ruling), never silently dropped",
             ));
         }
-        let hyperedge_type = self.enum_member_checked(type_ref)?;
+        let hyperedge_type = self.enum_member_checked(type_ref, "add-hyperedge")?;
         let name = self.fresh_declared_name(id_expr, env)?;
         let SExpr::List(member_items) = members_form else {
             return Err(plain("expected a (members <expr>+) form"));
@@ -1074,8 +1074,11 @@ impl<'a> EffectExecutor<'a> {
     /// producers" are the ones that mint a graph element the vocabulary is
     /// closed over; the non-minting verbs (`remove-edge`, `emit`) are
     /// unchanged by this task and keep calling [`Self::enum_member`]
-    /// directly.
-    fn enum_member_checked<'e>(&self, expr: &'e SExpr) -> Result<&'e str, EvalError> {
+    /// directly. `verb` is the calling verb's own name (F6, #534 fix round
+    /// item 6) — §4.6's house style names the offending form; this is the
+    /// one producer of the three where that form is a runtime call-site
+    /// fact, not something the checked value itself carries.
+    fn enum_member_checked<'e>(&self, expr: &'e SExpr, verb: &str) -> Result<&'e str, EvalError> {
         let SExpr::Atom(Atom::EnumRef { enum_type, member }) = expr else {
             // Reuses `enum_member`'s exact refusal for a non-enum-ref
             // operand — the same message either way.
@@ -1084,7 +1087,7 @@ impl<'a> EffectExecutor<'a> {
         if let Some(vocabulary) = self.vocabulary_registry {
             vocabulary
                 .check_enum_ref(enum_type, member)
-                .map_err(|e| plain(e.to_string()))?;
+                .map_err(|e| plain(format!("({verb} …): {e}")))?;
         }
         Ok(member)
     }
@@ -1688,6 +1691,8 @@ mod tests {
             .unwrap_err();
         assert!(err.message.contains("E-LOAD-031"), "{}", err.message);
         assert!(err.message.contains("FOO"), "{}", err.message);
+        // F6 (#534 fix round item 6): the offending verb is named too.
+        assert!(err.message.contains("add-node"), "{}", err.message);
         // The node must never have minted.
         assert_eq!(fixture.graph.nodes("FOO").len(), 0);
     }
@@ -3078,16 +3083,16 @@ mod tests {
         // nested verb invocation. The buggy walk treated every child
         // list's head as a fresh candidate and wrongly refused this exact
         // form.
-        let (probe, _) = read("(emit EventType/RUPTURE (add-node 5) (severity 1))")
-            .expect("probe must parse");
+        let (probe, _) =
+            read("(emit EventType/RUPTURE (add-node 5) (severity 1))").expect("probe must parse");
         assert!(
             super::check_no_deferred_shape_verbs(&probe).is_ok(),
             "a payload item's own LABEL must never be mistaken for a nested verb invocation"
         );
         // The same shape with a different label was always Ok — proves the
         // probe isolates the label collision, not some other cause.
-        let (control, _) = read("(emit EventType/RUPTURE (foo 5) (severity 1))")
-            .expect("control must parse");
+        let (control, _) =
+            read("(emit EventType/RUPTURE (foo 5) (severity 1))").expect("control must parse");
         assert!(super::check_no_deferred_shape_verbs(&control).is_ok());
     }
 

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -1388,6 +1388,26 @@ pub fn check_no_deferred_shape_verbs(rule: &SExpr) -> Result<(), String> {
 /// Depth-first search for the first [`DEFERRED_SHAPE_VERBS`] head anywhere
 /// in `expr`. `Option<&str>` borrows the symbol straight out of the AST —
 /// no allocation for a check that runs on every rule at load.
+///
+/// **Head-position-only at `emit`** (F5(b), #534 fix round item 5 — the
+/// same label-as-head misreading `grammar::check_type_operands_are_enum_
+/// refs` R2 already fixed, #528 delta-verify rider). `emit`'s own trailing
+/// operands are its type operand (an `<enum-ref>`, never a form) and zero
+/// or more `<payload-item>`s (`(<symbol> <expr>)`, §2.8) — a payload
+/// item's LABEL is an unconstrained `Atom::Symbol` that nothing stops
+/// content from spelling like one of `DEFERRED_SHAPE_VERBS` (`add-node`,
+/// `remove-edge`, …), even though it is a label, never a nested verb
+/// invocation. Before this, the unconditional recursion below treated
+/// every child list's head as a fresh candidate wherever it sat, so
+/// `(emit EventType/RUPTURE (add-node 5) (severity 1))` — a payload item
+/// merely LABELED `add-node` — was wrongly refused as if it invoked the
+/// verb. Stopping at `emit` is safe: none of `DEFERRED_SHAPE_VERBS` is
+/// legal in expression position (§2.4/§2.7 — they are effect-position-only,
+/// this const's own doc), so nothing genuinely nested inside `emit`'s own
+/// operands could ever be a real match. `guard`/`for-each` are unaffected:
+/// neither head matches here, so a form headed by either still falls
+/// through to the unconditional recursion, reaching any REAL deferred-shape
+/// verb nested in their bodies exactly as before.
 fn find_deferred_shape_verb(expr: &SExpr) -> Option<&str> {
     let SExpr::List(items) = expr else {
         return None;
@@ -1395,6 +1415,9 @@ fn find_deferred_shape_verb(expr: &SExpr) -> Option<&str> {
     if let Some(SExpr::Atom(Atom::Symbol(head))) = items.first() {
         if DEFERRED_SHAPE_VERBS.contains(&head.as_str()) {
             return Some(head.as_str());
+        }
+        if head == "emit" {
+            return None;
         }
     }
     for item in items {
@@ -3041,5 +3064,51 @@ mod tests {
             "the ORIGINAL non-enum catch-all message must be unchanged: {}",
             err.message
         );
+    }
+
+    // ---- F5(b) (#534 fix round item 5): `find_deferred_shape_verb`
+    // head-position discipline — the same label-as-head misreading R2
+    // (grammar.rs's `check_type_operands_are_enum_refs`) already fixed. ----
+
+    #[test]
+    fn a_payload_item_labeled_like_a_deferred_shape_verb_is_never_over_refused() {
+        // `emit`'s `<payload-item>` label is an unconstrained `Atom::Symbol`
+        // (§2.8's `<payload-item> ::= (<symbol> <expr>)`) — nothing stops
+        // content from naming one `add-node`, and that label is not a
+        // nested verb invocation. The buggy walk treated every child
+        // list's head as a fresh candidate and wrongly refused this exact
+        // form.
+        let (probe, _) = read("(emit EventType/RUPTURE (add-node 5) (severity 1))")
+            .expect("probe must parse");
+        assert!(
+            super::check_no_deferred_shape_verbs(&probe).is_ok(),
+            "a payload item's own LABEL must never be mistaken for a nested verb invocation"
+        );
+        // The same shape with a different label was always Ok — proves the
+        // probe isolates the label collision, not some other cause.
+        let (control, _) = read("(emit EventType/RUPTURE (foo 5) (severity 1))")
+            .expect("control must parse");
+        assert!(super::check_no_deferred_shape_verbs(&control).is_ok());
+    }
+
+    #[test]
+    fn a_genuine_verb_nested_inside_guard_or_for_each_is_still_caught() {
+        // The regression pair for the probe above: head-position-only
+        // stopping at `emit` must not blind the walk to a GENUINE nested
+        // deferred-shape verb inside `guard`/`for-each` effect bodies —
+        // neither head is `emit` nor a `DEFERRED_SHAPE_VERBS` member, so
+        // the walk must still fall through to the generic recursion and
+        // find the real verb.
+        for source in [
+            "(guard #t (remove-node self))",
+            "(for-each (edges EdgeType/SOLIDARITY) (remove-edge EdgeType/SOLIDARITY a b))",
+        ] {
+            let (probe, _) = read(source).unwrap_or_else(|e| panic!("{source}: {e:?}"));
+            let err = super::check_no_deferred_shape_verbs(&probe).expect_err(source);
+            assert!(
+                err.contains("remove-node") || err.contains("remove-edge"),
+                "{source}: {err}"
+            );
+        }
     }
 }

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -1657,7 +1657,11 @@ mod tests {
         let mut fuel = 128;
         let vocabulary = probe_vocabulary();
         let err = fixture
-            .run_with_vocabulary("(effects (add-node NodeType/FOO recruit))", &mut fuel, &vocabulary)
+            .run_with_vocabulary(
+                "(effects (add-node NodeType/FOO recruit))",
+                &mut fuel,
+                &vocabulary,
+            )
             .unwrap_err();
         assert!(err.message.contains("E-LOAD-031"), "{}", err.message);
         assert!(err.message.contains("FOO"), "{}", err.message);

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -1427,6 +1427,31 @@ pub fn check_no_deferred_shape_verbs(rule: &SExpr) -> Result<(), String> {
 /// headed by either still falls through to the unconditional recursion,
 /// reaching any REAL deferred-shape verb nested in their bodies exactly as
 /// before.
+///
+/// **G1's own fix still assumed two invariants no check here established
+/// (H1, #534 fix round 3 — one root cause with `grammar::
+/// check_enum_ref_membership`'s own sibling fix): that `items[1]` really
+/// is `emit`'s type operand (so `items[2..]` are genuinely payload
+/// items), and that a payload item has exactly two elements (so
+/// `pair.get(1)` finds its whole value).** Neither holds once a SECOND
+/// malformation is present. `(m (emit (add-node NodeType/SOCIAL_CLASS
+/// 5)))` is a payload item whose value is a NESTED `emit` MISSING its own
+/// type operand — `items[1]` there is `(add-node NodeType/SOCIAL_CLASS
+/// 5)` itself (the real verb invocation), not an `<enum-ref>`, and the
+/// old unconditional `skip(2)` silently treated it as "the confirmed type
+/// operand" and skipped it, so `add-node` was never inspected as a head
+/// at all. `(m 1 (add-node NodeType/SOCIAL_CLASS 5))` is an OVER-ARITY
+/// payload item — three elements, not two — so `pair.get(1)` (the literal
+/// `1`) never reached `pair[2]`, the real invocation. Corrected:
+/// `items[1]` is only trusted as `emit`'s type operand when it is
+/// genuinely an `<enum-ref>` (`items[2..]` payload, `pair[1..]` every
+/// value); otherwise no positional assumption is safe once the
+/// type-operand slot itself is broken, so every item after the head is
+/// recursed into in full (`items[1..]`, ordinary recursion) —
+/// `grammar::check_type_operands_are_enum_refs` is the earlier load-time
+/// gate that refuses this exact malformed-nested-`emit` shape outright,
+/// but this function must not rely on that gate having run first (it is
+/// driven directly by this module's own tests, same as its sibling).
 fn find_deferred_shape_verb(expr: &SExpr) -> Option<&str> {
     let SExpr::List(items) = expr else {
         return None;
@@ -1436,16 +1461,23 @@ fn find_deferred_shape_verb(expr: &SExpr) -> Option<&str> {
             return Some(head.as_str());
         }
         if head == "emit" {
-            // Payload-LABEL-only (G1): `items[2..]` are `emit`'s payload
-            // items, each `(<symbol> <expr>)`. Recurse into element 1
-            // (the VALUE) only — element 0 (the LABEL) is never read as a
-            // head.
-            for payload_item in items.iter().skip(2) {
-                if let SExpr::List(pair) = payload_item {
-                    if let Some(value_expr) = pair.get(1) {
-                        if let Some(verb) = find_deferred_shape_verb(value_expr) {
-                            return Some(verb);
+            // Payload-LABEL-only (G1), guarded (H1): see this function's
+            // own doc for the full reasoning — `items[1]` is only trusted
+            // as emit's type operand when it is genuinely an `<enum-ref>`.
+            if matches!(items.get(1), Some(SExpr::Atom(Atom::EnumRef { .. }))) {
+                for payload_item in items.iter().skip(2) {
+                    if let SExpr::List(pair) = payload_item {
+                        for value in pair.iter().skip(1) {
+                            if let Some(verb) = find_deferred_shape_verb(value) {
+                                return Some(verb);
+                            }
                         }
+                    }
+                }
+            } else {
+                for item in items.iter().skip(1) {
+                    if let Some(verb) = find_deferred_shape_verb(item) {
+                        return Some(verb);
                     }
                 }
             }
@@ -3171,5 +3203,56 @@ mod tests {
                 "{source}: {err}"
             );
         }
+    }
+
+    // ---- H1 (#534 fix round 3, residual of G1 — one root cause with
+    // `grammar::check_enum_ref_membership`'s/`check_type_operands_are_
+    // enum_refs`'s own sibling fixes): the G1 descent assumed `items[1]`
+    // is `emit`'s type operand (`skip(2)`) and that a payload item has
+    // exactly 2 elements (`pair.get(1)`). A SECOND malformation — a
+    // type-operand-less nested `emit`, or an over-arity payload item —
+    // breaks both assumptions at once and hides a genuine deferred-shape
+    // verb from this walk. ----
+
+    #[test]
+    fn a_deferred_verb_behind_a_type_operand_less_nested_emit_still_refuses() {
+        // `(m (emit (add-node NodeType/SOCIAL_CLASS 5)))` is a payload
+        // item whose value is a NESTED `emit` MISSING its own type
+        // operand — under the OLD `skip(2)`, that nested emit's own
+        // `items[1]` (`(add-node NodeType/SOCIAL_CLASS 5)`, the verb
+        // invocation itself) was silently treated as "the confirmed type
+        // operand" and skipped, so `add-node` was never inspected as a
+        // head at all.
+        let (probe, _) =
+            read("(emit EventType/RUPTURE (m (emit (add-node NodeType/SOCIAL_CLASS 5))))")
+                .expect("probe must parse");
+        let err = super::check_no_deferred_shape_verbs(&probe)
+            .expect_err("add-node behind a malformed nested emit must still be caught");
+        assert!(err.contains("add-node"), "{err}");
+    }
+
+    #[test]
+    fn remove_node_behind_a_type_operand_less_nested_emit_still_refuses() {
+        // The sibling probe with a REMOVAL verb (`remove-node`), not a
+        // minting one — proves the fix is not scoped to `add-node` alone.
+        let (probe, _) = read("(emit EventType/RUPTURE (m (emit (remove-node self))))")
+            .expect("probe must parse");
+        let err = super::check_no_deferred_shape_verbs(&probe)
+            .expect_err("remove-node behind a malformed nested emit must still be caught");
+        assert!(err.contains("remove-node"), "{err}");
+    }
+
+    #[test]
+    fn a_deferred_verb_in_an_over_arity_payload_item_still_refuses() {
+        // `(m 1 (add-node NodeType/SOCIAL_CLASS 5))` is an over-arity
+        // payload item — THREE elements, not the well-formed
+        // `(<symbol> <expr>)` two — so `pair.get(1)` alone (the literal
+        // `1`) never reached `pair[2]`, the real `add-node` invocation.
+        // The fix descends `pair[1..]`, every element after the label.
+        let (probe, _) = read("(emit EventType/RUPTURE (m 1 (add-node NodeType/SOCIAL_CLASS 5)))")
+            .expect("probe must parse");
+        let err = super::check_no_deferred_shape_verbs(&probe)
+            .expect_err("every value after an over-arity payload item's label must be checked");
+        assert!(err.contains("add-node"), "{err}");
     }
 }

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -1758,6 +1758,33 @@ mod tests {
     }
 
     #[test]
+    fn add_hyperedge_under_a_nodetype_only_vocabulary_is_inert_for_hyperedgetype() {
+        // G3(a) (#534 fix round 2): the eval-leg per-kind inertness pin,
+        // site-isolation style — mirrors F1's own scenario-load pin
+        // (`vocabulary::tests::a_kind_absent_from_the_vocabulary_is_inert_
+        // not_e_load_031`) one producer down, at verb EXECUTION. A
+        // vocabulary that declares NodeType but never HyperedgeType must
+        // leave HyperedgeType's own membership checking exactly as inert
+        // here as `ClosedVocabulary::check_enum_ref` already proves at the
+        // registry level — a kind never opted into checking is not being
+        // checked, never a fallback (§3.6).
+        let mut fixture = Fixture::new();
+        let mut fuel = 128;
+        let vocabulary = crate::vocabulary::ClosedVocabulary::new([(
+            crate::vocabulary::EnumKind::NodeType,
+            vec!["SOCIAL_CLASS".to_owned()],
+        )])
+        .unwrap();
+        fixture
+            .run_with_vocabulary(
+                "(effects (add-hyperedge HyperedgeType/ANYTHING nucleus (members self)))",
+                &mut fuel,
+                &vocabulary,
+            )
+            .expect("HyperedgeType was never declared — its checking must stay inert");
+    }
+
+    #[test]
     fn a_registered_type_mints_clean_under_a_declared_vocabulary() {
         let mut fixture = Fixture::new();
         let mut fuel = 128;

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -601,7 +601,15 @@ pub fn run_tick(
             }
         }
 
-        let mut executor = EffectExecutor::new(types, enums);
+        // `vocabulary_registry: None` — the collect path never reaches a
+        // minting verb (`add-node`/`add-edge`/`add-hyperedge`) at all: every
+        // rule `collect_item` sees here already survived
+        // `rule_pipeline::check_no_deferred_shape_verbs`'s unconditional
+        // load-time refusal of the six graph-shape verbs, so threading a
+        // registry through this specific construction site would change
+        // nothing observable (Task 8, Organization foundation plan — see
+        // `EffectExecutor`'s own field doc).
+        let mut executor = EffectExecutor::new(types, enums, None);
         let pending = executor.collect_effects(effects, &env, host, sink, &mut fuel)?;
         all_pending.extend(pending);
         fired += 1;
@@ -610,7 +618,7 @@ pub fn run_tick(
     // ---- Pass 2: apply, in the order collected (subject order outer,
     // source order inner) — `graph` is mutable again, the Pass-1 immutable
     // borrow having already ended. ----
-    let mut applier = EffectExecutor::new(types, enums);
+    let mut applier = EffectExecutor::new(types, enums, None);
     for write in &all_pending {
         applier.apply_pending_write(write, graph)?;
     }

--- a/rust/crates/babylon-bsl/src/vocabulary.rs
+++ b/rust/crates/babylon-bsl/src/vocabulary.rs
@@ -75,11 +75,20 @@ impl EnumKind {
 /// A closed-vocabulary rejection.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VocabularyError {
-    /// `E-LOAD-030` — an enum type name outside the registry (unregistered
-    /// altogether, or — since F2, #534 fix round item 2 — the wrong
-    /// STRUCTURAL kind for the demanding position; from that position's
-    /// own viewpoint the two are the same fact: nothing it accepts is
-    /// registered there, bsl-language.rst D119).
+    /// `E-LOAD-030` — an enum type name that names NO real type at all:
+    /// not one of the four structural kinds, and not any type this
+    /// scenario declared via `defenum` either. **Corrected by G2 (#534 fix
+    /// round 2 item 2, bsl-language.rst D119)**: F2 (#534 fix round item
+    /// 2) originally folded a SECOND, distinct fact in here too — a
+    /// syntactically-real type (a genuine structural kind, or a declared
+    /// `defenum` type) written at the WRONG position — under the same
+    /// code and a message that was false for exactly that case ("`EdgeType`
+    /// is not a registered enum type" when it plainly is one, just not
+    /// this position's). That case is [`Self::WrongEnumKind`]
+    /// (`E-TYPE-011`) now — see its own doc; this variant fires only when
+    /// the written name is not registered ANYWHERE, so its own message
+    /// ("is not a registered enum type") is true of every case it still
+    /// covers.
     UnknownEnumType {
         /// The offending type name.
         enum_type: String,
@@ -87,6 +96,24 @@ pub enum VocabularyError {
         /// `<enum-ref>` as written (F6, #534 fix round item 6), even
         /// though the type half is what failed.
         member: String,
+    },
+    /// `E-TYPE-011` — an `<enum-ref>` naming a type that genuinely exists
+    /// (one of the four structural kinds, or a scenario-declared
+    /// `defenum` type) but is the WRONG kind for the position demanding
+    /// it — §2.6's class rule (D74), split from [`Self::UnknownEnumType`]
+    /// by G2 (#534 fix round 2 item 2, bsl-language.rst D119). A real
+    /// type at the wrong position and a type name that is not registered
+    /// anywhere are different facts; the reference implementation's
+    /// hydration-side producer (`scenario::demand_enum_kind`) originally
+    /// conflated them under one code and a message that was false for
+    /// this half.
+    WrongEnumKind {
+        /// The type name as written.
+        enum_type: String,
+        /// The member written alongside it.
+        member: String,
+        /// The kind this position demands.
+        expected: EnumKind,
     },
     /// `E-LOAD-031` — a member the registered enum type does not carry.
     UnknownEnumMember {
@@ -129,6 +156,7 @@ impl VocabularyError {
     pub fn spec_code(&self) -> &'static str {
         match self {
             Self::UnknownEnumType { .. } => "E-LOAD-030",
+            Self::WrongEnumKind { .. } => "E-TYPE-011",
             Self::UnknownEnumMember { .. } => "E-LOAD-031",
             Self::RenderingCollision { .. } => "E-LOAD-032",
             Self::InvalidRendering { .. } => "E-LOAD-033",
@@ -144,6 +172,16 @@ impl std::fmt::Display for VocabularyError {
                 f,
                 "E-LOAD-030: {enum_type}/{member} — {enum_type} is not a \
                  registered enum type (§3.6)"
+            ),
+            Self::WrongEnumKind {
+                enum_type,
+                member,
+                expected,
+            } => write!(
+                f,
+                "E-TYPE-011: this position takes a {} member, found \
+                 {enum_type}/{member} (§2.6's class rule, D74)",
+                expected.type_name()
             ),
             Self::UnknownEnumMember {
                 enum_type,

--- a/rust/crates/babylon-bsl/src/vocabulary.rs
+++ b/rust/crates/babylon-bsl/src/vocabulary.rs
@@ -179,7 +179,7 @@ impl std::fmt::Display for VocabularyError {
                 expected,
             } => write!(
                 f,
-                "E-TYPE-011: this position takes a {} member, found \
+                "E-TYPE-011: this position takes a member of {}, found \
                  {enum_type}/{member} (§2.6's class rule, D74)",
                 expected.type_name()
             ),
@@ -603,5 +603,37 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(msg.contains("DoctrineTag/X"), "{msg}");
+    }
+
+    #[test]
+    fn the_e_type_011_message_sidesteps_the_article_for_every_expected_kind() {
+        // H3 (#534 fix round 3, cosmetic): "this position takes a {}
+        // member" reads as "a EdgeType member" / "a EventType member" for
+        // two of the four `EnumKind`s — grammatically wrong, since English
+        // needs "an" before a vowel sound. "takes a member of {}" sidesteps
+        // the article entirely rather than special-casing which kinds need
+        // "an" (a distinction with no game-logic meaning, so not worth a
+        // branch).
+        for expected in [
+            EnumKind::NodeType,
+            EnumKind::EdgeType,
+            EnumKind::HyperedgeType,
+            EnumKind::EventType,
+        ] {
+            let msg = VocabularyError::WrongEnumKind {
+                enum_type: "EdgeType".to_owned(),
+                member: "SOLIDARITY".to_owned(),
+                expected,
+            }
+            .to_string();
+            assert!(
+                msg.contains(&format!("a member of {}", expected.type_name())),
+                "{msg}"
+            );
+            assert!(!msg.contains("a NodeType member"), "{msg}");
+            assert!(!msg.contains("a EdgeType member"), "{msg}");
+            assert!(!msg.contains("a HyperedgeType member"), "{msg}");
+            assert!(!msg.contains("a EventType member"), "{msg}");
+        }
     }
 }

--- a/rust/crates/babylon-bsl/src/vocabulary.rs
+++ b/rust/crates/babylon-bsl/src/vocabulary.rs
@@ -272,11 +272,19 @@ impl ClosedVocabulary {
                 enum_type: enum_type.to_owned(),
             });
         };
-        let known = self
-            .members
-            .get(&kind)
-            .is_some_and(|names| names.iter().any(|n| n == member));
-        if known {
+        let Some(names) = self.members.get(&kind) else {
+            // F1 (#534 fix round item 1; bsl-language.rst §2.13, D119): a
+            // kind ABSENT from the declared vocabulary — no `defvocabulary`
+            // for it at all — leaves that kind's checking exactly as inert
+            // as it is today. Before this, `self.members.get(&kind)`
+            // returning `None` fell straight into `is_some_and`'s `false`
+            // arm below and was refused as `UnknownEnumMember`
+            // (`E-LOAD-031`) — indistinguishable from a DECLARED kind whose
+            // members just don't include this one. Never conflate the two:
+            // a DECLARED kind's own typo still refuses below.
+            return Ok(kind);
+        };
+        if names.iter().any(|n| n == member) {
             Ok(kind)
         } else {
             Err(VocabularyError::UnknownEnumMember {
@@ -444,6 +452,34 @@ mod tests {
                 .unwrap_err()
                 .spec_code(),
             "E-LOAD-030"
+        );
+    }
+
+    #[test]
+    fn a_kind_absent_from_the_vocabulary_is_inert_not_e_load_031() {
+        // F1 (#534 fix round item 1; docs/reference/bsl-language.rst §2.13:
+        // "a content set that declares no defvocabulary for a kind leaves
+        // THAT KIND's checking exactly as inert as it is today"). A
+        // PARTIAL vocabulary — NodeType declared, EdgeType never declared
+        // at all — must leave EdgeType's own checking INERT (`Ok`), never
+        // conflated with a DECLARED kind whose members happen not to
+        // include the one written (`enum_ref_membership_is_checked_at_
+        // load_never_defaulted` above pins THAT case, `NodeType/NOWHERE`,
+        // which stays `E-LOAD-031`).
+        let partial = ClosedVocabulary::new([(EnumKind::NodeType, vec!["SOCIAL_CLASS".to_owned()])])
+            .expect("a single-kind vocabulary is trivially disjoint");
+        assert_eq!(
+            partial.check_enum_ref("EdgeType", "SOLIDARITY"),
+            Ok(EnumKind::EdgeType),
+            "EdgeType was never declared — its checking must stay inert"
+        );
+        // The DECLARED kind's own typo check is unaffected by this fix.
+        assert_eq!(
+            partial
+                .check_enum_ref("NodeType", "NOWHERE")
+                .unwrap_err()
+                .spec_code(),
+            "E-LOAD-031"
         );
     }
 }

--- a/rust/crates/babylon-bsl/src/vocabulary.rs
+++ b/rust/crates/babylon-bsl/src/vocabulary.rs
@@ -75,10 +75,18 @@ impl EnumKind {
 /// A closed-vocabulary rejection.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VocabularyError {
-    /// `E-LOAD-030` — an enum type name outside the registry.
+    /// `E-LOAD-030` — an enum type name outside the registry (unregistered
+    /// altogether, or — since F2, #534 fix round item 2 — the wrong
+    /// STRUCTURAL kind for the demanding position; from that position's
+    /// own viewpoint the two are the same fact: nothing it accepts is
+    /// registered there, bsl-language.rst D119).
     UnknownEnumType {
         /// The offending type name.
         enum_type: String,
+        /// The member written alongside it — carried for the full
+        /// `<enum-ref>` as written (F6, #534 fix round item 6), even
+        /// though the type half is what failed.
+        member: String,
     },
     /// `E-LOAD-031` — a member the registered enum type does not carry.
     UnknownEnumMember {
@@ -86,6 +94,10 @@ pub enum VocabularyError {
         enum_type: String,
         /// The offending member identifier.
         member: String,
+        /// Every member this kind actually declares, ascending (F6, #534
+        /// fix round item 6) — so the refusal states what IS registered,
+        /// not only what was not found.
+        declared: Vec<String>,
     },
     /// `E-LOAD-032` — two graph-element types rendering to one symbol.
     RenderingCollision {
@@ -128,14 +140,20 @@ impl VocabularyError {
 impl std::fmt::Display for VocabularyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::UnknownEnumType { enum_type } => write!(
+            Self::UnknownEnumType { enum_type, member } => write!(
                 f,
-                "E-LOAD-030: {enum_type} is not a registered enum type (§3.6)"
+                "E-LOAD-030: {enum_type}/{member} — {enum_type} is not a \
+                 registered enum type (§3.6)"
             ),
-            Self::UnknownEnumMember { enum_type, member } => write!(
+            Self::UnknownEnumMember {
+                enum_type,
+                member,
+                declared,
+            } => write!(
                 f,
-                "E-LOAD-031: {enum_type} has no member {member} — never a \
-                 default (§1.5)"
+                "E-LOAD-031: {enum_type}/{member} is not a registered member \
+                 — never a default (§1.5); {enum_type} declares: {}",
+                format_declared_members(declared)
             ),
             Self::RenderingCollision {
                 symbol,
@@ -162,6 +180,27 @@ impl std::fmt::Display for VocabularyError {
 }
 
 impl std::error::Error for VocabularyError {}
+
+/// F6 (#534 fix round item 6): summarize a kind's declared members for a
+/// refusal message — the full list when short, a bounded prefix
+/// (`SHOWN_MEMBERS`) plus a count when long, so a vocabulary with hundreds
+/// of members never blows the message out.
+const SHOWN_MEMBERS: usize = 8;
+
+fn format_declared_members(declared: &[String]) -> String {
+    if declared.is_empty() {
+        return "no members".to_owned();
+    }
+    if declared.len() <= SHOWN_MEMBERS {
+        declared.join(", ")
+    } else {
+        format!(
+            "{}, … (+{} more)",
+            declared[..SHOWN_MEMBERS].join(", "),
+            declared.len() - SHOWN_MEMBERS
+        )
+    }
+}
 
 /// Render an enum member identifier to its BSL segment symbol (§2.9):
 /// lowercase, `_` → `-`. The result must satisfy §1.4's `symbol`
@@ -270,6 +309,7 @@ impl ClosedVocabulary {
         let Some(kind) = EnumKind::from_type_name(enum_type) else {
             return Err(VocabularyError::UnknownEnumType {
                 enum_type: enum_type.to_owned(),
+                member: member.to_owned(),
             });
         };
         let Some(names) = self.members.get(&kind) else {
@@ -290,6 +330,7 @@ impl ClosedVocabulary {
             Err(VocabularyError::UnknownEnumMember {
                 enum_type: enum_type.to_owned(),
                 member: member.to_owned(),
+                declared: names.clone(),
             })
         }
     }
@@ -466,8 +507,9 @@ mod tests {
         // include the one written (`enum_ref_membership_is_checked_at_
         // load_never_defaulted` above pins THAT case, `NodeType/NOWHERE`,
         // which stays `E-LOAD-031`).
-        let partial = ClosedVocabulary::new([(EnumKind::NodeType, vec!["SOCIAL_CLASS".to_owned()])])
-            .expect("a single-kind vocabulary is trivially disjoint");
+        let partial =
+            ClosedVocabulary::new([(EnumKind::NodeType, vec!["SOCIAL_CLASS".to_owned()])])
+                .expect("a single-kind vocabulary is trivially disjoint");
         assert_eq!(
             partial.check_enum_ref("EdgeType", "SOLIDARITY"),
             Ok(EnumKind::EdgeType),
@@ -481,5 +523,47 @@ mod tests {
                 .spec_code(),
             "E-LOAD-031"
         );
+    }
+
+    // ---- F6 (#534 fix round item 6): refusal message house style — the
+    // full ref as written, and the declared members of that kind. ----
+
+    #[test]
+    fn the_e_load_031_message_names_the_full_ref_and_the_declared_members() {
+        let v = vocabulary();
+        let msg = v
+            .check_enum_ref("NodeType", "NOWHERE")
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("NodeType/NOWHERE"), "{msg}");
+        assert!(msg.contains("SOCIAL_CLASS"), "{msg}");
+        assert!(msg.contains("POLITY"), "{msg}");
+    }
+
+    #[test]
+    fn the_e_load_031_message_bounds_a_long_declared_list() {
+        let long = ClosedVocabulary::new([(
+            EnumKind::NodeType,
+            (0..20).map(|i| format!("MEMBER_{i}")).collect(),
+        )])
+        .unwrap();
+        let msg = long
+            .check_enum_ref("NodeType", "NOWHERE")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            msg.contains("more"),
+            "a 20-member kind must summarize: {msg}"
+        );
+    }
+
+    #[test]
+    fn the_e_load_030_message_names_the_full_ref_as_written() {
+        let v = vocabulary();
+        let msg = v
+            .check_enum_ref("DoctrineTag", "X")
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("DoctrineTag/X"), "{msg}");
     }
 }

--- a/rust/crates/babylon-bsl/tests/conformance_corpus.rs
+++ b/rust/crates/babylon-bsl/tests/conformance_corpus.rs
@@ -921,7 +921,7 @@ fn bifurcation_routes_by_solidarity_density() {
             })
             .unwrap();
         let registries = registries();
-        let mut executor = EffectExecutor::new(&registries.types, &registries.enums);
+        let mut executor = EffectExecutor::new(&registries.types, &registries.enums, None);
         let mut sink = CollectingSink::default();
         let mut fuel = 512;
         executor

--- a/rust/crates/babylon-bsl/tests/r9_chapters.rs
+++ b/rust/crates/babylon-bsl/tests/r9_chapters.rs
@@ -1353,7 +1353,7 @@ mod c5_element_selection {
         };
         let types = type_env();
         let enum_registry = enums();
-        let mut executor = EffectExecutor::new(&types, &enum_registry);
+        let mut executor = EffectExecutor::new(&types, &enum_registry, None);
         let mut sink = CollectingSink::default();
         let mut fuel2 = 1_000;
         let pending = executor
@@ -1368,7 +1368,7 @@ mod c5_element_selection {
         // Pass 2 uses a FRESH executor, exactly as `tick.rs::run_tick`
         // does — the apply half must not depend on any state the
         // collecting executor accumulated (Copilot harvest, #520).
-        let mut apply_executor = EffectExecutor::new(&types, &enum_registry);
+        let mut apply_executor = EffectExecutor::new(&types, &enum_registry, None);
         for write in &pending {
             apply_executor
                 .apply_pending_write(write, &mut graph)
@@ -1536,10 +1536,10 @@ mod c6_effect_position_iteration {
                 graph: Some(&*graph as &dyn GraphSubstrate),
                 elements: Vec::new(),
             };
-            let mut collector = EffectExecutor::new(&types, &enum_registry);
+            let mut collector = EffectExecutor::new(&types, &enum_registry, None);
             collector.collect_effects(&items[1..], &env, &EmptyIntrinsicHost, &mut sink, fuel)?
         };
-        let mut applier = EffectExecutor::new(&types, &enum_registry);
+        let mut applier = EffectExecutor::new(&types, &enum_registry, None);
         for write in &pending {
             applier.apply_pending_write(write, &mut *graph)?;
         }

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -195,6 +195,11 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
         // under; same class of minimal driver-scaffolding addition as the
         // four above.
         "territory".to_owned(),
+        // The organization/* rule pack (Task 8, Organization foundation
+        // plan) — same class of minimal driver-scaffolding addition as the
+        // five above; Task 10 ships the first content using this
+        // namespace.
+        "organization".to_owned(),
     ]);
 
     // ONE shared LoadContext for every rule in the content set — the
@@ -211,11 +216,13 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
         systems: &systems,
         // The R9 chapters' vocabulary-dependent gates (D37's field-init
         // owner rule, D43's domain inference, §2.5's foreign-`:field`
-        // scoping) need a `ClosedVocabulary`. This driver declares none —
-        // the scenario's `deffield` forms are its whole registry — so they
-        // are skipped here rather than run against a guess. The registry is
-        // Phase-2 content work.
-        vocabulary_registry: None,
+        // scoping) AND Task 8's closed-vocabulary membership enforcement
+        // (E-LOAD-030/031) need a `ClosedVocabulary`. Task 7 landed the
+        // scenario-side declaration form (`defvocabulary`); Task 8 wires
+        // enforcement live — whatever the scenario declared (`Some`, or
+        // `None` for a scenario declaring none at all, exactly today's
+        // unchecked behavior) is what every rule loads against.
+        vocabulary_registry: scenario.vocabulary.as_ref(),
         rule_file: "rule",
     };
 

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -384,4 +384,46 @@ mod tests {
         let err = run_once(VOCAB_WIRING_SCENARIO, VOCAB_WIRING_RULE).unwrap_err();
         assert!(err.contains("E-LOAD-031"), "{err}");
     }
+
+    // G3(b) (#534 fix round 2): the "Task-10 detonation pin". The
+    // organization foundation plan's own scenario shape
+    // (docs/superpowers/plans/2026-08-11-organization-foundation-plan.md
+    // Task 10, ~lines 443-480) declares NodeType/EdgeType vocabularies but
+    // NEVER EventType, then its probe rule emits
+    // `EventType/ORGANIZATION_SEEDED` from inside an emit form carrying a
+    // payload item (`(probe 1)`) — the exact shape G1's tightened
+    // `check_enum_ref_membership`/`find_deferred_shape_verb` now recurse
+    // one level deeper into (each payload item's VALUE, not just its
+    // LABEL). This proves the plan's own real-world content still loads
+    // clean and fires through `run_once`, the actual production seam
+    // (scenario hydration's F1 inertness for an opted-out EventType kind,
+    // AND emit's own operand plus its payload value, all through one
+    // pipeline) — not merely each walker's own isolated unit tests.
+    const TASK_10_SCENARIO: &str = r"
+(scenario organization/foundation-detonation-pin
+  (defvocabulary NodeType (SOCIAL_CLASS ORGANIZATION))
+  (defvocabulary EdgeType (MEMBERSHIP))
+  (deffield organization/active int extensive)
+  (node worker NodeType/SOCIAL_CLASS)
+  (node cell NodeType/ORGANIZATION (organization/active 1))
+  (edge EdgeType/MEMBERSHIP cell worker 1))
+";
+    const TASK_10_RULE: &str = r#"(rule organization/kind-probe
+  :material-basis "Task 10's own probe rule shape (organization foundation plan) — EventType stays undeclared while NodeType/EdgeType are declared, proving hydration and the emit payload both leave an opted-out kind inert through the full production seam"
+  :fuel 32
+  (bindings (binding active :field organization/active))
+  (when (= active 1))
+  (effects (emit EventType/ORGANIZATION_SEEDED (probe 1))))"#;
+
+    #[test]
+    fn the_task_10_scenario_shape_loads_clean_and_fires_through_run_once() {
+        let report = run_once(TASK_10_SCENARIO, TASK_10_RULE).expect(
+            "EventType was never declared — its checking must stay inert, at both \
+             hydration and the emit payload G1 now recurses into",
+        );
+        assert_eq!(
+            report.fired, 1,
+            "the probe rule must fire for exactly the one active organization"
+        );
+    }
 }

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -355,4 +355,33 @@ mod tests {
         assert_eq!(report.per_rule_fired.len(), 1);
         assert_eq!(report.per_rule_fired[0].1, report.fired);
     }
+
+    // F3 (#534 fix round item 3, panel-proven): `prepare_rules`'s ONE
+    // production wiring line — `vocabulary_registry:
+    // scenario.vocabulary.as_ref()` — was unpinned; mutating it to `None`
+    // flipped zero tests. This drives `run_once`, the ACTUAL production
+    // seam (the CLI driver and `babylon-client`'s engine link both call
+    // exactly this function), with a scenario declaring a vocabulary and a
+    // rule whose enum-ref typos a member of a DECLARED kind — proving the
+    // registry really is threaded end to end through `prepare_rules`, not
+    // merely unit-tested in isolation at each of the three producers.
+    const VOCAB_WIRING_SCENARIO: &str = r"
+(scenario ft/vocab-wiring-probe
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (deffield social-class/wages int extensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/wages 100)))
+";
+    const VOCAB_WIRING_RULE: &str = r#"(rule vitality/vocab-wiring-probe
+  :material-basis "F3 (#534 fix round item 3): proves the production seam threads a declared vocabulary end to end"
+  :fuel 64
+  (domain NodeType/SOCIAL_CLA)
+  (bindings (binding wages :field social-class/wages))
+  (when (> wages 0))
+  (effects (emit EventType/PROBE)))"#;
+
+    #[test]
+    fn a_declared_vocabulary_typo_refuses_through_the_production_seam() {
+        let err = run_once(VOCAB_WIRING_SCENARIO, VOCAB_WIRING_RULE).unwrap_err();
+        assert!(err.contains("E-LOAD-031"), "{err}");
+    }
 }

--- a/tests/unit/reference/test_bsl_grammar_sync.py
+++ b/tests/unit/reference/test_bsl_grammar_sync.py
@@ -790,3 +790,59 @@ class TestTheEnumRowStaysInSync:
             "the register row must record that the enum row supersedes D94's "
             "exclusion by Director ruling (spec §1 Q12), never silently"
         )
+
+
+class TestTheD119HydrationSplitIsRecordedInTheRegister:
+    """G2 (#534 fix round 2 item 2, mutation-reproduced). D119 already
+    recorded the RULE-form split (``grammar::check_enum_ref_kinds``'s
+    ``E-TYPE-011`` vs ``ClosedVocabulary::check_enum_ref``'s
+    ``E-LOAD-030``/``E-LOAD-031``) but said nothing about the SECOND,
+    independent producer that conflated them the same way:
+    ``scenario::demand_enum_kind``, the unconditional hydration kind-demand
+    a ``.bscn`` file's own ``node``/``edge`` forms go through — §3.9
+    clause 1 authorizes it ("hydration is not a back door into the closed
+    vocabulary"). RHS-grain checks, the same class ``TestTheEnumCasPayload
+    ShapeStaysInSync``/``TestTheEnumArithmeticRefusalIsDeclaredInTheRegistry``
+    guard for D117/D118, so the extension cannot silently regress to the
+    narrower reading.
+    """
+
+    def test_d119_is_recorded_in_the_register(self) -> None:
+        body = _read(RST)
+        assert re.search(r"^\s+\* - D119$", body, re.MULTILINE), (
+            "D119 must still have its own Draft-Ruling Register row"
+        )
+        start = body.index("\nDraft-Ruling Register\n")
+        end = body.index("\nSee Also\n", start)
+        section = body[start:end]
+        d119_start = section.index("D119")
+        d119_row = section[d119_start:]
+        assert "demand_enum_kind" in d119_row, (
+            "D119's row text must name scenario.rs's own hydration-side "
+            "kind-demand producer, not just the rule-form one"
+        )
+        assert "E-TYPE-011" in d119_row and "E-LOAD-030" in d119_row, (
+            "D119's row text must record the SAME class split at hydration "
+            "positions that it already does for rule-form positions"
+        )
+        assert "3.9" in d119_row, (
+            "D119's row text must cite §3.9 clause 1's hydration authority "
+            "('hydration is not a back door into the closed vocabulary')"
+        )
+        assert "WrongEnumKind" in d119_row, (
+            "D119's row text must name the reference implementation's own "
+            "new variant (VocabularyError::WrongEnumKind), not just the code"
+        )
+
+    def test_d119_says_any_not_one_of_the_sixteen(self) -> None:
+        # G3(e) (#534 fix round 2): "at one of the sixteen" reads as if the
+        # divergence were localized to a single position rather than
+        # holding at any of the sixteen alike. `\s+` (not a literal space)
+        # because the rst hard-wraps prose across lines, so "at" and "any"
+        # can land on different source lines while still being one phrase.
+        body = _read(RST)
+        start = body.index("\nDraft-Ruling Register\n")
+        end = body.index("\nSee Also\n", start)
+        section = body[start:end]
+        assert re.search(r"at\s+any\s+of\s+the\s+sixteen", section)
+        assert not re.search(r"at\s+one\s+of\s+the\s+sixteen", section)

--- a/tests/unit/reference/test_bsl_grammar_sync.py
+++ b/tests/unit/reference/test_bsl_grammar_sync.py
@@ -694,6 +694,31 @@ class TestTheEnumArithmeticRefusalIsDeclaredInTheRegistry:
         )
 
 
+class TestThe46RowNamesTheUnregisteredMemberRuntimeTwin:
+    """#528 delta-verify rider R3. §4.6's Evaluation class-table row names
+    three of the four ``enum_write_value`` (``structural_verbs.rs``)
+    emitting sites for its §2.13 ``E-EVAL-042`` clause — the write-shape
+    violation (a non-``<enum-ref>`` value, or a cross-type ``<enum-ref>``)
+    and the ``add``/``sub``/``scale`` arithmetic refusal (D118). The
+    FOURTH site — an ``<enum-ref>`` of the RIGHT declared type naming a
+    member that type does not declare (``enum_write_value``'s
+    ``self.enums.ordinal(ty, &member)`` arm) — is ``E-EVAL-042`` too, and
+    is the runtime twin of ``E-LOAD-055`` (already named in the Load/link
+    row), but was never named in the Evaluation row itself.
+    """
+
+    def test_the_46_row_names_the_unregistered_member_case(self) -> None:
+        body = _read(RST)
+        start = body.index("   * - Evaluation")
+        end = body.index("**Every code the R9 chapters add", start)
+        section = body[start:end]
+        assert "E-LOAD-055" in section and "runtime twin" in section, (
+            "the §4.6 Evaluation class-table row must name the "
+            "right-type/unregistered-member runtime case as E-LOAD-055's "
+            "runtime twin — #528 delta-verify rider R3"
+        )
+
+
 class TestTheDraftRulingRegisterHasNoDuplicateRowNumbers:
     """A second row naming a D-number already in use passes every
     existence-only check above — each of D94/D95/D98/D99's own tests just


### PR DESCRIPTION
## Group D of the organization-foundation plan (#513): Tasks 8–9 + three #528 delta-verify riders

**Task 8 — enforcement goes live (`20ab6eab`):** with a scenario-declared `defvocabulary`, a typo'd `NodeType/FOO` now fails at **scenario load** (`load_node`/`load_edge`), at **rule load** (`rule_pipeline::load_rule_form` via the new `grammar::check_enum_ref_membership` pass), and at **verb execution** (`EffectExecutor::add_node/add_edge/add_hyperedge` via `enum_member_checked`) — the three producers the plan's Scout 3 proved all silently mint today. `grammar.rs`'s `owner_of` Err now propagates (E-LOAD-023 reachable). **Backward-compat pin:** everything is gated on `Some` — packs with no declared vocabulary behave exactly as today, proven by the untouched tick_goldens. `prepare_rules` threads `scenario.vocabulary.as_ref()` and the systems set gains `"organization"`.

**Task 9 — fixture fallout (`fee9d193`):** mechanical `None` appends at `EffectExecutor` construction sites in the two integration suites; zero behavioral edits.

**Riders (from the #528 delta verification, each cited in its commit):**
- `6ab0131e` — `remove-edge` joins the type-operand gate; honest rename to `TYPE_OPERAND_HEADS`/`check_type_operands_are_enum_refs` (remove-edge mints nothing).
- `7ec387f0` — that walker is now head-position-only, killing the pair-form label-collision over-refusal (`(emit EventType/RUPTURE (emit 5) …)` probe pinned as a regression pair).
- `669405a5` — §4.6's E-EVAL-042 row names the fourth emitting site (the unregistered-member runtime twin of E-LOAD-055), sync-guard pinned red-first.

**Gates:** four-leg cargo gate green (fmt/clippy/test×51/doc), tick_goldens byte-identical after every commit, grammar-sync 39/39.

**Noted, not fixed (disclosed follow-on):** `structural_verbs::find_deferred_shape_verb` shares the walks-every-child-list shape R2 fixed — future rider.

Part of the #513 org-foundation train (Groups A/B/C merged: #517/#518/#528). Group E (the org scenario + pinned goldens) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)