### PR TITLE
fix(graph): remove_node cascades sweep hyperedge own-field rows (#682 post-merge harvest)

### DIFF
--- a/rust/crates/babylon-graph/src/conformance.rs
+++ b/rust/crates/babylon-graph/src/conformance.rs
@@ -126,6 +126,32 @@ where
         "a hyperedge losing its last member is removed, not emptied: {}",
         err.message
     );
+    // Task 5 follow-up (PR #682's Copilot harvest — a REAL defect class):
+    // the same removal must sweep the dropped hyperedge's OWN attribute
+    // rows, or `all_hyperedge_attributes` reports corpses into section
+    // 0x07. Seeded before the removal, asserted absent after.
+    let mut graph = make();
+    let solo = graph.add_node("social_class").unwrap();
+    let lone = graph.add_hyperedge("economic_sector", &[solo]).unwrap();
+    graph
+        .update_hyperedge_attribute(lone, "community/heat", 0.5)
+        .unwrap();
+    graph.remove_node(solo).unwrap();
+    assert!(
+        !graph
+            .all_hyperedge_attributes()
+            .iter()
+            .any(|(id, _, _)| *id == lone),
+        "the implicitly-dropped hyperedge's attribute rows are swept, not orphaned"
+    );
+    let err = graph
+        .hyperedge_attribute(lone, "community/heat")
+        .unwrap_err();
+    assert!(
+        err.message.contains("no such hyperedge"),
+        "a read against the implicitly-dropped hyperedge is loud: {}",
+        err.message
+    );
 }
 
 /// §2.8: absence is never success. Adding what already exists and removing
@@ -1018,7 +1044,8 @@ where
 /// conformance row, mirroring
 /// `currency_attribute_round_trips_moves_the_hash_and_cascades_on_removal`'s
 /// shape exactly: a write round-trips, moves the state hash (section 0x07,
-/// layout version 4), reports in the sixth listing, and cascades on
+/// layout version 4), reports in the SEVENTH listing
+/// (`all_hyperedge_attributes`), and cascades on
 /// hyperedge removal (never orphaned).
 fn hyperedge_attribute_round_trips_moves_the_hash_and_cascades_on_removal<G, F>(make: &F)
 where

--- a/rust/crates/babylon-graph/src/hypergraph_store.rs
+++ b/rust/crates/babylon-graph/src/hypergraph_store.rs
@@ -208,6 +208,7 @@ impl GraphSubstrate for HypergraphStore {
                 message: format!("hyperedge-half removal of {id:?}: {e}"),
             })?;
 
+        let mut dropped: Vec<HyperedgeId> = Vec::new();
         for (edge_key, hyperedge_type) in prior_memberships {
             if !self.inner.has_edge(&edge_key) {
                 if let Some(hid) = self.hyperedge_keys.remove(&edge_key) {
@@ -215,10 +216,15 @@ impl GraphSubstrate for HypergraphStore {
                     // The implicitly-dropped hyperedge's own-field rows die
                     // with it (PR #682 harvest — this path missed the sweep
                     // before): no corpse rows into section 0x07.
-                    self.hyperedge_attributes
-                        .retain(|(hyperedge, _), _| *hyperedge != hid);
+                    dropped.push(hid);
                 }
             }
+        }
+        // One sweep for the whole drop set (PR #683's own review): retain
+        // per dropped id would make the cascade O(dropped × rows).
+        if !dropped.is_empty() {
+            self.hyperedge_attributes
+                .retain(|(hyperedge, _), _| !dropped.contains(hyperedge));
         }
         Ok(())
     }

--- a/rust/crates/babylon-graph/src/hypergraph_store.rs
+++ b/rust/crates/babylon-graph/src/hypergraph_store.rs
@@ -212,6 +212,11 @@ impl GraphSubstrate for HypergraphStore {
             if !self.inner.has_edge(&edge_key) {
                 if let Some(hid) = self.hyperedge_keys.remove(&edge_key) {
                     self.drop_from_type_index(&hyperedge_type, hid);
+                    // The implicitly-dropped hyperedge's own-field rows die
+                    // with it (PR #682 harvest — this path missed the sweep
+                    // before): no corpse rows into section 0x07.
+                    self.hyperedge_attributes
+                        .retain(|(hyperedge, _), _| *hyperedge != hid);
                 }
             }
         }

--- a/rust/crates/babylon-graph/src/memory.rs
+++ b/rust/crates/babylon-graph/src/memory.rs
@@ -194,6 +194,11 @@ impl GraphSubstrate for MemoryGraph {
         // a state that cannot be created directly.
         self.hyperedges
             .retain(|_, (_, members)| !members.is_empty());
+        // And their own-field rows die with them (PR #682 harvest — the
+        // implicit-drop path missed this before): sweep by liveness, never
+        // by assumption about which hyperedges emptied.
+        self.hyperedge_attributes
+            .retain(|(hyperedge, _), _| self.hyperedges.contains_key(hyperedge));
         Ok(())
     }
 


### PR DESCRIPTION
## Why

Copilot's post-merge review of #682 caught a real defect class, landed post-merge: the
`remove_node` cascade drops emptied hyperedges on BOTH backends but never swept their
`hyperedge_attributes` rows — `all_hyperedge_attributes()` would have reported corpses into
section 0x07 and the state hash would have hashed them.

## What

- `memory.rs`: the attribute map now sweeps by liveness after the empty-member prune (never by
  assumption about which hyperedges emptied).
- `hypergraph_store.rs`: the emptied-hyperedge arm (the `prior_memberships` loop) sweeps the rows
  for the dropped id.
- `conformance.rs`: the cascade row gains the seeded-then-implicitly-removed leg + a loud
  read-after assertion — proven RED on BOTH backends before the fix. Its doc slip ("sixth listing"
  for the seventh) corrected.

## Gates

`cargo test -p babylon-graph` 104/104 both backends; rust:check/qa legs green on the parent train
(this is a 3-file follow-up; full battery runs on the PR).

Co-Authored-By: Kimi Code <noreply@moonshot.cn>