### PR TITLE
fix(data): estate hygiene — trace_log docstring ghost + stale catalog rows

### DIFF
--- a/data-catalog.yaml
+++ b/data-catalog.yaml
@@ -3,7 +3,7 @@
 # Canonical machine-readable catalog for III.4 Data Source Traceability.
 # Runtime data sources are fetched/updated during operation.
 # Fixtures are pinned snapshots for reproducible tests and NEVER runtime dependencies.
-version: "2.7.2"
+version: "2.7.3"
 categories:
   - name: Federal Economic
     sources:
@@ -300,6 +300,9 @@ categories:
         granularity: Polygon
         cadence: Static
         class: Fixture
+      # Cadence caveat (data-gap audit §3.4): USGS explicitly warns AGAINST
+      # reading PAD-US version deltas as ground change — govern as a pinned
+      # static Fixture vintage, never diff versions to infer dispossession.
       - id: PAD_US
         agency: USGS
         dataset: Protected Areas Database
@@ -307,12 +310,15 @@ categories:
         granularity: Polygon
         cadence: Annual
         class: Fixture
+      # Cadence corrected 2026-08-12 (data-gap audit §3.4): the 5-year epoch
+      # product ended with NLCD 2021; Annual NLCD (1985-present, yearly
+      # releases) superseded it on 2024-10-24.
       - id: NLCD
         agency: USGS
-        dataset: National Land Cover Database
-        vintage: 5-year
+        dataset: National Land Cover Database (Annual NLCD)
+        vintage: Annual
         granularity: 30m pixel
-        cadence: 5-year
+        cadence: Annual
         class: Fixture
       - id: EPA_FRS
         agency: EPA
@@ -351,6 +357,12 @@ categories:
         granularity: Block/Tract
         cadence: Annual
         class: Runtime
+      # NEVER ACQUIRED — commercial, redistribution-prohibited, hard-blocked by
+      # ADR098 (a non-redistributable set cannot be a committed build source).
+      # Killed by the data-gap audit (reports/data-gap-audit-2026-08-12.md §3.4,
+      # §9); retained only as the record of the considered-and-rejected parcel
+      # option. Do NOT plan against this row — the free replacements are HMDA
+      # Modified LAR (flow) + AgCensus Table 45 (agricultural tenure).
       - id: ATTOM_CoreLogic
         agency: Commercial
         dataset: Property/parcel data

--- a/data-catalog.yaml
+++ b/data-catalog.yaml
@@ -300,9 +300,11 @@ categories:
         granularity: Polygon
         cadence: Static
         class: Fixture
-      # Cadence caveat (data-gap audit §3.4): USGS explicitly warns AGAINST
-      # reading PAD-US version deltas as ground change — govern as a pinned
-      # static Fixture vintage, never diff versions to infer dispossession.
+      # Cadence caveat (data-gap audit §3.4): upstream publishes annually
+      # (the fields below record the publisher's fact), but any acquisition
+      # must PIN ONE vintage (edition, version, sha256) — USGS explicitly
+      # warns AGAINST reading PAD-US version deltas as ground change, so
+      # never diff vintages to infer dispossession.
       - id: PAD_US
         agency: USGS
         dataset: Protected Areas Database

--- a/src/babylon/persistence/postgres_schema.py
+++ b/src/babylon/persistence/postgres_schema.py
@@ -9,7 +9,9 @@ Defines tables across 10 layers:
 3. Spatial (3): hex_cell, hex_state, hex_terrain_state
 3b. R8 Reference (2): hex_r8_reference, hex_r8_linear_features_reference
 4. Infrastructure (1): infrastructure_link_state
-5. Trace (1): trace_log (UNLOGGED, partitioned by session_id)
+5. Trace (0): no trace table — trace reads go through the
+   ``view_runtime_trace_emission`` view contract (migrations 0019/0023/0030);
+   the UNLOGGED partitioned ``trace_log`` design was never implemented here
 6. Semantic (1): document_chunk (pgvector)
 7. Game-Journal Domain (2): hex_map, game_defines_snapshot
 8. Game-Journal Snapshots (8): territory_snapshot, org_snapshot,


### PR DESCRIPTION
First slice of **#547** (estate hygiene, data-gap audit §7/§3.4 — dossier `reports/data-gap-audit-2026-08-12.md`):

1. **`postgres_schema.py` docstring ghost**: the header advertised "Layer 5: trace_log (UNLOGGED, partitioned by session_id)" — no such DDL exists anywhere in the file (verified: the only `trace_log` mention IS the docstring line). Trace reads go through the `view_runtime_trace_emission` view contract (migrations 0019/0023/0030). The layer line now says so.
2. **`ATTOM_CoreLogic` catalog ghost row**: annotated never-acquired / ADR098-redistribution-blocked, with pointers to the free replacements (HMDA flow + AgCensus Table 45), so no future agent plans against it.
3. **`NLCD` stale cadence**: 5-year → Annual (the epoch product ended with NLCD 2021; Annual NLCD superseded it 2024-10-24).
4. **`PAD_US` caveat**: USGS warns against reading version deltas as ground change — pinned-static-Fixture governance noted.

Catalog version 2.7.2 → 2.7.3. Sentinel tests: 27 passed (`test_catalog.py` + `test_catalog_db_probe.py`). The touched Python file ranks **A** on radon MI (docstring-only edit); push used the documented `SKIP=radon-mi` #529 precedent (the 4 pre-existing C-ranked blockers are unrelated to this branch).

Remaining #547 items (migration 0044 apply, empty-table dispositions, FAF grain note) ride their own trains per the fold-into-touching-train rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)