### PR TITLE
feat(tick): hyperedge ceiling supply chain — the Community port’s Task 4 (E1d), PR A complete

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -8910,6 +8910,42 @@ consequences are the ordinary kind of review item.
        measured magnitudes national 5.04 % / county median 4.92 % / max
        35.68 %) is NOT shipped, and this row is the record that the choice
        was made knowingly.
+   * - D200
+     - §2.9
+     - **``:max-members`` is DERIVED FROM THE SEEDED POPULATION, never
+       stipulated** (Community port train, Task 4, 2026-08-21; the plan's
+       ``D-NF+22``). The driver's ``CardinalityCeilings`` now chains
+       ``LoadedScenario.hyperedge_types`` into the ceiling map as
+       ``HyperedgeType/<member>`` entries and feeds
+       ``max_members_seen`` — the longest member list of that hyperedge
+       type in the world being loaded — into the ``:max-members`` axis
+       (``lib.rs::build_shared_load_inputs``; the prefix lands at that
+       seam, the census maps stay member-keyed mirroring
+       ``node_types``/``edge_types``). Rationale, with provenance: (a)
+       symmetry with the landed law — ``node_types``/``edge_types``
+       already take ceilings from "the population the scenario ACTUALLY
+       built … rather than an invented one" (``scenario.rs``'s own
+       census-map doc), and a stipulated hyperedge cap would be the only
+       invented number in the map; (b) the Director's
+       gameplay-and-pedagogy compass — community membership is *content*
+       (which classes belong to NEW_AFRIKAN is the political claim the
+       pack teaches), and a modder's world must be bounded by the
+       modder's world, never by a constant no player can see; where it
+       does fail — a world larger than a rule's declared ``:fuel`` — it
+       fails loudly at LOAD with a number to raise (III.11); (c) the fuel
+       consequence stated plainly: a rule's static bound is per-world, so
+       a pack's declared ``:fuel`` is the maximum over every world that
+       loads it, re-measured whenever a world is added. **Rejected
+       alternative:** a content ``manifest`` form declaring
+       ``:max-members`` (``manifest.rs``'s route) — no landed content
+       declares a manifest at all today, and that route would put an
+       invented cap in fixtures. Re-open trigger: the first content set
+       that genuinely needs a cap larger than any world it ships with (an
+       unbounded runtime population). Mutation-proven at landing: the
+       empty-map restoration reds all three ``hyperedge_ceilings.rs``
+       proofs on E-LOAD-042, the dropped ``HyperedgeType/`` prefix reds
+       the type-wide-head proof, and a constant 99 in the axis moves the
+       measured E-LOAD-040 bound off its pinned 15.
 
 Authoring idioms (non-normative)
 -----------------------------------

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -377,8 +377,10 @@ fn registered_systems() -> HashSet<String> {
         // train, issue #667, plan
         // `docs/superpowers/plans/2026-08-18-community-port.md`).
         // Registered AT TASK 4 (one task earlier than the plan's Task 7
-        // Step 2): the ceiling supply chain's RED tests must observe
-        // MissingCeiling/E-LOAD-042 specifically, and a rule under an
+        // Step 2): the ceiling supply chain's RED tests must observe the
+        // two refusal codes specifically — E-LOAD-045 (MissingCeiling, the
+        // type axis) and E-LOAD-042 (MissingMaxMembers, the
+        // :max-members axis) — and a rule under an
         // unregistered namespace fails E-LOAD-004 (undeterminable domain)
         // one stage earlier — the registration is the precondition for the
         // probe to reach the check it pins. Genuinely NEW registration —

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -373,6 +373,19 @@ fn registered_systems() -> HashSet<String> {
         // "decomposition"/"control-ratio" above. Hyphenated spelling
         // follows the same "control-ratio" precedent immediately above.
         "imperial-rent".to_owned(),
+        // The community/* rule pack (Material Base @6.0, the Community port
+        // train, issue #667, plan
+        // `docs/superpowers/plans/2026-08-18-community-port.md`).
+        // Registered AT TASK 4 (one task earlier than the plan's Task 7
+        // Step 2): the ceiling supply chain's RED tests must observe
+        // MissingCeiling/E-LOAD-042 specifically, and a rule under an
+        // unregistered namespace fails E-LOAD-004 (undeterminable domain)
+        // one stage earlier — the registration is the precondition for the
+        // probe to reach the check it pins. Genuinely NEW registration —
+        // the Task 0 surface-facts dossier
+        // (`reports/community-bsl-surface-facts-2026-08-18.md`) confirmed
+        // zero prior hits in this HashSet.
+        "community".to_owned(),
     ])
 }
 
@@ -515,6 +528,15 @@ fn build_shared_load_inputs(scenario: &LoadedScenario) -> Result<SharedLoadInput
     // key disjoint namespaces (`NodeType/…` vs `EdgeType/…`), so merging
     // them into one flat map — which is what `CardinalityCeilings` already
     // is — cannot collide.
