### PR TITLE
fix(security): remove the expired CVE-2026-11332 pip-audit ignore — fixed upstream

### DIFF
--- a/security/pip-audit-ignores.toml
+++ b/security/pip-audit-ignores.toml
@@ -21,8 +21,10 @@
 # environment reports zero known vulnerabilities, so the minimal passing policy
 # carries no [[ignore]] entries. Any new suppression added below must re-justify
 # itself and will trip the exact-pin test in tests/unit/tools/test_run_pip_audit.py.
-
-[[ignore]]
-id = "CVE-2026-11332"
-reason = "ansible-core 2.20.3 (transitive via ansible-dev-tools, dev tooling only — not a runtime dependency). As of 2026-07-16 the fix exists only in release candidates (2.20.7rc1 / 2.21.1rc1); pinning a prod lock to an rc is worse than a time-boxed suppression. Remove or renew when a stable ansible-core >= 2.20.7 lands."
-expires = "2026-08-15"
+#
+# 2026-08-17 — POLICY EMPTIED AGAIN. The CVE-2026-11332 entry (ansible-core
+# 2.20.3, dev tooling only; time-boxed to 2026-08-15 pending a stable fix)
+# expired and tripped the hard-fail exactly as designed. The removal condition
+# it named is now met: uv.lock carries ansible-core 2.21.2 (stable, >= the
+# 2.20.7 fix line), so the vulnerability is fixed upstream in the locked
+# environment and the entry is removed rather than renewed.

--- a/tests/unit/tools/test_run_pip_audit.py
+++ b/tests/unit/tools/test_run_pip_audit.py
@@ -304,18 +304,14 @@ class TestRealPolicyFile:
         assert main(["--check-only"]) == 0
 
     def test_real_policy_pins_the_item41_residue_exactly(self) -> None:
-        """The shipped policy carries exactly one reviewed ignore.
+        """The shipped policy carries no ignores at all.
 
-        The item-41 residue stayed cleared (dependabot-wave-20260711). The one
-        current entry is CVE-2026-11332 (ansible-core 2.20.3, transitive via
-        ansible-dev-tools, dev tooling only): as of 2026-07-16 the fix exists
-        only in release candidates, so a time-boxed suppression expiring
-        2026-08-15 carries it until a stable ansible-core >= 2.20.7 lands.
-        Any OTHER ignore appearing without review must fail this pin.
+        The item-41 residue stayed cleared (dependabot-wave-20260711), and the
+        one later entry — CVE-2026-11332 (ansible-core 2.20.3, dev tooling
+        only, time-boxed to 2026-08-15) — was removed 2026-08-17 because its
+        own removal condition landed: uv.lock carries ansible-core 2.21.2
+        (stable, >= the 2.20.7 fix line). Any ignore appearing without review
+        must fail this pin.
         """
         entries = get_ignore_entries(load_ignores_file(DEFAULT_IGNORES_FILE))
-        ids = sorted(e["id"] for e in entries)
-        assert ids == ["CVE-2026-11332"]
-        for entry in entries:
-            assert entry["reason"]
-            assert entry["expires"] == "2026-08-15"
+        assert entries == []

--- a/tests/unit/tools/test_run_pip_audit.py
+++ b/tests/unit/tools/test_run_pip_audit.py
@@ -303,7 +303,7 @@ class TestRealPolicyFile:
     def test_real_policy_passes_check_only(self) -> None:
         assert main(["--check-only"]) == 0
 
-    def test_real_policy_pins_the_item41_residue_exactly(self) -> None:
+    def test_real_policy_pins_the_emptied_policy_exactly(self) -> None:
         """The shipped policy carries no ignores at all.
 
         The item-41 residue stayed cleared (dependabot-wave-20260711), and the


### PR DESCRIPTION
The time-boxed suppression (ansible-core 2.20.3, dev tooling only, `expires = 2026-08-15`) expired and tripped `tools/run_pip_audit.py`'s hard-fail exactly as designed — currently failing two CI legs on every open PR (first seen on #598).

Its own removal condition is met: **uv.lock already carries ansible-core 2.21.2** (stable, ≥ the 2.20.7 fix line), so per the policy file's own rule the entry is **removed rather than renewed** and the policy is empty again. The exact-pin test (`tests/unit/tools/test_run_pip_audit.py::TestRealPolicyFile`) now pins the emptied policy, so any new ignore must re-justify itself.

Scoped test run: 24/24 green. Two-file change, no engine/economics/defines code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)