### PR TITLE
feat(bsl): Territory PR A — the D102 field-of-enum discharge + the #551 enum-fold load gate

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -2270,18 +2270,23 @@ of why — ``Enum<T>`` supports no arithmetic, so an enum-typed value never
 reaches §3.4's aggregation-law table with a kind to check — is recorded
 there, beside the production it explains, rather than repeated here.
 
-**The** ``field-of`` **deferral.** An ``:enum-type``-declared field is
-read through a ``:field`` binding exactly as any other node field is
-(§2.5); this section does **not** extend §2.10's ``field-of`` accessor —
-the edge/hyperedge equivalent — to enum-declared fields. A ``field-of``
-naming one refuses, loudly, citing this paragraph and D102 below. The gap
-is deferred, not forbidden: an enum-declared *edge* or *hyperedge* field
-is not ruled out by anything in this section, and such a field would need
-exactly this accessor, for exactly the reason §2.10 exists at all — it
-has no single owning body to bind a ``:field`` against. Building that
-path is left to whichever later revision first needs one; this row's job
-is only to make sure that revision does not have to rediscover the gap
-as an unexplained refusal.
+**The** ``field-of`` **read path (D102, discharged).** An
+``:enum-type``-declared field is read through a ``:field`` binding
+exactly as any other node field is (§2.5), **and** through §2.10's
+``field-of`` accessor — the two read routes agree, rendering the same
+``Value::Enum`` through the same ordinal→member conversion. D102
+originally deferred ``field-of`` on an enum-declared field, refusing it
+loudly at load with no error code; the Territory port train (P27)
+discharged the deferral once Territory's ``_find_sink_node`` became its
+chartered first consumer — a rule reading a *neighbor's* enum-declared
+field has no ``:field`` binding to reach it through, exactly the gap
+D102 named. Discharging the read path narrows nothing else: a
+``field-of``-sourced ``Enum<T>`` value is still refused as a
+``select-max``/``select-min`` score (D46, ``E-TYPE-016``, §2.7) and still
+refused in every arithmetic lane (§2.13's no-arithmetic law, D101/D118)
+— those two refusals were always independent mechanisms, never D102's
+own job, so nothing about them changed. See D102 below for the full
+history and the reference implementation.
 
 3. Static semantics
 ---------------------
@@ -5678,18 +5683,46 @@ consequences are the ordinary kind of review item.
        landing with the Phase-2 vocabulary-ceremony ADR.
    * - D102
      - §2.13, §2.10
-     - ``field-of`` (§2.10) is **not** extended to ``:enum-type``-declared
-       fields by D101 — such a field is read via a ``:field`` binding
-       only (§2.5). A ``field-of`` naming one refuses loudly, citing this
-       row. Deferred, not forbidden: an enum-declared EDGE or HYPEREDGE
-       field (this document does not rule one out) would need
+     - **Discharged (Territory port train, P27, 2026-08-12).**
+       ``field-of`` (§2.10) was **not** extended to ``:enum-type``-declared
+       fields by D101 — such a field could be read only via a ``:field``
+       binding (§2.5); a ``field-of`` naming one refused loudly, citing
+       this row, with no error code (a deferred gap, not a new failure
+       class). Deferred, not forbidden: an enum-declared EDGE or
+       HYPEREDGE field (this document does not rule one out) would need
        ``field-of`` access precisely because it has no single owning
        body to bind a ``:field`` against — the same reason §2.10 exists
-       for dyadic and hyperedge fields at all — and building that
-       accessor is left to whichever revision first has such a field to
-       read. This row names the gap so a future implementer does not
-       have to rediscover it as a silent "the enum-ref case must have
-       been an oversight" bug.
+       for dyadic and hyperedge fields at all — and this row named the
+       gap so a future implementer would not have to rediscover it as a
+       silent "the enum-ref case must have been an oversight" bug.
+       **First consumer, and the discharge:** Territory's
+       ``_find_sink_node`` (``src/babylon/engine/systems/territory.py``)
+       reads a *neighbor* territory's ``territory_type`` — an
+       enum-declared field with no ``:field`` binding available (a
+       binding's ``:field`` source can only name ``self``'s own field,
+       §2.5), so the sink-priority query needs exactly the accessor D102
+       withheld. The discharge is narrow: ``field-of`` on an
+       enum-declared field now typechecks (``score_class::classify``
+       types it ``Enum``, not ``Real`` or ``Unknown``) and evaluates
+       (``evaluator::field_of_node`` renders the stored ordinal to
+       ``Value::Enum`` via the SAME shared helper — ``tick::
+       bind_field_value``, widened ``pub(crate)`` — a ``:field``
+       binding's read of the identical field already used) for real. Its
+       two surviving refusals are each independent of D102 and untouched
+       by the discharge: **score position** (D46, ``E-TYPE-016``) still
+       refuses an ``Enum``-classed ``select-max``/``select-min`` score,
+       via ``score_class::classify`` and ``typecheck::
+       check_selection_scores`` exactly as it already refused a
+       ``:field``-bound enum score; **arithmetic** (§2.13's no-arithmetic
+       law, D101/D118) still refuses ``Value::Enum`` in every arithmetic
+       lane, via ``evaluator::apply_arith``'s unconditional fallthrough
+       refusal (expression position) and ``structural_verbs::
+       numeric_write_value``'s catch-all (an ``update-node`` write
+       operand). ``typecheck::check_no_field_of_on_enum_field`` — the
+       unconditional load-time deferral gate this row named — is deleted
+       rather than narrowed: with the deferral discharged and both
+       surviving refusals independently mechanised, there was nothing
+       left for a third gate to decide.
    * - D103
      - §4.2, §2.8
      - **Resolved (query-evaluation plan Q1).** ``tick.rs::run_tick``'s
@@ -5970,15 +6003,16 @@ consequences are the ordinary kind of review item.
        ``apply_pending_write``'s independent re-check at apply time.
        **Second half — the law is statically decidable, so it now ALSO
        runs at load** (§3's own law: "every check in this chapter runs
-       at content load"), matching D102's own precedent for §2.13's
-       sibling ``field-of`` deferral: ``typecheck.rs::
-       check_no_arithmetic_on_enum_field``, wired into
-       ``rule_pipeline.rs`` beside the D102 gate, refuses an
-       ``add``/``sub``/``scale`` ``update-op`` targeting an
-       ``:enum-type``-declared field at load, citing this row — the
-       three eval-time sites above STAY, unchanged, as defense in depth,
-       exactly as D102's own load-time gate left its eval-time siblings
-       standing.
+       at content load"), matching the precedent D102's own (since-
+       discharged) ``field-of`` deferral gate set for exactly this shape:
+       ``typecheck.rs::check_no_arithmetic_on_enum_field``, wired into
+       ``rule_pipeline.rs``, refuses an ``add``/``sub``/``scale``
+       ``update-op`` targeting an ``:enum-type``-declared field at load,
+       citing this row — the three eval-time sites above STAY, unchanged,
+       as defense in depth, exactly as D102's own load-time gate left its
+       eval-time siblings standing (before the Territory port train's
+       discharge deleted that gate; ``check_no_arithmetic_on_enum_field``
+       itself is untouched — see D102's row for the discharge).
    * - D119
      - §2.13, §3.6
      - **Resolved (#534 fix round item 1, adversarial-panel finding,

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -2590,11 +2590,19 @@ The aggregation law, per fold operator:
        extensive-kinded. Unweighted is ``E-TYPE-042``; a weight that is not
        extensive is ``E-TYPE-043``. **Result intensive** (D90).
    * - ``min`` / ``max``
-     - any
+     - extensive, intensive or neutral
      - Kind-neutral operation. Result carries the body kind.
+   * - ``sum`` / ``mean`` / ``min`` / ``max``
+     - enum (``:enum-type``-declared, D101)
+     - **``E-TYPE-044``** (#551, discharged by the Territory port train,
+       P27) — ``Enum<T>`` has no aggregation kind: ``sum``/``mean`` need
+       arithmetic and ``min``/``max`` need ordering, and §2.13/§3.1 give it
+       neither. Distinct from the row above: "kind-neutral" there means
+       intensive-vs-extensive doesn't matter, never "any type works."
    * - ``count``
-     - any
-     - Result ``Int``, extensive.
+     - any, including enum
+     - Result ``Int``, extensive. The body is never evaluated, so an
+       enum-declared body is legal — inert content, not a content error.
 
 This is the narrow, true form of the law: it rejects the unweighted mean of an
 intensive field across classes or space (the recorded variance error), and it
@@ -3639,8 +3647,10 @@ Sequence continuation is meant literally, and is checkable by inspection: every
 decade block of every family is **contiguous**, with no reserved and no
 skipped number — ``E-LOAD`` 001–004, 010–013, 020–025, 030–033, 040–056;
 ``E-PARSE`` 010–015, 020–022, 030–033, 040–042; ``E-TYPE`` 010–017, 020, 030,
-040–043; ``E-EVAL`` 010–014, 020–021, 030–042; ``E-LEX`` 001–003,
-010–011, 020–027. The ``E-LOAD`` 040 block now runs past its own decade, and
+040–044; ``E-EVAL`` 010–014, 020–021, 030–042; ``E-LEX`` 001–003,
+010–011, 020–027. ``E-TYPE-044`` (Territory port train, P27, #551 closure)
+continues the SAME overrun block — the next free ``E-TYPE`` number at the
+time of allocation, per the same rule. The ``E-LOAD`` 040 block now runs past its own decade, and
 deliberately: opening a fresh block at 050 for the Amendment AG codes would
 have **reserved** 046–049, and a reserved number is precisely what the rule
 above forbids. Contiguity outranks decade tidiness. The §3.2 addendum

--- a/reports/design-inputs-dossier-2026-07-29.md
+++ b/reports/design-inputs-dossier-2026-07-29.md
@@ -581,6 +581,8 @@ Required new rows (a `bsl-language.rst` revision, not new mathematics):
 | coarsen (`aggregate`) | `sum` | share-weighted mean; unweighted = `E-TYPE-042` |
 | refine (`allocate`) | share-split | **broadcast (copy parent value)**; share-split = **`E-TYPE-044` (new)** |
 
+*Rider (2026-08-12): the Territory port train (PR A) allocated `E-TYPE-044` to the enum-fold-body refusal (§3.4, `#551` closure) — `docs/reference/bsl-language.rst`'s register carries the authority. This page's proposal stays speculative; the refine/allocate kind rule must claim a fresh next-free number when it lands, never this one.*
+
 ### 2. The central mechanism
 
 ```mermaid

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -727,11 +727,13 @@ pub(crate) fn strip_as_name(items: &[SExpr]) -> (Option<String>, &[SExpr]) {
 /// value to inspect. `EvalEnv` carries no static field-type registry (that
 /// lives in `structural_verbs::TypeEnv`, used only for the store-boundary
 /// range check), so this recognizes the shapes slice 1's actual bodies take
-/// — a bare numeric literal, a `field-of` read (always `Real`: every
-/// node-attribute is the binary64 lane, `GraphSubstrate::node_attribute`
-/// returns `f64`), and homogeneous arithmetic over them — and returns `None`
-/// for anything else, which `fold_sum` turns into a loud, named refusal
-/// rather than a guess.
+/// — a bare numeric literal, a `field-of` read (assumed `Real` here — true
+/// for an ordinary field, false for an `:enum-type`-declared one which
+/// renders `Value::Enum` instead, D102 — but unreachable for the latter:
+/// `E-TYPE-044` (#551) refuses any `(fold sum …)` whose body resolves to an
+/// enum-declared field at load, before this function ever runs), and
+/// homogeneous arithmetic over them — and returns `None` for anything else,
+/// which `fold_sum` turns into a loud, named refusal rather than a guess.
 fn static_additive_identity(body: &SExpr) -> Option<Value> {
     match body {
         SExpr::Atom(Atom::Int(_)) => Some(Value::Int(0)),
@@ -1292,13 +1294,22 @@ pub(crate) fn check_node_referent_type(
 ///    `:enum-type`-declared field renders its stored ordinal to
 ///    `Value::Enum` through `tick::bind_field_value` — the SAME rendering
 ///    a `:field` binding's read path uses (§2.5) — rather than the raw
-///    `Value::Real` every other field gets. `env.types`/`env.enums` are
-///    `None` for the graph-free callers `require_graph` already refuses
-///    above, so this never has to guess: by the time this line runs, a
-///    `Some` graph implies `field-of` is live content, but `types`/`enums`
-///    can still be `None` for a caller that never threads them (§3.4
-///    aggregation-only test doubles) — that caller gets the pre-D102
-///    `Value::Real` behavior unchanged, never a silent misrender.
+///    `Value::Real` every other field gets.
+///
+/// **`env.types`/`env.enums` are REQUIRED (PR A verifier fix round,
+/// 2026-08-12), mirroring [`require_graph`]'s own driver-error shape one
+/// line up: a `None` here refuses loudly rather than silently degrading to
+/// the `Value::Real` lane.** Before this fix, `_ => Ok(Value::Real(value))`
+/// was a coincidental safety net — correct ONLY because every production
+/// caller reaching this line with a live graph ALSO happened to thread
+/// `types`/`enums` (`tick::collect_pass`, `rule_pipeline::
+/// resolve_expr_bindings`), never because an untyped `EvalEnv` was a
+/// legitimate shape for a `field-of`-evaluating one. §2.13 makes a field's
+/// declared type the authority on how `field-of` renders it; an `EvalEnv`
+/// that cannot consult that authority is the same "driver built an
+/// environment missing what this form needs" bug `require_graph` already
+/// names for a missing graph, not a value this function should ever guess
+/// at with a plausible-looking default.
 fn field_of_node(
     id: babylon_graph::substrate::NodeId,
     qname: &str,
@@ -1316,11 +1327,18 @@ fn field_of_node(
             ),
         )
     })?;
-    match (env.types, env.enums) {
-        (Some(types), Some(enums)) => crate::tick::bind_field_value(qname, value, types, enums)
-            .map_err(|e| EvalError::plain(e.to_string())),
-        _ => Ok(Value::Real(value)),
-    }
+    let (Some(types), Some(enums)) = (env.types, env.enums) else {
+        return Err(EvalError::plain(format!(
+            "(field-of …) needs the declared field-type registry (§2.13) but \
+             this EvalEnv carries none for {qname} — a driver error, the same \
+             shape as require_graph's: the caller built an environment with \
+             no declared-type registry for a field-of-evaluating form, never \
+             a value this function should guess at with a plausible-looking \
+             default"
+        )));
+    };
+    crate::tick::bind_field_value(qname, value, types, enums)
+        .map_err(|e| EvalError::plain(e.to_string()))
 }
 
 fn eval_intrinsic(
@@ -2381,23 +2399,31 @@ mod tests {
 
     // ---- Task 8: field-of ----
 
+    /// No test driven through here declares an enum-typed field — an empty
+    /// `TypeEnv`/`EnumRegistry` pair is the honest "no `defenum`s in scope"
+    /// input, and `tick::bind_field_value`'s own "unregistered field:
+    /// unchanged behavior" precedent means every qname these callers name
+    /// still renders `Value::Real`, byte-identical to this helper's
+    /// pre-verifier-fix-round behavior. **Threading `Some(..)` here (PR A
+    /// verifier fix round, 2026-08-12) is not optional dressing**:
+    /// `field_of_node` now REFUSES loudly on `None` (mirroring
+    /// `require_graph`), so a bare `types: None, enums: None` `EvalEnv` would
+    /// make every `field-of` vector below a driver-error test instead of
+    /// the field-read test it claims to be — delegates to
+    /// [`eval_field_of_over_typed`] rather than duplicating the `EvalEnv`
+    /// literal a second time.
     fn eval_field_of_over(
         source: &str,
         graph: &dyn babylon_graph::substrate::GraphSubstrate,
         subject: babylon_graph::substrate::NodeId,
         fuel: &mut u64,
     ) -> Result<Value, EvalError> {
-        let costs = costs();
-        let env = EvalEnv {
-            bindings: HashMap::from([("self".to_owned(), Value::NodeRef(subject))]),
-            intrinsic_costs: &costs,
-            graph: Some(graph),
-            types: None,
-            enums: None,
-            elements: Vec::new(),
+        let types = TypeEnv {
+            fields: HashMap::new(),
+            exemptions: &[],
         };
-        let (expr, _) = read(source).expect("test source must parse");
-        evaluate(&expr, &env, &EmptyIntrinsicHost, fuel)
+        let enums = EnumRegistry::default();
+        eval_field_of_over_typed(source, graph, subject, &types, &enums, fuel)
     }
 
     /// [`eval_field_of_over`]'s D102-discharge sibling: the SAME shape,
@@ -2558,6 +2584,46 @@ mod tests {
         );
     }
 
+    /// PR A verifier fix round (2026-08-12): `field_of_node` REFUSES
+    /// loudly, mirroring `require_graph`'s own driver-error shape, when an
+    /// `EvalEnv` carries a live graph but no declared-type registry — the
+    /// EXACT shape `rule_pipeline::resolve_expr_bindings` used to build
+    /// unconditionally (safe there only by the coincidence that it also
+    /// passed `graph: None`, so `require_graph` refused first). Before
+    /// this fix this same construction silently rendered `Value::Real`
+    /// off the raw stored ordinal — never surfacing that the field was
+    /// enum-declared at all.
+    #[test]
+    fn field_of_over_an_enum_field_with_no_type_registry_is_a_loud_driver_error() {
+        use babylon_graph::memory::MemoryGraph;
+        let mut graph = MemoryGraph::new();
+        let org = graph.add_node("ORGANIZATION").unwrap();
+        graph.update_node(org, "organization/kind", 1.0).unwrap();
+        let costs = costs();
+        let env = EvalEnv {
+            bindings: HashMap::from([("self".to_owned(), Value::NodeRef(org))]),
+            intrinsic_costs: &costs,
+            graph: Some(&graph),
+            types: None,
+            enums: None,
+            elements: Vec::new(),
+        };
+        let (expr, _) = read("(field-of self organization/kind)").expect("must parse");
+        let mut fuel = 1_000;
+        let err = evaluate(&expr, &env, &EmptyIntrinsicHost, &mut fuel).unwrap_err();
+        assert!(
+            err.message.contains("declared field-type registry"),
+            "{}",
+            err.message
+        );
+        assert!(err.message.contains("organization/kind"), "{}", err.message);
+        assert!(
+            err.message.contains("driver error"),
+            "must name itself a driver error, the same shape as require_graph: {}",
+            err.message
+        );
+    }
+
     #[test]
     fn field_of_reads_a_declared_field_of_the_referent() {
         use babylon_graph::memory::MemoryGraph;
@@ -2647,6 +2713,15 @@ mod tests {
     /// Evaluate `source` against a graph, with a `self` binding pointing at
     /// `subject` (when one is supplied) — the shared fixture every fold/
     /// exists/forall/select-*/field-of test below builds on.
+    ///
+    /// An empty `TypeEnv`/`EnumRegistry` pair, threaded `Some` (PR A
+    /// verifier fix round, 2026-08-12): none of this section's fold/
+    /// selection/field-of vectors declare an enum-typed field, so every
+    /// qname stays "unregistered" and renders `Value::Real` exactly as
+    /// before — but `field_of_node` now REFUSES on `None` (mirroring
+    /// `require_graph`), so a bare `None` pair would turn every `field-of`
+    /// vector this helper drives into a driver-error test instead of the
+    /// field-read test it claims to be.
     fn eval_over(
         source: &str,
         graph: &dyn babylon_graph::substrate::GraphSubstrate,
@@ -2658,12 +2733,17 @@ mod tests {
             Some(id) => HashMap::from([("self".to_owned(), Value::NodeRef(id))]),
             None => HashMap::new(),
         };
+        let types = TypeEnv {
+            fields: HashMap::new(),
+            exemptions: &[],
+        };
+        let enums = EnumRegistry::default();
         let env = EvalEnv {
             bindings,
             intrinsic_costs: &costs,
             graph: Some(graph),
-            types: None,
-            enums: None,
+            types: Some(&types),
+            enums: Some(&enums),
             elements: Vec::new(),
         };
         let (expr, _) = read(source).expect("test source must parse");

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -40,6 +40,8 @@ use crate::fuel::{cost, IntrinsicCosts};
 use crate::intrinsic_host::IntrinsicHost;
 use crate::query::Element;
 use crate::reader::{Atom, SExpr, ScaledKind};
+use crate::typecheck::TypeEnv;
+use crate::types::EnumRegistry;
 use babylon_graph::substrate::GraphSubstrate;
 use babylon_kernel::{Coefficient, Currency, Ratio};
 use std::collections::HashMap;
@@ -272,6 +274,19 @@ pub struct EvalEnv<'a> {
     /// conformance vectors) — a query head reached with no graph is a LOUD
     /// driver error (`require_graph`), never an empty set.
     pub graph: Option<&'a dyn GraphSubstrate>,
+    /// Declared field types/kinds (§3.4/§3.1). Threaded so `field-of`
+    /// (`field_of_node`, D102) can render an `:enum-type`-declared field's
+    /// stored ordinal to `Value::Enum` through the SAME rendering
+    /// `tick.rs::bind_field_value` uses for a `:field` binding's read path
+    /// (§2.5) — the whole point of discharging D102 is that both read
+    /// routes agree. `None` for the pure-expression / graph-free callers
+    /// `graph`'s own doc above already names: `field-of` requires a graph
+    /// before it would ever consult this, so those callers lose nothing.
+    pub types: Option<&'a TypeEnv>,
+    /// The enum member registry a `types` field's `BslType::Enum(id)`
+    /// resolves against (an `EnumTypeId` alone names no members — see
+    /// `types::EnumRegistry`'s own doc). Same threading rule as `types`.
+    pub enums: Option<&'a EnumRegistry>,
     /// The §2.6 chapter C8 element stack, innermost-last. `it` always reads
     /// the last entry's element; a `:as` name reads by name (wired in a
     /// later task) — the paired `Option<String>` is that declared name,
@@ -682,6 +697,8 @@ pub(crate) fn with_element<'a>(
         bindings: env.bindings.clone(),
         intrinsic_costs: env.intrinsic_costs,
         graph: env.graph,
+        types: env.types,
+        enums: env.enums,
         elements,
     }
 }
@@ -1270,7 +1287,18 @@ pub(crate) fn check_node_referent_type(
 /// 1. the qname's owning type must match the referent's declared type
 ///    (`check_node_referent_type`);
 /// 2. absence is not a value — a never-written field is the same
-///    `E-EVAL-033` as a type mismatch, never a default `0.0`.
+///    `E-EVAL-033` as a type mismatch, never a default `0.0`;
+/// 3. **(D102 discharge, Task 1 P27 territory-port train)** an
+///    `:enum-type`-declared field renders its stored ordinal to
+///    `Value::Enum` through `tick::bind_field_value` — the SAME rendering
+///    a `:field` binding's read path uses (§2.5) — rather than the raw
+///    `Value::Real` every other field gets. `env.types`/`env.enums` are
+///    `None` for the graph-free callers `require_graph` already refuses
+///    above, so this never has to guess: by the time this line runs, a
+///    `Some` graph implies `field-of` is live content, but `types`/`enums`
+///    can still be `None` for a caller that never threads them (§3.4
+///    aggregation-only test doubles) — that caller gets the pre-D102
+///    `Value::Real` behavior unchanged, never a silent misrender.
 fn field_of_node(
     id: babylon_graph::substrate::NodeId,
     qname: &str,
@@ -1288,7 +1316,11 @@ fn field_of_node(
             ),
         )
     })?;
-    Ok(Value::Real(value))
+    match (env.types, env.enums) {
+        (Some(types), Some(enums)) => crate::tick::bind_field_value(qname, value, types, enums)
+            .map_err(|e| EvalError::plain(e.to_string())),
+        _ => Ok(Value::Real(value)),
+    }
 }
 
 fn eval_intrinsic(
@@ -1653,6 +1685,8 @@ mod tests {
             bindings,
             intrinsic_costs: &costs,
             graph: None,
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let (expr, _) = read(source).expect("test source must parse");
@@ -2039,6 +2073,8 @@ mod tests {
             bindings: HashMap::new(),
             intrinsic_costs: &costs,
             graph: None,
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         // `Result::unwrap_err` needs `T: Debug`; `&dyn GraphSubstrate` isn't
@@ -2085,6 +2121,8 @@ mod tests {
             bindings: HashMap::new(),
             intrinsic_costs: &costs,
             graph: None,
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let (expr, _) = read("(double 5)").unwrap();
@@ -2112,6 +2150,8 @@ mod tests {
             bindings: HashMap::from([("x".to_owned(), Value::Real(7.8))]),
             intrinsic_costs: &costs,
             graph: None,
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let (expr, _) = read("(floor x)").unwrap();
@@ -2131,6 +2171,8 @@ mod tests {
             bindings: HashMap::from([("x".to_owned(), Value::Real(-2.5))]),
             intrinsic_costs: &costs,
             graph: None,
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let mut fuel2 = 100;
@@ -2217,6 +2259,8 @@ mod tests {
             bindings: HashMap::from([("self".to_owned(), Value::NodeRef(self_id))]),
             intrinsic_costs: &costs,
             graph: None,
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let (form, _) =
@@ -2348,10 +2392,170 @@ mod tests {
             bindings: HashMap::from([("self".to_owned(), Value::NodeRef(subject))]),
             intrinsic_costs: &costs,
             graph: Some(graph),
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let (expr, _) = read(source).expect("test source must parse");
         evaluate(&expr, &env, &EmptyIntrinsicHost, fuel)
+    }
+
+    /// [`eval_field_of_over`]'s D102-discharge sibling: the SAME shape,
+    /// but with `types`/`enums` actually threaded (`Some`), so `field-of`
+    /// over an `:enum-type`-declared field renders `Value::Enum` instead
+    /// of falling back to the pre-D102 `Value::Real`.
+    fn eval_field_of_over_typed(
+        source: &str,
+        graph: &dyn babylon_graph::substrate::GraphSubstrate,
+        subject: babylon_graph::substrate::NodeId,
+        types: &TypeEnv,
+        enums: &EnumRegistry,
+        fuel: &mut u64,
+    ) -> Result<Value, EvalError> {
+        let costs = costs();
+        let env = EvalEnv {
+            bindings: HashMap::from([("self".to_owned(), Value::NodeRef(subject))]),
+            intrinsic_costs: &costs,
+            graph: Some(graph),
+            types: Some(types),
+            enums: Some(enums),
+            elements: Vec::new(),
+        };
+        let (expr, _) = read(source).expect("test source must parse");
+        evaluate(&expr, &env, &EmptyIntrinsicHost, fuel)
+    }
+
+    /// `OrgKind` in declaration order: `STATE_APPARATUS`=0, `BUSINESS`=1 —
+    /// the same fixture shape `tick.rs::org_kind_fixture` uses, built
+    /// standalone here since this module's tests drive `evaluate`
+    /// directly rather than through the full rule pipeline.
+    fn org_kind_types_and_enums() -> (TypeEnv, EnumRegistry) {
+        use crate::types::{BslType, FieldDecl, FieldKind};
+        let mut enums = EnumRegistry::default();
+        let ty = enums
+            .declare(
+                "OrgKind",
+                &["STATE_APPARATUS".to_owned(), "BUSINESS".to_owned()],
+            )
+            .unwrap();
+        let types = TypeEnv {
+            fields: HashMap::from([(
+                "organization/kind".to_owned(),
+                FieldDecl {
+                    ty: BslType::Enum(ty),
+                    kind: FieldKind::NotApplicable,
+                },
+            )]),
+            exemptions: &[],
+        };
+        (types, enums)
+    }
+
+    /// D102 discharge (Task 1, P27 territory-port train): `field-of` over
+    /// an enum-declared field renders `Value::Enum` — the SAME rendering
+    /// `tick::bind_field_value` gives a `:field` binding's read of the
+    /// identical field — and a `=` comparison against an enum-ref member
+    /// literal returns the right `Bool` per node, not a `Value::Real`
+    /// comparison that would silently compare ordinals as magnitudes.
+    #[test]
+    fn field_of_over_an_enum_field_compares_correctly_per_node() {
+        use babylon_graph::memory::MemoryGraph;
+        let mut graph = MemoryGraph::new();
+        let state_org = graph.add_node("ORGANIZATION").unwrap();
+        graph
+            .update_node(state_org, "organization/kind", 0.0)
+            .unwrap();
+        let biz_org = graph.add_node("ORGANIZATION").unwrap();
+        graph
+            .update_node(biz_org, "organization/kind", 1.0)
+            .unwrap();
+        let (types, enums) = org_kind_types_and_enums();
+        let mut fuel = 1_000;
+
+        let state_result = eval_field_of_over_typed(
+            "(= (field-of self organization/kind) OrgKind/STATE_APPARATUS)",
+            &graph,
+            state_org,
+            &types,
+            &enums,
+            &mut fuel,
+        )
+        .unwrap();
+        assert_eq!(state_result, Value::Bool(true));
+
+        let biz_result = eval_field_of_over_typed(
+            "(= (field-of self organization/kind) OrgKind/STATE_APPARATUS)",
+            &graph,
+            biz_org,
+            &types,
+            &enums,
+            &mut fuel,
+        )
+        .unwrap();
+        assert_eq!(biz_result, Value::Bool(false));
+    }
+
+    /// §3.1: `Enum<T>` compares only to the same enum type — unaffected by
+    /// D102's discharge, whether the `Value::Enum` came from a `:field`
+    /// binding or (now) `field-of`. `NodeType/BUSINESS` is a real enum-ref
+    /// of the WRONG declared type, deliberately sharing a member NAME with
+    /// `OrgKind/BUSINESS` (`apply_equality`'s own doc precedent, `c268b83b`
+    /// / `structural_verbs.rs`'s cross-type write test) so a mutant that
+    /// skipped the type check and fell through to the member comparison
+    /// would find a plausible-looking match instead of an unrelated error.
+    #[test]
+    fn field_of_over_an_enum_field_cross_enum_type_comparison_still_errors() {
+        use babylon_graph::memory::MemoryGraph;
+        let mut graph = MemoryGraph::new();
+        let biz_org = graph.add_node("ORGANIZATION").unwrap();
+        graph
+            .update_node(biz_org, "organization/kind", 1.0)
+            .unwrap();
+        let (types, enums) = org_kind_types_and_enums();
+        let mut fuel = 1_000;
+        let err = eval_field_of_over_typed(
+            "(= (field-of self organization/kind) NodeType/BUSINESS)",
+            &graph,
+            biz_org,
+            &types,
+            &enums,
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("compares only to the same enum type"),
+            "{}",
+            err.message
+        );
+    }
+
+    /// §2.13's no-arithmetic law (D101) STANDS: `apply_arith` refuses
+    /// `Value::Enum` unconditionally, whether the value came from a
+    /// `:field` binding or (now, post-D102) `field-of` — D102's discharge
+    /// widened where `field-of` may legally appear, not what Enum<T> may
+    /// legally do once evaluated.
+    #[test]
+    fn field_of_over_an_enum_field_still_refuses_arithmetic() {
+        use babylon_graph::memory::MemoryGraph;
+        let mut graph = MemoryGraph::new();
+        let org = graph.add_node("ORGANIZATION").unwrap();
+        graph.update_node(org, "organization/kind", 0.0).unwrap();
+        let (types, enums) = org_kind_types_and_enums();
+        let mut fuel = 1_000;
+        let err = eval_field_of_over_typed(
+            "(+ (field-of self organization/kind) 5)",
+            &graph,
+            org,
+            &types,
+            &enums,
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("no arithmetic is defined"),
+            "{}",
+            err.message
+        );
     }
 
     #[test]
@@ -2458,6 +2662,8 @@ mod tests {
             bindings,
             intrinsic_costs: &costs,
             graph: Some(graph),
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let (expr, _) = read(source).expect("test source must parse");

--- a/rust/crates/babylon-bsl/src/query.rs
+++ b/rust/crates/babylon-bsl/src/query.rs
@@ -271,6 +271,8 @@ mod tests {
             bindings: HashMap::new(),
             intrinsic_costs: costs,
             graph: Some(graph),
+            types: None,
+            enums: None,
             elements: Vec::new(),
         }
     }
@@ -359,6 +361,8 @@ mod tests {
             bindings,
             intrinsic_costs: &costs,
             graph: Some(&graph as &dyn GraphSubstrate),
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let (expr, _) =
@@ -384,6 +388,8 @@ mod tests {
             bindings,
             intrinsic_costs: &costs,
             graph: Some(&graph as &dyn GraphSubstrate),
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let (expr, _) =
@@ -406,6 +412,8 @@ mod tests {
             bindings,
             intrinsic_costs: &costs,
             graph: Some(&graph as &dyn GraphSubstrate),
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let (expr, _) =
@@ -434,6 +442,8 @@ mod tests {
             bindings,
             intrinsic_costs: &costs,
             graph: Some(&graph as &dyn GraphSubstrate),
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let (expr, _) =

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -48,8 +48,8 @@ use crate::scope::{
 };
 use crate::structural_verbs::check_no_deferred_shape_verbs;
 use crate::typecheck::{
-    check_no_arithmetic_on_enum_field, check_no_field_of_on_enum_field,
-    check_reference_comparisons, check_selection_scores, typecheck_aggregation, TypeEnv, TypeError,
+    check_no_arithmetic_on_enum_field, check_reference_comparisons, check_selection_scores,
+    typecheck_aggregation, TypeEnv, TypeError,
 };
 use std::collections::{HashMap, HashSet};
 
@@ -290,16 +290,24 @@ pub fn load_rule_form(rule: SExpr, ctx: &LoadContext<'_>) -> Result<LoadedRule, 
     typecheck_rule_folds(&rule, ctx.types, &bindings).map_err(LoadError::Type)?;
     check_selection_scores(&rule, ctx.types, &bindings).map_err(LoadError::Type)?;
     check_reference_comparisons(&rule, ctx.types, &bindings).map_err(LoadError::Type)?;
-    // §2.13 (D101/D102): field-of is not extended to enum-declared fields —
-    // a static, content-only fact, so this is a load-time gate like its
-    // two siblings above, not a runtime surprise on the first admitted
-    // subject.
-    check_no_field_of_on_enum_field(&rule, ctx.types).map_err(LoadError::Type)?;
+    // §2.13 (D101/D102): the D102 field-of-on-enum-field DEFERRAL gate that
+    // used to run here is DISCHARGED (Task 1, P27 territory-port train) —
+    // `field-of` over an enum-declared field now typechecks (the §2.7
+    // classifier types it `Enum`, `score_class::classify`) and evaluates
+    // for real (`evaluator::field_of_node`). Its two surviving refusals
+    // each have their own independent mechanism, not a third load gate:
+    // D46/E-TYPE-016 (`check_selection_scores`, above) refuses it as a
+    // select-max/select-min SCORE; §2.13's no-arithmetic law refuses it as
+    // an arithmetic operand at evaluation (`evaluator::apply_arith`
+    // refuses `Value::Enum` unconditionally — the same runtime funnel
+    // `check_no_arithmetic_on_enum_field` below's own doc names for the
+    // update-node-target shape).
+    //
     // §2.13's no-arithmetic law (D101), the static half (D118, #528 fix
     // round Item C) — statically decidable from the field's declared
-    // type and the update-op's own symbol, so it belongs at load beside
-    // its sibling D102 gate above, not left to the three eval-time
-    // guards alone (which stay, as defense in depth).
+    // type and the update-op's own symbol, so it belongs at load, not
+    // left to the three eval-time guards alone (which stay, as defense
+    // in depth).
     check_no_arithmetic_on_enum_field(&rule, ctx.types).map_err(LoadError::Type)?;
     let anchor = check_anchor(&rule, ctx.systems).map_err(LoadError::Anchor)?;
     resolve_bindings(&bindings, ctx.vocabulary).map_err(LoadError::Binding)?;
@@ -490,6 +498,8 @@ pub fn resolve_expr_bindings<S: std::hash::BuildHasher + Clone>(
             // sites wait on the same collect-then-apply repair before a
             // live `&dyn GraphSubstrate` can be threaded in safely.
             graph: None,
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let value = evaluate(expr, &scope, host, fuel)?;

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -1009,6 +1009,146 @@ mod deferred_shape_verb_tests {
 }
 
 #[cfg(test)]
+mod enum_fold_body_tests {
+    // #551 closure (Task 2, P27 territory-port train): `(fold <op> <query>
+    // <enum-declared body>)` used to pass the §3.4 kind law silently,
+    // dying uncoded at evaluation on the first admitted subject — this
+    // module proves the load-time refusal (`typecheck::TypeCode::
+    // EnumFoldBody`, `E-TYPE-044`) is REACHABLE from the real production
+    // entry point (`load_rule`), through BOTH read routes a fold body can
+    // take to an enum-declared field: a `:field`-bound SYMBOL (§2.5) and
+    // `field-of` (§2.10, D102 — discharged by Task 1 of this same train,
+    // making this route newly reachable in the first place).
+    use super::{load_rule, LoadContext, LoadError};
+    use crate::bindings::BindingVocabulary;
+    use crate::fuel::{CardinalityCeilings, IntrinsicCosts};
+    use crate::typecheck::{TypeCode, TypeEnv};
+    use crate::types::{BslType, EnumRegistry, FieldDecl, FieldKind};
+    use std::collections::{HashMap, HashSet};
+
+    /// `OrgKind` in declaration order: `STATE_APPARATUS`=0, `BUSINESS`=1 —
+    /// the same fixture shape `tick.rs::org_kind_fixture`/
+    /// `structural_verbs::org_kind_types_and_enums` use. Leaked, matching
+    /// this module's sibling test modules' own `LoadContext<'static>`
+    /// convention (`deferred_shape_verb_tests::load_ctx`'s own doc).
+    fn load_ctx() -> LoadContext<'static> {
+        // `EnumRegistry` itself is not part of `LoadContext` — member
+        // *names* only matter at tick RUNTIME (`bind_field_value`); load
+        // only needs `TypeEnv`'s `BslType::Enum(id)` + `FieldKind::
+        // NotApplicable` kind, so the registry can be dropped right after
+        // minting `ty` (`EnumTypeId` is `Copy`, no borrow survives it).
+        let ty = EnumRegistry::default()
+            .declare(
+                "OrgKind",
+                &["STATE_APPARATUS".to_owned(), "BUSINESS".to_owned()],
+            )
+            .unwrap();
+        let fields = HashMap::from([(
+            "organization/kind".to_owned(),
+            FieldDecl {
+                ty: BslType::Enum(ty),
+                kind: FieldKind::NotApplicable,
+            },
+        )]);
+        LoadContext {
+            vocabulary: Box::leak(Box::new(BindingVocabulary {
+                fields: HashSet::from(["organization/kind".to_owned()]),
+                consts: HashSet::new(),
+                metrics: HashSet::new(),
+            })),
+            types: Box::leak(Box::new(TypeEnv {
+                fields,
+                exemptions: &[],
+            })),
+            ceilings: Box::leak(Box::new(CardinalityCeilings::new(
+                HashMap::from([("NodeType/ORGANIZATION".to_owned(), 100)]),
+                HashMap::new(),
+            ))),
+            intrinsics: Box::leak(Box::new(IntrinsicCosts::default())),
+            systems: Box::leak(Box::new(HashSet::from(["organization".to_owned()]))),
+            vocabulary_registry: None,
+            rule_file: "x.bsl",
+        }
+    }
+
+    /// Route 1: a `:field`-bound SYMBOL as the fold body — the shape
+    /// #551's own title names (`<:field-bound enum symbol>`).
+    #[test]
+    fn a_fold_sum_over_a_field_bound_enum_symbol_refuses_at_load_e_type_044() {
+        let ctx = load_ctx();
+        let err = load_rule(
+            r#"(rule organization/enum-fold-probe
+  :material-basis "x" :fuel 64
+  (bindings (binding kind :field organization/kind))
+  (when (> (fold sum (nodes NodeType/ORGANIZATION) kind) 0))
+  (effects (emit EventType/RUPTURE (probe 1))))"#,
+            &ctx,
+        )
+        .unwrap_err();
+        let LoadError::Type(type_err) = &err else {
+            panic!("expected LoadError::Type, got {err:?}");
+        };
+        assert_eq!(type_err.code, Some(TypeCode::EnumFoldBody));
+        assert_eq!(err.spec_code(), Some("E-TYPE-044"));
+        assert!(err.to_string().contains("organization/kind"), "{err}");
+    }
+
+    /// Route 2: `field-of` as the fold body — newly reachable now that
+    /// Task 1 discharged D102 (`field-of` over an enum-declared field used
+    /// to refuse unconditionally at load, before ever reaching this fold
+    /// kind law at all).
+    #[test]
+    fn a_fold_sum_over_a_field_of_enum_accessor_refuses_at_load_e_type_044() {
+        let ctx = load_ctx();
+        let err = load_rule(
+            r#"(rule organization/enum-fold-probe
+  :material-basis "x" :fuel 64
+  (bindings)
+  (when (> (fold sum (nodes NodeType/ORGANIZATION)
+                 (field-of it organization/kind)) 0))
+  (effects (emit EventType/RUPTURE (probe 1))))"#,
+            &ctx,
+        )
+        .unwrap_err();
+        let LoadError::Type(type_err) = &err else {
+            panic!("expected LoadError::Type, got {err:?}");
+        };
+        assert_eq!(type_err.code, Some(TypeCode::EnumFoldBody));
+        assert_eq!(err.spec_code(), Some("E-TYPE-044"));
+    }
+
+    /// `count` stays legal over an enum-declared body through BOTH routes
+    /// — the narrower verdict this closure's own doc records: `count`
+    /// never evaluates its body, so naming an enum field there is inert,
+    /// not a content error.
+    #[test]
+    fn a_fold_count_over_an_enum_declared_body_is_unaffected_through_both_routes() {
+        let ctx = load_ctx();
+        load_rule(
+            r#"(rule organization/enum-fold-count-probe
+  :material-basis "x" :fuel 256
+  (bindings (binding kind :field organization/kind))
+  (when (> (fold count (nodes NodeType/ORGANIZATION) kind) 0))
+  (effects (emit EventType/RUPTURE (probe 1))))"#,
+            &ctx,
+        )
+        .expect("count over a :field-bound enum symbol must stay legal");
+
+        let ctx = load_ctx();
+        load_rule(
+            r#"(rule organization/enum-fold-count-probe
+  :material-basis "x" :fuel 256
+  (bindings)
+  (when (> (fold count (nodes NodeType/ORGANIZATION)
+                 (field-of it organization/kind)) 0))
+  (effects (emit EventType/RUPTURE (probe 1))))"#,
+            &ctx,
+        )
+        .expect("count over a field-of enum accessor must stay legal");
+    }
+}
+
+#[cfg(test)]
 mod vocabulary_membership_tests {
     // Task 8 (Organization foundation plan): the load-time half of
     // closed-vocabulary enforcement, wired into `load_rule_form`'s

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -51,6 +51,7 @@ use crate::typecheck::{
     check_no_arithmetic_on_enum_field, check_reference_comparisons, check_selection_scores,
     typecheck_aggregation, TypeEnv, TypeError,
 };
+use crate::types::EnumRegistry;
 use std::collections::{HashMap, HashSet};
 
 /// Everything a rule loads against. Phase 1 takes each registry as an
@@ -476,6 +477,8 @@ pub fn resolve_expr_bindings<S: std::hash::BuildHasher + Clone>(
     decls: &[BindingDecl],
     env: &mut HashMap<String, Value, S>,
     intrinsic_costs: &IntrinsicCosts,
+    types: &TypeEnv,
+    enums: &EnumRegistry,
     host: &dyn crate::intrinsic_host::IntrinsicHost,
     fuel: &mut u64,
 ) -> Result<(), crate::evaluator::EvalError> {
@@ -497,9 +500,22 @@ pub fn resolve_expr_bindings<S: std::hash::BuildHasher + Clone>(
             // landing point as tick.rs's guard (`run_tick`'s `env`) — both
             // sites wait on the same collect-then-apply repair before a
             // live `&dyn GraphSubstrate` can be threaded in safely.
+            //
+            // `types`/`enums` are threaded NOW, ahead of that graph wiring
+            // (PR A verifier fix round, 2026-08-12) — closing the
+            // Option-None hazard class by construction rather than by
+            // coincidence: before this fix, this was production's ONE
+            // `types: None, enums: None` site, safe only because `graph`
+            // was ALSO `None` (`field_of_node`'s `require_graph` refuses
+            // before ever consulting them). That coincidence would have
+            // broken silently the moment P6/PR B Task 6 threads a real
+            // graph here for the `:expr` spillover binding, without
+            // anyone having to touch this line again. **When `graph`
+            // stops being `None` here, it must never be threaded alone —
+            // `types`/`enums` already are.**
             graph: None,
-            types: None,
-            enums: None,
+            types: Some(types),
+            enums: Some(enums),
             elements: Vec::new(),
         };
         let value = evaluate(expr, &scope, host, fuel)?;

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -2532,16 +2532,23 @@ mod tests {
             g.add_node("SOCIAL_CLASS").unwrap();
         });
         let self_id = NodeId(0);
+        let types = types();
+        let enums = enums();
+        // PR A verifier fix round (2026-08-12): `types`/`enums` were
+        // already built, right here, for `EffectExecutor` below — leaving
+        // the sibling `EvalEnv` on `None`/`None` was the exact
+        // coincidental-safety shape the fix round closed (harmless only
+        // because this rule text never happens to use `field-of` over an
+        // enum field; `field_of_node` now refuses loudly rather than
+        // trust that).
         let env = EvalEnv {
             bindings: HashMap::from([("self".to_owned(), Value::NodeRef(self_id))]),
             intrinsic_costs: &IntrinsicCosts::default(),
             graph: Some(&pre_state as &dyn GraphSubstrate),
-            types: None,
-            enums: None,
+            types: Some(&types),
+            enums: Some(&enums),
             elements: Vec::new(),
         };
-        let types = types();
-        let enums = enums();
         let mut executor = EffectExecutor::new(&types, &enums, None);
         let mut sink = CollectingSink::default();
         let mut fuel = 256;
@@ -2735,16 +2742,23 @@ mod tests {
                 .unwrap();
         });
         let [low, high] = [NodeId(0), NodeId(1)];
+        let types = organization_types();
+        let enums = enums();
+        // PR A verifier fix round (2026-08-12): same coincidental-safety
+        // shape as `for_each_query_does_not_see_an_earlier_verbs_effect_
+        // in_the_same_list` above — `types`/`enums` were already built for
+        // `EffectExecutor` below; the sibling `EvalEnv` now carries them
+        // too. This test's rule text DOES use `field-of` (over
+        // `organization/claim-strength`, a Coefficient field) inside its
+        // `select-max` score, so this was reachable, not merely defensive.
         let env = EvalEnv {
             bindings: HashMap::new(),
             intrinsic_costs: &IntrinsicCosts::default(),
             graph: Some(&pre_state as &dyn GraphSubstrate),
-            types: None,
-            enums: None,
+            types: Some(&types),
+            enums: Some(&enums),
             elements: Vec::new(),
         };
-        let types = organization_types();
-        let enums = enums();
         let mut executor = EffectExecutor::new(&types, &enums, None);
         let mut sink = CollectingSink::default();
         let mut fuel = 256;
@@ -3239,6 +3253,89 @@ mod tests {
              field-of-sourced enum value too: {}",
             err.message
         );
+    }
+
+    /// PR A verifier fix round (2026-08-12): the read/write ROUND TRIP
+    /// `field-of` + `update-node (set …)` makes possible for an
+    /// enum-declared field — `(update-node <n> <enum-field> (set
+    /// (field-of <m> <enum-field>)))`, the exact shape Territory's
+    /// `_find_sink_node` sink-priority write needs (a neighbor's
+    /// `territory_type` copied onto the acting node) — existed since D102's
+    /// discharge (Task 1) and `enum_write_value`'s own pre-existing type
+    /// check, but had no dedicated test. Both halves in one vector: a
+    /// same-type copy stores the SOURCE's ordinal (not a re-derivation —
+    /// the exact ordinal, proving the round trip is lossless); a
+    /// cross-type copy refuses `E-EVAL-042`, exactly as a literal
+    /// cross-type enum-ref write already does
+    /// (`a_cross_enum_type_write_is_e_eval_042` above).
+    #[test]
+    fn field_of_copied_into_an_update_node_set_round_trips_same_type_and_refuses_cross_type() {
+        // ---- same-type half ----
+        let mut graph = MemoryGraph::new();
+        let source = graph.add_node("ORGANIZATION").unwrap();
+        let target = graph.add_node("ORGANIZATION").unwrap();
+        graph.update_node(source, "organization/kind", 2.0).unwrap(); // POLITICAL_FACTION, declaration-order ordinal 2
+        let (types, enums) = org_kind_types_and_enums();
+        let mut fuel = 64;
+        collect_then_apply(
+            &mut graph,
+            &types,
+            &enums,
+            HashMap::from([
+                ("self".to_owned(), Value::NodeRef(target)),
+                ("source".to_owned(), Value::NodeRef(source)),
+            ]),
+            "(effects (update-node self organization/kind \
+                        (set (field-of source organization/kind))))",
+            &mut fuel,
+        )
+        .expect("a same-type field-of copy into an enum field must succeed");
+        let stored = graph.node_attribute(target, "organization/kind").unwrap();
+        assert!(
+            (stored - 2.0).abs() < 1e-12,
+            "the copy must land the SOURCE's ordinal, POLITICAL_FACTION=2: {stored}"
+        );
+
+        // ---- cross-type half: a second enum-declared field of a
+        // DIFFERENT declared type on the SAME node type ----
+        let mut cross_graph = MemoryGraph::new();
+        let cross_source = cross_graph.add_node("ORGANIZATION").unwrap();
+        let cross_target = cross_graph.add_node("ORGANIZATION").unwrap();
+        cross_graph
+            .update_node(cross_source, "organization/kind", 0.0)
+            .unwrap(); // STATE_APPARATUS
+        let (mut cross_types, mut cross_enums) = org_kind_types_and_enums();
+        let rank_ty = cross_enums
+            .declare("PartyRank", &["CADRE".to_owned(), "SYMPATHIZER".to_owned()])
+            .unwrap();
+        cross_types.fields.insert(
+            "organization/rank".to_owned(),
+            FieldDecl {
+                ty: BslType::Enum(rank_ty),
+                kind: FieldKind::NotApplicable,
+            },
+        );
+        let mut fuel2 = 64;
+        let err = collect_only(
+            &cross_graph,
+            &cross_types,
+            &cross_enums,
+            HashMap::from([
+                ("self".to_owned(), Value::NodeRef(cross_target)),
+                ("source".to_owned(), Value::NodeRef(cross_source)),
+            ]),
+            "(effects (update-node self organization/rank \
+                        (set (field-of source organization/kind))))",
+            &mut fuel2,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::EnumWriteShapeViolation));
+        assert!(
+            err.message.contains("declared enum type is PartyRank"),
+            "{}",
+            err.message
+        );
+        assert!(err.message.contains("OrgKind"), "{}", err.message);
     }
 
     // ---- F5(b) (#534 fix round item 5): `find_deferred_shape_verb`

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -1585,6 +1585,8 @@ mod tests {
                 bindings: HashMap::from([("self".to_owned(), Value::NodeRef(self.self_id))]),
                 intrinsic_costs: &self.costs,
                 graph: None,
+                types: None,
+                enums: None,
                 elements: Vec::new(),
             };
             let types = types();
@@ -1620,6 +1622,8 @@ mod tests {
                 bindings: HashMap::from([("self".to_owned(), Value::NodeRef(self.self_id))]),
                 intrinsic_costs: &self.costs,
                 graph: None,
+                types: None,
+                enums: None,
                 elements: Vec::new(),
             };
             let types = types();
@@ -1654,6 +1658,8 @@ mod tests {
                 bindings: HashMap::from([("self".to_owned(), Value::NodeRef(self.self_id))]),
                 intrinsic_costs: &self.costs,
                 graph: None,
+                types: None,
+                enums: None,
                 elements: Vec::new(),
             };
             let types = types();
@@ -2143,6 +2149,8 @@ mod tests {
                 bindings: HashMap::from([("self".to_owned(), Value::NodeRef(fixture.self_id))]),
                 intrinsic_costs: &costs,
                 graph: None,
+                types: None,
+                enums: None,
                 elements: Vec::new(),
             };
             let types = types();
@@ -2377,6 +2385,14 @@ mod tests {
                 bindings,
                 intrinsic_costs: &IntrinsicCosts::default(),
                 graph: Some(&*graph as &dyn GraphSubstrate),
+                // D102 discharge (Task 1, P27 territory-port train): thread
+                // the SAME registries `EffectExecutor::new` below already
+                // takes, so `field-of` over an enum-declared field renders
+                // `Value::Enum` here exactly as the real `run_tick` path
+                // does — a helper that silently fell back to `Value::Real`
+                // would mask the exact bug D102's discharge exists to fix.
+                types: Some(types),
+                enums: Some(enums),
                 elements: Vec::new(),
             };
             let mut collector = EffectExecutor::new(types, enums, None);
@@ -2416,6 +2432,10 @@ mod tests {
             bindings,
             intrinsic_costs: &IntrinsicCosts::default(),
             graph: Some(graph as &dyn GraphSubstrate),
+            // D102 discharge (Task 1, P27 territory-port train): same
+            // reasoning as `collect_then_apply`'s own env, above.
+            types: Some(types),
+            enums: Some(enums),
             elements: Vec::new(),
         };
         let mut collector = EffectExecutor::new(types, enums, None);
@@ -2516,6 +2536,8 @@ mod tests {
             bindings: HashMap::from([("self".to_owned(), Value::NodeRef(self_id))]),
             intrinsic_costs: &IntrinsicCosts::default(),
             graph: Some(&pre_state as &dyn GraphSubstrate),
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let types = types();
@@ -2717,6 +2739,8 @@ mod tests {
             bindings: HashMap::new(),
             intrinsic_costs: &IntrinsicCosts::default(),
             graph: Some(&pre_state as &dyn GraphSubstrate),
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let types = organization_types();
@@ -3033,6 +3057,8 @@ mod tests {
             bindings: HashMap::from([("self".to_owned(), Value::NodeRef(id))]),
             intrinsic_costs: &IntrinsicCosts::default(),
             graph: None,
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let mut sink = CollectingSink::default();
@@ -3171,6 +3197,46 @@ mod tests {
         assert!(
             err.message.contains("cannot store"),
             "the ORIGINAL non-enum catch-all message must be unchanged: {}",
+            err.message
+        );
+    }
+
+    /// D102 discharge (Task 1, P27 territory-port train): `field-of` over
+    /// an enum-declared field now typechecks and evaluates to a real
+    /// `Value::Enum` (previously refused at load) — this proves the
+    /// relaxation does NOT open an arithmetic hole. The catch-all proven
+    /// above for a LITERAL enum-ref operand fires identically when the
+    /// `Value::Enum` is sourced through `field-of` instead — same funnel,
+    /// same refusal, whichever expression produced the value.
+    #[test]
+    fn field_of_over_an_enum_field_still_refuses_as_an_add_operand() {
+        let mut graph = MemoryGraph::new();
+        let id = graph.add_node("ORGANIZATION").unwrap();
+        graph.update_node(id, "organization/kind", 0.0).unwrap(); // STATE_APPARATUS
+        let (mut types, enums) = org_kind_types_and_enums();
+        types.fields.insert(
+            "organization/budget".to_owned(),
+            FieldDecl {
+                ty: BslType::Int,
+                kind: FieldKind::Extensive,
+            },
+        );
+        graph.update_node(id, "organization/budget", 5.0).unwrap();
+        let mut fuel = 64;
+        let err = collect_only(
+            &graph,
+            &types,
+            &enums,
+            HashMap::from([("self".to_owned(), Value::NodeRef(id))]),
+            "(effects (update-node self organization/budget \
+                        (add (field-of self organization/kind))))",
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("cannot store"),
+            "the ORIGINAL non-enum catch-all message must fire for a \
+             field-of-sourced enum value too: {}",
             err.message
         );
     }

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -652,6 +652,8 @@ fn collect_pass(
             &loaded.bindings,
             &mut values,
             costs,
+            types,
+            enums,
             host,
             &mut fuel,
         )?;

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -309,7 +309,13 @@ fn bind_subject(
 /// it binds a malformed load). This is the one place a write bug elsewhere
 /// (or a hand-corrupted store, exercised by this task's own mutation-style
 /// integrity test) would surface.
-fn bind_field_value(
+///
+/// `pub(crate)` (D102 discharge, Task 1 P27 territory-port train):
+/// `evaluator::field_of_node` reuses this EXACT rendering for `field-of`
+/// over an enum-declared field, rather than re-deriving the ordinal→member
+/// conversion a second time — the same "reused, not re-derived" precedent
+/// `namespace_to_node_type`'s own doc set for the sibling §2.10 discipline.
+pub(crate) fn bind_field_value(
     qname: &str,
     stored: f64,
     types: &TypeEnv,
@@ -657,6 +663,12 @@ fn collect_pass(
             // function never performs one: `graph` here has no `&mut` form
             // anywhere in scope, by the SIGNATURE, not by discipline.
             graph: Some(graph),
+            // D102 discharge (Task 1, P27 territory-port train): the same
+            // registries `bind_subject` above already resolved this
+            // subject's `:field` bindings against, so `field-of` over an
+            // enum-declared field renders through the identical path.
+            types: Some(types),
+            enums: Some(enums),
             elements: Vec::new(),
         };
 
@@ -845,10 +857,10 @@ mod tests {
         }
 
         /// The non-panicking half of [`Self::load`] — for a test proving a
-        /// rule is REFUSED at load (§2.13's `field-of` deferral, D102),
+        /// rule is REFUSED at load (e.g. §2.13's no-arithmetic law, D118),
         /// driving the actual production entry point
-        /// (`rule_pipeline::load_rule`), not `check_no_field_of_on_enum_field`
-        /// in isolation.
+        /// (`rule_pipeline::load_rule`), not one of `typecheck`'s checks in
+        /// isolation.
         fn try_load(
             &self,
             rule_source: &str,
@@ -1297,28 +1309,73 @@ mod tests {
     }
 
     #[test]
-    fn a_rule_using_field_of_over_an_enum_field_is_refused_at_load_by_the_real_pipeline() {
-        // Drives `rule_pipeline::load_rule` — the actual production entry
-        // point (`Fixture::try_load`) — not `typecheck::
-        // check_no_field_of_on_enum_field` in isolation (that function has
-        // its own focused unit tests in typecheck.rs). Proves the D102
-        // gate wired into `load_rule_form` is REACHABLE, not merely
-        // correct.
+    fn a_rule_using_field_of_over_an_enum_field_now_loads_and_runs_by_the_real_pipeline() {
+        // D102 discharge (Task 1, P27 territory-port train): this used to
+        // be `..._is_refused_at_load_by_the_real_pipeline`, proving the
+        // (then-unconditional) D102 deferral gate was REACHABLE from
+        // `rule_pipeline::load_rule`, the actual production entry point
+        // (`Fixture::try_load`) — not `typecheck::
+        // check_no_field_of_on_enum_field` in isolation. That gate is
+        // deleted now (score-position and arithmetic each refuse through
+        // their own independent mechanism, typecheck.rs's own tests cover
+        // those) — this inverted test is the SAME end-to-end proof, the
+        // other direction: `field-of self organization/kind` in a `when`
+        // guard now LOADS clean and DISCRIMINATES correctly at
+        // evaluation, exactly like the `:field`-bound read of the
+        // identical field one test up
+        // (`a_when_guard_comparing_the_bound_enum_field_fires_only_for_the_matching_member`)
+        // — §2.5's read parity D102's own doc named as the reason to
+        // discharge, not merely defer, once Territory became a real
+        // consumer.
+        use babylon_graph::memory::MemoryGraph;
+        use babylon_graph::substrate::GraphSubstrate;
+
+        let mut graph = MemoryGraph::new();
+        // Declaration-order ordinals: STATE_APPARATUS=0, BUSINESS=1.
+        let state_org = graph.add_node("ORGANIZATION").unwrap();
+        graph
+            .update_node(state_org, "organization/kind", 0.0)
+            .unwrap();
+        let biz_org = graph.add_node("ORGANIZATION").unwrap();
+        graph
+            .update_node(biz_org, "organization/kind", 1.0)
+            .unwrap();
+
         let fixture = org_kind_fixture();
-        let err = fixture
-            .try_load(
-                r#"(rule organization/field-of-probe
-  :material-basis "field-of is not extended to enum-declared fields (D102)"
+        let loaded = fixture.load(
+            r#"(rule organization/field-of-probe
+  :material-basis "field-of over an enum field reads the SAME way a :field binding does (D102 discharge, §2.5 read parity)"
   :fuel 64
-  (bindings)
+  (bindings
+    ; Unused in the guard on purpose: the guard reads the field through
+    ; field-of, not this binding — this binding exists only so
+    ; `subject_type_of` can derive ORGANIZATION as the subject type,
+    ; exactly as every other rule's :field binding does.
+    (binding kind :field organization/kind))
   (when (= (field-of self organization/kind) OrgKind/BUSINESS))
   (effects (emit EventType/RUPTURE (probe 1))))"#,
-                "organization/field-of-probe.bsl",
-            )
-            .unwrap_err();
-        let message = err.to_string();
-        assert!(message.contains("D102"), "{message}");
-        assert!(message.contains("organization/kind"), "{message}");
+            "organization/field-of-probe.bsl",
+        );
+
+        let mut sink = crate::structural_verbs::CollectingSink::default();
+        let outcome = run_tick(
+            &loaded,
+            &fixture.types,
+            &fixture.enums,
+            &crate::intrinsic_host::EmptyIntrinsicHost,
+            &mut graph,
+            &mut sink,
+            &fixture.intrinsics,
+            &DefinesEnv::new(),
+            1,
+        )
+        .expect("the tick must run — field-of over an enum field is no longer refused");
+        assert_eq!(outcome.considered, 2, "both organizations are subjects");
+        assert_eq!(
+            outcome.fired, 1,
+            "the guard must discriminate — only the BUSINESS org matches"
+        );
+        assert_eq!(sink.events.len(), 1);
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/typecheck.rs
+++ b/rust/crates/babylon-bsl/src/typecheck.rs
@@ -243,58 +243,6 @@ pub fn check_reference_comparisons(
     walk_typed(expr, env, bindings, &HashMap::new(), Check::References)
 }
 
-/// **§2.13's `field-of` deferral (D101/D102, Organization spec §1 Q12).**
-/// An `:enum-type`-declared field is read through a `:field` binding
-/// exactly as any other node field is (§2.5); this is NOT extended to
-/// §2.10's `field-of` accessor. A `field-of` naming an enum-declared field
-/// refuses, loudly, citing D102 — deferred, not forbidden: an
-/// enum-declared EDGE or HYPEREDGE field (this document does not rule one
-/// out) would need `field-of` access precisely because it has no single
-/// owning body to bind a `:field` against, and building that accessor is
-/// left to whichever revision first has one.
-///
-/// This is a LOAD-time check (unlike Task 5's runtime write re-check):
-/// whether a `qname` is enum-declared is a static, content-only fact, so
-/// catching this before any tick executes matches §3's own law ("every
-/// check in this chapter runs at content load") rather than deferring an
-/// always-wrong construct to a runtime surprise on the first admitted
-/// subject.
-///
-/// # Errors
-///
-/// A structural [`TypeError`] (`code: None` — D102 mints no error code;
-/// this is a deferred gap, not a new failure class with its own number).
-pub fn check_no_field_of_on_enum_field(expr: &SExpr, env: &TypeEnv) -> Result<(), TypeError> {
-    if let SExpr::List(items) = expr {
-        if let [SExpr::Atom(Atom::Symbol(head)), _referent, SExpr::Atom(Atom::QName(qname))] =
-            items.as_slice()
-        {
-            if head == "field-of" {
-                if let Some(decl) = env.fields.get(qname) {
-                    if matches!(decl.ty, BslType::Enum(_)) {
-                        return Err(TypeError {
-                            code: None,
-                            message: format!(
-                                "field-of {qname}: an :enum-type-declared field is read \
-                                 via a :field binding only (§2.5) — field-of is not \
-                                 extended to enum-declared fields (§2.13, D102). The gap \
-                                 is deferred, not forbidden: an enum-declared edge or \
-                                 hyperedge field would need field-of for exactly the \
-                                 reason §2.10 exists, and building that path is left to \
-                                 whichever revision first has one"
-                            ),
-                        });
-                    }
-                }
-            }
-        }
-        for child in items {
-            check_no_field_of_on_enum_field(child, env)?;
-        }
-    }
-    Ok(())
-}
-
 /// **§2.13's no-arithmetic law (D101), the static half (D118, #528 fix
 /// round Item C).** `Enum<T>` supports no arithmetic (§2.13, §3.1) — an
 /// `add`/`sub`/`scale` `update-op` targeting an `:enum-type`-declared
@@ -305,10 +253,14 @@ pub fn check_no_field_of_on_enum_field(expr: &SExpr, env: &TypeEnv) -> Result<()
 /// so a rule shaped exactly like this check's own red-test content
 /// loaded clean and died mid-tick on the first admitted subject — the
 /// same "always-wrong construct deferred to a runtime surprise" shape
-/// [`check_no_field_of_on_enum_field`]'s own doc names for its sibling
-/// gap, and the same static-decidability argument as `rule_pipeline.rs`
-/// D102 wiring: §3's own law is "every check in this chapter runs at
-/// content load, before any tick executes."
+/// D102's own field-of deferral named for its sibling gap (D102 itself
+/// was discharged by the Task 1 P27 territory-port train — `field-of`
+/// over an enum-declared field now typechecks and evaluates for real,
+/// `evaluator::field_of_node` — but the static-decidability argument this
+/// function makes stands on its own, unchanged), and the same argument as
+/// `rule_pipeline.rs`'s own load-time wiring generally: §3's own law is
+/// "every check in this chapter runs at content load, before any tick
+/// executes."
 ///
 /// The three eval-time guards STAY, unchanged, as defense in depth
 /// (the same two-site discipline `refuse_arithmetic_on_enum_field`'s own
@@ -318,10 +270,9 @@ pub fn check_no_field_of_on_enum_field(expr: &SExpr, env: &TypeEnv) -> Result<()
 ///
 /// # Errors
 ///
-/// A structural [`TypeError`] (`code: None` — same precedent
-/// [`check_no_field_of_on_enum_field`] already sets: E-EVAL-042 already
-/// covers this refusal at evaluation, D118, so this is a
-/// static-decidability repair, not a new failure class).
+/// A structural [`TypeError`] (`code: None` — E-EVAL-042 already covers
+/// this refusal at evaluation, D118, so this is a static-decidability
+/// repair, not a new failure class).
 pub fn check_no_arithmetic_on_enum_field(expr: &SExpr, env: &TypeEnv) -> Result<(), TypeError> {
     if let SExpr::List(items) = expr {
         if let [SExpr::Atom(Atom::Symbol(head)), _node, SExpr::Atom(Atom::QName(qname)), SExpr::List(op_items)] =
@@ -529,7 +480,10 @@ fn check_one_comparison(items: &[SExpr], env: &ClassEnv<'_>) -> Result<(), TypeE
 
 #[cfg(test)]
 mod tests {
-    use super::{typecheck_aggregation, TypeCode, TypeEnv};
+    use super::{
+        check_reference_comparisons, check_selection_scores, typecheck_aggregation, TypeCode,
+        TypeEnv,
+    };
     use crate::exemptions::IntensiveAggregationExemption;
     use crate::reader::read;
     use crate::types::{BslType, FieldDecl, FieldKind};
@@ -766,7 +720,9 @@ mod tests {
         assert!(check("(mean wealth-share :weight)", &env()).is_err());
     }
 
-    // ---- §2.13's field-of deferral (D101/D102, Organization spec §1 Q12) ----
+    // ---- §2.13's enum-typed fields (D101), the D102 field-of deferral
+    // (discharged below) and D118's no-arithmetic law (Organization spec
+    // §1 Q12) ----
 
     fn org_env() -> TypeEnv {
         let mut registry = crate::types::EnumRegistry::default();
@@ -797,28 +753,65 @@ mod tests {
         }
     }
 
+    // ---- D102 discharge (Task 1, P27 territory-port train): field-of over
+    // an enum-declared field now TYPECHECKS AS THE ENUM, not `Real`, and not
+    // refused. `check_no_field_of_on_enum_field` (the unconditional D102
+    // deferral gate) is deleted rather than narrowed: score-position (D46)
+    // and arithmetic (D118/`apply_arith`) are each enforced by their OWN
+    // independent mechanism below, so nothing was left for a third gate to
+    // decide once the deferral itself lifted.
+
+    /// `score_class::classify` is §2.7's total static classifier — the
+    /// same one `check_selection_scores`/`check_reference_comparisons`
+    /// consult — so this is the load-bearing proof that `field-of` over an
+    /// enum-declared field types AS `Enum`, not `Real` and not `Unknown`,
+    /// matching the SAME class a `:field` binding over the identical field
+    /// already carries (§2.5's read parity, D102's whole point).
     #[test]
-    fn field_of_over_an_enum_declared_field_refuses_citing_d102() {
+    fn field_of_over_an_enum_declared_field_typechecks_as_enum() {
+        use crate::score_class::{classify, ClassEnv, ScoreClass};
         let (expr, _) = read("(field-of self organization/kind)").expect("must parse");
-        let err = super::check_no_field_of_on_enum_field(&expr, &org_env()).unwrap_err();
-        assert_eq!(err.code, None, "D102 mints no error code");
-        assert!(err.message.contains("D102"), "{}", err.message);
-        assert!(err.message.contains("organization/kind"), "{}", err.message);
+        let env = org_env();
+        let class = classify(
+            &expr,
+            &ClassEnv {
+                bindings: &[],
+                fields: &env.fields,
+                element_names: &HashMap::new(),
+            },
+        );
+        assert_eq!(class, ScoreClass::Enum);
     }
 
+    /// The walk recurses into `(and …)`/`(if …)`/… bodies (D53/D54's own
+    /// element-scope rule already covers this at the `classify`/`walk_typed`
+    /// level) — proven end to end via `check_reference_comparisons`, which
+    /// shares the exact classifier: a nested `field-of` over an enum field
+    /// classifies correctly deep inside another form, not just at the top.
     #[test]
-    fn field_of_over_a_non_enum_field_is_untouched() {
-        let (expr, _) = read("(field-of self organization/budget)").expect("must parse");
-        assert!(super::check_no_field_of_on_enum_field(&expr, &org_env()).is_ok());
-    }
-
-    #[test]
-    fn field_of_over_an_enum_field_nested_inside_another_form_still_refuses() {
-        // The walk must recurse into (and/if/fold/…) bodies, not just the
-        // top-level form.
+    fn field_of_over_an_enum_field_nested_inside_another_form_still_classifies_as_enum() {
         let (expr, _) = read("(and #t (= (field-of self organization/kind) OrgKind/BUSINESS))")
             .expect("must parse");
-        assert!(super::check_no_field_of_on_enum_field(&expr, &org_env()).is_err());
+        // A same-enum-type `=` comparison is D67-legal (both sides Enum, no
+        // ordering operator involved) — this must load clean, proving the
+        // nested field-of classified correctly rather than as `Unknown`
+        // (which `check_reference_comparisons` would also accept, silently,
+        // masking a classification regression).
+        assert!(check_reference_comparisons(&expr, &org_env(), &[]).is_ok());
+    }
+
+    /// D46/`E-TYPE-016` STANDS: ranking by an enum-classed score is refused
+    /// exactly as before — D102's discharge widens where `field-of` may
+    /// legally APPEAR, not what `select-max`/`select-min` may legally SCORE
+    /// BY.
+    #[test]
+    fn field_of_over_an_enum_field_as_a_select_max_score_still_refuses_e_type_016() {
+        let (expr, _) =
+            read("(select-max (nodes NodeType/ORGANIZATION) (field-of it organization/kind))")
+                .expect("must parse");
+        let err = check_selection_scores(&expr, &org_env(), &[]).unwrap_err();
+        assert_eq!(err.code, Some(TypeCode::NonComparableScore));
+        assert!(err.message.contains("E-TYPE-016"), "{}", err.message);
     }
 
     // ---- §2.13's no-arithmetic law, the static half (D118, #528 fix

--- a/rust/crates/babylon-bsl/src/typecheck.rs
+++ b/rust/crates/babylon-bsl/src/typecheck.rs
@@ -53,6 +53,11 @@ pub enum TypeCode {
     UnweightedMeanOfIntensive,
     /// `E-TYPE-043` — a `mean` weight that is not extensive-kinded.
     NonExtensiveWeight,
+    /// `E-TYPE-044` — a `sum`/`mean`/`min`/`max` fold body naming an
+    /// `:enum-type`-declared field (#551 closure). `count` is exempt: its
+    /// body is never evaluated (§3.4 row 6), so an enum-declared body
+    /// there is inert rather than a content error.
+    EnumFoldBody,
 }
 
 impl TypeCode {
@@ -65,6 +70,7 @@ impl TypeCode {
             Self::SumOfIntensive => "E-TYPE-041",
             Self::UnweightedMeanOfIntensive => "E-TYPE-042",
             Self::NonExtensiveWeight => "E-TYPE-043",
+            Self::EnumFoldBody => "E-TYPE-044",
         }
     }
 }
@@ -93,6 +99,24 @@ pub struct TypeEnv {
 /// `(mean field :weight weight-field)`, with `op` one of
 /// `sum | mean | min | max | count`, applying §3.4's per-operator table.
 ///
+/// **#551 closure:** an `:enum-type`-declared field (`FieldKind::
+/// NotApplicable` — §2.13/D101's "no aggregation kind" ruling) is refused,
+/// `E-TYPE-044`, for every op that actually EVALUATES its body —
+/// `sum`/`mean`/`min`/`max` — before this table's per-op law even runs.
+/// `count` is the sole exemption, for the same reason §3.4 row 6 already
+/// makes it kind-blind for `Intensive`/`Extensive`: it never evaluates its
+/// body at all (`evaluator::fold_count` takes no body argument), so an
+/// enum-declared name there is inert content, not a content error.
+/// `min`/`max` are NOT exempted despite being "kind-neutral" elsewhere in
+/// this table (§3.4 row 5) — kind-neutral there means "extensive vs.
+/// intensive doesn't matter", not "any type works": `min`/`max` compare
+/// via `apply_ordering`, which itself refuses `Value::Enum` (§3.1, "Enum
+/// and Bool compare with =/!= alone") — this closure just catches at load
+/// what would otherwise die at evaluation on the SECOND element only (a
+/// single-element enum-body fold would silently "succeed", returning the
+/// one value with no ordering ever invoked — a population-size-dependent
+/// landmine this refusal removes).
+///
 /// # Errors
 /// [`TypeError`] with the spec code for a §3.4 violation, or with
 /// `code: None` for a malformed form or an unknown field.
@@ -114,6 +138,30 @@ pub fn typecheck_aggregation(expr: &SExpr, env: &TypeEnv) -> Result<BslType, Typ
             message: format!("unknown aggregation operator '{op}'"),
         });
     };
+    // #551 closure: exhaustive over `FoldOp` (mirrors `rule_pipeline::
+    // carries_body_kind`'s own Sum/Mean/Min/Max-vs-Count split, no
+    // wildcard, so a 6th fold-op forces a decision here too) — every op
+    // that evaluates its body refuses an enum-declared one; `count` alone
+    // discards its body unevaluated and is unaffected.
+    let evaluates_body = match fold_op {
+        crate::grammar::FoldOp::Sum
+        | crate::grammar::FoldOp::Mean
+        | crate::grammar::FoldOp::Min
+        | crate::grammar::FoldOp::Max => true,
+        crate::grammar::FoldOp::Count => false,
+    };
+    if evaluates_body && field.kind == FieldKind::NotApplicable {
+        return Err(TypeError {
+            code: Some(TypeCode::EnumFoldBody),
+            message: format!(
+                "E-TYPE-044: {op} over enum-declared field '{field_name}': \
+                 Enum<T> has no aggregation kind (§2.13, D101) — sum, mean, \
+                 min and max are all undefined over it. Only count may name \
+                 an enum-declared field, because count never evaluates its \
+                 body (§3.4 row 6)"
+            ),
+        });
+    }
     match fold_op {
         crate::grammar::FoldOp::Sum => {
             if field.kind == FieldKind::Intensive && !exempted {
@@ -519,6 +567,18 @@ mod tests {
                 kind: FieldKind::Extensive,
             },
         );
+        // #551 closure (Task 2, P27 territory-port train): the NotApplicable
+        // (enum-typed) kind cell the legality table below now asserts
+        // instead of declining. `EnumTypeId(0)` is a bare id, not a real
+        // registry entry — `typecheck_aggregation`'s #551 check only reads
+        // `field.kind`, never resolving the id through an `EnumRegistry`.
+        fields.insert(
+            "org-kind".to_string(),
+            FieldDecl {
+                ty: BslType::Enum(crate::types::EnumTypeId(0)),
+                kind: FieldKind::NotApplicable,
+            },
+        );
         TypeEnv {
             fields,
             exemptions: &[],
@@ -635,34 +695,51 @@ mod tests {
     /// which is called once per row below — not make production exhaustive
     /// over it.
     ///
-    /// 5 fold-ops × the two kind-bearing `FieldKind` variants the §3.4 law
-    /// actually discriminates on (`Intensive`, `Extensive`; `wealth-share`/
+    /// 5 fold-ops × the three `FieldKind` variants — **all 15 real
+    /// `(FoldOp, FieldKind)` cells**, closing the table `#551` left
+    /// deliberately incomplete. `Intensive`/`Extensive` use `wealth-share`/
     /// `wealth` from `env()`, the SAME pair the individual tests above
-    /// already use) — **10 of the 15 real `(FoldOp, FieldKind)` cells**.
-    /// The other 5 — every `FoldOp` against `NotApplicable` (an enum-typed
-    /// field, §2.13/D101) — are DECLINED here, not asserted either way:
-    /// `typecheck_aggregation` never special-cases `NotApplicable`, so
-    /// every op reaches `Ok` for one today, but that is an observation
-    /// about the current code, not a law this table pins. **Declined cells
-    /// are a real, pre-existing hole, not a shrug:** `(fold <op> …)` over a
-    /// `:field`-bound enum symbol passes the KIND LAW silently — filed as
-    /// **issue #551**, which carries the full reachability trace. Each row
-    /// below states its OWN accept/refuse verdict; nothing here infers one
-    /// row from another.
+    /// already use; `NotApplicable` (an enum-typed field, §2.13/D101) uses
+    /// `org-kind`, also from `env()`.
+    ///
+    /// **#551 closure (Task 2, P27 territory-port train):** the 5
+    /// `NotApplicable` rows below used to be DECLINED — not asserted
+    /// either way, because `typecheck_aggregation` never special-cased
+    /// `NotApplicable`, so every op silently reached `Ok` for one, and
+    /// that was an observation about the code, not a law this table
+    /// pinned. `(fold <op> …)` over a `:field`-bound enum symbol (or,
+    /// since Task 1's D102 discharge, a `field-of` accessor) passing the
+    /// KIND LAW silently was filed as **issue #551** (full reachability
+    /// trace there; end-to-end proof through the real `load_rule` pipeline,
+    /// both routes, in `rule_pipeline::enum_fold_body_tests`). Now DECIDED:
+    /// `sum`/`mean`/`min`/`max` all refuse (`E-TYPE-044`, `TypeCode::
+    /// EnumFoldBody`) — each of those ops evaluates its body, and `Enum<T>`
+    /// supports neither arithmetic (sum/mean) nor ordering (min/max, §3.1).
+    /// `count` alone stays legal (§3.4 row 6's existing "always legal, kind
+    /// irrelevant" law): it never evaluates its body at all, so an
+    /// enum-declared name there is inert, not a content error — the
+    /// narrower verdict the closure's own tracking issue asked the
+    /// implementer to weigh. Each row below states its OWN accept/refuse
+    /// verdict; nothing here infers one row from another.
     #[test]
     fn fold_op_x_field_kind_legality_table() {
         use crate::grammar::FoldOp;
-        let table: [(FoldOp, &str, FieldKind, bool); 10] = [
+        let table: [(FoldOp, &str, FieldKind, bool); 15] = [
             (FoldOp::Sum, "wealth-share", FieldKind::Intensive, false), // E-TYPE-041
             (FoldOp::Sum, "wealth", FieldKind::Extensive, true),
+            (FoldOp::Sum, "org-kind", FieldKind::NotApplicable, false), // E-TYPE-044 (#551)
             (FoldOp::Mean, "wealth-share", FieldKind::Intensive, false), // E-TYPE-042 (unweighted)
             (FoldOp::Mean, "wealth", FieldKind::Extensive, true),
-            (FoldOp::Min, "wealth-share", FieldKind::Intensive, true), // kind-neutral
+            (FoldOp::Mean, "org-kind", FieldKind::NotApplicable, false), // E-TYPE-044 (#551)
+            (FoldOp::Min, "wealth-share", FieldKind::Intensive, true),   // kind-neutral
             (FoldOp::Min, "wealth", FieldKind::Extensive, true),
-            (FoldOp::Max, "wealth-share", FieldKind::Intensive, true), // kind-neutral
+            (FoldOp::Min, "org-kind", FieldKind::NotApplicable, false), // E-TYPE-044 (#551): no ordering on Enum<T>
+            (FoldOp::Max, "wealth-share", FieldKind::Intensive, true),  // kind-neutral
             (FoldOp::Max, "wealth", FieldKind::Extensive, true),
+            (FoldOp::Max, "org-kind", FieldKind::NotApplicable, false), // E-TYPE-044 (#551): no ordering on Enum<T>
             (FoldOp::Count, "wealth-share", FieldKind::Intensive, true), // always legal
             (FoldOp::Count, "wealth", FieldKind::Extensive, true),
+            (FoldOp::Count, "org-kind", FieldKind::NotApplicable, true), // narrower verdict: body never evaluated
         ];
         for (op, field, kind, expect_legal) in table {
             let kind_label = field_kind_is_exhaustively_named(kind);
@@ -673,6 +750,13 @@ mod tests {
                 expect_legal,
                 "{op:?} over {field} ({kind_label}, unweighted): expected legal={expect_legal}, got {result:?}"
             );
+            if !expect_legal && kind == FieldKind::NotApplicable {
+                assert_eq!(
+                    code_of(&source, &env()),
+                    Some(TypeCode::EnumFoldBody),
+                    "{op:?} over {field}: expected E-TYPE-044"
+                );
+            }
         }
     }
 

--- a/rust/crates/babylon-bsl/tests/conformance_corpus.rs
+++ b/rust/crates/babylon-bsl/tests/conformance_corpus.rs
@@ -206,6 +206,8 @@ fn eval_when(rule: &LoadedRule, supplied: &HashMap<String, Value>) -> bool {
         bindings: env_map,
         intrinsic_costs: &costs,
         graph: None,
+        types: None,
+        enums: None,
         elements: Vec::new(),
     };
     let mut fuel = 10_000;
@@ -235,6 +237,8 @@ fn eval_when_over_graph(
         bindings: env_map,
         intrinsic_costs: &costs,
         graph: Some(graph),
+        types: None,
+        enums: None,
         elements: Vec::new(),
     };
     match evaluate(when_clause(rule), &env, &EmptyIntrinsicHost, fuel)
@@ -772,6 +776,8 @@ fn wealth_aggregates_execute_over_a_real_graph() {
         bindings: env_map,
         intrinsic_costs: &costs,
         graph: Some(&graph as &dyn GraphSubstrate),
+        types: None,
+        enums: None,
         elements: Vec::new(),
     };
     let mut fuel5 = 10_000;
@@ -801,6 +807,8 @@ fn edge_count_stays_pinned_and_names_slice_2() {
         bindings: env_map,
         intrinsic_costs: &costs,
         graph: Some(&graph as &dyn GraphSubstrate),
+        types: None,
+        enums: None,
         elements: Vec::new(),
     };
     let mut fuel = 10_000;
@@ -904,6 +912,8 @@ fn bifurcation_routes_by_solidarity_density() {
             bindings: env_map,
             intrinsic_costs: &costs,
             graph: None,
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let babylon_bsl::SExpr::List(items) = &loaded.rule else {
@@ -1017,6 +1027,8 @@ fn eval_value(source: &str, env_pairs: &[(&str, Value)]) -> Value {
         bindings: owned(env_pairs.to_vec()),
         intrinsic_costs: &costs,
         graph: None,
+        types: None,
+        enums: None,
         elements: Vec::new(),
     };
     let (expr, _) = read(source).expect("vector source must parse");
@@ -1038,6 +1050,8 @@ fn eval_value_over_graph(
         bindings: bindings.clone(),
         intrinsic_costs: &costs,
         graph: Some(graph),
+        types: None,
+        enums: None,
         elements: Vec::new(),
     };
     let (expr, _) = read(source).expect("vector source must parse");
@@ -1057,6 +1071,8 @@ fn eval_cond_err(source: &str, env_pairs: &[(&str, Value)]) -> babylon_bsl::Eval
         bindings: owned(env_pairs.to_vec()),
         intrinsic_costs: &costs,
         graph: None,
+        types: None,
+        enums: None,
         elements: Vec::new(),
     };
     let (expr, _) = read(source).expect("vector source must parse");

--- a/rust/crates/babylon-bsl/tests/r9_chapters.rs
+++ b/rust/crates/babylon-bsl/tests/r9_chapters.rs
@@ -766,6 +766,7 @@ mod c4_rule_domain {
 // order is a dependency order; this is one it does not name.
 mod c7_computed_bindings {
     use super::{bound, e};
+    use super::{enums, type_env};
     use babylon_bsl::bindings::{parse_bindings, BindSource};
     use babylon_bsl::evaluator::Value;
     use babylon_bsl::fuel::IntrinsicCosts;
@@ -880,6 +881,8 @@ mod c7_computed_bindings {
             &named,
             &mut env,
             &costs,
+            &type_env(),
+            &enums(),
             &EmptyIntrinsicHost,
             &mut fuel_named,
         )
@@ -899,6 +902,8 @@ mod c7_computed_bindings {
             &inline,
             &mut env2,
             &costs,
+            &type_env(),
+            &enums(),
             &EmptyIntrinsicHost,
             &mut fuel_inline,
         )
@@ -1017,12 +1022,20 @@ mod c5_element_selection {
         fuel: &mut u64,
     ) -> Result<Value, EvalError> {
         let costs = IntrinsicCosts::default();
+        let types = type_env();
+        let enums = enums();
+        // PR A verifier fix round (2026-08-12): `field_of_node` now
+        // refuses loudly on a `None` types/enums pair (mirroring
+        // `require_graph`) rather than silently degrading to `Value::
+        // Real` — this family's own vectors drive `field-of` through this
+        // helper, so it needs the real registries `type_env()`/`enums()`
+        // already provide elsewhere in this file, not the untyped shape.
         let env = EvalEnv {
             bindings,
             intrinsic_costs: &costs,
             graph: Some(graph),
-            types: None,
-            enums: None,
+            types: Some(&types),
+            enums: Some(&enums),
             elements: Vec::new(),
         };
         evaluate(&e(source), &env, &EmptyIntrinsicHost, fuel)
@@ -1347,16 +1360,20 @@ mod c5_element_selection {
         let babylon_bsl::reader::SExpr::List(items) = form else {
             unreachable!()
         };
+        let types = type_env();
+        let enum_registry = enums();
+        // PR A verifier fix round (2026-08-12): same coincidental-safety
+        // gap as this module's other direct `EvalEnv` constructions —
+        // `types`/`enum_registry` were already built for `EffectExecutor`
+        // below.
         let env = EvalEnv {
             bindings: HashMap::new(),
             intrinsic_costs: &IntrinsicCosts::default(),
             graph: Some(&graph as &dyn GraphSubstrate),
-            types: None,
-            enums: None,
+            types: Some(&types),
+            enums: Some(&enum_registry),
             elements: Vec::new(),
         };
-        let types = type_env();
-        let enum_registry = enums();
         let mut executor = EffectExecutor::new(&types, &enum_registry, None);
         let mut sink = CollectingSink::default();
         let mut fuel2 = 1_000;
@@ -1534,12 +1551,17 @@ mod c6_effect_position_iteration {
         let enum_registry = enums();
         let mut sink = CollectingSink::default();
         let pending = {
+            // PR A verifier fix round (2026-08-12): `types`/`enum_registry`
+            // above were already built for `EffectExecutor` below — the
+            // sibling `EvalEnv` now carries them too, closing the same
+            // coincidental-safety gap `structural_verbs.rs`'s own
+            // `collect_then_apply` had (fixed in the same round).
             let env = EvalEnv {
                 bindings,
                 intrinsic_costs: &IntrinsicCosts::default(),
                 graph: Some(&*graph as &dyn GraphSubstrate),
-                types: None,
-                enums: None,
+                types: Some(&types),
+                enums: Some(&enum_registry),
                 elements: Vec::new(),
             };
             let mut collector = EffectExecutor::new(&types, &enum_registry, None);
@@ -1786,6 +1808,8 @@ mod c8_typed_neighbours_and_naming {
     use babylon_bsl::grammar::{check_arities_and_closed_sets, check_enum_ref_kinds};
     use babylon_bsl::intrinsic_host::EmptyIntrinsicHost;
     use babylon_bsl::scope::check_element_names;
+    use babylon_bsl::typecheck::TypeEnv;
+    use babylon_bsl::types::EnumRegistry;
     use babylon_graph::memory::MemoryGraph;
     use babylon_graph::substrate::GraphSubstrate;
     use std::collections::HashMap;
@@ -1919,12 +1943,24 @@ mod c8_typed_neighbours_and_naming {
         fuel: &mut u64,
     ) -> Value {
         let costs = IntrinsicCosts::default();
+        // PR A verifier fix round (2026-08-12): an empty pair, threaded
+        // `Some` — no vector in this family declares an enum-typed field,
+        // so every qname stays "unregistered" and renders `Value::Real`
+        // exactly as before, but `field_of_node` now refuses loudly on
+        // `None` (mirroring `require_graph`) rather than silently
+        // degrading, so `None` here would turn this family's `field-of`
+        // vectors into driver-error tests instead of field-read tests.
+        let types = TypeEnv {
+            fields: HashMap::new(),
+            exemptions: &[],
+        };
+        let enums = EnumRegistry::default();
         let env = EvalEnv {
             bindings,
             intrinsic_costs: &costs,
             graph: Some(graph),
-            types: None,
-            enums: None,
+            types: Some(&types),
+            enums: Some(&enums),
             elements: Vec::new(),
         };
         evaluate(&e(source), &env, &EmptyIntrinsicHost, fuel).expect("vector must evaluate")

--- a/rust/crates/babylon-bsl/tests/r9_chapters.rs
+++ b/rust/crates/babylon-bsl/tests/r9_chapters.rs
@@ -1021,6 +1021,8 @@ mod c5_element_selection {
             bindings,
             intrinsic_costs: &costs,
             graph: Some(graph),
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         evaluate(&e(source), &env, &EmptyIntrinsicHost, fuel)
@@ -1349,6 +1351,8 @@ mod c5_element_selection {
             bindings: HashMap::new(),
             intrinsic_costs: &IntrinsicCosts::default(),
             graph: Some(&graph as &dyn GraphSubstrate),
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         let types = type_env();
@@ -1534,6 +1538,8 @@ mod c6_effect_position_iteration {
                 bindings,
                 intrinsic_costs: &IntrinsicCosts::default(),
                 graph: Some(&*graph as &dyn GraphSubstrate),
+                types: None,
+                enums: None,
                 elements: Vec::new(),
             };
             let mut collector = EffectExecutor::new(&types, &enum_registry, None);
@@ -1917,6 +1923,8 @@ mod c8_typed_neighbours_and_naming {
             bindings,
             intrinsic_costs: &costs,
             graph: Some(graph),
+            types: None,
+            enums: None,
             elements: Vec::new(),
         };
         evaluate(&e(source), &env, &EmptyIntrinsicHost, fuel).expect("vector must evaluate")

--- a/tests/unit/reference/test_bsl_grammar_sync.py
+++ b/tests/unit/reference/test_bsl_grammar_sync.py
@@ -681,7 +681,11 @@ class TestTheEnumArithmeticRefusalIsDeclaredInTheRegistry:
         start = body.index("\nDraft-Ruling Register\n")
         end = body.index("\nSee Also\n", start)
         section = body[start:end]
-        d118_start = section.index("D118")
+        # Anchor on the row marker, not the first "D118" mention — D102's
+        # row cross-references D118 earlier in the register (the Territory
+        # port train's field-of discharge), and a bare index("D118") would
+        # window onto that citation instead of the row itself.
+        d118_start = section.index("* - D118")
         d118_row = section[d118_start : d118_start + 3000]
         assert "E-EVAL-042" in d118_row
         assert "add" in d118_row and "sub" in d118_row and "scale" in d118_row, (


### PR DESCRIPTION
## What

Tasks 1-2 of the merged Territory port plan (PR #552): the babylon-bsl slice that precedes the content estate.

- **Task 1 (faa40b1f):** ADR195's FIELD-OF DEFERRAL (D102) discharged — `(field-of <ref> <enum-declared-qname>)` typechecks as `Enum` and evaluates to `Value::Enum` through the SAME ordinal→member rendering the subject-side `:field` route uses (shared `bind_field_value`, widened pub(crate)). Territory's `_find_sink_node` (a neighbor's `territory_type`) is the chartered first consumer. The D46 score refusal (E-TYPE-016) and all arithmetic refusals stand, with tests.
- **Task 2 (bf6b4fe2):** #551 closed for real — **E-TYPE-044**: enum-typed fold BODIES refuse at load for sum/mean/min/max via BOTH routes (`:field`-bound symbol AND `field-of`), proven end-to-end through `load_rule`; `count` exempted with reasoning (its body is never evaluated — `fold_count` takes no body). Legality table extended 10 → 15 cells. Note: GitHub auto-closed #551 prematurely when the PLAN doc merged (magic-word match in #552's body); it was reopened and this PR closes it with the actual fix.
- **Fix round (0595baf0):** the verifier's None-lane hazard closed by construction, BOTH belts — `resolve_expr_bindings` threads types/enums now (so PR B's graph-wiring cannot reintroduce the silent-Real lane), and `field_of_node` refuses loudly on a missing registry (require_graph's shape). Blast radius established empirically: 24 fixture sites, each audited (no enum-field vector routed to an empty registry; zero test-semantics changes — the delta-verifier re-audited all 12 enum field-of occurrences independently).

## Verification arc

Sonnet implementation → fresh adversarial Opus verify (MERGE-OK; 27-probe interaction sweep: every misuse of a field-of-sourced Enum is a loud refusal) → fix round → same-verifier delta re-verify (**MERGE-OK-DELTA, original verdict strengthened**; both mutations replayed; the round-trip test proven non-tautological). Goldens 4/4 byte-identical at every commit; full six-leg gate green at tip.

## Notes

- `resolve_expr_bindings` is pub and re-exported: its signature change is an in-tree-only public-API break (sole production caller updated; two test callers updated).
- Pre-existing, out of scope, filed: **#555** (the load-vs-runtime enum-misuse parity class on BOTH routes). PR B dependency flagged: `field-of` inside `:expr` bindings still hits `require_graph` — Task 6's spillover binding needs the graph threaded there (never alone; types/enums already are).

Closes #551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)