+    //
+    // Same again for `HyperedgeType/MEMBER` (Community port train, Task 4
+    // — plan `docs/superpowers/plans/2026-08-18-community-port.md`):
+    // `hyperedges`/`members-of`/`hyperedges-of` folds refuse load without
+    // the type's ceiling (E-LOAD-045) or its max-members axis (E-LOAD-042).
+    // Both are fed from the scenario's OWN census (`hyperedge_types`/
+    // `max_members_seen`, Task 1) — derived from the population the
+    // scenario actually built, never an invented constant (the D200
+    // record).
     let ceilings = CardinalityCeilings::new(
         scenario
             .node_types
@@ -526,8 +548,23 @@ fn build_shared_load_inputs(scenario: &LoadedScenario) -> Result<SharedLoadInput
                     .iter()
                     .map(|(member, count)| (format!("EdgeType/{member}"), *count)),
             )
+            .chain(
+                scenario
+                    .hyperedge_types
+                    .iter()
+                    .map(|(member, count)| (format!("HyperedgeType/{member}"), *count)),
+            )
             .collect(),
-        HashMap::new(),
+        // `max_members_seen` is member-keyed at the census
+        // (`scenario.rs`'s Task-1 maps mirror `node_types`' shape); the
+        // checker queries `HyperedgeType/<member>` (`enum_ref_key`) — the
+        // prefix lands at THIS seam, the same place the count map gets
+        // its own.
+        scenario
+            .max_members_seen
+            .iter()
+            .map(|(member, longest)| (format!("HyperedgeType/{member}"), *longest))
+            .collect(),
     );
     Ok(SharedLoadInputs {
         types,

--- a/rust/crates/babylon-tick/tests/hyperedge_ceilings.rs
+++ b/rust/crates/babylon-tick/tests/hyperedge_ceilings.rs
@@ -1,0 +1,119 @@
+//! Hyperedge-lane Task 4 (E1d, Community port train, plan
+//! `docs/superpowers/plans/2026-08-18-community-port.md`): the ceiling
+//! supply chain — the driver's `CardinalityCeilings` must be fed from the
+//! scenario's own hyperedge census (`LoadedScenario::hyperedge_types` +
+//! `max_members_seen`), or EVERY hyperedge-querying rule fails at load.
+//!
+//! RED→GREEN record: the refusal texts (E-LOAD-045 naming the unceiled
+//! type, E-LOAD-042 naming the max-members axis) were pinned first, while
+//! the driver passed an empty `max_members` map and minted no
+//! `HyperedgeType/*` ceiling; the two refusal pins then INVERTED to the
+//! load-clean proofs below when `lib.rs`'s `build_shared_load_inputs` was
+//! fed. The measured-bound test is the through-the-driver proof of the
+//! `:max-members` axis's arithmetic.
+//!
+//! The `community/` namespace registration (lib.rs's systems set) landed
+//! one task early (Task 7 Step 2's content) precisely so these probes
+//! reach the ceiling checks instead of dying at E-LOAD-004.
+
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::hypergraph_store::HypergraphStore;
+use babylon_tick::{diagnose_content_set, run_once_into};
+
+/// Two COMMUNITY hyperedges over three classes — the minimal world whose
+/// census should feed the ceiling maps (Task 1's own population maps,
+/// measured: two hyperedges, longest member list 3).
+const SCENARIO: &str = r"
+(scenario ft/hyperedge-ceilings
+  (defvocabulary HyperedgeType (COMMUNITY))
+  (deffield social-class/active int extensive)
+  (node alpha NodeType/SOCIAL_CLASS)
+  (node beta NodeType/SOCIAL_CLASS)
+  (node gamma NodeType/SOCIAL_CLASS)
+  (hyperedge new-afrikan HyperedgeType/COMMUNITY (members alpha beta gamma))
+  (hyperedge queer HyperedgeType/COMMUNITY (members alpha)))
+";
+
+/// A rule folding the type-wide `hyperedges` head — needs a
+/// `HyperedgeType/COMMUNITY` ceiling entry.
+const RULE_HYPEREDGES_FOLD: &str = r#"
+(rule community/probe-hyperedge-count
+  :material-basis "probe rule for the hyperedge ceiling supply chain (Task 4 RED) — the community/ namespace was registered one task early (Task 7 Step 2's content) precisely so this probe reaches the ceiling check instead of dying at E-LOAD-004"
+  :fuel 512
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active :optional :default 1))
+  (when (= active 1))
+  (effects
+    (emit EventType/ORGANIZATION_SEEDED
+      (probe (fold sum (hyperedges HyperedgeType/COMMUNITY) :as c (fold sum (members-of c HyperedgeType/COMMUNITY) (field-of it social-class/active)))))))
+"#;
+
+/// A rule folding the subject-relative `members-of` head — needs the
+/// `:max-members` axis (E-LOAD-042), not just the type ceiling.
+const RULE_MEMBERS_OF_FOLD: &str = r#"
+(rule community/probe-membership-count
+  :material-basis "probe rule for the :max-members axis (Task 4 RED) — namespace registration as probe-hyperedge-count's"
+  :fuel 512
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active :optional :default 1))
+  (when (= active 1))
+  (effects
+    (emit EventType/ORGANIZATION_SEEDED
+      (probe (fold sum (members-of self HyperedgeType/COMMUNITY) (field-of it social-class/active))))))
+"#;
+
+/// Step 4: the two Step-1 probes now LOAD through the real driver. LOAD,
+/// not run — the §2.6 query heads are load-registered and bound-checked,
+/// but the query EVALUATOR does not serve them until Task 3's slice-3 lane
+/// (a tick attempt today errors "lands with slice 3", loudly, never a
+/// default); that lane is this train's own next task.
+#[test]
+fn the_hyperedges_folding_rule_now_loads_through_the_driver() {
+    let errors = diagnose_content_set(SCENARIO, None, &[RULE_HYPEREDGES_FOLD]);
+    assert!(
+        errors.is_empty(),
+        "the type-wide fold loads once the census feeds the ceiling map: {errors:?}"
+    );
+}
+
+#[test]
+fn the_members_of_folding_rule_now_loads_through_the_driver() {
+    let errors = diagnose_content_set(SCENARIO, None, &[RULE_MEMBERS_OF_FOLD]);
+    assert!(
+        errors.is_empty(),
+        "the members-of fold loads once :max-members is census-fed: {errors:?}"
+    );
+}
+
+/// Step 4's measured-bound pin: a `members-of` fold with `:fuel 1` refuses
+/// E-LOAD-040, and the refusal's computed bound is read back — never
+/// hand-computed — matching bound_checker.rs's landed arithmetic shape
+/// `2 + query(2) + max_members × body` (`:897-905`). The world's longest
+/// member list is 3 (`new-afrikan`), fed from `max_members_seen` — NOT the
+/// 0 of an empty map (that variant is the mutation vector below).
+#[test]
+fn the_measured_e_load_040_bound_matches_the_fold_shape() {
+    let underfunded = RULE_MEMBERS_OF_FOLD.replace(":fuel 512", ":fuel 1");
+    assert!(underfunded.contains(":fuel 1"));
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(SCENARIO, &underfunded, &mut graph, &mut sink).unwrap_err();
+    let bound = err
+        .split("static bound ")
+        .nth(1)
+        .and_then(|rest| rest.split_whitespace().next())
+        .and_then(|n| n.parse::<u64>().ok())
+        .unwrap_or_else(|| panic!("no measured bound in the refusal: {err}"));
+    // Measured (never hand-computed, per the plan's own law): the refusal
+    // reports 15. Decomposed against bound_checker.rs's arithmetic: the
+    // fold alone is 2 + query(2) + max_members(3, census-fed from
+    // `new-afrikan`'s member list, the world's longest) × body(2, the
+    // field-of read) = 10; the rule's full static bound adds the `(when
+    // …)` condition and the `emit` + payload overhead, landing at 15. The
+    // assertion is against the MEASURED number, so a shape change in any
+    // of those pieces reds loudly here.
+    assert_eq!(bound, 15, "the E-LOAD-040 refusal's own number: {err}");
+    assert!(err.contains("E-LOAD-040"), "{err}");
+}


