### PR TITLE
feat(p29): T2 PR B — Element::Edge, edge-between, field_of_edge, the e2e estate + Task 6a (closes #559)

### DIFF
--- a/ai/decisions/ADR201_t2_edge_reads_handoff.yaml
+++ b/ai/decisions/ADR201_t2_edge_reads_handoff.yaml
@@ -160,7 +160,17 @@ ADR201_t2_edge_reads_handoff:
     registered-systems scaffolding (E-LOAD-002 — a rule cannot land
     nowhere), exactly as "territory" itself was added by the
     query-evaluation train for query_lane_e2e.rs's vectors; NOT a system
-    port, documented as such at the entry.
+    port, documented as such at the entry. Full-PR verification found (and
+    this record's own scratch probe re-proved by execution: a rule id'd
+    unregistered-namespace/anchor-probe carrying (anchor :after vitality)
+    loaded and FIRED through run_once_into) an alternative neither the
+    plan nor this record had weighed: an explicit (anchor :after vitality)
+    on the e2e rules would have anchored them with ZERO production-surface
+    widening — mod_anchors.rs's explicit-anchor branch checks the NAMED
+    system, not the rule-id's first segment. The registered-system path is
+    KEPT for consistency with the territory precedent (c28c1f34 — same
+    shape, same comment convention); both are load-inert for shipped
+    content.
 
     **9. The hash-free proof — three chained facts, then the gate.**
     (a) state_hash.rs never touches Value/Element BY CONSTRUCTION —
@@ -179,8 +189,10 @@ ADR201_t2_edge_reads_handoff:
     arm is byte-identical and no shipped scenario CAN contain a scaled
     strength literal — one could not have loaded before 6a (the landed
     Task 2 probe's own int-1 fallback is the in-tree trace). All six
-    tick_goldens pins plus engine_link's pin ran byte-identical after
-    every one of the seven commits.
+    tick_goldens pins plus engine_link's pin ran byte-identical at every
+    gate run during implementation — each Rust-touching commit's own
+    six-leg gate (the docs-only commits ran no gate of their own) — and
+    re-confirmed at HEAD.
 
     **10. The `the` disposition (Task 7 Step 3) — its own micro-train
     (T2.5), for a stronger reason than #572's framing.** the's

--- a/ai/decisions/ADR201_t2_edge_reads_handoff.yaml
+++ b/ai/decisions/ADR201_t2_edge_reads_handoff.yaml
@@ -1,0 +1,236 @@
+ADR201_t2_edge_reads_handoff:
+  status: "accepted"
+  date: "2026-08-12"
+  title: "The T2 slice-2 edge-reads handoff (Program 29, issue #559) — edges/edge-between/field-of-over-an-EdgeRef served through the real run_once_into seam, hash-free by construction; EdgeKey minted with the cross-kind Element Ord RULED (Node < Edge) and Copy dropped; the D32 implicit-strength seeding WIRED as a recorded narrowing; the Task 6a load_edge strength-literal widening (kind-blind p/i/c, runtime-mirroring, adjudicated in its own amendment fix round); three e2e vectors incl. the §3.8-item-8 Solidarity-anticipating idiom; and the `the` disposition — its own micro-train (T2.5), #572 stays open"
+  context: |
+    docs/superpowers/plans/2026-08-12-t2-slice2-edge-reads-plan.md (three
+    adversarial review rounds, then a 2026-08-12 two-entry amendment with
+    its own review) served BSL query-evaluation slice 2 — the dyadic edge
+    read lane: the `edges` query head, the `edge-between` accessor, and
+    `field-of` over an `EdgeRef` — strength-only until T3 (ADR198 R1-R3)
+    widens edge-attribute storage. This is the language train, not a port:
+    it anticipates Solidarity's read shape (bsl-language.rst §3.8 item 8's
+    worked example) but ships no Solidarity content. PR A (Tasks 1-2,
+    merged separately) landed the one new GraphSubstrate method and the
+    D32 TypeEnv wiring; PR B (Tasks 3-7, this record) landed the
+    Value/Element additions, the three evaluator functions, the Task 6a
+    hydration widening the amendment forced, the e2e proof, and these
+    records. Mid-train, the implementer STOPPED on an execution-proven
+    contradiction (Task 6's fixture could not load — bare decimals cannot
+    lex, E-LEX-021, and the c-suffixed repair was refused by load_edge's
+    deliberate int-only strength restriction, scenario.rs's own comment);
+    the plan was amended rather than improvised around: Task 6a was
+    inserted before Task 6, itself adversarially reviewed (one MAJOR: the
+    first draft's c-only scope was adjudicated KIND-BLIND p/i/c, option
+    (i)), and Task 6's fixture literals became c-suffixed.
+  decision: |
+    **1. The substrate method (Task 1, PR A) — full-qname, suffix-checked,
+    owner-unchecked, forward-shaped for T3.** GraphSubstrate::
+    edge_attribute(edge_type, from, to, attribute) reads the strength
+    CanonicalState section 0x03 already hashes, on both backends
+    (identical HashMap<(String, NodeId, NodeId), f64> storage). The
+    attribute parameter is the FULL QNAME, mirroring node_attribute's own
+    convention exactly; the method's body checks only that the qname ends
+    in "/strength" (any other edge-owned qname reads as "never written" —
+    the E-EVAL-033 unification field_of_edge relies on), and deliberately
+    does NOT verify the owner segment — ownership is the CALLER's
+    obligation, the same division of labor node_attribute/
+    check_node_referent_type already have, pinned by the conformance row
+    edge_attribute_does_not_check_the_owner_segment on both backends. At
+    T3 only the body widens; the signature does not change. III.7
+    hash-invariance proven by the same fixture-hash test node_type_of used
+    (its doc and failure message now name both widenings). Register row
+    D141.
+
+    **2. The D32 implicit-strength wiring (Task 2, PR A) — a RULING, not a
+    convenience, and a recorded NARROWING.** prepare_rules's TypeEnv
+    construction seeds one <edge-type>/strength row per defvocabulary
+    EdgeType member, via FieldRegistry::with_implicit_edge_strength's
+    first production call — keyed off scenario.vocabulary, correcting the
+    scout dossier's own scenario.edge_types (census) pointer — with an
+    explicit deffield re-declaration refused as E-LOAD-001. A scenario
+    declaring no defvocabulary gets no seeding: a deliberate narrowing of
+    D32's literal "needs no deffield", chosen for reuse of already-tested
+    machinery and the Phase-2 registry direction; the bare accessor still
+    degrades gracefully (tick::bind_field_value's fallback), only
+    unweighted aggregation needs the declaration — edge-lane-e2e.bscn's
+    Shape-1 fold is the positive executed proof. Register row D139.
+
+    **3. EdgeKey, Value::EdgeRef, Element::Edge (Task 3) — and the
+    cross-kind Ord RULED.** EdgeKey { source, target, edge_type: String }
+    — field order matches §2.6's own (source-id, target-id, edge-type)
+    total order so the derive agrees with the spec (mutation-proven by
+    swapping field order: the direct Ord test flips, the
+    materialize-delegation test correctly does not — materialize_edges
+    never invokes the derive, its order comes entirely from
+    GraphSubstrate::edges' own sorted contract). Element's cross-kind Ord
+    RULED Node-before-Edge by declaration order — unreachable in
+    production (no materialize() mixes kinds), pinned per the enum's own
+    standing instruction (CT4P A5/#525). Element drops Copy (EdgeKey owns
+    a String): all nine enumerated call sites fixed mechanically, plus one
+    test-module exhaustiveness arm the compile-time trip-wire
+    (element_kind_name) forced — the trip-wire firing exactly as designed.
+    Register row D140.
+
+    **4. The edges-refusal sweep (Task 3 Step 7) — FIVE landed assertions
+    flipped, one more than the plan enumerated.** The plan's four:
+    query.rs's dispatch-table test (shrunk to three heads), evaluator.rs's
+    refusal_messages_name_their_slice edges leg (deleted),
+    r9_chapters.rs's four-heads selection test (shrunk to three), and
+    conformance_corpus.rs's event_edge_count.bsl pin — PROMOTED to two
+    positive evaluated vectors (empty graph counts 0 -> Bool(false); one
+    edge crosses the >= 1 threshold -> Bool(true)), discharging that
+    module's own standing doc promise. The fifth, which the plan missed:
+    evaluator.rs::every_seam_head_is_classified, the reserved-head
+    partition test — serving edge-between (Task 4) moved it from the
+    unserved bucket to EVALUATOR_SERVED (10 -> 11); edges itself moved
+    bucket-to-bucket (UNSERVED_EXPRESSION_HEADS -> SERVED_QUERY_HEADS) so
+    Task 3 kept the partition satisfied without a test edit.
+
+    **5. eval_edge_between (Task 4).** The §2.10 keyed lookup: evaluates
+    both node operands (refusing non-NodeRef values), constructs the
+    strength qname via vocabulary::render_member (it holds only the raw
+    enum member — the one caller that cannot pass a content-authored qname
+    through), maps substrate absence to E-EVAL-034, returns
+    Value::EdgeRef. Static bound and runtime meter agree at 3 for the
+    worked shape (ACCESSOR_BASE + two variable refs), asserted against
+    r9_chapters' own pinned static figure. Mutation: swapping from/to in
+    the substrate call flips the happy path red (a directional edge looked
+    up backwards is E-EVAL-034). query::enum_member widened pub(crate) —
+    reused, not re-implemented.
+
+    **6. field_of_edge (Task 5).** Generic over any edge-owned qname —
+    never hard-coded to strength: check_edge_referent_type compares the
+    qname's owner segment against the EdgeKey's inline type (cheaper than
+    the NodeRef case — no substrate round-trip), then the full qname
+    passes to edge_attribute UNMODIFIED, exactly as field_of_node passes
+    node_attribute; renders through the SAME tick::bind_field_value path
+    (dossier PLAN-MUST-VERIFY item 5 confirmed by the executed vectors: no
+    divergence). E-EVAL-034 is unreachable from inside this function
+    (every EdgeRef was validated live at construction); the error mapping
+    is therefore always E-EVAL-033 — declared-but-unstored (a deffield'd
+    solidarity/tension, storage arriving with T3) and never-written
+    degrade identically, zero special-casing, proven by its own executed
+    vector. Mutation: passing the edge type instead of the qname as the
+    attribute argument flips the happy path red.
+
+    **7. The Task 6a load_edge widening (amendment 2026-08-12, fix-round
+    adjudicated) — hydration mirrors the runtime writer.** load_edge's
+    strength position now accepts int (byte-identical arm) plus
+    KIND-BLIND p/i/c-suffixed unit-interval literals (reviewer MAJOR-1,
+    option (i): kinds do not survive evaluation, and the runtime writer of
+    this exact position — structural_verbs::add_edge's :strength — accepts
+    any Value::Real; a c-only loader would have minted a bidirectional
+    load/runtime divergence). r (Ratio) and $ (Currency) stay refused,
+    exactly as the runtime refuses their evaluated forms. Conversion is
+    the crate's one scaled-literal contract (unscaled / 10^scale), copied
+    verbatim as the ninth inline site — the DRY tradeoff owned explicitly,
+    extraction deferred to the post-port refactor ledger. NO range check
+    on either arm, mirroring the landed law: the lexer already bounds
+    p/i/c to [0,1] (E-LEX-024), while the int arm's unchecked domain
+    (an out-of-[0,1] int strength loads today; the runtime :strength
+    refuses Value::Int outright) is recorded as an OPEN question for a
+    future ruling, deliberately not resolved here. Red pin was
+    byte-exact to the plan's predicted refusal; mutations proved the
+    guard in BOTH directions (admit Ratio -> the 0.5r refusal row flips
+    while 1$ holds, a different Atom variant; narrow to c-only — the
+    adjudication's rejected option — -> both p/i seeding rows flip).
+    Per D93 the .bscn dialect is spec-unpinned, so NO register row was
+    minted: this ADR and the plan's own Amendment log are the record
+    homes.
+
+    **8. The three e2e vectors (Task 6) — through the real run_once_into
+    seam.** edge-lane-e2e.bscn (twelve nodes, seven c-suffixed SOLIDARITY
+    strengths, all exact dyadic rationals) + edge_lane_e2e.rs: Shape 1 —
+    the edges-fold sums every strength in the graph to exactly 0.796875
+    (proving both the query head and D139's aggregation-side seeding);
+    Shape 2a — edge-between resolves and its field-of read returns the
+    seeded 0.03125 exactly; Shape 2b — the REVERSED lookup of a
+    directional edge aborts the tick through run_once_into's own Result
+    ("tick failed in rule …: E-EVAL-034: … no edge from NodeId(3) to
+    NodeId(5) …" — the flagged judgment call confirmed by execution: a
+    genuine mid-tick E-EVAL abort propagates as Err, the first e2e vector
+    to exercise one); Shape 3 — the §3.8-item-8 self-anchored
+    neighbors+edge-between idiom sums hub's three incoming strengths to
+    exactly 0.375, the vector that unblocks Solidarity's port without
+    source-of/target-of. Determinism split per the plan (Blocker 3): the
+    three succeeding shapes through the TickReport-comparison loop, Shape
+    2b through its own two-run Err-string leg. One plan defect repaired on
+    in-code precedent: the social-class/* namespace joined the driver's
+    registered-systems scaffolding (E-LOAD-002 — a rule cannot land
+    nowhere), exactly as "territory" itself was added by the
+    query-evaluation train for query_lane_e2e.rs's vectors; NOT a system
+    port, documented as such at the entry.
+
+    **9. The hash-free proof — three chained facts, then the gate.**
+    (a) state_hash.rs never touches Value/Element BY CONSTRUCTION —
+    babylon-graph cannot import babylon-bsl (crate boundary), so Task 1's
+    method is hash-inert by the same argument every substrate read is.
+    (b) Task 2's wiring DOES touch three shipped scenarios' in-memory
+    TypeEnv.fields (territory/production/organization declare
+    defvocabulary EdgeType) — inert for the reason that matters, verified
+    by executed grep at this record's landing: zero content in
+    content/rules/*.bsl reads an edge-owned qname or uses
+    edges/edge-between (only "strengthening"/"strengthens" comment
+    substrings hit), so the seeded entries are never consulted by any
+    path the seven pinned goldens exercise; the one fixture that DOES
+    change (event_edge_count.bsl) is test-only, swept in item 4, and
+    backs no golden. (c) Task 6a is golden-inert by construction: the int
+    arm is byte-identical and no shipped scenario CAN contain a scaled
+    strength literal — one could not have loaded before 6a (the landed
+    Task 2 probe's own int-1 fallback is the in-tree trace). All six
+    tick_goldens pins plus engine_link's pin ran byte-identical after
+    every one of the seven commits.
+
+    **10. The `the` disposition (Task 7 Step 3) — its own micro-train
+    (T2.5), for a stronger reason than #572's framing.** the's
+    spec-normative legality gate (E-LOAD-043/E-LOAD-045) lives only in
+    manifest.rs, exercised only by r9_chapters' test harness; the
+    production driver builds CardinalityCeilings from hydrated counts and
+    references Manifest nowhere (re-executed grep: three comment hits in
+    rule_pipeline.rs, zero in the driver) — so the gate is unreachable
+    through run_once_into in either direction, and serving `the` needs a
+    real design choice (wire the manifest form, or redefine legality
+    against the census — two numbers that coincide today by accident).
+    Register row D142; issue #572 stays OPEN with this ADR as evidence.
+
+    **11. Four new register rows (D139-D142)** filed in
+    docs/reference/bsl-language.rst's Draft-Ruling Register (next-free
+    re-checked at landing: D138 was the tail); the 41-test Python
+    grammar-sync guard passed unrepaired — no probe anchor slid.
+
+    **12. A known pre-existing divergence T2 does NOT fix, named so no
+    future reader mistakes it for T2's own D32 reading:**
+    conformance_corpus.rs:101-104's hand-built TypeEnv fixture declares
+    solidarity/strength as BslType::Intensity/FieldKind::Intensive — the
+    OPPOSITE of D32's Coefficient/Extensive and of
+    FieldRegistry::with_implicit_edge_strength's own kinds. No breakage
+    (that harness is isolated, vocabulary_registry: None, untouched by
+    Task 2's wiring), but it is a real spec/fixture disagreement, outside
+    this train's scope to repair.
+  consequences: |
+    Slice 2's dyadic edge read lane is SERVED through the production seam:
+    (edges <enum-ref>) materializes (the <edge-pred> operand stays a loud
+    named gap, mirroring nodes' own), edge-between resolves or aborts
+    E-EVAL-034, field-of reads any edge-owned qname with strength the only
+    storable one until T3. Solidarity's port train (Wave C) has its read
+    idiom proven end-to-end (Shape 3). T3 (ADR198 R1-R3) inherits a
+    stable contract: edge_attribute's signature frozen, suffix check ->
+    real lookup, ownership stays caller-side.
+
+    OPEN, NAMED, NOT THIS TRAIN'S: `the` (T2.5 micro-train, #572, design
+    choice recorded in D142); the Task 6a int-arm domain questions (no
+    range check at hydration; int loads at hydration while the runtime
+    :strength refuses Value::Int — one future ruling owns both halves);
+    source-of/target-of edge-endpoint accessors (§3.8 item 8 — unscoped
+    by any Program 29 train; the self-anchored idiom is the workaround
+    this train proved); the conformance_corpus.rs Intensity/Intensive
+    fixture divergence (item 12); hyperedge/metric lanes (slice 3) and
+    membership-field-of (slice 4), untouched. GitHub closure of #559 and
+    the #572 comment ride the PR merge, not this record.
+  supersedes: []
+  related:
+    - ADR197_bsl_query_evaluation_slice1_handoff
+    - ADR198_program29_substrate_widening_charter
+    - ADR199_territory_port_handoff
+    - ADR200_production_port_handoff

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -915,3 +915,8 @@ decisions:
     status: accepted
     date: '2026-08-12'
     file: ADR200_production_port_handoff.yaml
+  ADR201_t2_edge_reads_handoff:
+    title: 'The T2 slice-2 edge-reads handoff (Program 29, issue #559) — the dyadic edge read lane (edges, edge-between, field-of over an EdgeRef) served through the real run_once_into seam, hash-free by construction (all seven golden pins byte-identical through every commit); EdgeKey minted with Element''s cross-kind Ord RULED Node-before-Edge and Copy dropped (nine call sites fixed by enumeration, one partition-test flip the plan missed swept alongside the plan''s own four); the D32 implicit-strength seeding WIRED as a recorded NARROWING (defvocabulary-gated, scenario.vocabulary not the census); a mid-train execution-proven STOP (Task 6''s fixture could not load — E-LEX-021 plus load_edge''s int-only strength restriction) resolved by plan amendment rather than improvisation: Task 6a widens load_edge to KIND-BLIND p/i/c unit-interval strength literals mirroring the runtime :strength writer (c-only rejected in the amendment''s own fix round; r/$ stay refused; int-arm domain questions recorded OPEN; no register row per D93 — this ADR and the Amendment log are the record homes); three e2e vectors incl. the §3.8-item-8 self-anchored idiom that unblocks Solidarity''s port and the first genuine mid-tick E-EVAL abort exercised through run_once_into''s Result; four new register rows D139-D142; the `the` disposition ruled its own micro-train (T2.5, #572 stays open — its legality gate is unreachable through the production driver, a design gap not a small task)'
+    status: accepted
+    date: '2026-08-12'
+    file: ADR201_t2_edge_reads_handoff.yaml

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -6695,6 +6695,124 @@ consequences are the ordinary kind of review item.
        p0_p1_p3_push_t_alphas_production_total_correctly`` red (``t-alpha``'s
        ``production-total`` inflates from ``comprador``'s own push);
        restored byte-identical.
+   * - D139
+     - §2.9, §3.4
+     - **T2 (issue #559), Task 2 — the D32 implicit-strength seeding is
+       WIRED, and its trigger is a deliberate NARROWING of D32's literal
+       text.** The implicit ``<edge-type>/strength`` registry
+       (``declarations.rs::FieldRegistry::with_implicit_edge_strength`` —
+       fully built and tested since the R9 chapters, zero production
+       callers until now) gained its first real caller:
+       ``babylon-tick::prepare_rules``'s ``TypeEnv`` construction seeds one
+       ``<edge-type>/strength`` row per ``defvocabulary EdgeType`` member
+       the scenario declares — keyed off ``scenario.vocabulary``, NOT
+       ``scenario.edge_types`` (the hydration census the scout dossier's
+       own text pointed at) — and refuses an explicit ``deffield``
+       re-declaring an implicit field as ``E-LOAD-001`` (D32's own named
+       violation, checked at the seeding site because ``scenario.rs``'s
+       simpler ``load_deffield`` has no notion of "implicit" to check
+       against). RULED, recorded honestly as a divergence rather than
+       smoothed over: seeding fires ONLY under a declared
+       ``(defvocabulary EdgeType …)`` block — a scenario declaring edges
+       with no ``defvocabulary`` at all gets NO seeding
+       (``scenario.vocabulary`` is ``None``, the opt-in-per-scenario
+       contract) — which NARROWS D32's unconditional "needs no
+       ``deffield``". Chosen for reuse of the already-tested
+       ``FieldRegistry`` machinery and the Phase-2 content-pack-registry
+       direction (``declarations.rs``'s own module doc), not because a
+       ``FieldDecl`` could not be built from the census directly (it
+       trivially could). The BARE accessor
+       (``field-of it <edge-type>/strength``, no aggregation) still works
+       without the declaration (``tick::bind_field_value``'s
+       unregistered-field fallback); only an UNWEIGHTED FOLD/aggregation
+       needs the seeding (``typecheck.rs::resolve_field`` hard-fails an
+       unknown field) — ``edge-lane-e2e.bscn``'s own
+       ``(defvocabulary EdgeType (SOLIDARITY))`` plus its Shape-1
+       ``(fold sum (edges …) (field-of it solidarity/strength))`` vector is
+       the requirement's positive, executed proof.
+   * - D140
+     - §2.6
+     - **T2 (issue #559), Task 3 — ``Element``'s cross-kind Ord RULED:
+       ``Node`` sorts before ``Edge``, by declaration order.** §2.6 defines
+       a total order WITHIN each query kind's own result set only — it is
+       silent on comparing a ``Node`` to an ``Edge``, and no production
+       ``materialize()`` call ever mixes kinds (``edges`` returns only
+       ``Edge`` elements; ``nodes``/``neighbors`` only ``Node``), so the
+       cross-kind order is UNREACHABLE in production by construction —
+       pinned anyway, per the enum's own standing instruction (CT4P A5,
+       issue #525): an arbitrary but DELIBERATE, DOCUMENTED, TESTED choice
+       (``query.rs::tests::node_sorts_before_edge_regardless_of_id``
+       value-pins kind-dominates-value), never silently inherited from
+       wherever ``#[derive(Ord)]``'s declaration order happens to put a new
+       arm. Companion ruling at the same landing: ``Element`` drops
+       ``Copy`` (``EdgeKey`` owns a ``String``); the nine Copy-dependent
+       call sites (five ``for &element in …`` loops, one index-and-move,
+       three ``to_value()`` receivers resolved by the ``&self`` signature
+       change) were fixed by enumeration, plus one test-module
+       exhaustiveness arm the enum's own compile-time trip-wire
+       (``element_kind_name``) forced — exactly the conscious-decision
+       mechanism that trip-wire exists to fire.
+   * - D141
+     - §2.10, §2.9
+     - **T2 (issue #559), Task 1 — ``GraphSubstrate::edge_attribute`` takes
+       the FULL QNAME, checks ONLY the ``/strength`` suffix, and NEVER the
+       owner segment.** The one new substrate method mirrors
+       ``node_attribute``'s own convention exactly: ``attribute`` is the
+       full qname (e.g. ``"solidarity/strength"``), never a bare segment.
+       What IS checked: the qname must END IN ``/strength`` — T2 stores
+       exactly one value per edge (D32's implicit field, already hashed in
+       ``CanonicalState`` section ``0x03``), so any other edge-owned qname
+       reads as "never written", the SAME ``GraphError`` shape a
+       never-written node field gives — which buys ``field_of_edge`` a
+       zero-special-casing ``E-EVAL-033`` unification (declared-but-
+       unstored and never-written degrade identically). What is NOT
+       checked: whether the qname's OWNER segment actually names
+       ``edge_type`` — deliberately, exactly as ``node_attribute`` performs
+       no ownership check of its own; that half of §2.10 discipline 1 is
+       the CALLER's obligation (``field_of_edge``'s
+       ``check_edge_referent_type``, upstream of every call), the same
+       division of labor ``node_attribute``/``check_node_referent_type``
+       already have — pinned as deliberate by the shared conformance row
+       ``edge_attribute_does_not_check_the_owner_segment`` (both backends)
+       so a future reader does not "fix" the suffix check into an owner
+       check by surprise. The suffix test is a plain string test, not a
+       call into ``babylon-bsl::vocabulary::render_member`` —
+       ``babylon-graph`` sits BELOW ``babylon-bsl`` in the crate graph and
+       cannot import it. T3 (ADR198 R1) must PRESERVE this contract when it
+       widens storage: the suffix check widens to a real
+       per-``(edge, qname)`` lookup, ownership validation stays the
+       caller's job, and the SIGNATURE does not change.
+   * - D142
+     - §2.10
+     - **T2 (issue #559), Task 7 — the ``the`` disposition: NOT folded into
+       T2; its own micro-train (T2.5), because serving it surfaces an
+       unscoped load-pipeline design gap.** ``the``'s spec-normative
+       load-time legality gate — ``E-LOAD-043`` (declared ``:ceiling``
+       other than 1) and ``E-LOAD-045`` (no manifest row) — is implemented
+       ONLY in ``babylon-bsl/src/manifest.rs``'s
+       ``Manifest``/``check_rule_against_manifest``, exercised ONLY by
+       ``tests/r9_chapters.rs``'s own test-only harness:
+       ``rule_pipeline.rs`` and ``babylon-tick/src/lib.rs`` reference
+       ``manifest``/``Manifest`` NOWHERE outside comments (re-executed at
+       this row's landing: three comment hits,
+       ``rule_pipeline.rs:339,356,384``, zero calls; zero hits at all in
+       ``babylon-tick``'s driver). The production driver builds
+       ``CardinalityCeilings`` straight from the scenario's own hydrated
+       node/edge COUNTS, never from a declared ``(manifest …)`` form's
+       ``:ceiling`` row — so ``the``'s legality check is NOT REACHABLE
+       through ``run_once_into`` at all today, in either direction (no
+       check fires, and no declared-ceiling concept exists to check
+       against). Serving ``the`` for real therefore needs a design decision
+       T2's dyadic-edge-focused charter does not license: either (a) wire
+       the ``(manifest …)`` form into the load pipeline — new surface,
+       non-trivial — or (b) redefine ``the``'s load-time legality against
+       the ALREADY-wired census number — a real semantic choice (the two
+       numbers coincide today by accident and diverge the moment a scenario
+       declares a larger-than-hydrated ceiling). That choice deserves its
+       own scoped review: issue #572 stays OPEN for the T2.5 micro-train,
+       with ADR201 as the evidence record — a stronger reason than #572's
+       original framing, which reasoned only from ``the``'s lack of
+       technical dependency on ``EdgeKey``.
 
 See Also
 ----------

--- a/docs/superpowers/plans/2026-08-12-t2-slice2-edge-reads-plan.md
+++ b/docs/superpowers/plans/2026-08-12-t2-slice2-edge-reads-plan.md
@@ -39,9 +39,11 @@ train's scope — see the disposition record, Task 7.
 
 ## Amendment log
 
-- **2026-08-12 — Task 6a: the `load_edge` Coefficient-strength widening; Task 6's fixture
+- **2026-08-12 — Task 6a: the `load_edge` strength-literal widening; Task 6's fixture
   literals `c`-suffixed.** Task 6's fixtures as first merged could not load — execution-proven
-  through the real `run_once_into` seam, twice over: a bare `0.125` strength cannot LEX
+  through the real driver seam (`run_once`, `babylon-tick/src/lib.rs:72`, whose `run_once_into`
+  core at `:330` funnels through `prepare_rules` → `load_scenario`, `:126`), twice over: a bare
+  `0.125` strength cannot LEX
   (`E-LEX-021`, "a non-integer literal requires a kind suffix ($, p, i, c) — §1.5",
   `reader.rs:774`), and the lex repair `0.125c` is refused by the loader's deliberate int-only
   strength restriction (`rust/crates/babylon-bsl/src/scenario.rs:1325-1336`, its own comment:
@@ -57,6 +59,27 @@ train's scope — see the disposition record, Task 7.
   `<edge-type>/strength`), every other literal kind stays refused, and every `(edge …)` strength
   literal in Task 6's fixture is now `c`-suffixed. No expected value, shape, or store-domain
   argument changed — each suffixed literal converts bit-exactly (Task 6a design decision 2).
+
+- **2026-08-12 (fix round) — Task 6a's scope adjudicated to KIND-BLIND `p`/`i`/`c` (reviewer
+  MAJOR-1, option (i)); supersedes the previous entry's scope clause.** The first amendment's
+  `c`-only scope was reviewed EXECUTE AFTER FIXES: its justification misread the node path
+  (`attribute_value_unit_interval` does not defer to the declaration — it takes the declared type
+  and deliberately ignores the literal's kind, `scenario.rs:1171-1177`, because kinds do not
+  survive evaluation) and never examined the runtime writer of the same position
+  (`structural_verbs.rs::add_edge` accepts any `Value::Real` at `:strength`, `:929-936` —
+  kind-blind for the same reason). `c`-only would have minted a new bidirectional load/runtime
+  divergence; the ruling is now: hydration mirrors the runtime writer — int + `p`/`i`/`c`
+  accepted, `r`/`$` refused (both also refused by the runtime `:strength` match, which takes only
+  `Value::Real`). Citation repairs landed in the same round: the conversion-site census corrected
+  to eight existing inline sites + Task 6a's ninth (with the DRY tradeoff owned explicitly),
+  `E-LEX-024` cited at its constructor/fire sites (`reader.rs:877-883`/`:887,:889,:893`),
+  `attribute_value_unit_interval`'s span extended to `:1210-1261`, §3.9 clause 1
+  (`bsl-language.rst:3042-3045`) added as design decision 3's spec hook, the remaining
+  int-at-hydration vs. runtime-`Value::Int`-refusal divergence recorded beside that open
+  question, the driver-seam naming corrected (`run_once`, `lib.rs:72`), and Task 6a added to the
+  Sequencing-note and PR-grouping enumerations of PR B. Two reviewer citations were themselves
+  corrected against a fresh Read during the fix round: `evaluator.rs:382` IS the p/i/c division
+  line (`:381` is its `#[allow]`), and E-LEX-024's fire sites are `:887`/`:889`/`:893`.
 
 ## Global Constraints
 
@@ -111,7 +134,10 @@ narrow, mechanical, and low-risk (a one-line-per-backend trait method plus a ~15
 function) — it can land and be reviewed fast, derisking the foundation before the semantically
 loaded evaluator work. Within PR B, Tasks 3-5 land in that order because `field_of_edge`
 (Task 5) pattern-matches on `Value::EdgeRef`, which Task 3 mints, and reuses the cost/referent-type
-machinery Task 4 establishes the shape for.
+machinery Task 4 establishes the shape for. Task 6a (amendment, 2026-08-12) lands after Task 5 and
+before Task 6, inside PR B: a hydration-loader widening rides in the evaluator PR because Task 6's
+fixtures cannot load without it — split out on its own, either PR would be unshippable alone (a
+loader widening with no consumer, then an e2e task whose fixture is plan-blocked).
 
 ---
 
@@ -1342,7 +1368,7 @@ fn field_of_edge(key: &EdgeKey, qname: &str, env: &EvalEnv<'_>) -> Result<Value,
 - [ ] **Step 5: Six legs + commit** `feat(bsl): field_of_edge — field-of over an EdgeRef, generic
   over any edge-owned qname (T2 slice 2)`.
 
-### Task 6a: Widen `load_edge` — `c`-suffixed Coefficient strength literals (amendment, 2026-08-12)
+### Task 6a: Widen `load_edge` — unit-interval (`p`/`i`/`c`) strength literals (amendment, 2026-08-12)
 
 **Sequencing:** runs BEFORE Task 6 (lettered, not renumbered, so every existing cross-reference to
 Tasks 6/7 stays valid) — Task 6's fixture cannot load without this widening. See the Amendment log
@@ -1352,28 +1378,45 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
 
 **Files:**
 - Modify: `rust/crates/babylon-bsl/src/scenario.rs` (`load_edge`'s strength match, `:1325-1336`;
-  its fn doc comment, `:1282-1284`; the destructure-refusal shape string, `:1297`; two new tests in
-  the same file's own `#[cfg(test)] mod tests` — the ONLY file this task touches)
+  its fn doc comment, `:1282-1284`; the destructure-refusal shape string, `:1297`; three new tests
+  in the same file's own `#[cfg(test)] mod tests` — the ONLY file this task touches)
 
 **Interfaces:**
 - Produces: `load_edge` accepting, in the strength position, exactly (a) integer literals — the
-  existing arm, byte-for-byte unchanged — and (b) `c`-suffixed Coefficient scaled literals
-  (`Atom::Scaled(ScaledLit { kind: ScaledKind::Coefficient, .. })`), converted
-  `unscaled / 10^scale`. Every other literal stays refused, loudly.
+  existing arm, byte-for-byte unchanged — and (b) `p`/`i`/`c`-suffixed unit-interval scaled
+  literals, KIND-BLIND among the three (adjudicated in the 2026-08-12 fix round — reviewer
+  MAJOR-1, option (i)), converted `unscaled / 10^scale`. `r`-suffixed Ratio and `$`-suffixed
+  Currency literals stay refused, loudly — exactly as the runtime `:strength` position refuses
+  their evaluated forms.
 
 **Design decisions, made explicitly per the module's own standing conventions:**
 
-1. **Scope: int + Coefficient exactly, nothing else.** D32 rules `<edge-type>/strength` implicitly
-   declared on every `EdgeType` as `Coefficient`, `extensive` (`bsl-language.rst` register row D32,
-   §2.9) — hydration accepting exactly int + Coefficient literals aligns the loader with the ruled
-   kind. `p`/`i`-suffixed unit-interval literals, `r`-suffixed Ratio literals, and `$`-suffixed
-   Currency literals all stay refused, in one arm whose message names the two accepted forms. This
-   is DELIBERATELY NARROWER than the node-field seed path — `attribute_value_unit_interval`
-   (`scenario.rs:1210-1251`) is kind-blind among `p`/`i`/`c` because the runtime store check it
-   mirrors is kind-blind — and the asymmetry is principled, not accidental: a node field's declared
-   type is whatever its `deffield` says, so the seed path there defers to the declaration; the
-   strength position has exactly ONE ruled kind (D32), no `deffield` governs it (the existing
-   comment at `:1323-1324` stays true), so the loader can and should be exact. The refusal stays a
+1. **Scope: int + kind-blind `p`/`i`/`c` — ADJUDICATED (fix round 2026-08-12, reviewer MAJOR-1,
+   option (i)).** This task's first draft accepted `c` alone, reasoning from D32's kind ruling;
+   the adversarial review found that justification doubly wrong, and the controller adjudicated
+   kind-blind. The governing facts, all read directly: (a) the RUNTIME writer of this exact
+   position is kind-blind — `structural_verbs.rs::add_edge` (`:898`) accepts any `Value::Real` at
+   `:strength` (`:929-936`), and kinds do not survive evaluation at all (`evaluator.rs:378-384`:
+   every `p`/`i`/`c` literal becomes an untagged `Value::Real`), so that function's own `0.5c`
+   test fixtures (`structural_verbs.rs:1734,1790,1850,2028`) would behave identically written
+   `0.5p`; (b) the node-field seed path made the SAME choice for the SAME reason and RECORDED it —
+   `attribute_value_unit_interval` accepts any of the three suffixes for any of the three declared
+   unit-interval types precisely because the runtime store check it mirrors is kind-blind
+   (`scenario.rs:1171-1177` — it does not defer to the declaration; it takes the declared type and
+   deliberately ignores the literal's kind, because `Value::Real` carries no `p`/`i`/`c` tag once
+   evaluated); (c) a `c`-only loader would therefore have MINTED a new bidirectional load/runtime
+   divergence — `(add-edge … :strength 0.5p)` writes at runtime while `(edge … 0.5p)` would
+   refuse at hydration — the exact asymmetry class `attribute_value_unit_interval`'s own doc
+   forbids for rounding (`scenario.rs:1199-1203`: a scenario-seeded value and a rule-computed
+   write of the identical field must never follow two different rules). So hydration MIRRORS THE
+   RUNTIME WRITER, exactly as the node path does. D32 still kinds the field `Coefficient` — that
+   fact belongs in the code comment (and Task 6's fixture keeps `c` as the idiomatic spelling) —
+   but the refusal message must not imply c-only. What stays out, each also mirroring the runtime:
+   `r` (Ratio) — the node path's own recorded exclusion (`scenario.rs:1177-1184`: `Value::Ratio`
+   is a genuinely distinct runtime type with its own `(0, ∞)` domain, not the binary64 lane; the
+   runtime `:strength` match refuses it identically, since `:930-935` accepts only `Value::Real`)
+   — and `$` (Currency) — the `currency_refusal_message` precedent (`scenario.rs:1273-1280`; the
+   runtime refuses `Value::Currency` at `:strength` the same way). The refusal stays a
    PLAIN `err(...)` (code `None`), matching the arm it replaces (`:1331-1335`) — the `.bscn` dialect
    is spec-unpinned (D93), so no `E-LOAD` code exists to cite, and `coded_err` is reserved for
    §3.9-coded hydration failures (`E-LOAD-044`'s own comment, `:1338-1341`). For the same D93
@@ -1382,15 +1425,21 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
    Python grammar-sync guard is NOT needed for this task (nothing in `docs/reference/` moves).
 2. **Conversion: `unscaled as f64 / 10_f64.powi(i32::from(scale))` — the crate's ONE conversion
    contract, copied verbatim, never re-derived.** There is no named helper to call — verified by
-   direct reading, the arithmetic appears inline at every door a scaled literal enters by:
-   `attribute_value_unit_interval` (`scenario.rs:1240-1242`), `load_defconst` (`:521-523`),
+   direct reading, the arithmetic appears inline at EIGHT existing sites (fix-round census,
+   MINOR-1): `attribute_value_unit_interval`'s p/i/c arm (`scenario.rs:1240-1242`) AND its
+   Ratio-refusal arm's message-building division (`:1228-1230`), `load_defconst` (`:521-523`),
    `ratio_from_scaled` (`:744`), `tick.rs::atom_to_value` (`:392-395`), `rule_pipeline.rs:529`,
-   `evaluator.rs:363,382`. `attribute_value_unit_interval`'s own doc comment (`:1186-1209`) is the
+   and `evaluator.rs`'s two atom arms (`:363` Ratio, `:382` p/i/c — `:382` IS the division line,
+   Read-verified against the fix round's own citation: `:381` is its `#[allow]`, `:383` its
+   `Ok(Value::Real(value))`). `attribute_value_unit_interval`'s own doc comment (`:1186-1209`) is the
    contract's normative home: one correctly-rounded IEEE-754 division of two exactly-representable
    operands (`unscaled` as an integer, `10^scale` exact in f64 for `scale <= 9`, the literal's own
    lex bound `E-LEX-023`), deliberately NOT `babylon_kernel::grid::quantize` — read that comment
-   before writing the arm; this task adds the seventh inline site, same three lines, same
-   `#[allow(clippy::cast_precision_loss)]`. Every fixture strength in Task 6 (`0.125`, `0.03125`,
+   before writing the arm; this task adds the NINTH inline site, same three lines, same
+   `#[allow(clippy::cast_precision_loss)]`. That is a real DRY tradeoff, owned deliberately:
+   extracting a shared helper across nine sites is a refactor with its own blast radius,
+   out of this amendment's surgical scope — the post-port refactor program's D-record ledger is
+   where that extraction belongs if it ever earns its cost. Every fixture strength in Task 6 (`0.125`, `0.03125`,
    `0.015625`, `0.0625`, `0.1875`, `0.25`) and both fold expecteds (`0.796875`, `0.375`) are dyadic
    rationals exactly representable in binary64, so the correctly-rounded division returns each one
    BIT-EXACTLY (a correctly-rounded op whose true result is representable returns it exactly —
@@ -1402,15 +1451,26 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
    neither backend's `add_edge` checks either (`memory.rs:147-167`, `hypergraph_store.rs:194-215`
    — both insert the f64 as given). Mirroring that law, the new scaled arm mints NO range check in
    `load_edge` — and needs none: the LEXER already bounds every `p`/`i`/`c` literal to `[0,1]`
-   (`E-LEX-024`, `reader.rs:171`, fire site `:877-883`), so a `c`-suffixed strength arrives
+   (`E-LEX-024`: the constructor closure `out_of_range`, `reader.rs:877-883`; fire sites `:887`,
+   `:889`, `:893` — Read-verified against the fix round's own citation, which was off by
+   one), so a `p`/`i`/`c`-suffixed strength arrives
    in-domain by construction. The resulting asymmetry — an int strength of `5` loads today while
    `5c` cannot even lex — PRE-EXISTS in the lexer (bare ints carry no lex-time domain, the same
    fact `attribute_value_unit_interval`'s Int arm documents at `:1217-1222`, where the node path's
-   load-time `[0,1]` check catches it; the strength position has no such check) and is recorded
+   load-time `[0,1]` check catches it — that check, `:1252-1259`, is the load-bearing tail of the
+   fn's full `:1210-1261` span (MINOR-5); the strength position has no such check) and is recorded
    here as an OPEN QUESTION for a future ruling, deliberately not resolved by this task: D32 rules
-   the field Coefficient-kinded (`[0,1]`) yet out-of-`[0,1]` int strengths load — tightening the
+   the field Coefficient-kinded (`[0,1]`) yet out-of-`[0,1]` int strengths load — and §3.9
+   clause 1 (`bsl-language.rst:3042-3045`, hydration "creates elements of declared types and
+   writes declared fields, and nothing else") is the spec hook that makes this a real OWED
+   ruling rather than a mere curiosity: an out-of-domain write into a Coefficient-ruled field
+   sits poorly against that clause. Tightening the
    int arm could refuse previously-loadable content and is a separate, content-auditable ruling,
-   not a side effect to smuggle into a literal-kind widening.
+   not a side effect to smuggle into a literal-kind widening. One MORE divergence remains under
+   the kind-blind widening, pre-existing and recorded beside this same open question rather than
+   resolved: an int strength LOADS at hydration while the runtime `:strength` position refuses
+   `Value::Int` outright (`structural_verbs.rs:929-936` accepts only `Value::Real`) — whatever
+   future ruling settles the int arm's domain owns both halves of that divergence too.
 4. **Test placement: `scenario.rs`'s own `#[cfg(test)] mod tests`, where every existing `load_edge`
    test lives** (`an_edge_to_an_undeclared_name_is_loud` `:1450`,
    `load_edge_demands_edgetype_regardless_of_what_is_declared` `:2744`,
@@ -1422,8 +1482,9 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
    refusals; `to_bits()` pins, never tolerances, for seeded values. The module's existing imports
    already cover everything needed (`load_scenario` `:1359`, `MemoryGraph` `:1367`,
    `GraphSubstrate`/`NodeId` `:1369`); `ScaledKind` is already imported by the non-test code
-   (`:61`). Note the loader-level test IS the real seam's own function: `run_once_into`'s
-   `prepare_rules` calls this same `load_scenario` (`babylon-tick/src/lib.rs:126`), and Task 6's
+   (`:61`). Note the loader-level test IS the real seam's own function: the driver funnel —
+   `run_once` (`babylon-tick/src/lib.rs:72`) → `run_once_into` (`:330`) → `prepare_rules`
+   (called at `:336`) — reaches this same `load_scenario` (`:126`), and Task 6's
    e2e vectors then re-prove the widening end-to-end through `run_once_into` itself.
 
 - [ ] **Step 1: Red — the widening test.** In `scenario.rs`'s test module, after
@@ -1466,8 +1527,9 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
 - [ ] **Step 2: Run it RED.** Expected exact failure: the `unwrap()` panics on
   `` Err(ScenarioError { message: "edge SOLIDARITY: expected an integer strength literal, found
   Scaled(ScaledLit { kind: Coefficient, unscaled: 125, scale: 3 })", code: None }) `` — the same
-  refusal already execution-proven through `run_once_into` (whose `prepare_rules` calls this same
-  `load_scenario`), byte for byte. `0.125c` canonicalizes to `unscaled: 125, scale: 3` (§1.5
+  refusal already execution-proven through the real driver (`run_once`, `lib.rs:72`, funneling
+  through `run_once_into` `:330` → `prepare_rules` `:336` → this same `load_scenario`, `:126`),
+  byte for byte. `0.125c` canonicalizes to `unscaled: 125, scale: 3` (§1.5
   minimal-scale canonicalization, `reader.rs:134-148`).
 
 - [ ] **Step 3: The minimal widening.** Replace the strength match (`scenario.rs:1323-1336`,
@@ -1476,22 +1538,31 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
 ```rust
     // An edge strength is not a node field, so no deffield governs it; the
     // literal restriction is stated directly here: an integer, or a
-    // c-suffixed Coefficient literal — D32's own ruled kind for
-    // <edge-type>/strength (T2 plan Task 6a, amendment 2026-08-12).
-    // Deliberately NARROWER than attribute_value_unit_interval's kind-blind
-    // p/i/c acceptance: a node field's type is whatever its deffield
-    // declares, but the strength position has exactly ONE ruled kind. No
-    // range check on either arm — ints were never checked here (an OPEN
-    // asymmetry, recorded in the T2 plan's Task 6a design decision 3, not
-    // silently resolved), and a c literal is already [0,1]-bounded at lex
-    // (E-LEX-024).
+    // p/i/c-suffixed unit-interval literal — KIND-BLIND among the three,
+    // mirroring both attribute_value_unit_interval (kinds do not survive
+    // evaluation; its doc records the choice) and the runtime writer of
+    // this exact position (structural_verbs.rs::add_edge accepts any
+    // Value::Real at :strength). D32 kinds the field Coefficient; the
+    // loader does not narrow to c-only because the runtime cannot (T2 plan
+    // Task 6a, amendment 2026-08-12, adjudicated in its fix round). Ratio
+    // (r) stays out for the node path's own recorded reason — Value::Ratio
+    // is not the binary64 lane, and the runtime :strength match refuses it
+    // identically. No range check on either arm — ints were never checked
+    // here (an OPEN asymmetry, recorded in the T2 plan's Task 6a design
+    // decision 3, not silently resolved), and a p/i/c literal is already
+    // [0,1]-bounded at lex (E-LEX-024).
     let strength = match strength {
         Atom::Int(value) => {
             #[allow(clippy::cast_precision_loss)]
             let widened = *value as f64;
             widened
         }
-        Atom::Scaled(scaled) if scaled.kind == ScaledKind::Coefficient => {
+        Atom::Scaled(scaled)
+            if matches!(
+                scaled.kind,
+                ScaledKind::Probability | ScaledKind::Intensity | ScaledKind::Coefficient
+            ) =>
+        {
             // `unscaled / 10^scale` — the crate's one scaled-literal
             // conversion contract (attribute_value_unit_interval's doc
             // comment is its normative home), copied verbatim.
@@ -1501,37 +1572,69 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
         }
         other => {
             return Err(err(format!(
-                "edge {member}: expected an integer or c-suffixed Coefficient \
-                 strength literal (D32 rules <edge-type>/strength \
-                 Coefficient-kinded), found {other:?}"
+                "edge {member}: expected an integer or p/i/c-suffixed \
+                 unit-interval strength literal, found {other:?}"
             )))
         }
     };
 ```
 
+  (The three `ScaledKind` variant names are Read-verified against `reader.rs:123-132`:
+  `Probability`/`Intensity`/`Coefficient`, plus `Ratio` which the guard deliberately omits.)
+
   Also update the two neighboring strings that still say `<int>`:
   - the fn doc comment (`:1282`): `` `(edge <enum-ref> <local-name> <local-name> <int>)` `` becomes
     `` `(edge <enum-ref> <local-name> <local-name> <strength>)` — `<strength>` is an int or a
-    `c`-suffixed Coefficient literal (D32's ruled kind; T2 plan Task 6a) `` (the rest of the doc
+    `p`/`i`/`c`-suffixed unit-interval literal (kind-blind, mirroring the runtime `:strength`
+    position; D32 kinds the field Coefficient; T2 plan Task 6a) `` (the rest of the doc
     sentence — the return-convention half — is unchanged);
   - the destructure-refusal shape string (`:1297`):
     `"expected (edge <EdgeType/MEMBER> <from-name> <to-name> <int>)"` becomes
-    `"expected (edge <EdgeType/MEMBER> <from-name> <to-name> <strength: int | c-lit>)"`.
+    `"expected (edge <EdgeType/MEMBER> <from-name> <to-name> <strength: int | p/i/c-lit>)"`.
 
 - [ ] **Step 4: GREEN.** Run Step 1's test — passes, the exact loaded f64 asserted bit-for-bit via
   `edge_attribute`. Re-run the whole `scenario.rs` test module: every existing test stays green
   (the int arm is byte-identical; nothing else in `load_edge` moved).
 
-- [ ] **Step 5: The refusal sweep — every kind that stays out, pinned per suffix.**
+- [ ] **Step 5: The kind sweep — the kind-blind half pinned GREEN, and every kind that stays out
+  pinned refused.** Two tests (the first is the fix round's own addition: without it, a
+  regression narrowing the guard back to c-only — the adjudication's REJECTED option — would
+  flip nothing):
 
 ```rust
     #[test]
-    fn a_non_coefficient_strength_literal_stays_refused() {
-        // Task 6a's kind gate, pinned per suffix: p/i/r are ScaledLit kinds
-        // the Coefficient guard refuses; $ (Currency) is a DIFFERENT Atom
-        // variant that falls to the same refusal arm without ever reaching
-        // the kind guard (see the Step-6 mutation split in the T2 plan).
-        for literal in ["0.125p", "0.125i", "0.5r", "1$"] {
+    fn a_probability_or_intensity_strength_literal_seeds_identically() {
+        // The kind-blind half of Task 6a's ruling (fix round, MAJOR-1
+        // option (i)), pinned GREEN: kinds do not survive evaluation
+        // (evaluator.rs's atom arm makes every p/i/c literal an untagged
+        // Value::Real), so hydration accepts p/i exactly as it accepts c —
+        // mirroring the runtime writer (structural_verbs.rs::add_edge, any
+        // Value::Real at :strength).
+        for literal in ["0.125p", "0.125i"] {
+            let source = format!(
+                "(scenario ft/kind-blind-strength\n  \
+                 (node core NodeType/SOCIAL_CLASS)\n  \
+                 (node periphery NodeType/SOCIAL_CLASS)\n  \
+                 (edge EdgeType/SOLIDARITY core periphery {literal}))"
+            );
+            let mut graph = MemoryGraph::new();
+            load_scenario(&source, &mut graph).unwrap();
+            let strength = graph
+                .edge_attribute("SOLIDARITY", NodeId(0), NodeId(1), "solidarity/strength")
+                .unwrap();
+            assert_eq!(strength.to_bits(), (0.125_f64).to_bits(), "{literal}");
+        }
+    }
+
+    #[test]
+    fn a_ratio_or_currency_strength_literal_stays_refused() {
+        // What stays out under the kind-blind widening, each mirroring the
+        // runtime :strength match (which accepts only Value::Real): r
+        // evaluates to Value::Ratio, $ to Value::Currency. r is a ScaledLit
+        // kind the guard refuses; $ (Currency) is a DIFFERENT Atom variant
+        // that falls to the same refusal arm without ever reaching the kind
+        // guard (see the Step-6 mutation split in the T2 plan).
+        for literal in ["0.5r", "1$"] {
             let source = format!(
                 "(scenario ft/wrong-kind-strength\n  \
                  (node core NodeType/SOCIAL_CLASS)\n  \
@@ -1542,7 +1645,7 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
             let err = load_scenario(&source, &mut graph).unwrap_err();
             assert!(
                 err.message.contains(
-                    "expected an integer or c-suffixed Coefficient strength literal"
+                    "expected an integer or p/i/c-suffixed unit-interval strength literal"
                 ),
                 "{literal}: {}",
                 err.message
@@ -1551,21 +1654,29 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
     }
 ```
 
-  The `$` row's exact full message is `` edge SOLIDARITY: expected an integer or c-suffixed
-  Coefficient strength literal (D32 rules <edge-type>/strength Coefficient-kinded), found
-  Currency(Currency(1000000)) `` (`Atom::Currency` wraps `babylon_kernel::Currency(i128)` in
-  micro-units — `1$` = 1,000,000 micro-units; both derive `Debug`, `currency.rs:35-36`). The
+  The `$` row's exact full message is `` edge SOLIDARITY: expected an integer or p/i/c-suffixed
+  unit-interval strength literal, found Currency(Currency(1000000)) `` (`Atom::Currency` wraps
+  `babylon_kernel::Currency(i128)` in
+  micro-units — `1$` = 1,000,000 micro-units; both derive `Debug`, `currency.rs:35-36`); the
+  `0.5r` row's Debug tail is `` Scaled(ScaledLit { kind: Ratio, unscaled: 5, scale: 1 }) `` (§1.5
+  minimal-scale canonicalization: `0.5` → `5 / 10^1`). The
   assertion pins the stable head via `.contains`, matching every sibling refusal test in this
   module — no existing test pins the `{other:?}` Debug tail today either (verified: nothing
   asserts on the current "found Scaled(…)" tail).
 
-- [ ] **Step 6: Mutation evidence — the guard, split honestly.** Delete the
-  `if scaled.kind == ScaledKind::Coefficient` guard (accepting every scaled kind) → Step 5's
-  `0.125p`/`0.125i`/`0.5r` rows flip RED (each now loads and the `unwrap_err` panics) while its
-  `1$` row and Step 1's test stay green — the pair proving the guard is the kind gate and that
-  Currency's refusal never rode it (`Atom::Currency` is a different VARIANT; no mutation of the
-  kind guard alone can accept a `$` literal, which is why the sweep pins it separately). Restore
-  byte-identical.
+- [ ] **Step 6: Mutation evidence — the guard, proven in BOTH directions, split honestly.**
+  - **Mutation A (widen):** append `| ScaledKind::Ratio` to the guard's `matches!` list → the
+    `0.5r` row of `a_ratio_or_currency_strength_literal_stays_refused` flips RED (`0.5r` now
+    converts `5 / 10^1` and loads, so its `unwrap_err` panics) while the `1$` row stays green
+    (`Atom::Currency` is a different VARIANT; no mutation of the kind guard alone can accept a
+    `$` literal, which is why the sweep pins it separately), and Step 1's test plus the p/i
+    companion stay green too. Restore byte-identical.
+  - **Mutation B (narrow — the adjudication's rejected option):** shrink the guard to
+    `scaled.kind == ScaledKind::Coefficient` → both rows of
+    `a_probability_or_intensity_strength_literal_seeds_identically` flip RED (each `unwrap()`
+    panics on the refusal) while Step 1's `0.125c` test and both refusal rows stay green — the
+    kind-blind ruling is mutation-provable in both directions, not just at the Ratio boundary.
+    Restore byte-identical.
 
 - [ ] **Step 7: Goldens + the six-leg gate.** All seven pins (six `tick_goldens.rs` +
   `engine_link.rs`) must stay byte-identical — structurally guaranteed here, twice over: the int
@@ -1574,8 +1685,8 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
   `rg -n "\(edge " rust/crates/babylon-tick/content/scenarios/*.bscn` shows integer literals
   only). Run the full six-leg gate anyway — the gate is the proof, not the assumption.
 
-- [ ] **Step 8: Commit** `feat(bsl): load_edge accepts c-suffixed Coefficient strength literals
-  (D32-aligned, T2 Task 6a)`.
+- [ ] **Step 8: Commit** `feat(bsl): load_edge accepts p/i/c unit-interval strength literals
+  (runtime-mirroring kind-blind widening, T2 Task 6a)`.
 
 ### Task 6: The e2e vectors
 
@@ -1599,7 +1710,9 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
   exactly in binary64, which is the property that matters here; no bit-pinning needed), and
   every FOLD SUM below is now re-verified to land inside `[0,1]`. **Every strength literal is
   `c`-suffixed (Task 6a, amendment 2026-08-12):** a bare decimal cannot LEX at all (`E-LEX-021`),
-  and post-6a `load_edge` accepts exactly int + `c`-suffixed Coefficient strength literals — the
+  and post-6a `load_edge` accepts int + `p`/`i`/`c`-suffixed unit-interval strength literals
+  (kind-blind, mirroring the runtime `:strength` writer — Task 6a's fix-round adjudication; `c`
+  stays this fixture's idiomatic spelling, since D32 kinds the field Coefficient) — the
   suffix changes NO value (each literal converts bit-exactly, Task 6a design decision 2), and
   `E-LEX-024` additionally bounds each literal to `[0,1]` at lex, one gate upstream of the
   `E-EVAL-020` store-domain argument above:
@@ -1828,8 +1941,8 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
      the int arm is byte-identical, and no shipped scenario CAN contain a scaled strength literal
      — one could not have LOADED before 6a (the pre-6a int-only refusal is execution-proven; the
      landed Task 2 probe's own fallback to an int strength `1`, `babylon-tick/src/lib.rs:458`, is
-     its in-tree trace) — so the new Coefficient arm is exercised by nothing but Task 6's own new
-     fixture, which backs no golden.
+     its in-tree trace) — so the new unit-interval arm is exercised by nothing but Task 6's own
+     new fixture, which backs no golden.
 
   Run, unmodified: all six `tick_goldens.rs` pins (`two_classes_fundamental_theorem_hashes_are_pinned`,
   `vitality_conformance_hashes_are_pinned`, `us_counties_lifecycle_demo_hashes_are_pinned`,
@@ -1907,9 +2020,12 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
   D32 wiring site and its correction of the dossier's own `scenario.edge_types` pointer (Task 2),
   the `EdgeKey`/`Value::EdgeRef`/`Element::Edge` additions and the cross-kind Ord ruling (Task 3),
   the three-file edges-refusal sweep (Task 3 Step 7), `eval_edge_between`/`field_of_edge`
-  (Tasks 4-5), the `load_edge` Coefficient-strength widening (Task 6a, amendment 2026-08-12 —
-  hydration's int-only strength restriction lifted for exactly D32's ruled kind, all other literal
-  kinds still refused, the int-arm range-check asymmetry recorded as an open question; per D93 the
+  (Tasks 4-5), the `load_edge` strength-literal widening (Task 6a, amendment 2026-08-12,
+  adjudicated KIND-BLIND `p`/`i`/`c` in its fix round — hydration mirrors
+  `structural_verbs.rs::add_edge`'s own kind-blind `:strength` rule, and `r`/`$` stay refused
+  exactly as the runtime refuses their evaluated forms; the int-arm open questions — no range
+  check, and int loading at hydration while the runtime `:strength` refuses `Value::Int` — are
+  recorded, not resolved; per D93 the
   widening minted no register row, so ADR201 and the plan's Amendment log are its record homes),
   the three e2e vectors (Task 6), the hash-free proof (Step 1), and the `the`
   disposition finding (Step 3) — filed as the evidence issue #572's own comment references. **Also
@@ -1941,7 +2057,10 @@ substrate half); merges alone so PR B's evaluator work reviews against a stable,
 foundation — matching the Territory port plan's own PR-A/PR-B split rationale (a babylon-bsl-
 adjacent surface slice merging first so the larger content-facing PR reviews against something
 already settled). **PR B (Tasks 3-7), branch `feat/t2-edge-reads-evaluation`:** the `Value`/
-`Element` additions, the three evaluator functions, the e2e proof, and the closing records. Kept as
+`Element` additions, the three evaluator functions, the Task 6a `load_edge` strength-literal
+widening (amendment, 2026-08-12 — a hydration widening riding in the evaluator PR because Task 6's
+fixtures cannot load without it; splitting it out would ship a plan-blocked PR), the e2e proof, and
+the closing records. Kept as
 ONE PR (not split further) because `edges`/`edge-between`/`field-of-over-EdgeRef` share one minted
 type (`EdgeKey`) and one Ord ruling that only makes sense read together — splitting further would
 leave a variant nothing yet constructs mid-review, which `query.rs`'s own doc calls "dead weight,

--- a/docs/superpowers/plans/2026-08-12-t2-slice2-edge-reads-plan.md
+++ b/docs/superpowers/plans/2026-08-12-t2-slice2-edge-reads-plan.md
@@ -37,6 +37,27 @@ train's scope — see the disposition record, Task 7.
   `edge_lane_e2e.rs` (Task 6) follows exactly: real driver, hand-derived expecteds, a shared
   discriminator-scoped fixture, a same-file determinism test.
 
+## Amendment log
+
+- **2026-08-12 — Task 6a: the `load_edge` Coefficient-strength widening; Task 6's fixture
+  literals `c`-suffixed.** Task 6's fixtures as first merged could not load — execution-proven
+  through the real `run_once_into` seam, twice over: a bare `0.125` strength cannot LEX
+  (`E-LEX-021`, "a non-integer literal requires a kind suffix ($, p, i, c) — §1.5",
+  `reader.rs:774`), and the lex repair `0.125c` is refused by the loader's deliberate int-only
+  strength restriction (`rust/crates/babylon-bsl/src/scenario.rs:1325-1336`, its own comment:
+  "the int-literal restriction is stated directly here"; the `.bscn` dialect is spec-unpinned per
+  D93, so this is a loader fact, not a spec fact — and the already-LANDED Task 2 probe hit the
+  same wall at execution time, falling back to an int strength `1` where this plan's Task 2 text
+  still shows `0.5`, `babylon-tick/src/lib.rs:458`). The fractional strengths are load-bearing
+  (Shape 1/2a/3's expecteds `0.796875`/`0.03125`/`0.375` and the Blocker-2 coefficient
+  store-domain arithmetic), and pre-seeding edges on the graph before `run_once_into` would
+  bypass the hydration seam these vectors exist to prove — so Task 6a (inserted before Task 6;
+  nothing renumbered, so every existing cross-reference stays valid) rules the widening:
+  `load_edge` accepts int + `c`-suffixed Coefficient strength literals (D32's own ruled kind for
+  `<edge-type>/strength`), every other literal kind stays refused, and every `(edge …)` strength
+  literal in Task 6's fixture is now `c`-suffixed. No expected value, shape, or store-domain
+  argument changed — each suffixed literal converts bit-exactly (Task 6a design decision 2).
+
 ## Global Constraints
 
 - **Port-as-is discipline does not apply here** — T2 is new language surface, not a transcription
@@ -1321,6 +1342,241 @@ fn field_of_edge(key: &EdgeKey, qname: &str, env: &EvalEnv<'_>) -> Result<Value,
 - [ ] **Step 5: Six legs + commit** `feat(bsl): field_of_edge — field-of over an EdgeRef, generic
   over any edge-owned qname (T2 slice 2)`.
 
+### Task 6a: Widen `load_edge` — `c`-suffixed Coefficient strength literals (amendment, 2026-08-12)
+
+**Sequencing:** runs BEFORE Task 6 (lettered, not renumbered, so every existing cross-reference to
+Tasks 6/7 stays valid) — Task 6's fixture cannot load without this widening. See the Amendment log
+at the top of this plan for the execution-proven impossibility that forced it; the landed Task 2
+probe already hit the same wall and fell back to an int strength `1` (`babylon-tick/src/lib.rs:458`,
+where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is executed history).
+
+**Files:**
+- Modify: `rust/crates/babylon-bsl/src/scenario.rs` (`load_edge`'s strength match, `:1325-1336`;
+  its fn doc comment, `:1282-1284`; the destructure-refusal shape string, `:1297`; two new tests in
+  the same file's own `#[cfg(test)] mod tests` — the ONLY file this task touches)
+
+**Interfaces:**
+- Produces: `load_edge` accepting, in the strength position, exactly (a) integer literals — the
+  existing arm, byte-for-byte unchanged — and (b) `c`-suffixed Coefficient scaled literals
+  (`Atom::Scaled(ScaledLit { kind: ScaledKind::Coefficient, .. })`), converted
+  `unscaled / 10^scale`. Every other literal stays refused, loudly.
+
+**Design decisions, made explicitly per the module's own standing conventions:**
+
+1. **Scope: int + Coefficient exactly, nothing else.** D32 rules `<edge-type>/strength` implicitly
+   declared on every `EdgeType` as `Coefficient`, `extensive` (`bsl-language.rst` register row D32,
+   §2.9) — hydration accepting exactly int + Coefficient literals aligns the loader with the ruled
+   kind. `p`/`i`-suffixed unit-interval literals, `r`-suffixed Ratio literals, and `$`-suffixed
+   Currency literals all stay refused, in one arm whose message names the two accepted forms. This
+   is DELIBERATELY NARROWER than the node-field seed path — `attribute_value_unit_interval`
+   (`scenario.rs:1210-1251`) is kind-blind among `p`/`i`/`c` because the runtime store check it
+   mirrors is kind-blind — and the asymmetry is principled, not accidental: a node field's declared
+   type is whatever its `deffield` says, so the seed path there defers to the declaration; the
+   strength position has exactly ONE ruled kind (D32), no `deffield` governs it (the existing
+   comment at `:1323-1324` stays true), so the loader can and should be exact. The refusal stays a
+   PLAIN `err(...)` (code `None`), matching the arm it replaces (`:1331-1335`) — the `.bscn` dialect
+   is spec-unpinned (D93), so no `E-LOAD` code exists to cite, and `coded_err` is reserved for
+   §3.9-coded hydration failures (`E-LOAD-044`'s own comment, `:1338-1341`). For the same D93
+   reason this task edits NO `bsl-language.rst` text and mints NO register row — the record homes
+   are ADR201 (Task 7 Step 4's amended records list) and this plan's own Amendment log — and the
+   Python grammar-sync guard is NOT needed for this task (nothing in `docs/reference/` moves).
+2. **Conversion: `unscaled as f64 / 10_f64.powi(i32::from(scale))` — the crate's ONE conversion
+   contract, copied verbatim, never re-derived.** There is no named helper to call — verified by
+   direct reading, the arithmetic appears inline at every door a scaled literal enters by:
+   `attribute_value_unit_interval` (`scenario.rs:1240-1242`), `load_defconst` (`:521-523`),
+   `ratio_from_scaled` (`:744`), `tick.rs::atom_to_value` (`:392-395`), `rule_pipeline.rs:529`,
+   `evaluator.rs:363,382`. `attribute_value_unit_interval`'s own doc comment (`:1186-1209`) is the
+   contract's normative home: one correctly-rounded IEEE-754 division of two exactly-representable
+   operands (`unscaled` as an integer, `10^scale` exact in f64 for `scale <= 9`, the literal's own
+   lex bound `E-LEX-023`), deliberately NOT `babylon_kernel::grid::quantize` — read that comment
+   before writing the arm; this task adds the seventh inline site, same three lines, same
+   `#[allow(clippy::cast_precision_loss)]`. Every fixture strength in Task 6 (`0.125`, `0.03125`,
+   `0.015625`, `0.0625`, `0.1875`, `0.25`) and both fold expecteds (`0.796875`, `0.375`) are dyadic
+   rationals exactly representable in binary64, so the correctly-rounded division returns each one
+   BIT-EXACTLY (a correctly-rounded op whose true result is representable returns it exactly —
+   e.g. `125/1000` is exactly `0.125 = 2^-3`); no tolerance appears anywhere in this lane.
+3. **Range law: MIRRORED, meaning NO new check.** Today's int path range-checks NOTHING — verified
+   by direct reading: `scenario.rs:1325-1330` widens any `i64` with a bare `as f64` (so
+   `(edge … 5)` loads as `5.0`, `(edge … -1)` as `-1.0`; unlike `attribute_value_int`'s own
+   `2^53` exactness guard at `:1150-1153`, the strength arm does not even bound magnitude), and
+   neither backend's `add_edge` checks either (`memory.rs:147-167`, `hypergraph_store.rs:194-215`
+   — both insert the f64 as given). Mirroring that law, the new scaled arm mints NO range check in
+   `load_edge` — and needs none: the LEXER already bounds every `p`/`i`/`c` literal to `[0,1]`
+   (`E-LEX-024`, `reader.rs:171`, fire site `:877-883`), so a `c`-suffixed strength arrives
+   in-domain by construction. The resulting asymmetry — an int strength of `5` loads today while
+   `5c` cannot even lex — PRE-EXISTS in the lexer (bare ints carry no lex-time domain, the same
+   fact `attribute_value_unit_interval`'s Int arm documents at `:1217-1222`, where the node path's
+   load-time `[0,1]` check catches it; the strength position has no such check) and is recorded
+   here as an OPEN QUESTION for a future ruling, deliberately not resolved by this task: D32 rules
+   the field Coefficient-kinded (`[0,1]`) yet out-of-`[0,1]` int strengths load — tightening the
+   int arm could refuse previously-loadable content and is a separate, content-auditable ruling,
+   not a side effect to smuggle into a literal-kind widening.
+4. **Test placement: `scenario.rs`'s own `#[cfg(test)] mod tests`, where every existing `load_edge`
+   test lives** (`an_edge_to_an_undeclared_name_is_loud` `:1450`,
+   `load_edge_demands_edgetype_regardless_of_what_is_declared` `:2744`,
+   `an_edge_under_an_undeclared_edge_type_is_inert_not_e_load_031` `:2802`; the bit-exact
+   scaled-literal genre this task's green test follows is
+   `a_scaled_literal_seeds_correctly_into_each_unit_interval_type` `:1528`) — NOT `r9_chapters.rs`
+   (which holds only the `E-LOAD-044` chapter vector, `r9_chapters.rs:436-447`). Conventions
+   matched: `load_scenario(source, &mut graph)` + `unwrap_err()` + `err.message.contains(…)` for
+   refusals; `to_bits()` pins, never tolerances, for seeded values. The module's existing imports
+   already cover everything needed (`load_scenario` `:1359`, `MemoryGraph` `:1367`,
+   `GraphSubstrate`/`NodeId` `:1369`); `ScaledKind` is already imported by the non-test code
+   (`:61`). Note the loader-level test IS the real seam's own function: `run_once_into`'s
+   `prepare_rules` calls this same `load_scenario` (`babylon-tick/src/lib.rs:126`), and Task 6's
+   e2e vectors then re-prove the widening end-to-end through `run_once_into` itself.
+
+- [ ] **Step 1: Red — the widening test.** In `scenario.rs`'s test module, after
+  `a_scaled_literal_seeds_correctly_into_each_unit_interval_type` (its genre neighbor):
+
+```rust
+    #[test]
+    fn a_coefficient_strength_literal_seeds_bit_exactly() {
+        // Task 6a (T2 plan amendment, 2026-08-12): D32 rules
+        // <edge-type>/strength Coefficient-kinded — a c-suffixed literal is
+        // hydration's own way to seed a fractional strength (a bare decimal
+        // is E-LEX-021, and pre-6a this loader refused every non-int
+        // strength). Bit-exact pin, NOT a tolerance — the same conversion
+        // contract `attribute_value_unit_interval`'s doc comment states;
+        // 0.125 = 2^-3 is dyadic-exact, so 125/1000 divides to it exactly.
+        let source = r"
+(scenario ft/coeff-strength
+  (node core NodeType/SOCIAL_CLASS)
+  (node periphery NodeType/SOCIAL_CLASS)
+  (edge EdgeType/SOLIDARITY core periphery 0.125c))
+";
+        let mut graph = MemoryGraph::new();
+        load_scenario(source, &mut graph).unwrap();
+        let strength = graph
+            .edge_attribute("SOLIDARITY", NodeId(0), NodeId(1), "solidarity/strength")
+            .unwrap();
+        assert_eq!(
+            strength.to_bits(),
+            (0.125_f64).to_bits(),
+            "a c-suffixed Coefficient strength must seed bit-exactly, got {strength}"
+        );
+    }
+```
+
+  (`NodeId(0)`/`NodeId(1)`: declaration order fixes id assignment — the same contract Task 6's
+  fixture comment already cites, and the same direct-`NodeId` convention the Half-1 bit-pin test
+  uses at `:1562`. The read-back goes through Task 1's landed `edge_attribute` — full qname, owner
+  segment deliberately unchecked.)
+
+- [ ] **Step 2: Run it RED.** Expected exact failure: the `unwrap()` panics on
+  `` Err(ScenarioError { message: "edge SOLIDARITY: expected an integer strength literal, found
+  Scaled(ScaledLit { kind: Coefficient, unscaled: 125, scale: 3 })", code: None }) `` — the same
+  refusal already execution-proven through `run_once_into` (whose `prepare_rules` calls this same
+  `load_scenario`), byte for byte. `0.125c` canonicalizes to `unscaled: 125, scale: 3` (§1.5
+  minimal-scale canonicalization, `reader.rs:134-148`).
+
+- [ ] **Step 3: The minimal widening.** Replace the strength match (`scenario.rs:1323-1336`,
+  comment included):
+
+```rust
+    // An edge strength is not a node field, so no deffield governs it; the
+    // literal restriction is stated directly here: an integer, or a
+    // c-suffixed Coefficient literal — D32's own ruled kind for
+    // <edge-type>/strength (T2 plan Task 6a, amendment 2026-08-12).
+    // Deliberately NARROWER than attribute_value_unit_interval's kind-blind
+    // p/i/c acceptance: a node field's type is whatever its deffield
+    // declares, but the strength position has exactly ONE ruled kind. No
+    // range check on either arm — ints were never checked here (an OPEN
+    // asymmetry, recorded in the T2 plan's Task 6a design decision 3, not
+    // silently resolved), and a c literal is already [0,1]-bounded at lex
+    // (E-LEX-024).
+    let strength = match strength {
+        Atom::Int(value) => {
+            #[allow(clippy::cast_precision_loss)]
+            let widened = *value as f64;
+            widened
+        }
+        Atom::Scaled(scaled) if scaled.kind == ScaledKind::Coefficient => {
+            // `unscaled / 10^scale` — the crate's one scaled-literal
+            // conversion contract (attribute_value_unit_interval's doc
+            // comment is its normative home), copied verbatim.
+            #[allow(clippy::cast_precision_loss)]
+            let numerator = scaled.unscaled as f64;
+            numerator / 10_f64.powi(i32::from(scaled.scale))
+        }
+        other => {
+            return Err(err(format!(
+                "edge {member}: expected an integer or c-suffixed Coefficient \
+                 strength literal (D32 rules <edge-type>/strength \
+                 Coefficient-kinded), found {other:?}"
+            )))
+        }
+    };
+```
+
+  Also update the two neighboring strings that still say `<int>`:
+  - the fn doc comment (`:1282`): `` `(edge <enum-ref> <local-name> <local-name> <int>)` `` becomes
+    `` `(edge <enum-ref> <local-name> <local-name> <strength>)` — `<strength>` is an int or a
+    `c`-suffixed Coefficient literal (D32's ruled kind; T2 plan Task 6a) `` (the rest of the doc
+    sentence — the return-convention half — is unchanged);
+  - the destructure-refusal shape string (`:1297`):
+    `"expected (edge <EdgeType/MEMBER> <from-name> <to-name> <int>)"` becomes
+    `"expected (edge <EdgeType/MEMBER> <from-name> <to-name> <strength: int | c-lit>)"`.
+
+- [ ] **Step 4: GREEN.** Run Step 1's test — passes, the exact loaded f64 asserted bit-for-bit via
+  `edge_attribute`. Re-run the whole `scenario.rs` test module: every existing test stays green
+  (the int arm is byte-identical; nothing else in `load_edge` moved).
+
+- [ ] **Step 5: The refusal sweep — every kind that stays out, pinned per suffix.**
+
+```rust
+    #[test]
+    fn a_non_coefficient_strength_literal_stays_refused() {
+        // Task 6a's kind gate, pinned per suffix: p/i/r are ScaledLit kinds
+        // the Coefficient guard refuses; $ (Currency) is a DIFFERENT Atom
+        // variant that falls to the same refusal arm without ever reaching
+        // the kind guard (see the Step-6 mutation split in the T2 plan).
+        for literal in ["0.125p", "0.125i", "0.5r", "1$"] {
+            let source = format!(
+                "(scenario ft/wrong-kind-strength\n  \
+                 (node core NodeType/SOCIAL_CLASS)\n  \
+                 (node periphery NodeType/SOCIAL_CLASS)\n  \
+                 (edge EdgeType/SOLIDARITY core periphery {literal}))"
+            );
+            let mut graph = MemoryGraph::new();
+            let err = load_scenario(&source, &mut graph).unwrap_err();
+            assert!(
+                err.message.contains(
+                    "expected an integer or c-suffixed Coefficient strength literal"
+                ),
+                "{literal}: {}",
+                err.message
+            );
+        }
+    }
+```
+
+  The `$` row's exact full message is `` edge SOLIDARITY: expected an integer or c-suffixed
+  Coefficient strength literal (D32 rules <edge-type>/strength Coefficient-kinded), found
+  Currency(Currency(1000000)) `` (`Atom::Currency` wraps `babylon_kernel::Currency(i128)` in
+  micro-units — `1$` = 1,000,000 micro-units; both derive `Debug`, `currency.rs:35-36`). The
+  assertion pins the stable head via `.contains`, matching every sibling refusal test in this
+  module — no existing test pins the `{other:?}` Debug tail today either (verified: nothing
+  asserts on the current "found Scaled(…)" tail).
+
+- [ ] **Step 6: Mutation evidence — the guard, split honestly.** Delete the
+  `if scaled.kind == ScaledKind::Coefficient` guard (accepting every scaled kind) → Step 5's
+  `0.125p`/`0.125i`/`0.5r` rows flip RED (each now loads and the `unwrap_err` panics) while its
+  `1$` row and Step 1's test stay green — the pair proving the guard is the kind gate and that
+  Currency's refusal never rode it (`Atom::Currency` is a different VARIANT; no mutation of the
+  kind guard alone can accept a `$` literal, which is why the sweep pins it separately). Restore
+  byte-identical.
+
+- [ ] **Step 7: Goldens + the six-leg gate.** All seven pins (six `tick_goldens.rs` +
+  `engine_link.rs`) must stay byte-identical — structurally guaranteed here, twice over: the int
+  arm is byte-identical, and no shipped scenario CAN contain a scaled strength literal (one could
+  not have LOADED before this task — every committed `.bscn` seeds int strengths, verified:
+  `rg -n "\(edge " rust/crates/babylon-tick/content/scenarios/*.bscn` shows integer literals
+  only). Run the full six-leg gate anyway — the gate is the proof, not the assumption.
+
+- [ ] **Step 8: Commit** `feat(bsl): load_edge accepts c-suffixed Coefficient strength literals
+  (D32-aligned, T2 Task 6a)`.
+
 ### Task 6: The e2e vectors
 
 **Files:**
@@ -1341,7 +1597,12 @@ fn field_of_edge(key: &EdgeKey, qname: &str, env: &EvalEnv<'_>) -> Result<Value,
   reason. Every value below is still an exact dyadic rational (a fraction with a power-of-two
   denominator — 0.1875 = 3/16 and 0.375 = 3/8 are not themselves powers of two, but both terminate
   exactly in binary64, which is the property that matters here; no bit-pinning needed), and
-  every FOLD SUM below is now re-verified to land inside `[0,1]`:
+  every FOLD SUM below is now re-verified to land inside `[0,1]`. **Every strength literal is
+  `c`-suffixed (Task 6a, amendment 2026-08-12):** a bare decimal cannot LEX at all (`E-LEX-021`),
+  and post-6a `load_edge` accepts exactly int + `c`-suffixed Coefficient strength literals — the
+  suffix changes NO value (each literal converts bit-exactly, Task 6a design decision 2), and
+  `E-LEX-024` additionally bounds each literal to `[0,1]` at lex, one gate upstream of the
+  `E-EVAL-020` store-domain argument above:
 
 ```scheme
 ; The T2 (Program 29, issue #559) edge-lane e2e fixture — dyadic edge reads (edges/edge-between/
@@ -1388,13 +1649,13 @@ fn field_of_edge(key: &EdgeKey, qname: &str, env: &EvalEnv<'_>) -> Result<Value,
   (node fold-c NodeType/SOCIAL_CLASS (social-class/shape 0) (social-class/fold-total 0))
   (node fold-d NodeType/SOCIAL_CLASS (social-class/shape 0) (social-class/fold-total 0))
 
-  (edge EdgeType/SOLIDARITY fold-a fold-b 0.125)
-  (edge EdgeType/SOLIDARITY pair-x pair-y 0.03125)
-  (edge EdgeType/SOLIDARITY pair-z pair-x 0.015625)
-  (edge EdgeType/SOLIDARITY spoke-1 hub 0.0625)
-  (edge EdgeType/SOLIDARITY spoke-2 hub 0.125)
-  (edge EdgeType/SOLIDARITY spoke-3 hub 0.1875)
-  (edge EdgeType/SOLIDARITY fold-c fold-d 0.25))
+  (edge EdgeType/SOLIDARITY fold-a fold-b 0.125c)
+  (edge EdgeType/SOLIDARITY pair-x pair-y 0.03125c)
+  (edge EdgeType/SOLIDARITY pair-z pair-x 0.015625c)
+  (edge EdgeType/SOLIDARITY spoke-1 hub 0.0625c)
+  (edge EdgeType/SOLIDARITY spoke-2 hub 0.125c)
+  (edge EdgeType/SOLIDARITY spoke-3 hub 0.1875c)
+  (edge EdgeType/SOLIDARITY fold-c fold-d 0.25c))
 ```
 
   `pair-z`'s edge points AT `pair-x` (not the reverse) — deliberately, so Shape 2b's reversed lookup
@@ -1563,6 +1824,12 @@ fn field_of_edge(key: &EdgeKey, qname: &str, env: &EvalEnv<'_>) -> Result<Value,
      specifically, not "T2 touches no content anywhere," is the real inertness proof for the
      GOLDENS — state it as such in the ADR (Step 4), alongside a pointer to Task 3 Step 7 for the
      one fixture that DOES change.
+  3. **Task 6a's `load_edge` widening (amendment, 2026-08-12) is golden-inert by construction:**
+     the int arm is byte-identical, and no shipped scenario CAN contain a scaled strength literal
+     — one could not have LOADED before 6a (the pre-6a int-only refusal is execution-proven; the
+     landed Task 2 probe's own fallback to an int strength `1`, `babylon-tick/src/lib.rs:458`, is
+     its in-tree trace) — so the new Coefficient arm is exercised by nothing but Task 6's own new
+     fixture, which backs no golden.
 
   Run, unmodified: all six `tick_goldens.rs` pins (`two_classes_fundamental_theorem_hashes_are_pinned`,
   `vitality_conformance_hashes_are_pinned`, `us_counties_lifecycle_demo_hashes_are_pinned`,
@@ -1640,7 +1907,11 @@ fn field_of_edge(key: &EdgeKey, qname: &str, env: &EvalEnv<'_>) -> Result<Value,
   D32 wiring site and its correction of the dossier's own `scenario.edge_types` pointer (Task 2),
   the `EdgeKey`/`Value::EdgeRef`/`Element::Edge` additions and the cross-kind Ord ruling (Task 3),
   the three-file edges-refusal sweep (Task 3 Step 7), `eval_edge_between`/`field_of_edge`
-  (Tasks 4-5), the three e2e vectors (Task 6), the hash-free proof (Step 1), and the `the`
+  (Tasks 4-5), the `load_edge` Coefficient-strength widening (Task 6a, amendment 2026-08-12 —
+  hydration's int-only strength restriction lifted for exactly D32's ruled kind, all other literal
+  kinds still refused, the int-arm range-check asymmetry recorded as an open question; per D93 the
+  widening minted no register row, so ADR201 and the plan's Amendment log are its record homes),
+  the three e2e vectors (Task 6), the hash-free proof (Step 1), and the `the`
   disposition finding (Step 3) — filed as the evidence issue #572's own comment references. **Also
   records a known pre-existing divergence T2 does NOT fix (adversarial review MINOR, verified):**
   `rust/crates/babylon-bsl/tests/conformance_corpus.rs:101-104` declares `solidarity/strength` as

--- a/docs/superpowers/plans/2026-08-12-t2-slice2-edge-reads-plan.md
+++ b/docs/superpowers/plans/2026-08-12-t2-slice2-edge-reads-plan.md
@@ -59,6 +59,7 @@ train's scope — see the disposition record, Task 7.
   `<edge-type>/strength`), every other literal kind stays refused, and every `(edge …)` strength
   literal in Task 6's fixture is now `c`-suffixed. No expected value, shape, or store-domain
   argument changed — each suffixed literal converts bit-exactly (Task 6a design decision 2).
+  (scope clause SUPERSEDED — see next entry)
 
 - **2026-08-12 (fix round) — Task 6a's scope adjudicated to KIND-BLIND `p`/`i`/`c` (reviewer
   MAJOR-1, option (i)); supersedes the previous entry's scope clause.** The first amendment's
@@ -1495,7 +1496,9 @@ where this plan's Task 2 text still shows `0.5` — left as written, Task 2 is e
     fn a_coefficient_strength_literal_seeds_bit_exactly() {
         // Task 6a (T2 plan amendment, 2026-08-12): D32 rules
         // <edge-type>/strength Coefficient-kinded — a c-suffixed literal is
-        // hydration's own way to seed a fractional strength (a bare decimal
+        // hydration's idiomatic way (D32 kinds the field Coefficient; p/i
+        // seed identically — see the companion test) to seed a fractional
+        // strength (a bare decimal
         // is E-LEX-021, and pre-6a this loader refused every non-int
         // strength). Bit-exact pin, NOT a tolerance — the same conversion
         // contract `attribute_value_unit_interval`'s doc comment states;

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -1266,12 +1266,11 @@ fn eval_edge_between(
     }))
 }
 
-/// `(field-of <expr> <qname>)` (§2.10). Slice 1 serves `NodeRef` referents
-/// only — an `EdgeRef` referent is unreachable today (no expression form
-/// produces one yet; slice 2 mints `EdgeKey`), and a `HyperedgeRef` referent
-/// is a genuine shape error (a hyperedge carries no attributes of its own —
-/// `structural_verbs`' own module doc says so — so `field-of` over one is
-/// never meaningful; a MEMBERSHIP's payload reads through
+/// `(field-of <expr> <qname>)` (§2.10). Serves `NodeRef` referents (slice 1)
+/// and `EdgeRef` referents (slice 2, T2 issue #559); a `HyperedgeRef`
+/// referent is a genuine shape error (a hyperedge carries no attributes of
+/// its own — `structural_verbs`' own module doc says so — so `field-of`
+/// over one is never meaningful; a MEMBERSHIP's payload reads through
 /// `membership-field-of`, slice 4).
 fn eval_field_of(
     items: &[SExpr],
@@ -1288,6 +1287,7 @@ fn eval_field_of(
     let referent = evaluate(ref_expr, env, host, fuel)?;
     match referent {
         Value::NodeRef(id) => field_of_node(id, qname, env),
+        Value::EdgeRef(key) => field_of_edge(&key, qname, env),
         Value::HyperedgeRef(_) => Err(EvalError::plain(
             "(field-of …) over a HyperedgeRef is not meaningful — a \
              hyperedge carries no attributes of its own (§2.8); a \
@@ -1296,7 +1296,7 @@ fn eval_field_of(
         )),
         other => Err(EvalError::plain(format!(
             "(field-of …)'s first operand must evaluate to a reference, got \
-             {other:?} (§2.10); edge referents ride slice 2"
+             {other:?} (§2.10)"
         ))),
     }
 }
@@ -1395,6 +1395,65 @@ fn field_of_node(
              no declared-type registry for a field-of-evaluating form, never \
              a value this function should guess at with a plausible-looking \
              default"
+        )));
+    };
+    crate::tick::bind_field_value(qname, value, types, enums)
+        .map_err(|e| EvalError::plain(e.to_string()))
+}
+
+/// The `EdgeRef` half of §2.10 discipline 1. Cheaper than `check_node_referent_type`: an `EdgeKey`
+/// carries its type inline (§2.6's own key), so no substrate round-trip is needed to learn it —
+/// unlike a `NodeRef`, whose type needs `graph.node_type_of`.
+fn check_edge_referent_type(key: &EdgeKey, qname: &str, form: &str) -> Result<(), EvalError> {
+    let owner_segment = qname.split('/').next().unwrap_or(qname);
+    let expected_type = crate::tick::namespace_to_node_type(owner_segment);
+    if key.edge_type != expected_type {
+        return Err(EvalError::coded(
+            EvalCode::AccessorTypeOrValueMismatch,
+            format!(
+                "{form} {qname}: the referent is a {} edge, not {expected_type} — the qname's \
+                 owning type does not match the referent's declared type (§2.10 discipline 1)",
+                key.edge_type
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// The `EdgeRef` half of `field-of`'s shared discipline (§2.10) — generic over any qname whose
+/// owning type is an `EdgeType` (T2 dossier §2 design: not hard-coded to `strength` alone). `qname`
+/// is passed to the substrate UNMODIFIED, exactly as `field_of_node` passes it to `node_attribute`
+/// — the FULL qname is the key convention both share (Task 1's Major-6 correction); a T3-era edge
+/// field resolves through this SAME function unmodified — only `GraphSubstrate::edge_attribute`'s
+/// body widens.
+///
+/// **`edge_attribute`'s "no such edge" failure mode (E-EVAL-034's own condition) is UNREACHABLE
+/// here.** Every `Value::EdgeRef` this function's caller (`eval_field_of`) can ever hand it was
+/// already validated to reference a LIVE edge before construction: `materialize_edges` builds one
+/// only from `graph.edges(edge_type)`'s own output (which by construction never names a dangling
+/// triple), and `eval_edge_between` only returns a `Value::EdgeRef` AFTER its own existence check
+/// already succeeded (erroring `E-EVAL-034` itself, before ever constructing one, otherwise). So the
+/// ONLY way `graph.edge_attribute(...)` can fail from inside this function is the "qname is not
+/// `<edge-type>/strength`" branch — the mapping below is therefore always `E-EVAL-033`
+/// ("declared/legal but never written") in practice, never a laundered `E-EVAL-034`.
+fn field_of_edge(key: &EdgeKey, qname: &str, env: &EvalEnv<'_>) -> Result<Value, EvalError> {
+    let graph = require_graph(env, "field-of")?;
+    check_edge_referent_type(key, qname, "field-of")?;
+    let value = graph
+        .edge_attribute(&key.edge_type, key.source, key.target, qname)
+        .map_err(|e| {
+            EvalError::coded(
+                EvalCode::AccessorTypeOrValueMismatch,
+                format!(
+                    "field-of {qname}: {} (§2.10 discipline 2 — absence is not a value)",
+                    e.message
+                ),
+            )
+        })?;
+    let (Some(types), Some(enums)) = (env.types, env.enums) else {
+        return Err(EvalError::plain(format!(
+            "(field-of …) needs the declared field-type registry (§2.13) but this EvalEnv \
+             carries none for {qname} — a driver error, the same shape as require_graph's"
         )));
     };
     crate::tick::bind_field_value(qname, value, types, enums)
@@ -2875,6 +2934,83 @@ mod tests {
             ":fuel-used is a conformance-vector quantity (§6.1) — the \
              static bound and the runtime meter must agree"
         );
+    }
+
+    // ---- T2 (issue #559): field-of over an EdgeRef ----
+
+    #[test]
+    fn field_of_an_edge_ref_reads_the_seeded_strength() {
+        use babylon_graph::memory::MemoryGraph;
+        let mut graph = MemoryGraph::new();
+        let subject = graph.add_node("SOCIAL_CLASS").unwrap();
+        let other = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph.add_edge("SOLIDARITY", subject, other, 0.5).unwrap();
+        let mut fuel = 1_000;
+        let result = eval_with_pair(
+            "(field-of (edge-between EdgeType/SOLIDARITY self other) solidarity/strength)",
+            &graph,
+            subject,
+            other,
+            &mut fuel,
+        )
+        .unwrap();
+        assert_eq!(result, Value::Real(0.5));
+    }
+
+    /// §2.10 discipline 1, the `EdgeRef` half: a qname owned by a DIFFERENT
+    /// type than the referent's own (here a NodeType-owned qname against a
+    /// SOLIDARITY edge) is `E-EVAL-033`, never a default and never an
+    /// absent read.
+    #[test]
+    fn field_of_an_edge_ref_with_a_wrong_owner_qname_is_e_eval_033() {
+        use babylon_graph::memory::MemoryGraph;
+        let mut graph = MemoryGraph::new();
+        let subject = graph.add_node("SOCIAL_CLASS").unwrap();
+        let other = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph.add_edge("SOLIDARITY", subject, other, 0.5).unwrap();
+        let mut fuel = 1_000;
+        let err = eval_with_pair(
+            "(field-of (edge-between EdgeType/SOLIDARITY self other) social-class/wealth)",
+            &graph,
+            subject,
+            other,
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.code,
+            Some(EvalCode::AccessorTypeOrValueMismatch),
+            "{err}"
+        );
+        assert_eq!(err.code.unwrap().spec_code(), "E-EVAL-033");
+    }
+
+    /// A LEGALLY-typed but never-written edge qname (a `deffield`-declarable
+    /// `solidarity/tension`, no storage behind it until T3 — ADR198 R1) is
+    /// ALSO `E-EVAL-033` — Task 1's "not yet stored" branch degrades
+    /// identically to a never-written field, with zero special-casing.
+    #[test]
+    fn field_of_an_edge_ref_with_an_unstored_qname_is_e_eval_033() {
+        use babylon_graph::memory::MemoryGraph;
+        let mut graph = MemoryGraph::new();
+        let subject = graph.add_node("SOCIAL_CLASS").unwrap();
+        let other = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph.add_edge("SOLIDARITY", subject, other, 0.5).unwrap();
+        let mut fuel = 1_000;
+        let err = eval_with_pair(
+            "(field-of (edge-between EdgeType/SOLIDARITY self other) solidarity/tension)",
+            &graph,
+            subject,
+            other,
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.code,
+            Some(EvalCode::AccessorTypeOrValueMismatch),
+            "{err}"
+        );
+        assert_eq!(err.code.unwrap().spec_code(), "E-EVAL-033");
     }
 
     // ---- Task 5: fold ----

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -38,7 +38,7 @@
 
 use crate::fuel::{cost, IntrinsicCosts};
 use crate::intrinsic_host::IntrinsicHost;
-use crate::query::Element;
+use crate::query::{EdgeKey, Element};
 use crate::reader::{Atom, SExpr, ScaledKind};
 use crate::typecheck::TypeEnv;
 use crate::types::EnumRegistry;
@@ -107,6 +107,10 @@ pub enum Value {
     /// query elements. Does NOT carry its `HyperedgeType` statically, which
     /// is why §2.6's hyperedge queries take the type as an operand.
     HyperedgeRef(babylon_graph::substrate::HyperedgeId),
+    /// `EdgeRef` (§3.1) — produced by `edges`/`edge-between` query elements.
+    /// No arithmetic, no ordering; refs are identities, same discipline as
+    /// `NodeRef`/`HyperedgeRef`.
+    EdgeRef(EdgeKey),
 }
 
 /// The spec's evaluation error codes (§4.6 / §3.2), one variant per code
@@ -504,8 +508,9 @@ const EFFECT_POSITION_ONLY: [&str; 19] = [
 /// of THIS plan remove their rows one by one (`fold`/`exists`/`forall`/
 /// `select-max`/`select-min`/`field-of`, each moved to [`EVALUATOR_SERVED`]
 /// once its task lands — their string names the edge/hyperedge shapes that
-/// still ride slices 2-3); `edges`/`edge-between`/`the` (slice 2, the dyadic
-/// edge lane); `hyperedges`/`members-of`/`hyperedges-of`/`metric-of`
+/// still ride slices 2-3); `edge-between`/`the` (slice 2, the dyadic edge
+/// lane — `edges` served as of T2, issue #559);
+/// `hyperedges`/`members-of`/`hyperedges-of`/`metric-of`
 /// (slice 3, the hyperedge + metric lane); `membership-field-of` (slice 4,
 /// the CanonicalState-widening storage lane — Director-ruled deferred to
 /// first consumer). `nodes`/`neighbors` moved to [`SERVED_QUERY_HEADS`] at
@@ -515,8 +520,7 @@ const EFFECT_POSITION_ONLY: [&str; 19] = [
 /// this is exhaustive over the pre-Task-1 `GRAPH_SEAM_HEADS` set AND the
 /// grammar's §2.8/§2.10 heads: a head in none of the three tables is
 /// `eval_intrinsic`'s.
-const UNSERVED_EXPRESSION_HEADS: [(&str, &str); 8] = [
-    ("edges", "slice 2"),
+const UNSERVED_EXPRESSION_HEADS: [(&str, &str); 7] = [
     ("edge-between", "slice 2"),
     ("the", "slice 2"),
     ("hyperedges", "slice 3"),
@@ -535,11 +539,12 @@ const UNSERVED_EXPRESSION_HEADS: [(&str, &str); 8] = [
 /// of `<expr>`'s productions), so reaching one of these heads HERE — through
 /// generic expression dispatch — means it was written somewhere the grammar
 /// does not admit a query: a shape error, not an unimplemented seam. Only
-/// `nodes`/`neighbors` are here; the other four §2.6 heads stay in
+/// `nodes`/`neighbors`/`edges` are here (`edges` joined at T2, issue #559);
+/// the other three §2.6 heads stay in
 /// [`UNSERVED_EXPRESSION_HEADS`] until their own slice serves them (at which
 /// point they join this table too, since serving a query head never means
 /// giving it a bare `<expr>` reading).
-const SERVED_QUERY_HEADS: [&str; 2] = ["nodes", "neighbors"];
+const SERVED_QUERY_HEADS: [&str; 3] = ["nodes", "neighbors", "edges"];
 
 fn eval_form(
     items: &[SExpr],
@@ -946,7 +951,7 @@ fn eval_exists_forall(
              reading",
         ));
     };
-    for &element in &elements {
+    for element in elements.iter().cloned() {
         let child = with_element(env, elem_name.clone(), element);
         let value = as_bool(evaluate(cond, &child, host, fuel)?)?;
         if value == is_exists {
@@ -996,10 +1001,10 @@ fn eval_selection(
     }
     let want_max = head == "select-max";
     let op = if want_max { ">" } else { "<" };
-    let mut best_element = elements[0];
+    let mut best_element = elements[0].clone();
     let mut best_score: Option<Value> = None;
-    for &element in &elements {
-        let child = with_element(env, elem_name.clone(), element);
+    for element in elements.iter().cloned() {
+        let child = with_element(env, elem_name.clone(), element.clone());
         let score = evaluate(score_expr, &child, host, fuel)?;
         best_score = Some(match best_score {
             None => {
@@ -1078,7 +1083,7 @@ fn fold_sum(
         });
     }
     let mut acc: Option<Value> = None;
-    for &element in elements {
+    for element in elements.iter().cloned() {
         let (body_val, _weight_val) =
             eval_body_and_weight(element, elem_name, body, weight, env, host, fuel)?;
         acc = Some(match acc {
@@ -1107,7 +1112,7 @@ fn fold_mean(
     }
     let mut sum_wx = 0.0_f64;
     let mut sum_w = 0.0_f64;
-    for &element in elements {
+    for element in elements.iter().cloned() {
         let (body_val, weight_val) =
             eval_body_and_weight(element, elem_name, body, weight, env, host, fuel)?;
         let x = match body_val {
@@ -1187,7 +1192,7 @@ fn fold_min_max(
     }
     let op = if want_min { "<" } else { ">" };
     let mut acc: Option<Value> = None;
-    for &element in elements {
+    for element in elements.iter().cloned() {
         let (body_val, _weight_val) =
             eval_body_and_weight(element, elem_name, body, weight, env, host, fuel)?;
         acc = Some(match acc {
@@ -2227,10 +2232,6 @@ mod tests {
         assert!(!emit_err.message.contains("Task 16"), "{emit_err}");
         assert!(emit_err.message.contains("§2.8"), "{emit_err}");
         assert!(emit_err.message.contains("effect position"), "{emit_err}");
-
-        // `edges` is unserved until slice 2.
-        let edges_err = eval("(edges EdgeType/SOLIDARITY)").unwrap_err();
-        assert!(edges_err.message.contains("slice 2"), "{edges_err}");
 
         // `members-of` is unserved until slice 3.
         let members_of_err = eval("(members-of self HyperedgeType/CELL)").unwrap_err();

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -508,8 +508,8 @@ const EFFECT_POSITION_ONLY: [&str; 19] = [
 /// of THIS plan remove their rows one by one (`fold`/`exists`/`forall`/
 /// `select-max`/`select-min`/`field-of`, each moved to [`EVALUATOR_SERVED`]
 /// once its task lands — their string names the edge/hyperedge shapes that
-/// still ride slices 2-3); `edge-between`/`the` (slice 2, the dyadic edge
-/// lane — `edges` served as of T2, issue #559);
+/// still ride slices 2-3); `the` (slice 2, the carrier-read lane —
+/// `edges`/`edge-between` served as of T2, issue #559);
 /// `hyperedges`/`members-of`/`hyperedges-of`/`metric-of`
 /// (slice 3, the hyperedge + metric lane); `membership-field-of` (slice 4,
 /// the CanonicalState-widening storage lane — Director-ruled deferred to
@@ -520,8 +520,7 @@ const EFFECT_POSITION_ONLY: [&str; 19] = [
 /// this is exhaustive over the pre-Task-1 `GRAPH_SEAM_HEADS` set AND the
 /// grammar's §2.8/§2.10 heads: a head in none of the three tables is
 /// `eval_intrinsic`'s.
-const UNSERVED_EXPRESSION_HEADS: [(&str, &str); 7] = [
-    ("edge-between", "slice 2"),
+const UNSERVED_EXPRESSION_HEADS: [(&str, &str); 6] = [
     ("the", "slice 2"),
     ("hyperedges", "slice 3"),
     ("members-of", "slice 3"),
@@ -577,6 +576,7 @@ fn eval_form(
         "exists" | "forall" => eval_exists_forall(head, items, env, host, fuel),
         "select-max" | "select-min" => eval_selection(head, items, env, host, fuel),
         "field-of" => eval_field_of(items, env, host, fuel),
+        "edge-between" => eval_edge_between(items, env, host, fuel),
         name => {
             if EFFECT_POSITION_ONLY.contains(&name) {
                 return Err(EvalError::plain(format!(
@@ -1209,6 +1209,61 @@ fn fold_min_max(
         });
     }
     Ok(acc.expect("non-empty elements guarantees at least one accumulation"))
+}
+
+/// `(edge-between <enum-ref> <expr> <expr>)` (§2.10). A keyed lookup (§2.10's own "well-defined
+/// because the triple is a key" ruling) — never a set, never a silent no-op on absence.
+fn eval_edge_between(
+    items: &[SExpr],
+    env: &EvalEnv<'_>,
+    host: &dyn IntrinsicHost,
+    fuel: &mut u64,
+) -> Result<Value, EvalError> {
+    charge(fuel, cost::ACCESSOR_BASE)?;
+    let [_, type_ref, from_expr, to_expr] = items else {
+        return Err(EvalError::plain(
+            "(edge-between <enum-ref> <expr> <expr>) — unrecognized shape",
+        ));
+    };
+    let edge_type = crate::query::enum_member(type_ref)?;
+    let from = match evaluate(from_expr, env, host, fuel)? {
+        Value::NodeRef(id) => id,
+        other => {
+            return Err(EvalError::plain(format!(
+                "(edge-between …)'s first node operand must evaluate to a NodeRef, got {other:?}"
+            )))
+        }
+    };
+    let to = match evaluate(to_expr, env, host, fuel)? {
+        Value::NodeRef(id) => id,
+        other => {
+            return Err(EvalError::plain(format!(
+                "(edge-between …)'s second node operand must evaluate to a NodeRef, got {other:?}"
+            )))
+        }
+    };
+    let graph = require_graph(env, "edge-between")?;
+    // Full qname (Major 6, matching `edge_attribute`'s node_attribute-mirroring convention,
+    // Task 1) — constructed here because `render_member` lives in THIS crate (`crate::vocabulary`)
+    // and `eval_edge_between` has only the raw enum member (e.g. "SOLIDARITY"), never a
+    // content-authored qname to pass through unmodified the way `field_of_edge` does.
+    let strength_qname = format!("{}/strength", crate::vocabulary::render_member(edge_type));
+    graph
+        .edge_attribute(edge_type, from, to, &strength_qname)
+        .map_err(|_| {
+            EvalError::coded(
+                EvalCode::NoSuchEdge,
+                format!(
+                    "(edge-between EdgeType/{edge_type} …): no edge from {from:?} to {to:?} \
+                     (§2.10) — the accessor never yields an absent reference"
+                ),
+            )
+        })?;
+    Ok(Value::EdgeRef(EdgeKey {
+        source: from,
+        target: to,
+        edge_type: edge_type.to_owned(),
+    }))
 }
 
 /// `(field-of <expr> <qname>)` (§2.10). Slice 1 serves `NodeRef` referents
@@ -2316,12 +2371,13 @@ mod tests {
     /// rows (a filed reservation-gap follow-up).
     #[test]
     fn every_seam_head_is_classified() {
-        const EVALUATOR_SERVED: [&str; 10] = [
+        const EVALUATOR_SERVED: [&str; 11] = [
             "and",
             "or",
             "not",
             "if",
             "field-of",
+            "edge-between",
             "fold",
             "exists",
             "forall",
@@ -2706,6 +2762,118 @@ mod tests {
         assert_eq!(
             fuel, 8,
             ":fuel-used is a conformance-vector quantity (§6.1)"
+        );
+    }
+
+    // ---- T2 (issue #559): edge-between ----
+
+    /// Evaluate `source` against a graph with `self`/`other` bound to the
+    /// two supplied nodes — the shared fixture for the `edge-between`
+    /// vectors (and Task 5's `field-of`-over-an-`EdgeRef` vectors, which
+    /// compose onto the same two-node shape). Empty-but-`Some`
+    /// `TypeEnv`/`EnumRegistry`, per this module's own standing pattern
+    /// (`eval_field_of_over`'s doc).
+    fn eval_with_pair(
+        source: &str,
+        graph: &dyn babylon_graph::substrate::GraphSubstrate,
+        self_id: babylon_graph::substrate::NodeId,
+        other_id: babylon_graph::substrate::NodeId,
+        fuel: &mut u64,
+    ) -> Result<Value, EvalError> {
+        let costs = costs();
+        let types = TypeEnv {
+            fields: HashMap::new(),
+            exemptions: &[],
+        };
+        let enums = EnumRegistry::default();
+        let env = EvalEnv {
+            bindings: HashMap::from([
+                ("self".to_owned(), Value::NodeRef(self_id)),
+                ("other".to_owned(), Value::NodeRef(other_id)),
+            ]),
+            intrinsic_costs: &costs,
+            graph: Some(graph),
+            types: Some(&types),
+            enums: Some(&enums),
+            elements: Vec::new(),
+        };
+        let (expr, _) = read(source).expect("test source must parse");
+        evaluate(&expr, &env, &EmptyIntrinsicHost, fuel)
+    }
+
+    #[test]
+    fn edge_between_resolves_to_an_edge_ref() {
+        use babylon_graph::memory::MemoryGraph;
+        let mut graph = MemoryGraph::new();
+        let subject = graph.add_node("SOCIAL_CLASS").unwrap();
+        let other = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph.add_edge("SOLIDARITY", subject, other, 0.5).unwrap();
+        let mut fuel = 1_000;
+        let result = eval_with_pair(
+            "(edge-between EdgeType/SOLIDARITY self other)",
+            &graph,
+            subject,
+            other,
+            &mut fuel,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Value::EdgeRef(EdgeKey {
+                source: subject,
+                target: other,
+                edge_type: "SOLIDARITY".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn edge_between_on_a_missing_pair_is_e_eval_034() {
+        use babylon_graph::memory::MemoryGraph;
+        let mut graph = MemoryGraph::new();
+        let subject = graph.add_node("SOCIAL_CLASS").unwrap();
+        let other = graph.add_node("SOCIAL_CLASS").unwrap();
+        let mut fuel = 1_000;
+        let err = eval_with_pair(
+            "(edge-between EdgeType/SOLIDARITY self other)",
+            &graph,
+            subject,
+            other,
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some(EvalCode::NoSuchEdge), "{err}");
+        assert_eq!(err.code.unwrap().spec_code(), "E-EVAL-034");
+    }
+
+    /// The static/runtime fuel agreement (§4.5's loud-failure-inversion
+    /// discipline): `r9_chapters.rs::edge_between_costs_one_plus_its_two_
+    /// endpoint_operands` pins the STATIC bound at
+    /// `cost("(edge-between EdgeType/SOLIDARITY self other)") == 3`
+    /// (`ACCESSOR_BASE(1) + self(1) + other(1)`); the runtime meter must
+    /// charge the SAME 3 for the identical shape — the same discipline
+    /// `query.rs::query_materialization_charges_the_3_7_query_base` already
+    /// proves for `nodes`/`neighbors`.
+    #[test]
+    fn edge_between_charges_the_static_bounds_own_three() {
+        use babylon_graph::memory::MemoryGraph;
+        let mut graph = MemoryGraph::new();
+        let subject = graph.add_node("SOCIAL_CLASS").unwrap();
+        let other = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph.add_edge("SOLIDARITY", subject, other, 0.5).unwrap();
+        let mut fuel = 10;
+        eval_with_pair(
+            "(edge-between EdgeType/SOLIDARITY self other)",
+            &graph,
+            subject,
+            other,
+            &mut fuel,
+        )
+        .unwrap();
+        assert_eq!(
+            fuel, 7,
+            ":fuel-used is a conformance-vector quantity (§6.1) — the \
+             static bound and the runtime meter must agree"
         );
     }
 

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -1243,10 +1243,12 @@ fn eval_edge_between(
         }
     };
     let graph = require_graph(env, "edge-between")?;
-    // Full qname (Major 6, matching `edge_attribute`'s node_attribute-mirroring convention,
-    // Task 1) — constructed here because `render_member` lives in THIS crate (`crate::vocabulary`)
-    // and `eval_edge_between` has only the raw enum member (e.g. "SOLIDARITY"), never a
-    // content-authored qname to pass through unmodified the way `field_of_edge` does.
+    // Full qname — `edge_attribute` mirrors `node_attribute`'s own convention and takes the FULL
+    // qname, never a bare segment (T2 plan Task 1,
+    // `docs/superpowers/plans/2026-08-12-t2-slice2-edge-reads-plan.md`). Constructed here because
+    // `render_member` lives in THIS crate (`crate::vocabulary`) and `eval_edge_between` has only
+    // the raw enum member (e.g. "SOLIDARITY"), never a content-authored qname to pass through
+    // unmodified the way `field_of_edge` does.
     let strength_qname = format!("{}/strength", crate::vocabulary::render_member(edge_type));
     graph
         .edge_attribute(edge_type, from, to, &strength_qname)
@@ -1423,7 +1425,9 @@ fn check_edge_referent_type(key: &EdgeKey, qname: &str, form: &str) -> Result<()
 /// The `EdgeRef` half of `field-of`'s shared discipline (§2.10) — generic over any qname whose
 /// owning type is an `EdgeType` (T2 dossier §2 design: not hard-coded to `strength` alone). `qname`
 /// is passed to the substrate UNMODIFIED, exactly as `field_of_node` passes it to `node_attribute`
-/// — the FULL qname is the key convention both share (Task 1's Major-6 correction); a T3-era edge
+/// — the FULL qname is the key convention both share, `GraphSubstrate::edge_attribute`'s own
+/// documented contract (T2 plan Task 1,
+/// `docs/superpowers/plans/2026-08-12-t2-slice2-edge-reads-plan.md`); a T3-era edge
 /// field resolves through this SAME function unmodified — only `GraphSubstrate::edge_attribute`'s
 /// body widens.
 ///

--- a/rust/crates/babylon-bsl/src/query.rs
+++ b/rust/crates/babylon-bsl/src/query.rs
@@ -34,9 +34,13 @@ use babylon_graph::substrate::{Direction, NodeId};
 /// A materialized edge's identity — the `(source, target, edge_type)` triple IS the identity
 /// (§2.10's own "well-defined because the triple is a key" ruling, `bsl-language.rst:1896-1904`);
 /// `GraphSubstrate` mints no separate `EdgeId` (only `NodeId`/`HyperedgeId` exist,
-/// `substrate.rs:33,41`). Field order is `(source, target, edge_type)` DELIBERATELY — see design
-/// decision 1 above (this crate's own direct Ord test, Step 9, is where this is actually
-/// exercised — NOT `materialize_edges`, which never invokes this derive).
+/// `substrate.rs:33,41`). Field order is `(source, target, edge_type)` DELIBERATELY: declaring the
+/// fields in §2.6's own `(source-id, target-id, edge-type)` total-order sequence makes the derived
+/// `Ord`'s field-by-field comparison agree with the spec's order by construction (T2 plan Task 3
+/// design decision 1, `docs/superpowers/plans/2026-08-12-t2-slice2-edge-reads-plan.md`). That
+/// property is exercised by this crate's own direct Ord test
+/// (`tests::edge_key_ord_prioritizes_source_over_edge_type`) — NOT by `materialize_edges`, which
+/// never invokes this derive.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EdgeKey {
     /// The edge's source node.
@@ -253,7 +257,9 @@ fn materialize_neighbors(
 /// **Performs no sort of its own.** `GraphSubstrate::edges` already returns a canonically sorted
 /// `Vec<(NodeId, NodeId)>` (both backends' `sort_unstable()`, before this function ever runs) — this
 /// maps that ALREADY-ordered output element-for-element; `EdgeKey`'s own `Ord` derive is never
-/// consulted here (design decision 1, above).
+/// consulted here — its field-order choice serves the derive's spec-agreement alone (see
+/// [`EdgeKey`]'s own doc), and `tests::edges_materializes_in_exactly_graph_edges_own_order` proves
+/// the delegation directly.
 fn materialize_edges(
     items: &[SExpr],
     env: &EvalEnv<'_>,

--- a/rust/crates/babylon-bsl/src/query.rs
+++ b/rust/crates/babylon-bsl/src/query.rs
@@ -6,18 +6,17 @@
 //! this module a task early, so [`crate::evaluator::EvalEnv`]'s §2.6
 //! chapter C8 element stack had a type to hold before any query head
 //! actually produced one. Task 4 is the one that fills in [`materialize`]:
-//! `nodes` and typed `neighbors` — the two heads slice 1 serves. The other
-//! four §2.6 heads (`edges`, `hyperedges`, `members-of`, `hyperedges-of`)
-//! are recognized here (so a fold/exists/forall/select-* over one of them
-//! refuses with the RIGHT slice number, never `eval_intrinsic`'s
-//! `E-LOAD-021` misdiagnosis) but are not materialized — that is slice 2/3's
-//! work.
+//! `nodes` and typed `neighbors` — the two heads slice 1 serves; `edges`
+//! joined them at T2 (slice 2, issue #559). The remaining three §2.6 heads
+//! (`hyperedges`, `members-of`, `hyperedges-of`) are recognized here (so a
+//! fold/exists/forall/select-* over one of them refuses with the RIGHT
+//! slice number, never `eval_intrinsic`'s `E-LOAD-021` misdiagnosis) but
+//! are not materialized — that is slice 3's work.
 //!
-//! Only [`Element::Node`] exists yet. `Edge(EdgeKey)` (slice 2 — `EdgeKey`
-//! is not a type this codebase has minted) and `Hyperedge(HyperedgeId)`
-//! (slice 3) are deliberately not added here: minting `EdgeKey` is slice 2's
-//! own scope, not Task 4's, and a variant nothing can construct would be
-//! dead weight, not forward-compatibility.
+//! [`Element::Node`] and [`Element::Edge`] exist ([`EdgeKey`] was minted at
+//! T2, slice 2). `Hyperedge(HyperedgeId)` (slice 3) is deliberately not
+//! added: minting it is slice 3's own scope, and a variant nothing can
+//! construct would be dead weight, not forward-compatibility.
 //!
 //! **Determinism (Constraint 2).** `nodes`/`neighbors` on `GraphSubstrate`
 //! already return a canonically sorted, deduplicated `Vec` (§2.6's total
@@ -32,49 +31,68 @@ use crate::intrinsic_host::IntrinsicHost;
 use crate::reader::{Atom, SExpr};
 use babylon_graph::substrate::{Direction, NodeId};
 
-/// One materialized graph element (§2.6). See the module doc for why only
-/// `Node` exists yet.
+/// A materialized edge's identity — the `(source, target, edge_type)` triple IS the identity
+/// (§2.10's own "well-defined because the triple is a key" ruling, `bsl-language.rst:1896-1904`);
+/// `GraphSubstrate` mints no separate `EdgeId` (only `NodeId`/`HyperedgeId` exist,
+/// `substrate.rs:33,41`). Field order is `(source, target, edge_type)` DELIBERATELY — see design
+/// decision 1 above (this crate's own direct Ord test, Step 9, is where this is actually
+/// exercised — NOT `materialize_edges`, which never invokes this derive).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EdgeKey {
+    /// The edge's source node.
+    pub source: NodeId,
+    /// The edge's target node.
+    pub target: NodeId,
+    /// The edge's declared `EdgeType` member — owned, matching both
+    /// backends' `HashMap<(String, NodeId, NodeId), f64>` key shape.
+    pub edge_type: String,
+}
+
+/// One materialized graph element (§2.6).
 ///
-/// **CT4P A5 (issue #525): the `derive(Ord)` below is a CHOICE, not yet a
-/// specification.** §2.6 is this order's authority; today, with one
-/// variant, the derive reduces exactly to `NodeId`'s own order (pinned by
-/// `tests::element_ordering_matches_ascending_node_id`) — harmless
-/// because there is nothing to compare it against. **The moment a second
-/// variant lands** (`Edge(EdgeKey)` at slice 2, `Hyperedge(HyperedgeId)` at
-/// slice 3, per the module doc), `#[derive(Ord)]` silently becomes
-/// **variant-declaration-order lexicographic** — a cross-kind total order
-/// that no spec section pins — and that order feeds a sort whose output
-/// feeds the tick hash. The cross-kind order MUST be pinned against the
-/// spec, explicitly, BEFORE that variant lands — never inherited from
-/// wherever the new arm happens to sit in this enum's declaration.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// **T2's cross-kind Ord ruling (register row D140, CT4P A5 / issue #525, T2 issue #559).** §2.6
+/// defines a total order WITHIN each query kind's own result set only — it is silent on comparing a
+/// `Node` to an `Edge`. No production `materialize()` call ever mixes kinds (`edges` returns only
+/// `Edge`; `nodes`/`neighbors` only `Node`), so this ordering is UNREACHABLE in practice — pinned
+/// anyway, per this enum's own standing instruction, rather than left to whatever `#[derive(Ord)]`
+/// happens to produce from declaration order. RULED: `Node` sorts before `Edge`, by declaration
+/// order below — arbitrary, deliberate, tested (`tests::node_sorts_before_edge_regardless_of_id`).
+///
+/// **No longer `Copy` (T2, issue #559): `EdgeKey` owns a `String`.** Every call site that relied on
+/// `Copy` is fixed at this variant's landing (see evaluator.rs's own Task-3 call-site fixes) —
+/// `Clone` is unaffected and remains the currency for every place that needs an owned `Element`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Element {
-    /// A materialized node — the only element kind slice 1's node-set query
-    /// lane produces.
+    /// A materialized node — see the module doc.
     Node(NodeId),
+    /// A materialized dyadic edge (slice 2, T2). Declared SECOND: see this enum's own cross-kind
+    /// Ord ruling above.
+    Edge(EdgeKey),
 }
 
 impl Element {
-    /// This element's runtime value. An element reached through `it` or a
-    /// `:as` name is a reference of the appropriate kind (§2.6) — for
-    /// `Node`, exactly what `self`/`add-node` already produce.
+    /// This element's runtime value. Takes `&self` (not `self`) now that `Element` is no longer
+    /// `Copy` — every existing caller already holds a `&Element` at the point it calls this
+    /// (`env.elements`'s own `(Option<String>, Element)` tuples are read by reference throughout),
+    /// so no caller needs to change; only the signature does, and the `Edge` arm clones its key.
     #[must_use]
-    pub fn to_value(self) -> Value {
+    pub fn to_value(&self) -> Value {
         match self {
-            Self::Node(id) => Value::NodeRef(id),
+            Self::Node(id) => Value::NodeRef(*id),
+            Self::Edge(key) => Value::EdgeRef(key.clone()),
         }
     }
 }
 
 /// The six §2.6 query heads, mapped to the slice that serves them — shared
-/// by [`materialize`]'s refusal for the four heads slice 1 does not serve.
-/// Kept in sync with `evaluator::UNSERVED_EXPRESSION_HEADS`'s own rows for
-/// the same four heads; the two tables answer different questions (that
-/// module classifies every expression-position head, this one is the
-/// query-position dispatch), so one small duplication here is cheaper than
-/// a cross-module lookup for four stable rows.
-const UNSERVED_QUERY_HEADS: [(&str, &str); 4] = [
-    ("edges", "slice 2"),
+/// by [`materialize`]'s refusal for the three heads not yet served (`edges`
+/// joined the served set at T2, issue #559). Kept in sync with
+/// `evaluator::UNSERVED_EXPRESSION_HEADS`'s own rows for the same three
+/// heads; the two tables answer different questions (that module classifies
+/// every expression-position head, this one is the query-position
+/// dispatch), so one small duplication here is cheaper than a cross-module
+/// lookup for three stable rows.
+const UNSERVED_QUERY_HEADS: [(&str, &str); 3] = [
     ("hyperedges", "slice 3"),
     ("members-of", "slice 3"),
     ("hyperedges-of", "slice 3"),
@@ -110,6 +128,7 @@ pub fn materialize(
     match head.as_str() {
         "nodes" => materialize_nodes(items, env, fuel),
         "neighbors" => materialize_neighbors(items, env, host, fuel),
+        "edges" => materialize_edges(items, env, fuel),
         h => {
             if let Some((_, slice)) = UNSERVED_QUERY_HEADS.iter().find(|(n, _)| *n == h) {
                 return Err(EvalError::plain(format!(
@@ -226,6 +245,48 @@ fn materialize_neighbors(
     Ok(out)
 }
 
+/// `(edges <enum-ref> <edge-pred>?)`. Like `nodes`' `<node-pred>`, the `<edge-pred>` operand is a
+/// real §2.6 grammar production with zero exercised conformance vectors and zero content rules
+/// (T2 scout dossier §1.1 point 4) — refused loudly by name, mirroring `materialize_nodes` exactly,
+/// rather than served on an unreviewed reading.
+///
+/// **Performs no sort of its own.** `GraphSubstrate::edges` already returns a canonically sorted
+/// `Vec<(NodeId, NodeId)>` (both backends' `sort_unstable()`, before this function ever runs) — this
+/// maps that ALREADY-ordered output element-for-element; `EdgeKey`'s own `Ord` derive is never
+/// consulted here (design decision 1, above).
+fn materialize_edges(
+    items: &[SExpr],
+    env: &EvalEnv<'_>,
+    fuel: &mut u64,
+) -> Result<Vec<Element>, EvalError> {
+    charge(fuel, cost::QUERY_BASE)?;
+    let [_, type_ref, extra @ ..] = items else {
+        return Err(EvalError::plain(
+            "(edges <enum-ref> <edge-pred>?) — missing the EdgeType operand",
+        ));
+    };
+    if !extra.is_empty() {
+        return Err(EvalError::plain(
+            "(edges <enum-ref> <edge-pred>) — the element-predicate operand is a real §2.6 \
+             production this evaluator does not yet serve (no exercised vector or content rule \
+             needs it); T2 serves the unpredicated (edges <enum-ref>) form only",
+        ));
+    }
+    let edge_type = enum_member(type_ref)?;
+    let graph = require_graph(env, "edges")?;
+    Ok(graph
+        .edges(edge_type)
+        .into_iter()
+        .map(|(source, target)| {
+            Element::Edge(EdgeKey {
+                source,
+                target,
+                edge_type: edge_type.to_owned(),
+            })
+        })
+        .collect())
+}
+
 /// An enum-ref operand's member name — read directly, exactly as
 /// `structural_verbs::EffectExecutor::enum_member` reads one, and NOT
 /// through `evaluate()`: an enum-ref atom is a static type annotation here,
@@ -322,6 +383,7 @@ mod tests {
             .iter()
             .map(|element| match element {
                 Element::Node(id) => *id,
+                Element::Edge(_) => panic!("nodes must materialize only Node elements"),
             })
             .collect();
         assert_eq!(ids.len(), N);
@@ -454,6 +516,144 @@ mod tests {
     }
 
     #[test]
+    fn edges_materializes_in_ascending_source_target_order_and_charges_query_base() {
+        let mut graph = MemoryGraph::new();
+        let a = graph.add_node("SOCIAL_CLASS").unwrap();
+        let b = graph.add_node("SOCIAL_CLASS").unwrap();
+        let c = graph.add_node("SOCIAL_CLASS").unwrap();
+        // Insertion order deliberately SHUFFLED against ascending (source, target).
+        graph.add_edge("SOLIDARITY", c, a, 0.9).unwrap();
+        graph.add_edge("SOLIDARITY", a, b, 0.1).unwrap();
+        graph.add_edge("SOLIDARITY", a, c, 0.5).unwrap();
+        let costs = costs();
+        let mut fuel = 10;
+        let result =
+            materialize_src("(edges EdgeType/SOLIDARITY)", &graph, &costs, &mut fuel).unwrap();
+        let keys: Vec<EdgeKey> = result
+            .iter()
+            .map(|element| match element {
+                Element::Edge(key) => key.clone(),
+                Element::Node(_) => panic!("edges must materialize only Edge elements"),
+            })
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                EdgeKey {
+                    source: a,
+                    target: b,
+                    edge_type: "SOLIDARITY".to_owned()
+                },
+                EdgeKey {
+                    source: a,
+                    target: c,
+                    edge_type: "SOLIDARITY".to_owned()
+                },
+                EdgeKey {
+                    source: c,
+                    target: a,
+                    edge_type: "SOLIDARITY".to_owned()
+                },
+            ],
+            "ascending (source-id, target-id) — §2.6; materialize_edges performs no sort of its \
+             own, it maps graph.edges()'s ALREADY-sorted output (see design decision 1 above)"
+        );
+        // QUERY_BASE(1) + enum-ref(0) = 1.
+        assert_eq!(fuel, 9);
+    }
+
+    #[test]
+    fn edges_materializes_in_ascending_source_target_order_at_scale() {
+        const N: usize = 50;
+        let mut graph = MemoryGraph::new();
+        let mut ids = Vec::with_capacity(N);
+        for _ in 0..N {
+            ids.push(graph.add_node("SOCIAL_CLASS").unwrap());
+        }
+        // Add edges over a SHUFFLED pairing of the id space (every id i -> id (i*17+3) % N,
+        // a fixed permutation with no monotonic relationship to insertion/id order) so the
+        // resulting edge set's ascending order cannot coincide with any single simple pattern
+        // the loop itself might accidentally produce.
+        for (i, &from) in ids.iter().enumerate() {
+            let to = ids[(i * 17 + 3) % N];
+            if from != to {
+                graph.add_edge("SOLIDARITY", from, to, 0.1).unwrap();
+            }
+        }
+        let costs = costs();
+        let mut fuel = 10_000;
+        let result =
+            materialize_src("(edges EdgeType/SOLIDARITY)", &graph, &costs, &mut fuel).unwrap();
+        let pairs: Vec<(NodeId, NodeId)> = result
+            .iter()
+            .map(|element| match element {
+                Element::Edge(key) => (key.source, key.target),
+                Element::Node(_) => panic!("edges must materialize only Edge elements"),
+            })
+            .collect();
+        assert!(
+            pairs.windows(2).all(|w| w[0] < w[1]),
+            "materialized edges must be strictly ascending by (source, target): {pairs:?}"
+        );
+    }
+
+    /// `EdgeKey`'s own law, directly: field order is `(source, target, edge_type)`, so `source`
+    /// dominates `edge_type` in comparison — proven with a pair CONSTRUCTED so the two possible
+    /// field orderings DISAGREE (a lower source but alphabetically LATER `edge_type` vs. a higher
+    /// source but alphabetically EARLIER `edge_type`), making the field-declaration choice
+    /// mutation-provable. This is independent of `materialize_edges` (design decision 1) — the
+    /// direct test this crate's own trip-wire has been asking for since `Element`'s derive doc was
+    /// written.
+    #[test]
+    fn edge_key_ord_prioritizes_source_over_edge_type() {
+        let lower_source_higher_type = EdgeKey {
+            source: NodeId(1),
+            target: NodeId(2),
+            edge_type: "ZZZZ".to_owned(),
+        };
+        let higher_source_lower_type = EdgeKey {
+            source: NodeId(2),
+            target: NodeId(1),
+            edge_type: "AAAA".to_owned(),
+        };
+        assert!(
+            lower_source_higher_type < higher_source_lower_type,
+            "source must dominate edge_type — §2.6's (source-id, target-id, edge-type) order"
+        );
+    }
+
+    /// `materialize_edges`' own ordering guarantee comes from `GraphSubstrate::edges`' own
+    /// contract, NOT from `EdgeKey`'s derived Ord (which this function never invokes) — proven by
+    /// direct equality against the substrate's own output, not merely by eyeballing one
+    /// hand-picked fixture (the small exact-triple test above).
+    #[test]
+    fn edges_materializes_in_exactly_graph_edges_own_order() {
+        let mut graph = MemoryGraph::new();
+        let a = graph.add_node("SOCIAL_CLASS").unwrap();
+        let b = graph.add_node("SOCIAL_CLASS").unwrap();
+        let c = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph.add_edge("SOLIDARITY", c, a, 0.9).unwrap();
+        graph.add_edge("SOLIDARITY", a, b, 0.1).unwrap();
+        graph.add_edge("SOLIDARITY", a, c, 0.5).unwrap();
+        let costs = costs();
+        let mut fuel = 10;
+        let result =
+            materialize_src("(edges EdgeType/SOLIDARITY)", &graph, &costs, &mut fuel).unwrap();
+        let materialized: Vec<(NodeId, NodeId)> = result
+            .iter()
+            .map(|element| match element {
+                Element::Edge(key) => (key.source, key.target),
+                Element::Node(_) => panic!("edges must materialize only Edge elements"),
+            })
+            .collect();
+        assert_eq!(
+            materialized,
+            graph.edges("SOLIDARITY"),
+            "materialize_edges must reproduce GraphSubstrate::edges' own order exactly, unchanged"
+        );
+    }
+
+    #[test]
     fn a_predicated_nodes_query_is_a_loud_named_gap() {
         let graph = MemoryGraph::new();
         let costs = costs();
@@ -469,11 +669,10 @@ mod tests {
     }
 
     #[test]
-    fn edges_hyperedges_and_members_of_name_their_slice() {
+    fn hyperedges_and_members_of_name_their_slice() {
         let graph = MemoryGraph::new();
         let costs = costs();
         for (source, slice) in [
-            ("(edges EdgeType/SOLIDARITY)", "slice 2"),
             ("(hyperedges HyperedgeType/CELL)", "slice 3"),
             ("(members-of self HyperedgeType/CELL)", "slice 3"),
             ("(hyperedges-of self HyperedgeType/CELL)", "slice 3"),
@@ -485,32 +684,48 @@ mod tests {
     }
 
     /// Compile-time trap (verifier fix round, MINOR-5 on issue #525): an
-    /// EXHAUSTIVE match over `Element`, no wildcard — a single
-    /// `Element::Node` arm today. The prose warning on `Element`'s own
-    /// derive is not, by itself, a mechanical guarantee that anyone reads
-    /// it before adding `Edge`/`Hyperedge` (slice 2/3); this function
-    /// breaks COMPILATION, at this exact test, the moment a second variant
-    /// lands — forcing the cross-kind order to be pinned against the spec
-    /// before the code can even build, not merely before a reviewer
-    /// happens to notice.
-    fn element_kind_name(element: Element) -> &'static str {
+    /// EXHAUSTIVE match over `Element`, no wildcard. The prose warning on
+    /// `Element`'s own derive is not, by itself, a mechanical guarantee
+    /// that anyone reads it before adding a new variant (`Hyperedge`,
+    /// slice 3); this function breaks COMPILATION, at this exact test, the
+    /// moment a new variant lands — forcing the cross-kind order to be
+    /// pinned against the spec before the code can even build, not merely
+    /// before a reviewer happens to notice. (T2, issue #559: `Edge` landed
+    /// exactly this way — the cross-kind ruling is on the enum's own doc,
+    /// pinned by `node_sorts_before_edge_regardless_of_id` below.) Takes
+    /// `&Element` now that `Element` is no longer `Copy`.
+    fn element_kind_name(element: &Element) -> &'static str {
         match element {
             Element::Node(_) => "node",
+            Element::Edge(_) => "edge",
         }
     }
 
-    /// CT4P A5 (issue #525): today's single-variant `Element` ordering
-    /// reduces exactly to `NodeId`'s own order — see the derive's own doc
-    /// for the warning this pins against, ahead of slice 2/3's new variants.
-    /// [`element_kind_name`] above is the mechanical trip-wire; this test is
-    /// the value-level pin.
+    /// CT4P A5 (issue #525): within one kind, `Element` ordering reduces
+    /// exactly to `NodeId`'s own order — see the derive's own doc for the
+    /// ruling this pins against. [`element_kind_name`] above is the
+    /// mechanical trip-wire; this test is the value-level pin.
     #[test]
     fn element_ordering_matches_ascending_node_id() {
         let a = Element::Node(NodeId(1));
         let b = Element::Node(NodeId(2));
-        assert_eq!(element_kind_name(a), "node");
+        assert_eq!(element_kind_name(&a), "node");
         assert!(a < b);
         assert!(b >= a);
         assert_eq!(Element::Node(NodeId(7)), Element::Node(NodeId(7)));
+    }
+
+    /// T2's cross-kind Ord ruling, value-pinned: Node < Edge regardless of id/key magnitude.
+    #[test]
+    fn node_sorts_before_edge_regardless_of_id() {
+        let node = Element::Node(NodeId(u64::MAX));
+        let edge = Element::Edge(EdgeKey {
+            source: NodeId(0),
+            target: NodeId(0),
+            edge_type: String::new(),
+        });
+        assert_eq!(element_kind_name(&node), "node");
+        assert_eq!(element_kind_name(&edge), "edge");
+        assert!(node < edge, "T2's ruling: kind dominates value");
     }
 }

--- a/rust/crates/babylon-bsl/src/query.rs
+++ b/rust/crates/babylon-bsl/src/query.rs
@@ -291,8 +291,10 @@ fn materialize_edges(
 /// `structural_verbs::EffectExecutor::enum_member` reads one, and NOT
 /// through `evaluate()`: an enum-ref atom is a static type annotation here,
 /// not a value the query computes with (`bound_checker`'s `atom_cost` charges
-/// it 0 for the same reason).
-fn enum_member(expr: &SExpr) -> Result<&str, EvalError> {
+/// it 0 for the same reason). `pub(crate)` (T2, issue #559):
+/// `evaluator::eval_edge_between` reuses this exact reading rather than
+/// re-implementing it.
+pub(crate) fn enum_member(expr: &SExpr) -> Result<&str, EvalError> {
     match expr {
         SExpr::Atom(Atom::EnumRef { member, .. }) => Ok(member),
         other => Err(EvalError::plain(format!(

--- a/rust/crates/babylon-bsl/src/query.rs
+++ b/rust/crates/babylon-bsl/src/query.rs
@@ -670,6 +670,22 @@ mod tests {
         assert!(err.message.contains("element-predicate"), "{err}");
     }
 
+    /// The `edges` twin of the predicated-`nodes` pin above (full-PR
+    /// verification, MINOR-1): the `<edge-pred>` refusal branch had ZERO
+    /// coverage — deleting it left the whole workspace green — and the
+    /// load gate does NOT save it (`grammar.rs`'s `ARITIES` admits arity 2
+    /// for `edges`), so the branch is reachable and was unpinned, against
+    /// the sentinel-every-error-class rule.
+    #[test]
+    fn a_predicated_edges_query_is_a_loud_named_gap() {
+        let graph = MemoryGraph::new();
+        let costs = costs();
+        let mut fuel = 1_000;
+        let err = materialize_src("(edges EdgeType/SOLIDARITY #t)", &graph, &costs, &mut fuel)
+            .unwrap_err();
+        assert!(err.message.contains("element-predicate"), "{err}");
+    }
+
     #[test]
     fn hyperedges_and_members_of_name_their_slice() {
         let graph = MemoryGraph::new();

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -1279,7 +1279,10 @@ fn currency_refusal_message(local: &str, field: &str) -> String {
     )
 }
 
-/// `(edge <enum-ref> <local-name> <local-name> <int>)` — returns the minted
+/// `(edge <enum-ref> <local-name> <local-name> <strength>)` — `<strength>`
+/// is an int or a `p`/`i`/`c`-suffixed unit-interval literal (kind-blind,
+/// mirroring the runtime `:strength` position; D32 kinds the field
+/// Coefficient; T2 plan Task 6a) — returns the minted
 /// `EdgeType` member (verbatim, matching `load_node`'s own return
 /// convention) so the caller can build the `edge_types` census.
 fn load_edge(
@@ -1294,7 +1297,7 @@ fn load_edge(
         parts
     else {
         return Err(err(
-            "expected (edge <EdgeType/MEMBER> <from-name> <to-name> <int>)",
+            "expected (edge <EdgeType/MEMBER> <from-name> <to-name> <strength: int | p/i/c-lit>)",
         ));
     };
     // F6 (#534 fix round item 6): an edge form has no local name of its
@@ -1321,16 +1324,43 @@ fn load_edge(
         })
     };
     // An edge strength is not a node field, so no deffield governs it; the
-    // int-literal restriction is stated directly here.
+    // literal restriction is stated directly here: an integer, or a
+    // p/i/c-suffixed unit-interval literal — KIND-BLIND among the three,
+    // mirroring both attribute_value_unit_interval (kinds do not survive
+    // evaluation; its doc records the choice) and the runtime writer of
+    // this exact position (structural_verbs.rs::add_edge accepts any
+    // Value::Real at :strength). D32 kinds the field Coefficient; the
+    // loader does not narrow to c-only because the runtime cannot (T2 plan
+    // Task 6a, amendment 2026-08-12, adjudicated in its fix round). Ratio
+    // (r) stays out for the node path's own recorded reason — Value::Ratio
+    // is not the binary64 lane, and the runtime :strength match refuses it
+    // identically. No range check on either arm — ints were never checked
+    // here (an OPEN asymmetry, recorded in the T2 plan's Task 6a design
+    // decision 3, not silently resolved), and a p/i/c literal is already
+    // [0,1]-bounded at lex (E-LEX-024).
     let strength = match strength {
         Atom::Int(value) => {
             #[allow(clippy::cast_precision_loss)]
             let widened = *value as f64;
             widened
         }
+        Atom::Scaled(scaled)
+            if matches!(
+                scaled.kind,
+                ScaledKind::Probability | ScaledKind::Intensity | ScaledKind::Coefficient
+            ) =>
+        {
+            // `unscaled / 10^scale` — the crate's one scaled-literal
+            // conversion contract (attribute_value_unit_interval's doc
+            // comment is its normative home), copied verbatim.
+            #[allow(clippy::cast_precision_loss)]
+            let numerator = scaled.unscaled as f64;
+            numerator / 10_f64.powi(i32::from(scaled.scale))
+        }
         other => {
             return Err(err(format!(
-                "edge {member}: expected an integer strength literal, found {other:?}"
+                "edge {member}: expected an integer or p/i/c-suffixed \
+                 unit-interval strength literal, found {other:?}"
             )))
         }
     };
@@ -1565,6 +1595,86 @@ mod tests {
                 expected_bits,
                 "{ty} {literal}: got 0x{:016x}, want 0x{expected_bits:016x}",
                 value.to_bits()
+            );
+        }
+    }
+
+    #[test]
+    fn a_coefficient_strength_literal_seeds_bit_exactly() {
+        // Task 6a (T2 plan amendment, 2026-08-12): D32 rules
+        // <edge-type>/strength Coefficient-kinded — a c-suffixed literal is
+        // hydration's idiomatic way (D32 kinds the field Coefficient; p/i
+        // seed identically — see the companion test) to seed a fractional
+        // strength (a bare decimal
+        // is E-LEX-021, and pre-6a this loader refused every non-int
+        // strength). Bit-exact pin, NOT a tolerance — the same conversion
+        // contract `attribute_value_unit_interval`'s doc comment states;
+        // 0.125 = 2^-3 is dyadic-exact, so 125/1000 divides to it exactly.
+        let source = r"
+(scenario ft/coeff-strength
+  (node core NodeType/SOCIAL_CLASS)
+  (node periphery NodeType/SOCIAL_CLASS)
+  (edge EdgeType/SOLIDARITY core periphery 0.125c))
+";
+        let mut graph = MemoryGraph::new();
+        load_scenario(source, &mut graph).unwrap();
+        let strength = graph
+            .edge_attribute("SOLIDARITY", NodeId(0), NodeId(1), "solidarity/strength")
+            .unwrap();
+        assert_eq!(
+            strength.to_bits(),
+            (0.125_f64).to_bits(),
+            "a c-suffixed Coefficient strength must seed bit-exactly, got {strength}"
+        );
+    }
+
+    #[test]
+    fn a_probability_or_intensity_strength_literal_seeds_identically() {
+        // The kind-blind half of Task 6a's ruling (fix round, MAJOR-1
+        // option (i)), pinned GREEN: kinds do not survive evaluation
+        // (evaluator.rs's atom arm makes every p/i/c literal an untagged
+        // Value::Real), so hydration accepts p/i exactly as it accepts c —
+        // mirroring the runtime writer (structural_verbs.rs::add_edge, any
+        // Value::Real at :strength).
+        for literal in ["0.125p", "0.125i"] {
+            let source = format!(
+                "(scenario ft/kind-blind-strength\n  \
+                 (node core NodeType/SOCIAL_CLASS)\n  \
+                 (node periphery NodeType/SOCIAL_CLASS)\n  \
+                 (edge EdgeType/SOLIDARITY core periphery {literal}))"
+            );
+            let mut graph = MemoryGraph::new();
+            load_scenario(&source, &mut graph).unwrap();
+            let strength = graph
+                .edge_attribute("SOLIDARITY", NodeId(0), NodeId(1), "solidarity/strength")
+                .unwrap();
+            assert_eq!(strength.to_bits(), (0.125_f64).to_bits(), "{literal}");
+        }
+    }
+
+    #[test]
+    fn a_ratio_or_currency_strength_literal_stays_refused() {
+        // What stays out under the kind-blind widening, each mirroring the
+        // runtime :strength match (which accepts only Value::Real): r
+        // evaluates to Value::Ratio, $ to Value::Currency. r is a ScaledLit
+        // kind the guard refuses; $ (Currency) is a DIFFERENT Atom variant
+        // that falls to the same refusal arm without ever reaching the kind
+        // guard (see the Step-6 mutation split in the T2 plan).
+        for literal in ["0.5r", "1$"] {
+            let source = format!(
+                "(scenario ft/wrong-kind-strength\n  \
+                 (node core NodeType/SOCIAL_CLASS)\n  \
+                 (node periphery NodeType/SOCIAL_CLASS)\n  \
+                 (edge EdgeType/SOLIDARITY core periphery {literal}))"
+            );
+            let mut graph = MemoryGraph::new();
+            let err = load_scenario(&source, &mut graph).unwrap_err();
+            assert!(
+                err.message.contains(
+                    "expected an integer or p/i/c-suffixed unit-interval strength literal"
+                ),
+                "{literal}: {}",
+                err.message
             );
         }
     }

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -151,6 +151,12 @@ pub type DefinesEnv = HashMap<String, Value>;
 /// needs the SAME rendering to compare a `field-of` qname's owning segment
 /// against `GraphSubstrate::node_type_of`'s result (§2.10 discipline 1) —
 /// reused rather than re-derived, so the two readings cannot drift apart.
+/// A second reuse caller landed at T2 (issue #559):
+/// `evaluator::check_edge_referent_type` renders a qname's owning segment
+/// to an `EdgeType` member through this SAME function (the rendering rule
+/// is identical for both enum kinds — uppercase, `-` → `_`), comparing it
+/// against an `EdgeKey`'s inline `edge_type` — the `EdgeRef` half of the
+/// same §2.10 discipline 1, on the same no-drift reasoning.
 pub(crate) fn namespace_to_node_type(namespace: &str) -> String {
     namespace.to_uppercase().replace('-', "_")
 }

--- a/rust/crates/babylon-bsl/tests/conformance_corpus.rs
+++ b/rust/crates/babylon-bsl/tests/conformance_corpus.rs
@@ -19,11 +19,12 @@
 //! and `event_wealth_aggregates.bsl` (`sum`/`max`/`min`/weighted `mean`) —
 //! against a real `MemoryGraph`, asserting the RAISED/returned value and a
 //! `:fuel-used` figure (§6.1), not merely that the fixture loads and
-//! bounds. `event_edge_count.bsl` is the one exception: its query is
-//! `(edges …)`, which slice 1 does not serve (slice 2's dyadic edge lane)
-//! — it stays pinned at load only, and evaluating it anyway is asserted to
-//! refuse LOUDLY, naming slice 2 by name (Constraint 4), never a silent
-//! skip. `event_bifurcation.bsl` and `event_metric_conditions.bsl` needed
+//! bounds. `event_edge_count.bsl` ALSO executes for real now (T2, issue
+//! #559, slice 2's dyadic edge lane) —
+//! `edge_count_evaluates_for_real_on_an_empty_graph`/
+//! `..._on_a_non_empty_graph` below, promoted from the load-only pin
+//! `edge_count_stays_pinned_and_names_slice_2` used to be.
+//! `event_bifurcation.bsl` and `event_metric_conditions.bsl` needed
 //! no query at all and already executed for real before this task (see
 //! `bifurcation_routes_by_solidarity_density` and
 //! `metric_conditions_load_and_evaluate` below) — unchanged.
@@ -569,8 +570,10 @@ fn nested_paths_are_qnames_and_absence_is_declared() {
 /// four; three of the four ALSO execute for real below
 /// (`node_condition_exists_executes_over_a_real_graph`,
 /// `forall_executes_over_a_real_graph`,
-/// `wealth_aggregates_execute_over_a_real_graph`) — `EDGE_COUNT` is the
-/// one exception (`edges` is slice 2, `edge_count_stays_pinned_and_names_slice_2`).
+/// `wealth_aggregates_execute_over_a_real_graph`) — `EDGE_COUNT`'s LOAD
+/// verdict is pinned here too, but it ALSO executes for real now (T2,
+/// issue #559) — see `edge_count_evaluates_for_real_on_an_empty_graph`/
+/// `..._on_a_non_empty_graph` below.
 #[test]
 fn aggregation_fixtures_load_and_bound() {
     for (fixture, name) in [
@@ -789,15 +792,12 @@ fn wealth_aggregates_execute_over_a_real_graph() {
     );
 }
 
-/// **PR 4, Task 14: still pinned, named by its slice.** Unlike its three
-/// siblings above, `event_edge_count.bsl`'s `<when>` — `(>= (fold count
-/// (edges EdgeType/SOLIDARITY) it) 1)` — queries `edges`, which slice 1
-/// does not serve (it lands in slice 2, the dyadic edge lane). It stays
-/// pinned at LOAD only (`aggregation_fixtures_load_and_bound` above).
-/// Evaluating it anyway must refuse LOUDLY, naming the slice — never a
-/// silent skip (Constraint 4) and never `E-LOAD-021`'s misdiagnosis.
+/// **T2 (issue #559, Task 3): event_edge_count.bsl now evaluates for real**, promoted from the
+/// load-only pin `edge_count_stays_pinned_and_names_slice_2` used to be — `edges` is served as
+/// of T2. An empty graph has zero SOLIDARITY edges: `(fold count (edges EdgeType/SOLIDARITY)
+/// it)` is `0`, and `(>= 0 1)` is `false` — the exact vector T2 exists to unblock.
 #[test]
-fn edge_count_stays_pinned_and_names_slice_2() {
+fn edge_count_evaluates_for_real_on_an_empty_graph() {
     let loaded = load(EDGE_COUNT, "x.bsl").unwrap();
     let graph = MemoryGraph::new();
     let costs = IntrinsicCosts::default();
@@ -812,8 +812,40 @@ fn edge_count_stays_pinned_and_names_slice_2() {
         elements: Vec::new(),
     };
     let mut fuel = 10_000;
-    let err = evaluate(when_clause(&loaded), &env, &EmptyIntrinsicHost, &mut fuel).unwrap_err();
-    assert!(err.message.contains("slice 2"), "{err}");
+    let result = evaluate(when_clause(&loaded), &env, &EmptyIntrinsicHost, &mut fuel).unwrap();
+    assert_eq!(
+        result,
+        Value::Bool(false),
+        "an empty graph has zero SOLIDARITY edges"
+    );
+}
+
+/// The non-empty companion: one SOLIDARITY edge is enough to cross the `>= 1` threshold.
+#[test]
+fn edge_count_evaluates_for_real_on_a_non_empty_graph() {
+    let loaded = load(EDGE_COUNT, "x.bsl").unwrap();
+    let mut graph = MemoryGraph::new();
+    let a = graph.add_node("SOCIAL_CLASS").unwrap();
+    let b = graph.add_node("SOCIAL_CLASS").unwrap();
+    graph.add_edge("SOLIDARITY", a, b, 0.5).unwrap();
+    let costs = IntrinsicCosts::default();
+    let env_map = bind_environment(&loaded.bindings, &HashMap::new())
+        .expect("EDGE_COUNT's bindings are empty — nothing to resolve");
+    let env = EvalEnv {
+        bindings: env_map,
+        intrinsic_costs: &costs,
+        graph: Some(&graph as &dyn GraphSubstrate),
+        types: None,
+        enums: None,
+        elements: Vec::new(),
+    };
+    let mut fuel = 10_000;
+    let result = evaluate(when_clause(&loaded), &env, &EmptyIntrinsicHost, &mut fuel).unwrap();
+    assert_eq!(
+        result,
+        Value::Bool(true),
+        "one SOLIDARITY edge crosses the >= 1 threshold"
+    );
 }
 
 /// §3.4 catches what Python's aggregate_and_compare silently permitted:

--- a/rust/crates/babylon-bsl/tests/r9_chapters.rs
+++ b/rust/crates/babylon-bsl/tests/r9_chapters.rs
@@ -1201,12 +1201,13 @@ mod c5_element_selection {
         assert_eq!(result2, Value::NodeRef(low));
     }
 
-    /// The other four §2.6 query heads a selection could in principle run
-    /// over stay refused at EVALUATION, each naming the slice that will
-    /// serve it (Constraint 4) — never a silent skip and never an
-    /// `E-LOAD-021` misdiagnosis.
+    /// The other THREE §2.6 query heads a selection could in principle run over stay refused at
+    /// EVALUATION, each naming the slice that will serve it (Constraint 4) — never a silent skip
+    /// and never an `E-LOAD-021` misdiagnosis. `edges` is no longer among them (T2, issue #559) —
+    /// see `edge_count_evaluates_for_real_on_an_empty_graph` (`conformance_corpus.rs`) for its own
+    /// positive vector.
     #[test]
-    fn the_other_four_selection_heads_stay_pinned_named_by_their_slice() {
+    fn the_other_three_selection_heads_stay_pinned_named_by_their_slice() {
         // `self` binds to a REAL node: were it a dangling id, a future
         // referent-validation pass could fire before the slice refusal
         // and this vector would pin the wrong error (Copilot harvest,
@@ -1214,7 +1215,6 @@ mod c5_element_selection {
         let mut graph = MemoryGraph::new();
         let subject = graph.add_node("SOCIAL_CLASS").unwrap();
         for (query, slice) in [
-            ("(edges EdgeType/SOLIDARITY)", "slice 2"),
             ("(hyperedges HyperedgeType/ECONOMIC_SECTOR)", "slice 3"),
             ("(members-of self HyperedgeType/ECONOMIC_SECTOR)", "slice 3"),
             (

--- a/rust/crates/babylon-tick/content/scenarios/edge-lane-e2e.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/edge-lane-e2e.bscn
@@ -1,0 +1,57 @@
+; The T2 (Program 29, issue #559) edge-lane e2e fixture — dyadic edge reads (edges/edge-between/
+; field-of over an EdgeRef). Anticipatory of Solidarity's own read shape (bsl-language.rst §3.8
+; item 8's worked example) but ships NO Solidarity content — Solidarity's own PORT is a separate
+; Wave C train (ADR198 consequences).
+;
+; Node groups, in declaration order (fixes id assignment, scenario.rs's own contract):
+;   0-1   fold-a/fold-b        the edges-fold graph, first pair (0.125)
+;   2     fold-reporter        Shape 1 subject — sums EVERY SOLIDARITY edge in the whole graph
+;   3-4   pair-x/pair-y        Shape 2a — edge-between resolves (0.03125, pair-x -> pair-y)
+;   5     pair-z                Shape 2b — edge-between fails on the REVERSED direction
+;   6-9   hub/spoke-1/spoke-2/spoke-3   Shape 3 — self-anchored neighbors+edge-between
+;   10-11 fold-c/fold-d        the edges-fold graph, second pair (0.25)
+;
+; social-class/fold-total is COEFFICIENT-typed (D32's own kind for strength) — every strength
+; below, and every fold SUM over them, is chosen to stay inside [0,1] (E-EVAL-020's own domain);
+; see this step's own note for the arithmetic that was corrected.
+;
+; Every strength literal is c-suffixed (Task 6a, T2 plan amendment 2026-08-12): a bare decimal
+; cannot LEX (E-LEX-021), and post-6a load_edge accepts int + p/i/c-suffixed unit-interval
+; strength literals (kind-blind, mirroring the runtime :strength writer; c stays this fixture's
+; idiomatic spelling, since D32 kinds the field Coefficient). The suffix changes NO value — each
+; literal converts bit-exactly (Task 6a design decision 2).
+;
+; `social-class/shape` discriminates which rule fires on which node (the territory/shape
+; convention, query_lane_e2e.rs). Only the SUBJECT of each shape carries a nonzero shape value;
+; every other node is shape 0 (inert — exists only as an edge endpoint).
+(scenario social-class/edge-lane-e2e
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (defvocabulary EdgeType (SOLIDARITY))
+  (deffield social-class/shape int extensive)
+  (deffield social-class/fold-total coefficient extensive)
+  ; solidarity/strength is IMPLICIT (D32) — deliberately NOT deffield'd here; this fixture is the
+  ; proof that Task 2's wiring seeds it without one.
+
+  (node fold-a NodeType/SOCIAL_CLASS (social-class/shape 0) (social-class/fold-total 0))
+  (node fold-b NodeType/SOCIAL_CLASS (social-class/shape 0) (social-class/fold-total 0))
+  (node fold-reporter NodeType/SOCIAL_CLASS (social-class/shape 1) (social-class/fold-total 0))
+
+  (node pair-x NodeType/SOCIAL_CLASS (social-class/shape 2) (social-class/fold-total 0))
+  (node pair-y NodeType/SOCIAL_CLASS (social-class/shape 0) (social-class/fold-total 0))
+  (node pair-z NodeType/SOCIAL_CLASS (social-class/shape 4) (social-class/fold-total 0))
+
+  (node hub NodeType/SOCIAL_CLASS (social-class/shape 3) (social-class/fold-total 0))
+  (node spoke-1 NodeType/SOCIAL_CLASS (social-class/shape 0) (social-class/fold-total 0))
+  (node spoke-2 NodeType/SOCIAL_CLASS (social-class/shape 0) (social-class/fold-total 0))
+  (node spoke-3 NodeType/SOCIAL_CLASS (social-class/shape 0) (social-class/fold-total 0))
+
+  (node fold-c NodeType/SOCIAL_CLASS (social-class/shape 0) (social-class/fold-total 0))
+  (node fold-d NodeType/SOCIAL_CLASS (social-class/shape 0) (social-class/fold-total 0))
+
+  (edge EdgeType/SOLIDARITY fold-a fold-b 0.125c)
+  (edge EdgeType/SOLIDARITY pair-x pair-y 0.03125c)
+  (edge EdgeType/SOLIDARITY pair-z pair-x 0.015625c)
+  (edge EdgeType/SOLIDARITY spoke-1 hub 0.0625c)
+  (edge EdgeType/SOLIDARITY spoke-2 hub 0.125c)
+  (edge EdgeType/SOLIDARITY spoke-3 hub 0.1875c)
+  (edge EdgeType/SOLIDARITY fold-c fold-d 0.25c))

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -257,6 +257,17 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
         // (reports/production-bsl-surface-facts-2026-08-12.md §3) confirmed
         // "production" had zero prior hits in this HashSet on either tree.
         "production".to_owned(),
+        // The social-class/* namespace (T2 slice-2 edge reads, issue #559).
+        // Added solely so `edge_lane_e2e.rs`'s three synthetic, Solidarity-
+        // SHAPED vectors have a legal namespace to anchor under (E-LOAD-002)
+        // — the SAME class of driver-scaffolding entry "territory" itself
+        // was when the query-evaluation train added it for
+        // `query_lane_e2e.rs`'s vectors (see that entry's own comment
+        // above). NOT a system port: T2 ships no Solidarity content
+        // (Solidarity's PORT is a separate Wave C train), and no engine
+        // system is named "social-class" — this is the e2e fixture's own
+        // subject-type namespace, nothing more.
+        "social-class".to_owned(),
     ]);
 
     // ONE shared LoadContext for every rule in the content set — the

--- a/rust/crates/babylon-tick/tests/edge_lane_e2e.rs
+++ b/rust/crates/babylon-tick/tests/edge_lane_e2e.rs
@@ -1,0 +1,290 @@
+//! The three T2 slice-2 edge-lane end-to-end vectors (Program 29 train T2,
+//! issue #559; plan `docs/superpowers/plans/2026-08-12-t2-slice2-edge-reads-
+//! plan.md`, Task 6).
+//!
+//! **This ships no Solidarity content.** It proves the three slice-2 heads —
+//! `edges`, `edge-between`, `field-of` over an `EdgeRef` — evaluate
+//! correctly through the real production entry point
+//! (`babylon_tick::run_once_into`, the same seam the CLI driver and
+//! `babylon-client`'s engine link both call), over a hand-built fixture
+//! (`content/scenarios/edge-lane-e2e.bscn`) anticipatory of Solidarity's own
+//! read shape (`bsl-language.rst` §3.8 item 8's worked example) — the same
+//! posture `query_lane_e2e.rs` took for Territory's shapes.
+//!
+//! Each shape below runs as its OWN single-rule content set, loaded fresh
+//! from the ONE shared scenario file each time — no shape's tick can observe
+//! another shape's writes, and the cross-RULE pre-state gap (D-row Q14)
+//! never applies: nothing in this file ever loads more than one `(rule …)`
+//! form in the same `rule_src`.
+//!
+//! **Why every rule declares `social-class/shape`.** `run_tick`'s subject
+//! loop walks EVERY node of a rule's derived subject type; `social-class/
+//! shape` is the discriminator that keeps each shape's rule from firing on
+//! the eleven nodes it does not own (the `territory/shape` convention,
+//! `query_lane_e2e.rs`).
+//!
+//! # Provenance
+//!
+//! Every expected value below is DERIVED in its test's own comment from the
+//! scenario's seeded strengths. Every seeded strength is an exact dyadic
+//! rational (a fraction whose denominator is a power of two — `0.1875 =
+//! 3/16`, `0.375 = 3/8` are not powers of two themselves, but terminate
+//! exactly in binary64, which is the property that matters), and every fold
+//! sum below is a sum of exact dyadic rationals whose intermediate and final
+//! values are all exactly representable — so IEEE-754 addition is EXACT at
+//! every step, plain `f64` equality is the right assertion, and no
+//! `to_bits()` pin is needed (`query_lane_e2e.rs` pins bits only where a
+//! multiply introduces real rounding; nothing here multiplies).
+
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::hypergraph_store::HypergraphStore;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::run_once_into;
+
+const SCENARIO: &str = include_str!("../content/scenarios/edge-lane-e2e.bscn");
+
+// Node ids, fixed by the scenario's own declaration order (scenario.rs's
+// "declaration order is the id order" contract) — see the scenario file's
+// header comment for the full id map.
+const FOLD_REPORTER: NodeId = NodeId(2);
+const PAIR_X: NodeId = NodeId(3);
+const HUB: NodeId = NodeId(6);
+
+// ============================================================ Shape 1
+
+/// `edges`-fold, graph-scope (no `the` needed): the subject sums the
+/// implicit strength (D32) of EVERY dyadic SOLIDARITY edge in the graph —
+/// proves `(edges <enum-ref>)` evaluates for real AND that Task 2's D32
+/// wiring resolves `<edge-type>/strength` through an UNWEIGHTED aggregation
+/// (`typecheck.rs::resolve_field`), not merely the bare accessor's graceful
+/// fallback.
+///
+/// # Derivation
+///
+/// All seven seeded strengths, in the substrate's ascending (source, target)
+/// order (each an exact dyadic rational; the sum is exact at every step):
+/// `0.125 + 0.03125 + 0.015625 + 0.0625 + 0.125 + 0.1875 + 0.25
+///  = 0.796875` — inside `[0,1]`, `E-EVAL-020`'s own domain for the
+/// Coefficient-typed `social-class/fold-total`.
+const RULE_EDGES_FOLD: &str = r#"
+(rule social-class/edges-fold-e2e
+  :material-basis "T2's edges query head materializing every dyadic SOLIDARITY edge in the graph and folding its implicit strength (D32) — proves (edges <enum-ref>) evaluates for real and Task 2's D32 wiring resolves <edge-type>/strength through an UNWEIGHTED aggregation (typecheck.rs::resolve_field), not merely the bare accessor's graceful fallback"
+  :fuel 512
+  (bindings (binding shape :field social-class/shape))
+  (when (= shape 1))
+  (effects
+    (update-node self social-class/fold-total
+      (set (fold sum (edges EdgeType/SOLIDARITY) (field-of it solidarity/strength))))))
+"#;
+
+#[test]
+fn shape_1_edges_fold_sums_every_solidarity_edge_in_the_graph() {
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(SCENARIO, RULE_EDGES_FOLD, &mut graph, &mut sink)
+        .expect("the edges-fold rule must load and run through run_once_into");
+    assert_eq!(report.fired, 1, "only fold-reporter (shape=1) fires");
+
+    let fold_total = graph
+        .node_attribute(FOLD_REPORTER, "social-class/fold-total")
+        .unwrap();
+    assert_eq!(
+        fold_total, 0.796875,
+        "0.125 + 0.03125 + 0.015625 + 0.0625 + 0.125 + 0.1875 + 0.25 = \
+         0.796875 exactly (all dyadic rationals; every intermediate sum \
+         exact in binary64)"
+    );
+}
+
+// ============================================================ Shape 2
+
+/// `edge-between` resolving successfully, its `field-of` read agreeing with
+/// the strength seeded at the edge's own declaration — the R9 chapter-C2
+/// required-vector family, turned into a real evaluation-level vector.
+///
+/// **Determinism caveat, stated explicitly (adversarial review nit):** the
+/// `select-max` scores by the CONSTANT `1` — deterministic ONLY because
+/// `pair-x`'s `:out` SOLIDARITY neighbor set is a SINGLETON (`pair-y`). A
+/// constant score genuinely exercises D46's ascending-id tiebreak only when
+/// two or more candidates tie, which this fixture does not attempt. If a
+/// future edit ever gives `pair-x` a second outgoing SOLIDARITY edge, this
+/// rule's constant score must become a real field (or the tiebreak must be
+/// deliberately exercised and asserted).
+///
+/// # Derivation
+///
+/// `edge-between(SOLIDARITY, pair-x, pair-y)` resolves the seeded
+/// `0.03125c` edge; `field-of … solidarity/strength` reads back `0.03125`
+/// exactly (dyadic; bit-exact through Task 6a's hydration conversion).
+const RULE_EDGE_BETWEEN_RESOLVES: &str = r#"
+(rule social-class/edge-between-resolves-e2e
+  :material-basis "edge-between resolving successfully and its field-of read agreeing with the strength seeded at the edge's own declaration — the R9 chapter-C2 required-vector family, turned into a real evaluation-level vector"
+  :fuel 256
+  (bindings (binding shape :field social-class/shape))
+  (when (= shape 2))
+  (effects
+    (update-node self social-class/fold-total
+      (set (field-of (edge-between EdgeType/SOLIDARITY self
+                        (select-max (neighbors self EdgeType/SOLIDARITY :out NodeType/SOCIAL_CLASS) 1))
+                      solidarity/strength)))))
+"#;
+
+/// The failing direction: `edge-between` is directional (§2.10's key is the
+/// ORDERED triple) — the fixture seeds `pair-z -> pair-x`, and this rule
+/// looks up the REVERSE (`pair-x -> pair-z`), which must fail loudly
+/// through the real driver (`E-EVAL-034`, a TICK ABORT), never a silent
+/// absent reference. Same singleton-neighbor determinism caveat as the
+/// resolving rule above (`pair-z`'s `:out` set is `{pair-x}` alone).
+const RULE_EDGE_BETWEEN_MISSING: &str = r#"
+(rule social-class/edge-between-missing-is-e-eval-034-e2e
+  :material-basis "edge-between is directional (§2.10's key is the ORDERED triple) — looking up the reverse of a seeded edge finds nothing and must fail loudly through the real driver, never a silent absent reference"
+  :fuel 256
+  (bindings (binding shape :field social-class/shape))
+  (when (= shape 4))
+  (effects
+    (update-node self social-class/fold-total
+      (set (field-of (edge-between EdgeType/SOLIDARITY
+                        (select-max (neighbors self EdgeType/SOLIDARITY :out NodeType/SOCIAL_CLASS) 1)
+                        self)
+                      solidarity/strength)))))
+"#;
+
+#[test]
+fn shape_2a_edge_between_resolves_and_reads_strength() {
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(SCENARIO, RULE_EDGE_BETWEEN_RESOLVES, &mut graph, &mut sink)
+        .expect("the edge-between-resolves rule must load and run through run_once_into");
+    assert_eq!(report.fired, 1, "only pair-x (shape=2) fires");
+
+    let fold_total = graph
+        .node_attribute(PAIR_X, "social-class/fold-total")
+        .unwrap();
+    assert_eq!(
+        fold_total, 0.03125,
+        "the strength seeded at (edge … pair-x pair-y 0.03125c), read back \
+         through edge-between + field-of, exactly"
+    );
+}
+
+#[test]
+fn shape_2b_edge_between_on_a_missing_pair_is_e_eval_034() {
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(SCENARIO, RULE_EDGE_BETWEEN_MISSING, &mut graph, &mut sink).expect_err(
+        "looking up the REVERSE of a seeded directional edge must abort \
+             the tick (E-EVAL-034), never yield an absent reference",
+    );
+    assert!(err.contains("E-EVAL-034"), "{err}");
+}
+
+// ============================================================ Shape 3
+
+/// The self-anchored `neighbors`+`edge-between` idiom — §3.8 item 8's worked
+/// example, Solidarity's own anticipated read shape: per TARGET node, walk
+/// incoming SOLIDARITY neighbours and resolve each edge's strength by key,
+/// needing no `(edges …)` iteration and no `source-of`/`target-of` endpoint
+/// accessor (the language does not have one — §3.8 item 8's own open item,
+/// dossier §8). This is the vector that unblocks Solidarity's own port
+/// train.
+///
+/// # Derivation
+///
+/// `hub`'s `:in` SOLIDARITY neighbours are `spoke-1`/`spoke-2`/`spoke-3`;
+/// their seeded strengths sum `0.0625 + 0.125 + 0.1875 = 0.375` exactly
+/// (dyadic at every step; inside `[0,1]`).
+const RULE_SELF_ANCHORED: &str = r#"
+(rule social-class/self-anchored-solidarity-fold-e2e
+  :material-basis "the §3.8 item 8 worked example — Solidarity's own anticipated read shape, self-anchored via neighbors+edge-between rather than iterating (edges ...) and needing an endpoint accessor the language does not have (§3.8 item 8's own open item, dossier §8). T2 proves this idiom evaluates for real, and this is the vector that unblocks Solidarity's own port train without needing source-of/target-of."
+  :fuel 512
+  (bindings (binding shape :field social-class/shape))
+  (when (= shape 3))
+  (effects
+    (update-node self social-class/fold-total
+      (set (fold sum (neighbors self EdgeType/SOLIDARITY :in NodeType/SOCIAL_CLASS)
+                 (field-of (edge-between EdgeType/SOLIDARITY it self) solidarity/strength))))))
+"#;
+
+#[test]
+fn shape_3_self_anchored_neighbors_and_edge_between_sums_incoming_strength() {
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(SCENARIO, RULE_SELF_ANCHORED, &mut graph, &mut sink)
+        .expect("the self-anchored rule must load and run through run_once_into");
+    assert_eq!(report.fired, 1, "only hub (shape=3) fires");
+
+    let fold_total = graph
+        .node_attribute(HUB, "social-class/fold-total")
+        .unwrap();
+    assert_eq!(
+        fold_total, 0.375,
+        "0.0625 + 0.125 + 0.1875 = 0.375 exactly — hub's three incoming \
+         spoke strengths, resolved per-edge via edge-between"
+    );
+}
+
+// ============================================================ Determinism
+
+/// §6.2 family 8, split (adversarial review Blocker 3): the three SUCCEEDING
+/// shapes run through the unmodified `query_lane_e2e.rs`-style
+/// `TickReport`-comparison loop — Shape 2b is DESIGNED to `Err` and gets its
+/// own two-run leg below, since this loop's `.unwrap_or_else(panic!)` would
+/// panic on it.
+#[test]
+fn every_succeeding_shape_is_deterministic_across_two_independent_runs() {
+    for (rule, label) in [
+        (RULE_EDGES_FOLD, "edges-fold"),
+        (RULE_EDGE_BETWEEN_RESOLVES, "edge-between-resolves"),
+        (RULE_SELF_ANCHORED, "self-anchored-fold"),
+    ] {
+        let mut graph_a = HypergraphStore::new();
+        let mut sink_a = CollectingSink::default();
+        let report_a = run_once_into(SCENARIO, rule, &mut graph_a, &mut sink_a)
+            .unwrap_or_else(|e| panic!("{label}: first run: {e}"));
+
+        let mut graph_b = HypergraphStore::new();
+        let mut sink_b = CollectingSink::default();
+        let report_b = run_once_into(SCENARIO, rule, &mut graph_b, &mut sink_b)
+            .unwrap_or_else(|e| panic!("{label}: second run: {e}"));
+
+        assert_eq!(report_a.before, report_b.before, "{label}: before hash");
+        assert_eq!(report_a.after, report_b.after, "{label}: after hash");
+        assert_eq!(report_a.fired, report_b.fired, "{label}: fired count");
+        assert_eq!(
+            report_a.per_rule_fired, report_b.per_rule_fired,
+            "{label}: per_rule_fired"
+        );
+    }
+}
+
+/// Shape 2b's own two-run leg: the same content must fail the same way both
+/// times — the error STRING is the comparison, since a tick that aborts
+/// yields no `TickReport` to compare.
+#[test]
+fn shape_2b_error_is_deterministic_across_two_independent_runs() {
+    let mut graph_a = HypergraphStore::new();
+    let mut sink_a = CollectingSink::default();
+    let err_a = run_once_into(
+        SCENARIO,
+        RULE_EDGE_BETWEEN_MISSING,
+        &mut graph_a,
+        &mut sink_a,
+    )
+    .expect_err("shape 2b must abort the tick");
+
+    let mut graph_b = HypergraphStore::new();
+    let mut sink_b = CollectingSink::default();
+    let err_b = run_once_into(
+        SCENARIO,
+        RULE_EDGE_BETWEEN_MISSING,
+        &mut graph_b,
+        &mut sink_b,
+    )
+    .expect_err("shape 2b must abort the tick");
+
+    assert_eq!(
+        err_a, err_b,
+        "the same content must fail the same way both times"
+    );
+    assert!(err_a.contains("E-EVAL-034"), "{err_a}");
+}


### PR DESCRIPTION
Part 2 of 2 for #559 (Program 29 T2 — Query Slice 2, edge reads). Closes #559. Executes Tasks 3–7 plus amendment Task 6a of `docs/superpowers/plans/2026-08-12-t2-slice2-edge-reads-plan.md`, on top of PR A (#574, the substrate read + D32 wiring).

## What lands

- **The edge value surface**: `EdgeKey` (§2.6 field order so the derived `Ord` agrees with the spec by construction), `Value::EdgeRef`, `Element::Edge` with the `Node < Edge` total-order law — `Element` drops `Copy`, all nine plan-enumerated call sites fixed (compiler-exhaustive under `-D warnings`).
- **`edges` served**: `materialize_edges` in `graph.edges()`'s own order, pinned by a 50-edge shuffled determinism vector (fixed-point-free permutation, 49 real strict comparisons) and a delegation test; the `<edge-pred>` operand refused loudly — and now mutation-pinned (the verify pass caught the refusal branch as mutation-dead; deleting it flips exactly one test).
- **`eval_edge_between`** — the §2.10 accessor; static fuel bound == runtime charge (3 == 3, both pinned); missing pair = E-EVAL-034 ("the accessor never yields an absent reference").
- **`field_of_edge`** — `field-of` over an `EdgeRef` via PR A's `edge_attribute`; unstored qnames = E-EVAL-033; generic over any edge-owned qname.
- **Task 6a (amendment)**: `load_edge` accepts kind-blind `p`/`i`/`c` unit-interval strength literals (int arm byte-identical; `r`/`$` refused). The original plan's fractional fixtures could not load — int-only strength literals, execution-proven — and the amendment went through its own two-round adversarial review, which re-adjudicated the widening from c-only to kind-blind (mirroring the runtime `add-edge` verb and the node-seed path's recorded reasoning).
- **The e2e estate**: `edge-lane-e2e.bscn` + six vectors through the real `run_once_into` seam — Shape 1 = 0.796875, Shape 2a = 0.03125, Shape 3 = 0.375, all hand-recomputed dyadic-exact by the verifier; Shape 2b pins the mid-tick E-EVAL-034 abort verbatim.
- **Records**: D139–D142 register rows (D139 records the D32 seeding narrowing and its graceful degradation, executed in both directions), ADR201 (including the Task 6a record and the verification-found explicit-anchor alternative to the `social-class` registered-system anchor, kept for the territory precedent `c28c1f34`), index row 1.75.0.

## Verification arc

Implementer (Tasks 3–5) → STOP at Task 6 on an execution-proven plan/reality contradiction → plan amendment (Task 6a) → amendment adversarial review (1 MAJOR: kind-scope re-adjudicated) → amendment delta re-verify (EXECUTE AS-IS) → implementer resumed (6a/6/7) → fresh full-PR adversarial verify with first-pass scrutiny on Tasks 3–5 (MERGEABLE AFTER FIXES: 1 required — the mutation-dead refusal; 2 recommended) → fix round → delta re-verify (**MERGEABLE AS-IS**, 1115 workspace tests, goldens 6/6 + engine_link byte-identical, doc-sync guard 41/41).

Every mutation was re-run independently by the verifier; every impossibility claim in the records was verified by executing the refused construct.

## Post-merge actions riding this PR

- #559 closes (this PR); the `the` micro-train (#572, Director-ruled 2026-08-12) becomes charterable.
- D-record handoff to #502's ledger: D139–D142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
