### PR TITLE
Train B item 6: the real type + content migration (#591)

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -3406,6 +3406,11 @@ merely exercised by a unit test.
   Register D98) — a ``deffield``'s or a ``metric``'s ``:type`` still cannot
   name it, since §3.1 rules ``Real`` "Not storable" for a field. A worked
   declaration: ``(intrinsic floor :params (real) :returns int :cost N)``.
+  **Train B note (2026-08-15, D155):** the "still cannot name it" half of
+  this bullet is superseded — ``real`` became a storable ``:type``
+  spelling via D155 (§3.1's eighth row, the register below). D98's
+  intrinsic-position law itself is unchanged: ``:params``/``:returns``
+  still admit ``real``, and this signature stands as written.
 - **A non-``Real``-lane argument is refused, not coerced.** §3.3 promotes
   ``Int`` to ``Real`` only *within* a binary64 expression; it does not reach
   the intrinsic-call boundary, and no full static typechecker exists yet to

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -7096,7 +7096,11 @@ consequences are the ordinary kind of review item.
        declaration spelling for what the store already does (Amendment
        AE clause (ii), representation-level). Byte-neutrality: no
        committed content declares ``real`` yet, and type tags are never
-       hashed, so every existing golden passes unedited.
+       hashed, so every existing golden passes unedited. (Written at
+       the mint; the train's Task-2 migration in the same PR then
+       re-typed the non-integral-f64 roster to ``real`` — every golden
+       still passes unedited, carried by the same mechanism: type tags
+       are never hashed.)
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -324,6 +324,16 @@ the engine's existing quantization grid is ``1e-5`` (``SnapToGrid``), so 9
 digits is comfortably beyond any authored precision while remaining exactly
 representable in the ``i128`` unscaled form.
 
+**Which literals a** ``real``\ **-declared field accepts** (Train B item 6,
+#591 — D155 in the register): an ``int`` literal (exact to 2⁵³), any
+``p``/``i``/``c`` literal, and any ``r`` literal — each already lex-bounded
+in its own lane above — all converting to ``binary64`` by the one contract,
+``unscaled / 10^scale``. A ``$`` literal is refused (the typed-storage
+deferral every field type states, §3.2). There is NO arbitrary-precision
+fractional literal: a bare ``0.5`` stays ``E-LEX-021`` under a ``real``
+declaration too — that is #591 item 5's territory, deliberately not this
+train's.
+
 **``r`` — ``Ratio`` (Director ruling 2026-08-11, #492/ADR194: the
 declared-domain Currency scale operation).** ``babylon_kernel::scalars::Ratio``
 is a **pre-existing** kernel sort (`𝔾 ∩ (0, ∞)`, grid-quantized like every
@@ -1802,6 +1812,16 @@ before this ruling); ``:type enum`` requires ``:enum-type`` — naming a
 type ``defenum`` has declared (§2.13) — and forbids ``:kind``. Either
 violation is ``E-LOAD-053``. Full declaration and read/write law: §2.13.
 
+**[Train B item 6, #591 — D155]** *The* ``:type`` *slot's eighth name is*
+``real``: the finite ``binary64`` lane as a STORED field type, carrying no
+declared-domain range law (§3.3's ``E-EVAL-020`` stays the three
+unit-interval types' own check). A ``real`` field is ordinary under every
+other clause of this section — it takes ``:kind`` like any non-``enum``
+type, its owner may be a node, ``EdgeType`` or ``HyperedgeType`` member,
+and kernel agreement stays ``E-LOAD-022``. Seed law: §1.5's acceptance
+paragraph; the full row: §3.1. A knowing supersession of D98's "not
+storable", recorded in the register — not a silent reopening.
+
 2.10 Element accessors
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2335,15 +2355,31 @@ degraded mode, and no rule that loads "partially".
        only to the same declared type; carries no aggregation ``:kind``
        (§2.9, §3.4). Supersedes D94's exclusion of a declarable
        closed-enum row — see D101 in the register below.
+   * - ``real``
+     - ``binary64``, finite
+     - **Train B item 6 (#591) — the eighth declarable row, D155:** the
+       honest declared home for what the store already does — a verbatim
+       finite ``binary64`` attribute carrying NO declared-domain range law
+       (§3.3's ``E-EVAL-020`` is the unit-interval types' check, not this
+       row's). Seeds accept int / ``p``/``i``/``c`` / ``r`` literals, each
+       converted by the one scaled-literal contract (``unscaled /
+       10^scale``, §1.5); writes store any finite ``binary64`` verbatim.
+       There is no arbitrary-precision fractional literal — ``E-LEX-021``
+       still refuses bare floats (#591 item 5's territory, not this
+       train's). Supersedes D98's "not storable" — see D155 in the
+       register below.
    * - ``Real``
      - ``binary64``, finite
-     - The **unbounded intermediate** type (§3.3). Not storable.
+     - The **unbounded intermediate** type (§3.3) — the typechecker
+       classification of every binary64 expression. The STORABLE spelling
+       is the lowercase ``real`` row above (D155); this capitalized row
+       remains the expression-type name, exactly the ``enum``/``Enum<T>``
+       split's two-jobs-one-root pattern.
    * - ``Ratio``
      - ``binary64``, ``(0, ∞)``
      - **§1.5 addendum** (Director ruling 2026-08-11, #492/ADR194): a
-       declared-domain positive scale factor. Not storable — joins ``Real``
-       in this row's category, not the six above. Its one legal operation is
-       ``Currency × Ratio`` (§3.2).
+       declared-domain positive scale factor. Not storable. Its one legal
+       operation is ``Currency × Ratio`` (§3.2).
    * - ``Enum<T>``
      - members of closed enum ``T``
      - Comparable with ``=``/``!=`` only, and only to the same ``T``.
@@ -2406,9 +2442,23 @@ so nothing needed re-spelling. D94 itself is left unedited (Immutability
 of History: it captured what was true through that review), and this
 paragraph is the current-law correction sitting beside it.
 
+**[Train B item 6, #591 — the eighth row, D155]** *The eighth declarable
+row,* ``real``, *was minted by Train B item 6* — a knowing supersession of
+D98's "``Real`` is not storable", the same posture D101 took toward D94.
+``real`` (lowercase, §1.4-lexable, D94's own spelling law) is what a
+``deffield`` or a ``metric`` writes after ``:type`` to declare a field in
+the finite ``binary64`` lane with NO declared-domain range law; ``Real``
+(capitalized) remains the *typechecker* classification of every binary64
+expression — the ``enum``/``Enum<T>`` two-jobs-one-root pattern exactly.
+The "remaining rows" sentence above is left unedited as history; the
+current law is: the reference and set kinds, ``Enum<T>``, ``Str`` and
+``Ratio`` are the typechecker types no ``<type-name>`` position can name,
+and ``Real`` is no longer among them. D155 in the register below records
+the supersession explicitly, by name.
+
 ``Ratio`` (added by the §1.5/§3.2 addendum below, #492/ADR194 — recorded as
-D99, not a re-opening of D94) joins this same non-storable category for the
-same reason ``Real`` does: it is produced by a literal and consumed by one
+D99, not a re-opening of D94) holds the non-storable-literal category
+alone after D155: it is produced by a literal and consumed by one
 operator, never declared as a field's or a metric's type.
 
 3.2 Currency operator and rounding table
@@ -7013,6 +7063,35 @@ consequences are the ordinary kind of review item.
        tv-tie-all-true (sum 0.999999) is healed ``l += 1e-6`` before its
        LIBERAL readout — lawful A-001 behavior, pinned bit-exactly by the
        conformance test.
+   * - D155
+     - §3.1, §2.9, §1.5
+     - **Train B item 6 (issue #591) —** ``real`` **is the eighth
+       declarable** ``<type-name>``**:** a ``deffield``/``metric``
+       ``:type`` spelling the finite ``binary64`` lane as a STORED type,
+       carrying no declared-domain range law — §3.3's ``E-EVAL-020``
+       stays the three unit-interval types' own check, and
+       ``store_range_check``'s ``matches!`` is deliberately NOT widened.
+       Seed law: int / ``p``/``i``/``c`` / ``r`` literals accepted, each
+       already lex-bounded in its own lane (int exact to 2⁵³,
+       ``p``/``i``/``c`` ``[0,1]`` at lex, ``r`` ``(0, ∞)`` at lex),
+       converted by the crate's one scaled-literal contract
+       (``unscaled / 10^scale`` — a basic IEEE-754 op, reproducing
+       bit-identically); ``$`` refused (the typed-storage deferral every
+       arm states). Write law: any finite ``binary64`` lands verbatim —
+       no range check, never a clamp; negative writes are lawful even
+       though no negative fractional seed literal exists. There is NO
+       arbitrary-precision fractional literal: ``E-LEX-021`` still
+       refuses bare floats — #591 item 5's territory, deliberately not
+       this train's. A knowing supersession of D94's sealed closure
+       (already seven rows by D101) and of D98's "``Real`` is not
+       storable": both rows stand unedited (Immutability of History);
+       this row is the correction, and §3.1 carries the current-law
+       paragraph beside them. Not new mathematics — §3.3/§4.3 already
+       name the binary64 lane; ``real`` mints no new type, only a
+       declaration spelling for what the store already does (Amendment
+       AE clause (ii), representation-level). Byte-neutrality: no
+       committed content declares ``real`` yet, and type tags are never
+       hashed, so every existing golden passes unedited.
 
 See Also
 ----------

--- a/docs/reference/bsl.ebnf
+++ b/docs/reference/bsl.ebnf
@@ -258,6 +258,21 @@ type-name   ::= symbol                                        /* §3.1 */
                    what was true through that review) rather than
                    rewritten to read as if it always said seven. */
 
+                   /* ADDENDUM (Train B item 6, #591, 2026-08-15 — a LATER
+                   row than D101 above, recorded as D155 and explicitly
+                   superseding D98's "`Real` is not storable", never a
+                   silent reopening): an eighth lowercase symbol, `real`,
+                   joins this production's whole vocabulary — the finite
+                   binary64 lane as a STORED field type, carrying no
+                   declared-domain range law. Its storage/seed/write law
+                   lives in §3.1's eighth row and §1.5's acceptance
+                   paragraph; a `deffield`'s or `metric`'s `:type` may now
+                   name it, so the `intrinsic-type-name` production below
+                   (D98) keeps its explicit `"real"` alternative as a
+                   subsumed historical record, not as a widening this
+                   production lacks. The D94/D101 records above stand
+                   unedited (Immutability of History). */
+
 intrinsic-type-name ::= type-name | "real"                    /* §2.7 */
                 /* D98 (workforce draft ruling, Phase 1 review). Widens
                    type-name with `real` — legal ONLY in an intrinsic-decl's

--- a/docs/superpowers/plans/2026-08-15-bsl-ergonomics-b.md
+++ b/docs/superpowers/plans/2026-08-15-bsl-ergonomics-b.md
@@ -1,0 +1,433 @@
+# BSL Surface-Ergonomics Train B (items 6, 3, 4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give unbounded f64 an honest declared home (`real`), make edge attributes seedable, and let scenarios share declarations — discharging W10's recorded narrowings (D151, the verbatim-f64 int lane) with zero unintended byte drift.
+
+**Architecture:** Three additive loader/type-surface extensions to `babylon-bsl` plus one content retrofit in `babylon-tick` content. Everything is representation-level: `BslType` is load-time metadata (never hashed), edge attributes already exist at runtime, and declaration sharing is loader composition. The only byte movement is Task 4's declared re-pin ceremony.
+
+**Tech Stack:** Rust workspace (`rust/crates/babylon-bsl`, `babylon-graph`, `babylon-tick`), BSL content (`.bsl` rules + `.bscn` scenarios), the dual-implementation Python oracle (`consciousness_ternary_conformance.py`), cargo + mise gates.
+
+**Spec:** `docs/superpowers/specs/2026-08-15-bsl-ergonomics-b-charter.md` — Director-ruled 2026-08-15 (all six decision points adopted as recommended: additive `real`; full-inventory migration; sequencing 6→3→4; identical-declaration recognition with `DuplicateType` preserved for differences; `wages-received` retired on un-narrowing; AE(ii) posture signed off). Archaeology digest: `ai/scratch/2026-08-15-bsl-ergonomics-b-archaeology.md` (every file:line below is verified there or re-verified by the controller against dev @17971664).
+
+## Global Constraints
+
+- **AE(ii):** no new mathematics, no new formal constructs. Type kinds, grammar forms, and loader composition only.
+- **Byte-neutrality:** Tasks 1, 2, 3, 5 move ZERO byte pins (type tags and declarations are never hashed — `scenario.rs:1044-1054`, `tick_goldens.rs:239-245`). Task 4 is the train's ONE declared re-pin ceremony (see its ceremony step).
+- **No `tests/baselines/**` movement anywhere** — III.13/§6.5 is the Python estate; nothing here crosses.
+- **Frozen Python engine untouched** (reference-only); any divergence earns a D-row.
+- **Conventional Commits** + `Co-Authored-By: Kimi Code <noreply@moonshot.ai>` trailer; `mise run commit` with a staged tree.
+- **`cargo test -p babylon-bsl` / `-p babylon-tick` green after every step**; full `mise run rust:check` before every commit that touches `rust/`.
+- Merges only via `mise run pr:merge`; Copilot review harvested per PR (zero unaddressed comments).
+- Every new law gets a register row (D-number) in `docs/reference/bsl-language.rst` in the task that mints it; the implementer picks the next free D-number (D155+ as of writing — verify with `rg -n '^D1[0-9]+' docs/reference/bsl-language.rst | tail -5`... actually `rg -o 'D1[0-9][0-9]' docs/reference/bsl-language.rst | sort -u | tail`).
+- Error codes: new codes take the next free number in their family (`rg -o 'E-LOAD-0[0-9]+' rust/crates/babylon-bsl/src docs/reference/bsl-language.rst | sort -u | tail`), with the spec-code registry entry.
+- **Worktree:** execution happens in `/home/user/projects/game/bsl-ergonomics-b` (branch `feature/bsl-ergonomics-b` from dev); created at execution time with the `data/` symlink farm + `.env` copied and `mise run install` if any Python leg is run.
+
+---
+
+### Task 1: `BslType::Real` — the type, the seed arm, the compiler-driven arms
+
+**Files:**
+- Modify: `rust/crates/babylon-bsl/src/types.rs:212-237` (the `BslType` enum)
+- Modify: `rust/crates/babylon-bsl/src/scenario.rs:919-931` (`load_deffield`'s type-name match), `:1055-1087` (`attribute_value`), after `:1163` (new `attribute_value_real`)
+- Modify: `rust/crates/babylon-bsl/src/declarations.rs:650-679` (`parse_type_name`)
+- Modify: `rust/crates/babylon-bsl/src/typecheck.rs:166-207` (fold/arith typing — compiler-flagged arms)
+- Modify: `rust/crates/babylon-bsl/src/score_class.rs:~87` (compiler-flagged arm)
+- Modify: `docs/reference/bsl-language.rst` (the new register row + §1.5/§2.9 prose)
+
+**Interfaces:**
+- Produces: `BslType::Real` (unit variant); `"real"` accepted by both type-name parsers; `attribute_value_real(atom, local, field) -> Result<f64, ScenarioError>`; the store's no-check lane now formally includes `Real` (no edit — `store_range_check`'s `matches!` at `structural_verbs.rs:1699-1703` already excludes it). Task 2 relies on `"real"` being a lawful deffield type; Task 3 relies on `attribute_value` handling `Real` for edge-attribute values.
+
+- [ ] **Step 1: The grep audit (before any edit — the catch-all hunt)**
+
+`BslType` matches with a wildcard arm compile silently past a new variant. Enumerate every match site and adjudicate it in the task report BEFORE writing code:
+
+```bash
+rg -n 'BslType::' rust/crates/babylon-bsl/src --glob '!*tests*' | grep -v '^.*//'
+rg -n 'other =>|_ =>' rust/crates/babylon-bsl/src/scenario.rs rust/crates/babylon-bsl/src/typecheck.rs rust/crates/babylon-bsl/src/score_class.rs
+```
+
+Known catch-all (MUST gain an explicit arm, compiler will NOT flag it): `attribute_value`'s `other =>` at `scenario.rs:1079-1085` — its refusal text ("stores only `int`, `probability`, `intensity`, `coefficient` or `enum`-declared …") is updated to name `real` too. Known no-edit site: `store_range_check` (`structural_verbs.rs:1699-1703`) — its `matches!` lists only the three unit-interval types; `Real` falls through to `Ok(())`, which IS the intended lane. Verify no other catch-all swallows `BslType`.
+
+- [ ] **Step 2: Write the failing tests**
+
+In `scenario.rs`'s `#[cfg(test)] mod tests` (the module at :1387; mirror its existing deffield/seed test idiom):
+
+```rust
+#[test]
+fn real_deffield_seeds_int_scaled_and_ratio_verbatim() {
+    // (deffield social-class/balance real intensive), node seeds:
+    //   int 9            -> 9.0
+    //   0.25c            -> 0.25
+    //   1.5r             -> 1.5
+    // assert stored attribute == expected f64, bit-exact
+}
+
+#[test]
+fn real_deffield_refuses_currency_and_bare_ident() {
+    // 9$ -> the currency refusal message (same text family as the int arm's)
+    // bare ident -> loud error naming node + field
+}
+
+#[test]
+fn real_field_store_has_no_range_check() {
+    // engine-side (structural_verbs.rs tests): writing 6962.099999999999 and
+    // -0.05263157894736842 into a real-declared field succeeds verbatim —
+    // E-EVAL-020 never fires for Real (negative seeds can't be written by
+    // literals, but WRITES may be negative; the store does not care).
+}
+```
+
+Also a typecheck test (in `typecheck.rs`'s tests) that a fold-sum over a `real extensive` field types as the fold's numeric lane and does not raise E-TYPE-041.
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `cargo test -p babylon-bsl real_ 2>&1 | tail -20`
+Expected: FAIL — `unknown type `real`` from `load_deffield`'s match.
+
+- [ ] **Step 4: Implement**
+
+`types.rs` (:222-224 area, between `Currency` and `Int` is fine — declaration order here is not content-facing):
+
+```rust
+    /// An unbounded finite binary64 scalar — the honest declared home for
+    /// what the store already does (verbatim f64, `numeric_write_value`).
+    /// Carries no range law: seeds accept int / p/i/c / r literals (each
+    /// already lex-bounded in its own lane), writes store any finite f64.
+    /// minted by Train B item 6 (ADR-pending), AE(ii) representation-level.
+    Real,
+```
+
+`scenario.rs` `load_deffield` (:919-931): add `"real" => BslType::Real,` and extend the refusal text's list to `int / real / probability / intensity / coefficient / currency / enum`.
+
+`scenario.rs` `attribute_value` (:1062-1086): add ABOVE the catch-all:
+
+```rust
+        BslType::Real => attribute_value_real(atom, local, field),
+```
+
+and update the catch-all text (:1079-1085) to include `real` in the listed types.
+
+New function after `attribute_value_int` (:1163):
+
+```rust
+/// `real`-declared fields (Train B item 6). Accepts the three literal lanes
+/// whose own lex laws already bound them — int (exact to 2^53, the same
+/// guard `attribute_value_int` states), p/i/c (`[0,1]` at lex), r (`(0,∞)`
+/// at lex) — each converted by the crate's one scaled-literal contract
+/// (`unscaled / 10^scale`). Currency is refused (the same deferral every
+/// other arm states). There is NO arbitrary-precision fractional literal:
+/// E-LEX-021 still refuses bare floats; that is #591 item 5's territory,
+/// not this train's.
+fn attribute_value_real(atom: &Atom, local: &str, field: &str) -> Result<f64, ScenarioError> {
+    match atom {
+        Atom::Int(value) => {
+            if value.unsigned_abs() > (1_u64 << 53) {
+                return Err(err(format!(
+                    "node `{local}` field `{field}`: {value} exceeds f64's exact integer range"
+                )));
+            }
+            #[allow(clippy::cast_precision_loss)]
+            Ok(*value as f64)
+        }
+        Atom::Scaled(scaled) => {
+            #[allow(clippy::cast_precision_loss)]
+            let numerator = scaled.unscaled as f64;
+            Ok(numerator / 10_f64.powi(i32::from(scaled.scale)))
+        }
+        Atom::Currency(_) => Err(err(currency_refusal_message(local, field))),
+        other => Err(err(format!(
+            "node `{local}` field `{field}`: expected an int, p/i/c or r literal for a \
+             real field, found {other:?}"
+        ))),
+    }
+}
+```
+
+(Verify `Atom::Scaled`'s `ScaledKind` covers the `r` lane — `classify_ratio` at `reader.rs:917+` returns `Atom::Scaled(ScaledLit { kind: ScaledKind::Ratio, .. })` per the p/i/c shape at :903-907; if Ratio is a separate `Atom` variant, add its arm with the same conversion. The reader source is the authority, not this plan.)
+
+`declarations.rs` `parse_type_name` (:650-679): add the `"real"` arm mirroring `"int"`.
+
+`typecheck.rs` (:166-207) + `score_class.rs` (:~87): add the compiler-flagged arms, giving `Real` the same typing as the numeric f64 lane (fold-sum over `real` = the numeric lane, never E-TYPE-041; a `real` field is not a unit-interval type anywhere). If any arm is genuinely unreachable, say so in the report rather than inventing behavior.
+
+`docs/reference/bsl-language.rst`: new register row (next free D-number) recording the real lane's seed/write law + the "no arbitrary fractional literal yet" note; §1.5's literal table gains the `real`-field acceptance line; §2.9's type list gains `real`.
+
+- [ ] **Step 5: Green + the byte-neutrality proof**
+
+Run: `cargo test -p babylon-bsl 2>&1 | grep -E 'test result|FAILED' | tail -5` then `mise run rust:check 2>&1 | tail -5`.
+Expected: all suites pass; then `git diff --stat` shows NO `.bscn`/golden-hash change anywhere (Task 1 touches no content) and `rg -c 'assert_eq!' rust/crates/babylon-tick/tests/tick_goldens.rs` unchanged — every existing golden byte-identical by construction (nothing committed declares `real` yet).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/crates/babylon-bsl/src docs/reference/bsl-language.rst
+mise run commit -- "feat(bsl): mint BslType::Real — the honest home for verbatim f64 (#591 item 6)"
+```
+
+---
+
+### Task 2: The content migration — every non-integral-f64 int field re-typed `real`
+
+**Files:**
+- Modify: `rust/crates/babylon-tick/content/scenarios/production-conformance.bscn:113-114,118`
+- Modify: `rust/crates/babylon-tick/content/scenarios/vitality-conformance.bscn:24`
+- Modify: `rust/crates/babylon-tick/content/scenarios/lifecycle-conformance.bscn:38-41,44,48,51`
+- Modify: `rust/crates/babylon-tick/content/scenarios/metabolism-conformance.bscn:25-26`
+- Modify: `rust/crates/babylon-tick/content/scenarios/dispossession-conformance.bscn:22-23`
+- Modify: `rust/crates/babylon-tick/content/scenarios/consciousness-ternary-conformance.bscn:195,207-210,212-213` + its comment at :83-92
+- Modify: `rust/crates/babylon-tick/content/rules/consciousness.bsl:106-122` (the rounding D-row text)
+
+**Interfaces:**
+- Consumes: Task 1's `"real"` deffield type.
+- Produces: the migrated field roster (below). Task 4 relies on `wages-received` being `real`-typed history — it REMOVES that field outright; every other field migrated here stays.
+
+- [ ] **Step 1: Re-type the roster (the digest's verified inventory)**
+
+In each `.bscn`, change ONLY the type token `int` → `real` on these deffield lines (kind token unchanged):
+
+| File | Fields |
+|---|---|
+| production-conformance.bscn | `social-class/wealth` (:113), `social-class/production-value` (:114), `territory/production-total` (:118) |
+| vitality-conformance.bscn | `social-class/wealth` (:24) |
+| lifecycle-conformance.bscn | `territory/pop-d`, `pop-p`, `pop-d-prime`, `wealth-d-prime` (:38-41), `dependency-ratio` (:44), `legitimation-index` (:48), `transmitted-ideology` (:51) |
+| metabolism-conformance.bscn | `territory/biocapacity`, `max-biocapacity` (:25-26) |
+| dispossession-conformance.bscn | `territory/dispossession-intensity` (:22), `territory/wealth` (:23) |
+| consciousness-ternary-conformance.bscn | `social-class/wealth` (:195), `agitation` (:207), `wage-balance` (:208), `solidarity-inbox` (:209), `wages-received` (:210), `previous-wages` (:212), `previous-wealth` (:213) |
+
+Do NOT touch: `social-class/population` / `active` / `wages-paid` / `value-produced` (integral content, stay `int` — the fractional-seed-refusal pin at `consciousness-ternary-conformance.bscn:100-105` depends on an int field staying int), `territory/rent-level-x1e6` (deliberately x1e6-scaled int, `territory.bsl:188`'s explicit `floor`), two-classes' `imperial-rent` (int arithmetic on int seeds), `territory/heat` (already `intensity`), `organization/active` (0/1 latch).
+
+In the same pass, update each migrated line's trailing comment where it says "int lane" / "verbatim-f64 int" to note the retirement — e.g. :207 becomes:
+
+```
+  (deffield social-class/agitation real intensive)         ; [0,∞) raw f64 (frozen: ge=0.0, unbounded — social_class.py:95-102). Retired from the verbatim-f64 int lane by Train B item 6 (the real type); zero seeds remain (R-MEASURED: produced, never authored)
+```
+
+- [ ] **Step 2: The D-row amendments**
+
+`consciousness.bsl:106-122` (the rounding D-row): append one sentence — "The verbatim-f64 int lane this row records was RETIRED by Train B item 6 (`BslType::Real`): the fields it governed now declare `real`; the store law itself (verbatim f64, no implicit truncation, `floor` available) is unchanged — only the declared home moved."
+
+`consciousness-ternary-conformance.bscn:83-92` (the mirrored note): same retirement sentence, one line.
+
+- [ ] **Step 3: The byte-neutrality proof (this task's whole point)**
+
+Run: `mise run rust:check 2>&1 | tail -5` — every suite green, and CRITICALLY every golden hash assertion passes UNEDITED: this task changes type tokens and comments only, and type tags are never hashed (`scenario.rs:1044-1054`). If ANY golden hash or exact-f64 conformance assertion fails, STOP — the failure means a seed literal that was int-typed now parses differently; find it before touching anything else. Then `mise run qa:regression 2>&1 | tail -3` (Python-side hygiene; untouched estate, 12/12 expected).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/crates/babylon-tick/content docs/reference/bsl-language.rst
+mise run commit -- "refactor(bsl-content): re-type the non-integral-f64 roster int -> real (#591 item 6 migration)"
+```
+
+- [ ] **Step 5: PR A** — push the branch, open PR A ("Train B items 6: the real type + migration") with the two commits, wait out CI + the Copilot harvest (median ~230s; `skipping` on the Dependabot leg is a TERMINAL state, not a pending one), merge via `mise run pr:merge -- <N>`.
+
+---
+
+### Task 3: `(edge-attr …)` — edge-attribute seeding
+
+**Files:**
+- Modify: `rust/crates/babylon-bsl/src/scenario.rs` — new `load_edge_attr` (modeled on `load_edge`, :1290-1385), the body-dispatch arm in `load_scenario`'s top loop, a `seeded_attrs: HashSet<(String, NodeId, NodeId, String)>` local alongside `seeded` (:336-342 area)
+- Modify: `docs/reference/bsl-language.rst` (the grammar's scenario-form list + the new register row)
+- Tests: `scenario.rs`'s `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Consumes: `attribute_value` (Task 1's `Real` arm included) for the value conversion; `GraphSubstrate::update_edge` (`rust/crates/babylon-graph/src/substrate.rs:168-175` — read it before writing the call).
+- Produces: the `(edge-attr <EdgeType/MEMBER> <from-name> <to-name> <deffield-qname> <value>)` top-form. Task 4 consumes it for `wages/value-flow`.
+
+- [ ] **Step 1: Write the failing tests** (scenario.rs test module, inline sources, the module's existing idiom):
+
+```rust
+#[test]
+fn edge_attr_seeds_a_declared_edge_field() {
+    // scenario with (deffield solidarity/tension intensity intensive),
+    // two nodes, (edge EdgeType/SOLIDARITY a b 0.5c), then
+    // (edge-attr EdgeType/SOLIDARITY a b solidarity/tension 0.25i)
+    // assert graph.edge_attribute(SOLIDARITY-edge, "solidarity/tension") == Some(0.25)
+}
+
+#[test]
+fn edge_attr_refuses_unknown_edge_undeclared_field_strength_and_currency() {
+    // (edge-attr ... a c ...) where no a→c edge exists     -> loud, names endpoints
+    // (edge-attr ... solidarity/nope 0.5i) undeclared      -> loud, names the field
+    // (edge-attr ... solidarity/strength 0.5c)             -> loud: strength seeds
+    //   via the edge form only (D32's implicit field is not in scenario.fields)
+    // (edge-attr ... solidarity/tension 5$)                -> the currency refusal
+}
+
+#[test]
+fn edge_attr_refuses_a_double_seed() {
+    // two (edge-attr ... a b solidarity/tension ...) forms with the same
+    // (member, from, to, field) key -> the new E-LOAD-0NN coded refusal
+    // (mirrors E-LOAD-044's key argument: the quadruple is a KEY)
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — `cargo test -p babylon-bsl edge_attr 2>&1 | tail -10`; expected: the reader/loader has no `edge-attr` head ("expected …" dispatch error).
+
+- [ ] **Step 3: Implement `load_edge_attr`**
+
+Model on `load_edge` (:1296-1385) with these deltas: six slots `(edge-attr <enum-ref> <from> <to> <field-qname> <value-atom>)`; the same `demand_enum_kind` + vocabulary checks; resolve both endpoints via `named` (same "reads top to bottom" law — the edge must already exist: look the `(member, from_id, to_id)` triple up in `seeded`, refuse loudly naming the endpoints if absent); look the field qname up in the scenario's `fields` map (absent → loud refusal naming the field — this is also what refuses `solidarity/strength`, since D32's implicit field is never in `scenario.fields`); verify the qname's prefix matches the edge type's lower-cased name (the `solidarity/tension` ↔ `SOLIDARITY` convention — find the existing prefix check used for node fields and reuse its shape; if none exists for edges, state the check explicitly in the register row); convert the value via `attribute_value(atom, local, field, decl, enums)` (the ONE per-type literal law, Currency refusal included); insert the quadruple key into `seeded_attrs` (double-seed → the new coded refusal); write via `graph.update_edge(...)`.
+
+Add the `"edge-attr"` arm to `load_scenario`'s body dispatch and the `seeded_attrs` local. Register the new E-LOAD code (next free; spec-code registry entry).
+
+`bsl-language.rst`: the scenario grammar's form list gains `(edge-attr …)`; new register row (next D-number) recording the form, the quadruple key, the strength refusal, and the top-to-bottom edge-existence law.
+
+- [ ] **Step 4: Green + byte-neutrality proof** — `cargo test -p babylon-bsl` green, then `mise run rust:check`: every existing golden byte-identical (no committed scenario uses `edge-attr` yet — additive grammar). `git diff` shows zero content/golden changes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/crates/babylon-bsl/src docs/reference/bsl-language.rst
+mise run commit -- "feat(bsl): the (edge-attr ...) scenario form — edge-attribute seeding (#591 item 3)"
+```
+
+---
+
+### Task 4: The WAGES un-narrowing — D151's discharge + the re-pin ceremony
+
+**Files:**
+- Modify: `rust/crates/babylon-tick/content/scenarios/consciousness-ternary-conformance.bscn` (:189 defvocabulary, :204-213 deffields, :237/:250/:264 seeds, ~:267+ employer node, new edge + edge-attr forms)
+- Modify: `rust/crates/babylon-tick/content/rules/consciousness.bsl` (header D151 note + inventory; `p1-inbox-reset`; new `p2-wages-push`; `p5-agitation`'s wage-change read; `p7-persist-baselines`)
+- Modify: `rust/crates/babylon-tick/content/scenarios/consciousness_ternary_conformance.py` (the dual-implementation oracle mirrors the machinery)
+- Modify: `rust/crates/babylon-tick/tests/consciousness_ternary_conformance.rs` (re-measured rows)
+- Modify: `rust/crates/babylon-tick/tests/tick_goldens.rs:327-351` (the re-pin + its header history)
+
+**Interfaces:**
+- Consumes: Task 1's `real` type (`wages/value-flow`, `wages-inbox` declare it), Task 3's `(edge-attr …)` form.
+- Produces: the un-narrowed wage flow — the frozen incoming-WAGES fold-sum (`ideology.py:299-309`) restored via the push-over-pull idiom (D136's canonical pattern).
+
+- [ ] **Step 1: The scenario edits**
+
+`defvocabulary EdgeType (SOLIDARITY WAGES)` (:189). Deffield block: DELETE `(deffield social-class/wages-received …)` (:210) and its three seed pairs (:237, :250, :264's `wages-received` pairs); ADD:
+
+```
+  (deffield wages/value-flow real intensive)               ; the per-edge wage flow (ADR203 edge deffield; retired-then-restored: W10's D151 narrowing discharged by Train B item 3)
+  (deffield social-class/wages-inbox real intensive)       ; [0,n) flow-sum — the push-over-pull accumulator (D136): reset by p1, pushed by p2-wages-push, read by p5, persisted by p7
+```
+
+After the employer node (~:272), add the edges (strength `1.0c` — a structural presence marker with NO semantic consumer; nothing reads WAGES `strength`; stated in the register row) and the seeded flows:
+
+```
+  (edge EdgeType/WAGES employer class-exploited 1.0c)
+  (edge-attr EdgeType/WAGES employer class-exploited wages/value-flow 9)
+  (edge EdgeType/WAGES employer class-bribed 1.0c)
+  (edge-attr EdgeType/WAGES employer class-bribed wages/value-flow 12)
+  (edge EdgeType/WAGES employer class-emergent 1.0c)
+  (edge-attr EdgeType/WAGES employer class-emergent wages/value-flow 9)
+```
+
+WAIT — verify against the anchors before committing to these numbers: class-emergent's wage CUT is 9→8 (previous-wages 9, received 8 — :264-265), so its value-flow is **8**, not 9; exploited 10→9 → **9**; bribed 12→12 → **12**. The flows are the CURRENT wage: 9, 12, 8 (plan `2026-08-15-class-surface-ternary-port.md:215` agrees). The implementer re-derives each flow from the node's own comment before writing — the oracle asserts these exact values post-tick.
+
+- [ ] **Step 2: The pack edits (consciousness.bsl)**
+
+Header: D151's row gains its retirement note ("narrowing retired by Train B item 3: the wage flow rides seeded WAGES-edge `wages/value-flow` again via push-over-pull; `wages-received` is gone"); the D116 byte-order map and the per-rule inventory table gain `p2-wages-push` (byte order: `p2-org-solidarity-push` < `p2-wages-push` — 'o' < 'w' — so wages-push fires immediately after org-push, both after p1's reset).
+
+`p1-inbox-reset`: gains a second reset write — `social-class/wages-inbox ← 0` — same subjects, same firing (its fired count is unchanged).
+
+New rule (its text adapts the W10 plan's original draft at `2026-08-15-class-surface-ternary-port.md:497-501`):
+
+```
+(rule consciousness/p2-wages-push
+  :material-basis "The wage flow: every WAGES edge's seeded value-flow is pushed into the
+   receiving class's wages-inbox (frozen ideology.py:299-309's incoming-WAGES fold-sum,
+   expressed per the D136 push-over-pull idiom — D138 forbids the filter-in-fold pull)."
+  ...subjects SOCIAL_CLASS, for-each (neighbors self EdgeType/WAGES :out NodeType/SOCIAL_CLASS):
+       (update-node it social-class/wages-inbox
+         (add (field-of (edge-between EdgeType/WAGES self it) wages/value-flow))))
+```
+
+(The pack's actual guard/shape idiom is the landed `p2-org-solidarity-push`'s — mirror ITS structure exactly, swapping the edge type, the read field, and dropping the strength gate; the text above shows the load-bearing expressions, not a re-derivation of the pack's rule syntax.)
+
+`p5-agitation`: the wage-change binding's read becomes `wages-inbox − previous-wages` (was `wages-received − previous-wages`) — one qname swap in the binding.
+
+`p7-persist-baselines`: persists `wages-inbox` into `previous-wages` (was `wages-received`) — one qname swap.
+
+- [ ] **Step 3: The fired-count spike (before any re-pin)**
+
+Write a throwaway test (or extend the conformance test's debug output) that prints the per-rule fired counts of the new pack. EXPECTED: `p2-wages-push` fires on `employer` only (+1 → total 51); p1 unchanged (11). If the pack's for-each idiom fires on edgeless subjects too, the total differs — MEASURE, record the truth, and pin the measured number with the arithmetic explained in the golden's header (the house pattern, `tick_goldens.rs:233-236`). Delete the throwaway.
+
+- [ ] **Step 4: The oracle + conformance re-measurement**
+
+`consciousness_ternary_conformance.py`: mirror the machinery — the scenario dict loses `wages-received`, gains the WAGES edges with their flows and `wages-inbox`; the p1/p2/p5/p7 mirrors updated to match; per-class wage flows 9/12/8 produce the SAME post-tick values as before (single-employer exactness: the fold-sum IS the one edge's flow). `consciousness_ternary_conformance.rs`: the field-name assertions re-point (`wages-inbox` where `wages-received` was asserted; the tick-2 accumulation witness's value pins are UNCHANGED — verify, don't assume). Every OTHER value assertion (ternaries, agitation, balances, dominants, tick-2 rows) must pass UNEDITED — that pass IS the ceremony's lawfulness proof.
+
+- [ ] **Step 5: The declared re-pin ceremony**
+
+Run the golden; it fails on the two hash assertions with the new values printed. Verify BEFORE re-pinning: the new pre-tick state differs from the old ONLY by (−3 `wages-received` attributes, +3 WAGES edges, +3 `wages/value-flow` edge attributes, +0 `wages-inbox` — unseeded) and the new post-tick state ONLY by (−`wages-received`, +`wages-inbox` on the reset/pushed classes per the fired spike). The conformance suite's value-level green (Step 4) is the proof that no VALUE drifted. Then re-pin both hashes at `tick_goldens.rs:333,340`, update the fired assertion (:344-350) to the spiked number, and extend the header's re-pin history (:310-326) with this ceremony's row: "Train B item 3 (D151 discharge): WAGES edges + `wages/value-flow` seeding restored the frozen fold-sum via push-over-pull; `wages-received` retired; BOTH hashes re-pinned (attribute-set change, zero value drift — proven by `consciousness_ternary_conformance.rs` passing with only the two field re-points); fired 50 → <measured>."
+
+- [ ] **Step 6: Full gates + commit**
+
+`mise run rust:check` green; `mise run qa:regression` 12/12 (Python-estate hygiene).
+
+```bash
+git add rust/crates/babylon-tick/content rust/crates/babylon-tick/tests
+mise run commit -- "feat(tick): un-narrow the wage flow onto seeded WAGES edges — D151 discharged (#591 item 3 retrofit)"
+```
+
+- [ ] **Step 7: PR B** — push, PR B ("Train B item 3: edge-attribute seeding + the WAGES un-narrowing"), CI + Copilot harvest, `mise run pr:merge -- <N>`. Comment on #591 with the ceremony evidence (old/new hashes, the fired spike number, the value-level green).
+
+---
+
+### Task 5: Scenario-declaration sharing + the train records
+
+**Files:**
+- Modify: `rust/crates/babylon-bsl/src/types.rs:121-135` (`EnumRegistry::declare` — identical-declaration recognition)
+- Modify: `rust/crates/babylon-bsl/src/scenario.rs:308-333` + new `load_scenario_with_prelude`
+- Modify: `rust/crates/babylon-tick/src/lib.rs:72-76,105-148` (`run_once_with_prelude` + `prepare_rules` threading)
+- Create: `rust/crates/babylon-tick/content/declarations/worldview.bscn` (the prelude — declaration forms only, header comment stating it is NOT a scenario)
+- Modify: `rust/crates/babylon-tick/content/scenarios/consciousness-ternary-conformance.bscn:190` (re-declaration dies) + :204's comment
+- Modify: `rust/crates/babylon-tick/tests/tick_goldens.rs` (:329 the call site, :353-372 the parity test dies)
+- Modify: `docs/reference/bsl-language.rst` (register row + §2.13 prose)
+- Modify: `ai/decisions/ADR208_*.yaml` + `index.yaml`, `ai/state.yaml`
+
+**Interfaces:**
+- Consumes: nothing from Tasks 1-4's surfaces (independent by design, §5 of the charter).
+- Produces: `load_scenario_with_prelude(prelude_src, scenario_src, graph) -> Result<LoadedScenario, ScenarioError>`; `run_once_with_prelude(scenario_src, prelude_src, rule_src) -> Result<TickReport, String>`; `EnumRegistry::declare`'s identical-recognition arm.
+
+- [ ] **Step 1: Failing tests**
+
+`types.rs` tests: identical re-declaration (same name, same members, same order) returns `Ok` with the SAME `EnumTypeId`; same name with reordered/renamed/extra members still returns `DuplicateType`.
+
+`scenario.rs` tests: `load_scenario_with_prelude` with a defenum prelude + a scenario declaring an enum-typed field resolves; a prelude containing a `node`/`edge`/`edge-attr` form is refused loudly; a scenario that ALSO declares the prelude's enum identically loads (recognition); one that declares it differently refuses.
+
+- [ ] **Step 2: Implement**
+
+`EnumRegistry::declare` (:131-135): replace the bare `any(name ==)` refusal with — same name AND identical member list (order-sensitive compare against the stored declaration) → `Ok(EnumTypeId(existing_index))`; same name, differing members → `DuplicateType` exactly as today. (Member lists are stored per declaration — the registry already keeps them for `ordinal`; the compare is a slice equality.)
+
+`load_scenario_with_prelude`: read the prelude's forms first — each MUST be `defenum` / `defvocabulary` / `defconst` / `deffield` (anything else → loud refusal naming the form head) — threading the SAME registries (`enums`, vocabulary, consts, fields) the subsequent scenario load uses; then run the existing single-scenario path on `scenario_src`. Refactor note: `load_scenario` currently builds those registries as locals (:336-342); the clean shape is an internal `load_scenario_inner(source, graph, registries…)` both entry points call — do the minimal extraction, no heroic refactor.
+
+`lib.rs`: `run_once_with_prelude(scenario_src, prelude_src, rule_src)` — `prepare_rules` gains a `prelude_src: Option<&str>` parameter (the existing `run_once`/`run_once_into` pass `None`; behavior unchanged), calling `load_scenario_with_prelude` when `Some`. `TickSession::new`'s path is NOT extended (no consumer today — noted in the register row as the session-path follow-up, YAGNI until production content shares).
+
+The prelude file `content/declarations/worldview.bscn`: header comment ("declaration prelude — consumed via `load_scenario_with_prelude`; NOT a scenario form") + `(defenum WorldView (REVOLUTIONARY LIBERAL FASCIST))`.
+
+- [ ] **Step 3: The conformance switch + the declared test death**
+
+`consciousness-ternary-conformance.bscn`: DELETE :190's `(defenum WorldView …)`; :204's comment becomes "consumes the WorldView declaration from `content/declarations/worldview.bscn` via the prelude (Train B item 4) — no re-declaration". The test-side constant wiring gains `WORLDVIEW_PRELUDE` (`include_str!`) and the golden's call (:329) becomes `run_once_with_prelude(CONSCIOUSNESS_TERNARY_SCENARIO, WORLDVIEW_PRELUDE, CONSCIOUSNESS_TERNARY_RULES)`. DELETE `consciousness_ternary_worldview_member_order_is_the_ruled_ordinal` (:353-372) — a declared test death, recorded here and in the register row: the prelude composition makes the re-declaration it guarded impossible; the mint's own `worldview_member_order_is_the_ruled_ordinal` (:285-296) survives as the single ordinal home.
+
+Byte-neutrality proof: pre- AND post-tick hashes at :333/:340 UNCHANGED (defenum declarations are unhashed; the graph content is identical), fired unchanged — if either hash moves, STOP: the prelude threading touched the graph.
+
+- [ ] **Step 4: Docs + the train records**
+
+`bsl-language.rst`: the prelude mechanism + the identical-recognition law as a register row (next D-number); §2.13's sharing prose; D151's retirement was Task 4's — cross-reference it here.
+
+`ai/decisions/ADR208_bsl_ergonomics_b.yaml` (+ `index.yaml` row): the train record — the three items, the Director's six charter rulings, the Task-4 ceremony (old/new hashes, fired 50→measured, the value-level proof), the declared test death, the follow-ups roster (session-path prelude threading; #591 items 1/2/5 still queued; the D151 citation-range nit folded to item 1's pass).
+
+`ai/state.yaml`: the closing entry.
+
+- [ ] **Step 5: Full gates + commit + PR C**
+
+`mise run rust:check` green; `mise run qa:regression` 12/12.
+
+```bash
+git add rust docs ai
+mise run commit -- "feat(bsl): scenario-declaration sharing via prelude composition + identical-recognition (#591 item 4); docs(decisions): ADR208 the train record"
+```
+
+PR C ("Train B item 4 + records"), CI + Copilot harvest, `mise run pr:merge -- <N>`; #591 commented with the discharge evidence for items 6/3/4 (the issue stays OPEN for items 1/2/5).
+
+---
+
+## Self-review notes (controller)
+
+- **Spec coverage:** charter §2 (item 6) → Tasks 1-2; §3 (item 3) → Tasks 3-4; §4 (item 4) → Task 5; §5 sequencing → task order; §6 ceremonies/gates → per-task proof steps + Task 4 Step 5 + Task 5 Step 3; §7 non-goals — honored (no intrinsics, no sci-notation, no push-over-pull doc item here; the D151 nit rides item 1's future pass, recorded on #591).
+- **The one charter refinement disclosed:** the charter's ceremony text expected Task 4's POST-tick hash unmoved. With ruling 6 adopted (`wages-received` retired, not kept-derived), the attribute SET changes (−`wages-received`, +`wages-inbox`), so BOTH hashes re-pin. No VALUE drifts — the exact-f64 conformance suite is the proof, and it passes with only the two field re-points (Task 4 Step 4). This is the mechanical consequence of the adopted ruling, not new drift.
+- **Type consistency:** `attribute_value_real` signature mirrors `attribute_value_int`; `load_edge_attr` mirrors `load_edge`'s parameter list plus the field qname; `load_scenario_with_prelude` / `run_once_with_prelude` argument order (scenario first, prelude second) matches `run_once(scenario, rules)`'s existing lead.

--- a/docs/superpowers/specs/2026-08-15-bsl-ergonomics-b-charter.md
+++ b/docs/superpowers/specs/2026-08-15-bsl-ergonomics-b-charter.md
@@ -1,0 +1,150 @@
+# BSL Surface-Ergonomics Train B — Design Charter (items 6, 3, 4)
+
+**Status: RULED 2026-08-15** — Director approved the charter wholesale ("approved"); all six §8 decision points adopted as recommended (additive `real`; full-inventory migration; sequencing 6→3→4; identical-declaration recognition with `DuplicateType` preserved for differences; `wages-received` retired on un-narrowing; §1's AE(ii) posture signed off).
+
+Authority: issue #591 items 6/3/4 (Director directive 2026-08-15) + the Director's goal text
+("Goal B — the deep machinery … it wants its own charter and it'll move some of this train's
+pins by declared ceremony"). Evidence: `ai/scratch/2026-08-15-bsl-ergonomics-b-archaeology.md`
+(the digest — every file:line citation below is verified there). Companion: ADR207 (the W10
+handoff whose narrowings this train discharges).
+
+## 1. Constitutional posture (AE ii)
+
+All three items are **surface ergonomics minting no new mathematics**:
+
+- **Item 6 (`real`)** gives an honest declared home to what the store already *does*. The store
+  is kind-blind f64 end to end (`structural_verbs.rs:1563-1603`); verbatim-f64-in-int is ruled
+  law (W10 controller amendment 1; consciousness.bsl D-record 5; ADR207 §3a). `BslType` is DSL
+  storage typing — load-time metadata, **never hashed** (`scenario.rs:1044-1054`) — not a
+  constitutional primitive. Representation-level, the same shape as AG(i)'s attributed
+  membership: a payload on existing elements, not a new element kind.
+- **Item 3 (edge-attribute seeding)** extends the loader to what the store already *holds*:
+  runtime edge attributes exist (section 0x05, `substrate.rs:168-175`; the `update-edge` write
+  law, T3/ADR198 R1–R3; the declarable-but-unseedable precedent `edge-write-lane-e2e.bscn:27`).
+- **Item 4 (scenario-declaration sharing)** is loader composition. Zero hash movement; the
+  ordinal law (declaration order = stored ordinal) is unchanged.
+
+Standing guardrails: no imposed functional forms; the frozen Python engine stays reference-only;
+any divergence earns a D-row. The formalism surface is not re-opened — these are loader, type,
+and content-migration mechanics.
+
+## 2. Item 6 — the `real` numeric type
+
+**Facts.** `Value::Real(f64)` exists at runtime (`evaluator.rs:55-62`) with no declared-field
+home. ~20 write sites across 6 committed packs hold non-integral f64 in `int`-typed fields
+(digest table: production `wealth` 11.538…, vitality `wealth` 999.95, lifecycle `pop-p`
+6962.099…, metabolism `biocapacity` 1.9000…, dispossession `dispossession-intensity` 0.358…,
+consciousness `agitation` 0.135, …). Seeds are the one strict door (`attribute_value_int`,
+`scenario.rs:1144-1163`: fractional seeds into int fields are loader-refused).
+
+**The fork:**
+
+- **(a) Additive `BslType::Real` (recommended).** Compiler-driven arms: `types.rs:214`,
+  `parse_type_name` (`declarations.rs:650-679`), `load_deffield` (`scenario.rs:919-931`),
+  `attribute_value` (`scenario.rs:1062-1086` — new arm accepting int + scaled literals without
+  the [0,1] check), `store_range_check` joins int's no-check lane
+  (`structural_verbs.rs:1699-1703`), typecheck fold/arith (`typecheck.rs:166-207`),
+  `score_class.rs:87`. `numeric_write_value` needs nothing (:1588 already verbatim). The
+  literal lane rides the existing `r` suffix (E-LEX-023 r-cap, `reader.rs:923-929`); real
+  fields gain seed acceptance. **Byte-neutral: type tags are never hashed, so adding the type
+  AND re-typing every committed field moves zero byte pins.**
+- **(b) Tighten `int` to integer-only — evidence-REJECTED.** One integrality clause in
+  `store_range_check` and every row of the digest's inventory table dies at the store boundary:
+  ~20 write sites across 6 packs, multiple goldens move. A content massacre, not a type fix.
+
+**Migration scope fork:** re-type the full digest inventory int→real (recommended — byte-neutral,
+retires the awkwardness in one mechanical pass) vs. only W10's three consciousness fields.
+
+**Done:** `real` landed; the inventory migrated; the W10 narrowing D-rows amended ("int-lane
+typing retired by `real`"); every existing golden byte-identical (proof obligation, not hope).
+
+## 3. Item 3 — edge-attribute seeding + the WAGES un-narrowing
+
+**Facts.** `load_edge` is strength-only (exact 5-slot pattern, `scenario.rs:1296-1302`; duplicate
+guard E-LOAD-044). Edges already carry attributes at runtime (`substrate.rs:168-175`; the
+`/strength` double-storage fork D143). Edge deffields are declarable but unseedable —
+`solidarity/tension` is committed and seeds nothing (`edge-write-lane-e2e.bscn:27,34-35`).
+
+**Design.** Extend the scenario surface to seed edge attributes. Mechanism (an extended edge
+form vs. a sibling `(edge-attr …)` form) is a plan-level decision; the binding constraint is to
+reuse `attribute_value`'s per-type literal law (including the Currency refusal) and to preserve
+the duplicate-guard posture.
+
+**The un-narrowing (D151's discharge).** The W10 narrowing — frozen's incoming-WAGES
+`value_flow` fold-sum (`ideology.py:299-309`) cut to one class-side `wages-received` field —
+was recorded as "exact for single-employer content" precisely because seeding was unserved.
+With seeding landed: `wages/value-flow` returns as an edge deffield declared `real` (per §5
+sequencing); the three WAGES edges return with seeded values; `p5-agitation`'s wage-change read
+becomes the frozen fold-sum over incoming WAGES edges (`consciousness.bsl:243,255` re-point);
+`p7-persist-baselines` re-points (`:320,324`); the scenario seeds move from class-side fields
+onto edge forms (`consciousness-ternary-conformance.bscn:210,237,250,264`).
+
+**Ceremony.** By the recorded single-employer exactness, post-tick values are byte-identical;
+the **pre-tick** hash moves (new edges + moved fields) — one re-pin at `tick_goldens.rs:333`,
+with post-tick (:340) expected unmoved. If post-tick moves: STOP and report. Conformance rows
+re-measured (crate goldens are measurements-not-ceremonies by precedent,
+`tick_goldens.rs:172-177`). D151 gains its "narrowing retired" note; the train ADR records the
+ceremony.
+
+## 4. Item 4 — scenario-declaration sharing
+
+**Facts.** One `(scenario …)` form per source (`scenario.rs:312-318`). The WorldView defenum is
+minted at `worldview-foundation.bscn:34` and re-declared verbatim at
+`consciousness-ternary-conformance.bscn:190`. Declaration order IS the stored ordinal
+(`types.rs:35-46`), which is why the re-declaration carries a parity test
+(`tick_goldens.rs:361-372` — its own header states it exists only because of the
+re-declaration).
+
+**Design constraint (binding).** Sharing = include/merge semantics that recognize an
+**identical** declaration as the same one. `EnumRegistry`'s `DuplicateType` guard
+(`types.rs:131-135`) is preserved for *differing* declarations — no silent relaxation.
+Mechanism (an `(include …)` form vs. multi-source composition at the entry points,
+`lib.rs:72-148`) is a plan-level decision.
+
+**Done:** the conformance scenario consumes the mint's WorldView declaration; the parity test
+dies (declared test death); the mint's own ordinal test (`tick_goldens.rs:285-296`) survives as
+the single ordinal home. Zero pins move (defenum declarations are unhashed).
+
+## 5. Sequencing: 6 → 3 → 4
+
+Digest-recommended, matching #591's own order. Item 6 first means item 3's edge seeds never
+answer "can an edge attribute hold an unbounded f64?" with the int-lane hack — `wages/value-flow`
+declares `real` on arrival. Item 3's un-narrowing is the train's only re-pin. Item 4 is purely
+loader-compositional, independent of the type system, and its test-killing lands cleanest once
+content settles. (3↔4 are disjoint — `load_edge` vs. the top loop — and could swap without
+conflict.)
+
+## 6. Ceremony and gates plan
+
+- **Byte-neutrality proofs:** items 6 and 4 move zero pins — proved by the hash-covering goldens
+  and every exact-f64 conformance suite staying byte-identical at each landing.
+- **Item 3's single pre-tick re-pin:** declared ceremony, recorded in the train ADR. No
+  `tests/baselines/**` movement anywhere in this train — III.13/§6.5 is the Python estate and
+  nothing here crosses into it.
+- **Per-task gates:** full `rust:check`; `qa:regression` as Python-side hygiene; Copilot harvest
+  and `mise run pr:merge` per PR; Conventional Commits + the `Co-Authored-By` trailer.
+- **Process:** subagent-driven development per the established pattern — fresh implementer per
+  task, per-task reviews, scoped re-reviews on fix rounds, final whole-branch review, ledger-first
+  in `.superpowers/sdd/`.
+
+## 7. Non-goals
+
+#591's other half — item 1 (push-over-pull as a named canonical pattern in `bsl-language.rst`),
+item 2 (`min`/`max`/`abs`/`clamp` intrinsics), item 5 (scientific-notation literals) — verified
+not yet landed (`intrinsic_host.rs:62` registers only `floor`; no push-over-pull section in the
+language reference); queued in #591, not this train. AG(i) payloads ride #536. No Python engine
+changes. No client work.
+
+## 8. Director decision points
+
+1. **Posture** — sign off §1's AE(ii) framing (all three items: representation-level, no new
+   mathematics).
+2. **Item 6 fork** — additive `real` (recommended; byte-neutral) over int-tightening
+   (evidence-rejected: ~20-site content massacre).
+3. **Migration scope** — the full digest inventory re-typed to `real` (recommended) vs. only
+   W10's agitation/wage-balance/solidarity-inbox.
+4. **Sequencing** — 6 → 3 → 4 (recommended).
+5. **Item 4 constraint** — identical-declaration recognition with `DuplicateType` preserved for
+   differences (mechanism delegated to the plan).
+6. **`wages-received` disposition** — retire the field on un-narrowing (recommended: the fold-sum
+   is exact and now honest) vs. keep it as a derived convenience readout.

--- a/rust/crates/babylon-bsl/src/declarations.rs
+++ b/rust/crates/babylon-bsl/src/declarations.rs
@@ -521,7 +521,7 @@ fn parse_deffield(
 
 /// The `:type enum` half of [`parse_deffield`] — split out because its own
 /// exclusivity checks (`E-LOAD-053`) and registry resolution
-/// (`E-LOAD-054`) are unrelated to the six-row concrete-type path.
+/// (`E-LOAD-054`) are unrelated to the non-`enum` concrete-type path.
 fn parse_enum_deffield(
     qname: &str,
     kind: Option<FieldKind>,
@@ -655,6 +655,14 @@ pub fn parse_type_name(name: &str) -> Result<BslType, DeclError> {
         "probability" => Ok(BslType::Probability),
         "intensity" => Ok(BslType::Intensity),
         "coefficient" => Ok(BslType::Coefficient),
+        // Train B item 6 (#591, D155): `real` IS one of §3.1's declarable
+        // rows now — the eighth — superseding D98's "not storable" note
+        // (the finite binary64 lane as a STORED type, with no
+        // declared-domain range law). The intrinsic-decl position still
+        // resolves `real` to `IntrinsicTypeName::Real` first
+        // (`parse_intrinsic_type_name`'s intercept), so nothing about
+        // `<intrinsic-decl>` parsing changes.
+        "real" => Ok(BslType::Real),
         // §2.13 (D101): `enum` IS one of §3.1's seven type names now, but
         // this function only ever receives the bare name string — it
         // cannot resolve a companion `:enum-type` operand, which lives in
@@ -741,17 +749,23 @@ pub fn check_intrinsic_cap(name: &str) -> Result<(), DeclError> {
 /// The `<type-name>` vocabulary as it applies inside an `<intrinsic-decl>`'s
 /// `:params`/`:returns` position — deliberately **separate** from
 /// [`parse_type_name`] (`deffield`'s / `metric`'s `:type`), not a widening
-/// of it. §3.1 rules `Real` "Not storable": a field or a registered metric
-/// can never be `Real`-typed, so `parse_type_name` stays exactly the
-/// six-row table it already was — this function does not touch it and
-/// nothing about `(deffield …)`/`(metric …)` parsing changes.
+/// of it. §3.1 used to rule `Real` "Not storable" (D98: a field or a
+/// registered metric could never be `Real`-typed, and `parse_type_name`
+/// stayed the six-row table it was); **Train B item 6 (#591, D155)
+/// superseded that** — `real` is now §3.1's eighth declarable row, and
+/// `parse_type_name` accepts it. What this type still guarantees is the
+/// intrinsic position's OWN resolution: the `name == "real"` intercept in
+/// [`parse_intrinsic_type_name`] fires BEFORE `parse_type_name` is
+/// consulted, so an intrinsic's `real` denotes the unbounded binary64
+/// intermediate (§3.3), never a storable field type.
 ///
 /// An intrinsic's argument routinely IS `Real`-typed: every binary64
 /// expression's static type is `Real` (§3.3), and before this row there was
 /// no way to spell that anywhere in `<intrinsic-decl>`, which left ADR188
 /// Row 2's own `floor` rider undeclarable in content — `(intrinsic floor
 /// :params (???) :returns int :cost N)` had no legal filler for `:params`.
-/// `real` is admitted HERE, and only here.
+/// `real` is admitted HERE, and (since Train B item 6) in the storable
+/// `<type-name>` position too.
 ///
 /// **Workforce draft ruling, following the D93/D97 Draft-Ruling Register
 /// convention** (recorded as the register's next row): `real` is not new
@@ -765,7 +779,8 @@ pub enum IntrinsicTypeName {
     /// The unbounded binary64 intermediate (§3.3) — legal only in an
     /// `<intrinsic-decl>`'s `:params`/`:returns` position.
     Real,
-    /// One of §3.1's six storable scalar types.
+    /// One of §3.1's storable scalar types (seven since Train B item 6
+    /// added `real` to the six D94 closed).
     Scalar(BslType),
 }
 
@@ -774,7 +789,8 @@ pub enum IntrinsicTypeName {
 /// # Errors
 ///
 /// [`DeclError::Malformed`] for a name outside this position's vocabulary
-/// (the six §3.1 rows, plus `real`).
+/// (§3.1's rows — eight since Train B item 6 — with `real` intercepted
+/// below as the unbounded intermediate, never `Scalar(BslType::Real)`).
 pub fn parse_intrinsic_type_name(name: &str) -> Result<IntrinsicTypeName, DeclError> {
     if name == "real" {
         return Ok(IntrinsicTypeName::Real);
@@ -1212,16 +1228,20 @@ mod tests {
         assert_eq!(parsed.cost, 5);
     }
 
-    /// `real` is spellable HERE — the whole point of D98/the intrinsic-decl
-    /// parameter scoping — without touching `parse_type_name` (deffield's
-    /// `:type`, which must still reject it).
+    /// `real` resolves PER POSITION. Train B item 6 (#591, D155) superseded
+    /// this test's original second half — D98's "not storable" meant
+    /// `parse_type_name("real")` was an error; `real` is now §3.1's eighth
+    /// declarable row, so both parsers accept it. What survives unchanged
+    /// is the intrinsic position's own resolution: the `name == "real"`
+    /// intercept fires first, so an `<intrinsic-decl>` still gets
+    /// `IntrinsicTypeName::Real`, never `Scalar(BslType::Real)`.
     #[test]
-    fn real_is_legal_only_in_the_intrinsic_type_name_position() {
+    fn real_resolves_per_position_after_train_b_item_6() {
         assert_eq!(
             parse_intrinsic_type_name("real"),
             Ok(IntrinsicTypeName::Real)
         );
-        assert!(super::parse_type_name("real").is_err());
+        assert_eq!(super::parse_type_name("real"), Ok(BslType::Real));
     }
 
     /// The cap check runs AS PART OF the parse, not after — a declaration

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -918,6 +918,7 @@ fn load_deffield(
         };
         let ty = match ty.as_str() {
             "int" => BslType::Int,
+            "real" => BslType::Real,
             "probability" => BslType::Probability,
             "intensity" => BslType::Intensity,
             "coefficient" => BslType::Coefficient,
@@ -925,7 +926,7 @@ fn load_deffield(
             other => {
                 return Err(err(format!(
                     "deffield `{qname}`: unknown type `{other}` — one of \
-                     int / probability / intensity / coefficient / currency / enum"
+                     int / real / probability / intensity / coefficient / currency / enum"
                 )))
             }
         };
@@ -1061,6 +1062,7 @@ fn attribute_value(
 ) -> Result<f64, ScenarioError> {
     match &decl.ty {
         BslType::Int => attribute_value_int(atom, local, field),
+        BslType::Real => attribute_value_real(atom, local, field),
         BslType::Probability | BslType::Intensity | BslType::Coefficient => {
             attribute_value_unit_interval(atom, local, field, &decl.ty)
         }
@@ -1069,16 +1071,17 @@ fn attribute_value(
         // Defense in depth, not a reachable content error: `load_deffield`
         // is the SOLE populator of the `declared` map `attribute_value` is
         // called against, and its own match on the type symbol admits only
-        // int/probability/intensity/coefficient/currency/enum (anything else
-        // is refused AT DECLARATION, before a `node` form naming the field
-        // can even be read). Reaching here is a wiring bug in the deffield
-        // parser, not a content error — kept anyway because `BslType` is
-        // not a closed match the compiler can prove exhaustive against this
-        // function's actual call graph, and a silent `unreachable!()` would
-        // panic rather than name the field that triggered it.
+        // int/real/probability/intensity/coefficient/currency/enum (anything
+        // else is refused AT DECLARATION, before a `node` form naming the
+        // field can even be read). Reaching here is a wiring bug in the
+        // deffield parser, not a content error — kept anyway because
+        // `BslType` is not a closed match the compiler can prove exhaustive
+        // against this function's actual call graph, and a silent
+        // `unreachable!()` would panic rather than name the field that
+        // triggered it.
         other => Err(err(format!(
             "node `{local}`: field `{field}` is declared {other:?}, and the scenario \
-             loader stores only `int`, `probability`, `intensity`, `coefficient` or \
+             loader stores only `int`, `real`, `probability`, `intensity`, `coefficient` or \
              `enum`-declared node attributes (currency is refused separately, deferred \
              to typed storage's first consumer) — {other:?} has no representation as a \
              GraphSubstrate f64 attribute at all"
@@ -1158,6 +1161,38 @@ fn attribute_value_int(atom: &Atom, local: &str, field: &str) -> Result<f64, Sce
         Atom::Currency(_) => Err(err(currency_refusal_message(local, field))),
         other => Err(err(format!(
             "node `{local}` field `{field}`: expected an integer literal, found {other:?}"
+        ))),
+    }
+}
+
+/// `real`-declared fields (Train B item 6). Accepts the three literal lanes
+/// whose own lex laws already bound them — int (exact to 2^53, the same
+/// guard `attribute_value_int` states), p/i/c (`[0,1]` at lex), r (`(0,∞)`
+/// at lex) — each converted by the crate's one scaled-literal contract
+/// (`unscaled / 10^scale`). Currency is refused (the same deferral every
+/// other arm states). There is NO arbitrary-precision fractional literal:
+/// E-LEX-021 still refuses bare floats; that is #591 item 5's territory,
+/// not this train's.
+fn attribute_value_real(atom: &Atom, local: &str, field: &str) -> Result<f64, ScenarioError> {
+    match atom {
+        Atom::Int(value) => {
+            if value.unsigned_abs() > (1_u64 << 53) {
+                return Err(err(format!(
+                    "node `{local}` field `{field}`: {value} exceeds f64's exact integer range"
+                )));
+            }
+            #[allow(clippy::cast_precision_loss)]
+            Ok(*value as f64)
+        }
+        Atom::Scaled(scaled) => {
+            #[allow(clippy::cast_precision_loss)]
+            let numerator = scaled.unscaled as f64;
+            Ok(numerator / 10_f64.powi(i32::from(scaled.scale)))
+        }
+        Atom::Currency(_) => Err(err(currency_refusal_message(local, field))),
+        other => Err(err(format!(
+            "node `{local}` field `{field}`: expected an int, p/i/c or r literal for a \
+             real field, found {other:?}"
         ))),
     }
 }
@@ -1988,6 +2023,72 @@ mod tests {
         enc.write_edges(&[]).unwrap();
         enc.write_hyperedges(&[]).unwrap();
         assert_eq!(hash, enc.finish());
+    }
+
+    // ---- Train B item 6 (#591): the `real` deffield type ----
+
+    #[test]
+    fn real_deffield_seeds_int_scaled_and_ratio_verbatim() {
+        // Exact-bit pins, the same discipline
+        // `a_scaled_literal_seeds_correctly_into_each_unit_interval_type`
+        // states above — the conversion is the crate's ONE scaled-literal
+        // contract (`unscaled / 10^scale`), not a tolerance. A `real`
+        // field accepts the three literal lanes whose own lex laws already
+        // bound them: int, p/i/c, and r (Ratio is `Atom::Scaled` with
+        // `ScaledKind::Ratio`, so one arm covers both scaled kinds).
+        for (literal, expected) in [("9", 9.0_f64), ("0.25c", 0.25_f64), ("1.5r", 1.5_f64)] {
+            let source = format!(
+                "(scenario ft/real\n  \
+                 (deffield social-class/balance real intensive)\n  \
+                 (node core NodeType/SOCIAL_CLASS (social-class/balance {literal})))"
+            );
+            let mut graph = MemoryGraph::new();
+            load_scenario(&source, &mut graph).unwrap();
+            let value = graph
+                .node_attribute(NodeId(0), "social-class/balance")
+                .unwrap();
+            assert_eq!(
+                value.to_bits(),
+                expected.to_bits(),
+                "{literal}: got 0x{:016x}, want 0x{:016x}",
+                value.to_bits(),
+                expected.to_bits()
+            );
+        }
+    }
+
+    #[test]
+    fn real_deffield_refuses_currency_and_bare_ident() {
+        // Currency: the same deferral every other arm states — f64 cannot
+        // hold i128 micro-units, and this refuses rather than casting
+        // lossily.
+        let source = r"
+(scenario ft/real-currency
+  (deffield social-class/balance real intensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/balance 9$)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(
+            err.message.contains("typed attribute storage"),
+            "{}",
+            err.message
+        );
+
+        // A bare identifier is not a numeric literal at all — loud, naming
+        // the node and the field.
+        let source = r"
+(scenario ft/real-ident
+  (deffield social-class/balance real intensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/balance someident)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(
+            err.message.contains("`core`") && err.message.contains("social-class/balance"),
+            "{}",
+            err.message
+        );
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/score_class.rs
+++ b/rust/crates/babylon-bsl/src/score_class.rs
@@ -85,6 +85,7 @@ fn of_type(ty: &BslType) -> ScoreClass {
         BslType::Enum(_) => ScoreClass::Enum,
         BslType::NodeSet(_) | BslType::EdgeSet(_) => ScoreClass::Set,
         BslType::Int
+        | BslType::Real
         | BslType::Currency
         | BslType::Probability
         | BslType::Intensity

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -2100,9 +2100,11 @@ mod tests {
     /// Probability/Intensity/Coefficient), and `Real` is not one of them.
     /// A write outside `[0,1]`, and a negative write, both land VERBATIM —
     /// bit-exact, no tolerance — matching what `numeric_write_value`
-    /// already does with any computed f64. (Negative values can't be
-    /// written by seed LITERALS — every fractional lane is lex-bounded —
-    /// but writes may be negative; the store does not care.)
+    /// already does with any computed f64. (No negative FRACTIONAL seed
+    /// literal exists — every scaled lane is lex-bounded non-negative —
+    /// but a negative `int` literal seeds fine (`attribute_value_real`
+    /// takes any `Atom::Int` exact to 2⁵³), and writes may be negative
+    /// either way; the store does not care.)
     #[test]
     fn real_field_store_has_no_range_check() {
         let mut graph = MemoryGraph::new();

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -2094,6 +2094,100 @@ mod tests {
         assert!((stored - 0.10).abs() < 1e-12);
     }
 
+    /// Train B item 6 (#591): a `real`-declared field carries NO
+    /// store-boundary range law — E-EVAL-020 is the unit-interval types'
+    /// check (`store_range_check`'s `matches!` names exactly
+    /// Probability/Intensity/Coefficient), and `Real` is not one of them.
+    /// A write outside `[0,1]`, and a negative write, both land VERBATIM —
+    /// bit-exact, no tolerance — matching what `numeric_write_value`
+    /// already does with any computed f64. (Negative values can't be
+    /// written by seed LITERALS — every fractional lane is lex-bounded —
+    /// but writes may be negative; the store does not care.)
+    #[test]
+    fn real_field_store_has_no_range_check() {
+        let mut graph = MemoryGraph::new();
+        let self_id = graph.add_node("SOCIAL_CLASS").unwrap();
+        let types = TypeEnv {
+            fields: HashMap::from([(
+                "social-class/balance".to_owned(),
+                FieldDecl {
+                    ty: BslType::Real,
+                    kind: FieldKind::Intensive,
+                },
+            )]),
+            exemptions: &[],
+        };
+        let enums = enums();
+        let costs = IntrinsicCosts::default();
+        let env = EvalEnv {
+            bindings: HashMap::from([("self".to_owned(), Value::NodeRef(self_id))]),
+            intrinsic_costs: &costs,
+            graph: None,
+            types: None,
+            enums: None,
+            elements: Vec::new(),
+        };
+        // The E-EVAL-020 boundary itself, probed directly with the two
+        // Train-B-content magnitudes the task brief names: both pass,
+        // for Real, where a unit-interval field would refuse loudly.
+        let probe = EffectExecutor::new(&types, &enums, None);
+        for value in [6_962.099_999_999_999_f64, -0.052_631_578_947_368_42_f64] {
+            probe
+                .store_range_check("social-class/balance", value)
+                .unwrap();
+        }
+        // End-to-end through `update-node`: the computed binary64 lands
+        // bit-verbatim. `(+ 6962 0.1c)` is 6962.1000000000003637… — one
+        // ulp ABOVE the 6962.099999999999… decimal, because the sum of
+        // the two rounded operands is not the rounding of the decimal
+        // sum (the IEEE subtlety this pin exists to state, not absorb).
+        // `(- 0 (/ 1.0c 19))` IS exactly -0.05263157894736842.
+        for (effects, expected) in [
+            (
+                "(effects (update-node self social-class/balance (set (+ 6962 0.1c))))",
+                6962.0_f64 + 0.1_f64,
+            ),
+            (
+                "(effects (update-node self social-class/balance (set (- 0 (/ 1.0c 19)))))",
+                -(1.0_f64 / 19.0_f64),
+            ),
+        ] {
+            let (form, _) = read(effects).expect("effects source must parse");
+            let SExpr::List(items) = form else {
+                unreachable!()
+            };
+            let mut executor = EffectExecutor::new(&types, &enums, None);
+            let mut sink = CollectingSink::default();
+            let mut fuel = 256;
+            executor
+                .execute_effects(
+                    &items[1..],
+                    &env,
+                    &EmptyIntrinsicHost,
+                    &mut graph,
+                    &mut sink,
+                    &mut fuel,
+                )
+                .unwrap();
+            let stored = graph
+                .node_attribute(self_id, "social-class/balance")
+                .unwrap();
+            assert_eq!(
+                stored.to_bits(),
+                expected.to_bits(),
+                "{effects}: got 0x{:016x}, want 0x{:016x}",
+                stored.to_bits(),
+                expected.to_bits()
+            );
+        }
+        // The second end-to-end value and the brief's named negative
+        // decimal are the same binary64 — pinned, not assumed.
+        assert_eq!(
+            (-(1.0_f64 / 19.0_f64)).to_bits(),
+            (-0.052_631_578_947_368_42_f64).to_bits()
+        );
+    }
+
     #[test]
     fn add_node_introduces_a_name_later_effects_can_use() {
         let mut fixture = Fixture::new();

--- a/rust/crates/babylon-bsl/src/typecheck.rs
+++ b/rust/crates/babylon-bsl/src/typecheck.rs
@@ -662,6 +662,28 @@ mod tests {
         assert_eq!(check("(count wealth-share)", &env()), Ok(BslType::Int));
     }
 
+    /// Train B item 6 (#591): a fold-sum over a `real extensive` field
+    /// types as the fold's numeric lane — the field's own `Real`, the same
+    /// pass-through every other storable numeric type already gets — and
+    /// never raises E-TYPE-041 (the sum-of-intensive refusal), because the
+    /// kind law keys on `FieldKind`, not on the type.
+    #[test]
+    fn sum_over_a_real_extensive_field_types_as_the_numeric_lane() {
+        let mut fields = HashMap::new();
+        fields.insert(
+            "balance".to_string(),
+            FieldDecl {
+                ty: BslType::Real,
+                kind: FieldKind::Extensive,
+            },
+        );
+        let env = TypeEnv {
+            fields,
+            exemptions: &[],
+        };
+        assert_eq!(check("(sum balance)", &env), Ok(BslType::Real));
+    }
+
     /// Compile-time trap for the `FieldKind` axis (verifier fix round,
     /// MINOR-2 on issue #525). `typecheck_aggregation` itself decides the
     /// kind law with per-variant EQUALITY checks (`field.kind ==

--- a/rust/crates/babylon-bsl/src/types.rs
+++ b/rust/crates/babylon-bsl/src/types.rs
@@ -220,6 +220,12 @@ pub enum BslType {
     Coefficient,
     /// Fixed-point i128 micro-unit currency.
     Currency,
+    /// An unbounded finite binary64 scalar — the honest declared home for
+    /// what the store already does (verbatim f64, `numeric_write_value`).
+    /// Carries no range law: seeds accept int / p/i/c / r literals (each
+    /// already lex-bounded in its own lane), writes store any finite f64.
+    /// minted by Train B item 6 (ADR-pending), AE(ii) representation-level.
+    Real,
     /// `int-lit`'s static type (§1.5); also `count`'s result type (§3.4).
     Int,
     /// `#t` / `#f`.

--- a/rust/crates/babylon-tick/content/rules/consciousness.bsl
+++ b/rust/crates/babylon-tick/content/rules/consciousness.bsl
@@ -119,7 +119,11 @@
 ;      = 1.9). All three
 ;      machinery accumulators are therefore int-typed verbatim-f64;
 ;      agitation seeds at 0 (a produced accumulator, R-MEASURED), the
-;      others unseeded until their writing tasks.
+;      others unseeded until their writing tasks. The verbatim-f64 int
+;      lane this row records was RETIRED by Train B item 6
+;      (`BslType::Real`): the fields it governed now declare `real`; the
+;      store law itself (verbatim f64, no implicit truncation, `floor`
+;      available) is unchanged — only the declared home moved.
 ;   6. The wage flow rides a CLASS-SIDE field (controller ruling 2, fix
 ;      round): social-class/wages-received carries the per-tick wage
 ;      inflow as declared content — the frozen engine's incoming-WAGES

--- a/rust/crates/babylon-tick/content/scenarios/consciousness-ternary-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/consciousness-ternary-conformance.bscn
@@ -90,6 +90,7 @@
 ;      D-row, verbatim: "no implicit truncation at the store; the int
 ;      lane holds verbatim f64; `floor` is the content-explicit
 ;      truncation intrinsic, unused in this pack."
+;      RETIRED by Train B item 6 (`BslType::Real`): the fields this row governed now declare `real`; the store law itself (verbatim f64, no implicit truncation, `floor` available) is unchanged — only the declared home moved.
 ;
 ;      FIX-ROUND DISCOVERY (ruling 3's escape clause, exercised), then
 ;      FIX-ROUND-2 CORRECTION (the escape retired): the FULL seed/write
@@ -192,7 +193,7 @@
   ; ---- carriers (reuse exact qnames from two-classes.bscn where present) ----
   (deffield social-class/population int extensive)
   (deffield social-class/active int intensive)            ; 0/1 latch convention (no bool on the live path)
-  (deffield social-class/wealth int extensive)
+  (deffield social-class/wealth real extensive)
   (deffield social-class/wages-paid int extensive)        ; frozen w_paid (ideology.py:239)
   (deffield social-class/value-produced int extensive)    ; frozen v_produced (ideology.py:240)
   (deffield organization/active int intensive)            ; latch convention (production.bsl header item 2)
@@ -204,13 +205,13 @@
   (deffield social-class/dominant-worldview enum WorldView)   ; re-declared here — spike 2's verdict; ONLY Task 2's consciousness/p8-dominant-worldview writes it (one-home law, controller ruling 1)
 
   ; ---- update-law machinery (verbatim-f64 posture: no store coercion, spike 4) ----
-  (deffield social-class/agitation int intensive)          ; [0,∞) raw f64 (frozen: ge=0.0, unbounded — social_class.py:95-102). Verbatim-f64 int lane: fractional WRITES are lawful (spike 4), fractional SEEDS are refused by the loader (verdict 4's fix-round note) — hence the zero seeds below: agitation is a produced accumulator (R-MEASURED), content seeds it at zero and Task 3's vectors produce it
-  (deffield social-class/wage-balance int intensive)       ; [-1,1] SIGNED raw f64 — a unit-interval type would refuse the negative half (store_range_check)
-  (deffield social-class/solidarity-inbox int intensive)   ; [0,n) strength-sum raw f64 — can exceed 1.0, so no unit-interval type is lawful; reset per tick (later tasks)
-  (deffield social-class/wages-received int extensive)     ; raw units — the per-tick wage flow as declared class-side content (controller ruling 2). Task 3's input: NOTHING in Task 1's pack reads it
+  (deffield social-class/agitation real intensive)         ; [0,∞) raw f64 (frozen: ge=0.0, unbounded — social_class.py:95-102). Retired from the verbatim-f64 int lane by Train B item 6 (the real type); zero seeds remain (R-MEASURED: produced, never authored)
+  (deffield social-class/wage-balance real intensive)      ; [-1,1] SIGNED raw f64 — a unit-interval type would refuse the negative half (store_range_check)
+  (deffield social-class/solidarity-inbox real intensive)  ; [0,n) strength-sum raw f64 — can exceed 1.0, so no unit-interval type is lawful; reset per tick (later tasks)
+  (deffield social-class/wages-received real extensive)    ; raw units — the per-tick wage flow as declared class-side content (controller ruling 2). Task 3's input: NOTHING in Task 1's pack reads it
   (deffield social-class/repression-faced intensity intensive) ; declared input only; nothing in Rust writes it yet
-  (deffield social-class/previous-wages int intensive)     ; raw units (the persistent_data re-home, digest gap 4)
-  (deffield social-class/previous-wealth int intensive)
+  (deffield social-class/previous-wages real intensive)    ; raw units (the persistent_data re-home, digest gap 4)
+  (deffield social-class/previous-wealth real intensive)
 
   ; ---- defines environment (transcribed; line cites = src/babylon/data/defines.yaml) ----
   (defconst consciousness/routing-scale 0.2c)                    ; :213

--- a/rust/crates/babylon-tick/content/scenarios/dispossession-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/dispossession-conformance.bscn
@@ -19,8 +19,8 @@
 ; behavior, and `dispossession_conformance.py` for the provenance script
 ; both files' numbers come from.
 (scenario dispossession/conformance
-  (deffield territory/wealth int extensive)
-  (deffield territory/dispossession-intensity int intensive)
+  (deffield territory/wealth real extensive)
+  (deffield territory/dispossession-intensity real intensive)
 
   ; Illustrative fixture values (Class C: nothing hydrates real per-county
   ; dispossession data on the canonical run today,

--- a/rust/crates/babylon-tick/content/scenarios/lifecycle-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/lifecycle-conformance.bscn
@@ -35,18 +35,18 @@
 ; the guard's RECOVERY half from the other direction, which is the
 ; reachable half of the same code path under THIS scenario's tuning.
 (scenario lifecycle/conformance
-  (deffield territory/pop-d int extensive)
-  (deffield territory/pop-p int extensive)
-  (deffield territory/pop-d-prime int extensive)
-  (deffield territory/wealth-d-prime int extensive)
+  (deffield territory/pop-d real extensive)
+  (deffield territory/pop-p real extensive)
+  (deffield territory/pop-d-prime real extensive)
+  (deffield territory/wealth-d-prime real extensive)
   ; Per-county ratios/indices: an unweighted mean across counties is the
   ; variance error §3.4 exists to reject, so these are intensive.
-  (deffield territory/dependency-ratio int intensive)
-  (deffield territory/legitimation-index int intensive)
+  (deffield territory/dependency-ratio real intensive)
+  (deffield territory/legitimation-index real intensive)
   ; 0 = STABLE, 1 = UNSTABLE, 2 = CRISIS — this pack's own encoding; see
   ; the .bsl header (LegitimationClassification has no BSL representation).
   (deffield territory/legitimation-crisis int intensive)
-  (deffield territory/transmitted-ideology int intensive)
+  (deffield territory/transmitted-ideology real intensive)
 
   ; The defines environment. Values transcribed from the canonical single
   ; source of truth, src/babylon/data/defines.yaml:507-543 (`lifecycle:`).

--- a/rust/crates/babylon-tick/content/scenarios/metabolism-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/metabolism-conformance.bscn
@@ -22,8 +22,8 @@
 ; See `metabolism_conformance.py` for the provenance script these numbers
 ; come from.
 (scenario metabolism/conformance
-  (deffield territory/biocapacity int extensive)
-  (deffield territory/max-biocapacity int extensive)
+  (deffield territory/biocapacity real extensive)
+  (deffield territory/max-biocapacity real extensive)
   (deffield territory/extraction-intensity int intensive)
 
   ; MetabolismDefines, src/babylon/data/defines.yaml (metabolism: section) —

--- a/rust/crates/babylon-tick/content/scenarios/production-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/production-conformance.bscn
@@ -110,12 +110,12 @@
   (deffield social-class/role enum SocialRole)
   (deffield social-class/active int extensive)
   (deffield social-class/population int extensive)
-  (deffield social-class/wealth int extensive)
-  (deffield social-class/production-value int extensive)
+  (deffield social-class/wealth real extensive)
+  (deffield social-class/production-value real extensive)
   (deffield territory/biocapacity int extensive)
   (deffield territory/max-biocapacity int extensive)
   (deffield territory/extraction-intensity coefficient intensive)
-  (deffield territory/production-total int extensive)
+  (deffield territory/production-total real extensive)
 
   ; EconomyDefines/TimescaleDefines, src/babylon/data/defines.yaml:73,374.
   ; `1.0c` sits exactly at the coefficient boundary [0,1] — legal today,

--- a/rust/crates/babylon-tick/content/scenarios/vitality-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/vitality-conformance.bscn
@@ -21,7 +21,7 @@
   ; type and GraphSubstrate attributes are f64. Recorded, not hidden.
   (deffield social-class/active int extensive)
   (deffield social-class/population int extensive)
-  (deffield social-class/wealth int extensive)
+  (deffield social-class/wealth real extensive)
   ; Per-head quantities: an unweighted mean of one across classes is the
   ; variance error §3.4 exists to reject, so they are declared intensive.
   (deffield social-class/subsistence-multiplier int intensive)


### PR DESCRIPTION
## Train B item 6 (#591): the `real` type + the content migration

Two commits on `feature/bsl-ergonomics-b`:

1. `021803c2` — `feat(bsl): mint BslType::Real — the honest home for verbatim f64 (#591 item 6)` (Task 1: the type itself, both type-name parsers, `attribute_value_real` seed law, register row **D155**)
2. `47e51ef0` — `refactor(bsl-content): re-type the non-integral-f64 roster int -> real (#591 item 6 migration)` (Task 2: the content migration — **type-token + comment edits ONLY; zero value changes, zero golden edits**)

### Byte-neutrality evidence (the train's proof obligation)

- `mise run rust:check` green end-to-end (fmt; clippy `-D warnings -D clippy::cognitive_complexity`; full workspace test run — `tick_goldens` + all six conformance suites + the ternary pack; pedantic legs; doc), with **every golden hash and every exact-f64 conformance assertion passing UNEDITED**. Type tags are never hashed (`CanonicalState` section `0x02` is a bare f64 regardless of declaring `BslType`; scenario.rs:1044-1054), so the type-token migration is byte-neutral by construction — and the gate proves it.
- `mise run qa:regression` green ("All regression tests passed!", incl. the E5b two-process determinism leg) — the Python estate is untouched.
- Migration diff: 9 files, 48 insertions / 23 deletions — every changed line is a deffield type token or a comment.

### Migration roster (20 fields across 6 scenarios)

| File | Fields re-typed `int` → `real` |
|---|---|
| production-conformance.bscn | `social-class/wealth`, `social-class/production-value`, `territory/production-total` |
| vitality-conformance.bscn | `social-class/wealth` |
| lifecycle-conformance.bscn | `territory/pop-d`, `pop-p`, `pop-d-prime`, `wealth-d-prime`, `dependency-ratio`, `legitimation-index`, `transmitted-ideology` |
| metabolism-conformance.bscn | `territory/biocapacity`, `max-biocapacity` |
| dispossession-conformance.bscn | `territory/wealth`, `dispossession-intensity` |
| consciousness-ternary-conformance.bscn | `social-class/wealth`, `agitation`, `wage-balance`, `solidarity-inbox`, `wages-received`, `previous-wages`, `previous-wealth` |

Integral content stays `int` per the digest's inventory: `population` / `active` / `wages-paid` / `value-produced` (the fractional-seed-refusal pin depends on it), `legitimation-crisis` (0/1/2 encoding), production-conformance's `biocapacity` pair, two-classes' `imperial-rent`, `rent-level-x1e6`, `heat`, `organization/active`.

### D155 + the Task-1 review sweep (F1/F2, folded into the migration commit)

- **D155** is the register row: `real` is the eighth declarable `<type-name>` — a knowing supersession of D98's "``Real`` is not storable" (both rows stand unedited; Immutability of History).
- **F1**: `docs/reference/bsl-language.rst` §3.10's undated `floor` Signature bullet gains the Train-B note — `real` became storable via D155; D98's intrinsic-position law itself (`:params`/`:returns`) is unchanged.
- **F2**: `docs/reference/bsl.ebnf`'s `type-name` production gains the D155 addendum — the eighth lowercase symbol, mirroring D101's addendum posture.
- The rounding D-row (`consciousness.bsl` item 5) and its ternary mirror note record the verbatim-f64 int lane's retirement; the store law itself (verbatim f64, no implicit truncation, `floor` available) is unchanged — only the declared home moved.