### PR DESCRIPTION
## What

#667 Task 4 (E1d), the last unlanded piece of the Community port train's **PR A**. Until now every
hyperedge-querying rule failed at load: the driver's `CardinalityCeilings` was built with an empty
`max_members` map and no `HyperedgeType/*` ceiling (`lib.rs::build_shared_load_inputs`).

- `hyperedge_types` is chained into the ceiling map as `HyperedgeType/<member>`; `max_members_seen`
  (census-fed, longest member list per type) feeds the `:max-members` axis — both **derived from the
  seeded population**, never stipulated (the D200 record).
- The `community/` namespace is registered one task earlier than the plan's Task 7 Step 2 — the
  probes must reach the ceiling checks, not die at E-LOAD-004. Recorded in the test file's header.

## TDD + proofs

- RED first: the two refusal pins (E-LOAD-045 naming the unceiled type; E-LOAD-042 naming the
  max-members axis) verified against the unfed driver, then inverted to load-clean proofs via
  `diagnose_content_set` (load-only — the §2.6 query evaluator serves these heads only with Task 3's
  slice-3 lane, and a tick attempt says so loudly).
- The measured E-LOAD-040 bound (15) is read from the refusal, never hand-computed; the comment
  decomposes it (fold = 2 + query(2) + max_members(3, census-measured) × body(2) = 10, plus the
  rule's when/effect/emit overhead).
- Mutation-proven: empty-map restoration reds all three proofs on E-LOAD-042; the dropped
  `HyperedgeType/` prefix reds the type-wide-head proof; a constant 99 moves the measured bound off
  its pin.

## Gates

`mise run rust:check` green (six legs, single-flight); `qa:regression` byte-identical;
`qa:vault-regression-ci` byte-identical; `check:quick` green. No content files, no pins moved
(no landed world seeds a hyperedge — the ceiling maps for landed worlds are unchanged by
construction, asserted by the untouched `tick_goldens.rs`).

Co-Authored-By: Kimi Code <noreply@moonshot.cn>