### PR TITLE
feat(bsl): serve hyperedges/members-of/hyperedges-of + Element::Hyperedge Ord ruling (#667 Task 3, slice 3)

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -8946,6 +8946,36 @@ consequences are the ordinary kind of review item.
        proofs on E-LOAD-042, the dropped ``HyperedgeType/`` prefix reds
        the type-wide-head proof, and a constant 99 in the axis moves the
        measured E-LOAD-040 bound off its pinned 15.
+   * - D201
+     - §2.6
+     - **Slice 3's cross-kind Ord ruling and the two-table move**
+       (Community port train, Task 3, 2026-08-22; the plan's ``D-NF+24``).
+       ``query::Element`` gains ``Hyperedge(HyperedgeId)`` declared
+       **THIRD**: ``Node`` sorts before ``Edge`` sorts before
+       ``Hyperedge``, by declaration order — arbitrary, deliberate, tested
+       (the companions ``edge_sorts_before_hyperedge_regardless_of_id``
+       and ``the_three_kind_order_holds_regardless_of_ids``, plus the
+       compile-time trap this enum already carries: an exhaustive match,
+       no wildcard, so a new variant breaks compilation at the pin
+       before a reviewer can notice). The three §2.6 hyperedge heads are
+       served by ``query::materialize`` — ``hyperedges``/``hyperedges-of``
+       yield ``Element::Hyperedge`` in ascending ``HyperedgeId`` order
+       (D25 — the substrate's own contract), ``members-of`` yields plain
+       ``Element::Node`` in ascending ``NodeId`` order. **The two-table
+       move:** ``query.rs``'s ``UNSERVED_QUERY_HEADS`` is DELETED with its
+       refusal arm (a zero-row table would be the plan's own M4 failure
+       mode — a duplicated table named once; the at-the-byte decision,
+       recorded here), and ``evaluator.rs``'s ``UNSERVED_EXPRESSION_HEADS``
+       drops the three heads (``metric-of`` stays; ``membership-field-of``'s
+       "slice 4" note is amended to cite #653 by number, per the plan's
+       own instruction). The query-operand-only law holds unchanged: a
+       served head in bare ``<expr>`` position still refuses with the
+       §2.7 text (pinned by
+       ``hyperedge_query_heads.rs::a_served_head_in_bare_expression_position_still_refuses_with_the_2_7_law``).
+       Mutation-proven at landing: inverting the materializer's order reds
+       the ascending-id pin; re-declaring ``Hyperedge`` first reds both
+       Ord companions; dropping the served-heads' bare-expr guard reds the
+       §2.7 position pin.
 
 Authoring idioms (non-normative)
 -----------------------------------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -8975,7 +8975,14 @@ consequences are the ordinary kind of review item.
        Mutation-proven at landing: inverting the materializer's order reds
        the ascending-id pin; re-declaring ``Hyperedge`` first reds both
        Ord companions; dropping the served-heads' bare-expr guard reds the
-       §2.7 position pin.
+       §2.7 position pin. **Added at PR review (#684):** ``members-of`` now
+       checks the annotated type against the referent's ACTUAL type at
+       materialize time — ``E-EVAL-032`` (``HyperedgeTypeMismatch``, D24's
+       pre-minted code) — via the new read-only
+       ``GraphSubstrate::hyperedge_type_of`` accessor (both backends, two
+       conformance rows); without it a referent of a different type would
+       iterate past the annotated type's census-fed max-members bound
+       unchecked. The check is a soundness obligation, not a filter.
 
 Authoring idioms (non-normative)
 -----------------------------------

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -532,22 +532,25 @@ const EFFECT_POSITION_ONLY: [&str; 19] = [
 /// still ride slices 2-3); `the` (slice 2, the carrier-read lane —
 /// `edges`/`edge-between` served as of T2, issue #559);
 /// `hyperedges`/`members-of`/`hyperedges-of`/`metric-of`
-/// (slice 3, the hyperedge + metric lane); `membership-field-of` (slice 4,
-/// the CanonicalState-widening storage lane — Director-ruled deferred to
-/// first consumer). `nodes`/`neighbors` moved to [`SERVED_QUERY_HEADS`] at
+/// (slice 3, the hyperedge + metric lane); `membership-field-of` (the
+/// AG(i) membership-payload lane, #653 — Director-ruled deferred to
+/// first consumer). `hyperedges`/`members-of`/`hyperedges-of` LEFT this
+/// table at slice 3's landing (Community port train Task 3, 2026-08-21) —
+/// they are served, as query operands of iterating forms only, per the
+/// `SERVED_QUERY_HEADS` law below. `nodes`/`neighbors` moved to [`SERVED_QUERY_HEADS`] at
 /// Task 4 — they are served, but only as the query operand of an iterating
 /// form, never as a bare `<expr>` (§2.7 has no query production of its
 /// own). Together with [`EFFECT_POSITION_ONLY`] and [`SERVED_QUERY_HEADS`]
 /// this is exhaustive over the pre-Task-1 `GRAPH_SEAM_HEADS` set AND the
 /// grammar's §2.8/§2.10 heads: a head in none of the three tables is
 /// `eval_intrinsic`'s.
-const UNSERVED_EXPRESSION_HEADS: [(&str, &str); 6] = [
+const UNSERVED_EXPRESSION_HEADS: [(&str, &str); 3] = [
     ("the", "slice 2"),
-    ("hyperedges", "slice 3"),
-    ("members-of", "slice 3"),
-    ("hyperedges-of", "slice 3"),
     ("metric-of", "slice 3"),
-    ("membership-field-of", "slice 4"),
+    (
+        "membership-field-of",
+        "the AG(i) membership-payload lane — #653",
+    ),
 ];
 
 /// The §2.6 query heads Task 4 onward serves — but **only** as the query
@@ -558,13 +561,19 @@ const UNSERVED_EXPRESSION_HEADS: [(&str, &str); 6] = [
 /// (unlike `<fold>`/`<accessor>`/`<selection>`, a bare `<query>` is not one
 /// of `<expr>`'s productions), so reaching one of these heads HERE — through
 /// generic expression dispatch — means it was written somewhere the grammar
-/// does not admit a query: a shape error, not an unimplemented seam. Only
-/// `nodes`/`neighbors`/`edges` are here (`edges` joined at T2, issue #559);
-/// the other three §2.6 heads stay in
-/// [`UNSERVED_EXPRESSION_HEADS`] until their own slice serves them (at which
-/// point they join this table too, since serving a query head never means
-/// giving it a bare `<expr>` reading).
-const SERVED_QUERY_HEADS: [&str; 3] = ["nodes", "neighbors", "edges"];
+/// does not admit a query: a shape error, not an unimplemented seam.
+/// `nodes`/`neighbors`/`edges`/`hyperedges`/`members-of`/`hyperedges-of`
+/// are here (`edges` joined at T2, issue #559; the three hyperedge heads at
+/// slice 3's landing, Community port train Task 3, 2026-08-21). Serving a
+/// query head never means giving it a bare `<expr>` reading.
+const SERVED_QUERY_HEADS: [&str; 6] = [
+    "nodes",
+    "neighbors",
+    "edges",
+    "hyperedges",
+    "members-of",
+    "hyperedges-of",
+];
 
 fn eval_form(
     items: &[SExpr],
@@ -1660,6 +1669,15 @@ fn element_content_id(
     };
     match element {
         Element::Node(id) => content_id_of(id),
+        // Slice 3 (Community Task 3): hyperedges have no content-id
+        // hydration map at all today (no scenario-side hyperedge name table
+        // is fed to the tick — the `declared_hyperedges` names live and die
+        // with the executor). The `HyperedgeId` IS declaration-ordered and
+        // deterministic, so the raw handle rendering is deterministic too —
+        // the same shape the `None` arm above gives nodes when no scenario
+        // was hydrated. If a hyperedge content-id lane ever lands, this arm
+        // moves to it.
+        Element::Hyperedge(id) => Ok(format!("{id:?}")),
         Element::Edge(key) => {
             let source = content_id_of(&key.source)?;
             let target = content_id_of(&key.target)?;
@@ -2542,10 +2560,18 @@ mod tests {
         assert!(emit_err.message.contains("§2.8"), "{emit_err}");
         assert!(emit_err.message.contains("effect position"), "{emit_err}");
 
-        // `members-of` is unserved until slice 3.
+        // `members-of` is SERVED at slice 3 (Community Task 3, 2026-08-21)
+        // — in bare-expr position it now refuses with the
+        // query-operand-only law (§2.7: no bare `<query>` production),
+        // never a slice number: the served heads' refusal is grammatical,
+        // not a TODO.
         let members_of_err = eval("(members-of self HyperedgeType/CELL)").unwrap_err();
         assert!(
-            members_of_err.message.contains("slice 3"),
+            members_of_err.message.contains("query operand"),
+            "{members_of_err}"
+        );
+        assert!(
+            !members_of_err.message.contains("slice"),
             "{members_of_err}"
         );
 
@@ -2566,9 +2592,10 @@ mod tests {
         assert!(upd_mem_err.message.contains("§2.8"), "{upd_mem_err}");
         assert!(!upd_mem_err.message.contains("E-LOAD-021"), "{upd_mem_err}");
 
-        // `membership-field-of` (§2.10) is unserved until slice 4.
+        // `membership-field-of` (§2.10) stays unserved — its note now cites
+        // #653 by number, never a slice (Task 3 Step 4's own amendment).
         let mem_field_err = eval("(membership-field-of self self x/y)").unwrap_err();
-        assert!(mem_field_err.message.contains("slice 4"), "{mem_field_err}");
+        assert!(mem_field_err.message.contains("#653"), "{mem_field_err}");
     }
 
     /// The effect-position half of the flip (T3, ADR198 R1-R3, issue #560):

--- a/rust/crates/babylon-bsl/src/query.rs
+++ b/rust/crates/babylon-bsl/src/query.rs
@@ -391,11 +391,27 @@ fn materialize_members_of(
     };
     let hyperedge_type = enum_member(type_ref)?;
     let graph = require_graph(env, "members-of")?;
-    // The type operand is not a filter — the HyperedgeRef carries its own
-    // type; a disagreement is the caller's bug, and the substrate's own
-    // hyperedges_of-type-vs-node asymmetry ruling (slice 3) leaves type
-    // validity to BSL's static check (E-TYPE-011), which the loader runs.
-    let _ = hyperedge_type;
+    // E-EVAL-032 (D24) — the annotated type must match the referent's
+    // ACTUAL type: the load-time bound checker bounds this fold by the
+    // annotated type's census-fed max-members, and a referent of a
+    // different type would iterate past that bound unchecked (PR #684's
+    // review found the gap). Never a silently empty set.
+    let actual_type = graph.hyperedge_type_of(hyperedge).map_err(|e| {
+        // D-row Q3's posture, same module: uncoded loud.
+        EvalError::plain(format!(
+            "(members-of …) over a dangling hyperedge operand: {}",
+            e.message
+        ))
+    })?;
+    if actual_type != hyperedge_type {
+        return Err(EvalError::coded(
+            crate::evaluator::EvalCode::HyperedgeTypeMismatch,
+            format!(
+                "(members-of …) annotated {hyperedge_type} but the referent is {actual_type} — \
+                 the annotated type bounds the fold's fuel (D24), never a silently empty set"
+            ),
+        ));
+    }
     Ok(graph
         .members_of(hyperedge)
         .map_err(|e| {
@@ -839,12 +855,16 @@ mod tests {
         let result = materialize_src("(hyperedges HyperedgeType/CELL)", &graph, &costs, &mut fuel)
             .expect("the type-wide head is served");
         assert_eq!(result, vec![Element::Hyperedge(cell)]);
+        // PR #684 review: independent assertions get independent fuel — a
+        // shared meter would couple the ordering pins to prior calls'
+        // consumption.
 
         // Iteration order is the ruled order — ascending HyperedgeId (D25),
         // pinned against a deliberately multi-hyperedge world; the Step-7
         // mutation (inverting the materializer's order) reds this.
         let cell2 = graph.add_hyperedge("CELL", &[beta]).unwrap();
         let cell0 = graph.add_hyperedge("CELL", &[alpha]).unwrap();
+        let mut fuel = 10_000;
         let result = materialize_src("(hyperedges HyperedgeType/CELL)", &graph, &costs, &mut fuel)
             .expect("the type-wide head is served");
         assert_eq!(
@@ -866,6 +886,7 @@ mod tests {
         .expect_err("a bare `self` outside a rule body has no referent — loud");
         assert!(result.message.contains("self"), "{result}");
 
+        let mut fuel = 10_000;
         let members = materialize_src(
             "(members-of it HyperedgeType/CELL)",
             &graph,
@@ -874,6 +895,33 @@ mod tests {
         )
         .expect_err("a bare `it` outside an iterating body has no referent — loud");
         assert!(members.message.contains("it"), "{members}");
+
+        // E-EVAL-032 (D24; PR #684 review): the annotated type must match
+        // the referent's ACTUAL type — the load-time bound is the annotated
+        // type's census-fed max-members, so a mismatch would iterate past
+        // the declared bound unchecked.
+        let mut env = env(&graph, &costs);
+        env.elements
+            .push((Some("c".to_owned()), Element::Hyperedge(cell)));
+        let mut fuel = 10_000;
+        let err = materialize(
+            &read("(members-of c HyperedgeType/OTHER)")
+                .expect("parses")
+                .0,
+            &env,
+            &EmptyIntrinsicHost,
+            &mut fuel,
+        )
+        .expect_err("a COMMUNITY referent annotated OTHER must refuse");
+        assert!(
+            err.message
+                .contains("annotated OTHER but the referent is CELL"),
+            "{err}"
+        );
+        assert_eq!(
+            err.code,
+            Some(crate::evaluator::EvalCode::HyperedgeTypeMismatch)
+        );
     }
 
     /// Compile-time trap (verifier fix round, MINOR-5 on issue #525): an

--- a/rust/crates/babylon-bsl/src/query.rs
+++ b/rust/crates/babylon-bsl/src/query.rs
@@ -8,15 +8,16 @@
 //! actually produced one. Task 4 is the one that fills in [`materialize`]:
 //! `nodes` and typed `neighbors` — the two heads slice 1 serves; `edges`
 //! joined them at T2 (slice 2, issue #559). The remaining three §2.6 heads
-//! (`hyperedges`, `members-of`, `hyperedges-of`) are recognized here (so a
-//! fold/exists/forall/select-* over one of them refuses with the RIGHT
-//! slice number, never `eval_intrinsic`'s `E-LOAD-021` misdiagnosis) but
-//! are not materialized — that is slice 3's work.
+//! (`hyperedges`, `members-of`, `hyperedges-of`) are MATERIALIZED as of
+//! slice 3's landing (Community port train, Task 3, 2026-08-21) — the
+//! refusal arm they used to route through is deleted with the unserved
+//! table (Task 3 Step 4's at-the-byte decision, recorded there).
 //!
 //! [`Element::Node`] and [`Element::Edge`] exist ([`EdgeKey`] was minted at
-//! T2, slice 2). `Hyperedge(HyperedgeId)` (slice 3) is deliberately not
-//! added: minting it is slice 3's own scope, and a variant nothing can
-//! construct would be dead weight, not forward-compatibility.
+//! T2, slice 2). `Element::Hyperedge(HyperedgeId)` landed with slice 3
+//! (Community port train, Task 3, 2026-08-21): the variant is constructed
+//! by this module's own materialization of the three §2.6 hyperedge heads,
+//! served below — never a constructed-by-nothing placeholder.
 //!
 //! **Determinism (Constraint 2).** `nodes`/`neighbors` on `GraphSubstrate`
 //! already return a canonically sorted, deduplicated `Vec` (§2.6's total
@@ -29,7 +30,7 @@ use crate::evaluator::{charge, evaluate, require_graph, EvalEnv, EvalError, Valu
 use crate::fuel::cost;
 use crate::intrinsic_host::IntrinsicHost;
 use crate::reader::{Atom, SExpr};
-use babylon_graph::substrate::{Direction, NodeId};
+use babylon_graph::substrate::{Direction, HyperedgeId, NodeId};
 
 /// A materialized edge's identity — the `(source, target, edge_type)` triple IS the identity
 /// (§2.10's own "well-defined because the triple is a key" ruling, `bsl-language.rst:1896-1904`);
@@ -62,6 +63,14 @@ pub struct EdgeKey {
 /// happens to produce from declaration order. RULED: `Node` sorts before `Edge`, by declaration
 /// order below — arbitrary, deliberate, tested (`tests::node_sorts_before_edge_regardless_of_id`).
 ///
+/// **Slice-3 ruling (Community port train, Task 3, rider 4 clause 1, C5 /
+/// D-NF+24, 2026-08-21): `Node` sorts before `Edge` sorts before
+/// `Hyperedge`, by declaration order — arbitrary, deliberate, tested** (the
+/// companions `edge_sorts_before_hyperedge_regardless_of_id` and
+/// `the_three_kind_order_holds_regardless_of_ids`). Exactly the reasoning
+/// the T2 paragraph above gives: pinned, never left to whatever
+/// `#[derive(Ord)]` happens to produce.
+///
 /// **No longer `Copy` (T2, issue #559): `EdgeKey` owns a `String`.** Every call site that relied on
 /// `Copy` is fixed at this variant's landing (see evaluator.rs's own Task-3 call-site fixes) —
 /// `Clone` is unaffected and remains the currency for every place that needs an owned `Element`.
@@ -72,6 +81,9 @@ pub enum Element {
     /// A materialized dyadic edge (slice 2, T2). Declared SECOND: see this enum's own cross-kind
     /// Ord ruling above.
     Edge(EdgeKey),
+    /// A materialized hyperedge (slice 3, Community Task 3). Declared
+    /// THIRD: the cross-kind ruling above.
+    Hyperedge(HyperedgeId),
 }
 
 impl Element {
@@ -84,24 +96,18 @@ impl Element {
         match self {
             Self::Node(id) => Value::NodeRef(*id),
             Self::Edge(key) => Value::EdgeRef(key.clone()),
+            Self::Hyperedge(id) => Value::HyperedgeRef(*id),
         }
     }
 }
 
-/// The six §2.6 query heads, mapped to the slice that serves them — shared
-/// by [`materialize`]'s refusal for the three heads not yet served (`edges`
-/// joined the served set at T2, issue #559). Kept in sync with
-/// `evaluator::UNSERVED_EXPRESSION_HEADS`'s own rows for the same three
-/// heads; the two tables answer different questions (that module classifies
-/// every expression-position head, this one is the query-position
-/// dispatch), so one small duplication here is cheaper than a cross-module
-/// lookup for three stable rows.
-const UNSERVED_QUERY_HEADS: [(&str, &str); 3] = [
-    ("hyperedges", "slice 3"),
-    ("members-of", "slice 3"),
-    ("hyperedges-of", "slice 3"),
-];
-
+/// All six §2.6 query heads are served (`hyperedges`/`members-of`/
+/// `hyperedges-of` joined at slice 3's landing, Community port train Task
+/// 3, 2026-08-21). The unserved table this comment once introduced is
+/// DELETED with this module's refusal arm — a zero-row table would be the
+/// plan's own M4 failure mode (a duplicated table named once), recorded as
+/// Task 3 Step 4's at-the-byte decision. `metric-of` is not a §2.6 query
+/// head at all (it lives in `evaluator::UNSERVED_EXPRESSION_HEADS`).
 /// Materialize a `<query>` form in §2.6's total order, charging §3.7's
 /// `cost(query)` base (the querying form's own base — `fold`/`exists`/…
 /// charge their own separately) plus this query's operand expression(s).
@@ -133,17 +139,12 @@ pub fn materialize(
         "nodes" => materialize_nodes(items, env, fuel),
         "neighbors" => materialize_neighbors(items, env, host, fuel),
         "edges" => materialize_edges(items, env, fuel),
-        h => {
-            if let Some((_, slice)) = UNSERVED_QUERY_HEADS.iter().find(|(n, _)| *n == h) {
-                return Err(EvalError::plain(format!(
-                    "({h} …) is a §2.6 query head the query evaluator does not \
-                     yet serve — it lands with {slice}, never as a default here"
-                )));
-            }
-            Err(EvalError::plain(format!(
-                "{h} is not one of §2.6's six query heads"
-            )))
-        }
+        "hyperedges" => materialize_hyperedges(items, env, fuel),
+        "hyperedges-of" => materialize_hyperedges_of(items, env, host, fuel),
+        "members-of" => materialize_members_of(items, env, host, fuel),
+        h => Err(EvalError::plain(format!(
+            "{h} is not one of §2.6's six query heads"
+        ))),
     }
 }
 
@@ -293,6 +294,122 @@ fn materialize_edges(
         .collect())
 }
 
+/// `(hyperedges <enum-ref>)` — every hyperedge of the type, as
+/// `Element::Hyperedge` in ascending `HyperedgeId` order (the substrate's
+/// own contract — `hyperedges()` is ascending-and-typed by the conformance
+/// suite — §2.6's total order is the substrate's, not re-established here).
+/// No predicate variant exists for this head today (same deliberate
+/// loud-gap posture as `nodes`/`edges` above).
+fn materialize_hyperedges(
+    items: &[SExpr],
+    env: &EvalEnv<'_>,
+    fuel: &mut u64,
+) -> Result<Vec<Element>, EvalError> {
+    charge(fuel, cost::QUERY_BASE)?;
+    let [_, type_ref, extra @ ..] = items else {
+        return Err(EvalError::plain(
+            "(hyperedges <enum-ref>) — missing the HyperedgeType operand",
+        ));
+    };
+    if !extra.is_empty() {
+        return Err(EvalError::plain(
+            "(hyperedges <enum-ref>) takes exactly one operand — no predicate variant exists \
+             for this head today (the deliberate loud-gap posture `nodes`/`edges` set)",
+        ));
+    }
+    let hyperedge_type = enum_member(type_ref)?;
+    let graph = require_graph(env, "hyperedges")?;
+    Ok(graph
+        .hyperedges(hyperedge_type)
+        .into_iter()
+        .map(Element::Hyperedge)
+        .collect())
+}
+
+/// `(hyperedges-of <elem-expr> <enum-ref>)` — the hyperedges of the type a
+/// NODE belongs to, as `Element::Hyperedge` in ascending `HyperedgeId`
+/// order (the substrate's contract, same as above).
+fn materialize_hyperedges_of(
+    items: &[SExpr],
+    env: &EvalEnv<'_>,
+    host: &dyn IntrinsicHost,
+    fuel: &mut u64,
+) -> Result<Vec<Element>, EvalError> {
+    charge(fuel, cost::QUERY_BASE)?;
+    let [_, elem_expr, type_ref] = items else {
+        return Err(EvalError::plain(
+            "(hyperedges-of <elem-expr> <enum-ref>) — exactly two operands",
+        ));
+    };
+    let node = match evaluate(elem_expr, env, host, fuel)? {
+        Value::NodeRef(id) => id,
+        other => {
+            return Err(EvalError::plain(format!(
+                "(hyperedges-of …)'s first operand must evaluate to a NodeRef, got \
+                 {other:?} (§3.1)"
+            )))
+        }
+    };
+    let hyperedge_type = enum_member(type_ref)?;
+    let graph = require_graph(env, "hyperedges-of")?;
+    let ids = graph.hyperedges_of(node, hyperedge_type).map_err(|e| {
+        // Same posture as `neighbors`' own operand error (D-row Q3, this
+        // module): the reference codes no query-operand case, so this is
+        // uncoded loud, never a default.
+        EvalError::plain(format!(
+            "(hyperedges-of …) over a dangling node operand: {}",
+            e.message
+        ))
+    })?;
+    Ok(ids.into_iter().map(Element::Hyperedge).collect())
+}
+
+/// `(members-of <elem-expr> <enum-ref>)` — the members of the hyperedge the
+/// first operand names, as plain `Element::Node` in ascending `NodeId`
+/// order (D25 — `members_of` is already ascending by substrate contract;
+/// declared order is never observable).
+fn materialize_members_of(
+    items: &[SExpr],
+    env: &EvalEnv<'_>,
+    host: &dyn IntrinsicHost,
+    fuel: &mut u64,
+) -> Result<Vec<Element>, EvalError> {
+    charge(fuel, cost::QUERY_BASE)?;
+    let [_, elem_expr, type_ref] = items else {
+        return Err(EvalError::plain(
+            "(members-of <elem-expr> <enum-ref>) — exactly two operands",
+        ));
+    };
+    let hyperedge = match evaluate(elem_expr, env, host, fuel)? {
+        Value::HyperedgeRef(id) => id,
+        other => {
+            return Err(EvalError::plain(format!(
+                "(members-of …)'s first operand must evaluate to a HyperedgeRef, got \
+                 {other:?} (§3.1)"
+            )))
+        }
+    };
+    let hyperedge_type = enum_member(type_ref)?;
+    let graph = require_graph(env, "members-of")?;
+    // The type operand is not a filter — the HyperedgeRef carries its own
+    // type; a disagreement is the caller's bug, and the substrate's own
+    // hyperedges_of-type-vs-node asymmetry ruling (slice 3) leaves type
+    // validity to BSL's static check (E-TYPE-011), which the loader runs.
+    let _ = hyperedge_type;
+    Ok(graph
+        .members_of(hyperedge)
+        .map_err(|e| {
+            // D-row Q3's posture, same module: uncoded loud.
+            EvalError::plain(format!(
+                "(members-of …) over a dangling hyperedge operand: {}",
+                e.message
+            ))
+        })?
+        .into_iter()
+        .map(Element::Node)
+        .collect())
+}
+
 /// An enum-ref operand's member name — read directly, exactly as
 /// `structural_verbs::EffectExecutor::enum_member` reads one, and NOT
 /// through `evaluate()`: an enum-ref atom is a static type annotation here,
@@ -392,7 +509,9 @@ mod tests {
             .iter()
             .map(|element| match element {
                 Element::Node(id) => *id,
-                Element::Edge(_) => panic!("nodes must materialize only Node elements"),
+                Element::Edge(_) | Element::Hyperedge(_) => {
+                    panic!("nodes must materialize only Node elements")
+                }
             })
             .collect();
         assert_eq!(ids.len(), N);
@@ -546,7 +665,9 @@ mod tests {
             .iter()
             .map(|element| match element {
                 Element::Edge(key) => key.clone(),
-                Element::Node(_) => panic!("edges must materialize only Edge elements"),
+                Element::Node(_) | Element::Hyperedge(_) => {
+                    panic!("edges must materialize only Edge elements")
+                }
             })
             .collect();
         assert_eq!(
@@ -601,7 +722,9 @@ mod tests {
             .iter()
             .map(|element| match element {
                 Element::Edge(key) => (key.source, key.target),
-                Element::Node(_) => panic!("edges must materialize only Edge elements"),
+                Element::Node(_) | Element::Hyperedge(_) => {
+                    panic!("edges must materialize only Edge elements")
+                }
             })
             .collect();
         assert!(
@@ -656,7 +779,9 @@ mod tests {
             .iter()
             .map(|element| match element {
                 Element::Edge(key) => (key.source, key.target),
-                Element::Node(_) => panic!("edges must materialize only Edge elements"),
+                Element::Node(_) | Element::Hyperedge(_) => {
+                    panic!("edges must materialize only Edge elements")
+                }
             })
             .collect();
         assert_eq!(
@@ -697,19 +822,58 @@ mod tests {
         assert!(err.message.contains("element-predicate"), "{err}");
     }
 
+    /// RED→GREEN record (slice 3, Community port train Task 3, 2026-08-21):
+    /// this test pinned the three heads' "lands with slice 3" refusal text
+    /// while they were unserved; the heads are SERVED now (the
+    /// materializers above), so the test inverts — the refusal text it
+    /// pinned survives in this comment as the historical record.
     #[test]
-    fn hyperedges_and_members_of_name_their_slice() {
-        let graph = MemoryGraph::new();
+    fn hyperedges_and_members_of_are_served_in_query_position() {
+        let mut graph = MemoryGraph::new();
+        let alpha = graph.add_node("social_class").unwrap();
+        let beta = graph.add_node("social_class").unwrap();
+        let cell = graph.add_hyperedge("CELL", &[alpha, beta]).unwrap();
         let costs = costs();
-        for (source, slice) in [
-            ("(hyperedges HyperedgeType/CELL)", "slice 3"),
-            ("(members-of self HyperedgeType/CELL)", "slice 3"),
-            ("(hyperedges-of self HyperedgeType/CELL)", "slice 3"),
-        ] {
-            let mut fuel = 1_000;
-            let err = materialize_src(source, &graph, &costs, &mut fuel).unwrap_err();
-            assert!(err.message.contains(slice), "{source}: {err}");
-        }
+        let mut fuel = 10_000;
+
+        let result = materialize_src("(hyperedges HyperedgeType/CELL)", &graph, &costs, &mut fuel)
+            .expect("the type-wide head is served");
+        assert_eq!(result, vec![Element::Hyperedge(cell)]);
+
+        // Iteration order is the ruled order — ascending HyperedgeId (D25),
+        // pinned against a deliberately multi-hyperedge world; the Step-7
+        // mutation (inverting the materializer's order) reds this.
+        let cell2 = graph.add_hyperedge("CELL", &[beta]).unwrap();
+        let cell0 = graph.add_hyperedge("CELL", &[alpha]).unwrap();
+        let result = materialize_src("(hyperedges HyperedgeType/CELL)", &graph, &costs, &mut fuel)
+            .expect("the type-wide head is served");
+        assert_eq!(
+            result,
+            vec![
+                Element::Hyperedge(cell),
+                Element::Hyperedge(cell2),
+                Element::Hyperedge(cell0)
+            ],
+            "ascending HyperedgeId, never creation/insertion order"
+        );
+
+        let result = materialize_src(
+            "(members-of self HyperedgeType/CELL)",
+            &graph,
+            &costs,
+            &mut fuel,
+        )
+        .expect_err("a bare `self` outside a rule body has no referent — loud");
+        assert!(result.message.contains("self"), "{result}");
+
+        let members = materialize_src(
+            "(members-of it HyperedgeType/CELL)",
+            &graph,
+            &costs,
+            &mut fuel,
+        )
+        .expect_err("a bare `it` outside an iterating body has no referent — loud");
+        assert!(members.message.contains("it"), "{members}");
     }
 
     /// Compile-time trap (verifier fix round, MINOR-5 on issue #525): an
@@ -727,6 +891,7 @@ mod tests {
         match element {
             Element::Node(_) => "node",
             Element::Edge(_) => "edge",
+            Element::Hyperedge(_) => "hyperedge",
         }
     }
 
@@ -756,5 +921,33 @@ mod tests {
         assert_eq!(element_kind_name(&node), "node");
         assert_eq!(element_kind_name(&edge), "edge");
         assert!(node < edge, "T2's ruling: kind dominates value");
+    }
+
+    /// Slice 3's cross-kind Ord ruling, value-pinned: Edge < Hyperedge
+    /// regardless of id/key magnitude (the enum's own standing instruction,
+    /// extended — arbitrary, deliberate, tested).
+    #[test]
+    fn edge_sorts_before_hyperedge_regardless_of_id() {
+        let edge = Element::Edge(EdgeKey {
+            source: NodeId(u64::MAX),
+            target: NodeId(u64::MAX),
+            edge_type: String::from("z"),
+        });
+        let hyperedge = Element::Hyperedge(HyperedgeId(0));
+        assert!(edge < hyperedge, "slice-3 ruling: kind dominates value");
+    }
+
+    /// The three-kind chain: Node < Edge < Hyperedge, all by declaration
+    /// order, regardless of the carried ids' magnitudes.
+    #[test]
+    fn the_three_kind_order_holds_regardless_of_ids() {
+        let node = Element::Node(NodeId(u64::MAX));
+        let edge = Element::Edge(EdgeKey {
+            source: NodeId(u64::MAX),
+            target: NodeId(u64::MAX),
+            edge_type: String::from("z"),
+        });
+        let hyperedge = Element::Hyperedge(HyperedgeId(0));
+        assert!(node < edge && edge < hyperedge, "Node < Edge < Hyperedge");
     }
 }

--- a/rust/crates/babylon-bsl/tests/hyperedge_lane_e2e.rs
+++ b/rust/crates/babylon-bsl/tests/hyperedge_lane_e2e.rs
@@ -472,6 +472,12 @@ impl GraphSubstrate for OrderSpyGraph {
         self.inner.node_type_of(id)
     }
 
+    // Task 3's review-driven addition (PR #684): pure delegation,
+    // un-spied, exactly as the own-field lane above.
+    fn hyperedge_type_of(&self, id: HyperedgeId) -> Result<&str, GraphError> {
+        self.inner.hyperedge_type_of(id)
+    }
+
     fn edge_attribute(
         &self,
         edge_type: &str,

--- a/rust/crates/babylon-bsl/tests/r9_chapters.rs
+++ b/rust/crates/babylon-bsl/tests/r9_chapters.rs
@@ -1217,7 +1217,7 @@ mod c5_element_selection {
     /// `edge_count_evaluates_for_real_on_an_empty_graph`
     /// (`conformance_corpus.rs`) for its own positive vector.
     #[test]
-    fn the_other_three_selection_heads_stay_pinned_named_by_their_slice() {
+    fn the_served_hyperedge_heads_refuse_empty_or_mistyped_results_honestly() {
         // `self` binds to a REAL node: were it a dangling id, a future
         // referent-validation pass could fire before the slice refusal
         // and this vector would pin the wrong error (Copilot harvest,

--- a/rust/crates/babylon-bsl/tests/r9_chapters.rs
+++ b/rust/crates/babylon-bsl/tests/r9_chapters.rs
@@ -1204,11 +1204,18 @@ mod c5_element_selection {
         assert_eq!(result2, Value::NodeRef(low));
     }
 
-    /// The other THREE §2.6 query heads a selection could in principle run over stay refused at
-    /// EVALUATION, each naming the slice that will serve it (Constraint 4) — never a silent skip
-    /// and never an `E-LOAD-021` misdiagnosis. `edges` is no longer among them (T2, issue #559) —
-    /// see `edge_count_evaluates_for_real_on_an_empty_graph` (`conformance_corpus.rs`) for its own
-    /// positive vector.
+    /// The three hyperedge §2.6 query heads are SERVED (slice 3, Community
+    /// Task 3, 2026-08-22) — this test's old "each names its slice"
+    /// refusal is retired; what is pinned now is each head's honest
+    /// behavior under a selection on an empty or wrongly-typed result:
+    /// `hyperedges`/`hyperedges-of` (a node's memberships — none seeded)
+    /// refuse the EMPTY query with the §4.4/D45 text; `members-of self`
+    /// refuses the operand kind (self is a `NodeRef`; the head wants a
+    /// `HyperedgeRef`, §3.1) — never a silent skip, never an
+    /// `E-LOAD-021` misdiagnosis, on any of the three. `edges` left this
+    /// set at T2 (issue #559) — see
+    /// `edge_count_evaluates_for_real_on_an_empty_graph`
+    /// (`conformance_corpus.rs`) for its own positive vector.
     #[test]
     fn the_other_three_selection_heads_stay_pinned_named_by_their_slice() {
         // `self` binds to a REAL node: were it a dangling id, a future
@@ -1217,12 +1224,18 @@ mod c5_element_selection {
         // #520).
         let mut graph = MemoryGraph::new();
         let subject = graph.add_node("SOCIAL_CLASS").unwrap();
-        for (query, slice) in [
-            ("(hyperedges HyperedgeType/ECONOMIC_SECTOR)", "slice 3"),
-            ("(members-of self HyperedgeType/ECONOMIC_SECTOR)", "slice 3"),
+        for (query, expected) in [
+            (
+                "(hyperedges HyperedgeType/ECONOMIC_SECTOR)",
+                "select-max over an empty query",
+            ),
+            (
+                "(members-of self HyperedgeType/ECONOMIC_SECTOR)",
+                "must evaluate to a HyperedgeRef",
+            ),
             (
                 "(hyperedges-of self HyperedgeType/ECONOMIC_SECTOR)",
-                "slice 3",
+                "select-max over an empty query",
             ),
         ] {
             let mut fuel = 1_000;
@@ -1233,7 +1246,7 @@ mod c5_element_selection {
                 &mut fuel,
             )
             .unwrap_err();
-            assert!(err.message.contains(slice), "{query}: {err}");
+            assert!(err.message.contains(expected), "{query}: {err}");
         }
     }
 

--- a/rust/crates/babylon-graph/src/conformance.rs
+++ b/rust/crates/babylon-graph/src/conformance.rs
@@ -46,6 +46,8 @@ where
     declared_order_never_leaks_through_any_ranged_accessor(&make);
     node_type_of_reports_the_declared_type(&make);
     node_type_of_a_dangling_id_is_loud_not_untyped(&make);
+    hyperedge_type_of_reports_the_declared_type(&make);
+    hyperedge_type_of_a_dangling_id_is_loud_not_untyped(&make);
     edge_attribute_reads_back_the_seeded_strength(&make);
     edge_attribute_on_a_missing_edge_is_loud_not_zero(&make);
     edge_attribute_of_an_unstored_qname_is_loud(&make);
@@ -671,6 +673,36 @@ where
     assert!(
         graph.node_type_of(NodeId(999_999)).is_err(),
         "a dangling NodeId must be a loud error, never an untyped read"
+    );
+}
+
+/// PR #684 (Community Task 3): `hyperedge_type_of` reports the declared
+/// type — the runtime half of E-EVAL-032's referent check needs it.
+fn hyperedge_type_of_reports_the_declared_type<G, F>(make: &F)
+where
+    G: GraphSubstrate + CanonicalState,
+    F: Fn() -> G,
+{
+    let mut graph = make();
+    let a = graph.add_node("social_class").unwrap();
+    let b = graph.add_node("social_class").unwrap();
+    let cell = graph.add_hyperedge("community", &[a, b]).unwrap();
+    let cell2 = graph.add_hyperedge("economic_sector", &[b]).unwrap();
+    assert_eq!(graph.hyperedge_type_of(cell).unwrap(), "community");
+    assert_eq!(graph.hyperedge_type_of(cell2).unwrap(), "economic_sector");
+}
+
+/// The dangling half, mirroring `node_type_of_a_dangling_id_is_loud_not_untyped`
+/// exactly (III.11, the same discipline).
+fn hyperedge_type_of_a_dangling_id_is_loud_not_untyped<G, F>(make: &F)
+where
+    G: GraphSubstrate + CanonicalState,
+    F: Fn() -> G,
+{
+    let graph = make();
+    assert!(
+        graph.hyperedge_type_of(HyperedgeId(999_999)).is_err(),
+        "a dangling HyperedgeId must be a loud error, never an untyped read"
     );
 }
 

--- a/rust/crates/babylon-graph/src/hypergraph_store.rs
+++ b/rust/crates/babylon-graph/src/hypergraph_store.rs
@@ -631,6 +631,17 @@ impl GraphSubstrate for HypergraphStore {
                 message: format!("no such node: {id:?} — a dangling ref never reads as untyped"),
             })
     }
+
+    fn hyperedge_type_of(&self, id: HyperedgeId) -> Result<&str, GraphError> {
+        self.inner
+            .edge_attrs(&hyperedge_key(id))
+            .map(String::as_str)
+            .ok_or_else(|| GraphError {
+                message: format!(
+                    "no such hyperedge: {id:?} — a dangling ref never reads as untyped"
+                ),
+            })
+    }
 }
 
 impl CanonicalState for HypergraphStore {

--- a/rust/crates/babylon-graph/src/memory.rs
+++ b/rust/crates/babylon-graph/src/memory.rs
@@ -554,6 +554,17 @@ impl GraphSubstrate for MemoryGraph {
                 message: format!("no such node: {id:?} — a dangling ref never reads as untyped"),
             })
     }
+
+    fn hyperedge_type_of(&self, id: HyperedgeId) -> Result<&str, GraphError> {
+        self.hyperedges
+            .get(&id)
+            .map(|(ty, _)| ty.as_str())
+            .ok_or_else(|| GraphError {
+                message: format!(
+                    "no such hyperedge: {id:?} — a dangling ref never reads as untyped"
+                ),
+            })
+    }
 }
 
 #[cfg(test)]

--- a/rust/crates/babylon-graph/src/substrate.rs
+++ b/rust/crates/babylon-graph/src/substrate.rs
@@ -358,6 +358,22 @@ pub trait GraphSubstrate {
     /// same shape [`Self::nodes`] and [`Self::edges`] already have.
     fn hyperedges(&self, hyperedge_type: &str) -> Vec<HyperedgeId>;
 
+    /// The declared type of a live hyperedge — the runtime half of
+    /// `E-EVAL-032` (D24: a `members-of`/`hyperedges-of` whose referent is
+    /// not of the annotated `HyperedgeType` is a mismatch, never a silently
+    /// empty set). The static bound checker bounds a `members-of` fold by
+    /// the annotated type's census-fed max-members; without this accessor a
+    /// referent of a DIFFERENT type would iterate past that bound
+    /// unchecked (PR #684's review found the gap).
+    ///
+    /// READ-ONLY, mirroring [`Self::node_type_of`] exactly: it reports a
+    /// fact the substrate already stores to satisfy [`Self::hyperedges`].
+    ///
+    /// # Errors
+    /// Returns [`GraphError`] if `id` names no live hyperedge — a dangling
+    /// `HyperedgeRef` never reads as an untyped hyperedge (III.11).
+    fn hyperedge_type_of(&self, id: HyperedgeId) -> Result<&str, GraphError>;
+
     /// The declared type of a live node — `(neighbors … <NodeType>)`'s
     /// filter (§2.6, D24: this operand FILTERS) and §2.10 discipline 1's
     /// `E-EVAL-033` referent check both need it, and neither is expressible

--- a/rust/crates/babylon-tick/tests/hyperedge_query_heads.rs
+++ b/rust/crates/babylon-tick/tests/hyperedge_query_heads.rs
@@ -4,10 +4,15 @@
 //! served by the query evaluator, plus the `Element::Hyperedge` cross-kind
 //! Ord ruling.
 //!
-//! RED (this commit): each head is pinned refusing through BOTH tables —
-//! `query::materialize`'s unserved-head refusal (query position) and
-//! `evaluator`'s expression-position classifier (bare `<expr>` position).
-//! The pins record the exact texts before they change meaning.
+//! RED→GREEN record: each head was first pinned refusing through BOTH
+//! tables — `query::materialize`'s unserved-head refusal (query position,
+//! "…is a §2.6 query head the query evaluator does not yet serve — it
+//! lands with slice 3, never as a default here") and `evaluator`'s
+//! expression-position classifier (bare `<expr>` position, "…is a
+//! query/selection/accessor form the evaluator does not yet serve
+//! (§2.6/§2.7/§2.10) — it lands with slice 3…"). Those pins ran green
+//! pre-landing and were then replaced by the served proofs below; the texts
+//! survive in this comment as the historical record (D201).
 //!
 //! NOTE on file placement (deviation, recorded): the plan's Task 3 names
 //! `tests/hyperedge_lane_e2e.rs` (babylon-bsl); that file's harness only
@@ -303,4 +308,41 @@ fn a_node_type_member_in_a_hyperedge_position_is_e_type_011() {
     let mut sink = CollectingSink::default();
     let err = run_once_into(SCENARIO, rule, &mut graph, &mut sink).unwrap_err();
     assert!(err.contains("E-TYPE-011"), "{err}");
+}
+
+/// PR #684 review (a REAL soundness gap): `members-of`'s annotated type
+/// must match the referent's actual type — the load-time bound checker
+/// bounds the fold by the ANNOTATED type's census-fed max-members, and a
+/// referent of a different type would iterate past that bound unchecked.
+/// Now refused with E-EVAL-032 (D24), driven content-level through the
+/// two-hop form: the outer fold binds a COMMUNITY referent, the inner
+/// annotates SECTOR.
+#[test]
+fn a_members_of_fold_with_a_mismatched_annotation_is_e_eval_032() {
+    let world = r"
+(scenario ft/type-mismatch
+  (defvocabulary HyperedgeType (COMMUNITY SECTOR))
+  (deffield social-class/active int extensive)
+  (node alpha NodeType/SOCIAL_CLASS (social-class/active 1))
+  (hyperedge cell HyperedgeType/COMMUNITY (members alpha))
+  (hyperedge sector HyperedgeType/SECTOR (members alpha)))
+";
+    let rule = r#"
+(rule community/probe-type-mismatch
+  :material-basis "E-EVAL-032 pin (PR #684 harvest)"
+  :fuel 2048
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (emit EventType/ORGANIZATION_SEEDED
+      (probe (fold sum (hyperedges HyperedgeType/COMMUNITY) :as c (fold sum (members-of c HyperedgeType/SECTOR) (field-of it social-class/active)))))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(world, rule, &mut graph, &mut sink).unwrap_err();
+    assert!(err.contains("E-EVAL-032"), "{err}");
+    assert!(err.contains("SECTOR"), "{err}");
+    assert!(err.contains("COMMUNITY"), "{err}");
 }

--- a/rust/crates/babylon-tick/tests/hyperedge_query_heads.rs
+++ b/rust/crates/babylon-tick/tests/hyperedge_query_heads.rs
@@ -1,0 +1,306 @@
+//! Hyperedge-lane Task 3 (E1c, Community port train, plan
+//! `docs/superpowers/plans/2026-08-18-community-port.md`): the three §2.6
+//! hyperedge query heads — `hyperedges`, `members-of`, `hyperedges-of` —
+//! served by the query evaluator, plus the `Element::Hyperedge` cross-kind
+//! Ord ruling.
+//!
+//! RED (this commit): each head is pinned refusing through BOTH tables —
+//! `query::materialize`'s unserved-head refusal (query position) and
+//! `evaluator`'s expression-position classifier (bare `<expr>` position).
+//! The pins record the exact texts before they change meaning.
+//!
+//! NOTE on file placement (deviation, recorded): the plan's Task 3 names
+//! `tests/hyperedge_lane_e2e.rs` (babylon-bsl); that file's harness only
+//! loads scenarios, while these pins must drive the tick — they live here
+//! beside Task 4's own tick-driver file, the seam the pins actually
+//! exercise.
+
+use babylon_bsl::evaluator::Value;
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::hypergraph_store::HypergraphStore;
+use babylon_tick::run_once_into;
+
+/// The Task-4 probe world: two COMMUNITY hyperedges over three classes.
+const SCENARIO: &str = r"
+(scenario ft/hyperedge-query-heads
+  (defvocabulary HyperedgeType (COMMUNITY))
+  (deffield social-class/active int extensive)
+  (node alpha NodeType/SOCIAL_CLASS (social-class/active 1))
+  (node beta NodeType/SOCIAL_CLASS (social-class/active 1))
+  (node gamma NodeType/SOCIAL_CLASS (social-class/active 1))
+  (hyperedge new-afrikan HyperedgeType/COMMUNITY (members alpha beta gamma))
+  (hyperedge queer HyperedgeType/COMMUNITY (members alpha)))
+";
+
+/// Build the probe rule: `<head-form>` in a fold body (query position) or
+/// a bare `:expr` binding (expression position).
+fn probe_rule(head_form: &str, position: &str) -> String {
+    match position {
+        "query" => format!(
+            r#"
+(rule community/probe-query
+  :material-basis "probe for the query-position refusal (Task 3 Step 1)"
+  :fuel 512
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (emit EventType/ORGANIZATION_SEEDED (probe (fold sum {head_form} (field-of it social-class/active))))))
+"#
+        ),
+        "expression" => format!(
+            r#"
+(rule community/probe-expression
+  :material-basis "probe for the expression-position refusal (Task 3 Step 1)"
+  :fuel 512
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active)
+    (binding x :expr {head_form}))
+  (when (= active 1))
+  (effects
+    (emit EventType/ORGANIZATION_SEEDED (probe 1))))
+"#
+        ),
+        other => panic!("unknown position {other}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Slice-3 GREEN proofs (Task 3 Steps 3-4): the three heads served, exercised
+// through the real driver. The Step-1 refusal pins above are the historical
+// record of the texts these proofs replaced.
+// ---------------------------------------------------------------------------
+
+/// The two-hop census: every active member of every COMMUNITY hyperedge,
+/// counted — `(fold sum (hyperedges …) :as c (fold sum (members-of c …)
+/// (field-of it social-class/active)))` is §2.6's own two-hop worked
+/// example's shape. The world's census is 3 (new-afrikan) + 1 (queer) = 4.
+/// The type-wide head serves the census. (domain :graph) fires once per
+/// tick in principle, but the driver's subject-type derivation reads the
+/// rule's :field bindings first (E-LOAD-004's domain surface), so this
+/// probe stays NodeType/SOCIAL_CLASS-scoped and fires once per class —
+/// the same census count each time, the point being the heads serve.
+#[test]
+fn the_type_wide_head_serves_the_census() {
+    let rule = r#"
+(rule community/probe-census-all
+  :material-basis "served-proof for the type-wide head (Task 3)"
+  :fuel 2048
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (emit EventType/ORGANIZATION_SEEDED
+      (probe (fold sum (hyperedges HyperedgeType/COMMUNITY) :as c (fold sum (members-of c HyperedgeType/COMMUNITY) (field-of it social-class/active)))))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    run_once_into(SCENARIO, rule, &mut graph, &mut sink).expect("the census must run");
+    let sums: Vec<f64> = sink
+        .events
+        .iter()
+        .filter_map(|(_, payload)| {
+            payload.iter().find_map(|(k, v)| {
+                (k == "probe").then_some(v).and_then(|v| match v {
+                    Value::Real(x) => Some(*x),
+                    _ => None,
+                })
+            })
+        })
+        .collect();
+    assert_eq!(
+        sums,
+        vec![4.0, 4.0, 4.0],
+        "one firing per class, each computing the world's census 3 + 1"
+    );
+}
+
+/// The subject-relative head: each class's own memberships counted.
+/// alpha (id 0) belongs to BOTH hyperedges (members 3 + 1 = 4); beta and
+/// gamma to new-afrikan only (3 each).
+#[test]
+fn the_subject_relative_head_serves_per_class_membership_sums() {
+    let rule = r#"
+(rule community/probe-census-per-class
+  :material-basis "served-proof for the subject-relative head (Task 3)"
+  :fuel 2048
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (emit EventType/ORGANIZATION_SEEDED
+      (probe (fold sum (hyperedges-of self HyperedgeType/COMMUNITY) :as h (fold sum (members-of h HyperedgeType/COMMUNITY) (field-of it social-class/active)))))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    run_once_into(SCENARIO, rule, &mut graph, &mut sink).expect("the per-class census must run");
+    let sums: Vec<f64> = sink
+        .events
+        .iter()
+        .filter_map(|(_, payload)| {
+            payload.iter().find_map(|(k, v)| {
+                (k == "probe").then_some(v).and_then(|v| match v {
+                    Value::Real(x) => Some(*x),
+                    _ => None,
+                })
+            })
+        })
+        .collect();
+    assert_eq!(
+        sums,
+        vec![4.0, 3.0, 3.0],
+        "alpha belongs to both; beta and gamma to new-afrikan only"
+    );
+}
+
+/// The Step-1 pins, inverted at the landing: a SERVED head in bare
+/// `<expr>` position still refuses — the query-operand-only law (§2.7: no
+/// bare `<query>` production) is grammatical, not a TODO. The
+/// query-position refusal texts these pins replaced are recorded in this
+/// file's header as the historical record.
+#[test]
+fn a_served_head_in_bare_expression_position_still_refuses_with_the_2_7_law() {
+    for head_form in [
+        "(hyperedges HyperedgeType/COMMUNITY)",
+        "(members-of self HyperedgeType/COMMUNITY)",
+        "(hyperedges-of self HyperedgeType/COMMUNITY)",
+    ] {
+        let mut graph = HypergraphStore::new();
+        let mut sink = CollectingSink::default();
+        let err = run_once_into(
+            SCENARIO,
+            &probe_rule(head_form, "expression"),
+            &mut graph,
+            &mut sink,
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("no <expr> production of its own (§2.7)"),
+            "{head_form}: {err}"
+        );
+    }
+}
+
+/// Step 5, the fuel axis VERIFIED (not rebuilt): a hyperedge-folding rule
+/// with a deliberate `:fuel 1` refuses E-LOAD-040 with the bound the
+/// already-landed ceiling machinery computes — read from the refusal,
+/// never hand-computed.
+#[test]
+fn the_fuel_axis_bounds_a_hyperedge_fold_as_landed() {
+    let rule = r#"
+(rule community/probe-fuel
+  :material-basis "fuel-axis readback (Task 3 Step 5)"
+  :fuel 1
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (emit EventType/ORGANIZATION_SEEDED
+      (probe (fold count (hyperedges HyperedgeType/COMMUNITY) :as c (fold count (members-of c HyperedgeType/COMMUNITY) (field-of it social-class/active)))))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(SCENARIO, rule, &mut graph, &mut sink).unwrap_err();
+    assert!(err.contains("E-LOAD-040"), "{err}");
+    let bound = err
+        .split("static bound ")
+        .nth(1)
+        .and_then(|rest| rest.split_whitespace().next())
+        .and_then(|n| n.parse::<u64>().ok())
+        .unwrap_or_else(|| panic!("no measured bound in the refusal: {err}"));
+    // Measured 2026-08-22: 28, read from the refusal, never hand-computed
+    // (the plan's own law). The pin guards that the number moves iff the
+    // machinery changes.
+    assert_eq!(bound, 28, "the E-LOAD-040 refusal's own number: {err}");
+}
+
+/// Step 5, the negative half: the same fold in a world seeding NO
+/// COMMUNITY hyperedge (an empty census) refuses E-LOAD-045 — the TYPE
+/// ceiling is checked before the max-members axis, and with nothing seeded
+/// both maps lack the entry, so 045 fires first. (The 042-only state — a
+/// type ceiling with no max-members entry — is not constructible from
+/// content: the two maps fill together at the Task-4 seam. That path stays
+/// pinned by bound_checker.rs's own unit test plus Task 4's mutation
+/// vector, recorded here so the absence is explained, not silent.)
+#[test]
+fn a_members_of_fold_in_an_empty_census_world_is_e_load_045() {
+    let empty_world = r"
+(scenario ft/no-communities
+  (defvocabulary HyperedgeType (COMMUNITY))
+  (deffield social-class/active int extensive)
+  (node alpha NodeType/SOCIAL_CLASS (social-class/active 1)))
+";
+    let rule = r#"
+(rule community/probe-fuel-empty
+  :material-basis "fuel-axis negative readback (Task 3 Step 5)"
+  :fuel 512
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (emit EventType/ORGANIZATION_SEEDED
+      (probe (fold count (hyperedges HyperedgeType/COMMUNITY) :as c (fold count (members-of c HyperedgeType/COMMUNITY) (field-of it social-class/active)))))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(empty_world, rule, &mut graph, &mut sink).unwrap_err();
+    assert!(err.contains("E-LOAD-045"), "{err}");
+    assert!(err.contains("COMMUNITY"), "{err}");
+}
+
+/// Step 6: a hyperedge element in a numeric position refuses at LOAD,
+/// through the same Phase-1 kind-propagation gate that covers nodes and
+/// edges today — no new machinery, pinned so the shared gate's coverage of
+/// this lane is on record.
+#[test]
+fn a_hyperedge_element_in_a_numeric_position_refuses_at_load() {
+    let rule = r#"
+(rule community/probe-numeric
+  :material-basis "Step-6 pin: hyperedge element in a numeric position"
+  :fuel 2048
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (emit EventType/ORGANIZATION_SEEDED
+      (probe (fold sum (hyperedges HyperedgeType/COMMUNITY) (+ it 1))))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(SCENARIO, rule, &mut graph, &mut sink).unwrap_err();
+    assert!(
+        err.contains("kind-propagation over compound expressions is not implemented in Phase 1"),
+        "{err}"
+    );
+}
+
+/// Step 6, the enum-ref operand position: a NodeType member where the head
+/// demands a HyperedgeType member refuses E-TYPE-011 (grammar.rs's own
+/// WrongEnumKind — the HyperedgeType positions pre-registered in
+/// ENUM_REF_POSITIONS are live).
+#[test]
+fn a_node_type_member_in_a_hyperedge_position_is_e_type_011() {
+    let rule = r#"
+(rule community/probe-wrong-kind
+  :material-basis "Step-6 pin: enum-ref kind check on a hyperedge position"
+  :fuel 2048
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (emit EventType/ORGANIZATION_SEEDED
+      (probe (fold sum (hyperedges NodeType/SOCIAL_CLASS) :as c (fold count (members-of c NodeType/SOCIAL_CLASS) (field-of it social-class/active)))))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(SCENARIO, rule, &mut graph, &mut sink).unwrap_err();
+    assert!(err.contains("E-TYPE-011"), "{err}");
+}


### PR DESCRIPTION
## What

#667 Task 3 (E1c) — the query-evaluator half of PR A (its grammar/bound-checker half landed in the
sweep): the three §2.6 hyperedge query heads (`hyperedges`, `members-of`, `hyperedges-of`) are
served by `query::materialize`, and `Element` gains `Hyperedge(HyperedgeId)` with the ruled
cross-kind order.

- **The Ord ruling (D201)**: `Node` < `Edge` < `Hyperedge`, by declaration order — arbitrary,
  deliberate, tested by two new companion pins beside `node_sorts_before_edge_regardless_of_id`;
  the enum's compile-time trap (exhaustive match, no wildcard) holds.
- **Materialization**: type-wide + subject-relative heads yield `Element::Hyperedge` ascending by
  `HyperedgeId`; `members-of` yields plain `Element::Node` ascending by `NodeId` (D25, the
  substrate's own contract — pinned against a multi-hyperedge world).
- **The two-table move**: `query.rs`'s `UNSERVED_QUERY_HEADS` is deleted with its refusal arm (a
  zero-row table is the plan's own M4 failure mode — the at-the-byte decision, recorded in D201);
  `evaluator`'s table drops the three heads (`metric-of` stays; `membership-field-of`'s note now
  cites #653 by number). The query-operand-only law (§2.7) holds and is pinned.

## Proofs

- Content-level through the tick driver (`hyperedge_query_heads.rs`): the two-hop census computes
  4 (new-afrikan 3 + queer 1); per-class membership sums [4, 3, 3] (alpha in both); the bare-expr
  position-law pin; the numeric-position refusal (the shared Phase-1 kind gate covers this lane —
  no new machinery); the E-TYPE-011 operand-kind check; the fuel-axis readbacks (measured bound 28,
  read never computed; empty-census worlds refuse E-LOAD-045 first — the 042-only state is not
  content-constructible, recorded in the test).
- Mutations red as designed: inverted iteration order; Hyperedge declared first (both Ord
  companions); the dropped bare-expr guard.
- Step 1's refusal pins (both tables, all three heads) ran green before the move and their texts
  are preserved as the file header's historical record.
- File-placement deviation, recorded: the plan names `tests/hyperedge_lane_e2e.rs` (babylon-bsl,
  scenario-load-only harness); these pins drive the tick, so they live in babylon-tick beside Task
  4's file.

## Gates

`mise run rust:check` green; `qa:regression` byte-identical; `qa:vault-regression-ci`
byte-identical; `check:quick` green. No golden/pin movement outside the new tests.

Co-Authored-By: Kimi Code <noreply@moonshot.cn>