### PR TITLE
chore(license): AGPL-3.0-or-later code + CC0-1.0 assets (#650)

### DIFF
--- a/LICENSE-ASSETS
+++ b/LICENSE-ASSETS
@@ -1,0 +1,123 @@
+# This file governs Babylon's shipped creative-asset directories (music, SFX); see LICENSING.md for the authoritative list.
+
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -6,9 +6,10 @@ Babylon splits its license by kind of content, not by directory tree shape:
   byte-identical to the FSF canonical text at
   `https://www.gnu.org/licenses/agpl-3.0.txt`).
 - **Shipped creative assets: CC0-1.0.** Full text:
-  [`LICENSE-ASSETS`](LICENSE-ASSETS) (verified byte-identical to the
-  Creative Commons canonical text at
-  `https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt`).
+  [`LICENSE-ASSETS`](LICENSE-ASSETS) — a two-line pointer header followed
+  by the Creative Commons canonical text
+  (`https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt`),
+  verified byte-identical from the legal text's first line onward.
 
 This file states which directories fall under which license and flags the
 ones that are not yet decided. It does not restate either license's legal

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,85 @@
+# Licensing
+
+Babylon splits its license by kind of content, not by directory tree shape:
+
+- **Code: AGPL-3.0-or-later.** Full text: [`LICENSE`](LICENSE) (verified
+  byte-identical to the FSF canonical text at
+  `https://www.gnu.org/licenses/agpl-3.0.txt`).
+- **Shipped creative assets: CC0-1.0.** Full text:
+  [`LICENSE-ASSETS`](LICENSE-ASSETS) (verified byte-identical to the
+  Creative Commons canonical text at
+  `https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt`).
+
+This file states which directories fall under which license and flags the
+ones that are not yet decided. It does not restate either license's legal
+text — read `LICENSE` or `LICENSE-ASSETS` for that.
+
+## AGPL-3.0-or-later (code)
+
+Everything that is source, configuration, or docs-as-code, including:
+
+- `src/babylon/**` — the Python engine (package root; see `pyproject.toml`'s
+  `license` field).
+- `rust/crates/**` — all five in-tree crates (`babylon-kernel`,
+  `babylon-tick`, `babylon-bsl`, `babylon-graph`, `babylon-client`), via
+  `rust/Cargo.toml`'s workspace `license` field and each crate's
+  `license.workspace = true`. This includes `babylon-bsl`'s BSL rule
+  content — BSL is executable rules-as-content (Constitution Amendment AE),
+  not a creative asset, so it is code for licensing purposes.
+- `tests/`, `tools/`, `scripts/`, `docs/` (the reStructuredText/Markdown
+  sources, not any rendered build output), `data-artifacts.yaml`,
+  `data-catalog.yaml`, and project TOML/YAML configuration.
+- `.design-sync/**` (the project's own design-sync tooling and generated
+  previews) — **except** the one vendored binary described below.
+- `design/mockups/**` and `design/ui_kits/webapp_v2/` (JSX/HTML/CSS/MD/JSON
+  markup and code) — **except** the one binary image described below.
+
+## CC0-1.0 (shipped creative assets)
+
+- `src/assets/sfx/` — the 39-sound interface SFX suite (ADR152). Also
+  carries its own `src/assets/LICENSE` (identical CC0-1.0 text) and states
+  "License: CC0-1.0" in `src/assets/README.md`.
+- `src/assets/music/` — the 13-track soundtrack (ADR153). Same
+  `src/assets/LICENSE` and README statement as above.
+
+## Third-party, not relicensed
+
+- `.design-sync/fonts-nerd/iosevka-nerd-mono.woff` — Iosevka Nerd Font,
+  ships under its own upstream license (SIL OFL 1.1). This repository does
+  not hold copyright over this file and does not relicense it AGPL or CC0.
+
+## Known gaps — flagged, not yet decided
+
+The following tracked paths are not covered by either license statement
+above because their provenance or intended disposition has not been ruled
+on. They are listed here rather than silently omitted so nobody assumes an
+absence of a rule means "AGPL by default":
+
+- **`assets/music/`** (legacy: `crisis/`, `fascist/`, `revolutionary/`
+  suites + `babylon_theme_panopticon.mid` / `babylon_theme_phi.mid`, 32
+  tracked files). Predates the `src/assets/` CC0 estates by about seven
+  months and was never folded into ADR152/ADR153's CC0 dedication.
+  Believed to be original project composition (same generator-script
+  authorship pattern as the later CC0 estates) but unconfirmed — pending
+  Director sign-off.
+- **`assets/images/generated-image-cover-art-1769575216094.jpg`** —
+  filename pattern suggests AI-image-tool output of unstated provenance;
+  pending Director confirmation of tool/ToS before any license is applied.
+- **`design/ui_kits/webapp_v2/assets/cover-art.jpg`** — same open question
+  as the item above; unclear whether it is the same asset relocated or a
+  distinct file.
+- **`docs/examples/ck-intrigue-1.png`, `-2.png`, `-3.png`** — unreferenced
+  anywhere in `docs/`; filenames suggest third-party reference screenshots
+  (not Babylon's copyright to license either way). Pending a Director
+  decision to delete or keep with an explicit third-party/fair-use note.
+- **Reference/data estates** (`src/babylon/data/reference/*.csv`, the built
+  `data/sqlite/marxist-data-3NF.sqlite`) derived from Census ACS, BEA, BLS
+  QCEW, LODES, IRS SOI, and similar sources. Out of scope for this split —
+  neither "code" nor "creative asset" in the sense this document addresses;
+  a future issue should decide whether a source-attribution `NOTICE` is
+  needed.
+
+`assets/audio/**` (MP3 renders) and the gitignored files under
+`assets/images/` (`fascist_flag.png`, `ff-template.zip`, `prolewiki.zip`,
+`templates.zip`) are excluded from this document because they are not
+tracked in git and are never shipped.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Third Worldist (MLM-TW) theory.
 
 **Mantra:** *Graph + Math = History*
 
+[![License: AGPL-3.0-or-later](https://img.shields.io/badge/code%20license-AGPL--3.0--or--later-blue.svg)](LICENSE)
+[![Assets: CC0-1.0](https://img.shields.io/badge/asset%20license-CC0--1.0-lightgrey.svg)](LICENSE-ASSETS)
+
 ## What Is This?
 
 Babylon models class struggle as a deterministic output of material conditions
@@ -299,7 +302,9 @@ git checkout -b feature/your-feature
 
 ## License
 
-MIT License — see [LICENSE](LICENSE).
+**AGPL-3.0-or-later** (code) + **CC0-1.0** (game assets) — see
+[LICENSE](LICENSE), [LICENSE-ASSETS](LICENSE-ASSETS), and
+[LICENSING.md](LICENSING.md) for the full split.
 
 ______________________________________________________________________
 

--- a/README.md
+++ b/README.md
@@ -302,9 +302,11 @@ git checkout -b feature/your-feature
 
 ## License
 
-**AGPL-3.0-or-later** (code) + **CC0-1.0** (game assets) — see
+**AGPL-3.0-or-later** (code) + **CC0-1.0** (shipped game assets) — see
 [LICENSE](LICENSE), [LICENSE-ASSETS](LICENSE-ASSETS), and
-[LICENSING.md](LICENSING.md) for the full split.
+[LICENSING.md](LICENSING.md) for the per-directory inventory, including
+the handful of legacy asset items whose provenance is still being
+confirmed there.
 
 ______________________________________________________________________
 

--- a/src/assets/README.md
+++ b/src/assets/README.md
@@ -6,7 +6,8 @@ generated deterministically, all CC0: 39 interface sounds in 5 families
 
 **License: CC0-1.0** (`LICENSE` in this directory) — the sounds, the manifest and
 the generator are dedicated to the public domain. Reuse them anywhere, for anything.
-(The wider repository currently declares no license; this directory carries its own.)
+(The wider repository is AGPL-3.0-or-later; this directory carries its own
+CC0-1.0 dedication instead — see [LICENSING.md](../../LICENSING.md).)
 
 ## Layout
 

--- a/tools/check_repo_hygiene.py
+++ b/tools/check_repo_hygiene.py
@@ -91,6 +91,8 @@ ALLOWED_TOP_LEVEL_FILES: frozenset[str] = frozenset(
         "CONSTITUTION.md",
         "CONTRIBUTORS.md",
         "LICENSE",
+        "LICENSE-ASSETS",  # #650 Director ruling: CC0-1.0 for assets (AGPL/CC0 split)
+        "LICENSING.md",  # #650: the code/assets license split + per-dir inventory
         "NORTH_STAR.md",  # BD-blessed orientation doc (2026-07-21); cited by CLAUDE.md as repo-root
         "README.md",
         "SETUP_GUIDE.md",


### PR DESCRIPTION
Implements the Director's licensing ruling (2026-08-17 docket, #650): **AGPL-3.0-or-later for code, CC0 1.0 for assets** — completing a migration that turned out to be half-done since 2025-12-10 (`664b0618` swapped `LICENSE` to AGPL and set `pyproject.toml`, but the README kept claiming MIT the whole time).

- **`LICENSE-ASSETS`** (new): canonical CC0-1.0 legal text (byte-verified against creativecommons.org) + a two-line pointer header.
- **`LICENSING.md`** (new): the code/assets split, the per-dir inventory, and a "Known gaps" section listing five asset items with unconfirmed provenance, deliberately left for the Director (legacy `assets/music/` MIDI estate, two cover-art images, three CK reference screenshots).
- **`README.md`**: the stale "MIT License" claim fixed; AGPL/CC0 badges added.
- **`src/assets/README.md`**: line 9 claimed the wider repo declares no license — false since Dec 2025; corrected.

No code touched; `pyproject.toml` and all crate `Cargo.toml`s verified already correct (`AGPL-3.0-or-later` / `license.workspace = true`) and left alone. Review: independent byte-verification of both legal texts, blame-verified staleness of both README claims, all five known-gap paths confirmed real. Gates: `check:quick` green; no test asserts on license metadata.

Closes #650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)