### PR TITLE
fix(bsl): Dec+CR final-review fix-forward — c04 round-2 gate restoration + record corrections

### DIFF
--- a/ai/decisions/ADR212_decomposition_controlratio_port_handoff.yaml
+++ b/ai/decisions/ADR212_decomposition_controlratio_port_handoff.yaml
@@ -60,9 +60,13 @@ ADR212_decomposition_controlratio_port_handoff:
     `-revolution-`; `-within-capacity-`; `-zero-enforcer-`) plus two for
     Pack A (`decomposition-conformance.bscn`, `-delay-`) plus the joint
     `carceral-arc-conformance.bscn` (Task 8, both packs loaded together,
-    112-tick horizon, the frozen five-phase sequence reproduced tick-for-
-    tick: SUPERWAGE_CRISIS@1, CLASS_DECOMPOSITION@53,
-    CONTROL_RATIO_CRISIS@105, TERMINAL_DECISION@106).
+    112-tick horizon, FOUR of the frozen engine's five carceral-arc
+    phases reproduced tick-for-tick: SUPERWAGE_CRISIS@1,
+    CLASS_DECOMPOSITION@53, CONTROL_RATIO_CRISIS@105, TERMINAL_DECISION@106
+    (fixed forward, final review M3: the fifth phase, `metabolic_rift_
+    opened` from the unported `ImperialRentSystem` @9.0, is deliberately
+    NOT reproduced — `carceral_arc_conformance.rs` documents the omission
+    correctly; only this summary previously overstated it as "five-phase").
 
     **2. The carrier reformulation.** The frozen `TickContext.
     persistent_data` state machine (`_superwage_crisis_tick`,
@@ -131,9 +135,12 @@ ADR212_decomposition_controlratio_port_handoff:
     (`INTERNAL_PROLETARIAT`/`LUMPENPROLETARIAT`) feeding the census.
     **ADR070/Program 19 rules ControlRatioSystem's revolution-vs-genocide
     branch explicitly LAST in the emergent-class-partition cutover**
-    (Constitution IX.5, "no exception … only after low flip-count
-    evidence, with a dedicated high-effort review") — this port
-    therefore deliberately does NOT re-base the branch onto a derived
+    (ADR070's own "Cutover roadmap" section,
+    `ai/decisions/ADR070_emergent_class_partition.yaml:100-103`: "no
+    exception, only after low flip-count evidence, with a dedicated
+    high-effort review" — corrected by the 2026-08-17 final whole-branch
+    review's I3 finding; the phrase is ADR070's, not Constitution IX.5's)
+    — this port therefore deliberately does NOT re-base the branch onto a derived
     class-cell partition. The transcription is consistent with ADR070's
     own slots-as-positions ruling (role is real, persistent seed
     vocabulary, not something a port should derive). The
@@ -147,6 +154,24 @@ ADR212_decomposition_controlratio_port_handoff:
     — answered: it respects it, the train does not split the branch
     onto a derived partition; row 12 is checked off #564). Register row:
     **D174**.
+
+    **Round-2 gate restoration (fixed forward, final review I2).** The
+    VERBATIM claim above was INCOMPLETE at first landing: `c04`'s
+    original `when` transcribed only the readiness/latch gates and
+    silently dropped TWO more of the frozen `step()`'s five early
+    returns — `if prisoner_pop == 0: return` (`:141-142`) and `if
+    prisoner_pop <= max_controllable: return` (`:150-151`, D-record 3's
+    SAME `<=` boundary) — both re-evaluated on the terminal tick against
+    the FRESH same-tick census, since `step()` is one function
+    re-executed from the top on every call. Restored as two added `when`
+    conjuncts; `c04`'s `:fuel` moved 46 -> 54. Proven by two new
+    mutation-killed fixtures in `control_ratio_conformance.rs`, each
+    cross-checked against the frozen engine. All 16 `tick_goldens.rs`
+    pins stayed byte-identical — no committed scenario exercises either
+    dropped-gate path. The RESERVED branch's own comparison, threshold
+    source, and role partition are unchanged; only the surrounding
+    `when`'s completeness moved. Full addendum: `docs/reference/
+    bsl-language.rst`'s D174 row.
 
     **6. The byte-order disclosure.** `control-ratio/*` sorts BEFORE
     `decomposition/*` in ascending rule-id byte order (the comparison
@@ -180,12 +205,16 @@ ADR212_decomposition_controlratio_port_handoff:
     zero-enforcer case — with the frozen payload's own redundant
     duplicate `control_ratio`/`actual-ratio` key DELIBERATELY preserved,
     not simplified away). **D173** (four inherited frozen-code defects,
-    transcribed verbatim per ADR183: docstring drift at TWO sites — both
+    transcribed verbatim per ADR183: docstring drift at THREE sites —
+    fixed forward, final review M5, adding a third —
     `decomposition.py`'s own "30%/70%" AND `CarceralDefines`'s stale
     "2.33:1"/"control_capacity >= 3: No crisis" arithmetic in
     `territory.py:265-267`, both computed off the stale 30/70 split
     rather than the shipped 15/85, under which `control_capacity = 4`
-    DOES produce a crisis; the additive/overwrite intake asymmetry; LA
+    DOES produce a crisis; AND `control_ratio.py:7`'s stale "1:20 ratio"
+    docstring claim against the shipped `control_capacity = 4`
+    (`defines.yaml:294`) — that same file's own `:145` comment already
+    says "US average ~4:1"; the additive/overwrite intake asymmetry; LA
     population/wealth non-conservation from independent flooring; the
     bare `2` literal with no `CarceralDefines` backing). **D168** (the
     event-history read omitted as PROVABLY unreachable, since
@@ -211,9 +240,14 @@ ADR212_decomposition_controlratio_port_handoff:
       `cargo fmt --check`, workspace clippy `-D warnings` plus all
       pedantic legs, `cargo doc`, and every test binary, with
       `carceral_arc_conformance.rs` 5/5, `control_ratio_conformance.rs`
-      22/22, `decomposition_conformance.rs` 20/20, and all 16
-      `tick_goldens.rs` golden pins byte-identical (matches the pins
-      bullet below). The RST-sync suite
+      22/22 (24/24 post-fix-forward, final review I2's two new gate
+      fixtures), `decomposition_conformance.rs` 20/20, and 16 total
+      `tick_goldens.rs` golden pins — 11 PRE-EXISTING byte-identical
+      (fixed forward, final review M2: the original "all 16 … byte-
+      identical" phrasing here conflated the pin COUNT with the
+      byte-identity claim, which correctly applies only to the 11
+      pre-existing pins; 5 are NEW pins this train measures, matching the
+      pins bullet below's own accurate phrasing). The RST-sync suite
       (`tests/unit/reference/test_bsl_grammar_sync.py`): **41/41 green**.
       `vale` on every touched `.rst`/`.md`: `docs/reference/
       bsl-language.rst` measured base 609 errors (pre-Task-9) + 20 new

--- a/ai/decisions/ADR212_decomposition_controlratio_port_handoff.yaml
+++ b/ai/decisions/ADR212_decomposition_controlratio_port_handoff.yaml
@@ -166,8 +166,9 @@ ADR212_decomposition_controlratio_port_handoff:
     re-executed from the top on every call. Restored as two added `when`
     conjuncts; `c04`'s `:fuel` moved 46 -> 54. Proven by two new
     mutation-killed fixtures in `control_ratio_conformance.rs`, each
-    cross-checked against the frozen engine. All 16 `tick_goldens.rs`
-    pins stayed byte-identical — no committed scenario exercises either
+    cross-checked against the frozen engine. Every `tick_goldens.rs`
+    pin (16 at this train's landing; sibling trains keep adding pins)
+    stayed byte-identical — no committed scenario exercises either
     dropped-gate path. The RESERVED branch's own comparison, threshold
     source, and role partition are unchanged; only the surrounding
     `when`'s completeness moved. Full addendum: `docs/reference/
@@ -241,8 +242,9 @@ ADR212_decomposition_controlratio_port_handoff:
       pedantic legs, `cargo doc`, and every test binary, with
       `carceral_arc_conformance.rs` 5/5, `control_ratio_conformance.rs`
       22/22 (24/24 post-fix-forward, final review I2's two new gate
-      fixtures), `decomposition_conformance.rs` 20/20, and 16 total
-      `tick_goldens.rs` golden pins — 11 PRE-EXISTING byte-identical
+      fixtures), `decomposition_conformance.rs` 20/20, and the
+      `tick_goldens.rs` golden pins (16 at this train's landing; the
+      file keeps growing) — 11 PRE-EXISTING byte-identical
       (fixed forward, final review M2: the original "all 16 … byte-
       identical" phrasing here conflated the pin COUNT with the
       byte-identity claim, which correctly applies only to the 11
@@ -273,7 +275,8 @@ ADR212_decomposition_controlratio_port_handoff:
       (fired 4), `control_ratio_zero_enforcer_conformance_hashes_are_
       pinned` (fired 6, all four PR B/Task 5-7); and
       `carceral_arc_conformance_hashes_are_pinned` (fired 13, Task 8) —
-      16 total golden pins in the crate, 11 pre-existing (9 pre-Pack-A +
+      16 golden pins in the crate at this train's landing (a live
+      count — sibling trains add pins), 11 pre-existing (9 pre-Pack-A +
       Pack A's 2) plus Pack B's 4 plus the arc's 1, every pre-existing
       pin verified byte-identical throughout.
     - The records: register rows D165 (Task 5) + D166-D174 (this task,

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -7944,8 +7944,8 @@ consequences are the ordinary kind of review item.
        ``c04_does_not_emit_when_the_terminal_tick_census_falls_back_within_capacity``
        — each cross-checked against the frozen engine (``control_ratio_conformance.py``'s
        ``WORLDS_WITH_PRIOR_CRISIS``), which emits nothing in both worlds when
-       ``persistent_data`` is pre-seeded as though the crisis already fired. All 16
-       ``tick_goldens.rs`` pins stayed byte-identical — no committed scenario exercises
+       ``persistent_data`` is pre-seeded as though the crisis already fired. Every
+       ``tick_goldens.rs`` pin stayed byte-identical — no committed scenario exercises
        either dropped-gate path. The RESERVED branch's own comparison, threshold
        source, and role partition are UNCHANGED by this fix; only the surrounding
        ``when``'s completeness moved.

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -7840,7 +7840,8 @@ consequences are the ordinary kind of review item.
    * - D173
      - N/A (four inherited frozen-code defects, transcribed verbatim per port-as-is
        law, ADR183; not BSL constructs)
-     - **(1) Docstring drift, TWO sites, both off the SAME stale 30/70 split.**
+     - **(1) Docstring drift, THREE sites** (fixed forward, final review M5 — a third
+       site added; the first two remain off the SAME stale 30/70 split).
        ``decomposition.py``'s module docstring (``:4-6``, class docstring ``:90-96``)
        claims "30% of Labor Aristocracy becomes CARCERAL_ENFORCER" / "70% falls into
        INTERNAL_PROLETARIAT", but the CODE reads ``CarceralDefines``
@@ -7856,7 +7857,16 @@ consequences are the ordinary kind of review item.
        "No crisis" claim. Transcribed as the shipped 15%/85% behavior in both
        ``decomposition/p03-trigger`` and its own defconsts; both stale comments are
        recorded here, neither "corrected" in the comment itself, per ADR183 (the code
-       is the port's oracle, not its own docstring). **(2) Additive/overwrite
+       is the port's oracle, not its own docstring). A THIRD, independently-stale
+       docstring sits in the ControlRatio frozen source itself, off a DIFFERENT stale
+       ratio (not the 30/70 lineage): ``control_ratio.py:7`` states "User
+       specification: 1:20 ratio (1 guard can control 20 prisoners)" while the
+       shipped ``carceral.control_capacity`` is **4** (``defines.yaml:294``) and the
+       SAME file's own ``:145`` comment already says "US average ~4:1" — the module
+       docstring was never updated when the shipped default moved to 4. Transcribed
+       as the shipped ``control_capacity = 4`` in ``control-ratio/c03-crisis`` and its
+       own defconst; the stale ``:7`` comment is recorded here, not corrected in the
+       frozen source, per ADR183. **(2) Additive/overwrite
        asymmetry** — ``decomposition/p04-enforcer-intake`` is ADDITIVE (``current +
        gain``, ``decomposition.py:327-332``) while ``decomposition/p05-ip-intake`` is
        a flat OVERWRITE (``decomposition.py:334-336``), transcribed as two DIFFERENT
@@ -7891,9 +7901,14 @@ consequences are the ordinary kind of review item.
        ``control-ratio/c01-prisoner-census``'s ``prisoner-gate``, transcribing
        ``control_ratio.py:32-37``'s ``_PRISONER_ROLES`` frozenset). **ADR070 /
        Program 19 rules ControlRatioSystem's revolution-vs-genocide branch explicitly
-       LAST in the emergent-class-partition cutover** (Constitution IX.5, "no
-       exception … only after low flip-count evidence, with a dedicated high-effort
-       review") — this port therefore deliberately does NOT re-base the branch onto a
+       LAST in the emergent-class-partition cutover** (ADR070's own "Cutover roadmap"
+       section, ``ai/decisions/ADR070_emergent_class_partition.yaml:100-103``: "no
+       exception, only after low flip-count evidence, with a dedicated high-effort
+       review" — corrected by the 2026-08-17 final whole-branch review's I3 finding;
+       the phrase is ADR070's, not Constitution IX.5's, which names the correct
+       authority for *a question touching the ideological line escalates to the
+       Director* but is not this sentence's source) — this port therefore
+       deliberately does NOT re-base the branch onto a
        derived class-cell partition; it transcribes the current ``SocialRole``-keyed
        reads as-is. The transcription is consistent with ADR070's own
        slots-as-positions ruling (``ADR070_emergent_class_partition.yaml``: "the
@@ -7909,6 +7924,31 @@ consequences are the ordinary kind of review item.
        the joint Class-D train respect that or split?" — answered here: it respects
        it, the train does not split the branch onto a derived partition, and row 12
        is now checked off #564).
+
+       **Round-2 gate restoration addendum (2026-08-17 final whole-branch review,
+       finding I2; fix-forward).** The verbatim-transcription claim above was
+       INCOMPLETE at first landing: ``control-ratio/c04-terminal``'s original
+       ``when`` transcribed only the readiness/latch gates
+       (``control_ratio.py:124-125,154-159,166-168``) and silently dropped TWO more
+       of the frozen ``step()``'s five early returns — ``if prisoner_pop == 0:
+       return`` (``:141-142``) and ``if prisoner_pop <= max_controllable: return``
+       (``:150-151``, the SAME ``<=`` boundary ``c03`` already transcribes) — both
+       re-evaluated on the terminal tick against a freshly recomputed census, since
+       ``step()`` is one function re-executed from the top on every call. Fixed
+       forward by restoring both as added ``when`` conjuncts (``(> prisoner-population
+       0)``, ``(> prisoner-population max-controllable)``, the latter needing a new
+       ``control-capacity`` ``:const``/``max-controllable`` ``:expr`` binding pair);
+       ``c04``'s ``:fuel`` moved 46 -> 54 (measured bound 53 + 1, §4.5). Proven by two
+       new mutation-killed fixtures in ``control_ratio_conformance.rs`` —
+       ``c04_does_not_emit_when_the_terminal_tick_census_has_zero_prisoners`` and
+       ``c04_does_not_emit_when_the_terminal_tick_census_falls_back_within_capacity``
+       — each cross-checked against the frozen engine (``control_ratio_conformance.py``'s
+       ``WORLDS_WITH_PRIOR_CRISIS``), which emits nothing in both worlds when
+       ``persistent_data`` is pre-seeded as though the crisis already fired. All 16
+       ``tick_goldens.rs`` pins stayed byte-identical — no committed scenario exercises
+       either dropped-gate path. The RESERVED branch's own comparison, threshold
+       source, and role partition are UNCHANGED by this fix; only the surrounding
+       ``when``'s completeness moved.
 
 See Also
 ----------

--- a/rust/crates/babylon-tick/content/rules/control-ratio.bsl
+++ b/rust/crates/babylon-tick/content/rules/control-ratio.bsl
@@ -57,8 +57,12 @@
 ; obligation this task also discharges — see that row for the census
 ; find-first -> per-node-aggregate reformulation and its p03 inheritance,
 ; which is a DECOMPOSITION-side, not a control-ratio-side, fact and so is
-; NOT re-stated in this Pack B header):
-;   1. THE TWO-ROLE PRISONER SET — the frozen `_PRISONER_ROLES =
+; NOT re-stated in this Pack B header. Global D-number cross-references
+; added inline below per the final review's I5 finding — this pack's own
+; numbering (1-6, 5b) is LOCAL to this file, identical in phrasing to
+; decomposition.bsl's own local "D-record N" numbering but NOT the same
+; sequence; do not confuse "D-record N" here with register row DN):
+;   1. (cited within global D174) THE TWO-ROLE PRISONER SET — the frozen `_PRISONER_ROLES =
 ;      frozenset({INTERNAL_PROLETARIAT, LUMPENPROLETARIAT})`
 ;      (`control_ratio.py:32-37`) is TWO roles, not one (unlike
 ;      Decomposition's single LABOR_ARISTOCRACY target). `c01`'s prisoner
@@ -67,7 +71,7 @@
 ;      D127 hash-neutral operand-gate idiom, matching `p01`'s own no-`when`
 ;      shape: every SOCIAL_CLASS subject fires and a non-participant writes
 ;      zero, keeping the census fresh every tick.
-;   2. THE UNCONDITIONAL CENSUS PUBLICATION — the frozen `step()` computes
+;   2. (global D170) THE UNCONDITIONAL CENSUS PUBLICATION — the frozen `step()` computes
 ;      the census (`:137-138`) only PAST the readiness gate
 ;      (`_terminal_decision_emitted` early-return `:124-125`,
 ;      `_class_decomposition_tick is None` early-return `:128-130`, the
@@ -89,8 +93,24 @@
 ;      three census inputs are all `SOCIAL_CLASS`-scoped, not
 ;      `INSTITUTION`-scoped), so it has no OTHER institution field to
 ;      anchor on. Reading it and never using it is the honest shape here,
-;      not a design accident.
-;   3. THE `<=` BOUNDARY (`c03`, LANDED Task 6) — `control_ratio.py:
+;      not a design accident. FOLD SCOPE INCLUDES INACTIVE NODES (final
+;      review M7, mirroring `decomposition.bsl`'s own note at `:166`,
+;      Pack A's Task 1->Task 2 deferred minor, discharged there and never
+;      inherited here until now): `c02`'s three `(fold sum (nodes
+;      NodeType/SOCIAL_CLASS) …)` calls sum over EVERY SOCIAL_CLASS node,
+;      active and inactive alike — the fold itself carries no active
+;      filter. It is safe only because `c01`'s own `enforcer-gate`/
+;      `prisoner-gate` (`item 1 above, both conjoined with `(= active
+;      1)`) already zero an inactive node's own three census-contribution
+;      fields THIS SAME TICK, ahead of `c02` in byte order (D116) — the
+;      fold sums honest zeros, it does not filter them out itself.
+;      `c01_publishes_the_two_prisoner_roles_and_the_enforcer_count`
+;      (`control_ratio_conformance.rs`) proves both inactive witnesses
+;      (`enforcer-inactive`, `prisoner-inactive`) contribute 0 despite
+;      nonzero seeded population.
+;   3. (no separate global row — a straightforward operator transcription,
+;      not a content-model divergence) THE `<=` BOUNDARY (`c03`, LANDED
+;      Task 6) — `control_ratio.py:
 ;      150`'s `if prisoner_pop <= max_controllable: return` (the frozen
 ;      suite's own `TestControlRatioMutationKillers` class pins this exact
 ;      operator), transcribed verbatim as `(> prisoner-population
@@ -103,7 +123,7 @@
 ;      capacity` (`control_ratio_conformance.rs`) is the mutation killer: a
 ;      `<=` -> `<` transcription error (i.e. flipping this `when` conjunct
 ;      from `>` to `>=`) flips it red.
-;   4. THE GUARD-SPLIT EMIT (`c03`, LANDED Task 6, BLOCKER-4) —
+;   4. (global D171 item 4) THE GUARD-SPLIT EMIT (`c03`, LANDED Task 6, BLOCKER-4) —
 ;      `float("inf")` (`control_ratio.py:185`'s zero-enforcer branch) and
 ;      `x/0` are both unrepresentable in BSL (`E-EVAL-014`/`E-EVAL-012`).
 ;      `control-ratio-zero-enforcer-conformance.bscn` seeds a REAL, active,
@@ -114,9 +134,12 @@
 ;      enforcer-population)) …` — required because `:expr` bindings
 ;      evaluate unconditionally every tick this rule's one INSTITUTION
 ;      subject is visited, regardless of `when`/`guard`
-;      (`decomposition.bsl`'s own p03 fuel-note precedent: "every `:expr`
-;      binding evaluates eagerly and unconditionally… regardless of what
-;      any later binding or guard does") — an UNPROTECTED division would
+;      (fixed forward, final review I4 — the citation below was wrong: this
+;      lives in Pack A's TEST file, not `decomposition.bsl` itself —
+;      `decomposition_conformance.rs:172-176`'s own "Retraction (fix round
+;      1, PR review)" paragraph: "every `:expr` binding … evaluates
+;      eagerly and unconditionally, once per subject per tick, regardless
+;      of what any later binding or guard does") — an UNPROTECTED division would
 ;      abort EVERY tick of the zero-enforcer world with `E-EVAL-012`, not
 ;      merely the crisis tick; (b) the EFFECTS themselves guard-split via
 ;      two `(guard (> enforcer-population 0) …)` / `(guard (=
@@ -131,7 +154,8 @@
 ;      guard-split) is what reproduces the frozen `float("inf")`
 ;      unrepresentability as a NAMED `E-EVAL-012` test failure rather than
 ;      a silent no-emit.
-;   5. THE NUMERIC `outcome` ENCODING (`c04`, LANDED Task 7, ADR070/
+;   5. (global D171 item 3; also D174's own RESERVED-LINE subject) THE
+;      NUMERIC `outcome` ENCODING (`c04`, LANDED Task 7, ADR070/
 ;      BLOCKER-5) — `emit` carries no string payload values at all (`Str`
 ;      has no `<payload-item>` production); the frozen `outcome` string
 ;      ("revolution"/"genocide", `control_ratio.py:222,228`) becomes a
@@ -164,19 +188,49 @@
 ;      BSL specifically (the frozen ternary is provably dead code within its
 ;      OWN single `step()` call — c04's carrier-anchored per-tick evaluation
 ;      is the general reason a future world COULD reach the zero branch).
-;      Honest caveat, checked directly (mutation exercise, not asserted):
-;      NONE of this pack's six fixtures ever actually has `prisoner-
-;      population == 0` at any tick `c04` evaluates — `c02` republishes the
-;      real (nonzero) census the SAME tick, ahead of `c04` in byte order, in
-;      every scenario/fixture this pack loads. Replacing the protected
-;      `:expr` with a bare `(/ prisoner-org-weighted prisoner-population)`
-;      leaves all 22 tests in `control_ratio_conformance.rs` green — the
-;      protector is NOT mutation-provable by this task's own fixture set
-;      (unlike `c03`'s own BLOCKER-4 protector, which the zero-enforcer
-;      world DOES reach). Kept anyway for :171's own transcription fidelity
-;      and as the same defensive idiom `c03` established; recorded honestly
-;      rather than claimed as proven.
-;   6. THE CROSS-PACK BYTE-ORDER INVERSION — `control-ratio/*` sorts
+;      DISCHARGED (final review I2's round-2 gate restoration, checked
+;      directly by mutation exercise): the ORIGINAL claim here — that none
+;      of this pack's fixtures ever reaches `prisoner-population == 0` at a
+;      tick `c04` evaluates — no longer holds now that `when` itself gates
+;      on `prisoner-population > 0` (D-record 5b below).
+;      `c04_does_not_emit_when_the_terminal_tick_census_has_zero_prisoners`
+;      (`control_ratio_conformance.rs`) seeds exactly that world; `:expr`
+;      bindings evaluate eagerly regardless of `when` (BLOCKER-4's own
+;      mechanism), so `avg-organization`'s protected ternary IS evaluated
+;      for that fixture even though `when` refuses the emit. Replacing the
+;      protector with a bare `(/ prisoner-org-weighted prisoner-population)`
+;      now aborts THAT fixture's own `run()` call with a NAMED
+;      `E-EVAL-012`, not a silent pass — mutation-provable like `c03`'s own
+;      BLOCKER-4 protector, restored byte-identical after the exercise.
+;   5b. THE ROUND-2 GATE RESTORATION (final review I2 / D174 addendum) —
+;      the frozen `step()` is ONE function re-executed from the top on
+;      every call, so TWO more early returns guard the terminal emit,
+;      re-evaluated on the terminal tick against the FRESH same-tick
+;      census: `if prisoner_pop == 0: return` (`:141-142`) and `if
+;      prisoner_pop <= max_controllable: return` (`:150-151`, D-record 3's
+;      SAME `<=` boundary). `c04`'s original `when` (Task 7) transcribed
+;      only the readiness/latch gates and dropped these two, unrecorded —
+;      at `prisoner-population == 0` it would have emitted a spurious
+;      GENOCIDE (the protector above yields `avg-organization = 0.0 <
+;      0.5`). Restored as two added `when` conjuncts —
+;      `(> prisoner-population 0)` and `(> prisoner-population
+;      max-controllable)`, `max-controllable = enforcer-population *
+;      control-capacity` (a new `:const`/`:expr` binding pair) — proven by
+;      `c04_does_not_emit_when_the_terminal_tick_census_has_zero_
+;      prisoners` and `c04_does_not_emit_when_the_terminal_tick_census_
+;      falls_back_within_capacity` (`control_ratio_conformance.rs`), both
+;      mutation-killed by reverting `when` to its pre-round-2 shape.
+;      E-LEX-026 HEADROOM (final review M1, remeasured post-round-2):
+;      `c04`'s `:material-basis` quoted string is **981 bytes** (no
+;      non-ASCII, no escapes, so char count = byte count), against
+;      E-LEX-026's **1024**-byte cap (`bsl-language.rst:467`,
+;      `reader.rs:175`) — **43 bytes of headroom**, down from the
+;      pre-round-2 974/1024 (50 headroom) the string was already
+;      compressed to once before. `c03`'s own string is now the
+;      TIGHTEST in this pack at 987/1024 (37 headroom). Recorded here so
+;      the next editor adding a clause to either string sees the E-LEX-026
+;      pressure coming instead of hitting a whole-load lexer refusal cold.
+;   6. (global D172) THE CROSS-PACK BYTE-ORDER INVERSION — `control-ratio/*` sorts
 ;      BEFORE `decomposition/*` in ascending rule-id byte order (D100's
 ;      class, `docs/superpowers/plans/2026-08-17-decomposition-
 ;      controlratio-port.md` §5), inverting the frozen @11.0-then-@12.0
@@ -284,8 +338,8 @@
     (update-node self institution/control-crisis-tick (set tick))))
 
 (rule control-ratio/c04-terminal
-  :material-basis "ADR070-RESERVED BRANCH (control_ratio.py:210-247, _emit_terminal_decision), transcribed VERBATIM under the P19 cutover (Constitution IX.5 / ADR070 / Program 19) -- same threshold source, same >= comparison, same two outcomes; changes neither WHICH measure decides nor the role partition. Subject INSTITUTION. `when` flattens the frozen early-return gates (:124-125, :154-159, :166-168): crisis already fired, decision not yet emitted, delay elapsed. avg-organization = prisoner-org-weighted / prisoner-population (:171), guarded by :171's OWN ternary (`if prisoner_pop > 0 else 0.0`) against eager :expr evaluation -- dead code in the frozen step(), defensive parity with c03 here (D-record 5). THE BRANCH, verbatim (:222,228): >= threshold -> REVOLUTION else GENOCIDE. D-record 5/BLOCKER-5: no Str payload value in BSL, so outcome becomes numeric (outcome 1)=revolution / (outcome 0)=genocide, narrative_hint dropped; keys in :239-245 order. Then the one-time latch (:173)."
-  :fuel 46
+  :material-basis "ADR070-RESERVED BRANCH (control_ratio.py:210-247, _emit_terminal_decision), transcribed VERBATIM under the P19 cutover (Constitution IX.5 / ADR070 / Program 19) -- same threshold, same >= comparison, same two outcomes. `when` flattens the frozen early-return gates: crisis fired, not yet emitted, delay elapsed (:124-125,:154-159,:166-168, `ready`); PLUS the two gates step() re-checks against the fresh census: prisoner-population > 0 (:141-142) and prisoner-population > max-controllable (enforcer-population * control-capacity, :150-151, D-record 3) (round-2, review I2/D174). avg-organization = prisoner-org-weighted / prisoner-population (:171), guarded by its own ternary against eager :expr eval (D-record 5). THE BRANCH, verbatim (:222,228): >= threshold -> REVOLUTION else GENOCIDE. D-record 5/BLOCKER-5: no Str payload, so outcome becomes numeric (outcome 1)=revolution/(outcome 0)=genocide, narrative_hint dropped; keys in :239-245 order. Then the one-time latch (:173)."
+  :fuel 54
   (bindings
     (binding control-crisis-emitted :field institution/control-crisis-emitted)
     (binding control-crisis-tick :field institution/control-crisis-tick)
@@ -296,12 +350,17 @@
     (binding tick :tick)
     (binding terminal-decision-delay :const carceral/terminal-decision-delay)
     (binding revolution-threshold :const carceral/revolution-threshold)
+    (binding control-capacity :const carceral/control-capacity)
     (binding ready :expr (and (= control-crisis-emitted 1)
                               (>= tick (+ control-crisis-tick terminal-decision-delay))))
+    (binding max-controllable :expr (* enforcer-population control-capacity))
     (binding avg-organization :expr (if (= prisoner-population 0)
                                         (- 0 0c)
                                         (/ prisoner-org-weighted prisoner-population))))
-  (when (and ready (= terminal-decision-emitted 0)))
+  (when (and ready
+             (> prisoner-population 0)
+             (> prisoner-population max-controllable)
+             (= terminal-decision-emitted 0)))
   (effects
     (guard (>= avg-organization revolution-threshold)
       (emit EventType/TERMINAL_DECISION

--- a/rust/crates/babylon-tick/content/rules/decomposition.bsl
+++ b/rust/crates/babylon-tick/content/rules/decomposition.bsl
@@ -15,10 +15,34 @@
 ; deactivate` — the two intake rules and the LA deactivation, closing Pack A.
 ;
 ; `(intrinsic floor :params (real) :returns int :cost 5)` is declared here
-; (Pack A only, `floor_intrinsic_e2e.rs:137-138`'s duplicate-declaration
-; refusal is why it lives in exactly one file) — `p03-trigger` (Task 3) is
-; the first caller (`(floor (* la-population enforcer-fraction))` etc); p01
-; and p02 never call it.
+; (Pack A) — `p03-trigger` (Task 3) is the first caller (`(floor (*
+; la-population enforcer-fraction))` etc); p01 and p02 never call it.
+; CORRECTED (final review I1 — this header previously claimed the
+; declaration "lives in exactly one file", which is FALSE):
+; `territory.bsl:67` ALREADY declares a BYTE-IDENTICAL `(intrinsic floor
+; :params (real) :returns int :cost 5)`, and
+; `babylon-bsl/src/declarations.rs:1010-1017` (`parse_intrinsic_decls`)
+; refuses a duplicate declaration BY NAME ONLY — `if
+; decls.contains_key(&decl.name)` — with NO content comparison, so two
+; BYTE-IDENTICAL declarations refuse just as hard as two conflicting ones.
+; The REAL constraint: the `floor` intrinsic is declared PER-FILE (not
+; deduplicated across files), the loader refuses a duplicate name
+; unconditionally, and Territory @3.0 + Decomposition @11.0 are both
+; Material Base systems — so ANY content set that co-loads
+; `decomposition.bsl` with `territory.bsl` dies at load with
+; `E-LOAD-001`, a landmine on the Checkpoint A path (all 13 Material Base
+; systems loaded together). No content set does this today (`floor_
+; intrinsic_e2e.rs:137-138`'s test proves the REFUSAL mechanism, not an
+; exemption from it) — checked directly: `load_scenario_with_prelude`
+; (the ONLY prelude mechanism in this estate, ADR209) operates on
+; SCENARIO-side declarations (`defenum`/`deffield`/`defconst` via
+; `EnumRegistry::declare`'s identical-recognition arm, `scenario.rs`) and
+; has NO counterpart for RULE-file `intrinsic` declarations at all —
+; `split_content`/`declarations.rs`'s intrinsic-parsing path is a
+; completely separate, prelude-unaware load path. A dedup/prelude rule
+; for rule-file intrinsics does not exist yet; until one lands, packs
+; declaring `floor` must never co-load in one content set. Follow-up
+; filed: **#646** (final review I1, Checkpoint A implication).
 ;
 ; D116 BYTE-ORDER MAP (docs/reference/bsl-language.rst) — rules run to
 ; completion in ascending rule-id byte order against the same mutable graph,
@@ -26,12 +50,12 @@
 ; same-tick read across this pack is a DELIBERATE reliance on that order,
 ; production.bsl/consciousness.bsl-header style:
 ;
-;   rule                  subject       reads                              writes
+;   rule                  subject       reads                               writes
 ;   p01-la-census         SOCIAL_CLASS  role, active, population, wealth,   la-census-population,
 ;                                       subsistence-threshold, s-bio,       la-census-wealth,
 ;                                       s-class, :const                     la-approaching-flag,
 ;                                                                           la-dying-flag
-;   p02-superwage-warning SOCIAL_CLASS  role, active,                      carrier superwage-
+;   p02-superwage-warning SOCIAL_CLASS  role, active,                       carrier superwage-
 ;                                       la-approaching-flag (p01, SAME     crisis-known/-tick
 ;                                       TICK), carrier superwage-crisis-
 ;                                       known
@@ -51,10 +75,14 @@
 ;                                       (pre-state — nothing earlier in
 ;                                       this pack writes them)
 ;
-; D-RECORDS this pack transcribes (full register rows land in Task 5;
-; production.bsl/consciousness.bsl's own header-first convention followed
-; here — the file is the record, the register catalogs it):
-;   1. THE CARRIER REFORMULATION — the frozen `persistent_data` dict
+; D-RECORDS this pack transcribes (full register rows D166-D174 landed in
+; Task 9, global-D-number cross-references added inline below per the
+; final review's I5 finding; D165 alone landed in Task 5, per that row's
+; own text — it lives in this file's p01/p03 :material-basis prose, not
+; in the numbered list below). production.bsl/consciousness.bsl's own
+; header-first convention followed here — the file is the record, the
+; register catalogs it):
+;   1. (global D166) THE CARRIER REFORMULATION — the frozen `persistent_data` dict
 ;      (`_superwage_crisis_tick`, `_decomposition_complete`,
 ;      `_class_decomposition_tick`, …) becomes `institution/*` fields on the
 ;      single `carceral-register` carrier (plan §2). Every `None`-sentinel
@@ -65,7 +93,7 @@
 ;      NodeType/INSTITUTION) 1) institution/…)`; writes via `(update-node
 ;      (select-max (nodes NodeType/INSTITUTION) 1) institution/… (set …))`
 ;      — the D103/D104 accumulate-into-a-non-self-target lane.
-;   2. THE OMITTED `add-node` BRANCH — `_create_target_entity`/spec-071's
+;   2. (global D167) THE OMITTED `add-node` BRANCH — `_create_target_entity`/spec-071's
 ;      create-on-demand path (`decomposition.py:225-261`, `_ENFORCER_ID_
 ;      OFFSET`/`_INTERNAL_PROLETARIAT_ID_OFFSET`) is OMITTED entirely:
 ;      `add-node` is refused at content load (`DEFERRED_SHAPE_VERBS`,
@@ -73,7 +101,7 @@
 ;      CARCERAL_ENFORCER/INTERNAL_PROLETARIAT targets instead (already
 ;      recorded as BLOCKER-1 in `decomposition-conformance.bscn`'s header);
 ;      p04/p05 read/write the pre-seeded nodes and never create one.
-;   3. THE OMITTED HISTORY READ — the frozen engine's `services.event_bus.
+;   3. (global D168) THE OMITTED HISTORY READ — the frozen engine's `services.event_bus.
 ;      get_history()` scan for `SUPERWAGE_CRISIS` events
 ;      (`decomposition.py:164-175`), which recovers `_superwage_crisis_tick`
 ;      from event history on a tick where `persistent_data` alone lost it,
@@ -83,7 +111,7 @@
 ;      `superwage-crisis-known`/`-tick` latch, written by p02 the same tick
 ;      it emits, is the sole source of truth — exactly the re-modelling the
 ;      language document itself names, not an invented shortcut.
-;   4. THE PAYLOAD FLATTENING — `SUPERWAGE_CRISIS`'s frozen payload carries
+;   4. (global D171 item 1) THE PAYLOAD FLATTENING — `SUPERWAGE_CRISIS`'s frozen payload carries
 ;      `payer_id` (a second NodeRef, always `CORE_BOURGEOISIE_ID`) and
 ;      `narrative_hint` (a string) that this port DROPS (item 5 below);
 ;      `CLASS_DECOMPOSITION`'s frozen payload nests `population_transferred`/
@@ -93,7 +121,7 @@
 ;      `wealth-transferred-to-enforcer`/`-to-proletariat`), since
 ;      `<payload-item>` values are flat `<expr>` (number/bool/enum-ref/
 ;      NodeRef) — no dict, no string.
-;   5. THE DROPPED NARRATIVE HINTS AND `trigger_event` — every
+;   5. (global D171 item 2) THE DROPPED NARRATIVE HINTS AND `trigger_event` — every
 ;      `narrative_hint` string (`decomposition.py:189-192`, `361-365`) AND
 ;      `CLASS_DECOMPOSITION`'s `trigger_event` string
 ;      (`decomposition.py:360`, always `"superwage_crisis"`) are OMITTED
@@ -102,12 +130,12 @@
 ;      item 4) — `trigger_event` is the same class of omission as
 ;      `narrative_hint`, not a separate divergence, since BSL's `p03`-`p06`
 ;      chain already makes the trigger unambiguous through the carrier's
-;      own `fire-tick` latch (D-record 3).
+;      own `fire-tick` latch (D-record 3, global D168).
 ;   6. D116 BYTE-ORDER RELIANCE — the map above; p02 reads p01's
 ;      `la-approaching-flag` write from THIS tick, p03 reads p01's/p02's
 ;      SAME-TICK carrier writes, and p04-p06 each read p03's this-tick
 ;      carrier write in turn.
-;   7. THE BARE-`2` LITERAL — `carceral/approaching-consumption-multiple`
+;   7. (global D173 item 4) THE BARE-`2` LITERAL — `carceral/approaching-consumption-multiple`
 ;      (defconst value `2`) has NO `CarceralDefines` backing anywhere in the
 ;      frozen source: it is a bare `2 * consumption` literal at
 ;      `decomposition.py:155` (`_APPROACHING_CONSUMPTION_MULTIPLE`-shaped,
@@ -126,7 +154,7 @@
 ;      CLASS_DECOMPOSITION, flipping
 ;      `the_delay_path_emits_the_warning_at_tick_1_and_decomposes_at_tick_53`
 ;      red.
-;   8. DOCSTRING DRIFT — the module docstring (`decomposition.py:4-5`) claims
+;   8. (global D173 item 1) DOCSTRING DRIFT — the module docstring (`decomposition.py:4-5`) claims
 ;      "30% of Labor Aristocracy becomes CARCERAL_ENFORCER" / "70% falls into
 ;      INTERNAL_PROLETARIAT", but the CODE reads the split from
 ;      `CarceralDefines` (`enforcer_fraction = 0.15`, `proletariat_fraction =
@@ -134,7 +162,7 @@
 ;      code is the port's oracle, not its own docstring; transcribed as
 ;      15%/85% exactly, the drift noted here rather than "corrected" in
 ;      either direction.
-;   9. NON-CONSERVATION — `enforcer_pop_gain = int(la_population *
+;   9. (global D173 item 3) NON-CONSERVATION — `enforcer_pop_gain = int(la_population *
 ;      enforcer_fraction)` and `proletariat_pop = int(la_population *
 ;      proletariat_fraction)` (`decomposition.py:298-299`) truncate
 ;      INDEPENDENTLY; for an `la_population` not evenly split by 0.15/0.85
@@ -243,7 +271,7 @@
                  (set tick))))
 
 (rule decomposition/p03-trigger
-  :material-basis "The carrier trigger + frozen split (decomposition.py:150-208, 296-299). Folds p01's four SAME-TICK census fields onto the carrier unconditionally (D127 idiom on the carrier side). should-decompose = la_about_to_die (now la-dying-count > 0) OR (superwage_tick not None (the known-flag, III.11) AND tick >= superwage_tick + delay). Gated on decomposition-complete == 0 (:129-130) AND la-population > 0 (_execute_decomposition's early return, :290-291). Writes fire-tick/-fired-known/-complete and the four amounts: enforcer_pop_gain = int(pop * enforcer_fraction), proletariat_pop = int(pop * proletariat_fraction) — each floors INDEPENDENTLY (D-record 9's non-conservation, transcribed verbatim); the two wealth amounts are NOT int()-demoted. fire-tick == tick is the idiom p04-p06 key off below; this rule's own complete gate makes its OWN re-fire idempotent."
+  :material-basis "The carrier trigger + frozen split (decomposition.py:150-208, 296-299). Folds p01's four SAME-TICK census fields onto the carrier unconditionally (D127 idiom on the carrier side). should-decompose = la_about_to_die (now la-dying-count > 0) OR (superwage_tick not None (the known-flag, III.11) AND tick >= superwage_tick + delay). Gated on decomposition-complete == 0 (:129-130) AND la-population > 0 (_execute_decomposition's early return, :290-291). Writes fire-tick/-fired-known/-complete and the four amounts: enforcer_pop_gain = int(pop * enforcer_fraction), proletariat_pop = int(pop * proletariat_fraction) — each floors INDEPENDENTLY (D-record 9/D173 item 3's non-conservation, transcribed verbatim); the two wealth amounts are NOT int()-demoted. fire-tick == tick is the idiom p04-p06 key off below; this rule's own complete gate makes its OWN re-fire idempotent."
   :fuel 177
   (bindings
     (binding decomposition-complete :field institution/decomposition-complete)
@@ -323,7 +351,7 @@
     (update-node self social-class/active (set 1))))
 
 (rule decomposition/p06-la-deactivate
-  :material-basis "Deactivates the decomposed LA — active SET to 0 ONLY, population/wealth left UNTOUCHED (decomposition.py:339's `graph.update_node(la_id, active=False)`, no population/wealth keys at all — the non-conservation vector: the frozen engine never zeroes the source class's own numbers, it only flips the active latch). Emits CLASS_DECOMPOSITION with the flattened payload (D-record 4: the two frozen nested dicts population_transferred/wealth_transferred become four flat keys; D-record 5: narrative_hint and trigger_event, both strings, are dropped — emit carries no string payloads at all). Reads p03's SAME-TICK carrier fire-tick and the four transfer amounts (D116); population/wealth read off self are PRE-STATE (nothing earlier in this pack writes LA's own population/wealth). Gated on role == LABOR_ARISTOCRACY, active == 1 (only the currently-active LA decomposes), and carrier decomposition-fire-tick == tick."
+  :material-basis "Deactivates the decomposed LA — active SET to 0 ONLY, population/wealth left UNTOUCHED (decomposition.py:339's `graph.update_node(la_id, active=False)`, no population/wealth keys at all — the non-conservation vector: the frozen engine never zeroes the source class's own numbers, it only flips the active latch). Emits CLASS_DECOMPOSITION with the flattened payload (D-record 4/D171 item 1: the two frozen nested dicts population_transferred/wealth_transferred become four flat keys; D-record 5/D171 item 2: narrative_hint and trigger_event, both strings, are dropped — emit carries no string payloads at all). Reads p03's SAME-TICK carrier fire-tick and the four transfer amounts (D116); population/wealth read off self are PRE-STATE (nothing earlier in this pack writes LA's own population/wealth). Gated on role == LABOR_ARISTOCRACY, active == 1 (only the currently-active LA decomposes), and carrier decomposition-fire-tick == tick."
   :fuel 46
   (bindings
     (binding role :field social-class/role)

--- a/rust/crates/babylon-tick/content/rules/territory.bsl
+++ b/rust/crates/babylon-tick/content/rules/territory.bsl
@@ -63,6 +63,17 @@
 ; `territory` is already a registered system (babylon-tick/src/lib.rs) —
 ; added earlier by the query-evaluation train as a namespace placeholder;
 ; this pack is the content that namespace was reserved for.
+;
+; CO-LOAD LANDMINE (final review I1, Decomposition+ControlRatio port
+; train, 2026-08-17): `decomposition.bsl` ALSO declares this SAME
+; byte-identical `(intrinsic floor …)`. The loader refuses a duplicate
+; declaration BY NAME ONLY (`declarations.rs:1010-1017`, no content
+; comparison), so co-loading `territory.bsl` with `decomposition.bsl` in
+; one content set dies at load with `E-LOAD-001` — see
+; `decomposition.bsl`'s own header for the full disclosure and the filed
+; follow-up issue, **#646**. Territory @3.0 and Decomposition @11.0 are both
+; Material Base systems, so this is a live Checkpoint A hazard, not a
+; hypothetical one.
 
 (intrinsic floor :params (real) :returns int :cost 5)
 

--- a/rust/crates/babylon-tick/content/scenarios/carceral_arc_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/carceral_arc_conformance.py
@@ -2,8 +2,8 @@
 Decomposition (@11.0) + ControlRatio (@12.0) port train
 (`docs/superpowers/plans/2026-08-17-decomposition-controlratio-port.md`).
 
-This script is the STRUCTURE and ORDERING oracle (ADR183), NOT a byte
-oracle — it exists to derive and cross-check the arc's tick schedule and to
+This script is the STRUCTURE and ORDERING oracle (ADR183), NOT a
+correctness oracle — it exists to derive and cross-check the arc's tick schedule and to
 prove the frozen engine's own cross-system composition (`DecompositionSystem`
 @11.0 THEN `ControlRatioSystem` @12.0, called in that order every tick,
 sharing ONE `TickContext.persistent_data`), which

--- a/rust/crates/babylon-tick/content/scenarios/control_ratio_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/control_ratio_conformance.py
@@ -272,6 +272,80 @@ WORLDS: list[tuple[str, list[tuple[str, dict[str, Any]]]]] = [
     ("control-ratio-population-weighted (Task 7 ad-hoc #2)", POPULATION_WEIGHTED_CLASSES),
 ]
 
+#: Final review I2, fix-forward round-2 fixture #1 — an active
+#: CARCERAL_ENFORCER and NO prisoner-role node at all, so
+#: `_count_prisoner_population_and_org` returns `(0, 0.0)`. Paired at
+#: `main()` with `persistent_data` PRE-SEEDED as though the crisis already
+#: fired and latched (`_control_crisis_emitted=True`,
+#: `_control_ratio_crisis_tick=0`) — the terminal tick's OWN `if
+#: prisoner_pop == 0: return` (`control_ratio.py:141-142`) must still block
+#: the emit, re-checked against the fresh census on every `step()` call.
+ZERO_PRISONERS_AT_TERMINAL_CLASSES: list[tuple[str, dict[str, Any]]] = [
+    (
+        "enforcer",
+        {
+            "role": SocialRole.CARCERAL_ENFORCER,
+            "active": True,
+            "population": 10,
+            "organization": 0.0,
+        },
+    ),
+]
+
+#: Final review I2, fix-forward round-2 fixture #2 — census falls back
+#: WITHIN capacity (enforcer 10 * control_capacity 4 = 40, prisoner
+#: 15 + 15 = 30 <= 40) by the terminal tick, paired the same way with
+#: `_control_crisis_emitted`/`_control_ratio_crisis_tick` pre-seeded. The
+#: terminal tick's OWN `if prisoner_pop <= max_controllable: return`
+#: (`control_ratio.py:150-151`) must still block the emit even though
+#: `avg_organization` (both prisoner classes at 0.6) would otherwise clear
+#: the revolution threshold.
+WITHIN_CAPACITY_AT_TERMINAL_CLASSES: list[tuple[str, dict[str, Any]]] = [
+    (
+        "enforcer",
+        {
+            "role": SocialRole.CARCERAL_ENFORCER,
+            "active": True,
+            "population": 10,
+            "organization": 0.0,
+        },
+    ),
+    (
+        "prisoner-ip",
+        {
+            "role": SocialRole.INTERNAL_PROLETARIAT,
+            "active": True,
+            "population": 15,
+            "organization": 0.6,
+        },
+    ),
+    (
+        "prisoner-lumpen",
+        {
+            "role": SocialRole.LUMPENPROLETARIAT,
+            "active": True,
+            "population": 15,
+            "organization": 0.6,
+        },
+    ),
+]
+
+#: Worlds run with `persistent_data` pre-seeded as though the crisis
+#: already fired and latched at tick 0 — proving the frozen engine ALSO
+#: emits NOTHING when the terminal-tick census falls back, the mirror
+#: `control_ratio_conformance.rs`'s two new I2 fixtures are checked
+#: against (final review I2, round-2 gate restoration).
+WORLDS_WITH_PRIOR_CRISIS: list[tuple[str, list[tuple[str, dict[str, Any]]]]] = [
+    (
+        "control-ratio-terminal-gate-zero-prisoners (I2 fix-forward #1)",
+        ZERO_PRISONERS_AT_TERMINAL_CLASSES,
+    ),
+    (
+        "control-ratio-terminal-gate-within-capacity (I2 fix-forward #2)",
+        WITHIN_CAPACITY_AT_TERMINAL_CLASSES,
+    ),
+]
+
 
 def build_graph(classes: list[tuple[str, dict[str, Any]]]) -> BabylonGraph:
     """Build a world's social classes, in its own scenario's declaration order.
@@ -323,6 +397,45 @@ def main() -> None:
 
             context = TickContext(tick=1)
             context.persistent_data["_class_decomposition_tick"] = 0
+            ControlRatioSystem().step(graph, services, context)
+
+            print("  post-tick persistent_data:")
+            for key in sorted(context.persistent_data):
+                print(f"    {key} = {context.persistent_data[key]!r}")
+
+            events = services.event_bus.get_history()
+            print("  events:")
+            for event in events:
+                print(f"    {event.type} {event.payload!r}")
+            if not events:
+                print("    (none)")
+            print()
+
+        # Final review I2, round-2 gate restoration: persistent_data
+        # PRE-SEEDED as though the crisis already fired and latched at
+        # tick 0 (`_control_crisis_emitted=True`, `_control_ratio_crisis_
+        # tick=0` — `terminal_decision_delay=0` so the delay has already
+        # elapsed), proving `step()`'s own `prisoner_pop == 0`/`prisoner_pop
+        # <= max_controllable` early returns (`:141-142`, `:150-151`) still
+        # block the terminal emit when re-checked against THIS tick's fresh
+        # census, even though the crisis was already recorded.
+        for label, classes in WORLDS_WITH_PRIOR_CRISIS:
+            print(f"=== {label} ===")
+            services.event_bus.clear_history()
+            graph = build_graph(classes)
+
+            enforcer_pop = _count_enforcer_population(graph)
+            prisoner_pop, prisoner_org_sum = _count_prisoner_population_and_org(graph)
+            print(
+                f"  census: enforcer_population={enforcer_pop!r} "
+                f"prisoner_population={prisoner_pop!r} "
+                f"prisoner_org_weighted_sum={prisoner_org_sum!r}"
+            )
+
+            context = TickContext(tick=1)
+            context.persistent_data["_class_decomposition_tick"] = 0
+            context.persistent_data["_control_crisis_emitted"] = True
+            context.persistent_data["_control_ratio_crisis_tick"] = 0
             ControlRatioSystem().step(graph, services, context)
 
             print("  post-tick persistent_data:")

--- a/rust/crates/babylon-tick/tests/control_ratio_conformance.rs
+++ b/rust/crates/babylon-tick/tests/control_ratio_conformance.rs
@@ -332,19 +332,72 @@
 //! `the_avg_organization_is_population_weighted_not_a_bare_mean` — every
 //! test asserting `outcome` at all. Restored byte-identical afterward.
 //!
-//! **Honest caveat on the division-by-zero protector** (the rule file's own
-//! D-record 5 addendum): replacing `avg-organization`'s protected `:expr`
-//! (`(if (= prisoner-population 0) (- 0 0c) (/ … …))`) with a bare `(/
-//! prisoner-org-weighted prisoner-population)` was also exercised, and it
-//! does NOT flip anything red — all 22 tests in this file stay green. None
-//! of this pack's six fixtures ever reaches `prisoner-population == 0` at a
-//! tick `c04` evaluates (`c02` republishes the real, nonzero census the
-//! SAME tick, ahead of `c04` in byte order, in every world this pack
-//! loads). Unlike `c03`'s own BLOCKER-4 protector (which the zero-enforcer
-//! world DOES reach and DOES mutation-prove), this protector is kept for
-//! `:171`'s own transcription fidelity and defensive parity with `c03`'s
-//! established idiom, not because this task's fixtures prove it necessary
-//! — recorded honestly rather than claimed as mutation-provable.
+//! **The division-by-zero protector's own caveat is DISCHARGED** (final
+//! review I2's round-2 gate restoration; the rule file's own D-record 5/5b
+//! addenda): the ORIGINAL claim here — that no fixture in this pack ever
+//! reaches `prisoner-population == 0` at a tick `c04` evaluates, so
+//! replacing `avg-organization`'s protected `:expr` with a bare `(/
+//! prisoner-org-weighted prisoner-population)` flips nothing red — no
+//! longer holds. `c04_does_not_emit_when_the_terminal_tick_census_has_
+//! zero_prisoners` (below) seeds exactly that world; `:expr` bindings
+//! evaluate eagerly regardless of `when` (BLOCKER-4's own mechanism), so
+//! the protector IS evaluated there even though the (round-2-restored)
+//! `when` refuses the emit. Re-exercised directly: dropping the protector
+//! now aborts THAT ONE test with a NAMED `E-EVAL-012`, the other 23 tests
+//! in this file staying green — mutation-provable now, like `c03`'s own
+//! BLOCKER-4 protector, restored byte-identical afterward.
+//!
+//! ## Final review fix-forward — I2 (round-2 gate restoration)
+//!
+//! `c04`'s original `when` (`ready ∧ terminal-decision-emitted == 0`)
+//! dropped two of the frozen `step()`'s five early returns:
+//! `if prisoner_pop == 0: return` (`:141-142`) and `if prisoner_pop <=
+//! max_controllable: return` (`:150-151`, D-record 3's SAME `<=`
+//! boundary) — both re-evaluated on the terminal tick against the FRESH
+//! same-tick census, since `step()` is one function re-executed from the
+//! top on every call. Restored as two added `when` conjuncts (a new
+//! `control-capacity` `:const` and `max-controllable` `:expr` binding
+//! pair) — proven by `c04_does_not_emit_when_the_terminal_tick_census_
+//! has_zero_prisoners` and `c04_does_not_emit_when_the_terminal_tick_
+//! census_falls_back_within_capacity` below, both of which flip red under
+//! `when`'s pre-round-2 shape (exercised directly, restored byte-identical
+//! afterward). c04's own `:fuel` moved 46 -> 54 (measured bound 53 + 1,
+//! §4.5) for the two new bindings.
+//!
+//! ### Frozen-mirror provenance (both new fixtures)
+//!
+//! `control_ratio_conformance.py`'s own `WORLDS_WITH_PRIOR_CRISIS` loop —
+//! `persistent_data` PRE-SEEDED as though the crisis already fired and
+//! latched at tick 0 (`_control_crisis_emitted=True`,
+//! `_control_ratio_crisis_tick=0`, matching each BSL fixture's own carrier
+//! seed) — re-run against the frozen engine, 2026-08-17, verbatim:
+//!
+//! ```text
+//! === control-ratio-terminal-gate-zero-prisoners (I2 fix-forward #1) ===
+//!   census: enforcer_population=10 prisoner_population=0 prisoner_org_weighted_sum=0.0
+//!   post-tick persistent_data:
+//!     _class_decomposition_tick = 0
+//!     _control_crisis_emitted = True
+//!     _control_ratio_crisis_tick = 0
+//!   events:
+//!     (none)
+//!
+//! === control-ratio-terminal-gate-within-capacity (I2 fix-forward #2) ===
+//!   census: enforcer_population=10 prisoner_population=30 prisoner_org_weighted_sum=18.0
+//!   post-tick persistent_data:
+//!     _class_decomposition_tick = 0
+//!     _control_crisis_emitted = True
+//!     _control_ratio_crisis_tick = 0
+//!   events:
+//!     (none)
+//! ```
+//!
+//! `_terminal_decision_emitted` is ABSENT from both post-tick dumps, not
+//! merely `False` — the early return fires before `step()` ever reaches
+//! the line that would set it, confirming the gate fires exactly where
+//! `control_ratio.py:141-142`/`:150-151` place it. Both BSL fixtures below
+//! assert the SAME shape: zero `TERMINAL_DECISION` events and
+//! `terminal-decision-emitted` staying at its seeded 0.
 
 use babylon_bsl::evaluator::Value;
 use babylon_bsl::scenario::load_scenario;
@@ -1768,4 +1821,309 @@ fn the_avg_organization_is_population_weighted_not_a_bare_mean() {
         ),
         other => panic!("avg-organization must be Value::Real, got {other:?}"),
     }
+}
+
+// ---------------------------------------------------------------------
+// Final review fix-forward, I2 — c04's round-2 gate restoration.
+//
+// The frozen `step()` is ONE function re-executed from the top on every
+// call: `_emit_terminal_decision` (`control_ratio.py:210-247`) is reached
+// only past FIVE early returns in total, not the three `c04`'s original
+// `when` transcribed. Two more sit BEFORE the crisis-emit/terminal-delay
+// logic and are re-evaluated on the terminal tick against a FRESHLY
+// recomputed census, exactly like every other tick's call: `if
+// prisoner_pop == 0: return` (`:141-142`) and `if prisoner_pop <=
+// max_controllable: return` (`:150-151`, the SAME `<=` boundary D-record 3
+// already transcribes into `c03`). A world where the crisis fired but the
+// census falls back — prisoners to zero, or back within capacity — before
+// the terminal tick must NOT emit `TERMINAL_DECISION`, even though the
+// crisis was already latched and the delay has elapsed. Both fixtures
+// below pre-seed the carrier as "crisis already fired at tick 0" (the same
+// ad-hoc-fixture idiom `c03_stays_silent_before_the_readiness_gate` and
+// Task 7's `EXACT_THRESHOLD_SCENARIO` already use) and vary ONLY the
+// current-tick `SOCIAL_CLASS` census `c01`/`c02` publish this same tick,
+// ahead of `c04` in byte order — proving the two round-2 conjuncts, not
+// the delay/latch gates `c04_respects_the_terminal_delay`/`c04_emits_once`
+// already cover.
+//
+// Mutation evidence: reverting `c04`'s `when` to `(and ready (=
+// terminal-decision-emitted 0))` (dropping the two round-2 conjuncts)
+// flips BOTH tests below red — `c04_does_not_emit_when_the_terminal_tick_
+// census_has_zero_prisoners` emits a spurious GENOCIDE (`avg-organization`
+// resolves to its own zero-population protector default, `0.0 < 0.5`),
+// exactly the false-positive the final review's I2 finding names;
+// `c04_does_not_emit_when_the_terminal_tick_census_falls_back_within_
+// capacity` emits a spurious REVOLUTION (`avg-organization` 0.6 >= 0.5).
+// Exercised directly against this file's own `run()` helper, restored
+// byte-identical afterward (`git diff` clean before commit).
+//
+// D-record 5 update: the zero-prisoners fixture ALSO discharges this
+// pack's own "honest caveat" above — `:expr` bindings evaluate eagerly
+// regardless of `when` (BLOCKER-4's mechanism, this file's own Task 6/7
+// precedent), so `avg-organization`'s protected ternary IS evaluated for
+// THIS fixture even though the (now-restored) `when` refuses the emit;
+// replacing the protector with a bare division aborts this world's own
+// `run()` call with a NAMED `E-EVAL-012`, not a silent pass — no longer
+// merely "kept for :171's own fidelity", now mutation-provable like
+// `c03`'s own BLOCKER-4 protector.
+// ---------------------------------------------------------------------
+
+/// I2 gate 1 — the frozen `if prisoner_pop == 0: return` (`:141-142`),
+/// re-checked at the terminal tick. The carrier is pre-seeded as though
+/// the crisis already fired and latched at tick 0 (`control-crisis-emitted
+/// 1`, `control-crisis-tick 0`, `terminal-decision-delay 0` so the delay
+/// has already elapsed) — but THIS tick's own census has zero prisoners
+/// (no `INTERNAL_PROLETARIAT`/`LUMPENPROLETARIAT` node at all), so `c01`/
+/// `c02` publish `prisoner-population 0` the SAME tick, ahead of `c04` in
+/// byte order. `c04` must stay silent.
+#[test]
+fn c04_does_not_emit_when_the_terminal_tick_census_has_zero_prisoners() {
+    const ZERO_PRISONERS_SCENARIO: &str = r#"
+(scenario control-ratio/terminal-gate-zero-prisoners
+  (defvocabulary NodeType (SOCIAL_CLASS INSTITUTION))
+  (defenum SocialRole (CORE_BOURGEOISIE PERIPHERY_PROLETARIAT LABOR_ARISTOCRACY PETTY_BOURGEOISIE LUMPENPROLETARIAT COMPRADOR_BOURGEOISIE INTERNAL_PROLETARIAT CARCERAL_ENFORCER))
+
+  (deffield social-class/role enum SocialRole)
+  (deffield social-class/active int extensive)
+  (deffield social-class/population int extensive)
+  (deffield social-class/organization coefficient intensive)
+  (deffield social-class/enforcer-census-population int extensive)
+  (deffield social-class/prisoner-census-population int extensive)
+  (deffield social-class/prisoner-census-org-weighted real extensive)
+
+  (deffield institution/decomposition-fire-tick int extensive)
+  (deffield institution/decomposition-fired-known int extensive)
+  (deffield institution/decomposition-complete int extensive)
+  (deffield institution/control-crisis-emitted int extensive)
+  (deffield institution/control-crisis-tick int extensive)
+  (deffield institution/terminal-decision-emitted int extensive)
+  (deffield institution/enforcer-population int extensive)
+  (deffield institution/prisoner-population int extensive)
+  (deffield institution/prisoner-org-weighted real extensive)
+
+  (defconst carceral/control-capacity 4)
+  (defconst carceral/revolution-threshold 0.5c)
+  (defconst carceral/control-ratio-delay 0)
+  (defconst carceral/terminal-decision-delay 0)
+
+  (node enforcer NodeType/SOCIAL_CLASS
+    (social-class/role SocialRole/CARCERAL_ENFORCER)
+    (social-class/active 1)
+    (social-class/population 10)
+    (social-class/organization 0.0c)
+    (social-class/enforcer-census-population 0)
+    (social-class/prisoner-census-population 0)
+    (social-class/prisoner-census-org-weighted 0))
+
+  (node carceral-register NodeType/INSTITUTION
+    ; Crisis ALREADY fired and latched at tick 0 — the delay has elapsed —
+    ; but no prisoner-role node exists in this world, so THIS tick's
+    ; census (c01/c02, same tick, ahead of c04 in byte order) publishes
+    ; prisoner-population 0.
+    (institution/decomposition-fire-tick 0)
+    (institution/decomposition-fired-known 1)
+    (institution/decomposition-complete 1)
+    (institution/control-crisis-emitted 1)
+    (institution/control-crisis-tick 0)
+    (institution/terminal-decision-emitted 0)
+    (institution/enforcer-population 0)
+    (institution/prisoner-population 0)
+    (institution/prisoner-org-weighted 0)))
+"#;
+    const ZP_CARCERAL_REGISTER: NodeId = NodeId(1);
+    let (graph, sink) = run(ZERO_PRISONERS_SCENARIO);
+
+    // Sanity: c01/c02 still publish this tick's real (zero) census.
+    assert_eq!(
+        attribute(
+            &graph,
+            ZP_CARCERAL_REGISTER,
+            "institution/enforcer-population"
+        ),
+        10.0
+    );
+    assert_eq!(
+        attribute(
+            &graph,
+            ZP_CARCERAL_REGISTER,
+            "institution/prisoner-population"
+        ),
+        0.0,
+        "no prisoner-role node in this world — the census is honestly zero"
+    );
+
+    let decisions: Vec<_> = sink
+        .events
+        .iter()
+        .filter(|(ty, _)| ty == "TERMINAL_DECISION")
+        .collect();
+    assert_eq!(
+        decisions.len(),
+        0,
+        "prisoner-population == 0 at the terminal tick must block the emit \
+         (control_ratio.py:141-142's `if prisoner_pop == 0: return`, \
+         re-checked every call) — the frozen engine would emit NOTHING \
+         here, not a spurious GENOCIDE"
+    );
+    assert_eq!(
+        attribute(
+            &graph,
+            ZP_CARCERAL_REGISTER,
+            "institution/terminal-decision-emitted"
+        ),
+        0.0,
+        "the latch must stay unset — no emit happened"
+    );
+
+    // c03's own `(= control-crisis-emitted 0)` latch conjunct independently
+    // blocks a second CONTROL_RATIO_CRISIS regardless of this fixture's
+    // zero census — confirming the silence above is c04's own gate, not an
+    // accidental crisis re-fire muddying the event count.
+    assert_eq!(
+        sink.events
+            .iter()
+            .filter(|(ty, _)| ty == "CONTROL_RATIO_CRISIS")
+            .count(),
+        0
+    );
+}
+
+/// I2 gate 2 — the frozen `if prisoner_pop <= max_controllable: return`
+/// (`:150-151`, D-record 3's SAME `<=` boundary), re-checked at the
+/// terminal tick. The carrier is pre-seeded the same "crisis already
+/// fired and latched at tick 0" way as gate 1's fixture, but THIS tick's
+/// census has fallen back WITHIN capacity: enforcer-population 10 *
+/// control-capacity 4 = 40, prisoner-population 30 (15 + 15) <= 40. `c04`
+/// must stay silent even though `avg-organization` (0.6, both prisoner
+/// nodes at organization 0.6) would clear the revolution threshold if it
+/// fired.
+#[test]
+fn c04_does_not_emit_when_the_terminal_tick_census_falls_back_within_capacity() {
+    const WITHIN_CAPACITY_AT_TERMINAL_SCENARIO: &str = r#"
+(scenario control-ratio/terminal-gate-within-capacity
+  (defvocabulary NodeType (SOCIAL_CLASS INSTITUTION))
+  (defenum SocialRole (CORE_BOURGEOISIE PERIPHERY_PROLETARIAT LABOR_ARISTOCRACY PETTY_BOURGEOISIE LUMPENPROLETARIAT COMPRADOR_BOURGEOISIE INTERNAL_PROLETARIAT CARCERAL_ENFORCER))
+
+  (deffield social-class/role enum SocialRole)
+  (deffield social-class/active int extensive)
+  (deffield social-class/population int extensive)
+  (deffield social-class/organization coefficient intensive)
+  (deffield social-class/enforcer-census-population int extensive)
+  (deffield social-class/prisoner-census-population int extensive)
+  (deffield social-class/prisoner-census-org-weighted real extensive)
+
+  (deffield institution/decomposition-fire-tick int extensive)
+  (deffield institution/decomposition-fired-known int extensive)
+  (deffield institution/decomposition-complete int extensive)
+  (deffield institution/control-crisis-emitted int extensive)
+  (deffield institution/control-crisis-tick int extensive)
+  (deffield institution/terminal-decision-emitted int extensive)
+  (deffield institution/enforcer-population int extensive)
+  (deffield institution/prisoner-population int extensive)
+  (deffield institution/prisoner-org-weighted real extensive)
+
+  (defconst carceral/control-capacity 4)
+  (defconst carceral/revolution-threshold 0.5c)
+  (defconst carceral/control-ratio-delay 0)
+  (defconst carceral/terminal-decision-delay 0)
+
+  (node enforcer NodeType/SOCIAL_CLASS
+    (social-class/role SocialRole/CARCERAL_ENFORCER)
+    (social-class/active 1)
+    (social-class/population 10)
+    (social-class/organization 0.0c)
+    (social-class/enforcer-census-population 0)
+    (social-class/prisoner-census-population 0)
+    (social-class/prisoner-census-org-weighted 0))
+
+  (node prisoner-ip NodeType/SOCIAL_CLASS
+    (social-class/role SocialRole/INTERNAL_PROLETARIAT)
+    (social-class/active 1)
+    (social-class/population 15)
+    (social-class/organization 0.6c)
+    (social-class/enforcer-census-population 0)
+    (social-class/prisoner-census-population 0)
+    (social-class/prisoner-census-org-weighted 0))
+
+  (node prisoner-lumpen NodeType/SOCIAL_CLASS
+    (social-class/role SocialRole/LUMPENPROLETARIAT)
+    (social-class/active 1)
+    (social-class/population 15)
+    (social-class/organization 0.6c)
+    (social-class/enforcer-census-population 0)
+    (social-class/prisoner-census-population 0)
+    (social-class/prisoner-census-org-weighted 0))
+
+  (node carceral-register NodeType/INSTITUTION
+    ; Crisis ALREADY fired and latched at tick 0 — the delay has elapsed —
+    ; but THIS tick's census (c01/c02, same tick, ahead of c04 in byte
+    ; order) has fallen back within capacity (30 <= 40).
+    (institution/decomposition-fire-tick 0)
+    (institution/decomposition-fired-known 1)
+    (institution/decomposition-complete 1)
+    (institution/control-crisis-emitted 1)
+    (institution/control-crisis-tick 0)
+    (institution/terminal-decision-emitted 0)
+    (institution/enforcer-population 0)
+    (institution/prisoner-population 0)
+    (institution/prisoner-org-weighted 0)))
+"#;
+    const WCT_CARCERAL_REGISTER: NodeId = NodeId(3);
+    let (graph, sink) = run(WITHIN_CAPACITY_AT_TERMINAL_SCENARIO);
+
+    // Sanity: this tick's own census IS within capacity (30 <= 40), and
+    // avg-organization WOULD clear the revolution threshold if c04 fired —
+    // proving the silence below is the round-2 capacity gate, not a
+    // coincidence of a low-organization world.
+    assert_eq!(
+        attribute(
+            &graph,
+            WCT_CARCERAL_REGISTER,
+            "institution/enforcer-population"
+        ),
+        10.0
+    );
+    assert_eq!(
+        attribute(
+            &graph,
+            WCT_CARCERAL_REGISTER,
+            "institution/prisoner-population"
+        ),
+        30.0,
+        "15 + 15, within enforcer-population(10) * control-capacity(4) = 40"
+    );
+
+    let decisions: Vec<_> = sink
+        .events
+        .iter()
+        .filter(|(ty, _)| ty == "TERMINAL_DECISION")
+        .collect();
+    assert_eq!(
+        decisions.len(),
+        0,
+        "prisoner-population (30) <= max-controllable (40) at the terminal \
+         tick must block the emit (control_ratio.py:150-151's `if \
+         prisoner_pop <= max_controllable: return`, re-checked every \
+         call) — the frozen engine would emit NOTHING here, not a \
+         spurious REVOLUTION"
+    );
+    assert_eq!(
+        attribute(
+            &graph,
+            WCT_CARCERAL_REGISTER,
+            "institution/terminal-decision-emitted"
+        ),
+        0.0,
+        "the latch must stay unset — no emit happened"
+    );
+    assert_eq!(
+        sink.events
+            .iter()
+            .filter(|(ty, _)| ty == "CONTROL_RATIO_CRISIS")
+            .count(),
+        0,
+        "c03's own (= control-crisis-emitted 0) latch conjunct \
+         independently blocks a second crisis regardless of this \
+         fixture's within-capacity census"
+    );
 }

--- a/rust/crates/babylon-tick/tests/decomposition_conformance.rs
+++ b/rust/crates/babylon-tick/tests/decomposition_conformance.rs
@@ -785,13 +785,6 @@ fn the_bourgeois_class_is_untouched_by_the_whole_pack() {
 // tick 52 (the exact `>=` boundary, decomposition.py:207).
 // ---------------------------------------------------------------------
 
-fn delay_attribute(session: &TickSession<HypergraphStore>, id: NodeId, field: &str) -> f64 {
-    session
-        .graph()
-        .node_attribute(id, field)
-        .unwrap_or_else(|e| panic!("node {id:?} field {field}: {}", e.message))
-}
-
 /// The full delay-path lifecycle: `SUPERWAGE_CRISIS` fires exactly once,
 /// at tick 1; `CLASS_DECOMPOSITION` fires exactly once, at tick 53; tick 54
 /// (one past firing) proves the fire-tick pins and does not re-fire —
@@ -811,8 +804,8 @@ fn the_delay_path_emits_the_warning_at_tick_1_and_decomposes_at_tick_53() {
         .collect();
     assert_eq!(crises.len(), 1, "exactly one SUPERWAGE_CRISIS at tick 1");
     assert_eq!(
-        delay_attribute(
-            &session,
+        attribute(
+            session.graph(),
             DELAY_CARCERAL_REGISTER,
             "institution/superwage-crisis-tick"
         ),
@@ -820,8 +813,8 @@ fn the_delay_path_emits_the_warning_at_tick_1_and_decomposes_at_tick_53() {
         "carrier: superwage-crisis-tick == 1"
     );
     assert_eq!(
-        delay_attribute(
-            &session,
+        attribute(
+            session.graph(),
             DELAY_CARCERAL_REGISTER,
             "institution/decomposition-complete"
         ),
@@ -833,8 +826,8 @@ fn the_delay_path_emits_the_warning_at_tick_1_and_decomposes_at_tick_53() {
     for tick in 2..=52 {
         session.advance(&mut filler_sink).expect("filler tick");
         assert_eq!(
-            delay_attribute(
-                &session,
+            attribute(
+                session.graph(),
                 DELAY_CARCERAL_REGISTER,
                 "institution/decomposition-complete"
             ),
@@ -846,8 +839,8 @@ fn the_delay_path_emits_the_warning_at_tick_1_and_decomposes_at_tick_53() {
     let mut sink53 = CollectingSink::default();
     session.advance(&mut sink53).expect("tick 53");
     assert_eq!(
-        delay_attribute(
-            &session,
+        attribute(
+            session.graph(),
             DELAY_CARCERAL_REGISTER,
             "institution/decomposition-fire-tick"
         ),
@@ -864,8 +857,8 @@ fn the_delay_path_emits_the_warning_at_tick_1_and_decomposes_at_tick_53() {
     let mut sink54 = CollectingSink::default();
     session.advance(&mut sink54).expect("tick 54");
     assert_eq!(
-        delay_attribute(
-            &session,
+        attribute(
+            session.graph(),
             DELAY_CARCERAL_REGISTER,
             "institution/decomposition-fire-tick"
         ),
@@ -890,8 +883,8 @@ fn the_delay_path_does_not_decompose_at_tick_52() {
         session.advance(&mut sink).expect("tick");
     }
     assert_eq!(
-        delay_attribute(
-            &session,
+        attribute(
+            session.graph(),
             DELAY_CARCERAL_REGISTER,
             "institution/decomposition-complete"
         ),
@@ -899,8 +892,8 @@ fn the_delay_path_does_not_decompose_at_tick_52() {
         "tick 52: 52 >= 1 + 52 is false — must not have fired"
     );
     assert_eq!(
-        delay_attribute(
-            &session,
+        attribute(
+            session.graph(),
             DELAY_CARCERAL_REGISTER,
             "institution/decomposition-fire-tick"
         ),
@@ -939,7 +932,7 @@ fn p01_la_inactive_contributes_nothing_to_the_census() {
         "social-class/la-dying-flag",
     ] {
         assert_eq!(
-            delay_attribute(&session, DELAY_LA_INACTIVE, field),
+            attribute(session.graph(), DELAY_LA_INACTIVE, field),
             0.0,
             "la-inactive: {field} must stay 0 — the active gate, not the \
              wealth-below-subsistence shape, is what keeps it silent"
@@ -948,7 +941,11 @@ fn p01_la_inactive_contributes_nothing_to_the_census() {
     // la-approaching's own dying-flag must independently stay 0 all
     // session — it is the delay-path vector, never the fallback.
     assert_eq!(
-        delay_attribute(&session, DELAY_LA_APPROACHING, "social-class/la-dying-flag"),
+        attribute(
+            session.graph(),
+            DELAY_LA_APPROACHING,
+            "social-class/la-dying-flag"
+        ),
         0.0,
         "la-approaching: never dying — wealth (515) stays above subsistence (500)"
     );


### PR DESCRIPTION
Fix-forward from the Opus final whole-branch review of the Dec+CR port train (#566; PRs #614/#645 already merged). One dispatch per SDD; scoped re-review at 247a7647 returned ALL RESOLVED.

**Centerpiece (I2):** `c04`'s `when` had dropped two frozen round-2 gate conditions (prisoner_pop == 0 and still-over-capacity) — TERMINAL_DECISION's genocide branch was emittable at zero prisoner population, undisclosed. The gates are now transcribed as the exact negation of the frozen engine's `control_ratio.py:141-142/150-151`; two mutation-killing fixtures added (conformance 22→24); frozen Python mirror re-run proves both new worlds emit no events, byte-for-byte. `tick_goldens.rs` untouched — all 18 pins byte-identical.

**Also resolved:** I1 duplicate `floor` declaration disclosed loudly in both packs (fix is #646's charter — latent E-LOAD-001 on co-load, no current test co-loads them); I3/I4 misattributed citations corrected; I5 global D-numbers added to the in-file records; I6 stale forward-ref corrected; FIX-NOW minors (Pack B INACTIVE note, p02 WRITES column alignment, delay_attribute DRY'd out of 9 call sites, c04 material-basis headroom recorded at 981/1024).

Review trail: `.superpowers/sdd/2026-08-17-decomposition-controlratio-port/final-review.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)