### PR TITLE
feat(sentinels): event-schema registry as data + one-way builder sync + the defevent amendment draft (refactor P4)

### DIFF
--- a/ai/_inbox/amendment-defevent-draft.md
+++ b/ai/_inbox/amendment-defevent-draft.md
@@ -15,11 +15,22 @@
   AG, also MINOR, for the same reason.
 - **Letter**: **AH** — the next free letter after AG (ratified v3.2.0,
   2026-08-10; confirmed no `Amendment AH` text exists anywhere in the tree
-  as of this draft).
-- **Amends**: NORTH_STAR §0's closed-formalism-surface sentence (a third
-  named additive construct joins BSL/Amendment AE and attributed-
-  membership + lattice-instances/Amendment AG); Article IX.2's amendment
-  registry (new entry, inserted after Amendment AG).
+  as of this draft). Letters **AH (this draft) and AI (the prior-tick
+  draft) controller-reserved 2026-08-18**; re-verify at the ratifying
+  sitting.
+- **Amends**: NORTH_STAR §0's closed-formalism-surface sentence — checked
+  directly (`NORTH_STAR.md:12-27`), that live parenthetical today names
+  **only** Amendment AE/BSL; `Amendment AG` is not mentioned anywhere in
+  `NORTH_STAR.md` despite `CONSTITUTION.md`'s own AG entry stating it
+  "re-opens NORTH_STAR §0's formalism closure for exactly two constructs"
+  — a pre-existing doc-drift gap between the constitutional text and the
+  explanation document, not introduced by this draft. Against the text as
+  it actually reads today, `defevent`/AH would be the **second** named
+  construct in that parenthetical, not the third; landing AH's §0
+  consequence is a reasonable moment to also backfill AG's still-missing
+  mention, though that backfill is not this amendment's own obligation.
+  Also amends: Article IX.2's amendment registry (new entry, inserted
+  after Amendment AG).
 - **Adds**: no new Article I–VIII principle text. `bsl-language.rst` gains
   one new normative section (a sibling of §2.13's `defenum`/`defvocabulary`)
   once ratified and specified; this draft does not write that section —
@@ -160,21 +171,62 @@ INSTANCES against an existing closed schema, never mint a new KIND.
 `defevent` mints instances (per-EventType schemas); `EventType` the kind
 stays exactly as closed as it is today.
 
-**(ii) Deliberately no per-key value kind.** The R4.1 registry —
+**(ii) No per-key value kind in v1 — not for lack of evidence, but for
+lack of a settled translation.** *Corrected in fix round 1 (2026-08-18):
+this clause originally claimed no per-key kind evidence exists at all.
+That was false, and is corrected below.* The R4.1 registry —
 `RegistryKey` in `src/babylon/sentinels/event_schema_registry/
-registry.py` — carries `name`, `required`, `source`, `note` per key. It
-does **not** carry a value type or kind (`Currency`/`Real`/`Probability`/…)
-because no existing evidence source states one: BSL's own `<payload-item>`
-grammar (§2.8) takes an unconstrained `<expr>`, and `EVENT_BUILDERS`
-(Python) does no per-field kind validation either. A `defevent` proposal
-that invented per-key kinds would manufacture evidence the registry does
-not have — exactly the false-authority failure R4.1's own tiering was
-built to avoid (`registry.py`'s module docstring, C-1 rescope). This
-amendment therefore scopes `defevent` to key NAME + required/optional
-only. Per-key value-kind checking is a genuinely separate, later
-extension (its own amendment, since it would mint a NEW checked
-invariant class, not extend this one) — named here so the boundary is not
-silently redrawn by a future implementer.
+registry.py` — carries `name`, `required`, `source`, `note` per key, no
+value type. But real per-field kind evidence DOES exist, for every one
+of the 80 `EventType` members `EVENT_BUILDERS` covers (the 12 Tier 1 +
+68 Tier 2 rows — every Tier 1 `EventType` also has an `EVENT_BUILDERS`
+entry, confirmed directly by name for all twelve): each builder
+constructs a typed Pydantic model, and those models declare real
+per-field types plus constraints. Two spot-read in full: the
+`CONTROL_RATIO_CRISIS` builder (`event_builders.py:226`) constructs
+`ControlRatioCrisisEvent`, whose model
+(`src/babylon/models/events/_legacy.py:387`, fields at `:416`, `:421`,
+`:426`) declares `prisoner_population: int = Field(..., ge=0, …)`,
+`enforcer_population: int = Field(..., ge=0, …)`,
+`control_ratio: float = Field(..., ge=0.0, …)`; the `ENTITY_DEATH`
+builder (`event_builders.py:536`) constructs `EntityDeathEvent`, whose
+model (`src/babylon/models/events/spine_payloads.py:48`, fields at
+`:56-61`) declares `entity_id: str`, `wealth: float`,
+`consumption_needs: float`, `s_bio: float`, `s_class: float`,
+`cause: str`. This is real, concrete evidence — not something a future
+`defevent`-kind extension would have to invent, the way this clause
+originally implied.
+
+What it is NOT, yet, is BSL-kinded evidence, and that gap — not an
+absence of evidence — is why `defevent` v1 still scopes to key NAME +
+required/optional only. Two concrete obstacles a mechanical
+Python-type-to-BSL-kind transcription would hit immediately: **(a)
+unit-interval disambiguation** — a Python `float` field constrained
+`ge=0.0`/`le=1.0` (the shape several of these Pydantic fields carry) is
+consistent with any of BSL's THREE unit-interval kinds
+(`probability`/`intensity`/`coefficient`, §3.1) and the Pydantic
+constraint alone cannot say which; today that choice is made by the
+*target field's own* `deffield :kind` declaration, a fact external to
+the event payload itself. **(b) string fields are structurally
+inadmissible** — `EntityDeathEvent.cause`/`entity_id` above are Python
+`str`, and `bsl-language.rst` §2.8's own existing rule (`:2989`, "No
+string payloads on `emit`" — `Str` has no operations, `<expr>` has no
+string literal, one in a payload is `E-PARSE-010`) already refuses a
+string value in ANY payload position; that same passage states the
+required treatment is to "convert them to enum-refs or drop them," an
+authoring judgment call per field, not a mechanical type copy. A
+per-key `defevent` kind is therefore a real, evidence-backed FUTURE
+extension — the 80 Pydantic models are exactly the source a follow-on
+task would transcribe from, the same role R4.1 already played for key
+*names* — but transcribing it needs the same kind of deliberate,
+per-field authoring pass R4.1 did, not a script over `EVENT_BUILDERS`'
+type annotations. This amendment therefore still scopes `defevent` to
+key NAME + required/optional only in v1; per-key value-kind checking is
+a genuinely separate, later extension (its own amendment, since it
+would mint a NEW checked invariant class, not extend this one) — named
+here, with its real evidence base now on record, so the boundary is not
+silently redrawn by a future implementer and the deferral is not
+mistaken for a claim that no such evidence exists.
 
 **(iii) Per-EventType activation, prelude-eligible.** `defevent` follows
 `defvocabulary`'s exact activation shape (D101): declaring nothing leaves
@@ -228,9 +280,13 @@ new mathematics.
   family/adjunction/level lattice/severity rule — the NORTH_STAR §0 test
   every additive re-opening since AE has had to clear.
 - **No per-key value-kind checking.** Clause (ii), deliberately deferred
-  — the evidence to ground it does not exist yet, and building it would
-  be a second, separately-amendable checked-invariant class layered on
-  top of this one, not part of it.
+  — real per-field kind evidence DOES exist (the 80 `EVENT_BUILDERS`
+  Pydantic models, Tier 1 + Tier 2), but it is Python-typed, not
+  BSL-kinded, and translating it needs a real per-field authoring pass
+  (unit-interval disambiguation; string fields converted to enum-refs or
+  dropped per §2.8's existing rule) rather than a mechanical copy;
+  building that translation would be a second, separately-amendable
+  checked-invariant class layered on top of this one, not part of it.
 - **No renaming of any BSL content payload key.** The registry this
   amendment's evidence base rests on already commits to this (port-AS-IS,
   ADR183, restated in the registry's own header comment); a `defevent`
@@ -286,9 +342,13 @@ when that PR lands.
 
 ## 5. Principles affected, and how their text moves (IX.3.3 required element)
 
-- **NORTH_STAR §0** — the closed-formalism-surface sentence gains a third
-  named additive construct in its parenthetical, alongside BSL (AE) and
-  attributed membership/lattice instances (AG).
+- **NORTH_STAR §0** — checked directly (`NORTH_STAR.md:12-27`): the live
+  closed-formalism-surface parenthetical today names only BSL (AE); AG's
+  own "exactly two constructs" reopening is not threaded into
+  `NORTH_STAR.md` at all (pre-existing drift, not this draft's doing —
+  see the header "Amends" bullet). Against the text as it stands,
+  `defevent`/AH would be the **second** named additive construct in that
+  parenthetical, not the third.
 - **Article IX.2** — one new registry entry (§1 above), inserted after
   Amendment AG.
 - **No Article I–VIII principle is redefined.** `bsl-language.rst` is a
@@ -379,7 +439,27 @@ implementation both future, separately-scoped work.
   `bound_checker.rs:577-591`, `typecheck.rs` (zero `emit`-payload hits),
   `docs/reference/event-schema-registry.toml` (all three tier tables,
   the `unminted_bsl_only` row), `registry.py` (the `RegistryKey` shape),
-  `bsl-language.rst` §2.13 (D101, D157), and the charter document at
-  `wt-hygiene` (§6, §14). No claim here is transcribed from the charter
-  without independent verification against the file it describes, per
-  this repo's Verifiability documentation standard.
+  `bsl-language.rst` §2.13 (D101, D157) and §2.8 (`:2989`, the existing
+  no-string-payload rule), `NORTH_STAR.md` §0 (`:12-27`, confirmed only
+  AE is named there), `event_builders.py` (`:226`, `:536`, and the
+  by-name presence check confirming all twelve Tier 1 `EventType`s also
+  have an `EVENT_BUILDERS` entry), `src/babylon/models/events/
+  _legacy.py` (`ControlRatioCrisisEvent`, `:387`, `:416`, `:421`, `:426`)
+  and `spine_payloads.py` (`EntityDeathEvent`, `:48`, `:56-61`), and the
+  charter document at `wt-hygiene` (§6, §14). No claim here is
+  transcribed from the charter without independent verification against
+  the file it describes, per this repo's Verifiability documentation
+  standard.
+- **Fix round 1 (2026-08-18)**: three verifiability defects (1 Critical,
+  2 Important) found by an independent review
+  (`.superpowers/sdd/2026-08-18-bsl-refactor-program/task-r46-review.md`)
+  were corrected in place — clause (ii)'s false "no evidence"/"no
+  per-field validation" claims (reworked with the real `EVENT_BUILDERS`
+  Pydantic evidence and why it still doesn't ground a v1 per-key kind),
+  the "unconstrained `<expr>`" overstatement of §2.8's existing
+  no-string rule, and the two "NORTH_STAR §0 already names AG" claims
+  (§0 names only AE; AH would be the second construct, not the third).
+  The proposed text in §1 and the operative scope decisions (no per-key
+  kind in v1, AH as the letter) were unaffected — every fix was to a
+  factual claim in the surrounding rationale, independently re-verified
+  against source before being written, not to the amendment itself.

--- a/ai/_inbox/amendment-defevent-draft.md
+++ b/ai/_inbox/amendment-defevent-draft.md
@@ -1,0 +1,385 @@
+# Amendment AH — Declared Event Schemas (`defevent`)
+
+- **Date**: 2026-08-18
+- **Status**: **DRAFT — DIRECTOR GATE.** Not ratified. This text is the R4.6
+  deliverable of the BSL refactor program (`docs/superpowers/plans/
+  2026-08-18-bsl-refactor-program.md` §14, worktree `wt-hygiene`): the
+  Director approved the *amendment path* for `defevent` at the 2026-08-18
+  popup sitting, over a deferred-to-WS1 alternative, and gated drafting on
+  R4.1's event-schema registry landing (`dev @ 126fe9402`, this worktree's
+  HEAD). Drafting is workforce work; **ratification is a future Director
+  sitting**, not this document.
+- **Version impact**: **MINOR** — a new additive `<top-form>` and its
+  load-time checks; no principle redefined or removed, no verb/intrinsic/
+  severity-rule/constructor-family minted (§3 below). Precedent: Amendment
+  AG, also MINOR, for the same reason.
+- **Letter**: **AH** — the next free letter after AG (ratified v3.2.0,
+  2026-08-10; confirmed no `Amendment AH` text exists anywhere in the tree
+  as of this draft).
+- **Amends**: NORTH_STAR §0's closed-formalism-surface sentence (a third
+  named additive construct joins BSL/Amendment AE and attributed-
+  membership + lattice-instances/Amendment AG); Article IX.2's amendment
+  registry (new entry, inserted after Amendment AG).
+- **Adds**: no new Article I–VIII principle text. `bsl-language.rst` gains
+  one new normative section (a sibling of §2.13's `defenum`/`defvocabulary`)
+  once ratified and specified; this draft does not write that section —
+  see §7.
+- **Supersedes**: nothing.
+- **Authorizes**: the Rust/BSL implementation of `defevent` (grammar
+  production, loader, the load-time refusal checks named in §5) as a
+  future, separately-scoped, cargo-gated task — **not built by this draft
+  and not built by R4.6**, which is documentation-only per its own brief.
+- **Source**: R4.1's event-schema registry (`docs/reference/
+  event-schema-registry.toml`, landed `dev @ 126fe9402efa28da604cda1d084c
+  bd6c166009bc2`, this worktree); the BSL refactor program charter §6
+  ("Phase 4 — event-schema registry as data") and §14 ("DIRECTOR RULINGS")
+  (`docs/superpowers/plans/2026-08-18-bsl-refactor-program.md`, read from
+  `wt-hygiene`); the D101 precedent for minting a declared construct
+  (`docs/reference/bsl-language.rst` §2.13, `ADR195_enum_deffield_row.yaml`).
+  **Recording ADR**: the next free number as of this draft is above
+  ADR215 (the highest file in `ai/decisions/` today) — re-checked at
+  ratification time per this repo's standing convention (ADR195's own
+  practice); the ratifying commit assigns it.
+
+---
+
+## 0. The problem (IX.3.3 required element)
+
+`emit` (BSL's event-effect verb, `bsl-language.rst` §2.8: `"(" "emit"
+<enum-ref> <payload-item>* ")"`) checks its `EventType` operand against the
+closed graph vocabulary today, and nothing else. Verified fresh against
+`rust/crates/babylon-bsl/src/` on this branch:
+
+- `grammar.rs:208` registers `("emit", 1, EnumKind::EventType)` — the
+  `<enum-ref>` operand is checked to be a legal `EventType` member, full
+  stop.
+- `bound_checker.rs:577-591` reads `<payload-item>` forms only for fuel
+  cost and to confirm each key `<symbol>` is static — it does not look at
+  what the key names ARE or what shape the value expressions must take.
+- `typecheck.rs` has **zero** lines that mention `emit`'s payload; the
+  file's only "emit"-adjacent text is an unrelated docstring for
+  `E-TYPE-016`/`E-TYPE-017`.
+
+So an `emit` site's payload — which keys it carries, whether a key is
+required, what kind of value belongs under it — is unchecked by the
+grammar in every direction. `control-ratio.bsl`'s own `CONTROL_RATIO_CRISIS`
+emits are the standing example the registry documents (`event-schema-
+registry.toml` lines 123-143): the `enforcer-population > 0` branch emits 8
+keys, the `= 0` branch emits 6 (both branches D-recorded, both legal,
+neither a defect) — a real two-shape payload no consumer written against
+one branch can see coming from the grammar.
+
+R4.1 closed the DATA half of this gap: `docs/reference/
+event-schema-registry.toml` now states, per `EventType` member, tiered by
+evidence class, what a real emit site or a Python builder actually
+carries. R4.2 (queued, not built by this draft) closes the ADVISORY half:
+a `bsl-lint` check comparing an emit site's keys against the registry,
+warning on drift — repo-relationship-shaped, per the Director's
+2026-08-18 check-placement boundary ruling (charter, same session):
+*"repo-relationship invariants (citations, numbering, cross-file
+duplication) → `bsl-lint`."*
+
+What neither R4.1 nor R4.2 can do, by that same boundary ruling, is make
+an undeclared or malformed payload **refuse to load**. The ruling's other
+half is explicit: *"semantic coherence of a content set → IN-LANGUAGE
+load/type refusal (new E-LOAD/E-TYPE codes, amendment-free loader
+hardening…)"* — but the charter's own Phase 4 section immediately notes
+the boundary this clause does NOT clear: *"moving `emit` payload
+enforcement INTO the grammar (a `defevent`-style declared construct)
+crosses into amendment-class per the D101 precedent."* D101
+(`bsl-language.rst` §2.13, ADR195) is the standing precedent for exactly
+this shape of question — minting a NEW `<top-form>` declaration and a new
+governing law for what it checks is not "amendment-free loader
+hardening" of an existing refusal; it is a new declared construct, and
+the Director ruled (§14, 2026-08-18) that this one specifically goes
+through the amendment path rather than a workforce-decided D-row.
+
+## 1. Proposed constitutional text (IX.3.3 required element)
+
+*Registry entry, to be inserted in IX.2 after Amendment AG, in the house
+voice:*
+
+> **Amendment AH — Declared Event Schemas (`defevent`)** (ratified vX.Y.Z):
+> re-opens NORTH_STAR §0's formalism closure for **exactly one** additive
+> construct, `defevent` — a BSL declaration form attaching a payload
+> schema to an existing, closed-vocabulary `EventType` member. Operative
+> clauses: **(i) what it declares** — a `defevent` form names one
+> `EventType` member (checked against the existing closed graph
+> vocabulary, §3.6/D101; `defevent` mints no new `EventType` member and no
+> new closed-vocabulary kind) and a set of payload keys, each flagged
+> required or optional; it does not itself declare a value KIND per key
+> (§2 below scopes this deliberately to what the R4.1 registry's own
+> evidence actually carries — name and required-ness, not a per-key
+> type). **(ii) what activates checking** — a `defevent` for `EventType/X`
+> makes every `(emit EventType/X …)` site reachable from its declaration
+> scope (a bare top-form or, joining `defenum`/`defvocabulary`/`defconst`/
+> `deffield`, a shared D157 prelude) subject to load-time payload
+> checking; an `EventType` with no `defevent` anywhere in scope is
+> unchecked, exactly as today — the same backward-compatible, per-kind
+> activation `defvocabulary` already established (D101). **(iii) what
+> refuses** — a duplicate `defevent` for the same `EventType` (`E-LOAD-001`,
+> the same code every duplicate declaration shares); an `emit` naming an
+> `EventType` under the closed-world rollout obligation of clause (iv)
+> with no matching `defevent` anywhere reachable; and a payload whose key
+> set does not match its `defevent`'s declared required/optional keys
+> (missing required, or a key the declaration does not name at all).
+> **(iv) the rollout obligation** — ratifying this amendment changes no
+> load behavior by itself; the implementing PR that turns on payload
+> checking for a cohort of `EventType`s MUST land `defevent` declarations
+> for that same cohort in the same change, so no existing content
+> regresses. The event-schema registry's three evidence tiers
+> (`docs/reference/event-schema-registry.toml`) are this obligation's
+> named schedule: Tier 1 (12 `verified-bsl` members) are the first
+> candidates, since real citations already back their key sets; Tier 2
+> (68 `verified-python-builder` members) migrate when their emitters port
+> from `EVENT_BUILDERS` to BSL at the engine-freeze cutover; Tier 3 (20
+> `no-known-emitter` members) stay undeclared — the honesty ledger — until
+> a first emitter exists for one. **(v) the closure re-seals** — this
+> amendment adds no verb, no intrinsic, no severity rule, no constructor
+> family, no adjunction, no level lattice; `defevent` expresses a payload
+> shape for an effect the grammar already has (`emit`), exactly as
+> `deffield` expresses a value shape for a field the grammar already has;
+> everything else under NORTH_STAR §0 stays closed. Windows-impact note
+> (AA duty): none — a content-declaration and loader change only. Source:
+> Director ruling, BSL refactor program §14 (2026-08-18, popup sitting);
+> D101 precedent (`bsl-language.rst` §2.13, ADR195); event-schema registry
+> evidence base, R4.1 (ADR<TBD>). Director-ratified <DATE>.
+
+## 2. Clause-by-clause rationale
+
+**(i) Closed-kind discipline.** `defevent`'s `<enum-ref>` operand is
+checked against the SAME closed `EventType` vocabulary `emit` already
+checks against (`grammar.rs:208`, `EnumKind::EventType`) — it cannot name
+a member outside it, and it cannot mint a new one. This mirrors
+`defvocabulary`'s own restriction to the four existing structural kinds
+(`bsl-language.rst` §2.13: *"needs no dedicated grammar production: the
+restriction is a load-time check… not a lexical one"*) and answers the
+"kinds closed" instruction directly: Amendment AG's clause (ii) already
+states the house rule this amendment follows — content may declare
+INSTANCES against an existing closed schema, never mint a new KIND.
+`defevent` mints instances (per-EventType schemas); `EventType` the kind
+stays exactly as closed as it is today.
+
+**(ii) Deliberately no per-key value kind.** The R4.1 registry —
+`RegistryKey` in `src/babylon/sentinels/event_schema_registry/
+registry.py` — carries `name`, `required`, `source`, `note` per key. It
+does **not** carry a value type or kind (`Currency`/`Real`/`Probability`/…)
+because no existing evidence source states one: BSL's own `<payload-item>`
+grammar (§2.8) takes an unconstrained `<expr>`, and `EVENT_BUILDERS`
+(Python) does no per-field kind validation either. A `defevent` proposal
+that invented per-key kinds would manufacture evidence the registry does
+not have — exactly the false-authority failure R4.1's own tiering was
+built to avoid (`registry.py`'s module docstring, C-1 rescope). This
+amendment therefore scopes `defevent` to key NAME + required/optional
+only. Per-key value-kind checking is a genuinely separate, later
+extension (its own amendment, since it would mint a NEW checked
+invariant class, not extend this one) — named here so the boundary is not
+silently redrawn by a future implementer.
+
+**(iii) Per-EventType activation, prelude-eligible.** `defevent` follows
+`defvocabulary`'s exact activation shape (D101): declaring nothing leaves
+behavior unchanged, so an `EventType` this amendment never gets a
+`defevent` for behaves exactly as it does today, forever, unless someone
+declares one. Making it prelude-eligible (D157: `defenum`/`defvocabulary`/
+`defconst`/`deffield`) lets the whole content estate share one canonical
+schema set per `EventType` rather than fifteen content files each
+re-declaring `CONTROL_RATIO_CRISIS`'s eight keys — the same motivation
+D157 names for the four forms it already covers.
+
+**(iv) The registry is the migration inventory, not just evidence.** This
+is the clause that answers "how does `defevent` relate to the three
+tiers" directly, and it is the one place this draft makes a **closed-
+world** claim (an `EventType` a `defevent`-checking implementation deems
+in-scope, but for which no schema exists anywhere reachable, is a load
+refusal — "emit of an undeclared event"). A closed-world rule is only
+honest if it is never turned on for a cohort of `EventType`s that has
+no matching `defevent` yet, which is why clause (iv) makes landing the
+declarations a same-change obligation, not a separate future cleanup.
+The tiers give that obligation a concrete, evidence-backed order:
+
+| Tier | Count | Registry file rows | What "first candidate" / "migrate at freeze" / "honesty ledger" means operationally |
+|---|---|---|---|
+| 1 — `verified-bsl` | 12 | `[[tier1]]`, lines 40-185 | Real `(emit …)` citations exist today (15 sites, `content/rules/*.bsl`); their key sets are already measured, D-recorded where two-shape (`CONTROL_RATIO_CRISIS`), and ready to transcribe into `defevent` forms with no invention. These are the first `defevent`s an implementing PR should write, since only they can turn on checking without landing new content first. |
+| 2 — `verified-python-builder` | 68 | `[[tier2]]`, lines 211-815 | No BSL emit site exists yet — these events are still emitted from Python's `EVENT_BUILDERS` (`src/babylon/engine/event_builders.py`). The closed-world rule is VACUOUS for them today (nothing in BSL emits them to refuse), so declaring their `defevent`s is naturally sequenced with each event's own port to BSL at the Amendment AE engine-freeze cutover, transcribing the Tier 2 row (itself already flagged as inheriting `EVENT_BUILDERS`' own incompleteness — see the registry's own tier-2 note) rather than re-deriving a schema from nothing. |
+| 3 — `no-known-emitter` | 20 | `[[tier3]]`, lines 825-883 | No builder, no BSL site — nothing anywhere emits these today. The closed-world rule stays vacuous for the same reason as Tier 2, but with no scheduled trigger: these stay undeclared, the honesty ledger `sentinels/fallback_coverage`'s `BUS_BOUNDARY_LEDGER` already ledgers independently (registry header comment, confirmed cross-check in the landed test suite), until a first emitter appears for one. |
+
+`unminted_bsl_only`'s one row (`ORGANIZATION_SEEDED`, `organization.bsl:31`)
+is deliberately outside this table — it is not an `EventType` member at
+all (the registry's own header: *"folding it into Tier 1 would falsely
+imply the three tiers exhaustively partition the 100-member Python
+universe"*), so `defevent EventType/ORGANIZATION_SEEDED` is not
+expressible: the `<enum-ref>` operand fails the same closed-vocabulary
+check clause (i) states, the same way any other unregistered `EventType`
+name would.
+
+**(v) The closure re-seal.** Word-for-word the same discipline AE clause
+(ii) and AG clause (iii) already state for their own additive constructs:
+no new generator, constructor family, adjunction, level lattice, or
+severity rule. `defevent` is schema-on-an-existing-effect, the same job
+`deffield` already does for schema-on-an-existing-node/edge-attribute —
+new DATA about the shape of something the grammar can already do, never
+new mathematics.
+
+## 3. What this does NOT mint
+
+- **No new `EventType` member.** Clause (i); the closed vocabulary is
+  unchanged.
+- **No new mathematics.** Clause (v); no generator/constructor
+  family/adjunction/level lattice/severity rule — the NORTH_STAR §0 test
+  every additive re-opening since AE has had to clear.
+- **No per-key value-kind checking.** Clause (ii), deliberately deferred
+  — the evidence to ground it does not exist yet, and building it would
+  be a second, separately-amendable checked-invariant class layered on
+  top of this one, not part of it.
+- **No renaming of any BSL content payload key.** The registry this
+  amendment's evidence base rests on already commits to this (port-AS-IS,
+  ADR183, restated in the registry's own header comment); a `defevent`
+  transcribing a Tier 1 row inherits that discipline — it transcribes
+  content's own kebab-case spelling, never a builder's snake_case
+  substitute (the registry's `normalize_key()` function documents the
+  one narrow `_`/`-` comparison rule this never widens into a rename).
+
+## 4. What refuses at load — the three classes, and the one open question
+
+1. **Duplicate `defevent`.** Two `defevent` forms (bare, or one bare and
+   one via a shared D157 prelude) naming the same `EventType`. Refuses
+   `E-LOAD-001`, following `defvocabulary`'s own precedent exactly
+   (`bsl-language.rst` §2.13: *"A duplicate `defenum` type name, or two
+   `defvocabulary` forms naming the same `<enum-kind>`, is `E-LOAD-001`
+   like any other duplicate declaration"*) — and, per D157, `defevent`
+   does NOT get `defenum`'s identical-recognition special case: a
+   re-declaration refuses even if byte-for-byte identical to the first,
+   the same rule `deffield`/`defconst`/`defvocabulary` already carry.
+
+2. **Payload-key mismatch.** An `emit EventType/X` site whose payload
+   omits a key `defevent EventType/X` declares required, or supplies a
+   key `defevent EventType/X` never declared at all. This is the SAME
+   check R4.2's `bsl-lint` pass already performs advisory-only against
+   the whole registry (Tier 1 and Tier 2 rows) — this amendment's
+   consequence, once implemented, is that for an `EventType` with a
+   ratified `defevent`, the identical comparison becomes a load refusal
+   rather than a lint warning; `bsl-lint`'s check remains the advisory
+   layer for every `EventType` that has not (yet, or ever) received a
+   `defevent`.
+
+3. **Emit of an undeclared event, under the closed-world rollout
+   obligation (§2 clause iv).** This is the one place this draft is
+   naming a design decision rather than transcribing an uncontested
+   precedent, and it is flagged as such for the ratifying sitting:
+   whether "no matching `defevent`" refuses **only** for the cohort an
+   implementing PR explicitly brings under checking (this draft's
+   proposed reading — §1 clause (ii)/(iv)), or refuses globally the
+   moment `defevent` exists as a construct (which clause (iv)'s own
+   Tier-2/Tier-3 vacuity argument shows would be harmless in practice,
+   since neither tier has a BSL emit site to trip it today, but is a
+   stricter, less reversible rule to ratify). The registry's own tiering
+   was built exactly to let this decision be made with real numbers
+   rather than a guess (12 sites needing schemas now, 68 needing them
+   later, 20 needing none yet) — the ratifying sitting has that evidence
+   in hand either way.
+
+Exact `E-LOAD` numbers for classes 2 and 3 are **not** assigned by this
+draft, following ADR195's own stated practice for D101's consequence
+codes (*"grep-verified next-free at execution time"*) — they are owed by
+the implementing PR, contiguous with whatever `E-LOAD` sequence is open
+when that PR lands.
+
+## 5. Principles affected, and how their text moves (IX.3.3 required element)
+
+- **NORTH_STAR §0** — the closed-formalism-surface sentence gains a third
+  named additive construct in its parenthetical, alongside BSL (AE) and
+  attributed membership/lattice instances (AG).
+- **Article IX.2** — one new registry entry (§1 above), inserted after
+  Amendment AG.
+- **No Article I–VIII principle is redefined.** `bsl-language.rst` is a
+  specification document, not constitutional text; its future normative
+  section for `defevent` is a **consequence** of ratification (§7's
+  Task R4.6 sibling, not yet scheduled), the same relationship D101's
+  ADR195 has to §2.13's actual prose.
+
+## 6. Draft invariance proof (IX.3.3 required element)
+
+**The pre-existing `emit` grammar is unchanged and strictly more
+constrained only where a `defevent` opts an `EventType` in.** Every
+content set that declares zero `defevent` forms — every content set that
+exists today — parses, typechecks, and evaluates identically to before
+this amendment: `defevent` is a new `<top-form>` alternative no existing
+file uses, and clause (ii)'s per-`EventType` activation means an
+`EventType` with no `defevent` anywhere in scope is checked exactly as
+today (nowhere). This is the same invariance argument D101 already
+proved for `defvocabulary` (*"backward-compatible with every existing
+content set (none of them declares one)"*), applied to a sibling
+construct built the same way.
+
+**The additive re-opening adds no expressive power to the closed
+algebra.** §3 above states this directly: no generator, constructor
+family, adjunction, level lattice, or severity rule. A `defevent` form
+is data — a name, a set of key names, and a required/optional flag per
+key — parsed and validated at load exactly like `deffield`'s existing
+`<field-init>` shape; `emit`'s runtime semantics (§2.8, evaluating each
+`<payload-item>`'s `<expr>` and posting the event) are unchanged by this
+amendment in every case where a schema check passes.
+
+## 7. What this draft does NOT do
+
+- It does not write `bsl-language.rst`'s normative section for
+  `defevent` — that is drafted once ratified, the same sequencing D101's
+  own ADR195 followed (ADR195 covered "the LANGUAGE CHANGE… No Rust
+  source is touched by this ADR").
+- It does not implement any Rust grammar, loader, or checker code.
+- It does not author any `defevent` content, including the Tier 1
+  transcriptions §2 clause (iv) names as the natural first candidates.
+- It does not assign `E-LOAD` numbers (§4).
+- It does not resolve §4 class 3's open activation-scope question — that
+  is this draft's one live decision for the ratifying sitting, named
+  explicitly rather than silently picked.
+
+All five are correctly out of scope for R4.6, whose own brief in the
+charter (§14) names this document's job as "draft the constitutional
+amendment… + its ADR" — drafting, not building — with ratification and
+implementation both future, separately-scoped work.
+
+## 8. DIRECTOR RULING REQUIRED
+
+1. **Ratify or revise the proposed text in §1** (letter AH, MINOR version
+   bump).
+2. **Resolve §4 class 3's open question**: does "emit of an undeclared
+   event" refuse only for the `EventType` cohort an implementing PR
+   explicitly declares, or globally the instant `defevent` exists as a
+   construct? This draft recommends the cohort-scoped reading (§2 clause
+   iv, §4 class 3's first option) as the lower-risk, more reversible
+   choice, consistent with `defvocabulary`'s own precedent.
+3. **Confirm the registry's tier schedule (§2's table) as the intended
+   rollout order** — Tier 1 first, Tier 2 at the engine freeze, Tier 3 on
+   first emitter — or direct a different one.
+4. **Assign the recording ADR number** at ratification time (§ header;
+   next free above ADR215 as of this draft).
+
+## 9. Drafting notes (not part of the proposed text)
+
+- This draft follows the `ai/_inbox/amendment-*-draft.md` convention this
+  repository already uses for a Director-gated, not-yet-ratified
+  amendment text: `ai/_inbox/amendment-v3-refoundation-draft.md`
+  (Amendment AE, P27 Phase 0 Task 16 — *"Create: `ai/_inbox/
+  amendment-v3-refoundation-draft.md` (draft; the ratified text lands in
+  `CONSTITUTION.md` via the Director's merge)"*), rather than
+  `ai/decisions/`. Checked directly: no drafted-but-unratified amendment
+  in this repo's history has an `ai/decisions/*.yaml` ADR filed for it
+  before ratification — every located ADR whose status is `"accepted"`
+  records a decision the Director had already made (ADR195's own D101
+  ruling is a "Director ruling… approved twice" before the ADR was
+  written; the AE precedent's own ADR172 is assigned "the ratifying
+  commit"). Per this task's own instruction — skip the ADR stub if drafts
+  don't get one pre-ratification — **no ADR stub accompanies this
+  draft.** The recording ADR is created when this amendment ratifies, by
+  the ratifying commit, exactly as ADR172 and ADR189 were.
+- Every factual claim about current grammar/registry/precedent state in
+  this draft was checked directly against source on this branch
+  (`dev @ 126fe9402`, `wt-p4`) on 2026-08-18: `grammar.rs:208`,
+  `bound_checker.rs:577-591`, `typecheck.rs` (zero `emit`-payload hits),
+  `docs/reference/event-schema-registry.toml` (all three tier tables,
+  the `unminted_bsl_only` row), `registry.py` (the `RegistryKey` shape),
+  `bsl-language.rst` §2.13 (D101, D157), and the charter document at
+  `wt-hygiene` (§6, §14). No claim here is transcribed from the charter
+  without independent verification against the file it describes, per
+  this repo's Verifiability documentation standard.

--- a/ai/_inbox/amendment-defevent-draft.md
+++ b/ai/_inbox/amendment-defevent-draft.md
@@ -401,6 +401,14 @@ implementation both future, separately-scoped work.
 
 ## 8. DIRECTOR RULING REQUIRED
 
+> **Ruling recorded (Director popup sequence, 2026-08-18 ~21:15 EDT):**
+> item 2 is RULED — the undeclared-emit refusal activates **PER-COHORT**
+> (this draft's own recommended reading: the refusal binds only content
+> sets containing at least one `defevent`; adopters opt in; the three-tier
+> registry is the drain plan; global enforcement arrives when the
+> inventory empties). Items 1, 3, and 4 remain for the ratifying sitting
+> proper (the ceremony that lands the §1 text in `CONSTITUTION.md`).
+
 1. **Ratify or revise the proposed text in §1** (letter AH, MINOR version
    bump).
 2. **Resolve §4 class 3's open question**: does "emit of an undeclared

--- a/docs/reference/event-schema-registry.toml
+++ b/docs/reference/event-schema-registry.toml
@@ -1,0 +1,883 @@
+### Event-schema registry — BSL `emit` payloads, tiered by evidence class.
+###
+### Theme 7 of the BSL refactor program (C-1 rescope, 2026-08-18). Loaded by
+### `babylon.sentinels.event_schema_registry.registry.load_registry`; synced
+### against `EVENT_BUILDERS` by `babylon.sentinels.event_schema_registry.sync`
+### (the one-way `EVENT_BUILDERS ⊆ registry` check, R4.4.1); proved against a
+### FRESH re-scan of `content/rules/*.bsl` and `EVENT_BUILDERS` on every test
+### run by `tests/unit/sentinels/test_event_schema_registry.py` — this file
+### is a snapshot, not a trusted-forever transcription, and a future emit
+### site or builder this snapshot does not yet know about reds that test
+### until the snapshot is updated (the same ratchet
+### `sentinels/fallback_coverage` already runs for the bus-boundary surface).
+###
+### Full design rationale (why three tiers, what each key's `source`/
+### `required` mean, why `ORGANIZATION_SEEDED` is not a tier row) lives in
+### `src/babylon/sentinels/event_schema_registry/registry.py`'s module
+### docstring — read that before editing this file by hand.
+###
+### BSL content payload keys are NEVER renamed here (port-AS-IS, ADR183):
+### Tier 1 keys are transcribed in BSL's own kebab-case exactly as content
+### spells them; Tier 2 keys are transcribed in EVENT_BUILDERS' own
+### snake_case exactly as the builder spells them. The sync check normalizes
+### (`_` <-> `-`) when COMPARING the two; this file never does.
+
+schema_version = 1
+measured_at = "2026-08-18"
+# The fresh AST count of `babylon.models.enums.events.EventType` members —
+# tier1 + tier2 + tier3 must sum to exactly this (CLAUDE.md's "100",
+# AST-verified, corrects the BSL-refactor-program survey's stale "98").
+python_event_type_total = 100
+bsl_content_glob = "rust/crates/babylon-tick/content/rules/*.bsl"
+
+# =============================================================================
+# TIER 1 — verified-bsl (12 members; 12 real `(emit …)` distinct EventTypes
+# out of the 15 total `(emit …)` sites and 13 distinct EMIT NAMES a fresh scan
+# of content/rules/*.bsl finds — the 13th name, ORGANIZATION_SEEDED, is BSL-
+# only and lives in `unminted_bsl_only` below, not here; see that table).
+# =============================================================================
+
+[[tier1]]
+event_type = "ENTITY_DEATH"
+citations = ["rust/crates/babylon-tick/content/rules/vitality.bsl:96"]
+keys = [
+  { name = "entity-id", required = true, source = "bsl" },
+  { name = "wealth", required = true, source = "bsl" },
+  { name = "consumption-needs", required = true, source = "bsl" },
+  { name = "s-bio", required = true, source = "bsl" },
+  { name = "s-class", required = true, source = "bsl" },
+  { name = "cause", required = false, source = "builder-only", note = "EVENT_BUILDERS' EntityDeathEvent builder reads payload.get('cause', 'unknown') defensively; vitality.bsl:90-95's own comment states why no BSL site provides it — §2.8 admits no string in a payload, so the frozen `cause` discriminant does not travel and is recoverable from the other fields instead (drained < death_threshold -> wealth_threshold, else starvation)." },
+]
+
+[[tier1]]
+event_type = "CONSCIOUSNESS_TRANSMISSION"
+citations = ["rust/crates/babylon-tick/content/rules/solidarity.bsl:254"]
+keys = [
+  { name = "source-id", required = true, source = "bsl" },
+  { name = "target-id", required = true, source = "bsl" },
+  { name = "delta", required = true, source = "bsl" },
+  { name = "solidarity-strength", required = true, source = "bsl" },
+  { name = "source-consciousness", required = true, source = "bsl" },
+  { name = "old-target-consciousness", required = true, source = "bsl" },
+  { name = "new-target-consciousness", required = true, source = "bsl" },
+]
+
+[[tier1]]
+event_type = "MASS_AWAKENING"
+citations = ["rust/crates/babylon-tick/content/rules/solidarity.bsl:360"]
+keys = [
+  { name = "target-id", required = true, source = "bsl" },
+  { name = "old-consciousness", required = true, source = "bsl" },
+  { name = "new-consciousness", required = true, source = "bsl" },
+  { name = "triggering-source", required = true, source = "bsl" },
+]
+
+[[tier1]]
+event_type = "LIFECYCLE_TRANSITION"
+citations = ["rust/crates/babylon-tick/content/rules/lifecycle.bsl:388"]
+keys = [
+  { name = "territory-id", required = true, source = "bsl" },
+  { name = "pop-d", required = true, source = "bsl" },
+  { name = "pop-p", required = true, source = "bsl" },
+  { name = "pop-d-prime", required = true, source = "bsl" },
+  { name = "dependency-ratio", required = true, source = "bsl" },
+]
+
+[[tier1]]
+event_type = "LEGITIMATION_CRISIS"
+citations = ["rust/crates/babylon-tick/content/rules/lifecycle.bsl:401"]
+keys = [
+  { name = "territory-id", required = true, source = "bsl" },
+  { name = "legitimation-index", required = true, source = "bsl" },
+]
+
+[[tier1]]
+event_type = "LEGITIMATION_RECOVERY"
+citations = ["rust/crates/babylon-tick/content/rules/lifecycle.bsl:405"]
+keys = [
+  { name = "territory-id", required = true, source = "bsl" },
+  { name = "legitimation-index", required = true, source = "bsl" },
+]
+
+[[tier1]]
+event_type = "VALUE_TRANSFER"
+citations = ["rust/crates/babylon-tick/content/rules/dispossession.bsl:401"]
+keys = [
+  { name = "territory", required = true, source = "bsl" },
+  { name = "total-transferred", required = true, source = "bsl" },
+  { name = "net-received", required = true, source = "bsl" },
+  { name = "deadweight-loss", required = true, source = "bsl" },
+]
+
+[[tier1]]
+event_type = "DISPOSSESSION_EVENT"
+citations = ["rust/crates/babylon-tick/content/rules/dispossession.bsl:412"]
+keys = [
+  { name = "territory", required = true, source = "bsl" },
+  { name = "intensity", required = true, source = "bsl" },
+  { name = "foreclosure-rate", required = true, source = "bsl" },
+  { name = "eviction-rate", required = true, source = "bsl" },
+  { name = "displacement-rate", required = true, source = "bsl" },
+]
+
+[[tier1]]
+event_type = "CONTROL_RATIO_CRISIS"
+citations = [
+  "rust/crates/babylon-tick/content/rules/control-ratio.bsl:320",
+  "rust/crates/babylon-tick/content/rules/control-ratio.bsl:330",
+]
+# Two-shape payload, D-recorded (control_ratio.py:210-247's frozen origin;
+# ADR183 port-AS-IS): the enforcer-population > 0 branch (:320) emits all 8
+# keys; the = 0 branch (:330) omits actual-ratio and control-ratio. The
+# registry lists the UNION with the two branch-specific keys flagged
+# optional, never a forced single shape.
+keys = [
+  { name = "enforcer-population", required = true, source = "bsl" },
+  { name = "prisoner-population", required = true, source = "bsl" },
+  { name = "control-capacity", required = true, source = "bsl" },
+  { name = "max-controllable", required = true, source = "bsl" },
+  { name = "over-capacity-by", required = true, source = "bsl" },
+  { name = "capacity-threshold", required = true, source = "bsl" },
+  { name = "actual-ratio", required = false, source = "bsl", note = "present only in the enforcer-population > 0 branch (control-ratio.bsl:325); the = 0 branch omits it (deliberate, D-recorded — both are the frozen engine's real shapes, not a defect)." },
+  { name = "control-ratio", required = false, source = "bsl", note = "present only in the enforcer-population > 0 branch (control-ratio.bsl:327); the = 0 branch omits it (same D-record as actual-ratio)." },
+]
+
+[[tier1]]
+event_type = "TERMINAL_DECISION"
+citations = [
+  "rust/crates/babylon-tick/content/rules/control-ratio.bsl:366",
+  "rust/crates/babylon-tick/content/rules/control-ratio.bsl:373",
+]
+# Same 5 keys in both branches (outcome 1=revolution / 0=genocide is the only
+# difference) — no optional flag needed, unlike CONTROL_RATIO_CRISIS above.
+keys = [
+  { name = "outcome", required = true, source = "bsl" },
+  { name = "avg-organization", required = true, source = "bsl" },
+  { name = "revolution-threshold", required = true, source = "bsl" },
+  { name = "prisoner-population", required = true, source = "bsl" },
+  { name = "enforcer-population", required = true, source = "bsl" },
+]
+
+[[tier1]]
+event_type = "SUPERWAGE_CRISIS"
+citations = ["rust/crates/babylon-tick/content/rules/decomposition.bsl:262"]
+keys = [
+  { name = "receiver", required = true, source = "bsl" },
+  { name = "desired-wages", required = true, source = "bsl" },
+  { name = "available-pool", required = true, source = "bsl" },
+  { name = "receiver-id", required = false, source = "builder-only", note = "EVENT_BUILDERS' SuperwageCrisisEvent builder reads payload.get('receiver_id', ...); decomposition.bsl:262-265 emits a bare 'receiver' key instead — a real spelling divergence between the frozen Python event's field name and the BSL port's payload, not yet reconciled (repair is R4.4.2, gated)." },
+  { name = "payer-id", required = false, source = "builder-only", note = "EVENT_BUILDERS' SuperwageCrisisEvent builder also reads payload.get('payer_id', ...); no observed BSL emit site provides any payer-side key at all — decomposition.bsl:262-265's payload is receiver-only." },
+]
+
+[[tier1]]
+event_type = "CLASS_DECOMPOSITION"
+citations = ["rust/crates/babylon-tick/content/rules/decomposition.bsl:377"]
+keys = [
+  { name = "source-class", required = true, source = "bsl" },
+  { name = "source-population", required = true, source = "bsl" },
+  { name = "source-wealth", required = true, source = "bsl" },
+  { name = "enforcer-fraction", required = true, source = "bsl" },
+  { name = "proletariat-fraction", required = true, source = "bsl" },
+  { name = "population-transferred-to-enforcer", required = true, source = "bsl" },
+  { name = "population-transferred-to-proletariat", required = true, source = "bsl" },
+  { name = "wealth-transferred-to-enforcer", required = true, source = "bsl" },
+  { name = "wealth-transferred-to-proletariat", required = true, source = "bsl" },
+]
+
+# =============================================================================
+# BSL-only emit names absent from Python's EventType enum entirely — NOT part
+# of the three tiers above (which exhaustively partition the 100-member
+# Python universe; folding this in would break that partition and falsely
+# imply it is a real, disposed member).
+# =============================================================================
+
+[[unminted_bsl_only]]
+name = "ORGANIZATION_SEEDED"
+citation = "rust/crates/babylon-tick/content/rules/organization.bsl:31"
+note = "organization.bsl's own D-1 comment (lines 12-18): a KNOWINGLY-UNMINTED, probe-only event name — not in ADR196's mint, not a member of the frozen Python EventType enum, no consumer anywhere. Exists solely so the organization/kind-probe rule has an effect to gate; retire or mint it when the Events-in-BSL workstream (WS1, #502) gives emit effects a real observable."
+keys = [
+  { name = "probe", required = true, source = "bsl" },
+]
+
+# =============================================================================
+# TIER 2 — verified-python-builder (68 members: every EVENT_BUILDERS entry
+# minus the 12 Tier 1 EventTypes above — 80 total builder entries, AST-
+# counted). Keys are transcribed VERBATIM in EVENT_BUILDERS' own snake_case
+# (never converted to kebab — that would misrepresent an un-cited spelling as
+# BSL-native). No completeness claim: this is what the builder currently
+# reads, nothing more.
+# =============================================================================
+
+[[tier2]]
+event_type = "ASPECT_REVERSAL"
+keys = [
+  { name = "source_id", required = true, source = "builder" },
+  { name = "target_id", required = true, source = "builder" },
+  { name = "previous_dominant", required = true, source = "builder" },
+  { name = "new_dominant", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "BETRAYAL_INTEGRAL_CROSSED"
+keys = [
+  { name = "class_id", required = true, source = "builder" },
+  { name = "incumbent_id", required = true, source = "builder" },
+  { name = "integral", required = true, source = "builder" },
+  { name = "threshold", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "BIFURCATION_THRESHOLD"
+keys = [
+  { name = "fips", required = true, source = "builder" },
+  { name = "score", required = true, source = "builder" },
+  { name = "direction", required = true, source = "builder" },
+  { name = "solidarity_density", required = true, source = "builder" },
+  { name = "legitimation", required = true, source = "builder" },
+  { name = "class_burden_ratio", required = true, source = "builder" },
+  { name = "threshold", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "CALIBRATION_AXIOM_VIOLATION"
+keys = [
+  { name = "industry", required = true, source = "builder" },
+  { name = "year", required = true, source = "builder" },
+  { name = "ratio", required = true, source = "builder" },
+  { name = "threshold", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "CALIBRATION_PHI_HOUR_OUTLIER"
+keys = [
+  { name = "county_fips", required = true, source = "builder" },
+  { name = "phi_hour", required = true, source = "builder" },
+  { name = "threshold_low", required = true, source = "builder" },
+  { name = "threshold_high", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "CALIBRATION_QCEW_CARRY_FORWARD"
+keys = [
+  { name = "county_fips", required = true, source = "builder" },
+  { name = "year", required = true, source = "builder" },
+  { name = "look_back_year", required = true, source = "builder" },
+  { name = "look_back_distance", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "CAPITAL_STRIKE"
+keys = [
+  { name = "sovereign_id", required = true, source = "builder" },
+  { name = "incidence", required = true, source = "builder" },
+  { name = "tolerance", required = true, source = "builder" },
+  { name = "outflow", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "CIVIL_WAR_DECLARED"
+keys = [
+  { name = "parent_sovereign_id", required = true, source = "builder" },
+  { name = "secessionist_faction_id", required = true, source = "builder" },
+  { name = "contested_territory_count", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "CO_OPTIVE_BREAKDOWN"
+keys = [
+  { name = "source_id", required = true, source = "builder" },
+  { name = "target_id", required = true, source = "builder" },
+  { name = "multiplier", required = true, source = "builder" },
+  { name = "latent_released", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "CRISIS_PHASE_TRANSITION"
+keys = [
+  { name = "fips", required = true, source = "builder" },
+  { name = "previous_phase", required = true, source = "builder" },
+  { name = "new_phase", required = true, source = "builder" },
+  { name = "profit_rate", required = true, source = "builder" },
+  { name = "crisis_duration", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "DELIVERY_GAP_CROSSED"
+keys = [
+  { name = "class_id", required = true, source = "builder" },
+  { name = "incumbent_id", required = true, source = "builder" },
+  { name = "gap", required = true, source = "builder" },
+  { name = "betrayal_integral", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "DISILLUSION_WINDOW_OPEN"
+keys = [
+  { name = "class_id", required = true, source = "builder" },
+  { name = "window_ticks", required = true, source = "builder" },
+  { name = "bridges_present", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "DISPOSSESSION_CASCADE"
+keys = [
+  { name = "fips", required = true, source = "builder" },
+  { name = "cumulative_la_decline", required = true, source = "builder" },
+  { name = "milestone_crossed", required = true, source = "builder" },
+  { name = "current_la_share", required = true, source = "builder" },
+  { name = "baseline_la_share", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "DOCTRINE_PURGE_FAILED"
+keys = [
+  { name = "org_id", required = true, source = "builder" },
+  { name = "node_id", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "DOCTRINE_TRAP_ESCAPED"
+keys = [
+  { name = "org_id", required = true, source = "builder" },
+  { name = "node_id", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "DOCTRINE_TRAP_SPRUNG"
+keys = [
+  { name = "org_id", required = true, source = "builder" },
+  { name = "node_id", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "DUAL_POWER_ACTIVE"
+keys = [
+  { name = "territory_id", required = true, source = "builder" },
+  { name = "control_level_sum", required = true, source = "builder" },
+  { name = "competing_sovereign_ids", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "ECOLOGICAL_OVERSHOOT"
+keys = [
+  { name = "overshoot_ratio", required = true, source = "builder" },
+  { name = "total_consumption", required = true, source = "builder" },
+  { name = "total_biocapacity", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "ECONOMIC_CRISIS"
+keys = [
+  { name = "pool_ratio", required = true, source = "builder" },
+  { name = "aggregate_tension", required = true, source = "builder" },
+  { name = "decision", required = true, source = "builder" },
+  { name = "wage_delta", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "EDGE_MODE_TRANSITION"
+keys = [
+  { name = "source_id", required = true, source = "builder" },
+  { name = "target_id", required = true, source = "builder" },
+  { name = "predicate", required = true, source = "builder" },
+  { name = "description", required = true, source = "builder" },
+  { name = "from_mode", required = true, source = "builder" },
+  { name = "to_mode", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "ELECTIONS_SUSPENDED"
+keys = [
+  { name = "sovereign_id", required = true, source = "builder" },
+  { name = "legitimation_index", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "ELECTION_HELD"
+keys = [
+  { name = "sovereign_id", required = true, source = "builder" },
+  { name = "jurisdiction_level", required = true, source = "builder" },
+  { name = "turnout", required = true, source = "builder" },
+  { name = "competitiveness", required = true, source = "builder" },
+  { name = "winning_coalition", required = true, source = "builder" },
+  { name = "spoiler_target", required = true, source = "builder" },
+  { name = "spoiler_shift", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "EXCESSIVE_FORCE"
+keys = [
+  { name = "node_id", required = true, source = "builder" },
+  { name = "repression", required = true, source = "builder" },
+  { name = "spark_probability", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "FACTION_VICTORY"
+keys = [
+  { name = "faction_id", required = true, source = "builder" },
+  { name = "aggregate_influence_share", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "FASCIST_DRIFT"
+keys = [
+  { name = "node_id", required = true, source = "builder" },
+  { name = "fascist_pull", required = true, source = "builder" },
+  { name = "fascist_alignment", required = true, source = "builder" },
+  { name = "entitlement", required = true, source = "builder" },
+  { name = "solidarity", required = true, source = "builder" },
+  { name = "regime", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "FASCIST_RECRUITMENT"
+keys = [
+  { name = "node_id", required = true, source = "builder" },
+  { name = "faction_id", required = true, source = "builder" },
+  { name = "fascist_alignment", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "FASCIST_REVANCHISM"
+keys = [
+  { name = "core_worker_id", required = true, source = "builder" },
+  { name = "revolutionary_capacity", required = true, source = "builder" },
+  { name = "identity_boost", required = true, source = "builder" },
+  { name = "acquiescence_boost", required = true, source = "builder" },
+  { name = "narrative_hint", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "GOVERNANCE_FORK_RESOLVED"
+keys = [
+  { name = "org_id", required = true, source = "builder" },
+  { name = "sovereign_id", required = true, source = "builder" },
+  { name = "arm", required = true, source = "builder" },
+  { name = "geometry", required = true, source = "builder" },
+  { name = "contact", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "GOVERNMENT_FORMED"
+keys = [
+  { name = "sovereign_id", required = true, source = "builder" },
+  { name = "governing_coalition", required = true, source = "builder" },
+  { name = "faction_balance_shift", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "HOPE_SPIKE"
+keys = [
+  { name = "class_id", required = true, source = "builder" },
+  { name = "hope", required = true, source = "builder" },
+  { name = "platform_id", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "HOST_DERECOGNIZED"
+keys = [
+  { name = "org_id", required = true, source = "builder" },
+  { name = "host_id", required = true, source = "builder" },
+  { name = "influence", required = true, source = "builder" },
+  { name = "threshold", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "IMPERIAL_SUBSIDY"
+keys = [
+  { name = "source_id", required = true, source = "builder" },
+  { name = "target_id", required = true, source = "builder" },
+  { name = "amount", required = true, source = "builder" },
+  { name = "repression_boost", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "INHERITANCE_TRANSFER"
+keys = [
+  { name = "territory_id", required = true, source = "builder" },
+  { name = "total_transferred", required = true, source = "builder" },
+  { name = "care_consumed", required = true, source = "builder" },
+  { name = "net_inheritance", required = true, source = "builder" },
+  { name = "inheritance_gini", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "INSTITUTION_BONAPARTIST_MODE"
+keys = [
+  { name = "institution_id", required = true, source = "builder" },
+  { name = "bonapartist_weight", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "INSTITUTION_FACTION_SHIFT"
+keys = [
+  { name = "institution_id", required = true, source = "builder" },
+  { name = "old_fraction", required = true, source = "builder" },
+  { name = "new_fraction", required = true, source = "builder" },
+  { name = "weights", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "LATENT_CONTRADICTION_RELEASE"
+keys = [
+  { name = "node_id", required = true, source = "builder" },
+  { name = "released_fields", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "LEGITIMATION_REFRESH"
+keys = [
+  { name = "territory_id", required = true, source = "builder" },
+  { name = "refresh", required = true, source = "builder" },
+  { name = "legitimation_index", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "LEVEL_TRANSITION"
+keys = [
+  { name = "opposition", required = true, source = "builder" },
+  { name = "from_level", required = true, source = "builder" },
+  { name = "to_level", required = true, source = "builder" },
+  { name = "gap", required = true, source = "builder" },
+  { name = "rate", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "LINE_STRUGGLE_SPLIT"
+keys = [
+  { name = "org_id", required = true, source = "builder" },
+  { name = "old_stance", required = true, source = "builder" },
+  { name = "new_stance", required = true, source = "builder" },
+  { name = "assets_retained", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "LOCKOUT"
+keys = [
+  { name = "org_id", required = true, source = "builder" },
+  { name = "target_id", required = true, source = "builder" },
+  { name = "wage_attenuation", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "MARKET_CORRECTION"
+keys = [
+  { name = "overhang", required = true, source = "builder" },
+  { name = "serviceable", required = true, source = "builder" },
+  { name = "profit_rate", required = true, source = "builder" },
+  { name = "fictitious_log_before", required = true, source = "builder" },
+  { name = "fictitious_log_after", required = true, source = "builder" },
+  { name = "price_log_before", required = true, source = "builder" },
+  { name = "price_log_after", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "ORGANIZATIONAL_ACTION"
+keys = [
+  { name = "layer0_count", required = true, source = "builder" },
+  { name = "action_count", required = true, source = "builder" },
+  { name = "org_count", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "ORGANIZATIONAL_FRACTURE"
+keys = [
+  { name = "org_id", required = true, source = "builder" },
+  { name = "member_id", required = true, source = "builder" },
+  { name = "chauvinism", required = true, source = "builder" },
+  { name = "defection_probability", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "PERIPHERAL_REVOLT"
+keys = [
+  { name = "node_id", required = true, source = "builder" },
+  { name = "edges_severed", required = true, source = "builder" },
+  { name = "p_acquiescence", required = true, source = "builder" },
+  { name = "p_revolution", required = true, source = "builder" },
+  { name = "capital_labor_gap", required = true, source = "builder" },
+  { name = "narrative_hint", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "PHASE_TRANSITION"
+keys = [
+  { name = "previous_state", required = true, source = "builder" },
+  { name = "new_state", required = true, source = "builder" },
+  { name = "percolation_ratio", required = true, source = "builder" },
+  { name = "num_components", required = true, source = "builder" },
+  { name = "largest_component_size", required = true, source = "builder" },
+  { name = "cadre_density", required = true, source = "builder" },
+  { name = "is_resilient", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "POGROM"
+keys = [
+  { name = "org_id", required = true, source = "builder" },
+  { name = "target_id", required = true, source = "builder" },
+  { name = "repression_increment", required = true, source = "builder" },
+  { name = "wealth_destroyed", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "POLICY_ENACTED"
+keys = [
+  { name = "sovereign_id", required = true, source = "builder" },
+  { name = "policy_axis", required = true, source = "builder" },
+  { name = "magnitude", required = true, source = "builder" },
+  { name = "delivery_ratio", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "POLICY_PREEMPTED"
+keys = [
+  { name = "sovereign_id", required = true, source = "builder" },
+  { name = "policy_axis", required = true, source = "builder" },
+  { name = "preempting_sovereign", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "POLICY_STRUCK"
+keys = [
+  { name = "sovereign_id", required = true, source = "builder" },
+  { name = "policy_axis", required = true, source = "builder" },
+  { name = "striking_institution", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "POPULAR_FRONT_CALLED"
+keys = [
+  { name = "axis_progress", required = true, source = "builder" },
+  { name = "trigger", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "POPULATION_ATTRITION"
+keys = [
+  { name = "entity_id", required = true, source = "builder" },
+  { name = "deaths", required = true, source = "builder" },
+  { name = "remaining_population", required = true, source = "builder" },
+  { name = "attrition_rate", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "POWER_VACUUM"
+keys = [
+  { name = "comprador_id", required = true, source = "builder" },
+  { name = "comprador_wealth", required = true, source = "builder" },
+  { name = "subsistence_threshold", required = true, source = "builder" },
+  { name = "revolutionary_capacity", required = true, source = "builder" },
+  { name = "jackson_threshold", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "PRINCIPAL_CONTRADICTION_SHIFT"
+keys = [
+  { name = "previous_field", required = true, source = "builder" },
+  { name = "new_field", required = true, source = "builder" },
+  { name = "max_abs_df_dt", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "RED_BROWN_COUP"
+keys = [
+  { name = "org_id", required = true, source = "builder" },
+  { name = "defections", required = true, source = "builder" },
+  { name = "member_count", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "RED_SETTLER_TRAP_DETECTED"
+keys = [
+  { name = "faction_id", required = true, source = "builder" },
+  { name = "class_reduction", required = true, source = "builder" },
+  { name = "colonial_stance", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "RESERVE_ARMY_PRESSURE"
+keys = [
+  { name = "territory", required = true, source = "builder" },
+  { name = "reserve_ratio", required = true, source = "builder" },
+  { name = "wage_pressure", required = true, source = "builder" },
+  { name = "median_wage", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "REVOLUTIONARY_OFFENSIVE"
+keys = [
+  { name = "periphery_id", required = true, source = "builder" },
+  { name = "revolutionary_capacity", required = true, source = "builder" },
+  { name = "agitation_boost", required = true, source = "builder" },
+  { name = "narrative_hint", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "RUPTURE"
+keys = [
+  { name = "edge", required = true, source = "builder" },
+  { name = "opposition", required = true, source = "builder" },
+  { name = "gap", required = true, source = "builder" },
+  { name = "rate", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "SECESSION_DECLARED"
+keys = [
+  { name = "secessionist_faction_id", required = true, source = "builder" },
+  { name = "parent_sovereign_id", required = true, source = "builder" },
+  { name = "observer_triggered", required = true, source = "builder" },
+  { name = "contiguous_territory_ids", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "SOLIDARITY_SPIKE"
+keys = [
+  { name = "node_id", required = true, source = "builder" },
+  { name = "solidarity_gained", required = true, source = "builder" },
+  { name = "edges_affected", required = true, source = "builder" },
+  { name = "triggered_by", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "SOVEREIGN_COLLAPSE"
+keys = [
+  { name = "sovereign_id", required = true, source = "builder" },
+  { name = "trigger", required = true, source = "builder" },
+  { name = "claimed_territories_count", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "SPONTANEOUS_RIOT"
+keys = [
+  { name = "node_id", required = true, source = "builder" },
+  { name = "volatility", required = true, source = "builder" },
+  { name = "organizational_discipline", required = true, source = "builder" },
+  { name = "riot_risk", required = true, source = "builder" },
+  { name = "wealth_before", required = true, source = "builder" },
+  { name = "wealth_after", required = true, source = "builder" },
+  { name = "narrative_hint", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "STATE_REPRESSION"
+keys = [
+  { name = "org_id", required = true, source = "builder" },
+  { name = "target_id", required = true, source = "builder" },
+  { name = "backfire_delta", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "STATE_SURVEILLANCE"
+keys = [
+  { name = "org_id", required = true, source = "builder" },
+  { name = "target_id", required = true, source = "builder" },
+  { name = "backfire_delta", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "SURPLUS_EXTRACTION"
+keys = [
+  { name = "source_id", required = true, source = "builder" },
+  { name = "target_id", required = true, source = "builder" },
+  { name = "amount", required = true, source = "builder" },
+  { name = "mechanism", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "TERRITORY_TRANSITION"
+keys = [
+  { name = "territory_id", required = true, source = "builder" },
+  { name = "from_sovereign_id", required = true, source = "builder" },
+  { name = "to_sovereign_id", required = true, source = "builder" },
+  { name = "from_winning_faction_id", required = true, source = "builder" },
+  { name = "to_winning_faction_id", required = true, source = "builder" },
+  { name = "reason", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "UPRISING"
+keys = [
+  { name = "node_id", required = true, source = "builder" },
+  { name = "trigger", required = true, source = "builder" },
+  { name = "agitation", required = true, source = "builder" },
+  { name = "repression", required = true, source = "builder" },
+]
+
+[[tier2]]
+event_type = "VIGILANTISM"
+keys = [
+  { name = "org_id", required = true, source = "builder" },
+  { name = "target_id", required = true, source = "builder" },
+  { name = "repression_increment", required = true, source = "builder" },
+]
+
+# =============================================================================
+# TIER 3 — no-known-emitter (20 members: no EVENT_BUILDERS entry, no observed
+# BSL emit site — the exact same 20 members `sentinels/fallback_coverage`'s
+# BUS_BOUNDARY_LEDGER already ledgers as absent from EVENT_BUILDERS, an
+# independent cross-check this registry's own test asserts against). No key
+# list: nothing observed, nothing claimed.
+# =============================================================================
+
+[[tier3]]
+event_type = "BIFURCATION_TENDENCY_CHANGE"
+
+[[tier3]]
+event_type = "CALIBRATION_DISAGREEMENT"
+
+[[tier3]]
+event_type = "CONSCIOUSNESS_SHIFT"
+
+[[tier3]]
+event_type = "DUAL_CIRCUIT_INTERFERENCE"
+
+[[tier3]]
+event_type = "ENDGAME_REACHED"
+
+[[tier3]]
+event_type = "EXPLOITATION_MODE_SHIFT"
+
+[[tier3]]
+event_type = "FACTION_SHIFT"
+
+[[tier3]]
+event_type = "FASCIST_CONVERGENCE"
+
+[[tier3]]
+event_type = "FRAGMENTED_COLLAPSE_ENDGAME"
+
+[[tier3]]
+event_type = "INFRASTRUCTURE_CHANGE"
+
+[[tier3]]
+event_type = "INITIATIVE_CONTESTED"
+
+[[tier3]]
+event_type = "INSTITUTION_REPRODUCTION"
+
+[[tier3]]
+event_type = "LEGAL_FRAMEWORK_ENACTED"
+
+[[tier3]]
+event_type = "LEGAL_FRAMEWORK_REVOKED"
+
+[[tier3]]
+event_type = "PATTERN_SHIFT"
+
+[[tier3]]
+event_type = "POPULATION_DEATH"
+
+[[tier3]]
+event_type = "RED_OGV_ENDGAME"
+
+[[tier3]]
+event_type = "SOLIDARITY_AWAKENING"
+
+[[tier3]]
+event_type = "STATE_ACTION_EXECUTED"
+
+[[tier3]]
+event_type = "THREAD_ESCALATION"

--- a/src/babylon/sentinels/_ast.py
+++ b/src/babylon/sentinels/_ast.py
@@ -433,6 +433,71 @@ def eventtype_dict_keys(path: Path, name: str) -> set[str]:
     raise SentinelCheckError(f"no module-level `{name} = {{...}}` dict literal in {path}")
 
 
+def eventtype_dict_value_get_string_keys(path: Path, name: str) -> dict[str, tuple[str, ...]]:
+    """Statically extract the ``payload.get("...")`` keys each ``EventType``-keyed
+    value of the module-level dict ``name`` reads.
+
+    Built for the event-schema-registry sync check
+    (:mod:`babylon.sentinels.event_schema_registry`): each ``_BUILDERS`` entry
+    is a lambda whose body calls ``payload.get(<literal>, ...)`` once per
+    field the builder reads off the bus event's payload dict. This walks the
+    ENTIRE value subtree (a bare call, a parenthesised call, or a multi-line
+    one — the three shapes ``event_builders.py`` actually uses) rather than
+    assuming one fixed layout, and restricts to calls on a variable literally
+    named ``payload`` (the builder signature's third parameter, uniform
+    across every entry) so an unrelated ``.get()`` elsewhere in a lambda body
+    cannot be mistaken for a payload read.
+
+    :param path: Source file to parse.
+    :param name: The module-level assignment target holding the dict literal.
+    :returns: ``{EventType member name: (payload keys read, in source order,
+        deduplicated)}`` for every ``EventType.<MEMBER>``-keyed entry; an
+        entry whose value reads no string-literal ``payload.get()`` key maps
+        to ``()`` (not an error — some builders take no payload fields).
+    :raises SentinelCheckError: If the source is missing/unparseable, or no
+        module-level ``name = {...}`` dict literal exists.
+    """
+    tree = parse_module(path)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target: ast.expr | None = node.targets[0]
+        elif isinstance(node, ast.AnnAssign):
+            target = node.target
+        else:
+            continue
+        if not (
+            isinstance(target, ast.Name) and target.id == name and isinstance(node.value, ast.Dict)
+        ):
+            continue
+        result: dict[str, tuple[str, ...]] = {}
+        for key_node, value_node in zip(node.value.keys, node.value.values, strict=True):
+            if not (
+                isinstance(key_node, ast.Attribute)
+                and isinstance(key_node.value, ast.Name)
+                and key_node.value.id == "EventType"
+            ):
+                continue
+            fields: list[str] = []
+            for call in ast.walk(value_node):
+                if not (
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "get"
+                    and isinstance(call.func.value, ast.Name)
+                    and call.func.value.id == "payload"
+                    and call.args
+                    and isinstance(call.args[0], ast.Constant)
+                    and isinstance(call.args[0].value, str)
+                ):
+                    continue
+                field = call.args[0].value
+                if field not in fields:
+                    fields.append(field)
+            result[key_node.attr] = tuple(fields)
+        return result
+    raise SentinelCheckError(f"no module-level `{name} = {{...}}` dict literal in {path}")
+
+
 def parse_module(path: Path) -> ast.Module:
     """Read and parse ``path`` with :mod:`ast`, failing loudly on either error.
 

--- a/src/babylon/sentinels/event_schema_registry/__init__.py
+++ b/src/babylon/sentinels/event_schema_registry/__init__.py
@@ -1,7 +1,8 @@
 """The event-schema registry sentinel family (theme 7, C-1 rescope).
 
-Re-exports the loader/dataclasses (:mod:`.registry`) and the BSL emit-site
-scanner (:mod:`.bsl_emit_scan`) for convenient importing.
+Re-exports the loader/dataclasses (:mod:`.registry`), the BSL emit-site
+scanner (:mod:`.bsl_emit_scan`), and the one-way ``EVENT_BUILDERS`` sync
+check (:mod:`.sync`, R4.4.1) for convenient importing.
 """
 
 from __future__ import annotations
@@ -20,7 +21,9 @@ from babylon.sentinels.event_schema_registry.registry import (
     Tier3Row,
     UnmintedRow,
     load_registry,
+    normalize_key,
 )
+from babylon.sentinels.event_schema_registry.sync import event_builders_subset_violations
 
 __all__ = [
     "REGISTRY_PATH",
@@ -31,7 +34,9 @@ __all__ = [
     "Tier2Row",
     "Tier3Row",
     "UnmintedRow",
+    "event_builders_subset_violations",
     "load_registry",
+    "normalize_key",
     "scan_directory",
     "scan_file",
 ]

--- a/src/babylon/sentinels/event_schema_registry/__init__.py
+++ b/src/babylon/sentinels/event_schema_registry/__init__.py
@@ -1,0 +1,37 @@
+"""The event-schema registry sentinel family (theme 7, C-1 rescope).
+
+Re-exports the loader/dataclasses (:mod:`.registry`) and the BSL emit-site
+scanner (:mod:`.bsl_emit_scan`) for convenient importing.
+"""
+
+from __future__ import annotations
+
+from babylon.sentinels.event_schema_registry.bsl_emit_scan import (
+    EmitSite,
+    scan_directory,
+    scan_file,
+)
+from babylon.sentinels.event_schema_registry.registry import (
+    REGISTRY_PATH,
+    EventSchemaRegistry,
+    RegistryKey,
+    Tier1Row,
+    Tier2Row,
+    Tier3Row,
+    UnmintedRow,
+    load_registry,
+)
+
+__all__ = [
+    "REGISTRY_PATH",
+    "EmitSite",
+    "EventSchemaRegistry",
+    "RegistryKey",
+    "Tier1Row",
+    "Tier2Row",
+    "Tier3Row",
+    "UnmintedRow",
+    "load_registry",
+    "scan_directory",
+    "scan_file",
+]

--- a/src/babylon/sentinels/event_schema_registry/bsl_emit_scan.py
+++ b/src/babylon/sentinels/event_schema_registry/bsl_emit_scan.py
@@ -74,7 +74,7 @@ class _Form:
     items: list[_Form | str]
 
 
-def _tokenize(text: str) -> list[_Token]:
+def _tokenize(text: str, path: Path) -> list[_Token]:
     """Lex BSL source into parens/atoms/strings, comments and whitespace dropped.
 
     A ``;`` starts a line comment ONLY outside a string literal — the
@@ -82,6 +82,11 @@ def _tokenize(text: str) -> list[_Token]:
     explicitly rather than stripping comments as a separate text pass (which
     would corrupt any ``;`` that happens to sit inside a doc string, and BSL
     doc strings are prose, not fenced off from stray punctuation).
+
+    An unterminated string refuses loudly (:class:`SentinelCheckError`) rather
+    than lexing as one token running to end of file — a to-EOF token swallows
+    every later form, including ``(emit …)`` sites, and when the leftover
+    parens happen to balance the under-count is silent.
     """
     tokens: list[_Token] = []
     i = 0
@@ -110,7 +115,12 @@ def _tokenize(text: str) -> list[_Token]:
                 if text[j] == "\n":
                     line += 1
                 j += 1
-            j = min(j + 1, n)  # consume the closing quote if present
+            if j >= n:
+                raise SentinelCheckError(
+                    f"{path}: unterminated string literal opened at line "
+                    f"{start_line} — no closing '\"' before end of file"
+                )
+            j += 1  # consume the closing quote
             tokens.append(_Token(text[i:j], start_line))
             i = j
             continue
@@ -204,13 +214,14 @@ def scan_file(path: Path, repo_root: Path) -> tuple[EmitSite, ...]:
     :param repo_root: Repository root — sites record ``path`` relative to
         this, so a citation reads the same regardless of the caller's cwd.
     :raises SentinelCheckError: If the file is missing, its parens are
-        unbalanced, or an ``emit`` form's shape cannot be read.
+        unbalanced, a string literal is unterminated, or an ``emit`` form's
+        shape cannot be read.
     """
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
         raise SentinelCheckError(f"cannot read {path}: {exc}") from exc
-    forest = _parse(_tokenize(text), path)
+    forest = _parse(_tokenize(text, path), path)
     repo_relative = path.resolve().relative_to(repo_root.resolve()).as_posix()
     sites: list[EmitSite] = []
     for top in forest:

--- a/src/babylon/sentinels/event_schema_registry/bsl_emit_scan.py
+++ b/src/babylon/sentinels/event_schema_registry/bsl_emit_scan.py
@@ -1,0 +1,240 @@
+"""A real S-expression scan for ``(emit EventType/X ...)`` sites in BSL content.
+
+Theme 7 (event-schema registry, C-1 rescope). Deliberately NOT the "obvious"
+``\\(emit `` grep the plan itself warns undercounts: at least two emit sites in
+this estate (``solidarity.bsl``'s ``CONSCIOUSNESS_TRANSMISSION``/``MASS_AWAKENING``)
+spell the form as ``(emit\\n  EventType/…`` — the operand on its own line — which
+a single-line, trailing-space pattern never matches. A grep undercount is silent:
+the missed site simply never contributes a row, and nothing says so.
+
+This module instead tokenizes and parses the *whole* rule file into a minimal
+S-expression tree (atoms, strings, parenthesised forms — enough structure to
+walk, not a validating BSL parser) and finds every form whose head symbol is
+``emit`` by tree shape, not by a string pattern. Two properties this buys that
+no line-oriented scan can:
+
+1. **Comments and strings are honored.** A rule's ``:material-basis`` doc
+   string routinely contains example S-expressions with their own literal
+   parentheses (``"...the frozen `if`/`elif`..."``) — a naive paren-counter
+   would mis-track depth on those. Strings are read as single opaque tokens;
+   ``;``-comments (outside a string, per the language's own lexical rule) are
+   dropped before tokenizing.
+2. **Payload keys are read from the real child forms**, not guessed from
+   indentation — each ``(key expr…)`` child of an ``emit`` form contributes
+   its head symbol, in source order, however deeply the ``expr`` itself nests
+   (§4.3's repeated-computation idiom means some of these expressions are
+   dozens of lines long).
+
+BSL content payload keys are NEVER renamed by this scanner or its registry
+consumer (ADR183, port-AS-IS) — it only reads what is there.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from babylon.sentinels.base import SentinelCheckError
+
+#: BSL's own EventType-reference spelling; every emit's first operand is one.
+_EVENT_TYPE_PREFIX = "EventType/"
+
+
+@dataclass(frozen=True)
+class EmitSite:
+    """One observed ``(emit EventType/X (k1 …) (k2 …) …)`` form.
+
+    :param event_type: The bare member name after ``EventType/`` — BSL's own
+        spelling, not necessarily a member of Python's ``EventType`` enum
+        (``organization.bsl``'s ``ORGANIZATION_SEEDED`` is a documented,
+        deliberate counter-example — a probe-only name, D-1 in that file).
+    :param path: Repo-relative path of the ``.bsl`` file this site is in.
+    :param line: 1-indexed line the ``(emit`` token starts on.
+    :param keys: The payload's key symbols, in source order, exactly as
+        spelled in content (never normalized, never renamed).
+    """
+
+    event_type: str
+    path: str
+    line: int
+    keys: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _Token:
+    text: str
+    line: int
+
+
+@dataclass
+class _Form:
+    """One parenthesised S-expression; ``items`` holds ``_Form | str`` children."""
+
+    line: int
+    items: list[_Form | str]
+
+
+def _tokenize(text: str) -> list[_Token]:
+    """Lex BSL source into parens/atoms/strings, comments and whitespace dropped.
+
+    A ``;`` starts a line comment ONLY outside a string literal — the
+    language's own lexical rule — so the scan tracks "inside a string" state
+    explicitly rather than stripping comments as a separate text pass (which
+    would corrupt any ``;`` that happens to sit inside a doc string, and BSL
+    doc strings are prose, not fenced off from stray punctuation).
+    """
+    tokens: list[_Token] = []
+    i = 0
+    n = len(text)
+    line = 1
+    while i < n:
+        ch = text[i]
+        if ch == "\n":
+            line += 1
+            i += 1
+            continue
+        if ch in " \t\r":
+            i += 1
+            continue
+        if ch == ";":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if ch == '"':
+            start_line = line
+            j = i + 1
+            while j < n and text[j] != '"':
+                if text[j] == "\\" and j + 1 < n:
+                    j += 2
+                    continue
+                if text[j] == "\n":
+                    line += 1
+                j += 1
+            j = min(j + 1, n)  # consume the closing quote if present
+            tokens.append(_Token(text[i:j], start_line))
+            i = j
+            continue
+        if ch in "()":
+            tokens.append(_Token(ch, line))
+            i += 1
+            continue
+        j = i
+        while j < n and text[j] not in ' \t\r\n();"':
+            j += 1
+        tokens.append(_Token(text[i:j], line))
+        i = j
+    return tokens
+
+
+def _parse(tokens: list[_Token], path: Path) -> list[_Form | str]:
+    """Parse a flat token stream into a forest of nested ``_Form`` nodes."""
+    pos = 0
+
+    def parse_one() -> _Form | str:
+        nonlocal pos
+        tok = tokens[pos]
+        if tok.text == "(":
+            start_line = tok.line
+            pos += 1
+            items: list[_Form | str] = []
+            while True:
+                if pos >= len(tokens):
+                    raise SentinelCheckError(
+                        f"{path}: unbalanced '(' opened at line {start_line} — "
+                        "no matching ')' before end of file"
+                    )
+                if tokens[pos].text == ")":
+                    pos += 1
+                    break
+                items.append(parse_one())
+            return _Form(line=start_line, items=items)
+        if tok.text == ")":
+            raise SentinelCheckError(f"{path}:{tok.line}: unmatched ')'")
+        pos += 1
+        return tok.text
+
+    forest: list[_Form | str] = []
+    while pos < len(tokens):
+        forest.append(parse_one())
+    return forest
+
+
+def _walk_emit_forms(node: _Form | str) -> list[_Form]:
+    """Every ``(emit …)`` form anywhere under ``node``, depth-first."""
+    if isinstance(node, str):
+        return []
+    found: list[_Form] = []
+    if node.items and node.items[0] == "emit":
+        found.append(node)
+    for child in node.items:
+        found.extend(_walk_emit_forms(child))
+    return found
+
+
+def _emit_site_from_form(form: _Form, repo_relative_path: str) -> EmitSite:
+    """Translate one parsed ``(emit EventType/X (k1 …) …)`` form to an :class:`EmitSite`."""
+    # items[0] == "emit"; items[1] should be the "EventType/X" operand atom.
+    if len(form.items) < 2 or not isinstance(form.items[1], str):
+        raise SentinelCheckError(
+            f"{repo_relative_path}:{form.line}: an (emit …) form's first "
+            "operand is not a bare EventType/X atom — cannot identify its type"
+        )
+    operand = form.items[1]
+    if not operand.startswith(_EVENT_TYPE_PREFIX):
+        raise SentinelCheckError(
+            f"{repo_relative_path}:{form.line}: an (emit …) form's first "
+            f"operand {operand!r} does not start with {_EVENT_TYPE_PREFIX!r}"
+        )
+    event_type = operand[len(_EVENT_TYPE_PREFIX) :]
+    keys: list[str] = []
+    for child in form.items[2:]:
+        if isinstance(child, _Form) and child.items and isinstance(child.items[0], str):
+            key = child.items[0]
+            if key not in keys:
+                keys.append(key)
+    return EmitSite(
+        event_type=event_type, path=repo_relative_path, line=form.line, keys=tuple(keys)
+    )
+
+
+def scan_file(path: Path, repo_root: Path) -> tuple[EmitSite, ...]:
+    """Every ``(emit …)`` site in one ``.bsl`` file, in source order.
+
+    :param path: The ``.bsl`` file to scan.
+    :param repo_root: Repository root — sites record ``path`` relative to
+        this, so a citation reads the same regardless of the caller's cwd.
+    :raises SentinelCheckError: If the file is missing, its parens are
+        unbalanced, or an ``emit`` form's shape cannot be read.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SentinelCheckError(f"cannot read {path}: {exc}") from exc
+    forest = _parse(_tokenize(text), path)
+    repo_relative = path.resolve().relative_to(repo_root.resolve()).as_posix()
+    sites: list[EmitSite] = []
+    for top in forest:
+        for form in _walk_emit_forms(top):
+            sites.append(_emit_site_from_form(form, repo_relative))
+    return tuple(sites)
+
+
+def scan_directory(rules_dir: Path, repo_root: Path) -> tuple[EmitSite, ...]:
+    """Every ``(emit …)`` site across every ``*.bsl`` file in ``rules_dir``.
+
+    :param rules_dir: Directory to scan (non-recursive — matches
+        ``content/rules/*.bsl``, the plan's own glob).
+    :param repo_root: Repository root, forwarded to :func:`scan_file`.
+    :returns: Sites sorted by ``(path, line)`` — deterministic regardless of
+        filesystem directory-listing order.
+    :raises SentinelCheckError: If ``rules_dir`` has no ``.bsl`` files at all
+        — an empty result would read as "content emits nothing," which is
+        indistinguishable from a wrong path (Constitution III.11).
+    """
+    bsl_files = sorted(rules_dir.glob("*.bsl"))
+    if not bsl_files:
+        raise SentinelCheckError(f"no *.bsl files found in {rules_dir}")
+    sites: list[EmitSite] = []
+    for bsl_file in bsl_files:
+        sites.extend(scan_file(bsl_file, repo_root))
+    return tuple(sorted(sites, key=lambda s: (s.path, s.line)))

--- a/src/babylon/sentinels/event_schema_registry/registry.py
+++ b/src/babylon/sentinels/event_schema_registry/registry.py
@@ -1,0 +1,275 @@
+"""The event-schema registry: BSL ``emit`` payloads, tiered by evidence class.
+
+Theme 7 (event-schema registry, C-1 rescope). The data itself lives in
+``docs/reference/event-schema-registry.toml`` — a single, cross-toolchain
+artifact (TOML, not a hand-kept pair of Rust/Python literals) — this module
+only loads and shapes it.
+
+**Why three tiers, not one flat table.** A single "here is EVERY EventType's
+schema" table cannot be built honestly today: BSL content emits only a
+minority of ``EventType`` members, the Python ``EVENT_BUILDERS`` bus->pydantic
+registry is itself already known-narrower-than-its-source in places (the
+``CONTROL_RATIO_CRISIS`` case both tiers below carry), and most members have
+no observed producer at all. Transcribing ``EVENT_BUILDERS``'s incomplete
+entries as "the schema," or inventing key lists for members nobody emits,
+would both manufacture a false authority this estate's verifiability
+discipline forbids. Instead:
+
+- **Tier 1 — verified-bsl.** Members with at least one observed
+  ``(emit EventType/X …)`` site in ``content/rules/*.bsl``
+  (:mod:`babylon.sentinels.event_schema_registry.bsl_emit_scan` reads these
+  directly — the strongest evidence class). A member with more than one
+  observed site carries the UNION of every site's keys; a key present at
+  every site is ``required``, a key present at only some is not (documented
+  reality, never a forced single shape — port-AS-IS, ADR183). A key no BSL
+  site provides but ``EVENT_BUILDERS`` reads anyway (with a default) is
+  included too, flagged ``source="builder-only"`` — the registry's job is to
+  describe what IS, including a builder expecting a field content does not
+  yet carry, not to silently omit that fact.
+- **Tier 2 — verified-python-builder.** Members with an ``EVENT_BUILDERS``
+  entry but no BSL emit site yet. The row transcribes the builder's own
+  field set, EXPLICITLY inheriting that source's own incompleteness — this
+  tier makes no claim of completeness, only "this is what the builder
+  currently declares."
+- **Tier 3 — no-known-emitter.** Every remaining Python ``EventType`` member:
+  no builder, no observed BSL emitter. No key list, honestly.
+
+**BSL-only, off the Python vocabulary entirely.** ``organization.bsl``'s
+``EventType/ORGANIZATION_SEEDED`` is a documented, deliberate probe-only name
+(that file's own D-1 comment) — content emits it, but it is NOT a member of
+Python's ``EventType`` enum. Folding it into Tier 1 would falsely imply the
+three tiers exhaustively partition the 100-member Python universe (they do —
+``python_event_type_total`` in the TOML pins that count, and
+``tests/unit/sentinels/test_event_schema_registry.py`` proves
+``len(tier1) + len(tier2) + len(tier3) == python_event_type_total`` at every
+run). It gets its own, separately-labelled table instead.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from babylon.sentinels.base import SentinelCheckError
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+#: The one canonical, cross-toolchain artifact — TOML avoids hand-keeping a
+#: second, Rust-side literal table in sync by construction (a future Rust
+#: consumer, R4.2, reads this same file rather than a transcription of it).
+REGISTRY_PATH = REPO_ROOT / "docs" / "reference" / "event-schema-registry.toml"
+
+
+@dataclass(frozen=True)
+class RegistryKey:
+    """One payload key on one registry row.
+
+    :param name: The key exactly as content or the builder spells it — BSL's
+        kebab-case where ``source`` is ``"bsl"``/``"builder-only"`` documents
+        a builder read, Python's snake_case where ``source`` is ``"builder"``
+        (Tier 2, transcribed straight from ``EVENT_BUILDERS``). This module
+        never renames either spelling (port-AS-IS, ADR183); the ``_``/``-``
+        normalization is the SYNC CHECK's job
+        (:mod:`babylon.sentinels.event_schema_registry.sync`), not the
+        registry's.
+    :param required: ``True`` if every evidence site for this row carries the
+        key; ``False`` if only some do (Tier 1's branch-specific keys) or if
+        the key is builder-only (never BSL-observed at all).
+    :param source: ``"bsl"`` (a real content citation backs it), ``"builder"``
+        (Tier 2 — transcribed from ``EVENT_BUILDERS``, no BSL site exists for
+        this row at all), or ``"builder-only"`` (Tier 1 — a BSL site exists
+        for this EventType, but THIS key comes only from the builder).
+    :param note: Free-text evidence/caveat, required whenever ``source`` is
+        ``"builder-only"`` (an unexplained divergence is indistinguishable
+        from an oversight).
+    """
+
+    name: str
+    required: bool
+    source: str
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class Tier1Row:
+    """A ``verified-bsl`` registry row — content demonstrably emits this."""
+
+    event_type: str
+    citations: tuple[str, ...]
+    keys: tuple[RegistryKey, ...]
+
+
+@dataclass(frozen=True)
+class Tier2Row:
+    """A ``verified-python-builder`` row — no BSL site, a builder exists."""
+
+    event_type: str
+    note: str
+    keys: tuple[RegistryKey, ...]
+
+
+@dataclass(frozen=True)
+class Tier3Row:
+    """A ``no-known-emitter`` row — bare vocabulary, no producer at all."""
+
+    event_type: str
+    note: str
+
+
+@dataclass(frozen=True)
+class UnmintedRow:
+    """A BSL-only emit name absent from Python's ``EventType`` enum entirely."""
+
+    name: str
+    citation: str
+    note: str
+    keys: tuple[RegistryKey, ...]
+
+
+@dataclass(frozen=True)
+class EventSchemaRegistry:
+    """The whole loaded registry."""
+
+    schema_version: int
+    measured_at: str
+    python_event_type_total: int
+    bsl_content_glob: str
+    tier1: tuple[Tier1Row, ...]
+    tier2: tuple[Tier2Row, ...]
+    tier3: tuple[Tier3Row, ...]
+    unminted_bsl_only: tuple[UnmintedRow, ...] = field(default_factory=tuple)
+
+    def tier1_by_event_type(self) -> dict[str, Tier1Row]:
+        return {row.event_type: row for row in self.tier1}
+
+    def tier2_by_event_type(self) -> dict[str, Tier2Row]:
+        return {row.event_type: row for row in self.tier2}
+
+    def tier3_by_event_type(self) -> dict[str, Tier3Row]:
+        return {row.event_type: row for row in self.tier3}
+
+    def key_names_for(self, event_type: str) -> frozenset[str] | None:
+        """Every declared key name for ``event_type`` (Tier 1 or Tier 2 only).
+
+        :returns: The row's key names, or ``None`` if ``event_type`` is not a
+            Tier 1 or Tier 2 member (Tier 3 declares no keys by definition).
+        """
+        tier1 = self.tier1_by_event_type().get(event_type)
+        if tier1 is not None:
+            return frozenset(k.name for k in tier1.keys)
+        tier2 = self.tier2_by_event_type().get(event_type)
+        if tier2 is not None:
+            return frozenset(k.name for k in tier2.keys)
+        return None
+
+
+def _require(mapping: dict[str, Any], key: str, row_desc: str) -> Any:
+    if key not in mapping:
+        raise SentinelCheckError(f"{REGISTRY_PATH}: {row_desc} is missing required field {key!r}")
+    return mapping[key]
+
+
+def _parse_keys(raw_keys: list[dict[str, Any]], row_desc: str) -> tuple[RegistryKey, ...]:
+    keys = []
+    for raw in raw_keys:
+        name = _require(raw, "name", f"{row_desc} key")
+        required = _require(raw, "required", f"{row_desc} key {name!r}")
+        source = _require(raw, "source", f"{row_desc} key {name!r}")
+        note = raw.get("note", "")
+        if source == "builder-only" and not note:
+            raise SentinelCheckError(
+                f"{REGISTRY_PATH}: {row_desc} key {name!r} is source=builder-only "
+                "with no note — an unexplained content/builder divergence must "
+                "be explained, not silently carried"
+            )
+        keys.append(RegistryKey(name=name, required=bool(required), source=source, note=note))
+    return tuple(keys)
+
+
+def normalize_key(name: str) -> str:
+    """The one stated normalization rule between BSL and Python spellings.
+
+    Tier 1 keys are transcribed in BSL's own kebab-case
+    (``legitimation-index``); Tier 2 keys and every ``EVENT_BUILDERS`` read
+    are transcribed in Python's snake_case (``legitimation_index``). The ONE
+    rule this registry and its sync check (:mod:`.sync`, R4.4.1) apply before
+    comparing the two: ``_`` and ``-`` are the same character. Nothing else
+    is normalized (case, prefixes, pluralization all stay literal) — a real
+    spelling divergence must still fail loudly.
+
+    :param name: A raw key spelling, either convention.
+    :returns: ``name`` with every underscore replaced by a hyphen.
+    """
+    return name.replace("_", "-")
+
+
+def load_registry(path: Path = REGISTRY_PATH) -> EventSchemaRegistry:
+    """Load and validate the event-schema registry from ``path``.
+
+    Structural validation is intentionally strict — a malformed row raises
+    rather than silently dropping a field, matching the sentinel family's
+    loud-failure discipline (Constitution III.11): a registry that failed to
+    parse is an infrastructure failure, not "zero coverage."
+
+    :raises SentinelCheckError: If ``path`` is missing/unparseable, or any
+        row is missing a required field.
+    """
+    try:
+        with path.open("rb") as handle:
+            data = tomllib.load(handle)
+    except OSError as exc:
+        raise SentinelCheckError(f"cannot read {path}: {exc}") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise SentinelCheckError(f"cannot parse {path}: {exc}") from exc
+
+    tier1 = tuple(
+        Tier1Row(
+            event_type=(et := _require(row, "event_type", "a tier1 row")),
+            citations=tuple(_require(row, "citations", f"tier1 row {et!r}")),
+            keys=_parse_keys(_require(row, "keys", f"tier1 row {et!r}"), f"tier1 row {et!r}"),
+        )
+        for row in data.get("tier1", [])
+    )
+    measured_at = _require(data, "measured_at", "the registry header")
+    _default_tier2_note = (
+        f"EVENT_BUILDERS entry only; no BSL emit site observed as of {measured_at} — "
+        "transcribed verbatim, inheriting that source's own incompleteness"
+    )
+    tier2 = tuple(
+        Tier2Row(
+            event_type=(et := _require(row, "event_type", "a tier2 row")),
+            note=row.get("note", _default_tier2_note),
+            keys=_parse_keys(_require(row, "keys", f"tier2 row {et!r}"), f"tier2 row {et!r}"),
+        )
+        for row in data.get("tier2", [])
+    )
+    _default_tier3_note = f"declared in events.py, no emitter or builder found as of {measured_at}"
+    tier3 = tuple(
+        Tier3Row(
+            event_type=_require(row, "event_type", "a tier3 row"),
+            note=row.get("note", _default_tier3_note),
+        )
+        for row in data.get("tier3", [])
+    )
+    unminted = tuple(
+        UnmintedRow(
+            name=(nm := _require(row, "name", "an unminted_bsl_only row")),
+            citation=_require(row, "citation", f"unminted row {nm!r}"),
+            note=_require(row, "note", f"unminted row {nm!r}"),
+            keys=_parse_keys(_require(row, "keys", f"unminted row {nm!r}"), f"unminted row {nm!r}"),
+        )
+        for row in data.get("unminted_bsl_only", [])
+    )
+
+    return EventSchemaRegistry(
+        schema_version=_require(data, "schema_version", "the registry header"),
+        measured_at=measured_at,
+        python_event_type_total=_require(data, "python_event_type_total", "the registry header"),
+        bsl_content_glob=_require(data, "bsl_content_glob", "the registry header"),
+        tier1=tier1,
+        tier2=tier2,
+        tier3=tier3,
+        unminted_bsl_only=unminted,
+    )

--- a/src/babylon/sentinels/event_schema_registry/sync.py
+++ b/src/babylon/sentinels/event_schema_registry/sync.py
@@ -1,0 +1,91 @@
+"""The ``EVENT_BUILDERS ⊆ registry`` one-way sync check (theme 7, C-1/I-5).
+
+**Why one-way, not a circular "sync."** "Repair ``EVENT_BUILDERS`` to match
+the registry" is circular exactly where the registry's own Tier 2 rows were
+BUILT FROM ``EVENT_BUILDERS`` in the first place — asking a transcription to
+match its own source proves nothing. The correct direction is
+``EVENT_BUILDERS ⊆ registry``, never the reverse: every field a builder
+reads off the bus payload must be a key the registry ALREADY documents
+(Tier 1 from real BSL evidence, or Tier 2 transcribed straight from the same
+builder), never a field the registry has no record of at all. This is
+satisfied by construction for every Tier 2 row (it IS the builder's own
+field set) and needs real verification only where a Tier 1 (BSL-observed)
+row and its builder might disagree — which is exactly where this check earns
+its keep: ``ENTITY_DEATH``'s builder reads a ``cause`` no observed BSL site
+provides (``vitality.bsl``'s own comment says why: no string payloads,
+§2.8), and ``SUPERWAGE_CRISIS``'s builder reads ``payer_id``/``receiver_id``
+where content emits only a bare ``receiver`` — both real, both now
+DOCUMENTED as ``source="builder-only"`` rows rather than silently
+undiscovered (Tier 1's own docstring in :mod:`.registry` names the rule).
+
+**Normalization.** Python builder fields are snake_case
+(``payload.get("legitimation_index", …)``); Tier 1's BSL-observed keys are
+kebab-case (``(legitimation-index …)``). The ONE normalization rule this
+check applies, in both directions, before comparing: ``_`` and ``-`` are the
+same character. Nothing else is normalized (case, prefixes, pluralization
+all stay literal) — a real spelling divergence must still fail loudly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from babylon.sentinels._ast import eventtype_dict_value_get_string_keys
+from babylon.sentinels.event_schema_registry.registry import (
+    EventSchemaRegistry,
+    normalize_key,
+)
+from babylon.sentinels.fallback_coverage.registry import EVENT_BUILDERS_DICT, EVENT_BUILDERS_PATH
+
+#: Re-exported for callers that import the normalization rule from its
+#: natural home in this module (the sync check) rather than from
+#: :mod:`.registry`, where it actually lives — the registry owns it because
+#: R4.1's own tests need it (comparing a Tier 1 row's ``builder-only`` keys
+#: against a fresh ``EVENT_BUILDERS`` read) independent of this module.
+__all__ = ["event_builders_subset_violations", "normalize_key"]
+
+
+def event_builders_subset_violations(
+    registry: EventSchemaRegistry,
+    *,
+    builders_path: Path = EVENT_BUILDERS_PATH,
+    builders_dict: str = EVENT_BUILDERS_DICT,
+) -> list[str]:
+    """Every ``EVENT_BUILDERS`` payload read the registry does not account for.
+
+    :param registry: The loaded event-schema registry.
+    :param builders_path: Source file holding the builder dict (overridable
+        for tests; defaults to the real ``event_builders.py``).
+    :param builders_dict: The dict's module-level assignment name.
+    :returns: One violation string per ``(EventType, field)`` pair the
+        builder reads that is absent — after ``_``/``-`` normalization —
+        from that EventType's registry row; empty means the containment
+        holds for the whole estate.
+    """
+    builder_fields = eventtype_dict_value_get_string_keys(builders_path, builders_dict)
+    violations: list[str] = []
+    for event_type, raw_fields in sorted(builder_fields.items()):
+        registry_keys = registry.key_names_for(event_type)
+        if registry_keys is None:
+            if raw_fields:
+                violations.append(
+                    f"EventType.{event_type}: EVENT_BUILDERS has an entry reading "
+                    f"{list(raw_fields)} but the registry has NO Tier 1/Tier 2 row "
+                    "for this EventType at all — a builder landed with no matching "
+                    "registry row (the registry is stale, or this EventType is "
+                    "wrongly Tier 3)."
+                )
+            continue
+        normalized_registry = {normalize_key(k) for k in registry_keys}
+        for raw_field in raw_fields:
+            normalized_field = normalize_key(raw_field)
+            if normalized_field not in normalized_registry:
+                violations.append(
+                    f"EventType.{event_type}: EVENT_BUILDERS reads payload key "
+                    f"{raw_field!r} (normalized {normalized_field!r}) which is not "
+                    f"in the registry's key set for this EventType "
+                    f"({sorted(normalized_registry)}) — the registry row is "
+                    "missing this key (add it, source=builder-only, with a note) "
+                    "or EVENT_BUILDERS drifted from what it used to read."
+                )
+    return violations

--- a/tests/unit/sentinels/test_event_builders_registry_sync.py
+++ b/tests/unit/sentinels/test_event_builders_registry_sync.py
@@ -1,0 +1,280 @@
+"""The ``EVENT_BUILDERS ⊆ registry`` one-way sync test (R4.4.1, C-1/I-5).
+
+Mechanism tests run against synthetic registries/builder sources so they pin
+the check's CONTRACT (the normalization rule, the direction of containment,
+what counts as a violation) independent of the estate's own current facts —
+the same split ``tests/unit/sentinels/test_fallback_coverage.py`` already
+uses. ``TestTheRealEstateSyncsToday`` is the conformance half: it proves the
+SHIPPED registry (``docs/reference/event-schema-registry.toml``) actually
+contains every field the real ``EVENT_BUILDERS`` reads, right now — the task
+brief's own requirement that this test "must PASS on the real estate at
+landing."
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from babylon.sentinels.event_schema_registry.registry import (
+    EventSchemaRegistry,
+    RegistryKey,
+    Tier1Row,
+    Tier2Row,
+    Tier3Row,
+    load_registry,
+)
+from babylon.sentinels.event_schema_registry.sync import (
+    event_builders_subset_violations,
+    normalize_key,
+)
+from babylon.sentinels.fallback_coverage.registry import EVENT_BUILDERS_DICT, EVENT_BUILDERS_PATH
+
+
+def _key(name: str, *, required: bool = True, source: str = "bsl") -> RegistryKey:
+    return RegistryKey(name=name, required=required, source=source)
+
+
+def _registry(
+    tier1: tuple[Tier1Row, ...] = (), tier2: tuple[Tier2Row, ...] = ()
+) -> EventSchemaRegistry:
+    return EventSchemaRegistry(
+        schema_version=1,
+        measured_at="2026-08-18",
+        python_event_type_total=100,
+        bsl_content_glob="rust/crates/babylon-tick/content/rules/*.bsl",
+        tier1=tier1,
+        tier2=tier2,
+        tier3=(Tier3Row(event_type="UNCOVERED", note="test"),),
+    )
+
+
+class TestNormalizeKey:
+    """The ONE stated normalization rule: ``_`` and ``-`` compare equal."""
+
+    def test_underscore_becomes_hyphen(self) -> None:
+        assert normalize_key("territory_id") == "territory-id"
+
+    def test_already_hyphenated_is_unchanged(self) -> None:
+        assert normalize_key("territory-id") == "territory-id"
+
+    def test_a_key_with_no_separator_is_unchanged(self) -> None:
+        assert normalize_key("wealth") == "wealth"
+
+    def test_both_spellings_normalize_to_the_same_string(self) -> None:
+        assert normalize_key("solidarity_strength") == normalize_key("solidarity-strength")
+
+    def test_case_is_not_touched(self) -> None:
+        """The stated rule is `_` <-> `-` ONLY — a case mismatch must still
+        fail loudly, not be silently forgiven by an over-eager normalizer."""
+        assert normalize_key("Territory_Id") != normalize_key("territory-id")
+
+
+class TestEventBuildersSubsetViolationsMechanism:
+    """Synthetic registries + synthetic builder sources — pins the CHECK's
+    contract, independent of the real estate's current facts."""
+
+    def _write_builders(self, tmp_path: Path, body: str) -> Path:
+        path = tmp_path / "synthetic_builders.py"
+        path.write_text(
+            f"from babylon.models.enums import EventType\n\n_BUILDERS = {{\n{body}\n}}\n"
+        )
+        return path
+
+    def test_exact_match_is_clean(self, tmp_path: Path) -> None:
+        registry = _registry(
+            tier1=(
+                Tier1Row(
+                    event_type="FOO",
+                    citations=("x.bsl:1",),
+                    keys=(_key("wealth"), _key("target-id")),
+                ),
+            )
+        )
+        builders = self._write_builders(
+            tmp_path,
+            "    EventType.FOO: lambda tick, timestamp, payload: Foo(\n"
+            '        wealth=payload.get("wealth", 0.0),\n'
+            '        target_id=payload.get("target_id", ""),\n'
+            "    ),\n",
+        )
+        violations = event_builders_subset_violations(
+            registry, builders_path=builders, builders_dict="_BUILDERS"
+        )
+        assert violations == []
+
+    def test_underscore_hyphen_mismatch_alone_is_not_a_violation(self, tmp_path: Path) -> None:
+        """The whole point of stating the normalization rule: the FIRST run
+        must not fail on spelling convention alone."""
+        registry = _registry(
+            tier1=(
+                Tier1Row(
+                    event_type="FOO",
+                    citations=("x.bsl:1",),
+                    keys=(_key("solidarity-strength"),),
+                ),
+            )
+        )
+        builders = self._write_builders(
+            tmp_path,
+            "    EventType.FOO: lambda tick, timestamp, payload: Foo(\n"
+            '        solidarity_strength=payload.get("solidarity_strength", 0.0),\n'
+            "    ),\n",
+        )
+        violations = event_builders_subset_violations(
+            registry, builders_path=builders, builders_dict="_BUILDERS"
+        )
+        assert violations == []
+
+    def test_a_builder_field_absent_from_the_registry_row_is_a_violation(
+        self, tmp_path: Path
+    ) -> None:
+        registry = _registry(
+            tier1=(Tier1Row(event_type="FOO", citations=("x.bsl:1",), keys=(_key("wealth"),)),)
+        )
+        builders = self._write_builders(
+            tmp_path,
+            "    EventType.FOO: lambda tick, timestamp, payload: Foo(\n"
+            '        wealth=payload.get("wealth", 0.0),\n'
+            '        cause=payload.get("cause", "unknown"),\n'
+            "    ),\n",
+        )
+        violations = event_builders_subset_violations(
+            registry, builders_path=builders, builders_dict="_BUILDERS"
+        )
+        assert len(violations) == 1
+        assert "FOO" in violations[0]
+        assert "cause" in violations[0]
+
+    def test_a_builder_for_an_eventtype_with_no_registry_row_at_all_is_a_violation(
+        self, tmp_path: Path
+    ) -> None:
+        registry = _registry()  # no tier1, no tier2 rows at all
+        builders = self._write_builders(
+            tmp_path,
+            "    EventType.UNREGISTERED: lambda tick, timestamp, payload: Foo(\n"
+            '        wealth=payload.get("wealth", 0.0),\n'
+            "    ),\n",
+        )
+        violations = event_builders_subset_violations(
+            registry, builders_path=builders, builders_dict="_BUILDERS"
+        )
+        assert len(violations) == 1
+        assert "UNREGISTERED" in violations[0]
+
+    def test_a_builder_with_no_payload_reads_at_all_is_never_a_violation(
+        self, tmp_path: Path
+    ) -> None:
+        """An EventType with no registry row and a builder that reads
+        nothing off the payload has nothing to be a subset violation about —
+        an empty field set is trivially a subset of anything, including
+        'no row'."""
+        registry = _registry()
+        builders = self._write_builders(
+            tmp_path,
+            "    EventType.NOFIELDS: lambda tick, timestamp, payload: Foo(),\n",
+        )
+        violations = event_builders_subset_violations(
+            registry, builders_path=builders, builders_dict="_BUILDERS"
+        )
+        assert violations == []
+
+    def test_tier2_rows_satisfy_the_check_by_construction(self, tmp_path: Path) -> None:
+        """Tier 2 rows ARE the builder's own field set (transcribed) — this
+        is the C-1 "satisfied by construction" case, exercised directly."""
+        registry = _registry(
+            tier2=(
+                Tier2Row(
+                    event_type="BAR",
+                    note="test",
+                    keys=(_key("org_id", source="builder"), _key("target_id", source="builder")),
+                ),
+            )
+        )
+        builders = self._write_builders(
+            tmp_path,
+            "    EventType.BAR: lambda tick, timestamp, payload: Bar(\n"
+            '        org_id=payload.get("org_id", ""),\n'
+            '        target_id=payload.get("target_id", ""),\n'
+            "    ),\n",
+        )
+        violations = event_builders_subset_violations(
+            registry, builders_path=builders, builders_dict="_BUILDERS"
+        )
+        assert violations == []
+
+    def test_a_control_ratio_crisis_shaped_narrower_builder_is_clean(self, tmp_path: Path) -> None:
+        """The survey's own worked example: a builder reading FEWER fields
+        than a Tier 1 row's UNION (some of them optional/branch-specific) is
+        not a violation — narrower is always fine, only EXTRA fields are."""
+        registry = _registry(
+            tier1=(
+                Tier1Row(
+                    event_type="CONTROL_RATIO_CRISIS",
+                    citations=("cr.bsl:1", "cr.bsl:2"),
+                    keys=(
+                        _key("enforcer-population"),
+                        _key("prisoner-population"),
+                        _key("control-capacity"),
+                        _key("max-controllable"),
+                        _key("over-capacity-by"),
+                        _key("capacity-threshold"),
+                        _key("actual-ratio", required=False),
+                        _key("control-ratio", required=False),
+                    ),
+                ),
+            )
+        )
+        builders = self._write_builders(
+            tmp_path,
+            "    EventType.CONTROL_RATIO_CRISIS: lambda tick, timestamp, payload: X(\n"
+            '        prisoner_population=payload.get("prisoner_population", 0),\n'
+            '        enforcer_population=payload.get("enforcer_population", 0),\n'
+            '        control_ratio=payload.get("control_ratio", 0.0),\n'
+            '        capacity_threshold=payload.get("capacity_threshold", 0.0),\n'
+            "    ),\n",
+        )
+        violations = event_builders_subset_violations(
+            registry, builders_path=builders, builders_dict="_BUILDERS"
+        )
+        assert violations == []
+
+
+class TestTheRealEstateSyncsToday:
+    """Conformance half: the SHIPPED registry against the REAL EVENT_BUILDERS.
+
+    This is the task brief's own binding requirement — "the sync test must
+    PASS on the real estate at landing (normalization correct) — a
+    failing-at-landing sync test means your registry or normalization is
+    wrong, not the estate." A green run here is exactly that proof.
+    """
+
+    @classmethod
+    @pytest.fixture(scope="class")
+    def registry(cls) -> EventSchemaRegistry:
+        return load_registry()
+
+    def test_event_builders_is_a_subset_of_the_registry(
+        self, registry: EventSchemaRegistry
+    ) -> None:
+        violations = event_builders_subset_violations(
+            registry, builders_path=EVENT_BUILDERS_PATH, builders_dict=EVENT_BUILDERS_DICT
+        )
+        assert violations == [], "\n".join(violations)
+
+    def test_the_entity_death_and_superwage_crisis_divergences_are_the_only_builder_only_keys(
+        self, registry: EventSchemaRegistry
+    ) -> None:
+        """Pins the two REAL divergences this check exists to catch (found
+        by direct comparison at authoring time, not invented) — a future
+        R4.4.2 repair should shrink this set, not grow it silently."""
+        builder_only_by_type = {
+            row.event_type: sorted(k.name for k in row.keys if k.source == "builder-only")
+            for row in registry.tier1
+            if any(k.source == "builder-only" for k in row.keys)
+        }
+        assert builder_only_by_type == {
+            "ENTITY_DEATH": ["cause"],
+            "SUPERWAGE_CRISIS": ["payer-id", "receiver-id"],
+        }

--- a/tests/unit/sentinels/test_event_schema_registry.py
+++ b/tests/unit/sentinels/test_event_schema_registry.py
@@ -1,0 +1,434 @@
+"""Unit + freshness tests for the event-schema registry (theme 7, C-1 rescope).
+
+R4.1.1 (RED) + R4.1.2 (GREEN) of the BSL refactor program's Phase 4: the
+registry's per-tier membership must match a FRESH measurement taken at test
+time — never a stale hardcoded count — and every Tier 1 row must cite a real
+``file:line`` a live re-scan of ``content/rules/*.bsl`` actually confirms.
+This is the same "documents-agree, re-derive from source, never trust a
+snapshot" discipline ``tests/unit/reference/test_bsl_grammar_sync.py`` runs
+for the BSL grammar appendix, applied to the event-schema registry instead.
+
+Scanner method note (the plan's own grep-undercount warning): the BSL side
+uses a REAL parse (:mod:`babylon.sentinels.event_schema_registry.bsl_emit_scan`
+tokenizes and parses ``.bsl`` source into an S-expression tree and finds
+``emit`` forms by tree shape), not a line-oriented pattern — the class of
+undercount the plan names (``solidarity.bsl``'s multi-line
+``(emit\\n  EventType/…`` forms) is exercised directly by
+``TestBslEmitScanner``. The Python side uses :mod:`ast`
+(``eventtype_dict_value_get_string_keys`` in ``babylon.sentinels._ast``) —
+also a real parse, never a regex over source text.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from babylon.models.enums.events import EventType
+from babylon.sentinels._ast import eventtype_dict_value_get_string_keys
+from babylon.sentinels.base import SentinelCheckError
+from babylon.sentinels.event_schema_registry.bsl_emit_scan import (
+    EmitSite,
+    scan_directory,
+    scan_file,
+)
+from babylon.sentinels.event_schema_registry.registry import (
+    REGISTRY_PATH,
+    REPO_ROOT,
+    EventSchemaRegistry,
+    load_registry,
+    normalize_key,
+)
+from babylon.sentinels.fallback_coverage.registry import (
+    BUS_BOUNDARY_LEDGER,
+    EVENT_BUILDERS_DICT,
+    EVENT_BUILDERS_PATH,
+)
+
+RULES_DIR = REPO_ROOT / "rust" / "crates" / "babylon-tick" / "content" / "rules"
+
+
+def _kebab_names(keys: tuple) -> frozenset[str]:
+    return frozenset(k.name for k in keys)
+
+
+def _bsl_only_names(keys: tuple) -> frozenset[str]:
+    return frozenset(k.name for k in keys if k.source == "bsl")
+
+
+def _builder_only_names(keys: tuple) -> frozenset[str]:
+    return frozenset(k.name for k in keys if k.source == "builder-only")
+
+
+# =============================================================================
+# The scanner itself: a real S-expression parse, not a line-oriented pattern.
+# =============================================================================
+
+
+class TestBslEmitScanner:
+    """Pins the scanner's actual claim: tree-shape, not text-pattern, matching."""
+
+    def test_single_line_emit_is_found(self, tmp_path: Path) -> None:
+        f = tmp_path / "single.bsl"
+        f.write_text("(rule r (effects (emit EventType/FOO (a 1) (b 2))))\n")
+        sites = scan_file(f, tmp_path)
+        assert len(sites) == 1
+        assert sites[0].event_type == "FOO"
+        assert sites[0].keys == ("a", "b")
+
+    def test_multiline_emit_is_found_the_plan_own_undercount_case(self, tmp_path: Path) -> None:
+        """The exact shape the plan warns a naive ``\\(emit `` grep misses:
+        the operand on its own line, not on the ``(emit`` line."""
+        f = tmp_path / "multi.bsl"
+        f.write_text("(rule r (effects\n  (emit\n    EventType/BAR\n    (x 1)\n    (y 2))))\n")
+        sites = scan_file(f, tmp_path)
+        assert len(sites) == 1
+        assert sites[0].event_type == "BAR"
+        assert sites[0].keys == ("x", "y")
+
+    def test_parens_inside_a_doc_string_do_not_corrupt_depth_tracking(self, tmp_path: Path) -> None:
+        """A ``:material-basis`` string containing literal ``(``/``)`` — as
+        the real estate's own doc strings routinely do — must not be
+        mistaken for structural parens."""
+        f = tmp_path / "doc.bsl"
+        f.write_text(
+            "(rule r\n"
+            '  :material-basis "the frozen (if a b) form, transcribed"\n'
+            "  (effects (emit EventType/BAZ (k 1))))\n"
+        )
+        sites = scan_file(f, tmp_path)
+        assert len(sites) == 1
+        assert sites[0].event_type == "BAZ"
+        assert sites[0].keys == ("k",)
+
+    def test_a_comment_containing_a_paren_is_dropped_not_parsed(self, tmp_path: Path) -> None:
+        f = tmp_path / "comment.bsl"
+        f.write_text(
+            "; a stray ) in a comment should never be treated as structure\n"
+            "(rule r (effects (emit EventType/QUX (k 1))))\n"
+        )
+        sites = scan_file(f, tmp_path)
+        assert len(sites) == 1
+        assert sites[0].event_type == "QUX"
+
+    def test_two_emit_sites_for_the_same_type_both_captured(self, tmp_path: Path) -> None:
+        f = tmp_path / "branches.bsl"
+        f.write_text(
+            "(rule r (effects\n"
+            "  (guard c1 (emit EventType/TWO_SHAPE (a 1) (b 2)))\n"
+            "  (guard c2 (emit EventType/TWO_SHAPE (a 1)))))\n"
+        )
+        sites = scan_file(f, tmp_path)
+        assert len(sites) == 2
+        assert {s.keys for s in sites} == {("a", "b"), ("a",)}
+
+    def test_line_numbers_point_at_the_open_paren(self, tmp_path: Path) -> None:
+        f = tmp_path / "lines.bsl"
+        f.write_text("(rule r\n  (effects\n    (emit EventType/LINE (k 1))))\n")
+        sites = scan_file(f, tmp_path)
+        assert sites[0].line == 3
+
+    def test_unbalanced_parens_raise_loudly(self, tmp_path: Path) -> None:
+        f = tmp_path / "broken.bsl"
+        f.write_text("(rule r (effects (emit EventType/X (k 1))\n")
+        with pytest.raises(SentinelCheckError, match="unbalanced"):
+            scan_file(f, tmp_path)
+
+    def test_missing_directory_raises_loudly_not_empty(self, tmp_path: Path) -> None:
+        with pytest.raises(SentinelCheckError, match="no \\*\\.bsl files"):
+            scan_directory(tmp_path / "does-not-exist", tmp_path)
+
+    def test_repo_relative_path_is_posix_and_stable(self, tmp_path: Path) -> None:
+        sub = tmp_path / "content" / "rules"
+        sub.mkdir(parents=True)
+        f = sub / "one.bsl"
+        f.write_text("(rule r (effects (emit EventType/X (k 1))))\n")
+        sites = scan_file(f, tmp_path)
+        assert sites[0].path == "content/rules/one.bsl"
+
+
+# =============================================================================
+# The loaded registry against the real, current estate.
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def registry() -> EventSchemaRegistry:
+    return load_registry()
+
+
+@pytest.fixture(scope="module")
+def fresh_bsl_sites() -> tuple[EmitSite, ...]:
+    return scan_directory(RULES_DIR, REPO_ROOT)
+
+
+@pytest.fixture(scope="module")
+def fresh_builder_fields() -> dict[str, tuple[str, ...]]:
+    return eventtype_dict_value_get_string_keys(EVENT_BUILDERS_PATH, EVENT_BUILDERS_DICT)
+
+
+@pytest.fixture(scope="module")
+def fresh_event_type_members() -> frozenset[str]:
+    return frozenset(member.name for member in EventType)
+
+
+class TestRegistryFileItself:
+    def test_the_registry_file_exists(self) -> None:
+        assert REGISTRY_PATH.exists(), f"{REGISTRY_PATH} is missing"
+
+    def test_loads_without_error(self, registry: EventSchemaRegistry) -> None:
+        assert registry.schema_version == 1
+
+    def test_declared_total_matches_a_fresh_events_py_count(
+        self, registry: EventSchemaRegistry, fresh_event_type_members: frozenset[str]
+    ) -> None:
+        """The TOML header's own ``python_event_type_total`` is itself a
+        claim this proves fresh, not a number to trust because it is
+        written down — CLAUDE.md's "100" and the plan's own AST-verified
+        correction of the survey's stale "98" both hinge on this staying
+        true."""
+        assert registry.python_event_type_total == len(fresh_event_type_members)
+
+
+class TestTier1MatchesAFreshBslScan:
+    """R4.1.1's core claim: Tier 1 membership and every row's key set must
+    equal what a live re-scan of content/rules/*.bsl finds RIGHT NOW — not
+    what was true when the TOML was authored. A new port adding an emit site
+    reds this test until the registry is updated (the same ratchet
+    ``sentinels/fallback_coverage`` runs for the bus-boundary surface)."""
+
+    def test_tier1_event_types_equal_the_fresh_distinct_emit_names_minus_unminted(
+        self,
+        registry: EventSchemaRegistry,
+        fresh_bsl_sites: tuple[EmitSite, ...],
+        fresh_event_type_members: frozenset[str],
+    ) -> None:
+        fresh_names = {s.event_type for s in fresh_bsl_sites}
+        # BSL-only names (no Python EventType counterpart) are NOT tier1 —
+        # they belong in unminted_bsl_only instead (see that test class).
+        fresh_real_names = fresh_names & fresh_event_type_members
+        registry_names = {row.event_type for row in registry.tier1}
+        assert registry_names == fresh_real_names
+
+    def test_no_fresh_bsl_only_name_is_missing_from_unminted(
+        self,
+        registry: EventSchemaRegistry,
+        fresh_bsl_sites: tuple[EmitSite, ...],
+        fresh_event_type_members: frozenset[str],
+    ) -> None:
+        fresh_names = {s.event_type for s in fresh_bsl_sites}
+        bsl_only = fresh_names - fresh_event_type_members
+        unminted_names = {row.name for row in registry.unminted_bsl_only}
+        assert bsl_only == unminted_names, (
+            f"BSL emits {sorted(bsl_only)} with no Python EventType counterpart "
+            f"— unminted_bsl_only declares {sorted(unminted_names)}"
+        )
+
+    def test_every_tier1_row_key_set_matches_the_union_of_its_fresh_sites(
+        self,
+        registry: EventSchemaRegistry,
+        fresh_bsl_sites: tuple[EmitSite, ...],
+    ) -> None:
+        by_type: dict[str, list[EmitSite]] = {}
+        for site in fresh_bsl_sites:
+            by_type.setdefault(site.event_type, []).append(site)
+
+        for row in registry.tier1:
+            sites = by_type.get(row.event_type, [])
+            assert sites, f"registry tier1 row {row.event_type!r} has no fresh emit site at all"
+            key_sets = [frozenset(s.keys) for s in sites]
+            union = frozenset().union(*key_sets)
+            always_present = frozenset.intersection(*key_sets)
+
+            bsl_keys = _bsl_only_names(row.keys)
+            assert bsl_keys == union, (
+                f"{row.event_type}: registry bsl-sourced keys {sorted(bsl_keys)} != "
+                f"fresh union {sorted(union)}"
+            )
+            for key in row.keys:
+                if key.source != "bsl":
+                    continue
+                is_always_present = key.name in always_present
+                assert key.required == is_always_present, (
+                    f"{row.event_type}.{key.name}: registry says required="
+                    f"{key.required}, but it is "
+                    f"{'present at every' if is_always_present else 'absent from at least one'} "
+                    "fresh site"
+                )
+
+    def test_builder_only_keys_are_real_builder_reads_not_bsl_provided(
+        self,
+        registry: EventSchemaRegistry,
+        fresh_bsl_sites: tuple[EmitSite, ...],
+        fresh_builder_fields: dict[str, tuple[str, ...]],
+    ) -> None:
+        by_type: dict[str, list[EmitSite]] = {}
+        for site in fresh_bsl_sites:
+            by_type.setdefault(site.event_type, []).append(site)
+
+        for row in registry.tier1:
+            builder_only = _builder_only_names(row.keys)
+            if not builder_only:
+                continue
+            observed_bsl = frozenset().union(
+                *(frozenset(s.keys) for s in by_type.get(row.event_type, [()]))
+            )
+            normalized_bsl = {normalize_key(k) for k in observed_bsl}
+            builder_fields = fresh_builder_fields.get(row.event_type, ())
+            normalized_builder_fields = {normalize_key(f) for f in builder_fields}
+            for key in builder_only:
+                assert normalize_key(key) not in normalized_bsl, (
+                    f"{row.event_type}.{key} is flagged builder-only but a fresh "
+                    "BSL site now provides it — promote it to source=bsl"
+                )
+                assert normalize_key(key) in normalized_builder_fields, (
+                    f"{row.event_type}.{key} is flagged builder-only but no fresh "
+                    "EVENT_BUILDERS read backs it any more — remove the row"
+                )
+
+
+class TestTier1CitationsAreReal:
+    """Every Tier 1 row's citation must point at a real, current emit site —
+    not a stale line number left behind by a later edit."""
+
+    @classmethod
+    @pytest.fixture(scope="class")
+    def fresh_sites_by_location(cls) -> dict[tuple[str, int], EmitSite]:
+        sites = scan_directory(RULES_DIR, REPO_ROOT)
+        return {(s.path, s.line): s for s in sites}
+
+    def test_every_tier1_row_has_at_least_one_citation(self, registry: EventSchemaRegistry) -> None:
+        for row in registry.tier1:
+            assert row.citations, f"{row.event_type} has no citations"
+
+    def test_every_citation_resolves_to_a_real_emit_site_of_the_right_type(
+        self,
+        registry: EventSchemaRegistry,
+        fresh_sites_by_location: dict[tuple[str, int], EmitSite],
+    ) -> None:
+        for row in registry.tier1:
+            for citation in row.citations:
+                path_str, _, line_str = citation.rpartition(":")
+                location = (path_str, int(line_str))
+                assert location in fresh_sites_by_location, (
+                    f"{row.event_type}'s citation {citation!r} does not resolve "
+                    "to any fresh emit site"
+                )
+                assert fresh_sites_by_location[location].event_type == row.event_type, (
+                    f"{row.event_type}'s citation {citation!r} resolves to a "
+                    f"DIFFERENT EventType at that line"
+                )
+
+
+class TestUnmintedBslOnlyNames:
+    """``ORGANIZATION_SEEDED``-shaped rows: real BSL evidence, deliberately
+    absent from Python's EventType universe."""
+
+    def test_no_unminted_name_is_a_real_event_type_member(
+        self, registry: EventSchemaRegistry, fresh_event_type_members: frozenset[str]
+    ) -> None:
+        for row in registry.unminted_bsl_only:
+            assert row.name not in fresh_event_type_members, (
+                f"{row.name} is flagged unminted_bsl_only but IS now a real "
+                "EventType member — move it to tier1/tier2/tier3, whichever fits"
+            )
+
+    def test_no_unminted_name_double_counted_in_a_tier(self, registry: EventSchemaRegistry) -> None:
+        tiered = (
+            {r.event_type for r in registry.tier1}
+            | {r.event_type for r in registry.tier2}
+            | {r.event_type for r in registry.tier3}
+        )
+        for row in registry.unminted_bsl_only:
+            assert row.name not in tiered
+
+    def test_organization_seeded_is_present_and_cited(self, registry: EventSchemaRegistry) -> None:
+        names = {row.name for row in registry.unminted_bsl_only}
+        assert "ORGANIZATION_SEEDED" in names
+        row = next(r for r in registry.unminted_bsl_only if r.name == "ORGANIZATION_SEEDED")
+        assert "organization.bsl" in row.citation
+
+
+class TestTier2MatchesFreshEventBuilders:
+    """Tier 2 = builder-covered EventTypes minus Tier 1, verbatim-transcribed."""
+
+    def test_tier2_event_types_equal_fresh_builder_coverage_minus_tier1(
+        self,
+        registry: EventSchemaRegistry,
+        fresh_builder_fields: dict[str, tuple[str, ...]],
+    ) -> None:
+        tier1_names = {row.event_type for row in registry.tier1}
+        fresh_tier2_expected = set(fresh_builder_fields.keys()) - tier1_names
+        registry_tier2_names = {row.event_type for row in registry.tier2}
+        assert registry_tier2_names == fresh_tier2_expected
+
+    def test_every_tier2_row_key_set_matches_its_fresh_builder_fields_verbatim(
+        self,
+        registry: EventSchemaRegistry,
+        fresh_builder_fields: dict[str, tuple[str, ...]],
+    ) -> None:
+        for row in registry.tier2:
+            fresh_fields = frozenset(fresh_builder_fields.get(row.event_type, ()))
+            registry_fields = _kebab_names(row.keys)
+            assert registry_fields == fresh_fields, (
+                f"{row.event_type}: registry keys {sorted(registry_fields)} != "
+                f"fresh EVENT_BUILDERS fields {sorted(fresh_fields)}"
+            )
+
+    def test_every_tier2_row_discloses_its_own_incompleteness(
+        self, registry: EventSchemaRegistry
+    ) -> None:
+        for row in registry.tier2:
+            assert row.note, f"{row.event_type} tier2 row has no note"
+
+
+class TestTier3IsTheArithmeticRemainder:
+    def test_tier3_equals_all_members_minus_tier1_minus_builder_covered(
+        self,
+        registry: EventSchemaRegistry,
+        fresh_event_type_members: frozenset[str],
+        fresh_builder_fields: dict[str, tuple[str, ...]],
+    ) -> None:
+        tier1_names = {row.event_type for row in registry.tier1}
+        builder_covered = set(fresh_builder_fields.keys())
+        expected_tier3 = fresh_event_type_members - tier1_names - builder_covered
+        registry_tier3_names = {row.event_type for row in registry.tier3}
+        assert registry_tier3_names == expected_tier3
+
+    def test_no_tier3_row_has_a_key_list(self, registry: EventSchemaRegistry) -> None:
+        for row in registry.tier3:
+            assert not hasattr(row, "keys")
+
+    def test_tier3_matches_the_fallback_coverage_bus_boundary_ledger(
+        self, registry: EventSchemaRegistry
+    ) -> None:
+        """Independent cross-check: ``sentinels/fallback_coverage``'s own
+        BUS_BOUNDARY_LEDGER already names every EventType absent from
+        EVENT_BUILDERS. Since Tier 1 ⊆ builder-covered for every landed
+        content EventType today, Tier 3 (no builder, no BSL) should equal
+        that ledger's member set exactly — two independently-built registries
+        agreeing is real evidence neither drifted."""
+        ledger_members = {row.member for row in BUS_BOUNDARY_LEDGER}
+        registry_tier3_names = {row.event_type for row in registry.tier3}
+        assert registry_tier3_names == ledger_members
+
+
+class TestPerTierCountsSumToTheDeclaredTotal:
+    def test_tier1_plus_tier2_plus_tier3_equals_python_event_type_total(
+        self, registry: EventSchemaRegistry
+    ) -> None:
+        assert (
+            len(registry.tier1) + len(registry.tier2) + len(registry.tier3)
+            == registry.python_event_type_total
+        )
+
+    def test_no_event_type_appears_in_more_than_one_tier(
+        self, registry: EventSchemaRegistry
+    ) -> None:
+        tier1 = {row.event_type for row in registry.tier1}
+        tier2 = {row.event_type for row in registry.tier2}
+        tier3 = {row.event_type for row in registry.tier3}
+        assert not (tier1 & tier2)
+        assert not (tier1 & tier3)
+        assert not (tier2 & tier3)

--- a/tests/unit/sentinels/test_event_schema_registry.py
+++ b/tests/unit/sentinels/test_event_schema_registry.py
@@ -135,6 +135,18 @@ class TestBslEmitScanner:
         with pytest.raises(SentinelCheckError, match="unbalanced"):
             scan_file(f, tmp_path)
 
+    def test_an_unterminated_string_raises_loudly_not_masks_swallowed_emits(
+        self, tmp_path: Path
+    ) -> None:
+        f = tmp_path / "unterminated.bsl"
+        f.write_text(
+            "(rule r (effects (emit EventType/A (k 1))))\n"
+            '"an unterminated string swallows the rest of the file\n'
+            "(rule s (effects (emit EventType/MASKED (k 1))))\n"
+        )
+        with pytest.raises(SentinelCheckError, match="unterminated string"):
+            scan_file(f, tmp_path)
+
     def test_missing_directory_raises_loudly_not_empty(self, tmp_path: Path) -> None:
         with pytest.raises(SentinelCheckError, match="no \\*\\.bsl files"):
             scan_directory(tmp_path / "does-not-exist", tmp_path)
@@ -272,7 +284,7 @@ class TestTier1MatchesAFreshBslScan:
             if not builder_only:
                 continue
             observed_bsl = frozenset().union(
-                *(frozenset(s.keys) for s in by_type.get(row.event_type, [()]))
+                *(frozenset(s.keys) for s in by_type.get(row.event_type, []))
             )
             normalized_bsl = {normalize_key(k) for k in observed_bsl}
             builder_fields = fresh_builder_fields.get(row.event_type, ())


### PR DESCRIPTION
**Refactor program Phase 4 (event registry as data) — R4.1 + R4.4.1 + the R4.6 amendment draft.** Umbrella: #671. Charter: `docs/superpowers/plans/2026-08-18-bsl-refactor-program.md` (lands with the Phase 0 PR).

**R4.1 — the event-schema registry as data** (`docs/reference/event-schema-registry.toml`): all 100 `EventType` members tiered by EVIDENCE CLASS — Tier 1 `verified-bsl` (12, from a real S-expression parse of `content/rules/*.bsl`, never a grep — the scanner directly handles the multi-line-emit undercount cases), Tier 2 `verified-python-builder` (68, verbatim from `EVENT_BUILDERS`), Tier 3 `no-known-emitter` (20, the arithmetic remainder, cross-validated byte-identical against `fallback_coverage`'s `BUS_BOUNDARY_LEDGER`), plus an `unminted_bsl_only` table (ORGANIZATION_SEEDED). New production modules under `src/babylon/sentinels/event_schema_registry/` (tokenizer/parser, strict TOML loader, dataclasses) with loud `SentinelCheckError` discipline. Both flagged builder-only divergences (ENTITY_DEATH `cause`, SUPERWAGE_CRISIS `payer_id`/`receiver_id`) documented with citations.

**R4.4.1 — the one-way sync test**: `event_builders_subset_violations()` proves `EVENT_BUILDERS ⊆ registry` with `_`↔`-` normalization. One-way by design (R4.4.2 repairs are gated, out of this PR).

**R4.6 — Amendment AH DRAFT (defevent)**: `ai/_inbox/amendment-defevent-draft.md` — the BSL event-schema declaration form, grounded in the registry's real tiers; DRAFT — DIRECTOR GATE, ratification at a sitting (per the 2026-08-18 ruling; no `ai/decisions/` ADR pre-ratification per the AE precedent). One design question honestly open (per-cohort vs global undeclared-emit refusal activation). Letters AH (this) / AI (the sibling prior-tick draft) controller-reserved, re-verified at ratification.

**Reviews**: implementation review clean (spec compliant, quality high, zero findings — every quantitative claim independently re-derived); the amendment draft's verifiability review found 3 accuracy defects, all fixed and re-verified (`4194a42f`).

**Gate**: `mise run check` — lint/format/typecheck green; `test:unit` 14,038 passed with ONE failure, `test_launcher_reexec.py::test_already_sealed_process_never_reexecs_again`, a 30s-subprocess-timeout contention flake under concurrent Rust link storms (unrelated to this diff; 4/4 green re-run solo, 7s). CI on this PR is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
