### PR TITLE
Train B item 3: edge-attribute seeding + the WAGES un-narrowing (#591)

### DIFF
--- a/docs/concepts/consciousness-taxonomy.rst
+++ b/docs/concepts/consciousness-taxonomy.rst
@@ -455,12 +455,15 @@ W12: the Value-Flow Coupling — Read Direction Landed
 W12 rules ideology a gravitational pull that commands labor vis-à-vis
 hegemony: the ternary couples to the value-flow estate, never an inert
 label. This train lands the READ couplings — the pack COMPUTES the
-class ternary from the value-flow estate: the wage inflow (the declared
-class-side ``social-class/wages-received`` field, riding in place of
-the frozen incoming-WAGES fold-sum until scenario-side edge-attribute
-seeding lands — #591 item 3), the ``wages-paid`` / ``value-produced``
-anchors and their signed ``wage-balance``, the wealth delta, and the
-SOLIDARITY topology that routes agitation. The PULL couplings —
+class ternary from the value-flow estate: the wage inflow (the seeded
+WAGES-edge ``wages/value-flow``, pushed into
+``social-class/wages-inbox`` — #591 item 3 landed the edge-attribute
+seeding a first draft deferred, closing the frozen incoming-WAGES
+fold-sum exactly via push-over-pull; the interim class-side
+``social-class/wages-received`` field is retired), the ``wages-paid`` /
+``value-produced`` anchors and their signed ``wage-balance``, the
+wealth delta, and the SOLIDARITY topology that routes agitation. The
+PULL couplings —
 measured shares modulating the value flow itself — are chartered
 port-stage design work (ADR207's follow-on roster), deliberately
 minting no new formalism.

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -3121,6 +3121,27 @@ What hydration may do, stated once because three chapters now depend on it:
    attributed membership has to be unrepresentable from both or from neither;
    this clause is the second half of that, and it is what lets §2.10 say that
    an existing membership never reads absent.
+7. **[draft ruling — Train B item 3, issue #591 — D156]** It seeds an edge
+   attribute only through the scenario dialect's
+   ``(edge-attr <EdgeType/MEMBER> <from-name> <to-name> <field-qname> <value>)``
+   form, and only under four conditions, each a loud refusal: both endpoints
+   and the ``(source, target, edge-type)`` triple itself were seeded ABOVE the
+   form (the top-to-bottom law — an attribute write never mints an edge,
+   exactly as ``update_edge`` never mints an attribute row for one); the
+   qname's owner segment names the edge's own type (§2.10 discipline 1,
+   checked at hydration exactly as ``check_edge_referent_type`` checks it at
+   evaluation); the qname does not end in ``/strength`` (D32's implicit field
+   seeds via the ``edge`` form's own 4th slot only — one datum, one writer;
+   the guard is unconditional because ``load_deffield`` accepts an explicit
+   ``(deffield <edge-type>/strength …)`` that only ``prepare_rules``'s
+   ``E-LOAD-001`` refuses later, and without the guard the write would fall
+   into the substrate's ``/strength`` fork (D143) and silently rewrite the
+   mint strength slot); and the field was declared by ``deffield``, the value
+   converting through the same per-type literal law a node attribute does
+   (``Currency`` refused identically). A scenario seeding one
+   ``(edge-type, source, target, field)`` quadruple twice is ``E-LOAD-057`` —
+   clause 5's key argument one axis wider: the file would carry two values
+   for one datum with only the later surviving.
 
 **[draft ruling — Phase 1 review, Amendment AG (ii)]** *Rungs and adjunction
 instances are* ``manifest`` *children, not a top-level form of their own.* Two
@@ -3657,7 +3678,9 @@ two times at which an error can occur.
        spec §1 Q12), a ``:type enum``/``:enum-type`` shape violation, a
        ``defenum``-registry type or member an ``:enum-type`` or ``<enum-ref>``
        does not resolve, and a non-``<enum-ref>`` value seeding an
-       ``:enum-type``-declared field in a ``.bscn`` body.
+       ``:enum-type``-declared field in a ``.bscn`` body; and, from Train B
+       item 3 (#591), a hydration seeding one
+       ``(edge-type, source, target, field)`` edge-attribute key twice.
    * - Evaluation
      - ``E-EVAL-0xx``
      - During a tick — checked-arithmetic failure, range violation at a store,
@@ -3700,7 +3723,7 @@ defect D75 ruled against.
 
 Sequence continuation is meant literally, and is checkable by inspection: every
 decade block of every family is **contiguous**, with no reserved and no
-skipped number — ``E-LOAD`` 001–004, 010–013, 020–025, 030–033, 040–056;
+skipped number — ``E-LOAD`` 001–004, 010–013, 020–025, 030–033, 040–057;
 ``E-PARSE`` 010–015, 020–022, 030–033, 040–042; ``E-TYPE`` 010–017, 020, 030,
 040–044; ``E-EVAL`` 010–014, 020–021, 030–042; ``E-LEX`` 001–003,
 010–011, 020–027. ``E-TYPE-044`` (Territory port train, P27, #551 closure)
@@ -3742,6 +3765,12 @@ parallel numbers for an identical check against a different registry
 would be exactly the hygiene defect D75 ruled against, the same reasoning
 the Amendment AG sections' paragraph above already applies to its own
 parse- and type-class reuse.
+
+**Train B item 3 (#591) continues the same** ``E-LOAD`` **block a fourth
+time.** ``E-LOAD-057`` — a hydration seeding one
+``(edge-type, source, target, field)`` edge-attribute key twice (§3.9
+clause 7, D156) — is the next free number at the time of allocation, per
+the same rule.
 
 **Load-time errors** report the offending file, line, column, form, and code,
 and reject the whole content set — there is no partial load and no "skip the
@@ -7101,6 +7130,47 @@ consequences are the ordinary kind of review item.
        re-typed the non-integral-f64 roster to ``real`` — every golden
        still passes unedited, carried by the same mechanism: type tags
        are never hashed.)
+   * - D156
+     - §3.9, §4.6
+     - **Train B item 3 (issue #591) — the** ``.bscn`` **dialect's**
+       ``(edge-attr <EdgeType/MEMBER> <from-name> <to-name> <field-qname>
+       <value>)`` **form:** edge-attribute seeding in the scenario loader,
+       closing the gap D151's narrowing 3 filed (``load_edge`` was
+       strength-only). §3.9's hydration contract gains clause 7 with the
+       whole law; this row records the decisions. The form list lives here
+       rather than in D93's row, which stands unedited (Immutability of
+       History — its list was already illustrative, naming neither
+       ``defconst`` nor ``defenum``/``defvocabulary`` when those landed).
+       **The quadruple key:** ``(edge-type, source, target, field)`` is a
+       KEY exactly as D73's triple is; a scenario seeding one twice is
+       ``E-LOAD-057`` (§4.6's contiguous ``E-LOAD`` overrun block, the next
+       free number at allocation). **The strength refusal is
+       unconditional,** not merely the deffield-registry miss: D32's
+       implicit ``<edge-type>/strength`` field is never in
+       ``scenario.fields``, but ``load_deffield`` would ACCEPT an explicit
+       re-declaration (only ``prepare_rules``'s ``E-LOAD-001`` refuses it,
+       later — D139), and without the guard the write would fall into the
+       substrate's ``/strength`` fork (D143) and silently rewrite the mint
+       strength slot. One datum, one writer: the ``edge`` form's own 4th
+       slot. **The top-to-bottom edge-existence law:** the ``(member,
+       from, to)`` triple must already be in the scenario's own seeded set
+       — an attribute write never mints an edge, mirroring
+       ``update_edge``'s never-mint-a-row discipline (§2.8). The qname's
+       owner segment must name the edge's own type — §2.10 discipline 1 at
+       hydration, through the same ``namespace_to_node_type`` rendering
+       ``check_edge_referent_type`` uses at evaluation; no scenario-side
+       owner check existed before this form (node-side fields are their
+       owner's by construction of the ``node`` form's subject), so this
+       check is stated here explicitly. The value converts through
+       ``attribute_value``, the crate's ONE per-type literal law —
+       ``Currency`` refused identically; its error-descriptor parameter
+       became noun-carrying at the call site ("node \`…\`" / "edge (… →
+       …)") so no refusal calls an edge a "node" — the node path's
+       emitted text is unchanged apart from the unreachable
+       defense-in-depth arm, whose "node attributes" generalizes to
+       "attributes" (correct for both element kinds). Byte-neutrality: additive grammar — no
+       committed scenario uses ``edge-attr``, so every committed scenario
+       parses identically and every golden passes unedited.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -7164,11 +7164,17 @@ consequences are the ordinary kind of review item.
        check is stated here explicitly. The value converts through
        ``attribute_value``, the crate's ONE per-type literal law —
        ``Currency`` refused identically; its error-descriptor parameter
-       became noun-carrying at the call site ("node \`…\`" / "edge (… →
-       …)") so no refusal calls an edge a "node" — the node path's
-       emitted text is unchanged apart from the unreachable
-       defense-in-depth arm, whose "node attributes" generalizes to
-       "attributes" (correct for both element kinds). Byte-neutrality: additive grammar — no
+       carries the noun AND its quoting from the call site ("node \`…\`" /
+       "edge (… → …)"), with the family's twelve format strings naming
+       ``{local}`` bare — so no refusal calls an edge a "node", and the
+       node path's emitted bytes are the pre-form rendering EXACTLY, one
+       wording apart: the unreachable defense-in-depth arm's "node
+       attributes" generalizes to "attributes" (correct for both element
+       kinds). The byte-identity is pinned executably
+       (``a_fractional_seed_into_an_int_field_is_refused_with_the_pinned_verbatim_message``,
+       a full-string assertion — added in fix round 1, after the descriptor
+       refactor's two-backtick drift escaped review behind a comment-only
+       quote at ``consciousness-ternary-conformance.bscn:101-106``). Byte-neutrality: additive grammar — no
        committed scenario uses ``edge-attr``, so every committed scenario
        parses identically and every golden passes unedited.
 

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -7067,7 +7067,14 @@ consequences are the ordinary kind of review item.
        flow value — exact for single-employer content — because
        scenario-side edge-attribute seeding is unserved
        (``load_edge`` is strength-only, ``scenario.rs:1296-1302``); the
-       seeding gap is filed as #591 item 3.
+       seeding gap is filed as #591 item 3. Narrowing 3 itself was
+       RETIRED by Train B item 3 (issue #591, PR B): ``social-class/
+       wages-received`` is deleted; the wage flow now rides seeded WAGES
+       edges' ``wages/value-flow`` (D156's ``(edge-attr ...)`` form,
+       which closed the loader-side half of this gap) pushed into
+       ``social-class/wages-inbox`` by the new ``consciousness/
+       p2-wages-push`` rule — this row's narrowing no longer holds as
+       live law.
    * - D152
      - N/A (a gate read re-pointed at the stored ternary — the W1
        unification re-home, not a BSL construct)

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -1047,13 +1047,14 @@ fn load_node(
             id,
             field,
             // `attribute_value`'s first parameter is the ELEMENT DESCRIPTOR,
-            // so the noun travels from the call site: the node path passes
-            // "node `…`" here, the edge-attr path passes "edge (… → …)".
-            // Emitted text for this path is unchanged from before the
-            // descriptor convention, one wording apart: the unreachable
-            // defense-in-depth arm's "node attributes" generalizes to
-            // "attributes", correct for both element kinds (Train B item 3,
-            // #591).
+            // so the noun — quoting included — travels from the call site:
+            // the node path passes "node `…`" here, the edge-attr path
+            // passes "edge (… → …)", and the family's format strings name
+            // `{local}` BARE. Emitted text for this path is byte-identical
+            // to the pre-descriptor rendering, one wording apart: the
+            // unreachable defense-in-depth arm's "node attributes"
+            // generalizes to "attributes", correct for both element kinds
+            // (Train B item 3, #591).
             attribute_value(value, &format!("node `{local}`"), field, decl, enums)?,
         )?;
     }
@@ -1081,11 +1082,13 @@ fn load_node(
 /// entirely in this function; widening it changes zero bytes for any
 /// existing scenario, since every one seeds only `int` fields today.
 ///
-/// `local` is the ELEMENT DESCRIPTOR for error text, noun included —
-/// `load_node` passes "node \`core\`", `load_edge_attr` passes
-/// "edge (a → b)" — so a refusal never calls an edge a "node" (Train B item
-/// 3, #591; the same form-parameter convention `vocab_err` and
-/// `evaluator.rs`'s `check_*_referent_type` already model).
+/// `local` is the ELEMENT DESCRIPTOR for error text, noun and quoting
+/// included — `load_node` passes "node \`core\`", `load_edge_attr` passes
+/// "edge (a → b)", and this family's format strings name `{local}` BARE, so
+/// the node path's emitted text is byte-identical to the pre-descriptor
+/// rendering and no refusal calls an edge a "node" (Train B item 3, #591;
+/// the same form-parameter convention `vocab_err` and `evaluator.rs`'s
+/// `check_*_referent_type` already model).
 fn attribute_value(
     atom: &Atom,
     local: &str,
@@ -1113,7 +1116,7 @@ fn attribute_value(
         // `unreachable!()` would panic rather than name the field that
         // triggered it.
         other => Err(err(format!(
-            "`{local}`: field `{field}` is declared {other:?}, and the scenario \
+            "{local}: field `{field}` is declared {other:?}, and the scenario \
              loader stores only `int`, `real`, `probability`, `intensity`, `coefficient` or \
              `enum`-declared attributes (currency is refused separately, deferred \
              to typed storage's first consumer) — {other:?} has no representation as a \
@@ -1146,7 +1149,7 @@ fn attribute_value_enum(
         return Err(coded_err(
             "E-LOAD-056",
             format!(
-                "`{local}` field `{field}`: an enum-typed field is seeded \
+                "{local} field `{field}`: an enum-typed field is seeded \
                  ONLY as <EnumType>/<MEMBER> — the ordinal is never a surface \
                  value; found {atom:?}"
             ),
@@ -1157,7 +1160,7 @@ fn attribute_value_enum(
         return Err(coded_err(
             "E-LOAD-056",
             format!(
-                "`{local}` field `{field}`: declared enum type is \
+                "{local} field `{field}`: declared enum type is \
                  {declared_type}, found {enum_type}/{member} — an <enum-ref> \
                  of a different declared type is exactly as illegal as a bare \
                  number here"
@@ -1168,7 +1171,7 @@ fn attribute_value_enum(
         return Err(coded_err(
             "E-LOAD-055",
             format!(
-                "`{local}` field `{field}`: {declared_type} has no \
+                "{local} field `{field}`: {declared_type} has no \
                  member {member} — never a default"
             ),
         ));
@@ -1185,7 +1188,7 @@ fn attribute_value_int(atom: &Atom, local: &str, field: &str) -> Result<f64, Sce
             // faithfully record.
             if value.unsigned_abs() > (1_u64 << 53) {
                 return Err(err(format!(
-                    "`{local}` field `{field}`: {value} exceeds f64's exact integer range"
+                    "{local} field `{field}`: {value} exceeds f64's exact integer range"
                 )));
             }
             #[allow(clippy::cast_precision_loss)]
@@ -1193,7 +1196,7 @@ fn attribute_value_int(atom: &Atom, local: &str, field: &str) -> Result<f64, Sce
         }
         Atom::Currency(_) => Err(err(currency_refusal_message(local, field))),
         other => Err(err(format!(
-            "`{local}` field `{field}`: expected an integer literal, found {other:?}"
+            "{local} field `{field}`: expected an integer literal, found {other:?}"
         ))),
     }
 }
@@ -1211,7 +1214,7 @@ fn attribute_value_real(atom: &Atom, local: &str, field: &str) -> Result<f64, Sc
         Atom::Int(value) => {
             if value.unsigned_abs() > (1_u64 << 53) {
                 return Err(err(format!(
-                    "`{local}` field `{field}`: {value} exceeds f64's exact integer range"
+                    "{local} field `{field}`: {value} exceeds f64's exact integer range"
                 )));
             }
             #[allow(clippy::cast_precision_loss)]
@@ -1224,7 +1227,7 @@ fn attribute_value_real(atom: &Atom, local: &str, field: &str) -> Result<f64, Sc
         }
         Atom::Currency(_) => Err(err(currency_refusal_message(local, field))),
         other => Err(err(format!(
-            "`{local}` field `{field}`: expected an int, p/i/c or r literal for a \
+            "{local} field `{field}`: expected an int, p/i/c or r literal for a \
              real field, found {other:?}"
         ))),
     }
@@ -1297,7 +1300,7 @@ fn attribute_value_unit_interval(
             let numerator = scaled.unscaled as f64;
             let value = numerator / 10_f64.powi(i32::from(scaled.scale));
             return Err(err(format!(
-                "`{local}` field `{field}`: {value}r is a Ratio (r-suffixed) literal, \
+                "{local} field `{field}`: {value}r is a Ratio (r-suffixed) literal, \
                  not a legal {ty:?} attribute value — Ratio is its own runtime type with \
                  domain (0, ∞), and a :field read can never legally produce one"
             )));
@@ -1312,14 +1315,14 @@ fn attribute_value_unit_interval(
         Atom::Currency(_) => return Err(err(currency_refusal_message(local, field))),
         other => {
             return Err(err(format!(
-                "`{local}` field `{field}`: expected an int or scaled (p/i/c) \
+                "{local} field `{field}`: expected an int or scaled (p/i/c) \
                  literal, found {other:?}"
             )))
         }
     };
     if !(0.0..=1.0).contains(&value) {
         return Err(err(format!(
-            "`{local}` field `{field}`: storing {value} leaves its declared \
+            "{local} field `{field}`: storing {value} leaves its declared \
              {ty:?} [0,1] domain — a loud failure, never a clamp (mirrors \
              structural_verbs.rs::store_range_check's runtime rule, checked one \
              call frame earlier)"
@@ -1340,7 +1343,7 @@ fn attribute_value_unit_interval(
 /// message cites the ruling directly rather than a phase number.
 fn currency_refusal_message(local: &str, field: &str) -> String {
     format!(
-        "`{local}` field `{field}`: Currency attributes need typed attribute \
+        "{local} field `{field}`: Currency attributes need typed attribute \
          storage — the Director ruled (2026-08-11) that this lands with Currency's \
          first real consumer, not this train — f64 cannot hold i128 micro-units, and \
          this refuses rather than casting lossily"
@@ -3415,5 +3418,69 @@ mod tests {
         let mut graph = MemoryGraph::new();
         let err = load_scenario(source, &mut graph).unwrap_err();
         assert_eq!(err.code, Some("E-LOAD-057"), "{}", err.message);
+    }
+
+    #[test]
+    fn edge_attr_refuses_a_declared_strength_field_too() {
+        // F2 (Task 3 fix round 1): the guard's motivating variant.
+        // `load_deffield` has no implicit-field notion and ACCEPTS
+        // `(deffield solidarity/strength …)` (only `prepare_rules`'s
+        // E-LOAD-001 refuses it, later, at `TypeEnv` construction — D139),
+        // so here the deffield-registry lookup would SUCCEED and the
+        // unconditional `/strength` guard is the SOLE refusal between this
+        // form and the D143 fork's silent rewrite of the mint strength
+        // slot. The refusal must name the field and the D32 reason.
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario ft/edge-attr-declared-strength
+  (deffield solidarity/strength coefficient intensive)
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (edge EdgeType/SOLIDARITY a b 0.5c)
+  (edge-attr EdgeType/SOLIDARITY a b solidarity/strength 0.25c))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("solidarity/strength") && err.message.contains("IMPLICIT"),
+            "{}",
+            err.message
+        );
+        // And the mint strength slot is untouched — the guard fired before
+        // any write reached the substrate.
+        let strength = graph
+            .edge_attribute("SOLIDARITY", NodeId(0), NodeId(1), "solidarity/strength")
+            .unwrap();
+        assert_eq!(strength.to_bits(), (0.5_f64).to_bits());
+    }
+
+    // ---- F1 (Task 3 fix round 1): the node-path refusal text, pinned EXECUTABLY ----
+
+    #[test]
+    fn a_fractional_seed_into_an_int_field_is_refused_with_the_pinned_verbatim_message() {
+        // The descriptor refactor (Train B item 3, deviation 1) drifted
+        // every `attribute_value`-family message by two backticks and every
+        // gate stayed green — the one committed verbatim record,
+        // consciousness-ternary-conformance.bscn:101-106's comment quoting
+        // this exact refusal, is not executable. This assertion is the FULL
+        // string, not a substring: the descriptor self-quotes ("node `…`")
+        // and the family's format strings name `{local}` bare, so the
+        // emitted bytes are the pre-Task-3 rendering the .bscn comment
+        // quotes. If this message's text ever changes again, this test — not
+        // a comment — is what goes red.
+        let source = r"
+(scenario ft/verbatim-refusal
+  (deffield social-class/agitation int intensive)
+  (node class-exploited NodeType/SOCIAL_CLASS (social-class/agitation 0.1i)))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(
+            err.message,
+            "node `class-exploited` field `social-class/agitation`: expected an integer \
+             literal, found Scaled(ScaledLit { kind: Intensity, unscaled: 1, scale: 1 })"
+        );
     }
 }

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -385,7 +385,8 @@ pub fn load_scenario(
     for form in body {
         let SExpr::List(parts) = form else {
             return Err(err(
-                "a scenario body holds only (deffield ...), (node ...), (edge ...) and \
+                "a scenario body holds only (defenum ...), (defvocabulary ...), \
+                 (deffield ...), (defconst ...), (node ...), (edge ...) and \
                  (edge-attr ...) forms",
             ));
         };

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -375,11 +375,18 @@ pub fn load_scenario(
     // edge iteration order is not a total order and §2.10's `edge-between`
     // has no rule for resolving two.
     let mut seeded_edges: HashSet<(String, NodeId, NodeId)> = HashSet::new();
+    // Train B item 3 (#591, D156): the `(edge-attr …)` form's own key, one
+    // axis wider than E-LOAD-044's triple — a declared FIELD of an already-
+    // seeded edge. The quadruple is a KEY for the same reason the triple
+    // is: a second seeding of one key silently overwrites the first, the
+    // file carrying two values for one datum with only the later surviving.
+    let mut seeded_attrs: HashSet<(String, NodeId, NodeId, String)> = HashSet::new();
 
     for form in body {
         let SExpr::List(parts) = form else {
             return Err(err(
-                "a scenario body holds only (deffield ...), (node ...) and (edge ...) forms",
+                "a scenario body holds only (deffield ...), (node ...), (edge ...) and \
+                 (edge-attr ...) forms",
             ));
         };
         match parts.first() {
@@ -424,10 +431,22 @@ pub fn load_scenario(
                 *edge_types.entry(minted).or_insert(0) += 1;
                 edge_count += 1;
             }
+            Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "edge-attr" => {
+                load_edge_attr(
+                    parts,
+                    graph,
+                    &named,
+                    &seeded_edges,
+                    &mut seeded_attrs,
+                    &fields,
+                    &enums,
+                    vocabulary_so_far.as_ref(),
+                )?;
+            }
             _ => {
                 return Err(err(
                     "a scenario body form must begin with `defenum`, `defvocabulary`, \
-                     `deffield`, `defconst`, `node` or `edge`",
+                     `deffield`, `defconst`, `node`, `edge` or `edge-attr`",
                 ))
             }
         }
@@ -1027,7 +1046,15 @@ fn load_node(
         graph.update_node(
             id,
             field,
-            attribute_value(value, local, field, decl, enums)?,
+            // `attribute_value`'s first parameter is the ELEMENT DESCRIPTOR,
+            // so the noun travels from the call site: the node path passes
+            // "node `…`" here, the edge-attr path passes "edge (… → …)".
+            // Emitted text for this path is unchanged from before the
+            // descriptor convention, one wording apart: the unreachable
+            // defense-in-depth arm's "node attributes" generalizes to
+            // "attributes", correct for both element kinds (Train B item 3,
+            // #591).
+            attribute_value(value, &format!("node `{local}`"), field, decl, enums)?,
         )?;
     }
     Ok(member.clone())
@@ -1053,6 +1080,12 @@ fn load_node(
 /// `int`-declared field hash byte-identically. The restriction lived
 /// entirely in this function; widening it changes zero bytes for any
 /// existing scenario, since every one seeds only `int` fields today.
+///
+/// `local` is the ELEMENT DESCRIPTOR for error text, noun included —
+/// `load_node` passes "node \`core\`", `load_edge_attr` passes
+/// "edge (a → b)" — so a refusal never calls an edge a "node" (Train B item
+/// 3, #591; the same form-parameter convention `vocab_err` and
+/// `evaluator.rs`'s `check_*_referent_type` already model).
 fn attribute_value(
     atom: &Atom,
     local: &str,
@@ -1080,9 +1113,9 @@ fn attribute_value(
         // `unreachable!()` would panic rather than name the field that
         // triggered it.
         other => Err(err(format!(
-            "node `{local}`: field `{field}` is declared {other:?}, and the scenario \
+            "`{local}`: field `{field}` is declared {other:?}, and the scenario \
              loader stores only `int`, `real`, `probability`, `intensity`, `coefficient` or \
-             `enum`-declared node attributes (currency is refused separately, deferred \
+             `enum`-declared attributes (currency is refused separately, deferred \
              to typed storage's first consumer) — {other:?} has no representation as a \
              GraphSubstrate f64 attribute at all"
         ))),
@@ -1113,7 +1146,7 @@ fn attribute_value_enum(
         return Err(coded_err(
             "E-LOAD-056",
             format!(
-                "node `{local}` field `{field}`: an enum-typed field is seeded \
+                "`{local}` field `{field}`: an enum-typed field is seeded \
                  ONLY as <EnumType>/<MEMBER> — the ordinal is never a surface \
                  value; found {atom:?}"
             ),
@@ -1124,7 +1157,7 @@ fn attribute_value_enum(
         return Err(coded_err(
             "E-LOAD-056",
             format!(
-                "node `{local}` field `{field}`: declared enum type is \
+                "`{local}` field `{field}`: declared enum type is \
                  {declared_type}, found {enum_type}/{member} — an <enum-ref> \
                  of a different declared type is exactly as illegal as a bare \
                  number here"
@@ -1135,7 +1168,7 @@ fn attribute_value_enum(
         return Err(coded_err(
             "E-LOAD-055",
             format!(
-                "node `{local}` field `{field}`: {declared_type} has no \
+                "`{local}` field `{field}`: {declared_type} has no \
                  member {member} — never a default"
             ),
         ));
@@ -1152,7 +1185,7 @@ fn attribute_value_int(atom: &Atom, local: &str, field: &str) -> Result<f64, Sce
             // faithfully record.
             if value.unsigned_abs() > (1_u64 << 53) {
                 return Err(err(format!(
-                    "node `{local}` field `{field}`: {value} exceeds f64's exact integer range"
+                    "`{local}` field `{field}`: {value} exceeds f64's exact integer range"
                 )));
             }
             #[allow(clippy::cast_precision_loss)]
@@ -1160,7 +1193,7 @@ fn attribute_value_int(atom: &Atom, local: &str, field: &str) -> Result<f64, Sce
         }
         Atom::Currency(_) => Err(err(currency_refusal_message(local, field))),
         other => Err(err(format!(
-            "node `{local}` field `{field}`: expected an integer literal, found {other:?}"
+            "`{local}` field `{field}`: expected an integer literal, found {other:?}"
         ))),
     }
 }
@@ -1178,7 +1211,7 @@ fn attribute_value_real(atom: &Atom, local: &str, field: &str) -> Result<f64, Sc
         Atom::Int(value) => {
             if value.unsigned_abs() > (1_u64 << 53) {
                 return Err(err(format!(
-                    "node `{local}` field `{field}`: {value} exceeds f64's exact integer range"
+                    "`{local}` field `{field}`: {value} exceeds f64's exact integer range"
                 )));
             }
             #[allow(clippy::cast_precision_loss)]
@@ -1191,7 +1224,7 @@ fn attribute_value_real(atom: &Atom, local: &str, field: &str) -> Result<f64, Sc
         }
         Atom::Currency(_) => Err(err(currency_refusal_message(local, field))),
         other => Err(err(format!(
-            "node `{local}` field `{field}`: expected an int, p/i/c or r literal for a \
+            "`{local}` field `{field}`: expected an int, p/i/c or r literal for a \
              real field, found {other:?}"
         ))),
     }
@@ -1264,7 +1297,7 @@ fn attribute_value_unit_interval(
             let numerator = scaled.unscaled as f64;
             let value = numerator / 10_f64.powi(i32::from(scaled.scale));
             return Err(err(format!(
-                "node `{local}` field `{field}`: {value}r is a Ratio (r-suffixed) literal, \
+                "`{local}` field `{field}`: {value}r is a Ratio (r-suffixed) literal, \
                  not a legal {ty:?} attribute value — Ratio is its own runtime type with \
                  domain (0, ∞), and a :field read can never legally produce one"
             )));
@@ -1279,14 +1312,14 @@ fn attribute_value_unit_interval(
         Atom::Currency(_) => return Err(err(currency_refusal_message(local, field))),
         other => {
             return Err(err(format!(
-                "node `{local}` field `{field}`: expected an int or scaled (p/i/c) \
+                "`{local}` field `{field}`: expected an int or scaled (p/i/c) \
                  literal, found {other:?}"
             )))
         }
     };
     if !(0.0..=1.0).contains(&value) {
         return Err(err(format!(
-            "node `{local}` field `{field}`: storing {value} leaves its declared \
+            "`{local}` field `{field}`: storing {value} leaves its declared \
              {ty:?} [0,1] domain — a loud failure, never a clamp (mirrors \
              structural_verbs.rs::store_range_check's runtime rule, checked one \
              call frame earlier)"
@@ -1307,7 +1340,7 @@ fn attribute_value_unit_interval(
 /// message cites the ruling directly rather than a phase number.
 fn currency_refusal_message(local: &str, field: &str) -> String {
     format!(
-        "node `{local}` field `{field}`: Currency attributes need typed attribute \
+        "`{local}` field `{field}`: Currency attributes need typed attribute \
          storage — the Director ruled (2026-08-11) that this lands with Currency's \
          first real consumer, not this train — f64 cannot hold i128 micro-units, and \
          this refuses rather than casting lossily"
@@ -1417,6 +1450,149 @@ fn load_edge(
     }
     graph.add_edge(member, from_id, to_id, strength)?;
     Ok(member.clone())
+}
+
+/// `(edge-attr <enum-ref> <local-name> <local-name> <field-qname> <value>)` —
+/// Train B item 3 (#591, D156): seed one DECLARED field of an edge the same
+/// scenario already minted, through the same binary64 attribute lane every
+/// node field uses (`GraphSubstrate::update_edge`, the fifth-section store —
+/// the D143 `/strength` fork never engages because the strength guard below
+/// fires first). The value converts through [`attribute_value`], the crate's
+/// ONE per-type literal law — the Currency refusal included, unchanged.
+///
+/// The reading law is `load_edge`'s own, one form later in the file: the
+/// enum-ref demands `EdgeType` unconditionally, the declared vocabulary (if
+/// any) checks membership, both endpoints resolve through `named`, and the
+/// `(member, from, to)` triple must already be in `seeded` — an edge-attr
+/// for an edge not yet seeded in THIS scenario is a loud refusal naming the
+/// endpoints, the same top-to-bottom discipline as every other
+/// declared-registry lookup here. Three further refusals, in order:
+///
+/// 1. The qname's OWNER segment must name the edge's own type — §2.10
+///    discipline 1's ownership law, checked at hydration through the same
+///    rendering (`tick::namespace_to_node_type`)
+///    `evaluator.rs::check_edge_referent_type` uses at evaluation.
+/// 2. A `/strength`-suffixed qname is refused UNCONDITIONALLY — not merely
+///    via the registry miss (D32's implicit field is never in
+///    `scenario.fields`): `load_deffield` would ACCEPT an explicit
+///    `(deffield <edge-type>/strength …)` (only `prepare_rules`'s E-LOAD-001
+///    refuses it, later, at `TypeEnv` construction), and without this guard
+///    the write would fall into the substrate's `/strength` fork (D143) and
+///    silently rewrite the edge's mint strength slot. One datum, one writer:
+///    the `(edge …)` form's own 4th slot.
+/// 3. An undeclared qname is a typo, not a new field — `load_node`'s
+///    registry contract verbatim.
+///
+/// The `(edge-type, source, target, field)` quadruple is a KEY — a second
+/// seeding of one key is `E-LOAD-057`, E-LOAD-044's own argument one axis
+/// wider: the file would carry two values for one datum with only the later
+/// surviving, a silent overwrite.
+// Eight arguments, over clippy's seven: `parts`/`graph` are the form and its
+// target, `named`/`seeded`/`seeded_attrs`/`declared`/`enums`/`vocabulary` are
+// the six load-time registries the top-to-bottom law consults — the same
+// shape `load_node`/`load_edge` already take, plus this form's own second
+// seed set. Bundling them into a struct would rename, not reduce, them.
+#[allow(clippy::too_many_arguments)]
+fn load_edge_attr(
+    parts: &[SExpr],
+    graph: &mut dyn GraphSubstrate,
+    named: &HashMap<String, NodeId>,
+    seeded: &HashSet<(String, NodeId, NodeId)>,
+    seeded_attrs: &mut HashSet<(String, NodeId, NodeId, String)>,
+    declared: &HashMap<String, FieldDecl>,
+    enums: &EnumRegistry,
+    vocabulary: Option<&ClosedVocabulary>,
+) -> Result<(), ScenarioError> {
+    let [_, SExpr::Atom(Atom::EnumRef { enum_type, member }), SExpr::Atom(Atom::Symbol(from)), SExpr::Atom(Atom::Symbol(to)), SExpr::Atom(Atom::QName(field)), SExpr::Atom(value)] =
+        parts
+    else {
+        return Err(err(
+            "expected (edge-attr <EdgeType/MEMBER> <from-name> <to-name> <field-qname> <value>)",
+        ));
+    };
+    // An edge-attr form has no local name of its own — its edge's endpoints
+    // identify it (load_edge's own F6 convention).
+    let form = format!("edge-attr ({from} → {to})");
+    // The enum-ref position demands EdgeType, unconditionally — see
+    // `load_node`'s identical comment (F2, #534 fix round item 2).
+    demand_enum_kind(enum_type, member, EnumKind::EdgeType, enums)
+        .map_err(|e| vocab_err(&form, &e))?;
+    // See `load_node`'s identical comment (Task 8, Organization foundation
+    // plan) — the same membership check, before anything is written.
+    if let Some(vocabulary) = vocabulary {
+        vocabulary
+            .check_enum_ref(enum_type, member)
+            .map_err(|e| vocab_err(&form, &e))?;
+    }
+    let resolve = |name: &String| -> Result<NodeId, ScenarioError> {
+        named.get(name).copied().ok_or_else(|| {
+            err(format!(
+                "edge-attr names unknown node `{name}` — a node must be declared before an \
+                 edge-attr referring to it, so a scenario reads top to bottom"
+            ))
+        })
+    };
+    let (from_id, to_id) = (resolve(from)?, resolve(to)?);
+    // Edge-existence, against the SAME `seeded` set `load_edge` populates:
+    // the edge must have been seeded ABOVE this form in this scenario — an
+    // attribute write never mints an edge, exactly as `update_edge` never
+    // mints an attribute row for one that does not exist.
+    if !seeded.contains(&(member.clone(), from_id, to_id)) {
+        return Err(err(format!(
+            "edge-attr ({from} → {to}): no such edge — no {member} edge between this ordered \
+             pair was seeded ABOVE this form; an edge must exist before its attributes are \
+             seeded, so a scenario reads top to bottom"
+        )));
+    }
+    // §2.10 discipline 1 at hydration: the qname's owner segment must name
+    // the edge's own type, through the same rendering
+    // `check_edge_referent_type` uses at evaluation.
+    let owner_segment = field.split('/').next().unwrap_or(field);
+    let owner_type = crate::tick::namespace_to_node_type(owner_segment);
+    if owner_type != *member {
+        return Err(err(format!(
+            "edge-attr ({from} → {to}): field `{field}` is owned by {owner_type}, not \
+             {member} — an edge attribute's qname owner must name the edge's own type \
+             (§2.10 discipline 1, checked at hydration exactly as \
+             `check_edge_referent_type` checks it at evaluation)"
+        )));
+    }
+    // The strength guard — see this function's doc, refusal 2.
+    if field.ends_with("/strength") {
+        return Err(err(format!(
+            "edge-attr ({from} → {to}): `{field}` — strength seeds via the (edge ...) form's \
+             own 4th slot only. D32 kinds <edge-type>/strength an IMPLICIT field (never in a \
+             scenario's deffield registry), and the substrate's /strength write fork (D143) \
+             would route this write onto the edge's existing strength slot — a silent rewrite \
+             of the mint datum, never a second home"
+        )));
+    }
+    // The registry contract, ENFORCED — load_node's undeclared-field refusal
+    // verbatim, one element kind over.
+    let Some(decl) = declared.get(field) else {
+        return Err(err(format!(
+            "edge-attr ({from} → {to}): field `{field}` was never declared — add a \
+             (deffield {field} <type> <intensive|extensive>) form ABOVE the node and edge \
+             forms that use it"
+        )));
+    };
+    // The ONE per-type literal law — Currency refusal included. `attribute_value`
+    // takes the element descriptor, so the noun is honest on this path too.
+    let converted = attribute_value(value, &format!("edge ({from} → {to})"), field, decl, enums)?;
+    // §3.9 clause 7 / D156 — E-LOAD-044's key argument one axis wider.
+    if !seeded_attrs.insert((member.clone(), from_id, to_id, field.clone())) {
+        return Err(coded_err(
+            "E-LOAD-057",
+            format!(
+                "hydration seeds the {member} edge ({from} → {to})'s attribute `{field}` \
+                 twice; the (edge-type, source, target, field) quadruple is a KEY, exactly \
+                 as E-LOAD-044's triple is — a second seeding silently overwrites the first, \
+                 the file carrying two values for one datum with only the later surviving"
+            ),
+        ));
+    }
+    graph.update_edge(member, from_id, to_id, field, converted)?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -3060,5 +3236,184 @@ mod tests {
         let loaded = load_scenario(source, &mut graph)
             .expect("a node minted before any defvocabulary form is unchecked");
         assert_eq!(loaded.node_count, 1);
+    }
+
+    // ---- Train B item 3 (#591): the (edge-attr ...) scenario form ----
+
+    #[test]
+    fn edge_attr_seeds_a_declared_edge_field() {
+        // The positive lane: a declared edge field seeded onto an edge the
+        // same scenario already minted, read back through the substrate's
+        // fifth-section edge-attribute store (section 0x05 — the D143 fork
+        // does not engage, the qname does not end in `/strength`). Bit-exact
+        // pin, not a tolerance: 0.25 = 2^-2 is dyadic-exact, so 25/100
+        // divides to it exactly under the crate's one scaled-literal
+        // conversion contract.
+        let source = r"
+(scenario ft/edge-attr
+  (deffield solidarity/tension intensity intensive)
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (edge EdgeType/SOLIDARITY a b 0.5c)
+  (edge-attr EdgeType/SOLIDARITY a b solidarity/tension 0.25i))
+";
+        let mut graph = MemoryGraph::new();
+        let loaded = load_scenario(source, &mut graph).unwrap();
+        assert_eq!(loaded.edge_count, 1, "edge-attr mints no edge of its own");
+        let value = graph
+            .edge_attribute("SOLIDARITY", NodeId(0), NodeId(1), "solidarity/tension")
+            .unwrap();
+        assert_eq!(value.to_bits(), (0.25_f64).to_bits());
+        // …and the strength slot the `edge` form seeded is untouched.
+        let strength = graph
+            .edge_attribute("SOLIDARITY", NodeId(0), NodeId(1), "solidarity/strength")
+            .unwrap();
+        assert_eq!(strength.to_bits(), (0.5_f64).to_bits());
+    }
+
+    #[test]
+    fn edge_attr_refuses_unknown_edge_undeclared_field_strength_and_currency() {
+        // The four refusals, each a fresh scenario:
+        //
+        // 1. An edge-attr naming an edge this scenario never seeded — both
+        //    endpoints exist as NODES, which is what makes this the
+        //    edge-existence refusal rather than the unknown-node one. Loud,
+        //    naming the endpoints (the form has no local name of its own —
+        //    load_edge's own F6 convention).
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario ft/edge-attr-unknown-edge
+  (deffield solidarity/tension intensity intensive)
+  (node a NodeType/SOCIAL_CLASS)
+  (node c NodeType/SOCIAL_CLASS)
+  (edge-attr EdgeType/SOLIDARITY a c solidarity/tension 0.5i))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("a → c") && err.message.contains("no such edge"),
+            "{}",
+            err.message
+        );
+
+        // 2. An undeclared field qname is a typo, not a new field — the
+        //    same registry contract load_node enforces, one element kind
+        //    over. Loud, naming the field.
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario ft/edge-attr-undeclared
+  (deffield solidarity/tension intensity intensive)
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (edge EdgeType/SOLIDARITY a b 0.5c)
+  (edge-attr EdgeType/SOLIDARITY a b solidarity/nope 0.5i))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("solidarity/nope") && err.message.contains("never declared"),
+            "{}",
+            err.message
+        );
+
+        // 3. `solidarity/strength` — D32 kinds `<edge-type>/strength` an
+        //    IMPLICIT field: it is never in a scenario's deffield registry,
+        //    and strength seeds via the (edge ...) form's own 4th slot
+        //    only. Refused unconditionally (NOT merely via the registry
+        //    miss): a scenario CAN `(deffield solidarity/strength …)` —
+        //    `load_deffield` accepts it and only `prepare_rules`'s E-LOAD-001
+        //    refuses it later — and without this guard the write would fall
+        //    into the substrate's `/strength` fork (D143) and silently
+        //    rewrite the edge's mint strength slot.
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario ft/edge-attr-strength
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (edge EdgeType/SOLIDARITY a b 0.5c)
+  (edge-attr EdgeType/SOLIDARITY a b solidarity/strength 0.5c))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("strength") && err.message.contains("IMPLICIT"),
+            "{}",
+            err.message
+        );
+
+        // 4. Currency — the typed-storage deferral every attribute_value
+        //    arm states, unchanged on the edge lane.
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario ft/edge-attr-currency
+  (deffield solidarity/cost currency intensive)
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (edge EdgeType/SOLIDARITY a b 0.5c)
+  (edge-attr EdgeType/SOLIDARITY a b solidarity/cost 5$))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("typed attribute storage"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn edge_attr_refuses_a_field_owned_by_another_type() {
+        // The qname's owner segment must name the edge's own type — §2.10
+        // discipline 1's ownership law, checked at hydration exactly as
+        // `check_edge_referent_type` checks it at evaluation. `wages/
+        // value-flow` is a legal WAGES-edge field (Task 4's consumer); on a
+        // SOLIDARITY edge it is an owner mismatch.
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario ft/edge-attr-foreign-owner
+  (deffield wages/value-flow real intensive)
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (edge EdgeType/SOLIDARITY a b 0.5c)
+  (edge-attr EdgeType/SOLIDARITY a b wages/value-flow 5))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("wages/value-flow") && err.message.contains("SOLIDARITY"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn edge_attr_refuses_a_double_seed() {
+        // Two edge-attr forms with the same (edge-type, source, target,
+        // field) key — mirrors E-LOAD-044's own argument one axis wider:
+        // the quadruple is a KEY, and a second seeding would silently
+        // overwrite the first (only the later value surviving in the file
+        // that carries both).
+        let source = r"
+(scenario ft/edge-attr-dup
+  (deffield solidarity/tension intensity intensive)
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (edge EdgeType/SOLIDARITY a b 0.5c)
+  (edge-attr EdgeType/SOLIDARITY a b solidarity/tension 0.25i)
+  (edge-attr EdgeType/SOLIDARITY a b solidarity/tension 0.5i))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-057"), "{}", err.message);
     }
 }

--- a/rust/crates/babylon-tick/content/rules/consciousness.bsl
+++ b/rust/crates/babylon-tick/content/rules/consciousness.bsl
@@ -32,26 +32,27 @@
 ; D116 BYTE-ORDER MAP (docs/reference/bsl-language.rst, the recorded
 ; cross-rule same-tick visibility divergence this pack deliberately relies
 ; on, production.bsl-header style): rules run to completion in ascending
-; rule-id byte order against the same mutable graph, so the nine rules'
+; rule-id byte order against the same mutable graph, so the ten rules'
 ; reads see every earlier rule's same-tick writes. The ordering obligation
 ; binds every later addition — keep the pN prefixes monotone in the frozen
 ; engine's own causality order:
 ;
 ;   rule                        subject       reads                         writes
 ;   p0-position                 SOCIAL_CLASS  active, anchors, ternary      r/l/f, agitation (seed)
-;   p1-inbox-reset              SOCIAL_CLASS  ternary (sum-guard)           solidarity-inbox <- 0
+;   p1-inbox-reset              SOCIAL_CLASS  ternary (sum-guard)           solidarity-inbox, wages-inbox <- 0
 ;   p2-org-solidarity-push      ORGANIZATION  active; per-edge strength     targets' solidarity-inbox (add),
 ;                                           strength > 0.01 gate
+;   p2-wages-push               SOCIAL_CLASS  active; per-edge value-flow   targets' wages-inbox (add)
 ;   p3-class-solidarity-push    SOCIAL_CLASS  own r (optional); per-edge    targets' solidarity-inbox (add),
 ;                                           strength                      r > 0.3 percolation gate
 ;   p4-wage-balance             SOCIAL_CLASS  wages-paid, value-produced    wage-balance (verbatim f64)
 ;                                           (optional sentinels)
-;   p5-agitation                SOCIAL_CLASS  wages-received, previous-*,   agitation (UNDECAYED)
+;   p5-agitation                SOCIAL_CLASS  wages-inbox, previous-*,      agitation (UNDECAYED)
 ;                                           repression-faced, ternary
 ;                                           sum-guard, anchors, consts
 ;   p6-route                    SOCIAL_CLASS  agitation, inbox,             r/l/f (routed + closure),
 ;                                           wage-balance, ternary, consts   agitation (decayed store)
-;   p7-persist-baselines        SOCIAL_CLASS  wages-received, wealth,       previous-wages,
+;   p7-persist-baselines        SOCIAL_CLASS  wages-inbox, wealth,          previous-wages,
 ;                                           anchors                         previous-wealth
 ;   p8-dominant-worldview       SOCIAL_CLASS  ternary                       dominant-worldview
 ;
@@ -117,7 +118,7 @@
 ;      tick-1 undecayed write is already 1.0 (class-bribed), and the
 ;      accumulator crosses the ceiling at tick 2 (0.9 decayed + 1.0 fresh
 ;      = 1.9). All three
-;      machinery accumulators are therefore int-typed verbatim-f64;
+;      machinery accumulators were therefore int-typed verbatim-f64;
 ;      agitation seeds at 0 (a produced accumulator, R-MEASURED), the
 ;      others unseeded until their writing tasks. The verbatim-f64 int
 ;      lane this row records was RETIRED by Train B item 6
@@ -134,6 +135,12 @@
 ;      OUT: scenario-side edge-attribute seeding is unserved (load_edge
 ;      is strength-only), a gap recorded for the port train's closing
 ;      ADR.
+;      RETIRED by Train B item 3 (#591, D151's discharge): the WAGES edge
+;      machinery described above as having come OUT is back IN —
+;      edge-attribute seeding is served (D156's (edge-attr ...) form) and
+;      social-class/wages-received is gone; the wage flow now rides the
+;      pushed wages-inbox accumulator (consciousness/p2-wages-push). See
+;      D151's header row below for the retirement note.
 ;   7. The `social-class/active` / `organization/active` latches are
 ;      declared `intensive` here against production-conformance.bscn's and
 ;      organization-foundation.bscn's `extensive` — a per-node state is
@@ -157,7 +164,10 @@
 ;   D151. Solidarity pull→push redesign (the D136 fix-round pattern) +
 ;      the per-pair multi-edge unreachability record (both backends
 ;      refuse a duplicate (type, from, to) edge), the strength <= 0
-;      skip, and the WAGES fold-sum → wages-received narrowing.
+;      skip, and the WAGES fold-sum → wages-received narrowing —
+;      narrowing retired by Train B item 3 — the wage flow rides seeded
+;      WAGES-edge wages/value-flow via push-over-pull; wages-received is
+;      gone.
 ;   D152. Class-source percolation re-pointed at the source's r share.
 ;   D153. Positioned-only agitation (the anchored ∧ positioned guard).
 ;   D154. Same-tick closure heal observed (D116; tv-tie-all-true).
@@ -187,7 +197,7 @@
     (update-node self social-class/agitation (set 0))))
 
 (rule consciousness/p1-inbox-reset
-  :material-basis "Per-tick accumulator reset (the production p0 idiom; D103/D104 collect-then-apply makes reset-then-accumulate safe): the solidarity inbox is machinery, not state — it carries this tick's pushed contributions only. Positioned classes only (the sum-guard): an unpositioned class has no organization to receive, and the reset must not fabricate the field onto it (L-ABS)."
+  :material-basis "Per-tick accumulator reset (the production p0 idiom; D103/D104 collect-then-apply makes reset-then-accumulate safe): the solidarity inbox and the wages inbox are both machinery, not state — each carries this tick's pushed contributions only. Positioned classes only (the sum-guard): an unpositioned class has no organization to receive, and the reset must not fabricate either field onto it (L-ABS)."
   :fuel 32
   (bindings
     (binding r :field social-class/revolutionary :optional :default 0.0p)
@@ -195,7 +205,8 @@
     (binding f :field social-class/fascist :optional :default 0.0p))
   (when (> (+ r (+ l f)) 0))
   (effects
-    (update-node self social-class/solidarity-inbox (set 0))))
+    (update-node self social-class/solidarity-inbox (set 0))
+    (update-node self social-class/wages-inbox (set 0))))
 
 (rule consciousness/p2-org-solidarity-push
   :material-basis "Org-sourced solidarity: strength above negligible_transmission counts (frozen ideology.py:339-356's org arm — org mass work has no ideology of its own to gate on; the edge's strength IS the signal, ADR087). Push form (the D136 fix-round pattern; exact vs the frozen pull at :337-356 — each edge is pushed exactly once by its unique source). One SOLIDARITY edge per (source, target) pair is STRUCTURAL, not discipline: both GraphSubstrate backends key edges on (type, from, to) and refuse a duplicate loudly — the frozen per-edge fold's multi-edge sum is unrepresentable here (recorded, D151)."
@@ -209,6 +220,17 @@
       (guard (> (field-of (edge-between EdgeType/SOLIDARITY self it) solidarity/strength) negligible)
         (update-node it social-class/solidarity-inbox
           (add (field-of (edge-between EdgeType/SOLIDARITY self it) solidarity/strength)))))))
+
+(rule consciousness/p2-wages-push
+  :material-basis "The wage flow, un-narrowed (D151's narrowing 3 discharged, Train B item 3, #591): every WAGES edge's seeded wages/value-flow is pushed into the receiving class's wages-inbox (frozen ideology.py:299-309's incoming-WAGES fold-sum, expressed per the D136 push-over-pull idiom — D138 forbids the filter-in-fold pull). Push form (the D136 fix-round pattern, mirroring p2-org-solidarity-push's own shape exactly): each edge is pushed exactly once by its unique source. No transmission-floor gate — every seeded wage flow counts; the WAGES edge's own strength slot (1.0c, seeded above) is a structural presence marker with no semantic consumer (the register row) — nothing reads it."
+  :fuel 128
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (for-each (neighbors self EdgeType/WAGES :out NodeType/SOCIAL_CLASS)
+      (update-node it social-class/wages-inbox
+        (add (field-of (edge-between EdgeType/WAGES self it) wages/value-flow))))))
 
 (rule consciousness/p3-class-solidarity-push
   :material-basis "Class-sourced solidarity transmits only past the percolation threshold (frozen: source class_consciousness > activation_threshold, ideology.py:339-356) — re-pointed to the source's revolutionary share (the same quantity post-W1 unification; D152). An UNPOSITIONED source reads r = 0.0p by the idiom and never transmits: absence is not organization. The frozen loop's strength <= 0 skip is not transcribed (inert on declared content; recorded narrowing, D151)."
@@ -236,7 +258,7 @@
     (update-node self social-class/wage-balance (set balance))))
 
 (rule consciousness/p5-agitation
-  :material-basis "compute_agitation_delta (consciousness_routing.py:48-200) + the frozen call-site's exact argument mapping (ideology.py:372-380): exploitation_delta = |wage_change| when wages fall; wealth_change passed as imperial_rent_delta; visibility 0.0 verbatim; the Curve-5 balance component ABSENT (ADR202 R7 — the replacement rides #491, D147); repression as produced-excess-over-baseline, absent contributing zero (MEDIUM-2 discipline). The wage flow rides the declared class-side wages-received (controller ruling 2 — the frozen incoming-WAGES fold-sum narrows to one declared value per class per tick, exact for single-employer content). Guarded anchored AND positioned (D153: an unpositioned class never accumulates — the frozen step accumulated on every active class). Writes the UNDECAYED level; p6 routes on it and writes the decayed store."
+  :material-basis "compute_agitation_delta (consciousness_routing.py:48-200) + the frozen call-site's exact argument mapping (ideology.py:372-380): exploitation_delta = |wage_change| when wages fall; wealth_change passed as imperial_rent_delta; visibility 0.0 verbatim; the Curve-5 balance component ABSENT (ADR202 R7 — the replacement rides #491, D147); repression as produced-excess-over-baseline, absent contributing zero (MEDIUM-2 discipline). The wage flow rides the pushed wages-inbox accumulator (D151's narrowing 3 discharged, Train B item 3, #591 — the frozen incoming-WAGES fold-sum now rides the seeded WAGES-edge wages/value-flow via p2-wages-push's push-over-pull, exact for single-employer content since each class receives exactly one employer edge). Guarded anchored AND positioned (D153: an unpositioned class never accumulates — the frozen step accumulated on every active class). Writes the UNDECAYED level; p6 routes on it and writes the decayed store."
   :fuel 224
   (bindings
     (binding wages :field social-class/wages-paid :optional :default -1)
@@ -244,7 +266,7 @@
     (binding r :field social-class/revolutionary :optional :default 0.0p)
     (binding l :field social-class/liberal :optional :default 0.0p)
     (binding f :field social-class/fascist :optional :default 0.0p)
-    (binding wages-in :field social-class/wages-received :optional :default 0)
+    (binding wages-in :field social-class/wages-inbox :optional :default 0)
     (binding prev-wages :field social-class/previous-wages :optional :default 0)
     (binding wealth :field social-class/wealth :optional :default 0)
     (binding prev-wealth :field social-class/previous-wealth :optional :default 0)
@@ -321,7 +343,7 @@
   (bindings
     (binding wages :field social-class/wages-paid :optional :default -1)
     (binding value :field social-class/value-produced :optional :default -1)
-    (binding wages-in :field social-class/wages-received :optional :default 0)
+    (binding wages-in :field social-class/wages-inbox :optional :default 0)
     (binding wealth :field social-class/wealth :optional :default 0))
   (when (and (>= wages 0) (>= value 0)))
   (effects

--- a/rust/crates/babylon-tick/content/scenarios/consciousness-ternary-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/consciousness-ternary-conformance.bscn
@@ -79,6 +79,15 @@
 ;      content — so this world seeds NO WAGES edges and declares NO
 ;      edge-attribute deffield. The seeding gap itself is recorded for
 ;      the port train's closing ADR.
+;      RETIRED by Train B item 3 (#591, D151's discharge, 2026-08-17):
+;      scenario-side edge-attribute seeding IS now served — the
+;      `(edge-attr ...)` form (D156) — and this world now seeds three
+;      WAGES edges plus declares the `wages/value-flow` edge-attribute
+;      deffield below; `social-class/wages-received` is gone.
+;      The wage flow rides the pushed `social-class/wages-inbox`
+;      accumulator (`consciousness/p2-wages-push`, consciousness.bsl)
+;      instead of the declared class-side flow value this paragraph
+;      originally recorded.
 ;
 ;   4. FLOAT-EXPR -> INT-FIELD WRITE COERCION — THERE IS NONE. The store
 ;      is kind-blind f64 end to end: structural_verbs.rs's
@@ -125,7 +134,7 @@
 ;
 ; Node census, in declaration order (which fixes the store ids):
 ;   0  class-exploited    positioned (0.5, 0.4, 0.1), anchored, wage cut
-;                         this tick (previous-wages 10 -> wages-received 9),
+;                         this tick (previous-wages 10 -> wages-inbox 9),
 ;                         one org SOLIDARITY edge (0.4p) — later tasks'
 ;                         revolutionary-routing vector.
 ;   1  class-bribed       positioned (0.1, 0.6, 0.3), positive wage balance

--- a/rust/crates/babylon-tick/content/scenarios/consciousness-ternary-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/consciousness-ternary-conformance.bscn
@@ -187,7 +187,7 @@
 ; are hand-checkable.
 (scenario consciousness/ternary-conformance
   (defvocabulary NodeType (SOCIAL_CLASS ORGANIZATION))
-  (defvocabulary EdgeType (SOLIDARITY))
+  (defvocabulary EdgeType (SOLIDARITY WAGES))
   (defenum WorldView (REVOLUTIONARY LIBERAL FASCIST))
 
   ; ---- carriers (reuse exact qnames from two-classes.bscn where present) ----
@@ -208,7 +208,8 @@
   (deffield social-class/agitation real intensive)         ; [0,∞) raw f64 (frozen: ge=0.0, unbounded — social_class.py:95-102). Retired from the verbatim-f64 int lane by Train B item 6 (the real type); zero seeds remain (R-MEASURED: produced, never authored)
   (deffield social-class/wage-balance real intensive)      ; [-1,1] SIGNED raw f64 — a unit-interval type would refuse the negative half (store_range_check)
   (deffield social-class/solidarity-inbox real intensive)  ; [0,n) strength-sum raw f64 — can exceed 1.0, so no unit-interval type is lawful; reset per tick (later tasks)
-  (deffield social-class/wages-received real extensive)    ; raw units — the per-tick wage flow as declared class-side content (controller ruling 2). Task 3's input: NOTHING in Task 1's pack reads it
+  (deffield wages/value-flow real intensive)               ; the per-edge wage flow (ADR203 edge deffield; retired-then-restored: W10's D151 narrowing discharged by Train B item 3)
+  (deffield social-class/wages-inbox real intensive)       ; [0,n) flow-sum — the push-over-pull accumulator (D136): reset by p1, pushed by p2-wages-push, read by p5, persisted by p7
   (deffield social-class/repression-faced intensity intensive) ; declared input only; nothing in Rust writes it yet
   (deffield social-class/previous-wages real intensive)    ; raw units (the persistent_data re-home, digest gap 4)
   (deffield social-class/previous-wealth real intensive)
@@ -235,7 +236,6 @@
     (social-class/wealth 50) (social-class/wages-paid 9) (social-class/value-produced 10)
     (social-class/revolutionary 0.5p) (social-class/liberal 0.4p) (social-class/fascist 0.1p)
     (social-class/agitation 0)                         ; produced accumulator (R-MEASURED): zero-seeded, Task 3 produces it
-    (social-class/wages-received 9)                ; cut: previous-wages 10 -> 9
     (social-class/previous-wages 10)
     (social-class/previous-wealth 50))
 
@@ -248,7 +248,6 @@
     (social-class/wealth 90) (social-class/wages-paid 12) (social-class/value-produced 10)
     (social-class/revolutionary 0.1p) (social-class/liberal 0.6p) (social-class/fascist 0.3p)
     (social-class/agitation 0)                         ; produced accumulator (R-MEASURED): zero-seeded, Task 3 produces it
-    (social-class/wages-received 12)               ; flat: previous-wages 12 -> 12
     (social-class/previous-wages 12)
     (social-class/previous-wealth 95))
 
@@ -262,13 +261,24 @@
   (node class-emergent NodeType/SOCIAL_CLASS
     (social-class/population 600) (social-class/active 1)
     (social-class/wealth 30) (social-class/wages-paid 8) (social-class/value-produced 10)
-    (social-class/wages-received 8)                ; cut: previous-wages 9 -> 8
     (social-class/previous-wages 9) (social-class/previous-wealth 30))
 
   ; employer — active, NO anchors: the anchorless witness that must never
   ; be positioned (p0 guard) nor routed (sum-guard).
   (node employer NodeType/SOCIAL_CLASS
     (social-class/population 50) (social-class/active 1))
+
+  ; The wage flow, un-narrowed (D151 discharge, Train B item 3, #591):
+  ; employer's per-class WAGES edges carry the seeded flow directly, pushed
+  ; into each class's wages-inbox by consciousness/p2-wages-push. Strength
+  ; 1.0c is a structural presence marker only — nothing reads WAGES
+  ; strength (the register row).
+  (edge EdgeType/WAGES employer class-exploited 1.0c)
+  (edge-attr EdgeType/WAGES employer class-exploited wages/value-flow 9)
+  (edge EdgeType/WAGES employer class-bribed 1.0c)
+  (edge-attr EdgeType/WAGES employer class-bribed wages/value-flow 12)
+  (edge EdgeType/WAGES employer class-emergent 1.0c)
+  (edge-attr EdgeType/WAGES employer class-emergent wages/value-flow 8)
 
   ; org-solid — the org solidarity source (active latch convention).
   (node org-solid NodeType/ORGANIZATION (organization/active 1))

--- a/rust/crates/babylon-tick/content/scenarios/consciousness_ternary_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/consciousness_ternary_conformance.py
@@ -16,11 +16,18 @@ Gaussian is retired, ADR202 R7).
 Controller amendments applied (2026-08-15, binding over the Task-3 brief):
 no micros anywhere (the int lane holds verbatim f64 — spike 4's verdict,
 scenario header D-record 5); agitation seeds integer 0 (produced
-accumulator, R-MEASURED); the wage flow rides the declared class-side
-social-class/wages-received field (controller ruling 2 — the WAGES-edge
-machinery is dead); nine rule ids p0..p8 per the amendment map; epsilon
-rides the expr quotient (/ 1c 10000000000), bit-identical to Python's
-1e-10 via one correctly-rounded IEEE-754 division (E-LEX-023 dodged).
+accumulator, R-MEASURED); nine rule ids p0..p8 per the amendment map;
+epsilon rides the expr quotient (/ 1c 10000000000), bit-identical to
+Python's 1e-10 via one correctly-rounded IEEE-754 division (E-LEX-023
+dodged).
+
+SUPERSEDED (Train B item 3, issue #591 — D151's narrowing 3 discharged):
+the wage flow no longer rides social-class/wages-received (that field is
+gone) — it rides the seeded WAGES-edge wages/value-flow, pushed into
+social-class/wages-inbox by the new consciousness/p2-wages-push, mirroring
+p2-org-solidarity-push's push shape minus the strength gate. The pack is
+now TEN rule ids: p0..p8 plus p2-wages-push (byte order p2-org-solidarity-
+push < p2-wages-push < p3-class-solidarity-push).
 
 Frozen transcription sources (reference-only; transcribed exactly):
   src/babylon/engine/systems/ideology.py:115-442  — the step: input reads
@@ -87,11 +94,11 @@ WORLD: World = {
         "l": 0.4,
         "f": 0.1,
         "agitation": 0.0,
-        "wages_received": 9.0,
         "previous_wages": 10.0,
         "previous_wealth": 50.0,
         "repression_faced": ABSENT,
         "solidarity_inbox": ABSENT,
+        "wages_inbox": ABSENT,
         "wage_balance": ABSENT,
         "dominant": ABSENT,
     },
@@ -106,11 +113,11 @@ WORLD: World = {
         "l": 0.6,
         "f": 0.3,
         "agitation": 0.0,
-        "wages_received": 12.0,
         "previous_wages": 12.0,
         "previous_wealth": 95.0,
         "repression_faced": ABSENT,
         "solidarity_inbox": ABSENT,
+        "wages_inbox": ABSENT,
         "wage_balance": ABSENT,
         "dominant": ABSENT,
     },
@@ -126,11 +133,11 @@ WORLD: World = {
         "wealth": 30.0,
         "wages_paid": 8.0,
         "value_produced": 10.0,
-        "wages_received": 8.0,
         "previous_wages": 9.0,
         "previous_wealth": 30.0,
         "repression_faced": ABSENT,
         "solidarity_inbox": ABSENT,
+        "wages_inbox": ABSENT,
         "wage_balance": ABSENT,
         "dominant": ABSENT,
         "r": ABSENT,
@@ -224,6 +231,16 @@ SOLIDARITY_EDGES = [
     ("class-bribed", "class-emergent", 0.9),
 ]
 
+# (source, target, wages/value-flow) in declaration order — the un-narrowed
+# wage flow (Train B item 3, #591, D151's narrowing 3 discharged). Strength
+# 1.0c is seeded on each WAGES edge (structural presence marker only, no
+# semantic consumer) but is not represented here since nothing reads it.
+WAGES_EDGES = [
+    ("employer", "class-exploited", 9.0),
+    ("employer", "class-bribed", 12.0),
+    ("employer", "class-emergent", 8.0),
+]
+
 
 def opt(node: Node, key: str, default: float) -> float:
     """The :optional + :default binding mirror: absent reads observe ONLY the
@@ -262,12 +279,14 @@ def p0_position(world: World) -> int:
 
 
 def p1_inbox_reset(world: World) -> int:
-    """p1-inbox-reset: the solidarity inbox is per-tick machinery, zeroed
-    before this tick's pushes accumulate (D103/D104). Positioned only."""
+    """p1-inbox-reset: the solidarity inbox AND the wages inbox are both
+    per-tick machinery, zeroed before this tick's pushes accumulate
+    (D103/D104). Positioned only."""
     fired = 0
     for node in world.values():
         if is_class(node) and ternary_sum(node) > 0:
             node["solidarity_inbox"] = 0
+            node["wages_inbox"] = 0
             fired += 1
     return fired
 
@@ -288,6 +307,26 @@ def p2_org_solidarity_push(world: World) -> int:
                 continue
             if strength > NEGLIGIBLE_TRANSMISSION:  # the guard effect form
                 world[tgt]["solidarity_inbox"] = opt(world[tgt], "solidarity_inbox", 0) + strength
+    return fired
+
+
+def p2_wages_push(world: World) -> int:
+    """p2-wages-push: mirrors p2-org-solidarity-push's push shape exactly,
+    over WAGES edges — no transmission-floor gate (the strength guard is
+    dropped; every seeded wage flow counts). Train B item 3 (#591): D151's
+    narrowing 3 discharged — the wage flow rides the seeded WAGES-edge
+    wages/value-flow again, pushed into each class's wages-inbox."""
+    fired = 0
+    for name, node in world.items():
+        if not is_class(node) or "active" not in node:
+            continue  # social-class/active is a required binding
+        if node["active"] != 1:
+            continue
+        fired += 1
+        for src, tgt, flow in WAGES_EDGES:
+            if src != name or not is_class(world[tgt]):
+                continue
+            world[tgt]["wages_inbox"] = opt(world[tgt], "wages_inbox", 0) + flow
     return fired
 
 
@@ -340,7 +379,7 @@ def p5_agitation(node: Node, anchored: bool, positioned: bool) -> bool:
     store."""
     if not (anchored and positioned):
         return False
-    wages_in = opt(node, "wages_received", 0)  # controller ruling 2
+    wages_in = opt(node, "wages_inbox", 0)  # Train B item 3 (#591): pushed, not class-side
     prev_wages = opt(node, "previous_wages", 0)
     wealth = opt(node, "wealth", 0)
     prev_wealth = opt(node, "previous_wealth", 0)
@@ -425,7 +464,7 @@ def p7_persist_baselines(node: Node, anchored: bool) -> bool:
     declared flow. Anchored classes only."""
     if not anchored:
         return False
-    node["previous_wages"] = opt(node, "wages_received", 0)
+    node["previous_wages"] = opt(node, "wages_inbox", 0)
     node["previous_wealth"] = opt(node, "wealth", 0)
     return True
 
@@ -455,13 +494,16 @@ def p8_dominant(world: World) -> int:
 
 
 def run_pack(world: World) -> dict[str, int]:
-    """One tick of the nine-rule pack, in D116 byte order (p0..p8), against
-    the same mutable world — rules run to completion in ascending rule-id
-    order and later rules see earlier rules' writes this same tick."""
+    """One tick of the ten-rule pack, in D116 byte order (p0, p1, p2-org,
+    p2-wages, p3..p8 — p2-org-solidarity-push < p2-wages-push < p3-class-
+    solidarity-push), against the same mutable world — rules run to
+    completion in ascending rule-id order and later rules see earlier
+    rules' writes this same tick."""
     fired = {
         "p0": p0_position(world),
         "p1": p1_inbox_reset(world),
         "p2": p2_org_solidarity_push(world),
+        "p2w": p2_wages_push(world),
         "p3": p3_class_solidarity_push(world),
         "p4": 0,
         "p5": 0,

--- a/rust/crates/babylon-tick/tests/consciousness_ternary_conformance.rs
+++ b/rust/crates/babylon-tick/tests/consciousness_ternary_conformance.rs
@@ -36,7 +36,13 @@
 //!     rust/crates/babylon-tick/content/scenarios/consciousness_ternary_conformance.py
 //! ```
 //!
-//! Its output on 2026-08-15, verbatim:
+//! Its output on 2026-08-15, verbatim (Task 1-3); RE-RUN on 2026-08-17 for
+//! Train B item 3 (#591, D151's narrowing 3 discharged) — the wage flow
+//! rides the un-narrowed WAGES-edge push (`consciousness/p2-wages-push`,
+//! printed as `p2w` below, D116-ordered between `p2` and `p3`), and the
+//! per-class value columns are BIT-IDENTICAL to the 2026-08-15 run (the
+//! single-employer exactness the ceremony proves — only the fired counts
+//! moved, +13 both ticks):
 //!
 //! ```text
 //! --- tick 1 ---
@@ -44,13 +50,14 @@
 //!   consciousness/p0: 1
 //!   consciousness/p1: 11
 //!   consciousness/p2: 1
+//!   consciousness/p2w: 13
 //!   consciousness/p3: 6
 //!   consciousness/p4: 3
 //!   consciousness/p5: 3
 //!   consciousness/p6: 11
 //!   consciousness/p7: 3
 //!   consciousness/p8: 11
-//!   total: 50
+//!   total: 63
 //!
 //! p0 seed result for class-emergent's tick-1 start: (0.0, 1.0, 0.0)
 //!
@@ -74,13 +81,14 @@
 //!   consciousness/p0: 0
 //!   consciousness/p1: 11
 //!   consciousness/p2: 1
+//!   consciousness/p2w: 13
 //!   consciousness/p3: 6
 //!   consciousness/p4: 3
 //!   consciousness/p5: 3
 //!   consciousness/p6: 11
 //!   consciousness/p7: 3
 //!   consciousness/p8: 11
-//!   total: 49
+//!   total: 62
 //!
 //! node                     r                      l                      f                      agitation_out          inbox    balance                prev_w   prev_wealth dominant
 //! class-exploited          0.51368                0.3658                 0.12052000000000002    0.12150000000000001    0.4      -0.05263157894736842   9.0      50.0     'REVOLUTIONARY'
@@ -97,6 +105,19 @@
 //! tv-strict-gap            0.333333               0.333333               0.333334               0.0                    0        ABSENT                 ABSENT   ABSENT   'FASCIST'
 //! tv-tie-all-true          0.333333               0.333334               0.333333               0.0                    0        ABSENT                 ABSENT   ABSENT   'LIBERAL'
 //! ```
+//!
+//! The fired-count arithmetic (the ceremony's spike, Step 3): the EXPECTED
+//! hypothesis was "employer only, +1" — MEASURED reality differs, recorded
+//! honestly rather than forced. `p2-wages-push`'s subject type is
+//! SOCIAL_CLASS (its one `:field` binding, `social-class/active`, pins it —
+//! `tick.rs::subject_type_of`), mirroring `p2-org-solidarity-push`'s own
+//! `active`-gated shape exactly; EVERY social class in this world seeds
+//! `active 1` (all thirteen), so the `when` guard passes thirteen times —
+//! the for-each idiom fires on edgeless subjects too (`collect_pass`'s
+//! `fired += 1` runs regardless of how many neighbors the for-each finds,
+//! `tick.rs:715`), and only `employer`'s three WAGES edges actually push a
+//! write. Tick 1: 50 (Task 3's total) + 13 = 63. Tick 2: 49 (tick-2's prior
+//! total, p0 not re-firing) + 13 = 62.
 //!
 //! Controller ruling 2026-08-15 (Ruling A, extended — resolving the Task-3
 //! NEEDS_CONTEXT): class-bribed's tick-1 dominant is LIBERAL — the vector's
@@ -162,7 +183,7 @@ fn unpositioned_class_gets_no_reading() {
     let mut graph = HypergraphStore::new();
     let mut sink = babylon_bsl::structural_verbs::CollectingSink::default();
     let report = run_once_into(SCENARIO, CONSCIOUSNESS_RULES, &mut graph, &mut sink)
-        .expect("the consciousness ternary scenario plus the nine-rule pack must load and run");
+        .expect("the consciousness ternary scenario plus the ten-rule pack must load and run");
 
     // p0 fired exactly once: class-emergent is the ONLY subject that is
     // active, anchored (wages-paid + value-produced present), and
@@ -179,9 +200,12 @@ fn unpositioned_class_gets_no_reading() {
         "p0-position fires for class-emergent and nothing else"
     );
     assert_eq!(
-        report.fired, 50,
+        report.fired, 63,
         "p0:1 (class-emergent) + p1:11 (every positioned class's inbox \
-         reset) + p2:1 (org-solid) + p3:6 (r > 0.3 sources: class-exploited, \
+         reset) + p2:1 (org-solid) + p2-wages-push:13 (every active \
+         SOCIAL_CLASS subject — the for-each idiom fires on edgeless \
+         subjects too; only employer's three WAGES edges write, Step-3 \
+         spike) + p3:6 (r > 0.3 sources: class-exploited, \
          tv-revolutionary-clear, tv-tie-lr, tv-tie-rf, tv-strict-gap, \
          tv-tie-all-true) + p4:3 + p5:3 + p6:11 (every positioned class — \
          the sum-guard alone) + p7:3 (anchored) + p8:11 (the readout)"
@@ -401,7 +425,8 @@ fn dominant_worldview_readout_vectors() {
     }
 }
 
-/// Task 3's measured-update-law conformance: one tick of the nine-rule pack,
+/// Task 3's measured-update-law conformance (extended by Train B item 3,
+/// #591, with the un-narrowed wage flow): one tick of the ten-rule pack,
 /// every positioned class's outputs asserted against the dual-implementation
 /// generator's repr floats EXACTLY (no tolerance). The seven per-class
 /// outputs: the routed ternary (r, l, f), the decayed agitation store, the
@@ -413,11 +438,16 @@ fn measured_update_law_matches_the_dual_implementation_exactly() {
     let mut graph = HypergraphStore::new();
     let mut sink = babylon_bsl::structural_verbs::CollectingSink::default();
     let report = run_once_into(SCENARIO, CONSCIOUSNESS_RULES, &mut graph, &mut sink)
-        .expect("the consciousness ternary scenario plus the nine-rule pack must load and run");
+        .expect("the consciousness ternary scenario plus the ten-rule pack must load and run");
 
     // Per-rule fired counts (guard-passed subjects). p3's six include four
     // tv-* classes whose for-each iterates an empty neighbor set — a
     // guard-passed subject fires even when its bounded iteration is empty.
+    // p2-wages-push's thirteen is the starkest instance of the same law:
+    // its subject type is SOCIAL_CLASS (its one :field binding pins it) and
+    // EVERY social class in this world seeds active 1, so the guard passes
+    // thirteen times — only employer's three WAGES edges actually push a
+    // write (the Step-3 spike, module header).
     let fired_of = |rule: &str| {
         report
             .per_rule_fired
@@ -429,6 +459,7 @@ fn measured_update_law_matches_the_dual_implementation_exactly() {
         ("consciousness/p0-position", 1),
         ("consciousness/p1-inbox-reset", 11),
         ("consciousness/p2-org-solidarity-push", 1),
+        ("consciousness/p2-wages-push", 13),
         ("consciousness/p3-class-solidarity-push", 6),
         ("consciousness/p4-wage-balance", 3),
         ("consciousness/p5-agitation", 3),
@@ -512,7 +543,7 @@ fn measured_update_law_matches_the_dual_implementation_exactly() {
         assert_eq!(
             read("social-class/previous-wages"),
             prev_w,
-            "{id:?} previous-wages (p7 persisted this tick's wages-received)"
+            "{id:?} previous-wages (p7 persisted this tick's pushed wages-inbox)"
         );
         assert_eq!(
             read("social-class/previous-wealth"),
@@ -588,17 +619,17 @@ fn measured_update_law_matches_the_dual_implementation_exactly() {
 
 /// Controller-ruled witness (Ruling A extended, 2026-08-15): a TWO-tick run
 /// pinning the accumulation law. p7-persist-baselines ran at tick 1, so
-/// tick-2's wage/wealth increments are ZERO (wages-received unchanged, the
-/// persisted baselines now equal it — the zero increment IS the persist
-/// machinery's differential witness) and the tick-1 decayed agitation routes
-/// again: class-bribed's dominant flips LIBERAL -> FASCIST at tick 2.
-/// Hegemony erodes; it doesn't snap.
+/// tick-2's wage/wealth increments are ZERO (the pushed wage flow
+/// unchanged, the persisted baselines now equal it — the zero increment IS
+/// the persist machinery's differential witness) and the tick-1 decayed
+/// agitation routes again: class-bribed's dominant flips LIBERAL -> FASCIST
+/// at tick 2. Hegemony erodes; it doesn't snap.
 #[test]
 fn tick_two_accumulation_witness() {
     let mut session =
         babylon_tick::TickSession::new(SCENARIO, CONSCIOUSNESS_RULES, HypergraphStore::new())
             .expect(
-            "the consciousness ternary scenario plus the nine-rule pack must load into a session",
+            "the consciousness ternary scenario plus the ten-rule pack must load into a session",
         );
     let mut sink = babylon_bsl::structural_verbs::CollectingSink::default();
     session.advance(&mut sink).expect("tick 1");
@@ -613,7 +644,12 @@ fn tick_two_accumulation_witness() {
         .find(|(id, _)| id == "consciousness/p0-position")
         .map(|(_, n)| *n);
     assert_eq!(p0_fired, Some(0), "p0 has no tick-2 subject");
-    assert_eq!(report2.fired, 49, "tick-2 total: 50 minus p0's one firing");
+    assert_eq!(
+        report2.fired, 62,
+        "tick-2 total: 49 (Task 3's tick-2 total, 50 minus p0's one firing) \
+         + 13 (p2-wages-push, unchanged tick to tick — social-class/active \
+         is never written)"
+    );
 
     const REVOLUTIONARY: f64 = 0.0;
     const LIBERAL: f64 = 1.0;
@@ -692,9 +728,11 @@ fn tick_two_accumulation_witness() {
     );
 
     // The persist machinery, pinned directly: previous-wages now equals the
-    // declared wages-received (9/12/8), so tick-2's wage-change was exactly
-    // zero — the differential witness for the zero increments above.
-    for (id, wages_received) in [
+    // pushed wage flow (9/12/8, still bit-identical to the retired
+    // wages-received values — the single-employer exactness the ceremony
+    // proves), so tick-2's wage-change was exactly zero — the differential
+    // witness for the zero increments above.
+    for (id, wage_flow) in [
         (CLASS_EXPLOITED, 9.0),
         (CLASS_BRIBED, 12.0),
         (CLASS_EMERGENT, 8.0),
@@ -703,8 +741,8 @@ fn tick_two_accumulation_witness() {
             graph
                 .node_attribute(id, "social-class/previous-wages")
                 .expect("persisted baseline present"),
-            wages_received,
-            "{id:?} previous-wages == wages-received after tick 1's p7"
+            wage_flow,
+            "{id:?} previous-wages == the pushed wage flow after tick 1's p7"
         );
     }
 

--- a/rust/crates/babylon-tick/tests/consciousness_ternary_conformance.rs
+++ b/rust/crates/babylon-tick/tests/consciousness_ternary_conformance.rs
@@ -307,8 +307,13 @@ fn unpositioned_class_gets_no_reading() {
 
     // employer (active, population, NO anchors): p0 did NOT position it —
     // the -1 anchor sentinels reject it even though it IS active. An
-    // anchorless class is never a consciousness subject until it carries
-    // its own wage relation — and none of p1..p7 touches it either.
+    // anchorless class is never a consciousness subject via p0/p4/p5/p6/
+    // p7/p8 — even though employer now carries a wage relation of its own
+    // (the seeded WAGES edges + wages/value-flow, D151's discharge) and is
+    // p2-wages-push's only WRITING subject: its for-each pushes into the
+    // three classes below, never back onto itself, so none of ITS OWN
+    // fields — ternary, agitation, inbox, balance, baselines, dominant —
+    // is ever written by any of the ten rules.
     for field in [
         "social-class/revolutionary",
         "social-class/liberal",

--- a/rust/crates/babylon-tick/tests/tick_goldens.rs
+++ b/rust/crates/babylon-tick/tests/tick_goldens.rs
@@ -324,28 +324,52 @@ fn worldview_member_order_is_the_ruled_ordinal() {
 /// goldens). Every structural claim the post-tick hash summarizes is pinned
 /// exactly in `consciousness_ternary_conformance.rs` against the
 /// dual-implementation oracle.
+///
+/// FIFTH RE-PIN — Train B item 3 (issue #591, D151's discharge): WAGES
+/// edges + `wages/value-flow` seeding restored the frozen fold-sum via
+/// push-over-pull; `wages-received` retired; BOTH hashes re-pinned
+/// (attribute-set change, zero value drift — proven by
+/// `consciousness_ternary_conformance.rs` passing with only the two field
+/// re-points); fired 50 -> 63. The attribute-set delta is exactly the
+/// brief's own predicted shape, verified rather than assumed: pre-tick
+/// state differs ONLY by −3 `wages-received` node attributes, +3 WAGES
+/// edges, +3 `wages/value-flow` edge attributes (+0 `wages-inbox` —
+/// unseeded); post-tick state differs ONLY by −`wages-received`,
+/// +`wages-inbox` on the reset/pushed classes. The fired-count spike (Step
+/// 3, measured against the EXPECTED "employer only, +1" hypothesis): the
+/// mirrored `active`-gated shape does not discriminate on WAGES-edge
+/// presence, so all thirteen SOCIAL_CLASS subjects fire (not one) — the
+/// measured arithmetic is 50 + 13 = 63 (tick 1), 49 + 13 = 62 (tick 2, p0
+/// not re-firing) — recorded honestly per the house pattern this file's own
+/// `production_conformance_hashes_are_pinned` header sets.
 #[test]
 fn consciousness_ternary_foundation_hashes_are_pinned() {
     let report = run_once(CONSCIOUSNESS_TERNARY_SCENARIO, CONSCIOUSNESS_TERNARY_RULES)
         .expect("consciousness-ternary tick");
     assert_eq!(
         hex(&report.before),
-        "8a906d31b63d573cc1c2f9cfe7434b4af424cb144b192f08aec336f3e8c79600",
+        "e2582dd4f3537a6baa26fdb273e9aaf39299ab4994cf0dcf2664a90b920821fe",
         "pre-tick hash moved — this is the SUBSTRATE'S load of \
          consciousness-ternary-conformance.bscn (thirteen social classes + one \
-         organization + three SOLIDARITY edges)"
+         organization + three SOLIDARITY edges + three WAGES edges — the \
+         Train B item 3 re-pin, D151's discharge)"
     );
     assert_eq!(
         hex(&report.after),
-        "7e049462626ddaec6f261c2913ce54cd427e07ca20f68ee6622cbb13a9e3fff9",
-        "post-tick hash moved — the nine-rule pack's combined tick-1 output \
-         (p0's positioning, p1..p7's measured update law, p8's readout)"
+        "4346278b3e075b338b5d4b847de054da6738d74f05895f8945dad78b13f46da9",
+        "post-tick hash moved — the ten-rule pack's combined tick-1 output \
+         (p0's positioning, p1..p7's measured update law plus the new \
+         p2-wages-push, p8's readout) — attribute-set change only, zero \
+         value drift (Train B item 3's re-pin)"
     );
     assert_eq!(
-        report.fired, 50,
+        report.fired, 63,
         "p0:1 + p1:11 (inbox reset on every positioned class) + p2:1 + \
-         p3:6 (r > 0.3 sources) + p4:3 + p5:3 + p6:11 + p7:3 + p8:11 — \
-         the per-rule breakdown is pinned in \
+         p2-wages-push:13 (every active SOCIAL_CLASS subject — the mirrored \
+         active gate does not discriminate on WAGES-edge presence, so the \
+         for-each idiom fires on edgeless subjects too; only employer's \
+         three WAGES edges write) + p3:6 (r > 0.3 sources) + p4:3 + p5:3 + \
+         p6:11 + p7:3 + p8:11 — the per-rule breakdown is pinned in \
          consciousness_ternary_conformance.rs"
     );
 }


### PR DESCRIPTION
## Summary

Discharges D151's narrowing 3 (the WAGES fold-sum → `wages-received` narrowing recorded in `consciousness.bsl`'s W10 header): the wage flow moves off the interim class-side `social-class/wages-received` field and back onto seeded WAGES edges, consuming Task 1's `real` deffield type and Task 3's `(edge-attr ...)` scenario form (both already landed on this branch).

- New rule `consciousness/p2-wages-push` mirrors the landed `consciousness/p2-org-solidarity-push`'s shape exactly (same for-each/binding idiom over the subject's own edges), swapping SOLIDARITY→WAGES and `solidarity/strength`→`wages/value-flow`, and dropping the strength gate — pushes each WAGES edge's seeded flow into the receiving class's `social-class/wages-inbox` (D136 push-over-pull).
- `p1-inbox-reset` gains a second reset write (`wages-inbox <- 0`), same subjects/firing.
- `p5-agitation` / `p7-persist-baselines` re-point their one wage-flow binding from `wages-received` to `wages-inbox`.
- Scenario: `EdgeType` gains `WAGES`; `social-class/wages-received` is deleted; `wages/value-flow` (edge deffield) and `social-class/wages-inbox` are added; `employer` gets three seeded WAGES edges (strength `1.0c`, a structural presence marker with no semantic consumer) with `wages/value-flow` 9/12/8 to class-exploited/class-bribed/class-emergent — re-derived from each node's own wage-cut comment, not copied from the brief's draft numbers (which had a typo on class-emergent).
- Python oracle (`consciousness_ternary_conformance.py`) mirrors the new machinery term-for-term (dual-implementation bit-exactness).

## Ceremony evidence (Step 3 spike + Step 5 re-pin)

**Fired-count spike:** the brief's EXPECTED hypothesis was "`p2-wages-push` fires on `employer` only, +1 → 51". MEASURED reality differs and is recorded honestly: `p2-wages-push`'s subject type is `SOCIAL_CLASS` (its one `:field` binding pins it, mirroring `p2-org-solidarity-push`'s own `active`-gated shape), and every one of the thirteen `SOCIAL_CLASS` nodes in the conformance world seeds `active 1` — so the `when` guard passes thirteen times (the for-each idiom fires on edgeless subjects too; only `employer`'s three WAGES edges actually push a write). Verified against the real Rust engine, not just the Python oracle.

| | before | after |
|---|---|---|
| pre-tick hash | `8a906d31b63d573cc1c2f9cfe7434b4af424cb144b192f08aec336f3e8c79600` | `e2582dd4f3537a6baa26fdb273e9aaf39299ab4994cf0dcf2664a90b920821fe` |
| post-tick hash | `7e049462626ddaec6f261c2913ce54cd427e07ca20f68ee6622cbb13a9e3fff9` | `4346278b3e075b338b5d4b847de054da6738d74f05895f8945dad78b13f46da9` |
| fired (tick 1) | 50 | 63 (50 + 13) |
| fired (tick 2) | 49 | 62 (49 + 13) |

Both hashes moved because the attribute SET changed (−`wages-received`, +3 WAGES edges, +3 `wages/value-flow` edge attributes, +`wages-inbox` on reset/pushed classes) — **not because any value drifted**. That's proven by `consciousness_ternary_conformance.rs`'s exact-f64 conformance suite passing with only the two field re-points (the p5/p7 bindings) touched: every other value assertion (routed ternaries, agitation, wage balances, dominant readouts, the tick-2 accumulation-witness rows) passes UNEDITED against the same pinned floats as before this PR.

## Test plan

- [x] `mise run rust:check` green (format + clippy + full test + doc, 561+ tests)
- [x] `mise run qa:regression` 12/12 (Python-estate hygiene, + determinism leg)
- [x] `consciousness_ternary_conformance.rs`'s 4 tests green, value assertions unedited except the two field re-points
- [x] Pre-push gate (sentinels, import-linter, radon, semgrep, `rust:check` mirror) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)