### PR TITLE
chore(pre-commit): hooks for the Rust reality — rust:check pre-push mirror, clippy complexity gate, radon frozen-estate exemptions

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1633,12 +1633,14 @@ run = "uv run python manage.py migrate"
 # ── Rust client (the raster cutover, Amendment AC / ADR150) ──────────────────
 
 [tasks."rust:check"]
-description = "Rust full gate for the in-tree rust/ client workspace: format:check + lint (clippy -D warnings) + test + doc — CI parity. Sequential run-block, NOT parallel depends: one cargo target dir has one file lock, so parallel legs only contend (machine-safety: heavy builds single-flight). Shape mirrored from hypergraph-rs."
+description = "Rust full gate for the in-tree rust/ client workspace: format:check + lint (clippy -D warnings -D clippy::cognitive_complexity, threshold in rust/clippy.toml) + test + doc — CI parity. Sequential run-block, NOT parallel depends: one cargo target dir has one file lock, so parallel legs only contend (machine-safety: heavy builds single-flight). Shape mirrored from hypergraph-rs."
 dir = "rust"
 run = """
 set -e
 cargo fmt --all -- --check
-cargo clippy --workspace --all-targets --locked -- -D warnings
+# cognitive_complexity (threshold owned in rust/clippy.toml, Director ruling
+# 2026-08-15) is the Rust radon-equivalent: denied workspace-wide here.
+cargo clippy --workspace --all-targets --locked -- -D warnings -D clippy::cognitive_complexity
 cargo test --workspace --locked
 cargo clippy -p babylon-kernel --all-targets --locked -- -D warnings -D clippy::pedantic
 cargo test -p babylon-kernel --locked

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,7 +103,10 @@ repos:
         name: radon (maintainability index >= B)
         entry: >-
           bash -c 'set -euo pipefail;
-          excl="*/topology/graph.py,*/systems/electoral.py,*/sentinels/_ast.py,*/tick/system/__init__.py";
+          excl="src/babylon/topology/graph.py,";
+          excl+="src/babylon/engine/systems/electoral.py,";
+          excl+="src/babylon/sentinels/_ast.py,";
+          excl+="src/babylon/domain/economics/tick/system/__init__.py";
           output="$(uv run radon mi src/babylon -s -e "$excl")";
           echo "$output"; if echo "$output" | grep -Eq " - [CDEF]"; then
           echo "radon: maintainability rank below B detected"; exit 1; fi'
@@ -160,8 +163,9 @@ repos:
           bash -c 'set -euo pipefail;
           git fetch -q origin dev 2>/dev/null || true;
           base="$(git merge-base HEAD origin/dev 2>/dev/null || git merge-base HEAD dev 2>/dev/null || echo "")";
-          if [ -n "$base" ] && [ -z "$(git diff --name-only "${base}..HEAD" -- rust/)" ]; then
-            echo "rust:check skipped — push range touches no rust/ paths";
+          dirty="$(git status --porcelain -- rust/)";
+          if [ -n "$base" ] && [ -z "$(git diff --name-only "${base}..HEAD" -- rust/)" ] && [ -z "$dirty" ]; then
+            echo "rust:check skipped — push range and working tree touch no rust/ paths";
             exit 0;
           fi;
           mise run rust:check'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,10 +92,19 @@ repos:
         always_run: true
         stages: [pre-push]
 
+      # radon has NO CI leg (verified 2026-08-15: grep radon .github/workflows/
+      # is empty) — it is a local-only stricter gate. The four excluded files
+      # are pre-existing C ranks in the FROZEN Python engine estate (Amendment
+      # AE: reference-only, deliberately not refactored), tracked as #580; the
+      # gate stays live for every other file, so any NEW sub-B rank still
+      # fails the push. Removing an exclusion IS fixing #580 — do it file by
+      # file, never by widening this list.
       - id: radon-mi
         name: radon (maintainability index >= B)
         entry: >-
-          bash -c 'set -euo pipefail; output="$(uv run radon mi src/babylon -s)";
+          bash -c 'set -euo pipefail;
+          excl="*/topology/graph.py,*/systems/electoral.py,*/sentinels/_ast.py,*/tick/system/__init__.py";
+          output="$(uv run radon mi src/babylon -s -e "$excl")";
           echo "$output"; if echo "$output" | grep -Eq " - [CDEF]"; then
           echo "radon: maintainability rank below B detected"; exit 1; fi'
         language: system
@@ -121,6 +130,42 @@ repos:
       - id: semgrep
         name: semgrep (test-estate process rules)
         args: [--config, .semgrep-tests.yml, --severity, ERROR, --error, --quiet, tests/]
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
+  # ==========================================================================
+  # RUST - the engine estate (Amendment AE). CI's Rust Gate is `mise run
+  # rust:check`; these legs mirror it locally. fmt runs at commit time on any
+  # staged .rs (no build, seconds). The FULL gate runs at pre-push behind a
+  # range guard: when neither the push range nor the working tree touches
+  # rust/, the gate's inputs are unchanged and its result cannot differ —
+  # skipping loses no signal (unlike the ADR181 R4 staged-files blind spot;
+  # when it fires it runs FULL-TREE, exactly as CI does). When it does fire
+  # it is the complete CI mirror: fmt + clippy -D warnings
+  # -D clippy::cognitive_complexity + tests + pedantic legs + doc.
+  # ==========================================================================
+  - repo: local
+    hooks:
+      - id: rust-fmt-check
+        name: cargo fmt --check (Rust, staged .rs)
+        entry: bash -c 'cd rust && cargo fmt --all -- --check'
+        language: system
+        pass_filenames: false
+        files: '\.rs$'
+
+      - id: rust-full-gate
+        name: rust:check (full Rust gate, pre-push CI mirror)
+        entry: >-
+          bash -c 'set -euo pipefail;
+          git fetch -q origin dev 2>/dev/null || true;
+          base="$(git merge-base HEAD origin/dev 2>/dev/null || git merge-base HEAD dev 2>/dev/null || echo "")";
+          if [ -n "$base" ] && [ -z "$(git diff --name-only "${base}..HEAD" -- rust/)" ]; then
+            echo "rust:check skipped — push range touches no rust/ paths";
+            exit 0;
+          fi;
+          mise run rust:check'
+        language: system
         pass_filenames: false
         always_run: true
         stages: [pre-push]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,10 @@ or to the Director — never improvise it. Full model: `CONTRIBUTORS.md`. Branch
 commits (`type(scope): desc`). **Commit after each unit of work** — pre-commit hooks test only staged
 files, so intertwined units force ugly giant commits. Use `mise run commit -- "type(scope): msg"`
 (hook-safe: pre-runs hooks, re-stages fixes, verifies HEAD moved). End commit messages with the
-`Co-Authored-By` trailer. Full workflow: `CONTRIBUTORS.md`.
+`Co-Authored-By` trailer. Full workflow: `CONTRIBUTORS.md`. **Pre-push mirrors CI per ecosystem:**
+the Python full-tree legs always run (ADR181 R4); a `rust/`-touching push additionally runs the
+full `mise run rust:check` (range-guarded — non-Rust pushes skip the build; radon's four
+frozen-estate exemptions cite #580).
 
 **Merge protocol (ADR181, ratified 2026-07-30):** before self-merging a PR, (1) verify every CI
 check completed and `headRefOid` == the green run's `headSha`; (2) **harvest the Copilot review** —

--- a/rust/clippy.toml
+++ b/rust/clippy.toml
@@ -1,0 +1,8 @@
+# Director ruling 2026-08-15: the Rust estate gets the same complexity gating
+# radon gives Python — clippy's cognitive_complexity lint, with the threshold
+# owned HERE so every clippy invocation (the rust:check gate, editor,
+# rust-analyzer) reads the same number. 25 is clippy's default; written
+# explicitly so lowering it is a deliberate ratchet (its own issue), never
+# drift. Function LENGTH (the power-of-10 ~100-line rule) already rides the
+# pedantic legs on kernel/bsl/graph via clippy::too_many_lines.
+cognitive-complexity-threshold = 25


### PR DESCRIPTION
## Why

Director directive 2026-08-15: the hook pipeline predates the Rust estate — it gated Python full-tree at pre-push but had **zero Rust legs**, so Rust defects only surfaced as red CI, while a local-only Python gate (radon) blocked Rust-only pushes on pre-existing frozen-estate debt (#580). This PR updates the hook reality for Amendment AE.

## What

- **pre-commit:** `cargo fmt --check` on staged `.rs` files (no build, seconds).
- **pre-push:** full `mise run rust:check` — the exact CI Rust Gate (fmt + clippy `-D warnings -D clippy::cognitive_complexity` + workspace tests + pedantic legs + doc) — behind a **range guard**: pushes touching no `rust/` paths skip the build (deterministic inputs ⇒ no signal lost); Rust pushes get the full gate *locally* instead of red CI. ADR181 R4's full-tree discipline is preserved *within* the ecosystem whenever it fires.
- **Complexity gating for Rust (the radon-equivalent, Director ruling):** `clippy::cognitive_complexity` denied workspace-wide via the `rust:check` clippy leg; threshold owned in new `rust/clippy.toml` (= 25, explicit so ratcheting is deliberate). Chosen per production-Rust practice (tokio/serde/Bevy/Embark pattern: toolchain-native lints as gates, thresholds in config every clippy invocation reads — never external metric tools). Function *length* already rides `clippy::too_many_lines` (pedantic legs, ~100 lines ≈ the power-of-10 rule). Estate measured **clean at 25** via forced re-lint.
- **radon-mi:** exempts exactly the four pre-existing frozen-estate C ranks (`graph.py`, `electoral.py`, `sentinels/_ast.py`, `tick/system/__init__.py` — #580, scope-corrected there 2026-08-15). radon has **no CI leg** (verified: grep is empty); the gate stays live for every other Python file — any *new* sub-B rank still fails the push.
- `CLAUDE.md`: hooks-reality note under Git & commits.

## Dogfood evidence

This branch's own push ran the new suite: radon **Passed** (exemptions), `rust:check (full Rust gate, pre-push CI mirror)` **Passed** (range guard fired on `rust/clippy.toml`, full gate green — including the new complexity lint, denied).

Unblocks: T3 PR B (#560's execution half), which was push-blocked by the radon anomaly.

🤖 Generated with Kimi Code