### PR TITLE
feat(graph): #491 PR B — Currency 0x06 typed storage, CanonicalState layout v3 (T3)

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -8461,6 +8461,62 @@ consequences are the ordinary kind of review item.
        not foreclosed — ``s_bio``/``s_class`` are already per-class
        intensive fields, so a per-``(class, county)`` ``S`` needs zero
        redesign.
+   * - D189
+     - §1.5, §2.9
+     - **T3 (#491, OQ-J), Half 2 of the typed-attribute-seeding design —
+       Currency's node-attribute canonical section lands as tag ``0x06``,
+       NOT the design doc's assumed ``0x05``: entries ``u64 id ‖ str name
+       ‖ i128 value`` (16 raw bytes, big-endian, via ``i128::to_be_bytes()``),
+       ascending ``(id, name)``, ELIDED WHEN EMPTY, ``CANONICAL_LAYOUT_VERSION``
+       bumped 2 → 3.** The design doc
+       (``reports/typed-attribute-seeding-design-2026-08-11.md`` §B) specced
+       section ``0x05`` for Currency, written before the SEPARATE T3/#560
+       edge-attribute train (D144) claimed that same tag for its own fifth
+       section — a real cross-train collision, not a drafting slip: both
+       trains independently reached for "the next tag after 0x04." RESOLVED
+       by taking the actual next-free tag against this checkout at landing
+       time (``0x06``), mirroring D144's own shape verbatim one tag over:
+       the entry layout mirrors section ``0x02``'s ``(id, name)`` key (the
+       SAME node-attribute space, partitioned by declared type rather than
+       widened in place — a ``currency``-declared field never reports in
+       BOTH ``all_attributes`` and ``all_currency_attributes``, mirroring
+       D143's one-datum-one-hashed-home discipline for the strength/
+       edge-attribute split); the elision rule is D144's, extended one
+       section further (every FUTURE section follows this rule, per D144's
+       own text). ``babylon-graph``'s two new ``GraphSubstrate`` methods
+       (``update_node_currency``/``node_attribute_currency``) are
+       NODE-scoped only — no edge/hyperedge Currency lane exists or is
+       licensed by this row. Layout byte-pinned by
+       ``the_sixth_section_is_pinned_byte_for_byte``; elision behavior-
+       pinned by ``an_empty_currency_attribute_listing_writes_no_sixth_section_bytes``;
+       every pre-existing golden (``tick_goldens.rs``, ``qa:regression``)
+       left byte-identical, since no committed content declares a
+       ``currency``-typed ``deffield`` yet.
+   * - D190
+     - §4.2, §2.8
+     - **T3 (#491, OQ-J) — ``PendingWrite``'s reduced operand widens to a
+       SUM TYPE (``WriteOperand::Real(f64) | WriteOperand::Currency``), not
+       a parallel Currency-write batch: the SAME reasoning D145 already
+       settled for ``WriteTarget``, applied one field over.** Currency's
+       typed storage needs `update-node`'s collected operand to sometimes
+       carry an ``i128`` value rather than an ``f64`` one, and the batch's
+       own documented algebra (the free-monoid-collect /
+       monoid-action-apply split D145's own text states) again picks the
+       shape: a SEPARATE ``Vec<PendingCurrencyWrite>`` could not preserve
+       the single interleaved collection order the application law
+       requires, exactly the argument that ruled out a parallel
+       ``Vec<PendingEdgeWrite>`` in D145. A Currency ``set`` sits in the
+       identical batch position an ``f64`` ``set`` would; only `set` is
+       licensed on the Currency lane (`add`/`sub`/`scale` would need to
+       pick which of Currency's five legal §3.2 operators applies, which
+       this row does not license — mirrors the enum lane's identical
+       `set`-only narrowness, §2.13). ``EffectExecutor::update_node``,
+       ``collect_update_node`` and ``apply_pending_write`` each fork on the
+       field's declared type BEFORE reaching the ``f64``
+       ``numeric_write_value`` lane; ``update-edge`` takes no such fork —
+       there is no edge-scoped Currency lane, so a ``WriteOperand::Currency``
+       reaching the edge arm of ``apply_pending_write`` is a named
+       collect/apply wiring-bug error, never reachable from content.
 
 See Also
 ----------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -8498,7 +8498,7 @@ consequences are the ordinary kind of review item.
        SUM TYPE (``WriteOperand::Real(f64) | WriteOperand::Currency``), not
        a parallel Currency-write batch: the SAME reasoning D145 already
        settled for ``WriteTarget``, applied one field over.** Currency's
-       typed storage needs `update-node`'s collected operand to sometimes
+       typed storage needs ``update-node``'s collected operand to sometimes
        carry an ``i128`` value rather than an ``f64`` one, and the batch's
        own documented algebra (the free-monoid-collect /
        monoid-action-apply split D145's own text states) again picks the
@@ -8506,11 +8506,11 @@ consequences are the ordinary kind of review item.
        the single interleaved collection order the application law
        requires, exactly the argument that ruled out a parallel
        ``Vec<PendingEdgeWrite>`` in D145. A Currency ``set`` sits in the
-       identical batch position an ``f64`` ``set`` would; only `set` is
-       licensed on the Currency lane (`add`/`sub`/`scale` would need to
+       identical batch position an ``f64`` ``set`` would; only ``set`` is
+       licensed on the Currency lane (``add``/``sub``/``scale`` would need to
        pick which of Currency's five legal §3.2 operators applies, which
        this row does not license — mirrors the enum lane's identical
-       `set`-only narrowness, §2.13). ``EffectExecutor::update_node``,
+       ``set``-only narrowness, §2.13). ``EffectExecutor::update_node``,
        ``collect_update_node`` and ``apply_pending_write`` each fork on the
        field's declared type BEFORE reaching the ``f64``
        ``numeric_write_value`` lane; ``update-edge`` takes no such fork —

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -41,7 +41,7 @@ use crate::intrinsic_host::{DrawContext, IntrinsicCallCtx, IntrinsicHost};
 use crate::query::{EdgeKey, Element};
 use crate::reader::{Atom, SExpr, ScaledKind};
 use crate::typecheck::TypeEnv;
-use crate::types::EnumRegistry;
+use crate::types::{BslType, EnumRegistry};
 use babylon_graph::substrate::GraphSubstrate;
 use babylon_kernel::{Coefficient, Currency, Ratio};
 use std::collections::HashMap;
@@ -1404,16 +1404,6 @@ fn field_of_node(
 ) -> Result<Value, EvalError> {
     let graph = require_graph(env, "field-of")?;
     check_node_referent_type(graph, id, qname, "field-of")?;
-    let value = graph.node_attribute(id, qname).map_err(|e| {
-        EvalError::coded(
-            EvalCode::AccessorTypeOrValueMismatch,
-            format!(
-                "field-of {qname}: {} (§2.10 discipline 2 — absence is not a \
-                 value)",
-                e.message
-            ),
-        )
-    })?;
     let (Some(types), Some(enums)) = (env.types, env.enums) else {
         return Err(EvalError::plain(format!(
             "(field-of …) needs the declared field-type registry (§2.13) but \
@@ -1424,6 +1414,39 @@ fn field_of_node(
              default"
         )));
     };
+    // T3 #491, OQ-J: a `currency`-declared field lives in the substrate's
+    // SEPARATE i128 map, never `node_attribute`'s f64 one — the SAME
+    // type-first dispatch `tick::bind_subject` uses for a `:field` binding,
+    // reused here so `field-of` reads a Currency field correctly rather
+    // than mis-reporting a real value as "never written" (the map it would
+    // have read `node_attribute` against is simply the wrong one).
+    if matches!(
+        types.fields.get(qname).map(|decl| &decl.ty),
+        Some(BslType::Currency)
+    ) {
+        return graph
+            .node_attribute_currency(id, qname)
+            .map(Value::Currency)
+            .map_err(|e| {
+                EvalError::coded(
+                    EvalCode::AccessorTypeOrValueMismatch,
+                    format!(
+                        "field-of {qname}: {} (§2.10 discipline 2 — absence is not a value)",
+                        e.message
+                    ),
+                )
+            });
+    }
+    let value = graph.node_attribute(id, qname).map_err(|e| {
+        EvalError::coded(
+            EvalCode::AccessorTypeOrValueMismatch,
+            format!(
+                "field-of {qname}: {} (§2.10 discipline 2 — absence is not a \
+                 value)",
+                e.message
+            ),
+        )
+    })?;
     crate::tick::bind_field_value(qname, value, types, enums)
         .map_err(|e| EvalError::plain(e.to_string()))
 }

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -2598,6 +2598,17 @@ mod tests {
             grown[0], 0x06,
             "the grown suffix is exactly one 0x06 section"
         );
+        // L-6 (#491 T3 review): `grown[0] == 0x06` alone would still pass if
+        // a SECOND section were hypothetically appended after it — this
+        // test's own name claims "exactly one", so pin the suffix's exact
+        // LENGTH too: tag(1) + u32 count(4) + one entry's
+        // [u64 id(8) + u32 name-len-prefix(4) + name bytes + i128 value(16)].
+        let expected_len = 1 + 4 + 8 + 4 + "social-class/treasury".len() + 16;
+        assert_eq!(
+            grown.len(),
+            expected_len,
+            "the grown suffix must be EXACTLY one entry's worth of 0x06 bytes, not more"
+        );
         assert_eq!(
             currency_graph
                 .node_attribute_currency(NodeId(0), "social-class/treasury")

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -46,15 +46,19 @@
 //!
 //! # What this deliberately does not do
 //!
-//! - **No `Currency` attributes.** `GraphSubstrate` attributes are `f64`,
-//!   which cannot hold `Currency`'s i128 micro-units; the verb layer already
-//!   refuses such a write loudly rather than casting lossily. Typed
-//!   attribute storage (Half 2 of the typed-attribute-seeding design,
-//!   `reports/typed-attribute-seeding-design-2026-08-11.md`) is DEFERRED TO
-//!   ITS FIRST CONSUMER (Director ruling, 2026-08-11 popup) — not to a fixed
-//!   phase boundary — and the Fundamental Theorem will want it once it
-//!   lands: wages and value produced are properly money. This module states
-//!   the gap rather than hiding it.
+//! - **`currency`-declared node attributes now seed** (T3 #491, OQ-J — Half
+//!   2 of the typed-attribute-seeding design,
+//!   `reports/typed-attribute-seeding-design-2026-08-11.md`, landed on
+//!   Currency's first real consumer per the Director's 2026-08-11 popup
+//!   ruling). A `$`-suffixed literal into a `currency`-declared field routes
+//!   through [`babylon_graph::substrate::GraphSubstrate::update_node_currency`]
+//!   — the i128 lane, a map PARALLEL to the ordinary `f64` attribute lane
+//!   this module otherwise writes through, never the same map. Everywhere
+//!   ELSE a `$` literal is refused exactly as before: `:default`, a
+//!   non-`currency`-declared field, an edge attribute (edge-scoped Currency
+//!   storage is out of scope for this train) — the refusal message now
+//!   names the actual reason (wrong declared type, or no edge lane), not
+//!   "no Currency storage exists at all".
 //! - **`int`- and fractional-typed attributes only (Half 1).** An
 //!   `int`-declared field takes an integer literal, exact in `f64` to 2^53.
 //!   A `probability`/`intensity`/`coefficient`-declared field takes any
@@ -71,7 +75,7 @@ use crate::reader::{read_all, Atom, ReadError, SExpr, ScaledKind};
 use crate::types::{BslType, EnumRegistry, EnumTypeId, FieldDecl, FieldKind};
 use crate::vocabulary::{ClosedVocabulary, EnumKind, VocabularyError};
 use babylon_graph::substrate::{GraphError, GraphSubstrate, NodeId};
-use babylon_kernel::Ratio;
+use babylon_kernel::{Currency, Ratio};
 use std::collections::{HashMap, HashSet};
 
 /// Why a scenario would not load.
@@ -699,10 +703,11 @@ fn invert_content_ids(named: &HashMap<String, NodeId>) -> HashMap<NodeId, String
 /// into the rule — putting a magnitude in the file that owns the shape.
 ///
 /// Of the five literal atom classes §2.2 admits at `:default` plus §1.5's
-/// addendum, four are legal here — `Int`, `Scaled` (`p`/`i`/`c`/`r`), and
-/// `Bool` (defines carry toggles as well as magnitudes); `Currency` is
-/// refused exactly as `:default` refuses it (no i128 storage in slice 1).
-/// The literal-only rule holds for the same reason `:default`'s does: a
+/// addendum, all five are legal here — `Int`, `Scaled` (`p`/`i`/`c`/`r`),
+/// `Bool` (defines carry toggles as well as magnitudes), and — since T3
+/// #491/OQ-J — `Currency`, carried exactly as `:default` now carries it
+/// (`tick.rs::atom_to_value`). The literal-only rule holds for the same
+/// reason `:default`'s does: a
 /// define is a value, not an expression, and an expression would need an
 /// evaluation environment that does not exist at scenario-load time.
 ///
@@ -760,25 +765,19 @@ fn load_defconst(
             reject_stray_bounds(qname, floor_literal, cap_literal, "a Bool")?;
             Value::Bool(*value)
         }
-        // Refused, not carried. `tick.rs::atom_to_value` refuses a Currency
-        // `:default` and `attribute_value` above refuses a Currency
-        // attribute, both because slice 1 has no typed storage for i128
-        // micro-units. Accepting one HERE would make the same literal legal
-        // through one door and rejected through the others — the entry point
-        // deciding the type system, which is the drift the sibling refusals
-        // exist to prevent. Currency coefficients arrive with typed
-        // attribute storage once it lands — DEFERRED TO ITS FIRST CONSUMER
-        // (Director ruling, 2026-08-11 popup), not to a fixed phase
-        // boundary — not before.
-        Atom::Currency(_) => {
-            return Err(err(format!(
-                "defconst `{qname}`: a Currency coefficient needs typed \
-                 attribute storage — the Director ruled (2026-08-11) that \
-                 this lands with Currency's first real consumer — the \
-                 `:default` and node-attribute paths refuse one for the same \
-                 reason, and admitting it here alone would make the literal's \
-                 legality depend on which form it was written in"
-            )))
+        // Carried, not refused (T3 #491, OQ-J — Half 2 landed): Currency's
+        // typed storage exists now, `tick.rs::atom_to_value` carries a
+        // Currency `:default` and `attribute_value_currency` carries a
+        // Currency node attribute, both into `Value::Currency` — a
+        // `defconst` follows the same rule for the same reason every other
+        // literal kind here does: one literal, one legality, regardless of
+        // which door it enters by. `Value::Currency` needs no NEW carrier
+        // (`consts: &mut HashMap<String, Value>` already holds any `Value`
+        // variant); this is a pure environment lookup, never hashed graph
+        // state, so it touches no `CanonicalState` section.
+        Atom::Currency(c) => {
+            reject_stray_bounds(qname, floor_literal, cap_literal, "a Currency literal")?;
+            Value::Currency(*c)
         }
         other => {
             return Err(err(format!(
@@ -1258,20 +1257,33 @@ fn load_node(
                  (deffield {field} <type> <intensive|extensive>) form ABOVE this node"
             )));
         };
-        graph.update_node(
-            id,
-            field,
-            // `attribute_value`'s first parameter is the ELEMENT DESCRIPTOR,
-            // so the noun — quoting included — travels from the call site:
-            // the node path passes "node `…`" here, the edge-attr path
-            // passes "edge (… → …)", and the family's format strings name
-            // `{local}` BARE. Emitted text for this path is byte-identical
-            // to the pre-descriptor rendering, one wording apart: the
-            // unreachable defense-in-depth arm's "node attributes"
-            // generalizes to "attributes", correct for both element kinds
-            // (Train B item 3, #591).
-            attribute_value(value, &format!("node `{local}`"), field, decl, enums)?,
-        )?;
+        let descriptor = format!("node `{local}`");
+        // T3 #491, OQ-J: a `currency`-declared field routes to the i128
+        // lane — a SEPARATE trait method and a SEPARATE store map, never
+        // `update_node`'s f64 one. Every other declared type is unchanged
+        // (`attribute_value`'s own dispatch, below).
+        if matches!(decl.ty, BslType::Currency) {
+            graph.update_node_currency(
+                id,
+                field,
+                attribute_value_currency(value, &descriptor, field)?,
+            )?;
+        } else {
+            graph.update_node(
+                id,
+                field,
+                // `attribute_value`'s first parameter is the ELEMENT
+                // DESCRIPTOR, so the noun — quoting included — travels from
+                // the call site: the node path passes "node `…`" here, the
+                // edge-attr path passes "edge (… → …)", and the family's
+                // format strings name `{local}` BARE. Emitted text for this
+                // path is byte-identical to the pre-descriptor rendering,
+                // one wording apart: the unreachable defense-in-depth arm's
+                // "node attributes" generalizes to "attributes", correct
+                // for both element kinds (Train B item 3, #591).
+                attribute_value(value, &descriptor, field, decl, enums)?,
+            )?;
+        }
     }
     Ok(member.clone())
 }
@@ -1282,9 +1294,13 @@ fn load_node(
 /// literal into a `probability`/`intensity`/`coefficient`-declared field.
 ///
 /// The declaration is checked, not just consulted. A `120` written into a
-/// field declared `intensity` is out of that type's `[0, 1]` domain, and one
-/// written into a `currency` field would silently become an f64 where i128
-/// micro-units were promised — both are the store lying about what it holds.
+/// field declared `intensity` is out of that type's `[0, 1]` domain — the
+/// store lying about what it holds. A `currency`-declared field never
+/// reaches this function's `BslType::Currency` arm from the NODE path
+/// (`load_node` dispatches to [`attribute_value_currency`] before calling
+/// here, T3 #491/OQ-J); it is still reachable from the EDGE path
+/// ([`load_edge_attr`]), which this function refuses — there is no
+/// edge-scoped Currency lane in this train.
 ///
 /// **Half 1 needs no new typed storage.** `GraphSubstrate` attributes are
 /// already `f64` in and out (`rust/crates/babylon-graph/src/substrate.rs`);
@@ -1317,7 +1333,7 @@ fn attribute_value(
         BslType::Probability | BslType::Intensity | BslType::Coefficient => {
             attribute_value_unit_interval(atom, local, field, &decl.ty)
         }
-        BslType::Currency => Err(err(currency_refusal_message(local, field))),
+        BslType::Currency => Err(err(currency_edge_unsupported_message(local, field))),
         BslType::Enum(ty) => attribute_value_enum(atom, local, field, *ty, enums),
         // Defense in depth, not a reachable content error: `load_deffield`
         // is the SOLE populator of the `declared` map `attribute_value` is
@@ -1333,9 +1349,9 @@ fn attribute_value(
         other => Err(err(format!(
             "{local}: field `{field}` is declared {other:?}, and the scenario \
              loader stores only `int`, `real`, `probability`, `intensity`, `coefficient` or \
-             `enum`-declared attributes (currency is refused separately, deferred \
-             to typed storage's first consumer) — {other:?} has no representation as a \
-             GraphSubstrate f64 attribute at all"
+             `enum`-declared attributes through this function (currency is refused \
+             separately here, or routed to node-scoped typed storage by the caller) \
+             — {other:?} has no representation as a GraphSubstrate f64 attribute at all"
         ))),
     }
 }
@@ -1546,22 +1562,68 @@ fn attribute_value_unit_interval(
     Ok(value)
 }
 
-/// Currency's refusal, worded identically at every site it fires — the
-/// Half-2 typed-storage gap this train (Half 1) explicitly does not close.
+/// `currency`-declared fields (T3 #491, OQ-J — Half 2 of the
+/// typed-attribute-seeding design). Accepts ONLY a `$`-suffixed literal —
+/// `load_node`'s caller routes this to
+/// [`babylon_graph::substrate::GraphSubstrate::update_node_currency`], the
+/// i128 lane, never the ordinary f64 attribute map. No domain re-check is
+/// needed here: `$` literals are already lex-bound to `[0, ∞)`
+/// (`E-LEX-022` refuses a negative one at parse time,
+/// `docs/reference/bsl-language.rst` §1.5's Currency row) — the SAME
+/// guarantee `attribute_value_int`'s 2^53 comment leans on for `Int`,
+/// applied to a domain instead of a range. Anything else — an `Int`, a
+/// scaled `p`/`i`/`c`/`r` literal, an enum-ref — is refused, naming what
+/// was found: those literal lanes exist for the OTHER declared types, and
+/// admitting one here would let a `currency`-declared field silently widen
+/// a non-Currency literal into i128 micro-units, which is exactly the
+/// "entry point decides the type system" drift the sibling `attribute_value_*`
+/// functions all refuse.
+fn attribute_value_currency(
+    atom: &Atom,
+    local: &str,
+    field: &str,
+) -> Result<Currency, ScenarioError> {
+    match atom {
+        Atom::Currency(c) => Ok(*c),
+        other => Err(err(format!(
+            "{local} field `{field}`: a currency-declared field is seeded ONLY by a \
+             $-suffixed Currency literal, found {other:?}"
+        ))),
+    }
+}
+
+/// The KIND-MISMATCH refusal: a `$`-suffixed (Currency) literal written
+/// into a field NOT declared `currency` — worded identically at every site
+/// it fires (`attribute_value_int`/`_real`/`_unit_interval`).
 ///
-/// Wording note (typed-attribute-seeding train, 2026-08-11): earlier
-/// revisions of this message cited "a declared Phase-2 trait revision"
-/// pending on the Phase-1 exit checklist's own DEFERRED row. The Director's
-/// 2026-08-11 popup ruling supersedes that framing: Half 2 (Currency i128
-/// typed storage) is DEFERRED TO ITS FIRST CONSUMER — whichever port first
-/// needs a real Currency field — not to a fixed phase boundary, so the
-/// message cites the ruling directly rather than a phase number.
+/// Wording note (T3 #491, OQ-J — Half 2 landed): earlier revisions of this
+/// message said Currency attributes "need typed attribute storage" at all,
+/// because none existed. That storage now exists
+/// ([`babylon_graph::substrate::GraphSubstrate::update_node_currency`]), so
+/// the honest reason a `$` literal is refused HERE is narrower: this
+/// particular field is declared something else, and f64 cannot hold i128
+/// micro-units without lying about what it stores — never a lossy cast.
 fn currency_refusal_message(local: &str, field: &str) -> String {
     format!(
-        "{local} field `{field}`: Currency attributes need typed attribute \
-         storage — the Director ruled (2026-08-11) that this lands with Currency's \
-         first real consumer, not this train — f64 cannot hold i128 micro-units, and \
-         this refuses rather than casting lossily"
+        "{local} field `{field}`: a Currency ($-suffixed) literal needs a \
+         currency-declared field — this field is declared something else, \
+         and f64 cannot hold i128 micro-units without lying about what it \
+         stores, so this refuses rather than casting lossily"
+    )
+}
+
+/// The EDGE-SCOPE refusal: a field genuinely declared `currency`, targeted
+/// through the edge-attribute path (`load_edge_attr`) — Currency's typed
+/// storage is node-scoped ONLY in this train (T3 #491, OQ-J); there is no
+/// `update_edge_currency`. Distinct wording from
+/// [`currency_refusal_message`] on purpose: this is not a kind mismatch,
+/// it is a real, named scope gap.
+fn currency_edge_unsupported_message(local: &str, field: &str) -> String {
+    format!(
+        "{local} field `{field}`: currency-declared fields have typed storage \
+         for NODE attributes only (T3 #491, OQ-J) — there is no edge-scoped \
+         Currency lane, so this refuses rather than casting lossily into the \
+         f64 edge-attribute store"
     )
 }
 
@@ -1676,7 +1738,10 @@ fn load_edge(
 /// node field uses (`GraphSubstrate::update_edge`, the fifth-section store —
 /// the D143 `/strength` fork never engages because the strength guard below
 /// fires first). The value converts through [`attribute_value`], the crate's
-/// ONE per-type literal law — the Currency refusal included, unchanged.
+/// ONE per-type literal law — Currency is STILL refused here (T3 #491,
+/// OQ-J's typed storage is node-scoped only), now for a narrower, named
+/// reason ([`currency_edge_unsupported_message`]) rather than "no storage
+/// exists at all".
 ///
 /// The reading law is `load_edge`'s own, one form later in the file: the
 /// enum-ref demands `EdgeType` unconditionally, the declared vocabulary (if
@@ -1829,7 +1894,7 @@ mod tests {
     use babylon_graph::memory::MemoryGraph;
     use babylon_graph::state_hash::{CanonicalState, StateEncoder};
     use babylon_graph::substrate::{Direction, GraphSubstrate, NodeId};
-    use babylon_kernel::SessionId;
+    use babylon_kernel::{Currency, SessionId};
     use std::collections::{HashMap, HashSet};
 
     const TWO_CLASSES: &str = r"
@@ -2045,21 +2110,26 @@ mod tests {
     }
 
     #[test]
-    fn a_currency_attribute_is_refused_not_cast() {
-        // The known Phase-2 gap, stated at the boundary instead of silently
-        // truncating i128 micro-units into an f64.
+    fn a_currency_attribute_seeds_the_i128_lane_not_a_lossy_f64_cast() {
+        // T3 #491, OQ-J: the Phase-2 gap this test used to pin as a refusal
+        // is closed for node attributes — the literal routes through
+        // `GraphSubstrate::update_node_currency`, the i128 lane, never a
+        // truncating cast into f64.
         let source = r"
 (scenario ft/money
   (deffield social-class/wages currency extensive)
   (node core NodeType/SOCIAL_CLASS (social-class/wages 120$)))
 ";
         let mut graph = MemoryGraph::new();
-        let err = load_scenario(source, &mut graph).unwrap_err();
-        assert!(
-            err.message.contains("typed attribute storage"),
-            "{}",
-            err.message
+        load_scenario(source, &mut graph).unwrap();
+        assert_eq!(
+            graph.node_attribute_currency(NodeId(0), "social-class/wages"),
+            Ok(Currency::from_micro_units(120_000_000))
         );
+        // And the ordinary f64 lane never received a shadow row.
+        assert!(graph
+            .node_attribute(NodeId(0), "social-class/wages")
+            .is_err());
     }
 
     #[test]
@@ -2348,6 +2418,195 @@ mod tests {
     }
 
     #[test]
+    fn a_seeded_currency_literal_bit_matches_the_same_literal_written_by_a_rule() {
+        // T3 #491, OQ-J: extends the PR #505 bit-equality contract
+        // (`a_seeded_literal_bit_matches_the_same_literal_written_by_a_rule`,
+        // above) to the Currency lane — a seeded `$`-suffixed literal (the
+        // scenario-load path, `attribute_value_currency`) must bit-match
+        // the SAME literal written by a rule's `(update-node self …
+        // (set …))` (the runtime path, `tick.rs::atom_to_value` /
+        // `structural_verbs.rs::update_node_currency_op`), computed
+        // INDEPENDENTLY through two different code paths — not two
+        // numbers that merely happen to agree.
+        for literal in ["120$", "0.5$", "0$", "1000000$"] {
+            let source = format!(
+                "(scenario ft/currency-bit-equality\n  \
+                 (deffield social-class/seeded currency extensive)\n  \
+                 (deffield social-class/written currency extensive)\n  \
+                 (node core NodeType/SOCIAL_CLASS (social-class/seeded {literal})))"
+            );
+            let mut graph = MemoryGraph::new();
+            let loaded_scenario = load_scenario(&source, &mut graph).unwrap();
+
+            let types = TypeEnv {
+                fields: HashMap::from([
+                    (
+                        "social-class/seeded".to_owned(),
+                        FieldDecl {
+                            ty: BslType::Currency,
+                            kind: FieldKind::Extensive,
+                        },
+                    ),
+                    (
+                        "social-class/written".to_owned(),
+                        FieldDecl {
+                            ty: BslType::Currency,
+                            kind: FieldKind::Extensive,
+                        },
+                    ),
+                ]),
+                exemptions: &[],
+            };
+            let vocabulary = BindingVocabulary {
+                fields: types.fields.keys().cloned().collect(),
+                consts: HashSet::new(),
+                metrics: HashSet::new(),
+            };
+            let ceilings = CardinalityCeilings::new(
+                HashMap::from([("NodeType/SOCIAL_CLASS".to_owned(), 100)]),
+                HashMap::new(),
+            );
+            let intrinsics = IntrinsicCosts::default();
+            let systems = HashSet::from(["ft".to_owned()]);
+            let ctx = LoadContext {
+                vocabulary: &vocabulary,
+                types: &types,
+                ceilings: &ceilings,
+                intrinsics: &intrinsics,
+                systems: &systems,
+                vocabulary_registry: None,
+                rule_file: "ft/currency-bit-equality.bsl",
+            };
+            let rule = format!(
+                "(rule ft/currency-mirror\n  \
+                 :material-basis \"pins the Currency seed path and the Currency runtime \
+                 write path to the SAME i128 value, as one relation rather than two \
+                 independently-eyeballed numbers\"\n  \
+                 :fuel 64\n  \
+                 (bindings (binding seeded :field social-class/seeded))\n  \
+                 (when (>= seeded 0$))\n  \
+                 (effects (update-node self social-class/written (set {literal}))))"
+            );
+            let loaded =
+                load_rule(&rule, &ctx).unwrap_or_else(|e| panic!("{literal}: rule must load: {e}"));
+            let mut sink = CollectingSink::default();
+            let enums = EnumRegistry::default();
+            run_tick(
+                &loaded,
+                &types,
+                &enums,
+                &EmptyIntrinsicHost,
+                &mut graph,
+                &mut sink,
+                &intrinsics,
+                &DefinesEnv::new(),
+                1,
+                "ft/currency-mirror",
+                Some(&loaded_scenario.node_content_ids),
+                &SessionId::new("scenario-currency-bit-equality-test").expect("non-empty"),
+            )
+            .unwrap_or_else(|e| panic!("{literal}: tick must run: {e}"));
+
+            let seeded = graph
+                .node_attribute_currency(NodeId(0), "social-class/seeded")
+                .unwrap();
+            let written = graph
+                .node_attribute_currency(NodeId(0), "social-class/written")
+                .unwrap();
+            assert_eq!(
+                seeded, written,
+                "{literal}: seed path {seeded:?} != runtime path {written:?}"
+            );
+            assert_eq!(
+                seeded.micro_units(),
+                written.micro_units(),
+                "{literal}: micro-unit i128 values must match exactly, not just Eq"
+            );
+        }
+    }
+
+    #[test]
+    fn a_currency_free_scenario_encodes_byte_identically_to_before_this_train() {
+        // 3.1's second encoder leg: a scenario declaring no `currency` field
+        // at all must produce EXACTLY the same state hash it always has —
+        // no 0x06 tag, no byte moved — since the sixth section is elided
+        // when empty (D189). Proven at the scenario-load level, not just
+        // the raw `StateEncoder` level `state_hash.rs`'s own tests already
+        // cover, so a regression in `load_node`'s NEW branch (routing on
+        // `BslType::Currency`) would be caught here too.
+        let source = r"
+(scenario ft/no-currency
+  (deffield social-class/wages int extensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/wages 120)))
+";
+        let mut graph = MemoryGraph::new();
+        load_scenario(source, &mut graph).unwrap();
+        let bytes = graph.encode_state().unwrap();
+        // Hand-built expected encoding: one node, one int attribute, no
+        // edges, no hyperedges, no edge attributes, no currency attributes
+        // — sections 0x01/0x02 only, 0x03-0x06 all empty-but-present or
+        // elided per their own rules (0x03/0x04 unconditional per version
+        // 1; 0x05/0x06 elided when empty per version 2/3).
+        let mut manual = StateEncoder::new();
+        manual
+            .write_nodes(&[(NodeId(0), "SOCIAL_CLASS".to_owned())])
+            .unwrap();
+        manual
+            .write_attributes(&[(NodeId(0), "social-class/wages".to_owned(), 120.0)])
+            .unwrap();
+        manual.write_edges(&[]).unwrap();
+        manual.write_hyperedges(&[]).unwrap();
+        assert_eq!(
+            bytes.as_bytes(),
+            manual.as_bytes(),
+            "a Currency-free scenario must encode byte-identically to the pre-T3 shape — \
+             no 0x06 bytes at all"
+        );
+    }
+
+    #[test]
+    fn a_scenario_with_one_currency_attribute_grows_exactly_one_sixth_section() {
+        // 3.1's third encoder leg: a scenario declaring ONE currency field
+        // grows the encoding by exactly one 0x06 section, appended after
+        // whatever the Currency-free encoding already produced — proven as
+        // a byte-length/prefix relationship, not merely "the hash differs".
+        let bare_source = r"
+(scenario ft/bare
+  (deffield social-class/wages int extensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/wages 120)))
+";
+        let mut bare_graph = MemoryGraph::new();
+        load_scenario(bare_source, &mut bare_graph).unwrap();
+        let bare_bytes = bare_graph.encode_state().unwrap();
+
+        let currency_source = r"
+(scenario ft/with-currency
+  (deffield social-class/wages int extensive)
+  (deffield social-class/treasury currency extensive)
+  (node core NodeType/SOCIAL_CLASS (social-class/wages 120) (social-class/treasury 5$)))
+";
+        let mut currency_graph = MemoryGraph::new();
+        load_scenario(currency_source, &mut currency_graph).unwrap();
+        let currency_bytes = currency_graph.encode_state().unwrap();
+
+        assert!(
+            currency_bytes.as_bytes().starts_with(bare_bytes.as_bytes()),
+            "the four version-1 sections (plus the elided 0x05) are an untouched PREFIX"
+        );
+        let grown = &currency_bytes.as_bytes()[bare_bytes.as_bytes().len()..];
+        assert_eq!(
+            grown[0], 0x06,
+            "the grown suffix is exactly one 0x06 section"
+        );
+        assert_eq!(
+            currency_graph
+                .node_attribute_currency(NodeId(0), "social-class/treasury")
+                .unwrap(),
+            Currency::from_micro_units(5_000_000)
+        );
+    }
+
+    #[test]
     fn unit_interval_literal_acceptance_is_kind_blind_among_p_i_c() {
         // `store_range_check`'s own runtime predicate does not distinguish
         // Probability/Intensity/Coefficient from one another — `Value::Real`
@@ -2449,34 +2708,10 @@ mod tests {
     }
 
     #[test]
-    fn the_currency_refusal_cites_the_directors_defer_to_first_consumer_ruling() {
-        // Wording update (typed-attribute-seeding train, 2026-08-11): the
-        // refusal used to cite "a declared Phase-2 trait revision"; the
-        // Director's popup ruling supersedes that framing.
-        let source = r"
-(scenario ft/money-ruling
-  (deffield social-class/wages currency extensive)
-  (node core NodeType/SOCIAL_CLASS (social-class/wages 120$)))
-";
-        let mut graph = MemoryGraph::new();
-        let err = load_scenario(source, &mut graph).unwrap_err();
-        assert!(
-            err.message.contains("typed attribute storage"),
-            "{}",
-            err.message
-        );
-        assert!(
-            err.message.contains("first real consumer"),
-            "{}",
-            err.message
-        );
-        assert!(err.message.contains("2026-08-11"), "{}", err.message);
-    }
-
-    #[test]
     fn a_currency_literal_into_an_int_declared_field_is_refused() {
         // The OTHER Currency-refusal site: the field is legally declared
-        // `int`, but the literal itself is `$`-suffixed.
+        // `int`, but the literal itself is `$`-suffixed — a kind mismatch,
+        // not the "no storage at all" gap (T3 #491/OQ-J closed that one).
         let source = r"
 (scenario ft/currency-into-int
   (deffield social-class/wages int extensive)
@@ -2485,7 +2720,7 @@ mod tests {
         let mut graph = MemoryGraph::new();
         let err = load_scenario(source, &mut graph).unwrap_err();
         assert!(
-            err.message.contains("typed attribute storage"),
+            err.message.contains("needs a currency-declared field"),
             "{}",
             err.message
         );
@@ -2501,7 +2736,7 @@ mod tests {
         let mut graph = MemoryGraph::new();
         let err = load_scenario(source, &mut graph).unwrap_err();
         assert!(
-            err.message.contains("typed attribute storage"),
+            err.message.contains("needs a currency-declared field"),
             "{}",
             err.message
         );
@@ -2585,9 +2820,10 @@ mod tests {
 
     #[test]
     fn real_deffield_refuses_currency_and_bare_ident() {
-        // Currency: the same deferral every other arm states — f64 cannot
-        // hold i128 micro-units, and this refuses rather than casting
-        // lossily.
+        // Currency: a kind mismatch, not the retired "no storage at all"
+        // gap (T3 #491/OQ-J closed that one for currency-declared fields) —
+        // `real` is a different declared type, and f64 cannot hold i128
+        // micro-units without lying about what it stores.
         let source = r"
 (scenario ft/real-currency
   (deffield social-class/balance real intensive)
@@ -2596,7 +2832,7 @@ mod tests {
         let mut graph = MemoryGraph::new();
         let err = load_scenario(source, &mut graph).unwrap_err();
         assert!(
-            err.message.contains("typed attribute storage"),
+            err.message.contains("needs a currency-declared field"),
             "{}",
             err.message
         );
@@ -2918,22 +3154,37 @@ mod tests {
     }
 
     #[test]
-    fn a_currency_defconst_is_refused_exactly_as_a_currency_default_is() {
-        // One literal, one legality. `tick.rs::atom_to_value` refuses a
-        // Currency `:default` and `attribute_value` refuses a Currency
-        // attribute; a defconst that accepted one would make the form the
-        // literal was written in decide whether it typechecks.
+    fn a_currency_defconst_is_carried_exactly_as_a_currency_default_is() {
+        // T3 #491, OQ-J: one literal, one legality, now landed as ACCEPTANCE
+        // rather than refusal — `tick.rs::atom_to_value` carries a Currency
+        // `:default` into `Value::Currency`, and `load_defconst` now carries
+        // a Currency literal the same way, for the same "one form, one
+        // legality" reason the retired refusal test named.
         let source = r"
 (scenario ft/money-coefficient
   (defconst economy/floor-wage 15$))
 ";
         let mut graph = MemoryGraph::new();
-        let err = load_scenario(source, &mut graph).unwrap_err();
-        assert!(
-            err.message.contains("typed attribute storage"),
-            "{}",
-            err.message
+        let loaded = load_scenario(source, &mut graph).unwrap();
+        assert_eq!(
+            loaded.consts["economy/floor-wage"],
+            crate::evaluator::Value::Currency(Currency::from_micro_units(15_000_000))
         );
+    }
+
+    #[test]
+    fn a_currency_defconst_rejects_stray_floor_and_cap() {
+        // `:floor`/`:cap` are legal ONLY on a Ratio (`r`-suffixed) literal
+        // (#492/ADR194) — Currency joins Int/Bool's existing refusal here,
+        // the same `reject_stray_bounds` call every non-Ratio literal kind
+        // makes.
+        let source = r"
+(scenario ft/money-coefficient-bounded
+  (defconst economy/floor-wage 15$ :cap 20$))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert!(err.message.contains("Currency literal"), "{}", err.message);
     }
 
     #[test]
@@ -3697,8 +3948,9 @@ mod tests {
             err.message
         );
 
-        // 4. Currency — the typed-storage deferral every attribute_value
-        //    arm states, unchanged on the edge lane.
+        // 4. Currency — node-scoped typed storage now exists (T3 #491,
+        //    OQ-J), but there is still no edge-scoped Currency lane, so this
+        //    refusal survives with an UPDATED reason.
         let mut graph = MemoryGraph::new();
         let err = load_scenario(
             r"
@@ -3713,10 +3965,11 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            err.message.contains("typed attribute storage"),
+            err.message.contains("NODE attributes only"),
             "{}",
             err.message
         );
+        assert!(err.message.contains("no edge-scoped"), "{}", err.message);
     }
 
     #[test]

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -34,10 +34,22 @@
 //! absorbed** (the dossier's scope tension, recorded): nothing in this
 //! module enforces the edge-mode transition law, so no E-EVAL-030 can fire
 //! — the §6.2 chapter-C2 vector family's I.15 leg is unserved until the
-//! machine itself is chartered. Typed attribute storage (Currency i128
-//! exactness — the trait's `f64` attributes cannot hold it, so a
-//! Currency-typed write is a LOUD error, not a lossy cast) is the same
-//! declared gap it was on the node side.
+//! machine itself is chartered.
+//!
+//! **`update-node` against a `currency`-declared field writes the i128
+//! lane** (T3 #491, OQ-J — Half 2 of the typed-attribute-seeding design):
+//! [`EffectExecutor::update_node`]/[`EffectExecutor::collect_update_node`]/
+//! [`EffectExecutor::apply_pending_write`] each fork on the field's
+//! declared type BEFORE reaching [`EffectExecutor::numeric_write_value`]'s
+//! f64 lane, routing a `Value::Currency` through
+//! `GraphSubstrate::update_node_currency` instead — a SEPARATE store map,
+//! never a lossy cast. Only `set` is licensed on the Currency lane;
+//! `add`/`sub`/`scale` would need to pick which of Currency's five legal
+//! operators (§3.2) applies, which this train does not license (mirrors
+//! [`EffectExecutor::refuse_arithmetic_on_enum_field`]'s identical
+//! narrowness for `Enum<T>`). **`update-edge` against a `currency`-declared
+//! field is still refused** — there is no edge-scoped Currency lane in
+//! this train, the same declared gap it always was on that side.
 //!
 //! **Id operands are effect-list-scoped names** (draft ruling recorded in
 //! §2.8, implementation-discovered): `add-node`/`add-hyperedge`'s id
@@ -71,6 +83,7 @@ use crate::types::{BslType, EnumRegistry, EnumTypeId};
 use crate::vocabulary::ClosedVocabulary;
 use crate::write_log::{Write, WriteObserver, WriteRecord};
 use babylon_graph::substrate::{GraphError, GraphSubstrate, HyperedgeId, NodeId};
+use babylon_kernel::Currency;
 use std::collections::HashMap;
 
 /// Where `emit` lands (§2.8): an event sink the engine wires to the kernel
@@ -160,10 +173,26 @@ pub struct PendingWrite {
     pub field: String,
     /// Which of the four update-ops.
     pub op: UpdateOp,
-    /// The reduced operand — `set`'s final value, or the amount
-    /// `add`/`sub`/`scale` combine with the target's CURRENT value at apply
-    /// time.
-    pub operand: f64,
+    /// The reduced operand (T3 #491, OQ-J widened this from a bare `f64`):
+    /// `set`'s final value, or the amount `add`/`sub`/`scale` combine with
+    /// the target's CURRENT value at apply time, in EITHER the binary64
+    /// lane or the i128 Currency lane.
+    pub operand: WriteOperand,
+}
+
+/// The reduced operand a [`PendingWrite`] carries forward from collect to
+/// apply (T3 #491, OQ-J). One flat `Vec<PendingWrite>` batch still carries
+/// BOTH lanes in collection order — a Currency `set` sits in the identical
+/// position an f64 `set` would, so [`PendingWrite`]'s own documented
+/// ordering law is unaffected: this widens WHAT a write carries, never the
+/// sequence it carries in.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum WriteOperand {
+    /// The binary64 lane — every declared type except `currency`.
+    Real(f64),
+    /// The i128 lane — `currency`-declared node fields only, `set` only
+    /// (no read-modify-write; see [`EffectExecutor::update_node_currency_op`]).
+    Currency(Currency),
 }
 
 /// What a [`PendingWrite`] writes to (T3, ADR198 R3, issue #560). A sum
@@ -205,6 +234,35 @@ fn canonical_zero(v: f64) -> f64 {
     } else {
         v
     }
+}
+
+/// The `add`/`sub`/`scale` combine step [`EffectExecutor::apply_pending_write`]'s
+/// Node and Edge arms both perform, extracted here because the two arms
+/// were byte-identical apart from which verb name they cited (T3 #491,
+/// OQ-J pulled this out incidentally while keeping `apply_pending_write`
+/// under the ≤100-line bound, but the duplication removal stands on its
+/// own). Never called for `UpdateOp::Set` — the caller handles `set`
+/// before reaching here.
+fn combine_and_check_finite(
+    op: UpdateOp,
+    current: f64,
+    operand: f64,
+    field: &str,
+    verb: &str,
+) -> Result<f64, EvalError> {
+    let combined = match op {
+        UpdateOp::Add => current + operand,
+        UpdateOp::Sub => current - operand,
+        UpdateOp::Scale => current * operand,
+        UpdateOp::Set => unreachable!("Set is handled by the caller before combining"),
+    };
+    if !combined.is_finite() {
+        return Err(EvalError::coded(
+            EvalCode::NonFinite,
+            format!("{verb} on {field} produced a non-finite value"),
+        ));
+    }
+    Ok(combined)
 }
 
 /// Executes one rule's effect list against a substrate, carrying the
@@ -338,6 +396,20 @@ impl<'a> EffectExecutor<'a> {
         graph
             .edge_attribute(&key.edge_type, key.source, key.target, field)
             .ok()
+    }
+
+    /// The Currency-lane half of [`Self::probe_previous`] (T3 #491, OQ-J) —
+    /// same discipline through `node_attribute_currency`: a never-written
+    /// currency field records `None`, and this is still never called to
+    /// make a decision.
+    fn probe_previous_currency(
+        &self,
+        graph: &dyn GraphSubstrate,
+        id: NodeId,
+        field: &str,
+    ) -> Option<Currency> {
+        self.observer.as_ref()?;
+        graph.node_attribute_currency(id, field).ok()
     }
 
     /// Execute the items of an `(effects …)` form in source order (§2.8),
@@ -603,6 +675,16 @@ impl<'a> EffectExecutor<'a> {
             return Err(plain("update-op must be (add|sub|set|scale <expr>)"));
         };
         charge(fuel, cost::UPDATE_OP_BASE)?;
+        // T3 #491, OQ-J: a `currency`-declared field forks BEFORE
+        // `numeric_write_value`'s f64 lane — it never reaches that lane at
+        // all, the same "check the declared type first" shape §2.13's enum
+        // fork already models (`enum_write_value`).
+        if matches!(
+            self.types.fields.get(field).map(|decl| &decl.ty),
+            Some(BslType::Currency)
+        ) {
+            return self.update_node_currency_op(id, field, op, operand, env, host, graph, fuel);
+        }
         let operand_value =
             self.numeric_write_value(operand, env, host, fuel, field, "update-node")?;
         // `previous` is for the write log only. `set` does not otherwise read
@@ -643,6 +725,51 @@ impl<'a> EffectExecutor<'a> {
             field: field.clone(),
             previous,
             value: new_value,
+        });
+        Ok(())
+    }
+
+    /// The `currency`-declared field fork of [`Self::update_node`]'s
+    /// read-modify-write (T3 #491, OQ-J — Currency's i128 typed storage).
+    /// Only `set` is licensed: `add`/`sub`/`scale` over Currency would need
+    /// to pick which of Currency's five legal operators (`bsl-language.rst`
+    /// §3.2) applies, and nothing in this train's brief asks for that —
+    /// narrower is correct here, mirroring
+    /// [`Self::refuse_arithmetic_on_enum_field`]'s identical discipline for
+    /// `Enum<T>`. Shared by [`Self::update_node`] (this immediate-apply
+    /// call) and — via [`WriteOperand::Currency`] — the collect-then-apply
+    /// path's `set` case in [`Self::apply_pending_write`].
+    #[allow(clippy::too_many_arguments)]
+    fn update_node_currency_op(
+        &mut self,
+        id: NodeId,
+        field: &str,
+        op: &str,
+        operand: &SExpr,
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        graph: &mut dyn GraphSubstrate,
+        fuel: &mut u64,
+    ) -> Result<(), EvalError> {
+        if op != "set" {
+            return Err(plain(format!(
+                "update-node {field}: only `set` is licensed for a currency-declared \
+                 field — add/sub/scale would need to pick one of Currency's five legal \
+                 operators (§3.2), which this typed-storage train does not license"
+            )));
+        }
+        let value = evaluate(operand, env, host, fuel)?;
+        let currency = currency_write_value(value, field, "update-node")?;
+        store_range_check_currency(field, currency)?;
+        let previous = self.probe_previous_currency(&*graph, id, field);
+        graph
+            .update_node_currency(id, field, currency)
+            .map_err(from_graph)?;
+        self.record(Write::NodeCurrencyAttribute {
+            id,
+            field: field.to_owned(),
+            previous,
+            value: currency,
         });
         Ok(())
     }
@@ -916,6 +1043,31 @@ impl<'a> EffectExecutor<'a> {
             return Err(plain("update-op must be (add|sub|set|scale <expr>)"));
         };
         charge(fuel, cost::UPDATE_OP_BASE)?;
+        // T3 #491, OQ-J: the SAME collect-time fork `update_node`'s own
+        // immediate-apply path takes, before `numeric_write_value`'s f64
+        // lane. The domain check (`store_range_check_currency`) is
+        // deliberately deferred to `apply_pending_write`, exactly as the
+        // f64 lane's own `store_range_check` is — one check point, not two.
+        if matches!(
+            self.types.fields.get(field).map(|decl| &decl.ty),
+            Some(BslType::Currency)
+        ) {
+            if op != "set" {
+                return Err(plain(format!(
+                    "update-node {field}: only `set` is licensed for a currency-declared \
+                     field — add/sub/scale would need to pick one of Currency's five legal \
+                     operators (§3.2), which this typed-storage train does not license"
+                )));
+            }
+            let value = evaluate(operand, env, host, fuel)?;
+            let currency = currency_write_value(value, field, "update-node")?;
+            return Ok(PendingWrite {
+                target: WriteTarget::Node(id),
+                field: field.clone(),
+                op: UpdateOp::Set,
+                operand: WriteOperand::Currency(currency),
+            });
+        }
         let operand_value =
             self.numeric_write_value(operand, env, host, fuel, field, "update-node")?;
         let update_op = match op.as_str() {
@@ -942,7 +1094,7 @@ impl<'a> EffectExecutor<'a> {
             target: WriteTarget::Node(id),
             field: field.clone(),
             op: update_op,
-            operand: operand_value,
+            operand: WriteOperand::Real(operand_value),
         })
     }
 
@@ -1004,8 +1156,44 @@ impl<'a> EffectExecutor<'a> {
             target: WriteTarget::Edge(key),
             field: field.clone(),
             op: update_op,
-            operand: operand_value,
+            operand: WriteOperand::Real(operand_value),
         })
+    }
+
+    /// The Currency-lane half of [`Self::apply_pending_write`]'s Node arm
+    /// (T3 #491, OQ-J), extracted so that function stays under the
+    /// ≤100-line bound (Power-of-10 rule 3). Only `UpdateOp::Set` is
+    /// legitimate here — `collect_update_node`'s own fork already refuses
+    /// `add`/`sub`/`scale` for a currency-declared field, so `op` arriving
+    /// as anything else is a collect/apply wiring bug, named rather than
+    /// panicked.
+    fn apply_pending_currency_write(
+        &mut self,
+        id: NodeId,
+        field: &str,
+        op: UpdateOp,
+        currency: Currency,
+        graph: &mut dyn GraphSubstrate,
+    ) -> Result<(), EvalError> {
+        if op != UpdateOp::Set {
+            return Err(plain(format!(
+                "update-node {field}: a Currency operand reached apply with a non-Set \
+                 op — collect_update_node should have refused this already (wiring bug \
+                 between collect and apply, not content)"
+            )));
+        }
+        let previous = self.probe_previous_currency(&*graph, id, field);
+        store_range_check_currency(field, currency)?;
+        graph
+            .update_node_currency(id, field, currency)
+            .map_err(from_graph)?;
+        self.record(Write::NodeCurrencyAttribute {
+            id,
+            field: field.to_owned(),
+            previous,
+            value: currency,
+        });
+        Ok(())
     }
 
     /// APPLY phase (Task 12): perform ONE collected write against the LIVE
@@ -1031,31 +1219,35 @@ impl<'a> EffectExecutor<'a> {
     ) -> Result<(), EvalError> {
         match &write.target {
             WriteTarget::Node(id) => {
+                // T3 #491, OQ-J: the Currency lane forks first, extracted
+                // to its own method to keep this function under the
+                // ≤100-line bound (Power-of-10 rule 3).
+                if let WriteOperand::Currency(currency) = write.operand {
+                    return self.apply_pending_currency_write(
+                        *id,
+                        &write.field,
+                        write.op,
+                        currency,
+                        graph,
+                    );
+                }
+                let WriteOperand::Real(operand) = write.operand else {
+                    unreachable!("the Currency arm above returns before reaching here");
+                };
                 let (new_value, previous) = match write.op {
-                    UpdateOp::Set => (
-                        write.operand,
-                        self.probe_previous(&*graph, *id, &write.field),
-                    ),
+                    UpdateOp::Set => (operand, self.probe_previous(&*graph, *id, &write.field)),
                     UpdateOp::Add | UpdateOp::Sub | UpdateOp::Scale => {
                         self.refuse_arithmetic_on_enum_field(&write.field, "update-node")?;
                         let current = graph
                             .node_attribute(*id, &write.field)
                             .map_err(from_graph)?;
-                        let combined = match write.op {
-                            UpdateOp::Add => current + write.operand,
-                            UpdateOp::Sub => current - write.operand,
-                            UpdateOp::Scale => current * write.operand,
-                            UpdateOp::Set => unreachable!("Set is handled in the arm above"),
-                        };
-                        if !combined.is_finite() {
-                            return Err(EvalError::coded(
-                                EvalCode::NonFinite,
-                                format!(
-                                    "update-node on {} produced a non-finite value",
-                                    write.field
-                                ),
-                            ));
-                        }
+                        let combined = combine_and_check_finite(
+                            write.op,
+                            current,
+                            operand,
+                            &write.field,
+                            "update-node",
+                        )?;
                         (combined, Some(current))
                     }
                 };
@@ -1073,9 +1265,21 @@ impl<'a> EffectExecutor<'a> {
                 Ok(())
             }
             WriteTarget::Edge(key) => {
+                // There is no edge-scoped Currency lane (T3 #491, OQ-J) —
+                // `collect_update_edge` never produces `WriteOperand::Currency`,
+                // so reaching one here would be the same collect/apply
+                // wiring-bug shape the node arm names above.
+                let WriteOperand::Real(operand) = write.operand else {
+                    return Err(plain(format!(
+                        "update-edge {}: a Currency operand reached apply — there is no \
+                         edge-scoped Currency lane; collect_update_edge should never have \
+                         produced this (wiring bug, not content)",
+                        write.field
+                    )));
+                };
                 let (new_value, previous) = match write.op {
                     UpdateOp::Set => (
-                        write.operand,
+                        operand,
                         self.probe_previous_edge(&*graph, key, &write.field),
                     ),
                     UpdateOp::Add | UpdateOp::Sub | UpdateOp::Scale => {
@@ -1083,21 +1287,13 @@ impl<'a> EffectExecutor<'a> {
                         let current = graph
                             .edge_attribute(&key.edge_type, key.source, key.target, &write.field)
                             .map_err(from_graph)?;
-                        let combined = match write.op {
-                            UpdateOp::Add => current + write.operand,
-                            UpdateOp::Sub => current - write.operand,
-                            UpdateOp::Scale => current * write.operand,
-                            UpdateOp::Set => unreachable!("Set is handled in the arm above"),
-                        };
-                        if !combined.is_finite() {
-                            return Err(EvalError::coded(
-                                EvalCode::NonFinite,
-                                format!(
-                                    "update-edge on {} produced a non-finite value",
-                                    write.field
-                                ),
-                            ));
-                        }
+                        let combined = combine_and_check_finite(
+                            write.op,
+                            current,
+                            operand,
+                            &write.field,
+                            "update-edge",
+                        )?;
                         (combined, Some(current))
                     }
                 };
@@ -1542,11 +1738,14 @@ impl<'a> EffectExecutor<'a> {
     }
 
     /// Evaluate a value that will be WRITTEN to `field`, in the binary64
-    /// lane the trait's attribute storage carries. A Currency-typed value
-    /// is a loud declared gap (i128 exactness does not survive an f64
-    /// attribute), never a lossy cast — typed Currency storage is DEFERRED
-    /// TO ITS FIRST CONSUMER (Director ruling, 2026-08-11 popup), not to a
-    /// fixed phase boundary.
+    /// lane the trait's attribute storage carries. **A `currency`-declared
+    /// `field` never reaches this function at all (T3 #491, OQ-J)** — every
+    /// caller forks to the i128 lane before calling here (`update_node`'s
+    /// and `update_edge`'s own callers check `self.types.fields.get(field)`
+    /// first), so a `Value::Currency` reaching the match below means the
+    /// field is declared something ELSE: a kind mismatch, not "no Currency
+    /// storage exists" — i128 exactness does not survive an f64 attribute
+    /// regardless, so this still refuses rather than casting lossily.
     ///
     /// **§2.13 addendum (D101).** When `field` is declared `BslType::Enum`
     /// (`self.types`), the write funnels through [`Self::enum_write_value`]
@@ -1559,7 +1758,11 @@ impl<'a> EffectExecutor<'a> {
     ///
     /// `verb` names the calling form (`update-node`, `update-edge`,
     /// `add-node`/`add-edge` field-init) for diagnostics only — the write
-    /// law is identical on both target kinds (T3, ADR198 R3).
+    /// law is identical on both target kinds (T3, ADR198 R3). **`update-edge`
+    /// still reaches the `Value::Currency` arm below unconditionally** —
+    /// there is no edge-scoped Currency fork, so an edge write against a
+    /// `currency`-declared field is refused here regardless of the field's
+    /// declared type.
     fn numeric_write_value(
         &self,
         expr: &SExpr,
@@ -1591,10 +1794,9 @@ impl<'a> EffectExecutor<'a> {
             #[allow(clippy::cast_precision_loss)]
             Value::Int(n) => Ok(n as f64),
             Value::Currency(_) => Err(plain(format!(
-                "writing a Currency value to {field} needs typed attribute \
-                 storage — the Director ruled (2026-08-11) that this lands \
-                 with Currency's first real consumer — refusing the lossy \
-                 f64 cast"
+                "writing a Currency value to {field} needs a currency-declared field \
+                 (T3 #491, OQ-J's i128 typed storage is node-scoped and type-gated) \
+                 — refusing the lossy f64 cast rather than truncating i128 micro-units"
             ))),
             other => Err(plain(format!(
                 "cannot store {other:?} as a numeric attribute for {field} ({verb})"
@@ -1712,6 +1914,44 @@ impl<'a> EffectExecutor<'a> {
         }
         Ok(())
     }
+}
+
+/// The Currency-lane half of write-value evaluation (T3 #491, OQ-J) — the
+/// free-function counterpart of [`EffectExecutor::numeric_write_value`] for
+/// a `currency`-declared field's `set` operand (an associated function, not
+/// a method: it consults no `EffectExecutor` state). Accepts ONLY
+/// `Value::Currency`; anything else is refused, naming what was found — the
+/// same "the entry point never decides the type system" discipline the
+/// sibling `*_write_value` functions hold.
+fn currency_write_value(value: Value, field: &str, verb: &str) -> Result<Currency, EvalError> {
+    match value {
+        Value::Currency(c) => Ok(c),
+        other => Err(plain(format!(
+            "{verb} {field}: a currency-declared field is written ONLY a Currency \
+             value — found {other:?}"
+        ))),
+    }
+}
+
+/// The Currency-lane counterpart of [`EffectExecutor::store_range_check`]
+/// (a free function for the same "consults no executor state" reason
+/// [`currency_write_value`] is one): the BSL spec's own declared domain for
+/// the type is `[0, ∞)` (`bsl-language.rst` §1.5's Currency row) — enforced
+/// HERE at the store boundary because a `$`-suffixed LITERAL is already
+/// lex-bound non-negative (`E-LEX-022`), but a rule-COMPUTED
+/// `Value::Currency` (e.g. a subtraction) is not checked anywhere upstream
+/// of this write.
+fn store_range_check_currency(field: &str, value: Currency) -> Result<(), EvalError> {
+    if value.micro_units() < 0 {
+        return Err(EvalError::coded(
+            EvalCode::StoreRangeViolation,
+            format!(
+                "storing a negative Currency value to {field} leaves its declared \
+                 [0, ∞) domain (bsl-language.rst §1.5) — a loud failure, never a clamp"
+            ),
+        ));
+    }
+    Ok(())
 }
 
 /// The six graph-shape verbs Task 12's collect-then-apply pre-state split
@@ -2432,7 +2672,10 @@ mod tests {
     }
 
     #[test]
-    fn currency_writes_are_a_loud_declared_gap_never_a_lossy_cast() {
+    fn currency_writes_into_a_non_currency_field_are_refused_not_cast() {
+        // T3 #491, OQ-J: `social-class/head-count` is Int-declared (see
+        // `types()` above) — a kind mismatch, not the retired "no Currency
+        // storage exists at all" gap.
         let mut fixture = Fixture::new();
         let mut fuel = 64;
         let err = fixture
@@ -2441,8 +2684,10 @@ mod tests {
                 &mut fuel,
             )
             .unwrap_err();
-        assert!(err.message.contains("typed attribute storage"), "{err}");
-        assert!(err.message.contains("first real consumer"), "{err}");
+        assert!(
+            err.message.contains("needs a currency-declared field"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -2670,7 +2915,7 @@ mod tests {
             target: WriteTarget::Node(id),
             field: "social-class/agitation".to_owned(),
             op: UpdateOp::Scale,
-            operand: -1.0,
+            operand: WriteOperand::Real(-1.0),
         };
         let types = types();
         let enums = enums();
@@ -2694,7 +2939,7 @@ mod tests {
             }),
             field: "solidarity/tension".to_owned(),
             op: UpdateOp::Scale,
-            operand: -1.0,
+            operand: WriteOperand::Real(-1.0),
         };
         let types = edge_types();
         let enums = enums();
@@ -3736,7 +3981,7 @@ mod tests {
             target: WriteTarget::Node(id),
             field: "organization/kind".to_owned(),
             op: UpdateOp::Add,
-            operand: 1.0,
+            operand: WriteOperand::Real(1.0),
         };
         let mut applier = EffectExecutor::new(&types, &enums, None);
         let err = applier.apply_pending_write(&write, &mut graph).unwrap_err();
@@ -4351,7 +4596,7 @@ mod tests {
             }),
             field: "solidarity/mode".to_owned(),
             op: UpdateOp::Add,
-            operand: 1.0,
+            operand: WriteOperand::Real(1.0),
         };
         let mut applier = EffectExecutor::new(&types, &enums, None);
         let err = applier.apply_pending_write(&write, &mut graph).unwrap_err();

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -38,16 +38,15 @@
 //!
 //! **`update-node` against a `currency`-declared field writes the i128
 //! lane** (T3 #491, OQ-J — Half 2 of the typed-attribute-seeding design):
-//! [`EffectExecutor::update_node`]/[`EffectExecutor::collect_update_node`]/
-//! [`EffectExecutor::apply_pending_write`] each fork on the field's
-//! declared type BEFORE reaching [`EffectExecutor::numeric_write_value`]'s
-//! f64 lane, routing a `Value::Currency` through
+//! `update_node`/`collect_update_node`/[`EffectExecutor::apply_pending_write`]
+//! each fork on the field's declared type BEFORE reaching
+//! `numeric_write_value`'s f64 lane, routing a `Value::Currency` through
 //! `GraphSubstrate::update_node_currency` instead — a SEPARATE store map,
 //! never a lossy cast. Only `set` is licensed on the Currency lane;
 //! `add`/`sub`/`scale` would need to pick which of Currency's five legal
 //! operators (§3.2) applies, which this train does not license (mirrors
-//! [`EffectExecutor::refuse_arithmetic_on_enum_field`]'s identical
-//! narrowness for `Enum<T>`). **`update-edge` against a `currency`-declared
+//! `refuse_arithmetic_on_enum_field`'s identical narrowness for `Enum<T>`).
+//! **`update-edge` against a `currency`-declared
 //! field is still refused** — there is no edge-scoped Currency lane in
 //! this train, the same declared gap it always was on that side.
 //!
@@ -191,7 +190,7 @@ pub enum WriteOperand {
     /// The binary64 lane — every declared type except `currency`.
     Real(f64),
     /// The i128 lane — `currency`-declared node fields only, `set` only
-    /// (no read-modify-write; see [`EffectExecutor::update_node_currency_op`]).
+    /// (no read-modify-write; see `update_node_currency_op`).
     Currency(Currency),
 }
 
@@ -1738,14 +1737,23 @@ impl<'a> EffectExecutor<'a> {
     }
 
     /// Evaluate a value that will be WRITTEN to `field`, in the binary64
-    /// lane the trait's attribute storage carries. **A `currency`-declared
-    /// `field` never reaches this function at all (T3 #491, OQ-J)** — every
-    /// caller forks to the i128 lane before calling here (`update_node`'s
-    /// and `update_edge`'s own callers check `self.types.fields.get(field)`
-    /// first), so a `Value::Currency` reaching the match below means the
-    /// field is declared something ELSE: a kind mismatch, not "no Currency
-    /// storage exists" — i128 exactness does not survive an f64 attribute
-    /// regardless, so this still refuses rather than casting lossily.
+    /// lane the trait's attribute storage carries. **`update_node`'s OWN
+    /// call site forks to the i128 lane before calling here (T3 #491,
+    /// OQ-J)** — a `currency`-declared field reaching THIS function via
+    /// `update-node` is therefore impossible. Three OTHER call sites carry
+    /// no such fork and still reach the `Value::Currency` arm below
+    /// unconditionally: `update-edge`/`collect_update_edge` (no edge-scoped
+    /// Currency lane exists) and the `add-node`/`add-edge` field-init tails
+    /// (field-init never routes through the typed lane, even for a
+    /// node-scoped field). The match below therefore distinguishes the two
+    /// REASONS a `Value::Currency` can arrive: `field` declared something
+    /// else entirely (a genuine kind mismatch), or `field` genuinely
+    /// declared `currency` but reached via one of those three paths (a
+    /// real, named scope gap — not a kind mismatch, and not "no Currency
+    /// storage exists" the way it was before T3 landed the node-scoped
+    /// lane). Either way this refuses rather than casting lossily — i128
+    /// exactness does not survive an f64 attribute regardless of the
+    /// reason.
     ///
     /// **§2.13 addendum (D101).** When `field` is declared `BslType::Enum`
     /// (`self.types`), the write funnels through [`Self::enum_write_value`]
@@ -1758,11 +1766,7 @@ impl<'a> EffectExecutor<'a> {
     ///
     /// `verb` names the calling form (`update-node`, `update-edge`,
     /// `add-node`/`add-edge` field-init) for diagnostics only — the write
-    /// law is identical on both target kinds (T3, ADR198 R3). **`update-edge`
-    /// still reaches the `Value::Currency` arm below unconditionally** —
-    /// there is no edge-scoped Currency fork, so an edge write against a
-    /// `currency`-declared field is refused here regardless of the field's
-    /// declared type.
+    /// law is identical on both target kinds (T3, ADR198 R3).
     fn numeric_write_value(
         &self,
         expr: &SExpr,
@@ -1793,10 +1797,31 @@ impl<'a> EffectExecutor<'a> {
             // the typed-attribute-storage gap named in the module doc.
             #[allow(clippy::cast_precision_loss)]
             Value::Int(n) => Ok(n as f64),
+            // L-3 (#491 T3 review): two DIFFERENT reasons, two DIFFERENT
+            // messages — a field genuinely declared `currency` reaching
+            // here (via `update-edge` or an `add-node`/`add-edge`
+            // field-init, none of which fork to the typed lane) is not a
+            // kind mismatch, and telling its author "needs a
+            // currency-declared field" when it already IS one would be
+            // false.
+            Value::Currency(_)
+                if matches!(
+                    self.types.fields.get(field).map(|decl| &decl.ty),
+                    Some(BslType::Currency)
+                ) =>
+            {
+                Err(plain(format!(
+                    "{verb} {field}: currency-declared fields have typed i128 storage for \
+                     `update-node`'s runtime `set` write ONLY (T3 #491, OQ-J) — {verb} does not \
+                     route through that lane, so this refuses rather than casting lossily into \
+                     the f64 attribute store"
+                )))
+            }
             Value::Currency(_) => Err(plain(format!(
                 "writing a Currency value to {field} needs a currency-declared field \
-                 (T3 #491, OQ-J's i128 typed storage is node-scoped and type-gated) \
-                 — refusing the lossy f64 cast rather than truncating i128 micro-units"
+                 — this field is declared something else, and f64 cannot hold i128 \
+                 micro-units without lying about what it stores, so this refuses rather \
+                 than casting lossily"
             ))),
             other => Err(plain(format!(
                 "cannot store {other:?} as a numeric attribute for {field} ({verb})"
@@ -4493,6 +4518,101 @@ mod tests {
                 .edge_attribute("SOLIDARITY", a, b, "solidarity/tension")
                 .is_err(),
             "the refused write must not have landed"
+        );
+    }
+
+    /// L-3 (#491 T3 review): `numeric_write_value`'s Currency refusal for a
+    /// field that IS genuinely `currency`-declared, reached through the
+    /// three paths with no typed-lane fork — `update-edge` here, and the
+    /// two field-init tails below. The message must say the field has no
+    /// route to the typed lane THROUGH THIS FORM, never "needs a
+    /// currency-declared field" (which would be false — it already is one).
+    #[test]
+    fn update_edge_against_a_currency_declared_field_names_the_scope_gap_not_a_kind_mismatch() {
+        let (mut graph, a, b) = edge_fixture();
+        let types = TypeEnv {
+            fields: HashMap::from([(
+                "solidarity/subsidy".to_owned(),
+                FieldDecl {
+                    ty: BslType::Currency,
+                    kind: FieldKind::Extensive,
+                },
+            )]),
+            exemptions: &[],
+        };
+        let enums = enums();
+        let mut fuel = 128;
+        let err = collect_then_apply(
+            &mut graph,
+            &types,
+            &enums,
+            edge_binding(a, b),
+            "(effects (update-edge e solidarity/subsidy (set 5$)))",
+            &mut fuel,
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("update-node")
+                && err.message.contains("set")
+                && err.message.contains("update-edge"),
+            "{err}"
+        );
+        assert!(
+            !err.message.contains("needs a currency-declared field"),
+            "the field IS declared currency — this framing would be false: {err}"
+        );
+    }
+
+    /// The `add-node` field-init half of the same L-3 fix: a node-scoped
+    /// `currency`-declared field STILL cannot be seeded via a field-init
+    /// (only `update-node`'s runtime `set` reaches the typed lane) — a real,
+    /// named scope gap, not a kind mismatch.
+    #[test]
+    fn add_node_field_init_against_a_currency_declared_field_names_the_scope_gap() {
+        let mut graph = MemoryGraph::new();
+        let types = TypeEnv {
+            fields: HashMap::from([(
+                "social-class/treasury".to_owned(),
+                FieldDecl {
+                    ty: BslType::Currency,
+                    kind: FieldKind::Extensive,
+                },
+            )]),
+            exemptions: &[],
+        };
+        let enums = enums();
+        let mut executor = EffectExecutor::new(&types, &enums, None);
+        let env = EvalEnv {
+            bindings: HashMap::new(),
+            intrinsic_costs: &IntrinsicCosts::default(),
+            graph: None,
+            types: None,
+            enums: None,
+            elements: Vec::new(),
+            draw_context: None,
+        };
+        let (form, _) =
+            read("(effects (add-node NodeType/SOCIAL_CLASS n (social-class/treasury 5$)))")
+                .expect("effects source must parse");
+        let SExpr::List(items) = form else {
+            unreachable!()
+        };
+        let mut sink = CollectingSink::default();
+        let mut fuel = 128;
+        let err = executor
+            .execute_effects(
+                &items[1..],
+                &env,
+                &EmptyIntrinsicHost,
+                &mut graph,
+                &mut sink,
+                &mut fuel,
+            )
+            .unwrap_err();
+        assert!(err.message.contains("add-node"), "{err}");
+        assert!(
+            !err.message.contains("needs a currency-declared field"),
+            "the field IS declared currency — this framing would be false: {err}"
         );
     }
 

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -322,7 +322,8 @@ fn field_default_or_err(
     };
     atom_to_value(default).ok_or_else(|| {
         err(format!(
-            "binding `{}` has a :default that is not a numeric literal",
+            "binding `{}` has a :default that is not a recognized literal \
+             (numeric, boolean, or currency)",
             binding.name
         ))
     })

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -282,23 +282,50 @@ fn bind_subject(
                 )))
             }
         };
-        let value = match graph.node_attribute(subject, qname) {
-            Ok(value) => bind_field_value(qname, value, types, enums)?,
-            Err(graph_err) => {
-                let Some(default) = binding.default.as_ref().filter(|_| binding.optional) else {
-                    return Err(err(format!("subject {subject:?}: {}", graph_err.message)));
-                };
-                atom_to_value(default).ok_or_else(|| {
-                    err(format!(
-                        "binding `{}` has a :default that is not a numeric literal",
-                        binding.name
-                    ))
-                })?
+        // T3 #491, OQ-J: a `currency`-declared field lives in the substrate's
+        // SEPARATE i128 map — `node_attribute`'s f64 lane never holds it, so
+        // the field's declared type must be consulted BEFORE choosing which
+        // read method to call, not after. Every other declared type is
+        // unchanged: still `node_attribute` + `bind_field_value`.
+        let value = if matches!(
+            types.fields.get(qname).map(|decl| &decl.ty),
+            Some(BslType::Currency)
+        ) {
+            match graph.node_attribute_currency(subject, qname) {
+                Ok(currency) => Value::Currency(currency),
+                Err(graph_err) => field_default_or_err(binding, subject, &graph_err)?,
+            }
+        } else {
+            match graph.node_attribute(subject, qname) {
+                Ok(value) => bind_field_value(qname, value, types, enums)?,
+                Err(graph_err) => field_default_or_err(binding, subject, &graph_err)?,
             }
         };
         env.insert(binding.name.clone(), value);
     }
     Ok(env)
+}
+
+/// The shared "unwritten field" fallback both branches of the `:field`
+/// bind-source arm above use: an `:optional` binding with no stored value
+/// falls back to its declared `:default`; a required one that was never
+/// written propagates the substrate's loud error (III.11 — absence is not
+/// zero). Extracted (T3 #491, OQ-J) so the Currency-lane fork and the f64
+/// fork share ONE copy of this fallback rather than two that could drift.
+fn field_default_or_err(
+    binding: &BindingDecl,
+    subject: NodeId,
+    graph_err: &babylon_graph::substrate::GraphError,
+) -> Result<Value, TickError> {
+    let Some(default) = binding.default.as_ref().filter(|_| binding.optional) else {
+        return Err(err(format!("subject {subject:?}: {}", graph_err.message)));
+    };
+    atom_to_value(default).ok_or_else(|| {
+        err(format!(
+            "binding `{}` has a :default that is not a numeric literal",
+            binding.name
+        ))
+    })
 }
 
 /// **§2.13 addendum (D101).** Render one stored field value through its
@@ -403,6 +430,13 @@ fn atom_to_value(atom: &Atom) -> Option<Value> {
             ))
         }
         Atom::Bool(value) => Some(Value::Bool(*value)),
+        // T3 #491, OQ-J: Half 2 landed — a Currency `:default` literal now
+        // carries into `Value::Currency`, the SAME "open the door" this
+        // train opened at `scenario.rs::load_defconst`'s identical arm and
+        // `scenario.rs::attribute_value_currency`'s node-attribute lane, so
+        // the literal's legality does not depend on which of the three
+        // doors it entered by.
+        Atom::Currency(c) => Some(Value::Currency(*c)),
         _ => None,
     }
 }

--- a/rust/crates/babylon-bsl/src/write_log.rs
+++ b/rust/crates/babylon-bsl/src/write_log.rs
@@ -31,6 +31,7 @@
 //!    violated, and a determinism divergence with it.
 
 use babylon_graph::substrate::{HyperedgeId, NodeId};
+use babylon_kernel::Currency;
 
 /// One mutation, as it crossed the store boundary.
 ///
@@ -62,6 +63,24 @@ pub enum Write {
         previous: Option<f64>,
         /// The value now stored.
         value: f64,
+    },
+    /// A Currency field write — from `update-node` against a
+    /// `currency`-declared field (T3 #491, OQ-J: the i128 typed-storage
+    /// lane). `set` only — Currency has no read-modify-write here (see
+    /// `structural_verbs::EffectExecutor`'s currency write fork), so unlike
+    /// [`Self::NodeAttribute`] this variant never represents an `add`/`sub`/
+    /// `scale` combine.
+    NodeCurrencyAttribute {
+        /// The node written to.
+        id: NodeId,
+        /// The fully-qualified field name.
+        field: String,
+        /// The value the field held before this write, or `None` where it
+        /// held nothing (the same discipline 3 probe, through
+        /// [`babylon_graph::substrate::GraphSubstrate::node_attribute_currency`]).
+        previous: Option<Currency>,
+        /// The value now stored.
+        value: Currency,
     },
     /// A field write on a dyadic edge — from `update-edge`, or from an
     /// `add-edge` field-init (T3, ADR198 R1/R3, issue #560). A write to

--- a/rust/crates/babylon-graph/src/conformance.rs
+++ b/rust/crates/babylon-graph/src/conformance.rs
@@ -19,6 +19,7 @@
 
 use crate::state_hash::CanonicalState;
 use crate::substrate::{Direction, GraphSubstrate, NodeId};
+use babylon_kernel::Currency;
 
 /// Run every invariant in this module against a fresh store from `make`.
 ///
@@ -51,6 +52,7 @@ where
     update_edge_on_a_missing_edge_is_loud_and_stores_nothing(&make);
     update_edge_against_strength_writes_the_existing_slot_never_a_fifth_section_row(&make);
     edge_removal_takes_the_edges_attributes_and_never_resurrects_them(&make);
+    currency_attribute_round_trips_moves_the_hash_and_cascades_on_removal(&make);
 }
 
 /// ADR185 R2: removing a node takes its incident dyadic edges, its
@@ -177,6 +179,20 @@ where
     );
     graph.update_node(node, "wealth", 42.0).unwrap();
     assert_eq!(graph.node_attribute(node, "wealth"), Ok(42.0));
+
+    // The Currency lane holds the SAME honest-null discipline (T3 #491,
+    // OQ-J) — a second, PARALLEL map, never the one above.
+    assert!(
+        graph.node_attribute_currency(node, "wages").is_err(),
+        "an unwritten Currency attribute must error, never read as 0"
+    );
+    graph
+        .update_node_currency(node, "wages", Currency::from_micro_units(120_000_000))
+        .unwrap();
+    assert_eq!(
+        graph.node_attribute_currency(node, "wages"),
+        Ok(Currency::from_micro_units(120_000_000))
+    );
 }
 
 /// Amendment D / BSL D25: declared member order is never observable —
@@ -862,6 +878,56 @@ where
     assert!(
         graph.all_edge_attributes().is_empty(),
         "the remove_node cascade takes incident edges' attribute rows too"
+    );
+}
+
+/// T3 #491, OQ-J (Half 2 of the typed-attribute-seeding design): the i128
+/// Currency lane round-trips exactly, moves the state hash when written,
+/// is reported by `all_currency_attributes`, and — the cascade half,
+/// mirroring `removal_cascades_edges_memberships_and_attributes`'s own
+/// proof for the f64 lane — a removed node's Currency-attribute row goes
+/// with it, never orphaned.
+fn currency_attribute_round_trips_moves_the_hash_and_cascades_on_removal<G, F>(make: &F)
+where
+    G: GraphSubstrate + CanonicalState,
+    F: Fn() -> G,
+{
+    let mut graph = make();
+    let doomed = graph.add_node("social_class").unwrap();
+    let survivor = graph.add_node("social_class").unwrap();
+    let before = graph.state_hash().unwrap();
+
+    graph
+        .update_node_currency(doomed, "wages", Currency::from_micro_units(1))
+        .unwrap();
+    graph
+        .update_node_currency(survivor, "wages", Currency::from_micro_units(2))
+        .unwrap();
+    let after = graph.state_hash().unwrap();
+    assert_ne!(before, after, "a Currency-attribute write moves the hash");
+
+    assert_eq!(
+        graph
+            .all_currency_attributes()
+            .into_iter()
+            .find(|(id, name, _)| *id == survivor && name == "wages")
+            .map(|(_, _, value)| value),
+        Some(Currency::from_micro_units(2)),
+        "the sixth-section listing reports the written value"
+    );
+
+    graph.remove_node(doomed).unwrap();
+    assert!(
+        !graph
+            .all_currency_attributes()
+            .iter()
+            .any(|(id, _, _)| *id == doomed),
+        "the removed node's Currency-attribute row is gone, not orphaned"
+    );
+    assert_eq!(
+        graph.node_attribute_currency(survivor, "wages"),
+        Ok(Currency::from_micro_units(2)),
+        "the survivor's Currency attribute is untouched"
     );
 }
 

--- a/rust/crates/babylon-graph/src/hypergraph_store.rs
+++ b/rust/crates/babylon-graph/src/hypergraph_store.rs
@@ -36,6 +36,7 @@
 
 use crate::state_hash::CanonicalState;
 use crate::substrate::{Direction, GraphError, GraphSubstrate, HyperedgeId, NodeId};
+use babylon_kernel::Currency;
 use hypergraph_rs::Hypergraph;
 use std::collections::HashMap;
 
@@ -76,6 +77,12 @@ pub struct HypergraphStore {
     nodes: HashMap<NodeId, String>,
     node_keys: HashMap<String, NodeId>,
     attributes: HashMap<(NodeId, String), f64>,
+    /// `(node, name)` -> Currency — the sixth-section store (T3 #491,
+    /// OQ-J), adapter-native like the rest of the dyadic half: Currency
+    /// attributes never touch the library. Mirrors `MemoryGraph`'s own
+    /// field exactly — see its doc for the "never the same key as
+    /// `attributes`" partition.
+    currency_attributes: HashMap<(NodeId, String), Currency>,
     edges: HashMap<(String, NodeId, NodeId), f64>,
     /// `(edge_type, from, to, qname)` -> value — the fifth-section store
     /// (T3, ADR198 R1, issue #560), adapter-native like the rest of the
@@ -158,6 +165,7 @@ impl GraphSubstrate for HypergraphStore {
         let key = node_key(id);
         self.node_keys.remove(&key);
         self.attributes.retain(|(node, _), _| *node != id);
+        self.currency_attributes.retain(|(node, _), _| *node != id);
         self.edges
             .retain(|(_, from, to), _| *from != id && *to != id);
         // The cascade sweeps the fifth section too (T3, ADR198 R1): an
@@ -253,6 +261,39 @@ impl GraphSubstrate for HypergraphStore {
         }
         self.attributes.insert((id, attribute.to_owned()), value);
         Ok(())
+    }
+
+    fn update_node_currency(
+        &mut self,
+        id: NodeId,
+        attribute: &str,
+        value: Currency,
+    ) -> Result<(), GraphError> {
+        self.check_not_frozen()?;
+        if !self.node_exists(id) {
+            return Err(GraphError {
+                message: format!("no such node: {id:?}"),
+            });
+        }
+        self.currency_attributes
+            .insert((id, attribute.to_owned()), value);
+        Ok(())
+    }
+
+    fn node_attribute_currency(&self, id: NodeId, attribute: &str) -> Result<Currency, GraphError> {
+        if !self.node_exists(id) {
+            return Err(GraphError {
+                message: format!("no such node: {id:?}"),
+            });
+        }
+        self.currency_attributes
+            .get(&(id, attribute.to_owned()))
+            .copied()
+            .ok_or_else(|| GraphError {
+                message: format!(
+                    "currency attribute {attribute} was never written on {id:?} — never a default"
+                ),
+            })
     }
 
     fn update_edge(
@@ -539,6 +580,13 @@ impl CanonicalState for HypergraphStore {
         self.edge_attributes
             .iter()
             .map(|((ty, from, to, name), value)| (ty.clone(), *from, *to, name.clone(), *value))
+            .collect()
+    }
+
+    fn all_currency_attributes(&self) -> Vec<(NodeId, String, Currency)> {
+        self.currency_attributes
+            .iter()
+            .map(|((id, name), value)| (*id, name.clone(), *value))
             .collect()
     }
 

--- a/rust/crates/babylon-graph/src/memory.rs
+++ b/rust/crates/babylon-graph/src/memory.rs
@@ -35,6 +35,7 @@
 //! unchanged by the swap, which is the entire point of the insulation.
 use crate::state_hash::CanonicalState;
 use crate::substrate::{Direction, GraphError, GraphSubstrate, HyperedgeId, NodeId};
+use babylon_kernel::Currency;
 use std::collections::HashMap;
 
 /// The in-memory substrate. See the module documentation.
@@ -42,6 +43,13 @@ use std::collections::HashMap;
 pub struct MemoryGraph {
     nodes: HashMap<NodeId, String>,
     attributes: HashMap<(NodeId, String), f64>,
+    /// `(node, name)` -> Currency — the SIXTH-section store (T3 #491, OQ-J:
+    /// Half 2 of the typed-attribute-seeding design), a map PARALLEL to
+    /// `attributes` above, never sharing a key: a `currency`-declared field
+    /// lives here and ONLY here, an `attributes`-declared field never here.
+    /// A row exists only while its node does — `remove_node`'s cascade
+    /// sweeps it exactly as it sweeps `attributes` (ADR185 R2, extended).
+    currency_attributes: HashMap<(NodeId, String), Currency>,
     /// `(edge_type, from, to)` -> strength. Real storage, so the §2.8
     /// duplicate-add / absent-remove discipline is checkable.
     edges: HashMap<(String, NodeId, NodeId), f64>,
@@ -77,6 +85,13 @@ impl MemoryGraph {
     #[must_use]
     pub fn attribute_key_count(&self) -> usize {
         self.attributes.len()
+    }
+
+    /// The Currency-lane analogue of [`Self::attribute_key_count`] (T3 #491,
+    /// OQ-J), for the same cascade-orphan check.
+    #[must_use]
+    pub fn currency_attribute_key_count(&self) -> usize {
+        self.currency_attributes.len()
     }
 }
 
@@ -117,6 +132,13 @@ impl CanonicalState for MemoryGraph {
             .map(|(id, (ty, members))| (*id, ty.clone(), members.clone()))
             .collect()
     }
+
+    fn all_currency_attributes(&self) -> Vec<(NodeId, String, Currency)> {
+        self.currency_attributes
+            .iter()
+            .map(|((id, name), value)| (*id, name.clone(), *value))
+            .collect()
+    }
 }
 
 impl GraphSubstrate for MemoryGraph {
@@ -144,6 +166,7 @@ impl GraphSubstrate for MemoryGraph {
         // silently, and reading as real data. The invariant is what makes
         // that class of bug unavailable to the next implementor.
         self.attributes.retain(|(node, _), _| *node != id);
+        self.currency_attributes.retain(|(node, _), _| *node != id);
         self.edges
             .retain(|(_, from, to), _| *from != id && *to != id);
         // The cascade sweeps the fifth section too (T3, ADR198 R1): an
@@ -208,6 +231,38 @@ impl GraphSubstrate for MemoryGraph {
         }
         self.attributes.insert((id, attribute.to_owned()), value);
         Ok(())
+    }
+
+    fn update_node_currency(
+        &mut self,
+        id: NodeId,
+        attribute: &str,
+        value: Currency,
+    ) -> Result<(), GraphError> {
+        if !self.node_exists(id) {
+            return Err(GraphError {
+                message: format!("no such node: {id:?}"),
+            });
+        }
+        self.currency_attributes
+            .insert((id, attribute.to_owned()), value);
+        Ok(())
+    }
+
+    fn node_attribute_currency(&self, id: NodeId, attribute: &str) -> Result<Currency, GraphError> {
+        if !self.node_exists(id) {
+            return Err(GraphError {
+                message: format!("no such node: {id:?}"),
+            });
+        }
+        self.currency_attributes
+            .get(&(id, attribute.to_owned()))
+            .copied()
+            .ok_or_else(|| GraphError {
+                message: format!(
+                    "currency attribute {attribute} was never written on {id:?} — never a default"
+                ),
+            })
     }
 
     fn update_edge(
@@ -636,6 +691,61 @@ mod tests {
         let mut graph = MemoryGraph::new();
         let node = graph.add_node("social_class").unwrap();
         assert!(graph.node_attribute(node, "wealth").is_err());
+    }
+
+    #[test]
+    fn add_then_update_currency_then_read_back() {
+        // T3 #491, OQ-J: the i128 lane round-trips exactly, PARALLEL to the
+        // f64 lane above — the same field name in both maps would be two
+        // different rows, but this test only exercises one lane.
+        use babylon_kernel::Currency;
+        let mut graph = MemoryGraph::new();
+        let node = graph.add_node("social_class").unwrap();
+        graph
+            .update_node_currency(node, "wages", Currency::from_micro_units(120_000_000))
+            .unwrap();
+        assert_eq!(
+            graph.node_attribute_currency(node, "wages"),
+            Ok(Currency::from_micro_units(120_000_000))
+        );
+    }
+
+    #[test]
+    fn an_unwritten_currency_attribute_reads_loud_never_zero() {
+        let mut graph = MemoryGraph::new();
+        let node = graph.add_node("social_class").unwrap();
+        assert!(graph.node_attribute_currency(node, "wages").is_err());
+    }
+
+    #[test]
+    fn removal_takes_the_nodes_currency_attributes_with_it() {
+        // ADR185 R2's cascade, extended to the sixth-section map: no
+        // internal map may hold a key naming a dead node, the SAME
+        // invariant `removal_takes_the_nodes_attributes_with_it` proves for
+        // the f64 lane.
+        use babylon_kernel::Currency;
+        let mut graph = MemoryGraph::new();
+        let doomed = graph.add_node("social_class").unwrap();
+        let survivor = graph.add_node("social_class").unwrap();
+        graph
+            .update_node_currency(doomed, "wages", Currency::from_micro_units(1))
+            .unwrap();
+        graph
+            .update_node_currency(survivor, "wages", Currency::from_micro_units(2))
+            .unwrap();
+
+        graph.remove_node(doomed).unwrap();
+
+        assert_eq!(
+            graph.currency_attribute_key_count(),
+            1,
+            "the removed node's currency-attribute row is gone, not orphaned"
+        );
+        assert_eq!(
+            graph.node_attribute_currency(survivor, "wages"),
+            Ok(Currency::from_micro_units(2)),
+            "and the survivor's is untouched"
+        );
     }
 
     #[test]

--- a/rust/crates/babylon-graph/src/state_hash.rs
+++ b/rust/crates/babylon-graph/src/state_hash.rs
@@ -27,6 +27,8 @@
 //! 0x05 ‖ u32 count ‖ per edge attribute, ascending (type, from, to, qname):
 //!                                    str type ‖ u64 from ‖ u64 to ‖ str qname
 //!                                           ‖ u64 value-bits
+//! 0x06 ‖ u32 count ‖ per Currency node attribute, ascending (id, name):
+//!                                    u64 id ‖ str name ‖ i128 value (16 bytes, big-endian)
 //! ```
 //!
 //! **An edge's strength is NOT an edge attribute.** The `add_edge` operand
@@ -35,6 +37,17 @@
 //! `<edge-type>/strength` MUST land in the `0x03` slot, never mint a `0x05`
 //! row shadowing it — one datum, one hashed home (the double-storage
 //! ruling, D143; `GraphSubstrate::update_edge`'s suffix fork enforces it).
+//!
+//! **Section `0x06` is a SEPARATE lane from `0x02`, not a widened row
+//! shape.** A `currency`-declared node attribute never appears in section
+//! `0x02` at all (`babylon-bsl`'s executor routes it through
+//! [`crate::substrate::GraphSubstrate::update_node_currency`], never
+//! `update_node`) — the two sections partition the node-attribute space by
+//! declared type, they do not compete for the same row (T3 #491, OQ-J —
+//! Half 2 of the typed-attribute-seeding design). The i128 value is written
+//! via `i128::to_be_bytes()` — 16 raw bytes, big-endian — the same "every
+//! integer is big-endian" rule this module's other sections hold, extended
+//! to 128 bits rather than inventing a second integer convention.
 //!
 //! # Layout versions
 //!
@@ -54,19 +67,33 @@
 //!   version-1 state encodes byte-identically under version 2, so every
 //!   existing golden, baseline and save survives the widening unmoved — no
 //!   rebless ceremony.
+//! - **Version 3** (T3 #491, OQ-J, Currency typed-attribute storage): section
+//!   `0x06` — Currency node attributes — exists, and is **elided when
+//!   empty**, the same rule `0x05` set as precedent. Every version-2 state
+//!   (equivalently, every version-1 state with an empty `0x05`) encodes
+//!   byte-identically under version 3: nothing in the tree declares a
+//!   `currency`-typed `deffield` yet, so this landing moves zero existing
+//!   goldens — the design doc's own recommended shape (conditional
+//!   emission over the unconditional variant, chosen exactly so Half 2's
+//!   landing PR is byte-free until content opts in). Collision note: the
+//!   design doc that specced this train assumed section `0x05` for
+//!   Currency; `0x05` was independently claimed by the T3/#560 edge-
+//!   attribute widening before this train landed, so Currency takes the
+//!   next-free tag, `0x06`, instead — a deviation from the design doc's
+//!   literal number, not from its shape.
 //!
 //! **The deliberate asymmetry, recorded as ADR198 R2's own text
 //! orders.** Section `0x04`'s empty section IS written (version-1 behavior,
-//! unchanged); section `0x05`'s is NOT. The conventions genuinely differ
-//! and the difference is deliberate: elision is what makes a widening
-//! byte-compatible, and retrofitting elision onto `0x04` would itself move
-//! every existing hash — the cure would be the disease. Every FUTURE
-//! section follows `0x05`'s rule: added at the next tag, elided when
-//! empty, so a widening no state yet exercises never moves an existing
-//! hash. A change to an EXISTING section's layout is never a version bump;
-//! it is a contract change that invalidates every stored state hash and
-//! every other implementation (see the pinned byte vectors in this
-//! module's tests).
+//! unchanged); sections `0x05`/`0x06`'s are NOT. The conventions genuinely
+//! differ and the difference is deliberate: elision is what makes a
+//! widening byte-compatible, and retrofitting elision onto `0x04` would
+//! itself move every existing hash — the cure would be the disease. Every
+//! FUTURE section follows `0x05`/`0x06`'s rule: added at the next tag,
+//! elided when empty, so a widening no state yet exercises never moves an
+//! existing hash. A change to an EXISTING section's layout is never a
+//! version bump; it is a contract change that invalidates every stored
+//! state hash and every other implementation (see the pinned byte vectors
+//! in this module's tests).
 //!
 //! **Section tags are not decoration.** Without them a graph with one node
 //! and no edges could serialize identically to one with no nodes and one
@@ -95,23 +122,25 @@
 //! no rounding, no locale.
 
 use crate::substrate::{GraphError, HyperedgeId, NodeId};
-use babylon_kernel::sha256_of;
+use babylon_kernel::{sha256_of, Currency};
 
 const TAG_NODES: u8 = 0x01;
 const TAG_ATTRIBUTES: u8 = 0x02;
 const TAG_EDGES: u8 = 0x03;
 const TAG_HYPEREDGES: u8 = 0x04;
 const TAG_EDGE_ATTRIBUTES: u8 = 0x05;
+const TAG_CURRENCY_ATTRIBUTES: u8 = 0x06;
 
-/// The canonical-layout version (module doc, "Layout versions"). **2** =
-/// version 1's four unconditional sections plus section `0x05` (edge
-/// attributes, ADR198 R1/R2), the fifth **elided when empty** — a
-/// byte-compatible widening: every version-1 state hashes identically
-/// under version 2. Never written into the encoding itself; this versions
-/// the CONTRACT for cross-language reimplementations, not the payload.
-/// Bumping it is a contract event — the module doc's "Layout versions"
-/// section says what each version means and what may never be one.
-pub const CANONICAL_LAYOUT_VERSION: u32 = 2;
+/// The canonical-layout version (module doc, "Layout versions"). **3** =
+/// version 2's five sections plus section `0x06` (Currency node
+/// attributes, T3 #491/OQ-J), the sixth **elided when empty** — a
+/// byte-compatible widening: every version-2 state (so every version-1
+/// state too, since `0x05` was already elidable) hashes identically under
+/// version 3. Never written into the encoding itself; this versions the
+/// CONTRACT for cross-language reimplementations, not the payload. Bumping
+/// it is a contract event — the module doc's "Layout versions" section
+/// says what each version means and what may never be one.
+pub const CANONICAL_LAYOUT_VERSION: u32 = 3;
 
 /// Accumulates the canonical encoding described in the module docs.
 ///
@@ -274,6 +303,34 @@ impl StateEncoder {
         Ok(())
     }
 
+    /// Section `0x06` (layout version 3 — the module doc's "Layout
+    /// versions"). `currency_attributes` must already be sorted ascending
+    /// by `(id, name)` — the SAME key section `0x02` sorts by, since this
+    /// is the identical node-attribute space, partitioned by declared type.
+    /// **The elision decision is the CALLER's**: this method writes what it
+    /// is given, unconditionally; [`CanonicalState::encode_state`] is the
+    /// one place that decides an empty sixth listing contributes zero
+    /// bytes (mirroring ADR198 R2's `0x05` precedent).
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if a count or string length overflows its
+    /// prefix. Currency has no non-finite/negative-zero hazard — `i128` is
+    /// exact by construction — so this method has no value-level refusal
+    /// the way [`Self::write_attributes`] does for `f64`.
+    pub fn write_currency_attributes(
+        &mut self,
+        currency_attributes: &[(NodeId, String, Currency)],
+    ) -> Result<(), GraphError> {
+        self.push_count(TAG_CURRENCY_ATTRIBUTES, currency_attributes.len())?;
+        for (id, name, value) in currency_attributes {
+            self.bytes.extend_from_slice(&id.0.to_be_bytes());
+            self.push_str(name)?;
+            self.bytes
+                .extend_from_slice(&value.micro_units().to_be_bytes());
+        }
+        Ok(())
+    }
+
     /// The canonical bytes, for a differential when two hashes disagree.
     ///
     /// A bare hash says only *that* two states differ; the bytes say where.
@@ -333,22 +390,34 @@ pub trait CanonicalState {
     /// `0x03`; this listing is section `0x05`'s facts and nothing else (the
     /// double-storage ruling, D143 — one datum, one hashed home).
     fn all_edge_attributes(&self) -> Vec<(String, NodeId, NodeId, String, f64)>;
+    /// Every Currency-typed node-attribute row as `(id, name, value)`, in
+    /// any order (T3 #491, OQ-J — Half 2 of the typed-attribute-seeding
+    /// design). **A `currency`-declared field never reports here AND in
+    /// [`Self::all_attributes`]** — the two listings partition the
+    /// node-attribute space by declared type, they never overlap on the
+    /// same `(id, name)` key, mirroring [`Self::all_edge_attributes`]'s
+    /// own disjointness from [`Self::all_edges`] (the double-storage
+    /// ruling, D143, restated for the sixth section).
+    fn all_currency_attributes(&self) -> Vec<(NodeId, String, Currency)>;
 
     /// The canonical encoding (module docs) — the ONLY place the sort and
-    /// the five `write_*` calls happen, for every store that ever implements
+    /// the six `write_*` calls happen, for every store that ever implements
     /// this trait.
     ///
     /// Sorts: nodes by id; attributes by `(id, name)`; edges by
     /// `(type, from, to)`; hyperedges by id, each member list ascending;
-    /// edge attributes by `(type, from, to, qname)`. The
+    /// edge attributes by `(type, from, to, qname)`; Currency attributes by
+    /// `(id, name)` — the same key section `0x02` sorts by. The
     /// member lists are sorted HERE, not only trusted from the listing — a
     /// store reporting them in storage order must still hash correctly,
     /// because the sort contract belongs to the encoder, never to the
     /// store's internal order.
     ///
-    /// **Elision (ADR198 R2):** the fifth section is written ONLY when at
-    /// least one edge attribute exists — a state holding none emits no
-    /// `0x05` bytes, so every version-1 hash stays byte-identical. The four
+    /// **Elision (ADR198 R2, extended to `0x06` by T3 #491/OQ-J):** the
+    /// fifth section is written ONLY when at least one edge attribute
+    /// exists, and the sixth ONLY when at least one Currency attribute
+    /// exists — a state holding none emits no `0x05`/`0x06` bytes, so
+    /// every version-1 (or version-2) hash stays byte-identical. The four
     /// version-1 sections are written unconditionally (the deliberate
     /// asymmetry the module doc's "Layout versions" records).
     ///
@@ -394,6 +463,14 @@ pub trait CanonicalState {
             encoder.write_edge_attributes(&edge_attributes)?;
         }
 
+        let mut currency_attributes = self.all_currency_attributes();
+        currency_attributes.sort_unstable_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+        // Same elision rule as 0x05 above (module doc, "Layout versions"
+        // version 3): no tag, no count, no bytes at all when empty.
+        if !currency_attributes.is_empty() {
+            encoder.write_currency_attributes(&currency_attributes)?;
+        }
+
         Ok(encoder)
     }
 
@@ -411,9 +488,10 @@ pub trait CanonicalState {
 mod tests {
     use super::{CanonicalState, StateEncoder};
     use crate::substrate::{HyperedgeId, NodeId};
+    use babylon_kernel::Currency;
     use std::fmt::Write as _;
 
-    /// A hand-built fixture implementing only the five listings, so
+    /// A hand-built fixture implementing only the six listings, so
     /// [`CanonicalState::encode_state`]/`state_hash` are exercised as the
     /// PROVIDED methods they are — never re-derived per store.
     struct Facts {
@@ -422,6 +500,7 @@ mod tests {
         edges: Vec<(String, NodeId, NodeId, f64)>,
         hyperedges: Vec<(HyperedgeId, String, Vec<NodeId>)>,
         edge_attributes: Vec<(String, NodeId, NodeId, String, f64)>,
+        currency_attributes: Vec<(NodeId, String, Currency)>,
     }
 
     impl CanonicalState for Facts {
@@ -439,6 +518,9 @@ mod tests {
         }
         fn all_edge_attributes(&self) -> Vec<(String, NodeId, NodeId, String, f64)> {
             self.edge_attributes.clone()
+        }
+        fn all_currency_attributes(&self) -> Vec<(NodeId, String, Currency)> {
+            self.currency_attributes.clone()
         }
     }
 
@@ -459,6 +541,7 @@ mod tests {
             edges: vec![("E".to_owned(), NodeId(1), NodeId(2), 0.5)],
             hyperedges: vec![(HyperedgeId(7), "H".to_owned(), vec![NodeId(1), NodeId(2)])],
             edge_attributes: vec![],
+            currency_attributes: vec![],
         };
 
         #[rustfmt::skip]
@@ -508,14 +591,22 @@ mod tests {
         );
     }
 
-    /// The provided method sorts — a store reporting its five facts in
+    /// The provided method sorts — a store reporting its six facts in
     /// deliberately scrambled order must hash identically to one reporting
     /// them already sorted, because the sort contract lives in the provided
     /// method and never depends on the caller's listing order. The
     /// `edge_attributes` rows (T3, ADR198 R1/R2) swap their listing order
     /// between the two fixtures, so the fifth section's own sort —
     /// `(type, from, to, qname)` — is what this test proves, not just the
-    /// first four sections'.
+    /// first four sections'. The `currency_attributes` rows (T3 #491, OQ-J)
+    /// swap order too, proving the sixth section's `(id, name)` sort the
+    /// same way.
+    // The two hand-built `Facts` fixtures are inherently one flat literal
+    // each (six fields, several rows apiece) — splitting them into helper
+    // functions would obscure the "same facts, deliberately scrambled
+    // order" pairing the test's whole point rests on, worse than the length
+    // itself.
+    #[allow(clippy::too_many_lines)]
     #[test]
     fn the_provided_encode_state_sorts_regardless_of_listing_order() {
         let sorted = Facts {
@@ -555,6 +646,18 @@ mod tests {
                     NodeId(2),
                     "solidarity/trust".to_owned(),
                     0.2,
+                ),
+            ],
+            currency_attributes: vec![
+                (
+                    NodeId(1),
+                    "social-class/wages".to_owned(),
+                    Currency::from_micro_units(500_000),
+                ),
+                (
+                    NodeId(2),
+                    "social-class/wages".to_owned(),
+                    Currency::from_micro_units(1_000_000),
                 ),
             ],
         };
@@ -597,6 +700,18 @@ mod tests {
                     NodeId(2),
                     "solidarity/tension".to_owned(),
                     0.7,
+                ),
+            ],
+            currency_attributes: vec![
+                (
+                    NodeId(2),
+                    "social-class/wages".to_owned(),
+                    Currency::from_micro_units(1_000_000),
+                ),
+                (
+                    NodeId(1),
+                    "social-class/wages".to_owned(),
+                    Currency::from_micro_units(500_000),
                 ),
             ],
         };
@@ -775,6 +890,81 @@ mod tests {
         );
     }
 
+    /// **The sixth section's layout is normative too — pinned byte for
+    /// byte** (T3 #491, OQ-J). The five-section prefix below is the
+    /// version-2 golden vector VERBATIM (the fifth section's own pinned
+    /// test above, one entry); the `0x06` block is the new section appended
+    /// after it. A single 1-micro-unit value keeps the i128 hand-encoding
+    /// unambiguous: 15 zero bytes then `0x01`. A reimplementation in any
+    /// language can be checked against this array without running Rust.
+    #[test]
+    fn the_sixth_section_is_pinned_byte_for_byte() {
+        let mut enc = StateEncoder::new();
+        enc.write_nodes(&[(NodeId(1), "c".to_owned())]).unwrap();
+        enc.write_attributes(&[(NodeId(1), "w".to_owned(), 1.0)])
+            .unwrap();
+        enc.write_edges(&[("E".to_owned(), NodeId(1), NodeId(2), 0.5)])
+            .unwrap();
+        enc.write_hyperedges(&[(HyperedgeId(7), "H".to_owned(), vec![NodeId(1), NodeId(2)])])
+            .unwrap();
+        enc.write_edge_attributes(&[("E".to_owned(), NodeId(1), NodeId(2), "t".to_owned(), 0.25)])
+            .unwrap();
+        enc.write_currency_attributes(&[(
+            NodeId(1),
+            "m".to_owned(),
+            Currency::from_micro_units(1),
+        )])
+        .unwrap();
+
+        #[rustfmt::skip]
+        let expected: &[u8] = &[
+            // ── sections 0x01-0x05: the version-2 golden vector, verbatim ──
+            0x01,
+            0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x01, b'c',
+            0x02,
+            0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x01, b'w',
+            0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x03,
+            0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x01, b'E',
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+            0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x04,
+            0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07,
+            0x00, 0x00, 0x00, 0x01, b'H',
+            0x00, 0x00, 0x00, 0x02,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+            0x05,
+            0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x01, b'E',
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+            0x00, 0x00, 0x00, 0x01, b't',
+            0x3F, 0xD0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            // ── section 0x06: Currency node attributes (layout version 3) ──
+            0x06,                                                              // tag
+            0x00, 0x00, 0x00, 0x01,                                            // u32 count = 1
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,                    // u64 id = 1
+            0x00, 0x00, 0x00, 0x01, b'm',                                      // str "m"
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,                    // i128 hi = 0
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,                    // i128 lo = 1 micro-unit
+        ];
+
+        assert_eq!(
+            enc.as_bytes(),
+            expected,
+            "the sixth section's canonical encoding moved — a CONTRACT CHANGE of the same \
+             order as the fifth-section golden above, not a test to re-bless casually"
+        );
+    }
+
     /// ADR198 R2's elision rule, pinned as behavior rather than prose: the
     /// provided `encode_state` over a store reporting NO edge attributes
     /// produces exactly the bytes a hand-driven four-section encoder
@@ -788,6 +978,7 @@ mod tests {
             edges: vec![("E".to_owned(), NodeId(1), NodeId(2), 0.5)],
             hyperedges: vec![(HyperedgeId(7), "H".to_owned(), vec![NodeId(1), NodeId(2)])],
             edge_attributes: vec![],
+            currency_attributes: vec![],
         };
         let mut manual = StateEncoder::new();
         manual.write_nodes(&[(NodeId(1), "c".to_owned())]).unwrap();
@@ -819,6 +1010,7 @@ mod tests {
             edges: vec![("E".to_owned(), NodeId(1), NodeId(2), 0.5)],
             hyperedges: vec![(HyperedgeId(7), "H".to_owned(), vec![NodeId(1), NodeId(2)])],
             edge_attributes: vec![],
+            currency_attributes: vec![],
         };
         let with_attribute = Facts {
             edge_attributes: vec![("E".to_owned(), NodeId(1), NodeId(2), "t".to_owned(), 0.25)],
@@ -828,6 +1020,7 @@ mod tests {
                 edges: bare.edges.clone(),
                 hyperedges: bare.hyperedges.clone(),
                 edge_attributes: vec![],
+                currency_attributes: vec![],
             }
         };
 
@@ -852,6 +1045,90 @@ mod tests {
         );
     }
 
+    /// The `0x06` analogue of `an_empty_edge_attribute_listing_writes_no_fifth_section_bytes`
+    /// (T3 #491, OQ-J): the provided `encode_state` over a store reporting
+    /// NO Currency attributes produces exactly the bytes a hand-driven
+    /// five-section encoder produces — no `0x06` tag, no zero count,
+    /// nothing. (If the elision branch is deleted, this flips red.)
+    #[test]
+    fn an_empty_currency_attribute_listing_writes_no_sixth_section_bytes() {
+        let facts = Facts {
+            nodes: vec![(NodeId(1), "c".to_owned())],
+            attributes: vec![(NodeId(1), "w".to_owned(), 1.0)],
+            edges: vec![("E".to_owned(), NodeId(1), NodeId(2), 0.5)],
+            hyperedges: vec![(HyperedgeId(7), "H".to_owned(), vec![NodeId(1), NodeId(2)])],
+            edge_attributes: vec![("E".to_owned(), NodeId(1), NodeId(2), "t".to_owned(), 0.25)],
+            currency_attributes: vec![],
+        };
+        let mut manual = StateEncoder::new();
+        manual.write_nodes(&[(NodeId(1), "c".to_owned())]).unwrap();
+        manual
+            .write_attributes(&[(NodeId(1), "w".to_owned(), 1.0)])
+            .unwrap();
+        manual
+            .write_edges(&[("E".to_owned(), NodeId(1), NodeId(2), 0.5)])
+            .unwrap();
+        manual
+            .write_hyperedges(&[(HyperedgeId(7), "H".to_owned(), vec![NodeId(1), NodeId(2)])])
+            .unwrap();
+        manual
+            .write_edge_attributes(&[("E".to_owned(), NodeId(1), NodeId(2), "t".to_owned(), 0.25)])
+            .unwrap();
+        assert_eq!(
+            facts.encode_state().unwrap().as_bytes(),
+            manual.as_bytes(),
+            "an empty sixth listing must contribute ZERO bytes (the 0x05 elision precedent, \
+             extended to 0x06)"
+        );
+    }
+
+    /// The `0x06` analogue of `a_single_edge_attribute_moves_the_hash_and_trails_the_four_sections`
+    /// (T3 #491, OQ-J): ONE stored Currency attribute must be hash-visible,
+    /// and the sixth section trails the five prior sections rather than
+    /// inserting among them.
+    #[test]
+    fn a_single_currency_attribute_moves_the_hash_and_trails_the_five_sections() {
+        let bare = Facts {
+            nodes: vec![(NodeId(1), "c".to_owned())],
+            attributes: vec![(NodeId(1), "w".to_owned(), 1.0)],
+            edges: vec![("E".to_owned(), NodeId(1), NodeId(2), 0.5)],
+            hyperedges: vec![(HyperedgeId(7), "H".to_owned(), vec![NodeId(1), NodeId(2)])],
+            edge_attributes: vec![("E".to_owned(), NodeId(1), NodeId(2), "t".to_owned(), 0.25)],
+            currency_attributes: vec![],
+        };
+        let with_attribute = Facts {
+            currency_attributes: vec![(NodeId(1), "m".to_owned(), Currency::from_micro_units(1))],
+            ..Facts {
+                nodes: bare.nodes.clone(),
+                attributes: bare.attributes.clone(),
+                edges: bare.edges.clone(),
+                hyperedges: bare.hyperedges.clone(),
+                edge_attributes: bare.edge_attributes.clone(),
+                currency_attributes: vec![],
+            }
+        };
+
+        assert_ne!(
+            bare.state_hash().unwrap(),
+            with_attribute.state_hash().unwrap(),
+            "one stored Currency attribute must move the hash"
+        );
+        let bare_encoding = bare.encode_state().unwrap();
+        let with_encoding = with_attribute.encode_state().unwrap();
+        let bare_bytes = bare_encoding.as_bytes();
+        let with_bytes = with_encoding.as_bytes();
+        assert_eq!(
+            &with_bytes[..bare_bytes.len()],
+            bare_bytes,
+            "the five prior sections are an untouched PREFIX — 0x06 appends, never inserts"
+        );
+        assert_eq!(
+            with_bytes[bare_bytes.len()],
+            0x06,
+            "the sixth section's tag immediately follows the fifth's last byte"
+        );
+    }
+
     /// The layout version constant is the minted versioning convention
     /// (ADR198 R2: the elision rule is "documented and versioned" — there
     /// was no version anchor before T3, so T3 minted one). Pinning the
@@ -861,10 +1138,10 @@ mod tests {
     fn the_canonical_layout_version_is_pinned() {
         assert_eq!(
             super::CANONICAL_LAYOUT_VERSION,
-            2,
-            "layout version 2 = version 1 (sections 0x01-0x04, unconditional) + section 0x05 \
-             (edge attributes, elided when empty) — bumping this is a contract event, see the \
-             module doc's 'Layout versions'"
+            3,
+            "layout version 3 = version 2 (sections 0x01-0x05) + section 0x06 (Currency node \
+             attributes, elided when empty, T3 #491/OQ-J) — bumping this is a contract event, \
+             see the module doc's 'Layout versions'"
         );
     }
 

--- a/rust/crates/babylon-graph/src/substrate.rs
+++ b/rust/crates/babylon-graph/src/substrate.rs
@@ -23,9 +23,19 @@
 //! makes mandatory; and `node_attribute` exists because §2.8's four
 //! update-ops (`add`/`sub`/`scale` read-modify-write) are unimplementable
 //! without a read point. Attribute values are `f64` — the binary64 lane
-//! only; typed attribute storage (Currency's i128 exactness) is a declared
-//! Phase-2 gap, not a silent coercion (`babylon-bsl`'s executor rejects
-//! Currency-typed writes loudly).
+//! only; a SECOND, parallel i128 lane exists for `currency`-declared node
+//! attributes ([`GraphSubstrate::update_node_currency`]/
+//! [`GraphSubstrate::node_attribute_currency`] — Half 2 of the
+//! typed-attribute-seeding design, T3 #491/OQ-J). The two lanes never
+//! share a map: `f64` cannot carry `Currency`'s i128 exactness or its
+//! half-even rounding law across a round trip (the design doc's §A), so
+//! the binary64 attribute lane still refuses a `Currency`-typed write
+//! loudly (`babylon-bsl`'s executor) rather than casting it — the gap this
+//! doc used to call "a declared Phase-2 gap" now has its own typed
+//! storage, node-scoped only (no edge/hyperedge Currency lane in this
+//! train).
+
+use babylon_kernel::Currency;
 
 /// Opaque node identity — a newtype so no caller depends on it being an
 /// integer index vs. a UUID vs. anything else the concrete shape picks.
@@ -182,6 +192,35 @@ pub trait GraphSubstrate {
     /// never been written — never a default `0.0` (the honest-null
     /// discipline, §3.5).
     fn node_attribute(&self, id: NodeId, attribute: &str) -> Result<f64, GraphError>;
+
+    /// Write a Currency-typed node attribute — Half 2 of the
+    /// typed-attribute-seeding design (T3 #491, OQ-J): the i128 lane,
+    /// stored in a map PARALLEL to [`Self::update_node`]'s `f64` one, never
+    /// the same map. Node-scoped only — there is no edge/hyperedge Currency
+    /// lane in this train.
+    ///
+    /// Values are non-negative (`bsl-language.rst` §1.5's Currency row,
+    /// `[0, ∞)`) — enforced by the caller (`babylon-bsl`'s executor, the
+    /// same division [`Self::update_node`] holds for its own `[0,1]`
+    /// domain checks), never by this trait.
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if `id` names no node in this substrate.
+    fn update_node_currency(
+        &mut self,
+        id: NodeId,
+        attribute: &str,
+        value: Currency,
+    ) -> Result<(), GraphError>;
+
+    /// Read a single Currency-typed node attribute — the read half of
+    /// [`Self::update_node_currency`].
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if `id` names no node, or the attribute has
+    /// never been written — never a default (the honest-null discipline,
+    /// §3.5), exactly as [`Self::node_attribute`] holds for its own lane.
+    fn node_attribute_currency(&self, id: NodeId, attribute: &str) -> Result<Currency, GraphError>;
 
     /// Whether `id` names a live node.
     fn node_exists(&self, id: NodeId) -> bool;


### PR DESCRIPTION
**PR B of the #491 stacked structure** (base: `feature/491-language-and-units` = PR A; retargets to `dev` when A merges). Scope: T3 only. Acceptance posture: byte-identity.

**Currency 0x06 storage + layout v3 (T3, D189–D190).** Half 2 of the typed-attribute-seeding design: node-scoped Currency attributes get a real `i128` typed-storage lane, parallel to the existing `f64` map, never sharing it. `CanonicalState` gains section `0x06` (`TAG_CURRENCY_ATTRIBUTES`, `rust/crates/babylon-graph/src/state_hash.rs:132`) — not the design doc's assumed `0x05`, which a separate, independent T3/#560 edge-attribute train (D144) had already claimed; D189 records the collision and the next-free-tag resolution. `CANONICAL_LAYOUT_VERSION` bumps 2→3 (`state_hash.rs:143`), elided when empty exactly as section `0x05` is. All 18 pre-existing `tick_goldens.rs` pins verified byte-identical before and after. Register rows D189–D190 at `docs/reference/bsl-language.rst:8464-8519` (this branch's tree).

**Gates.** T3 closed with scoped equivalents run twice (`cargo fmt --check`, `clippy -D warnings`, full per-crate test suites) after finding the box busy under the sweep-then-defer protocol; its full-workspace `mise run rust:check` was recorded deferred in the task ledger — **this PR's own CI runs the full Rust leg on T3's tip, discharging that deferral directly** (a point in favor of the stacked split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
