### PR TITLE
feat(p29): T2 PR A — the edge_attribute substrate read + D32 implicit-strength wiring

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1644,6 +1644,7 @@ cargo clippy -p babylon-kernel --all-targets --locked -- -D warnings -D clippy::
 cargo test -p babylon-kernel --locked
 cargo clippy -p babylon-bsl --all-targets --locked -- -D warnings -D clippy::pedantic
 cargo test -p babylon-bsl --locked
+cargo clippy -p babylon-graph --all-targets --locked -- -D warnings -D clippy::pedantic
 RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --locked
 """
 

--- a/rust/crates/babylon-bsl/src/declarations.rs
+++ b/rust/crates/babylon-bsl/src/declarations.rs
@@ -285,23 +285,27 @@ pub struct OwnedFieldDecl {
 
 /// Every declared field of a content set, keyed by qname.
 ///
-/// **Dormant — declared, not wired (ADR109's declared-not-wired
-/// discipline; #528 fix round, MINOR item 5).** This type, its
-/// [`Self::declare`] (the only minting path for `E-LOAD-053`/`E-LOAD-054`'s
+/// **Half-wired (ADR109's declared-not-wired discipline; #528 fix round,
+/// MINOR item 5; wiring updated by T2, issue #559).**
+/// [`Self::with_implicit_edge_strength`] IS production-wired — the D32
+/// implicit-strength wiring: `babylon_tick`'s `prepare_rules`
+/// (`rust/crates/babylon-tick/src/lib.rs`, on both `run_once_into`'s and
+/// `TickSession::new`'s path) calls it to seed the implicit
+/// `<edge-type>/strength` `TypeEnv` rows from the scenario's declared
+/// `defvocabulary EdgeType` members. [`Self::declare`] (the only minting
+/// path for `E-LOAD-053`/`E-LOAD-054`'s
 /// `EnumKindShapeViolation`/`UnknownEnumRegistryType` in production shape)
-/// and [`Self::with_implicit_edge_strength`] have no production caller
-/// today: every reference outside this module's own `#[cfg(test)]` tests
-/// and `tests/r9_chapters.rs` is zero. Production builds its `TypeEnv`
-/// straight from a loaded scenario's own `deffield` forms instead —
-/// `babylon_tick::run_once`'s `TypeEnv { fields: scenario.fields.clone(),
-/// .. }` (`rust/crates/babylon-tick/src/lib.rs`), whose own comment names
-/// the same gap from the other side: "the scenario's `deffield` forms ARE
-/// the registries for slice 1. When Phase 2's content registries land they
-/// replace this wholesale." This type IS that Phase-2 registry, waiting on
-/// its consumer: rule-side `deffield` CONTENT PACKS (fields declared
-/// alongside `.bsl` rule content rather than re-declared per scenario) are
-/// what will wire it in — until then it stays fully built, fully tested,
-/// and correctly unreferenced from any live tick.
+/// remains uncalled from any live tick path: every reference to it outside
+/// this module's own `#[cfg(test)]` tests and `tests/r9_chapters.rs` is
+/// zero. Authored fields still reach production's `TypeEnv` straight from
+/// a loaded scenario's own `deffield` forms — `prepare_rules`'s own
+/// comment names the remaining gap from the other side: "the scenario's
+/// `deffield` forms ARE the registries for slice 1. When Phase 2's content
+/// registries land they replace this wholesale." Rule-side `deffield`
+/// CONTENT PACKS (fields declared alongside `.bsl` rule content rather
+/// than re-declared per scenario) are what will wire `declare` in — until
+/// then it stays fully built, fully tested, and correctly unreferenced
+/// from any live tick.
 #[derive(Debug, Clone, Default)]
 pub struct FieldRegistry {
     fields: HashMap<String, OwnedFieldDecl>,

--- a/rust/crates/babylon-graph/src/conformance.rs
+++ b/rust/crates/babylon-graph/src/conformance.rs
@@ -540,7 +540,7 @@ where
             .unwrap()
             - 0.5)
             .abs()
-            < 1e-12
+            < f64::EPSILON
     );
 }
 
@@ -604,7 +604,7 @@ where
             .unwrap()
             - 0.5)
             .abs()
-            < 1e-12,
+            < f64::EPSILON,
         "the owner segment ('tenancy' vs the edge's real type 'solidarity') is not verified here \
          — deliberately, by design; ownership is the CALLER's obligation"
     );

--- a/rust/crates/babylon-graph/src/conformance.rs
+++ b/rust/crates/babylon-graph/src/conformance.rs
@@ -43,6 +43,10 @@ where
     declared_order_never_leaks_through_any_ranged_accessor(&make);
     node_type_of_reports_the_declared_type(&make);
     node_type_of_a_dangling_id_is_loud_not_untyped(&make);
+    edge_attribute_reads_back_the_seeded_strength(&make);
+    edge_attribute_on_a_missing_edge_is_loud_not_zero(&make);
+    edge_attribute_of_an_unstored_qname_is_loud(&make);
+    edge_attribute_does_not_check_the_owner_segment(&make);
 }
 
 /// ADR185 R2: removing a node takes its incident dyadic edges, its
@@ -511,6 +515,98 @@ where
     assert!(
         graph.node_type_of(NodeId(999_999)).is_err(),
         "a dangling NodeId must be a loud error, never an untyped read"
+    );
+}
+
+/// T2 (issue #559, `bsl-language.rst` §2.10): `edge_attribute` reads back the strength seeded at
+/// `add_edge` — the same fact `CanonicalState` section `0x03` already hashes, read through a keyed
+/// lookup instead of `edges`' ranged listing.
+fn edge_attribute_reads_back_the_seeded_strength<G, F>(make: &F)
+where
+    G: GraphSubstrate + CanonicalState,
+    F: Fn() -> G,
+{
+    let mut graph = make();
+    let a = graph.add_node("social_class").unwrap();
+    let b = graph.add_node("social_class").unwrap();
+    graph.add_edge("solidarity", a, b, 0.5).unwrap();
+    // Epsilon-diff, not assert_eq! (clippy::float_cmp, crate-wide #![warn(clippy::pedantic)] —
+    // matches this file's own precedent, e.g. removal_cascades_edges_memberships_and_attributes'
+    // wealth check above): the value is an exact HashMap round-trip with no arithmetic, so the
+    // comparison is deterministic regardless of the epsilon's width.
+    assert!(
+        (graph
+            .edge_attribute("solidarity", a, b, "solidarity/strength")
+            .unwrap()
+            - 0.5)
+            .abs()
+            < 1e-12
+    );
+}
+
+/// A dangling `(edge_type, from, to)` triple must never read as an untyped edge's strength — the
+/// same honest-null discipline `node_attribute`/`node_type_of` already hold (III.11).
+fn edge_attribute_on_a_missing_edge_is_loud_not_zero<G, F>(make: &F)
+where
+    G: GraphSubstrate + CanonicalState,
+    F: Fn() -> G,
+{
+    let mut graph = make();
+    let a = graph.add_node("social_class").unwrap();
+    let b = graph.add_node("social_class").unwrap();
+    assert!(
+        graph
+            .edge_attribute("solidarity", a, b, "solidarity/strength")
+            .is_err(),
+        "no edge was ever added — never a default 0.0"
+    );
+}
+
+/// A non-strength qname is loud, never silently resolved to the strength value or a default 0.0 —
+/// T2 stores exactly one edge attribute per edge (D32); T3 (ADR198 R1) widens this.
+fn edge_attribute_of_an_unstored_qname_is_loud<G, F>(make: &F)
+where
+    G: GraphSubstrate + CanonicalState,
+    F: Fn() -> G,
+{
+    let mut graph = make();
+    let a = graph.add_node("social_class").unwrap();
+    let b = graph.add_node("social_class").unwrap();
+    graph.add_edge("solidarity", a, b, 0.5).unwrap();
+    assert!(
+        graph
+            .edge_attribute("solidarity", a, b, "solidarity/tension")
+            .is_err(),
+        "T2 stores <edge-type>/strength only — a different edge-owned qname is 'never written', \
+         not the strength value"
+    );
+}
+
+/// **Deliberate: the OWNER segment is NOT checked here (adversarial review, Major 6 residue).**
+/// `edge_attribute` performs no ownership validation of its own — exactly `node_attribute`'s own
+/// division of labor with `check_node_referent_type` (evaluator-side, upstream of every call this
+/// trait receives). A qname whose owner segment names a DIFFERENT `EdgeType` than `edge_type`
+/// still SUCCEEDS, because only the ATTRIBUTE segment (`strength`) is checked. Pinned here so a
+/// future reader does not "fix" the suffix check into an owner check by surprise.
+fn edge_attribute_does_not_check_the_owner_segment<G, F>(make: &F)
+where
+    G: GraphSubstrate + CanonicalState,
+    F: Fn() -> G,
+{
+    let mut graph = make();
+    let a = graph.add_node("social_class").unwrap();
+    let b = graph.add_node("social_class").unwrap();
+    graph.add_edge("solidarity", a, b, 0.5).unwrap();
+    // Epsilon-diff, not assert_eq! — same clippy::float_cmp reason as the sibling test above.
+    assert!(
+        (graph
+            .edge_attribute("solidarity", a, b, "tenancy/strength")
+            .unwrap()
+            - 0.5)
+            .abs()
+            < 1e-12,
+        "the owner segment ('tenancy' vs the edge's real type 'solidarity') is not verified here \
+         — deliberately, by design; ownership is the CALLER's obligation"
     );
 }
 

--- a/rust/crates/babylon-graph/src/hypergraph_store.rs
+++ b/rust/crates/babylon-graph/src/hypergraph_store.rs
@@ -278,6 +278,37 @@ impl GraphSubstrate for HypergraphStore {
         found
     }
 
+    fn edge_attribute(
+        &self,
+        edge_type: &str,
+        from: NodeId,
+        to: NodeId,
+        attribute: &str,
+    ) -> Result<f64, GraphError> {
+        // The owner-segment half of §2.10 discipline 1 (does `attribute`'s first segment name
+        // `edge_type`?) is the CALLER's job (field_of_edge's check_edge_referent_type) — this
+        // method, like node_attribute, does no ownership validation of its own. Here we only ask:
+        // is the ATTRIBUTE half "strength", the one thing T2 actually stores?
+        if !attribute.ends_with("/strength") {
+            return Err(GraphError {
+                message: format!(
+                    "edge attribute '{attribute}' was never written — T2 stores a .../strength \
+                     attribute only (D32; the owner segment is not checked here — see this \
+                     method's own doc); other deffield-declared edge attributes land with T3 \
+                     (ADR198 R1), never a default 0.0"
+                ),
+            });
+        }
+        self.edges
+            .get(&(edge_type.to_owned(), from, to))
+            .copied()
+            .ok_or_else(|| GraphError {
+                message: format!(
+                    "no such edge: ({edge_type}, {from:?}, {to:?}) — never a default 0.0"
+                ),
+            })
+    }
+
     fn neighbors(
         &self,
         node: NodeId,
@@ -502,7 +533,10 @@ mod tests {
     /// literal below was captured from `dev` BEFORE `node_type_of` was
     /// added — this fixture (3 nodes, 2 edges, 1 hyperedge, mixed
     /// attributes) is the III.7 baseline, and this test is run again AFTER
-    /// the trait widens to prove the hash did not move.
+    /// the trait widens to prove the hash did not move. T2's `edge_attribute`
+    /// (issue #559) is the SECOND widening this test proves clean, alongside
+    /// `node_type_of` — the same fixture and hex digest still apply, since
+    /// `edge_attribute` is read-only and adds no `CanonicalState` byte.
     #[test]
     fn adding_a_read_only_query_method_does_not_move_the_state_hash() {
         let mut graph = HypergraphStore::new();
@@ -523,8 +557,9 @@ mod tests {
         });
         assert_eq!(
             hex, "9577d95124a7c4ed6faad2c4aca5980b435fb73e7b58813413500a5fdef798ed",
-            "state_hash moved — node_type_of must be III.7-clean (read-only, \
-             no new CanonicalState section, no byte moved)"
+            "state_hash moved — a read-only GraphSubstrate method addition (node_type_of \
+             or edge_attribute) must be III.7-clean (read-only, no new CanonicalState \
+             section, no byte moved)"
         );
     }
 }

--- a/rust/crates/babylon-graph/src/memory.rs
+++ b/rust/crates/babylon-graph/src/memory.rs
@@ -228,6 +228,37 @@ impl GraphSubstrate for MemoryGraph {
         found
     }
 
+    fn edge_attribute(
+        &self,
+        edge_type: &str,
+        from: NodeId,
+        to: NodeId,
+        attribute: &str,
+    ) -> Result<f64, GraphError> {
+        // The owner-segment half of §2.10 discipline 1 (does `attribute`'s first segment name
+        // `edge_type`?) is the CALLER's job (field_of_edge's check_edge_referent_type) — this
+        // method, like node_attribute, does no ownership validation of its own. Here we only ask:
+        // is the ATTRIBUTE half "strength", the one thing T2 actually stores?
+        if !attribute.ends_with("/strength") {
+            return Err(GraphError {
+                message: format!(
+                    "edge attribute '{attribute}' was never written — T2 stores a .../strength \
+                     attribute only (D32; the owner segment is not checked here — see this \
+                     method's own doc); other deffield-declared edge attributes land with T3 \
+                     (ADR198 R1), never a default 0.0"
+                ),
+            });
+        }
+        self.edges
+            .get(&(edge_type.to_owned(), from, to))
+            .copied()
+            .ok_or_else(|| GraphError {
+                message: format!(
+                    "no such edge: ({edge_type}, {from:?}, {to:?}) — never a default 0.0"
+                ),
+            })
+    }
+
     fn neighbors(
         &self,
         node: NodeId,

--- a/rust/crates/babylon-graph/src/substrate.rs
+++ b/rust/crates/babylon-graph/src/substrate.rs
@@ -246,4 +246,33 @@ pub trait GraphSubstrate {
     /// Returns [`GraphError`] if `id` names no live node — a dangling
     /// `NodeRef` never reads as an untyped node (III.11).
     fn node_type_of(&self, id: NodeId) -> Result<&str, GraphError>;
+
+    /// Read one dyadic edge's attribute (§2.10's `edge-between`/`field-of` share this) — the read
+    /// half `edge-between`'s existence check and `field-of` over an `EdgeRef` both derive from.
+    /// `attribute` is the FULL QNAME (e.g. `"solidarity/strength"`), mirroring
+    /// [`Self::node_attribute`]'s own convention exactly — never a bare segment.
+    ///
+    /// **T2 scope (issue #559): the only PATTERN resolvable against real storage today is a qname
+    /// ENDING IN `/strength`** — every `EdgeType` carries one implicit, always-written `Coefficient`
+    /// field (D32, `bsl-language.rst` §2.9), and `add_edge`'s mandatory `:strength` operand is the
+    /// only thing this trait's edge storage holds. **This method does NOT verify that `attribute`'s
+    /// OWNER segment names `edge_type`** — exactly as [`Self::node_attribute`] performs no
+    /// ownership check of its own, that half of §2.10 discipline 1 is the CALLER's obligation
+    /// (`field_of_edge`'s `check_edge_referent_type`, upstream of every call this trait receives).
+    /// A qname whose ATTRIBUTE segment is anything but `strength` is legal grammar (a `deffield`
+    /// may own off an `EdgeType`, dossier-confirmed) but has no storage behind it until T3
+    /// (ADR198 R1) — it reads exactly like a never-written node field: `GraphError`, never a
+    /// default `0.0`. **READ-ONLY**: reports a fact `CanonicalState` section `0x03` already hashes
+    /// (III.7, the `node_type_of` precedent — `ai/decisions/ADR197_bsl_query_evaluation_slice1_handoff.yaml`).
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if no `(edge_type, from, to)` edge exists, or if `attribute` does not
+    /// END IN `/strength` — absence is never a default `0.0`.
+    fn edge_attribute(
+        &self,
+        edge_type: &str,
+        from: NodeId,
+        to: NodeId,
+        attribute: &str,
+    ) -> Result<f64, GraphError>;
 }

--- a/rust/crates/babylon-graph/tests/storage_benchmark.rs
+++ b/rust/crates/babylon-graph/tests/storage_benchmark.rs
@@ -142,8 +142,8 @@ fn measure_across_a_hundredfold_range() {
     measure_size(2_000, 5); // 100x
 }
 
-/// D4 (PR #494 adversarial review): the original three points (20/200/2_000)
-/// undersold the shape of the curve. Extended to 5_000/10_000/20_000 — a
+/// D4 (PR #494 adversarial review): the original three points (`20/200/2_000`)
+/// undersold the shape of the curve. Extended to `5_000/10_000/20_000` — a
 /// 1000x range from the smallest point — to make the complexity CLASS
 /// visible rather than merely its sign at one scale. See ADR193 and
 /// `docs/reference/graph-storage-capability-delta.md` for the reading:

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -148,7 +148,18 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
     // own module doc).
     let mut fields = scenario.fields.clone();
     if let Some(vocabulary) = scenario.vocabulary.as_ref() {
-        let implicit = FieldRegistry::with_implicit_edge_strength(vocabulary).type_env_fields();
+        let mut implicit: Vec<_> = FieldRegistry::with_implicit_edge_strength(vocabulary)
+            .type_env_fields()
+            .into_iter()
+            .collect();
+        // Byte order, the same convention `rules.sort_by` uses below: the
+        // Err/Ok verdict never depended on `type_env_fields()`'s HashMap
+        // iteration order, but the refusal TEXT did — with two or more
+        // colliding qnames it nondeterministically named a different field
+        // per process. Sorting makes the message always name the byte-least
+        // colliding qname (declarations.rs's own reporting sorts the same
+        // way before its first-failure checks).
+        implicit.sort_by(|(a, _), (b, _)| a.as_bytes().cmp(b.as_bytes()));
         for (qname, decl) in implicit {
             if fields.contains_key(&qname) {
                 return Err(format!(
@@ -493,6 +504,45 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("E-LOAD-001"), "{err}");
+    }
+
+    // Adversarial-verifier fix round, Fix 2: with TWO explicit re-declarations colliding against
+    // the implicit seed set, the pre-fix loop iterated `type_env_fields()`'s HashMap directly and
+    // returned on the first hit — so the refusal nondeterministically named either
+    // `solidarity/strength` or `tenancy/strength` across runs (proven empirically over 64 runs).
+    // Post-fix the seed pairs are byte-sorted before the collision check, so the refusal always
+    // names the byte-least colliding qname. Pinned as an EXACT full-string assertion, looped over
+    // fresh `prepare_rules` calls (each loop builds fresh HashMaps with fresh RandomState keys, so
+    // a regression to unsorted iteration gets many chances to surface in one test run).
+    const D32_TWO_COLLISION_SCENARIO: &str = r"
+(scenario ft/d32-two-collision-probe
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (defvocabulary EdgeType (SOLIDARITY TENANCY))
+  (deffield social-class/shape int extensive)
+  (deffield solidarity/strength int extensive)
+  (deffield tenancy/strength int extensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/shape 1))
+  (node other NodeType/SOCIAL_CLASS (social-class/shape 1))
+  (edge EdgeType/SOLIDARITY core other 1))
+";
+
+    #[test]
+    fn a_two_collision_e_load_001_refusal_always_names_the_byte_least_field() {
+        for _ in 0..20 {
+            let mut graph = babylon_graph::hypergraph_store::HypergraphStore::new();
+            let err = prepare_rules(
+                D32_TWO_COLLISION_SCENARIO,
+                D32_WIRING_PROBE_RULE,
+                &mut graph,
+            )
+            .unwrap_err();
+            assert_eq!(
+                err,
+                "E-LOAD-001: solidarity/strength is the implicit <edge-type>/strength field \
+                 (D32) — re-declaring it with an explicit deffield is a duplicate declaration, \
+                 never a silent override (bsl-language.rst §2.9)"
+            );
+        }
     }
 
     // G3(b) (#534 fix round 2): the "Task-10 detonation pin". The

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -4,7 +4,7 @@
 //! exactly one implementation. See `main.rs` for the CLI-facing docs; this
 //! module is the seam itself.
 
-use babylon_bsl::declarations::parse_intrinsic_decls;
+use babylon_bsl::declarations::{parse_intrinsic_decls, FieldRegistry};
 use babylon_bsl::evaluator::Value;
 use babylon_bsl::fuel::{CardinalityCeilings, IntrinsicCosts};
 use babylon_bsl::intrinsic_host::KernelIntrinsicHost;
@@ -85,6 +85,11 @@ pub fn run_once(scenario_src: &str, rule_src: &str) -> Result<TickReport, String
 /// exactly tick 1) and, from `session.rs` on, `TickSession::new` (Program
 /// 28 B2, `docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md` Phase A
 /// Task 4).
+///
+/// `Debug` (T2, issue #559): needed so `Result<PreparedRules, String>` can be
+/// formatted with `{:?}` in a test assertion message (every field already
+/// derives `Debug`, so this is additive only).
+#[derive(Debug)]
 pub(crate) struct PreparedRules {
     pub rules: Vec<(String, LoadedRule)>,
     pub types: TypeEnv,
@@ -124,8 +129,39 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
     // Phase 2's content registries land they replace this wholesale; until
     // then a field's type and intensivity come from a declaration rather
     // than from a guess about its stored value.
+    //
+    // D32 (bsl-language.rst §2.9): every EdgeType carries one implicit
+    // <edge-type>/strength field, needing no deffield. FieldRegistry::
+    // with_implicit_edge_strength already builds this seed set, fully tested
+    // (declarations.rs, r9_chapters.rs's own type_env() fixture) but had no
+    // production caller until T2 (issue #559) — this is that caller. Seeded
+    // from the scenario's declared defvocabulary EdgeType members
+    // (scenario.vocabulary; `None` for a scenario declaring no defvocabulary
+    // at all — the loop below is then a no-op, matching every pre-T2
+    // scenario's behavior exactly). An explicit deffield re-declaring an
+    // implicit field is D32's own named violation (E-LOAD-001,
+    // FieldRegistry::declare's own duplicate guard) — checked here rather
+    // than through that guard, because scenario.rs's simpler load_deffield
+    // builds `scenario.fields` with no notion of "implicit" to check
+    // against; this is that check's only home until Phase 2's content-pack
+    // field registries replace scenario.fields wholesale (declarations.rs's
+    // own module doc).
+    let mut fields = scenario.fields.clone();
+    if let Some(vocabulary) = scenario.vocabulary.as_ref() {
+        let implicit = FieldRegistry::with_implicit_edge_strength(vocabulary).type_env_fields();
+        for (qname, decl) in implicit {
+            if fields.contains_key(&qname) {
+                return Err(format!(
+                    "E-LOAD-001: {qname} is the implicit <edge-type>/strength field (D32) — \
+                     re-declaring it with an explicit deffield is a duplicate declaration, never \
+                     a silent override (bsl-language.rst §2.9)"
+                ));
+            }
+            fields.insert(qname, decl);
+        }
+    }
     let types = TypeEnv {
-        fields: scenario.fields.clone(),
+        fields,
         exemptions: &[],
     };
     let vocabulary = BindingVocabulary {
@@ -347,7 +383,7 @@ pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
 
 #[cfg(test)]
 mod tests {
-    use super::run_once;
+    use super::{prepare_rules, run_once};
     const SCENARIO: &str = include_str!("../content/scenarios/two-classes.bscn");
     const RULE: &str = include_str!("../content/rules/fundamental-theorem.bsl");
 
@@ -393,6 +429,70 @@ mod tests {
     fn a_declared_vocabulary_typo_refuses_through_the_production_seam() {
         let err = run_once(VOCAB_WIRING_SCENARIO, VOCAB_WIRING_RULE).unwrap_err();
         assert!(err.contains("E-LOAD-031"), "{err}");
+    }
+
+    // T2 (issue #559) PLAN-MUST-VERIFY probe: proves the D32 implicit-strength seed reaches
+    // typecheck_aggregation through prepare_rules's REAL production wiring, using only
+    // already-served slice-1 infrastructure (neighbors) — provable BEFORE edges/field-of-over-
+    // EdgeRef land in PR B (Tasks 3-5). The rule LOADS today only if the wiring works; it would
+    // still refuse E-EVAL-033 if actually RUN (its fold body reads a NodeRef's field-of an
+    // edge-owned qname, a referent-type mismatch) — this probe tests LOADING only, deliberately.
+    const D32_WIRING_PROBE_SCENARIO: &str = r"
+(scenario ft/d32-wiring-probe
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (defvocabulary EdgeType (SOLIDARITY))
+  (deffield social-class/shape int extensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/shape 1))
+  (node other NodeType/SOCIAL_CLASS (social-class/shape 1))
+  (edge EdgeType/SOLIDARITY core other 1))
+";
+    const D32_WIRING_PROBE_RULE: &str = r#"(rule vitality/d32-wiring-probe
+  :material-basis "PLAN-MUST-VERIFY probe (T2, issue #559): the D32 implicit-strength field must resolve through prepare_rules's real TypeEnv construction, not merely in isolation (r9_chapters.rs::type_env already proves the isolated chain)"
+  :fuel 128
+  (bindings (binding shape :field social-class/shape))
+  (when (= shape 1))
+  (effects (emit EventType/PROBE
+    (s (fold sum (neighbors self EdgeType/SOLIDARITY :any NodeType/SOCIAL_CLASS)
+             (field-of it solidarity/strength))))))"#;
+
+    #[test]
+    fn the_d32_implicit_strength_field_resolves_through_the_real_wiring_seam() {
+        let mut graph = babylon_graph::hypergraph_store::HypergraphStore::new();
+        let result = prepare_rules(D32_WIRING_PROBE_SCENARIO, D32_WIRING_PROBE_RULE, &mut graph);
+        assert!(
+            result.is_ok(),
+            "the D32 implicit-strength field must resolve through prepare_rules's real \
+             TypeEnv construction: {result:?}"
+        );
+    }
+
+    // Task 2 Step 4: proves the E-LOAD-001 half, not just the happy path — a rule-irrelevant
+    // EXPLICIT `deffield` re-declaring the implicit `<edge-type>/strength` field must refuse,
+    // never silently override. Zero-regression check (verified, not assumed):
+    // `rg -n "strength" rust/crates/babylon-tick/content/scenarios/*.bscn` returns no hits today
+    // — no committed scenario explicitly declares an edge-owned `strength` field, so this new
+    // refusal cannot regress any existing content.
+    const D32_WIRING_PROBE_SCENARIO_WITH_EXPLICIT_REDECLARATION: &str = r"
+(scenario ft/d32-wiring-probe
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (defvocabulary EdgeType (SOLIDARITY))
+  (deffield social-class/shape int extensive)
+  (deffield solidarity/strength int extensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/shape 1))
+  (node other NodeType/SOCIAL_CLASS (social-class/shape 1))
+  (edge EdgeType/SOLIDARITY core other 1))
+";
+
+    #[test]
+    fn an_explicit_deffield_redeclaring_the_implicit_strength_field_is_e_load_001() {
+        let mut graph = babylon_graph::hypergraph_store::HypergraphStore::new();
+        let err = prepare_rules(
+            D32_WIRING_PROBE_SCENARIO_WITH_EXPLICIT_REDECLARATION,
+            D32_WIRING_PROBE_RULE,
+            &mut graph,
+        )
+        .unwrap_err();
+        assert!(err.contains("E-LOAD-001"), "{err}");
     }
 
     // G3(b) (#534 fix round 2): the "Task-10 detonation pin". The


### PR DESCRIPTION
Part 1 of 2 for #559 (Program 29 T2 — Query Slice 2, edge reads). Executes Tasks 1–2 of the merged plan `docs/superpowers/plans/2026-08-12-t2-slice2-edge-reads-plan.md`; PR B (Tasks 3–7: `Element::Edge`, `materialize_edges`, `eval_edge_between`, `field_of_edge`, the edges-refusal sweep, D139–D142 + ADR201) follows from the merged base.

## What lands

**Task 1 — the one new substrate read.** `GraphSubstrate::edge_attribute` (full-qname-keyed, strength-only for now, forward-shaped for T3) at the trait's end, implemented on both backends (`MemoryGraph`, `HypergraphStore`). Four new shared conformance rows — read-back, missing-edge loudness, unknown-qname loudness, and the owner-segment-caller-owned row — plus the hash-guard assert-message generalization (pinned hex `9577d951…` unchanged: a read-only query method does not move the state hash).

**Task 2 — the D32 implicit-strength wiring.** `prepare_rules` now seeds the implicit `<edge-type>/strength` `TypeEnv` rows from the scenario's declared `defvocabulary EdgeType` members via `FieldRegistry::with_implicit_edge_strength` (previously built-but-dormant), with E-LOAD-001 collision refusal when a scenario explicitly re-declares one. Collision refusal is deterministic: implicit qnames sort by byte order before the check, so a multi-collision scenario always names the byte-least field — pinned by an exact-full-string test looping 20 fresh `prepare_rules` calls.

**Hash-free by construction, proven empirically:** three shipped scenarios (`organization-foundation`, `territory-conformance`, `production-conformance`) declare non-empty `defvocabulary EdgeType` blocks and genuinely gain TypeEnv rows from this wiring — all six tick goldens plus the `babylon-client` engine-link pin stay byte-identical.

## Verification arc

Implementer → fresh adversarial verifier (verdict: mergeable after fixes) → fix round → same-verifier delta re-verify (verdict: **mergeable as-is**). The verifier re-executed rather than read: the RED-probe experiment reproduced the plan's predicted failure verbatim; the wiring mutation (comment out the `if let Some(vocabulary)` block) flips exactly the two new tests; the sort mutation flips the exact-string test in 5/5 external processes; all four plan deviations were confirmed by building the refused construct (float_cmp refusal, E-LEX-021 on the bare `0.5` fixture) or field-by-field reading (`#[derive(Debug)]`).

Fix-round commits (verifier dispositions):
- `docs(bsl)` — the wiring falsified `with_implicit_edge_strength`'s "no production caller" rustdoc; rewritten with every claim rg-verified (the `declare`-is-still-dormant half survives, independently re-derived from all 30 `.declare(` call sites).
- `fix(tick)` — deterministic E-LOAD-001 refusal ordering (above).
- `chore(rust)` — `rust:check` gains the babylon-graph pedantic clippy leg; the pre-existing `storage_benchmark.rs` doc-markdown violation on dev existed precisely because this leg was missing, and its fix now cannot silently regress (CI runs `rust:check`).
- `test(graph)` — the two f64-comparing conformance rows tightened `1e-12` → `f64::EPSILON` (exact HashMap round-trip; ~1 ULP slack at 0.5).

## Documented deviations from plan text

1. Conformance asserts use epsilon-diff, not `assert_eq!` — the plan's literal form fails `clippy::float_cmp` under babylon-graph's crate-wide pedantic (refusal executed, exit 101).
2. D32 probe fixture strength `0.5` → `1` — `load_edge` accepts integer strength literals only and bare `0.5` is E-LEX-021 regardless (both refusals executed); immaterial, the probe asserts load success only, no tick runs.
3. `#[derive(Debug)]` added to `PreparedRules` (plan's `{result:?}` needed it; all five fields already derive Debug).
4. `fix(graph)` pre-commit: two-line backtick fix in `storage_benchmark.rs`, pre-existing on dev, surfaced by the plan's per-commit babylon-graph pedantic leg.

## Sequenced into PR B (not defects)

- `BindingVocabulary` intentionally stays narrow (TypeEnv widened only) — the evaluation surface lands in PR B; the write side was checked for a hash-affecting hole and has none (E-EVAL-033 + E-LOAD-032 disjointness close it).
- D139 (the register row recording the D32 seeding narrowing: implicit rows only under a declared `defvocabulary EdgeType`) lands in PR B Task 7 with the rest of the D139–D142 register block.

Gate: six legs green per commit (fmt, workspace clippy `-D warnings`, workspace tests, pedantic clippy on kernel/bsl/graph, `RUSTDOCFLAGS='-D warnings' cargo doc`, goldens `--locked` + engine_link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
