### PR TITLE
feat(bsl): hyperedge own-field read/write + (hyperedge-attr …) seeding (Community Task 6, E2b)

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -8983,6 +8983,61 @@ consequences are the ordinary kind of review item.
        conformance rows); without it a referent of a different type would
        iterate past the annotated type's census-fed max-members bound
        unchecked. The check is a soundness obligation, not a filter.
+   * - D202
+     - §2.8, §2.10, §2.5
+     - **Task 6's read/write surface for hyperedge own-fields** (Community
+       port train, E2b, 2026-08-22; the plan's ``D-NF+25``).
+       ``update-hyperedge`` is **served in BOTH dispatch sites** — the
+       execute path and the collect path defer through
+       ``WriteTarget::Hyperedge`` with the same ``set``/``add``/``sub``/
+       ``scale`` parity and enum-``set`` inclusion as the other two update
+       verbs, applying in the APPLY phase against the Task-5 substrate lane
+       (the pre-state law holds for this element kind exactly as for the
+       other two), and recording ``Write::HyperedgeAttribute``. The §2.10
+       discipline-1 referent check is ONE function,
+       ``evaluator::check_hyperedge_referent_type``, shared by the write
+       side and by ``field-of``'s new ``HyperedgeRef`` arm — which serves a
+       hyperedge's OWN declared field (Task-5 storage), retiring the
+       Task-1-era "not meaningful" refusal; the surviving membership-payload
+       lane cites **#653**, never "slice 4". **The D29 mechanism** (§2.5's
+       node-scoped-binding law, the Community plan §8c guard 2's machinery):
+       ``tick::subject_type_of`` gains the owner-kind filter, threaded the
+       scenario's ``ClosedVocabulary`` through ``run_tick`` — a ``:field``
+       binding whose qname resolves to an EdgeType/HyperedgeType owner is
+       INVISIBLE to subject derivation, so a rule whose only field bindings
+       are hyperedge-owned refuses with the subject-type error instead of
+       iterating an empty population in silence. The filter acts on a
+       **positive** owner-kind answer only: a segment the (possibly
+       partial) vocabulary does not know passes through — unknown-owner is
+       E-LOAD-023's lane at load, never this filter's, and filtering it
+       would empty every subject population of every scenario declaring a
+       vocabulary for one kind only. ``(hyperedge-attr <name> <qname>
+       <literal>)`` seeds a declared own-field at hydration, mirroring
+       ``(edge-attr …)``: the local name resolves through the
+       name→``HyperedgeId`` table Task 1 grew for exactly this consumer,
+       the owner check reads the hyperedge's ACTUAL type back from the
+       substrate (``hyperedge_type_of``), the ``(hyperedge, field)`` pair
+       is a KEY (``E-LOAD-057``), and the value converts through
+       ``attribute_value``'s one per-type literal law (the int/fractional
+       contract and the enum-ordinal lane included; Currency refuses — no
+       hyperedge-scoped Currency lane, the edge lane's own ruling one kind
+       over). Hydration writes carry no write log, exactly as
+       ``(edge-attr …)``'s direct ``update_edge`` does not. **Typecheck
+       parity:** the wrong-scalar write refuses at ``numeric_write_value``'s
+       one funnel and the enum-field read in arithmetic position refuses at
+       ``apply_arith`` (``bind_field_value`` renders ``Value::Enum`` — the
+       D102 discharge one element kind over); the *static* enum-arithmetic
+       check stays ``update-node``-only, ``update-edge``'s own parity
+       level, deliberately not widened here. Mutation-proven at landing:
+       killing the execute arm reds both execute-side proofs
+       (``evaluator::tests::update_edge_and_update_hyperedge_are_both_served``,
+       ``structural_verbs::tests::update_hyperedge_writes_a_declared_hyperedge_field_on_both_dispatch_sites``
+       site 1); killing the collect arm reds the collect-side proofs (site
+       2 and the content-driver
+       ``hyperedge_surface.rs::update_hyperedge_writes_through_the_tick``).
+       Mint-time ``<field-init>``s on ``add-hyperedge`` STAY refused, with
+       the reason corrected: the storage exists; the init sugar is not
+       routed to it in this train.
 
 Authoring idioms (non-normative)
 -----------------------------------

--- a/rust/crates/babylon-bsl/src/evaluator.rs
+++ b/rust/crates/babylon-bsl/src/evaluator.rs
@@ -490,8 +490,9 @@ pub(crate) fn require_graph<'a>(
 /// grammar error, not an unimplemented seam — §2.7's `<expr>` production has
 /// no production for any of them. (Whether the head is SERVED in effect
 /// position varies: most dispatch in [`crate::structural_verbs`]; `for-each`
-/// and `update-edge`/`update-hyperedge`/`update-membership` refuse there too,
-/// pending their own tasks/slices — the message below claims only the
+/// and `update-membership` refuses there too, pending the AG(i) lane (#653)
+/// — `for-each`, `update-edge` and (since Community port train Task 6)
+/// `update-hyperedge` all serve there today; the message below claims only the
 /// grammar, never service.) §2.8's `<verb>` production has ELEVEN
 /// alternatives: the ten structural verbs (`update-node`, `update-edge`,
 /// `update-hyperedge`, `update-membership`, `add-node`, `remove-node`,
@@ -1302,12 +1303,12 @@ fn eval_edge_between(
     }))
 }
 
-/// `(field-of <expr> <qname>)` (§2.10). Serves `NodeRef` referents (slice 1)
-/// and `EdgeRef` referents (slice 2, T2 issue #559); a `HyperedgeRef`
-/// referent is a genuine shape error (a hyperedge carries no attributes of
-/// its own — `structural_verbs`' own module doc says so — so `field-of`
-/// over one is never meaningful; a MEMBERSHIP's payload reads through
-/// `membership-field-of`, slice 4).
+/// `(field-of <expr> <qname>)` (§2.10). Serves `NodeRef` referents (slice 1),
+/// `EdgeRef` referents (slice 2, T2 issue #559), and `HyperedgeRef`
+/// referents (Community port train Task 6, E2b — a hyperedge's OWN field,
+/// the substrate storage Task 5 minted). A MEMBERSHIP's payload reads
+/// through `membership-field-of` (the AG(i) lane, #653), never through
+/// `field-of` over a hyperedge.
 fn eval_field_of(
     items: &[SExpr],
     env: &EvalEnv<'_>,
@@ -1324,12 +1325,7 @@ fn eval_field_of(
     match referent {
         Value::NodeRef(id) => field_of_node(id, qname, env),
         Value::EdgeRef(key) => field_of_edge(&key, qname, env),
-        Value::HyperedgeRef(_) => Err(EvalError::plain(
-            "(field-of …) over a HyperedgeRef is not meaningful — a \
-             hyperedge carries no attributes of its own (§2.8); a \
-             membership's payload reads through membership-field-of instead \
-             (slice 4)",
-        )),
+        Value::HyperedgeRef(id) => field_of_hyperedge(id, qname, env),
         other => Err(EvalError::plain(format!(
             "(field-of …)'s first operand must evaluate to a reference, got \
              {other:?} (§2.10)"
@@ -1485,6 +1481,49 @@ pub(crate) fn check_edge_referent_type(
     Ok(())
 }
 
+/// The `HyperedgeRef` half of §2.10 discipline 1 (Community port train,
+/// Task 6, E2b). Unlike an `EdgeKey`, a `HyperedgeId` does NOT carry its
+/// type inline, so — like `check_node_referent_type` — the check needs a
+/// substrate round-trip through `GraphSubstrate::hyperedge_type_of` (the
+/// read-only accessor PR #684 minted for exactly this). The rendering rule
+/// is the same one both sibling checks reuse: the stored type string is the
+/// verbatim `HyperedgeType` member (e.g. `COMMUNITY`), which
+/// `tick::namespace_to_node_type`'s uppercase + dash→underscore transform
+/// reproduces from the qname's owning segment. Shared by the read side
+/// (`field_of_hyperedge`) and the write side (`structural_verbs.rs`'s
+/// `update-hyperedge`), whose E-EVAL-033 obligation is the same law.
+///
+/// # Errors
+///
+/// `E-EVAL-033` if `id` names no live hyperedge, or if it does but is not
+/// of the qname's owning type.
+pub(crate) fn check_hyperedge_referent_type(
+    id: babylon_graph::substrate::HyperedgeId,
+    qname: &str,
+    form: &str,
+    graph: &dyn GraphSubstrate,
+) -> Result<(), EvalError> {
+    let owner_segment = qname.split('/').next().unwrap_or(qname);
+    let expected_type = crate::tick::namespace_to_node_type(owner_segment);
+    let actual_type = graph.hyperedge_type_of(id).map_err(|e| {
+        EvalError::coded(
+            EvalCode::AccessorTypeOrValueMismatch,
+            format!("{form} {qname}: {} (§2.10 discipline 1)", e.message),
+        )
+    })?;
+    if actual_type != expected_type {
+        return Err(EvalError::coded(
+            EvalCode::AccessorTypeOrValueMismatch,
+            format!(
+                "{form} {qname}: the referent is a {actual_type} hyperedge, not \
+                 {expected_type} — the qname's owning type does not match \
+                 the referent's declared type (§2.10 discipline 1)"
+            ),
+        ));
+    }
+    Ok(())
+}
+
 /// The `EdgeRef` half of `field-of`'s shared discipline (§2.10) — generic over any qname whose
 /// owning type is an `EdgeType` (T2 dossier §2 design: not hard-coded to `strength` alone). `qname`
 /// is passed to the substrate UNMODIFIED, exactly as `field_of_node` passes it to `node_attribute`
@@ -1517,6 +1556,47 @@ fn field_of_edge(key: &EdgeKey, qname: &str, env: &EvalEnv<'_>) -> Result<Value,
                 ),
             )
         })?;
+    let (Some(types), Some(enums)) = (env.types, env.enums) else {
+        return Err(EvalError::plain(format!(
+            "(field-of …) needs the declared field-type registry (§2.13) but this EvalEnv \
+             carries none for {qname} — a driver error, the same shape as require_graph's"
+        )));
+    };
+    crate::tick::bind_field_value(qname, value, types, enums)
+        .map_err(|e| EvalError::plain(e.to_string()))
+}
+
+/// The `HyperedgeRef` half of `field-of`'s shared discipline (§2.10) —
+/// Community port train Task 6 (E2b), reading the own-field storage Task 5
+/// (E2a) minted. Mirrors [`field_of_edge`] exactly: §2.10 discipline 1
+/// through [`check_hyperedge_referent_type`], then the substrate read, with
+/// the same "absence is not a value" mapping (E-EVAL-033) — a never-written
+/// hyperedge field is a mismatch, never a default `0.0`.
+///
+/// **`hyperedge_attribute`'s "no such hyperedge" failure mode is UNREACHABLE
+/// here**, for the same reason `field_of_edge`'s doc names: every
+/// `Value::HyperedgeRef` `eval_field_of` can hand this function was built by
+/// `query::materialize` from the substrate's own live census, and
+/// [`check_hyperedge_referent_type`] has already errorred on a dangling id
+/// before the read. The substrate error that can actually surface is the
+/// never-written one — hence always E-EVAL-033, never a laundered existence
+/// error.
+fn field_of_hyperedge(
+    id: babylon_graph::substrate::HyperedgeId,
+    qname: &str,
+    env: &EvalEnv<'_>,
+) -> Result<Value, EvalError> {
+    let graph = require_graph(env, "field-of")?;
+    check_hyperedge_referent_type(id, qname, "field-of", graph)?;
+    let value = graph.hyperedge_attribute(id, qname).map_err(|e| {
+        EvalError::coded(
+            EvalCode::AccessorTypeOrValueMismatch,
+            format!(
+                "field-of {qname}: {} (§2.10 discipline 2 — absence is not a value)",
+                e.message
+            ),
+        )
+    })?;
     let (Some(types), Some(enums)) = (env.types, env.enums) else {
         return Err(EvalError::plain(format!(
             "(field-of …) needs the declared field-type registry (§2.13) but this EvalEnv \
@@ -2603,12 +2683,12 @@ mod tests {
     /// the storage refusal ("Constitution III.7"); serving a
     /// previously-refused head flips the assertion (the T2 plan's own
     /// enumerate-and-flip discipline). What is pinned now: a well-formed
-    /// update-edge WRITES through the execute path, and `update-hyperedge`
-    /// — the retired refusal arm's other half — KEEPS refusing, with a
-    /// message that still names the constitutional reason but no longer
-    /// describes pre-T3 edge storage.
+    /// update-edge WRITES through the execute path, and — since Community
+    /// port train Task 6 (E2b) discharged the III.7 storage gap via
+    /// `GraphSubstrate::update_hyperedge_attribute` — `update-hyperedge`
+    /// writes too, through the SAME execute path.
     #[test]
-    fn update_edge_is_served_and_update_hyperedge_keeps_refusing() {
+    fn update_edge_and_update_hyperedge_are_both_served() {
         use crate::structural_verbs::{CollectingSink, EffectExecutor};
         use crate::typecheck::TypeEnv;
         use crate::types::EnumRegistry;
@@ -2621,14 +2701,26 @@ mod tests {
         graph
             .add_edge("SOLIDARITY", self_id, other_id, 0.5)
             .unwrap();
+        let cell = graph
+            .add_hyperedge("COMMUNITY", &[self_id, other_id])
+            .unwrap();
         let types = TypeEnv {
-            fields: HashMap::from([(
-                "solidarity/strength".to_owned(),
-                crate::types::FieldDecl {
-                    ty: crate::types::BslType::Coefficient,
-                    kind: crate::types::FieldKind::Extensive,
-                },
-            )]),
+            fields: HashMap::from([
+                (
+                    "solidarity/strength".to_owned(),
+                    crate::types::FieldDecl {
+                        ty: crate::types::BslType::Coefficient,
+                        kind: crate::types::FieldKind::Extensive,
+                    },
+                ),
+                (
+                    "community/heat".to_owned(),
+                    crate::types::FieldDecl {
+                        ty: crate::types::BslType::Coefficient,
+                        kind: crate::types::FieldKind::Intensive,
+                    },
+                ),
+            ]),
             exemptions: &[],
         };
         let enums = EnumRegistry::default();
@@ -2641,7 +2733,10 @@ mod tests {
         let mut sink = CollectingSink::default();
         let costs = costs();
         let effect_env = EvalEnv {
-            bindings: HashMap::from([("e".to_owned(), Value::EdgeRef(edge_key))]),
+            bindings: HashMap::from([
+                ("e".to_owned(), Value::EdgeRef(edge_key)),
+                ("h".to_owned(), Value::HyperedgeRef(cell)),
+            ]),
             intrinsic_costs: &costs,
             graph: None,
             types: None,
@@ -2673,13 +2768,16 @@ mod tests {
             "0.5 scaled by 0.5, stored: {stored}"
         );
 
+        // The hyperedge half — refused with a III.7 "no substrate storage"
+        // message before Task 6, a plain write now. `set` never reads the
+        // prior value, so the never-written field is no obstacle.
         let (form, _) =
-            read("(effects (update-hyperedge h sector/output (set 1)))").expect("must parse");
+            read("(effects (update-hyperedge h community/heat (set 0.5c)))").expect("must parse");
         let SExpr::List(items) = form else {
             unreachable!()
         };
         let mut fuel = 128;
-        let update_hyperedge_err = executor
+        executor
             .execute_effects(
                 &items[1..],
                 &effect_env,
@@ -2688,15 +2786,9 @@ mod tests {
                 &mut sink,
                 &mut fuel,
             )
-            .unwrap_err();
-        assert!(
-            update_hyperedge_err.message.contains("Constitution III.7"),
-            "{update_hyperedge_err}"
-        );
-        assert!(
-            !update_hyperedge_err.message.contains("one f64 strength"),
-            "the retained refusal must not describe pre-T3 edge storage: {update_hyperedge_err}"
-        );
+            .expect("update-hyperedge is served since Task 6 (E2b)");
+        let stored = graph.hyperedge_attribute(cell, "community/heat").unwrap();
+        assert!((stored - 0.5).abs() < 1e-12, "set to 0.5, stored: {stored}");
     }
 
     /// The sentinel Task 1 exists to install: a form the language HAS can

--- a/rust/crates/babylon-bsl/src/scenario.rs
+++ b/rust/crates/babylon-bsl/src/scenario.rs
@@ -96,7 +96,7 @@ use crate::evaluator::Value;
 use crate::reader::{read_all, Atom, ReadError, ReadErrorKind, SExpr, ScaledKind};
 use crate::types::{BslType, EnumRegistry, EnumTypeId, FieldDecl, FieldKind};
 use crate::vocabulary::{ClosedVocabulary, EnumKind, VocabularyError};
-use babylon_graph::substrate::{GraphError, GraphSubstrate, NodeId};
+use babylon_graph::substrate::{GraphError, GraphSubstrate, HyperedgeId, NodeId};
 use babylon_kernel::{Currency, Ratio};
 use std::collections::{HashMap, HashSet};
 
@@ -645,11 +645,16 @@ fn load_scenario_inner(
     let mut max_members_seen: HashMap<String, u64> = HashMap::new();
     // Fix round 1, review I3: the local-name table `load_hyperedge` checks
     // duplicates against — same purpose as `named` does for nodes
-    // (`load_node`'s own duplicate refusal), but a `HashSet` suffices today:
-    // no resolve-by-name consumer exists yet (Task 6's `hyperedge-attr` adds
-    // the first one, at which point this may grow into a name->HyperedgeId
-    // map without changing the duplicate check's own behaviour).
-    let mut seeded_hyperedge_names: HashSet<String> = HashSet::new();
+    // (`load_node`'s own duplicate refusal). Task 6's `(hyperedge-attr …)`
+    // landed the resolve-by-name consumer this comment's predecessor
+    // anticipated, so the table is now a name→HyperedgeId map — the
+    // duplicate check's own behaviour is unchanged (`contains_key` where
+    // the set's `insert` returned false).
+    let mut seeded_hyperedge_names: HashMap<String, HyperedgeId> = HashMap::new();
+    // Task 6's `(hyperedge-attr …)` KEY, mirroring `seeded_attrs` one element
+    // kind over: a second seeding of one (hyperedge, field) pair silently
+    // overwrites the first — E-LOAD-057's argument, one axis narrower.
+    let mut seeded_hyperedge_attrs: HashSet<(HyperedgeId, String)> = HashSet::new();
     let mut node_count = 0_usize;
     let mut edge_count = 0_usize;
     // §3.9 clause 5 (D73): hydration may not seed two dyadic edges sharing
@@ -670,7 +675,7 @@ fn load_scenario_inner(
             return Err(err(
                 "a scenario body holds only (defenum ...), (defvocabulary ...), \
                  (deffield ...), (defconst ...), (node ...), (edge ...), \
-                 (edge-attr ...) and (hyperedge ...) forms",
+                 (edge-attr ...), (hyperedge ...) and (hyperedge-attr ...) forms",
             ));
         };
         match parts.first() {
@@ -742,10 +747,21 @@ fn load_scenario_inner(
                     *longest = member_count;
                 }
             }
+            Some(SExpr::Atom(Atom::Symbol(tag))) if tag == "hyperedge-attr" => {
+                load_hyperedge_attr(
+                    parts,
+                    graph,
+                    &seeded_hyperedge_names,
+                    &mut seeded_hyperedge_attrs,
+                    &fields,
+                    &enums,
+                )?;
+            }
             _ => {
                 return Err(err(
                     "a scenario body form must begin with `defenum`, `defvocabulary`, \
-                     `deffield`, `defconst`, `node`, `edge`, `edge-attr` or `hyperedge`",
+                     `deffield`, `defconst`, `node`, `edge`, `edge-attr`, `hyperedge` \
+                     or `hyperedge-attr`",
                 ))
             }
         }
@@ -2059,7 +2075,7 @@ fn load_hyperedge(
     parts: &[SExpr],
     graph: &mut dyn GraphSubstrate,
     named: &HashMap<String, NodeId>,
-    seeded_hyperedge_names: &mut HashSet<String>,
+    seeded_hyperedge_names: &mut HashMap<String, HyperedgeId>,
     enums: &EnumRegistry,
     vocabulary: Option<&ClosedVocabulary>,
 ) -> Result<(String, u64), ScenarioError> {
@@ -2075,7 +2091,7 @@ fn load_hyperedge(
     // local name denotes exactly one hyperedge, and silently rebinding it
     // would make a later `hyperedge-attr` form (Task 6) ambiguous about
     // which hyperedge it targets.
-    if !seeded_hyperedge_names.insert(local.clone()) {
+    if seeded_hyperedge_names.contains_key(local) {
         return Err(err(format!(
             "duplicate scenario name `{local}` — a local name denotes exactly one \
              hyperedge, and silently rebinding it would make later hyperedge-attr \
@@ -2135,8 +2151,100 @@ fn load_hyperedge(
     // Member canonicalization is the executor's already-landed law — see
     // this function's doc comment.
     members.sort_unstable();
-    graph.add_hyperedge(member, &members)?;
+    let id = graph.add_hyperedge(member, &members)?;
+    seeded_hyperedge_names.insert(local.clone(), id);
     Ok((member.clone(), member_count))
+}
+
+/// `(hyperedge-attr <local-name> <field-qname> <value>)` — Community port
+/// train Task 6 (E2b): seed one DECLARED own-field of a hyperedge the same
+/// scenario already minted, through the Task-5 substrate lane
+/// (`GraphSubstrate::update_hyperedge_attribute`). Mirrors
+/// [`load_edge_attr`]'s discipline one element kind over:
+///
+/// 1. The local name resolves through `seeded_hyperedge_names` — a
+///    hyperedge must have been seeded ABOVE this form (the top-to-bottom
+///    discipline every declared-registry lookup here shares), and the map
+///    (not a set) is what Task 6 grew it into for exactly this resolution.
+/// 2. §2.10 discipline 1 at hydration: the qname's OWNER segment must
+///    render to the hyperedge's own declared type — read back from the
+///    substrate (`hyperedge_type_of`), through the same
+///    `tick::namespace_to_node_type` rendering
+///    `evaluator.rs::check_hyperedge_referent_type` uses at evaluation.
+/// 3. An undeclared qname is a typo, not a new field — `load_node`'s
+///    registry contract verbatim.
+/// 4. The value converts through [`attribute_value`], the crate's ONE
+///    per-type literal law — the int/fractional contract and the enum
+///    lane (`community/kind` seeded as `<CommunityType>/<MEMBER>`,
+///    ordinal-stored) included; Currency refuses, there being no
+///    hyperedge-scoped Currency lane (the same ruling as the edge lane).
+///
+/// The `(hyperedge, field)` pair is a KEY — a second seeding is
+/// `E-LOAD-057`, the same silent-overwrite argument `load_edge_attr`'s
+/// quadruple makes, one axis narrower.
+fn load_hyperedge_attr(
+    parts: &[SExpr],
+    graph: &mut dyn GraphSubstrate,
+    seeded: &HashMap<String, HyperedgeId>,
+    seeded_attrs: &mut HashSet<(HyperedgeId, String)>,
+    declared: &HashMap<String, FieldDecl>,
+    enums: &EnumRegistry,
+) -> Result<(), ScenarioError> {
+    let [_, SExpr::Atom(Atom::Symbol(local)), SExpr::Atom(Atom::QName(field)), SExpr::Atom(value)] =
+        parts
+    else {
+        return Err(err(
+            "expected (hyperedge-attr <local-name> <field-qname> <value>)",
+        ));
+    };
+    let form = format!("hyperedge-attr `{local}`");
+    let id = seeded.get(local).copied().ok_or_else(|| {
+        err(format!(
+            "hyperedge-attr names unknown hyperedge `{local}` — a hyperedge must be \
+             declared before a hyperedge-attr referring to it, so a scenario reads \
+             top to bottom"
+        ))
+    })?;
+    // §2.10 discipline 1 at hydration — refusal 2, checked against the
+    // hyperedge's OWN seeded type (read back from the substrate, never
+    // re-derived from the form, which carries no type operand).
+    let actual_type = graph.hyperedge_type_of(id)?;
+    let owner_segment = field.split('/').next().unwrap_or(field);
+    let owner_type = crate::tick::namespace_to_node_type(owner_segment);
+    if owner_type != actual_type {
+        return Err(err(format!(
+            "{form}: field `{field}` is owned by {owner_type}, not {actual_type} — a \
+             hyperedge attribute's qname owner must name the hyperedge's own type \
+             (§2.10 discipline 1, checked at hydration exactly as \
+             `check_hyperedge_referent_type` checks it at evaluation)"
+        )));
+    }
+    // The registry contract, ENFORCED — load_node's undeclared-field refusal
+    // verbatim, one element kind over.
+    let Some(decl) = declared.get(field) else {
+        return Err(err(format!(
+            "{form}: field `{field}` was never declared — add a \
+             (deffield {field} <type> <intensive|extensive>) form ABOVE the \
+             hyperedge and hyperedge-attr forms that use it"
+        )));
+    };
+    // The ONE per-type literal law — Currency refusal included. `attribute_value`
+    // takes the element descriptor, so the noun is honest on this path too.
+    let converted = attribute_value(value, &format!("hyperedge `{local}`"), field, decl, enums)?;
+    // E-LOAD-057, one axis narrower than the edge lane's quadruple.
+    if !seeded_attrs.insert((id, field.clone())) {
+        return Err(coded_err(
+            "E-LOAD-057",
+            format!(
+                "hydration seeds hyperedge `{local}`'s attribute `{field}` twice; the \
+                 (hyperedge, field) pair is a KEY, exactly as the edge lane's quadruple \
+                 is — a second seeding silently overwrites the first, the file carrying \
+                 two values for one datum with only the later surviving"
+            ),
+        ));
+    }
+    graph.update_hyperedge_attribute(id, field, converted)?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -2154,7 +2262,7 @@ mod tests {
     use crate::typecheck::TypeEnv;
     use babylon_graph::memory::MemoryGraph;
     use babylon_graph::state_hash::{CanonicalState, StateEncoder};
-    use babylon_graph::substrate::{Direction, GraphSubstrate, NodeId};
+    use babylon_graph::substrate::{Direction, GraphSubstrate, HyperedgeId, NodeId};
     use babylon_kernel::{Currency, SessionId};
     use std::collections::{HashMap, HashSet};
 
@@ -2659,6 +2767,7 @@ mod tests {
                 "ft/mirror",
                 Some(&loaded_scenario.node_content_ids),
                 &SessionId::new("scenario-bit-equality-test").expect("literal is non-empty"),
+                None,
             )
             .unwrap_or_else(|e| panic!("{literal}: tick must run: {e}"));
 
@@ -2765,6 +2874,7 @@ mod tests {
                 "ft/currency-mirror",
                 Some(&loaded_scenario.node_content_ids),
                 &SessionId::new("scenario-currency-bit-equality-test").expect("non-empty"),
+                None,
             )
             .unwrap_or_else(|e| panic!("{literal}: tick must run: {e}"));
 
@@ -4388,6 +4498,158 @@ mod tests {
             .edge_attribute("SOLIDARITY", NodeId(0), NodeId(1), "solidarity/strength")
             .unwrap();
         assert_eq!(strength.to_bits(), (0.5_f64).to_bits());
+    }
+
+    // ---- Community port train Task 6 (E2b): the (hyperedge-attr ...) scenario form ----
+
+    #[test]
+    fn hyperedge_attr_seeds_a_declared_hyperedge_field() {
+        // The positive lane, mirroring `edge_attr_seeds_a_declared_edge_field`
+        // one element kind over: the seed lands in the substrate's Task-5
+        // hyperedge-attribute store and reads back bit-exact (0.25 = 2^-2 is
+        // dyadic-exact). The write travels NO write log — hydration has none
+        // (the write log is a tick-time construct; `load_edge_attr`'s own
+        // direct `update_edge` is the precedent), which is exactly why this
+        // test reads the substrate rather than a log.
+        let source = r"
+(scenario ft/hyperedge-attr
+  (deffield community/heat coefficient intensive)
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (hyperedge cell HyperedgeType/COMMUNITY (members a b))
+  (hyperedge-attr cell community/heat 0.25c))
+";
+        let mut graph = MemoryGraph::new();
+        load_scenario(source, &mut graph).unwrap();
+        let value = graph
+            .hyperedge_attribute(HyperedgeId(0), "community/heat")
+            .unwrap();
+        assert_eq!(value.to_bits(), (0.25_f64).to_bits());
+    }
+
+    #[test]
+    fn hyperedge_attr_seeds_an_enum_typed_field_as_its_ordinal() {
+        // The enum lane (`community/kind`, Task 6 Step 4's named case):
+        // seeded ONLY as <EnumType>/<MEMBER> (`attribute_value_enum`'s law),
+        // stored as the ordinal — never a surface number.
+        let source = r"
+(scenario ft/hyperedge-attr-enum
+  (defenum CommunityType (REVOLUTIONARY LIBERAL))
+  (deffield community/kind enum CommunityType)
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (hyperedge cell HyperedgeType/COMMUNITY (members a b))
+  (hyperedge-attr cell community/kind CommunityType/LIBERAL))
+";
+        let mut graph = MemoryGraph::new();
+        load_scenario(source, &mut graph).unwrap();
+        let value = graph
+            .hyperedge_attribute(HyperedgeId(0), "community/kind")
+            .unwrap();
+        assert_eq!(value.to_bits(), (1.0_f64).to_bits(), "LIBERAL is ordinal 1");
+    }
+
+    #[test]
+    fn hyperedge_attr_refuses_a_fractional_seed_on_an_int_declared_field() {
+        // The int/fractional conversion contract, verbatim — the same
+        // refusal `load_node`'s field-init path pins executably above.
+        let source = r"
+(scenario ft/hyperedge-attr-int
+  (deffield community/count int extensive)
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (hyperedge cell HyperedgeType/COMMUNITY (members a b))
+  (hyperedge-attr cell community/count 0.5c))
+";
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(source, &mut graph).unwrap_err();
+        assert_eq!(
+            err.message,
+            "hyperedge `cell` field `community/count`: expected an integer \
+             literal, found Scaled(ScaledLit { kind: Coefficient, unscaled: 5, scale: 1 })"
+        );
+    }
+
+    #[test]
+    fn hyperedge_attr_refuses_unknown_name_undeclared_field_owner_mismatch_and_double_seed() {
+        // 1. A hyperedge-attr naming a hyperedge this scenario never
+        //    seeded — the top-to-bottom discipline, by name.
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario ft/hyperedge-attr-unknown
+  (deffield community/heat coefficient intensive)
+  (node a NodeType/SOCIAL_CLASS)
+  (hyperedge-attr ghost community/heat 0.5c))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert!(
+            err.message
+                .contains("hyperedge-attr names unknown hyperedge `ghost`"),
+            "{}",
+            err.message
+        );
+
+        // 2. A field no deffield declared is a typo, not a new field.
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario ft/hyperedge-attr-typo
+  (deffield community/heat coefficient intensive)
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (hyperedge cell HyperedgeType/COMMUNITY (members a b))
+  (hyperedge-attr cell community/heta 0.5c))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("community/heta") && err.message.contains("never declared"),
+            "{}",
+            err.message
+        );
+
+        // 3. §2.10 discipline 1 at hydration: the qname's owner must name
+        //    the hyperedge's own type, read back from the substrate.
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario ft/hyperedge-attr-owner
+  (deffield economic-sector/output coefficient intensive)
+  (node a NodeType/SOCIAL_CLASS)
+  (hyperedge cell HyperedgeType/COMMUNITY (members a))
+  (hyperedge-attr cell economic-sector/output 0.5c))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert!(
+            err.message
+                .contains("is owned by ECONOMIC_SECTOR, not COMMUNITY"),
+            "{}",
+            err.message
+        );
+
+        // 4. The (hyperedge, field) pair is a KEY — a second seeding of one
+        //    key is E-LOAD-057, the silent-overwrite refusal.
+        let mut graph = MemoryGraph::new();
+        let err = load_scenario(
+            r"
+(scenario ft/hyperedge-attr-double
+  (deffield community/heat coefficient intensive)
+  (node a NodeType/SOCIAL_CLASS)
+  (node b NodeType/SOCIAL_CLASS)
+  (hyperedge cell HyperedgeType/COMMUNITY (members a b))
+  (hyperedge-attr cell community/heat 0.25c)
+  (hyperedge-attr cell community/heat 0.5c))
+",
+            &mut graph,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, Some("E-LOAD-057"), "{}", err.message);
     }
 
     // ---- F1 (Task 3 fix round 1): the node-path refusal text, pinned EXECUTABLY ----

--- a/rust/crates/babylon-bsl/src/structural_verbs.rs
+++ b/rust/crates/babylon-bsl/src/structural_verbs.rs
@@ -13,22 +13,30 @@
 //! replacement, `remove-hyperedge` then `add-hyperedge` in one effect list
 //! (§2.8 draft ruling, D26 — whose member-list half **stands**).
 //!
-//! **`update-edge` is served (T3, ADR198 R1-R3, issue #560); `update-hyperedge`
-//! remains refused loudly, with the reason named.** T3 PR A gave
+//! **`update-edge` is served (T3, ADR198 R1-R3, issue #560);
+//! `update-hyperedge` is served too (Community port train, Task 6 E2b —
+//! the charter T3's doc said did not exist).** T3 PR A gave
 //! `GraphSubstrate` full symmetric edge-attribute storage (deffield rows per
 //! edge type, the empty-elided fifth canonical section), and this module's
 //! collect-then-apply machinery widened to match: `update-edge` defers
 //! through the same [`PendingWrite`] batch as `update-node` (the target sum
 //! type [`WriteTarget`]), with `set`/`add`/`sub`/`scale` parity, enum set
 //! included, and the strength fork (D143) routing `<edge-type>/strength`
-//! writes to the edge's existing 0x03-slot strength. `update-hyperedge` has
-//! no such charter: hyperedge own-field storage is chartered by no Program
-//! 29 train (D65's runtime half; AG(i) membership payloads are #536's
-//! separate ceremony, ADR198 R4), and widening that state widens the
-//! canonical `state_hash` field set (Constitution III.7) — never a
-//! silently-dropped write. The grammar, the §3.7 cost rows, the §2.8 static
+//! writes to the edge's existing 0x03-slot strength. The Community port
+//! train then chartered the hyperedge half outright: Task 5 (E2a) minted
+//! `GraphSubstrate::update_hyperedge_attribute` (the seventh canonical
+//! section, `0x07`), and Task 6 wired the verb to it through BOTH dispatch
+//! sites — `update-hyperedge` defers through `WriteTarget::Hyperedge` with
+//! the same `set`/`add`/`sub`/`scale` parity, enum set included, the
+//! §2.10 discipline-1 referent check (`evaluator::check_hyperedge_referent_type`)
+//! shared with `field-of`'s new `HyperedgeRef` arm. What STAYS refused:
+//! per-membership payloads (Amendment AG(i)'s ceremony, #653) and
+//! mint-time `<field-init>`s on `add-hyperedge` (a distinct unserved lane —
+//! the storage exists; the init sugar is not routed to it in this train).
+//! The grammar, the §3.7 cost rows, the §2.8 static
 //! checks and the error codes landed with the R9 chapters; the storage and
-//! the apply path are what T3 adds.
+//! the apply path are what T3 added for edges and Task 5+6 added for
+//! hyperedges.
 //!
 //! **I.15 stays a declared Phase-2 gap, named here rather than silently
 //! absorbed** (the dossier's scope tension, recorded): nothing in this
@@ -207,6 +215,9 @@ pub enum WriteTarget {
     /// (issue #559), shared unmodified exactly as D36's "the two trains
     /// share the type" intends.
     Edge(EdgeKey),
+    /// A hyperedge's own field (`update-hyperedge`) — the Community port
+    /// train's Task 6 (E2b); the id alone is the identity (VIII.9).
+    Hyperedge(HyperedgeId),
 }
 
 fn plain(message: impl Into<String>) -> EvalError {
@@ -520,21 +531,7 @@ impl<'a> EffectExecutor<'a> {
             "emit" => Self::emit(items, env, host, sink, fuel),
             "for-each" => self.for_each(items, env, host, graph, sink, fuel),
             "update-edge" => self.update_edge(items, env, host, graph, fuel),
-            "update-hyperedge" => {
-                // The verb EXISTS (D65) — this is a storage gap, not an
-                // unknown head, and the message must not confuse the two.
-                // T3 (ADR198 R1-R3) served update-edge's storage; hyperedge
-                // own-field storage is chartered by no Program 29 train
-                // (AG(i) membership payloads are #536's separate ceremony,
-                // ADR198 R4).
-                Err(plain(
-                    "(update-hyperedge …) has no substrate storage: GraphSubstrate gives a \
-                     hyperedge no attributes at all. Widening that state widens the canonical \
-                     state_hash field set, which is a declared substrate decision (Constitution \
-                     III.7), never a silently-dropped write"
-                        .to_owned(),
-                ))
-            }
+            "update-hyperedge" => self.update_hyperedge(items, env, host, graph, fuel),
             other => Err(plain(format!(
                 "unknown effect head ({other} …) — the §2.8 verb set is closed"
             ))),
@@ -861,6 +858,97 @@ impl<'a> EffectExecutor<'a> {
         Ok(())
     }
 
+    /// `(update-hyperedge <expr> <qname> <update-op>)` — the hyperedge
+    /// own-field write (Community port train, Task 6, E2b), the execute
+    /// path. Mirrors [`Self::update_edge`]'s discipline exactly: the
+    /// referent's declared type is checked against the qname's owner
+    /// segment (E-EVAL-033's hyperedge half), `set` never reads the prior
+    /// value for the combine (only the log probe), `add`/`sub`/`scale`
+    /// read-combine through `hyperedge_attribute`, non-finite combines
+    /// refuse (E-EVAL-014), the write is range-checked at the store
+    /// boundary (E-EVAL-020) and canonical-zeroed, and the substrate
+    /// errors map to E-EVAL-031.
+    fn update_hyperedge(
+        &mut self,
+        items: &[SExpr],
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        graph: &mut dyn GraphSubstrate,
+        fuel: &mut u64,
+    ) -> Result<(), EvalError> {
+        charge(fuel, cost::STRUCTURAL_VERB_BASE)?;
+        let [_, hyperedge, SExpr::Atom(Atom::QName(field)), op_form] = items else {
+            return Err(plain(
+                "(update-hyperedge <expr> <qname> <update-op>) — unrecognized shape",
+            ));
+        };
+        let id = self.resolve_hyperedge(hyperedge, env, host, fuel)?;
+        crate::evaluator::check_hyperedge_referent_type(id, field, "update-hyperedge", &*graph)?;
+        let SExpr::List(op_items) = op_form else {
+            return Err(plain(
+                "update-op must be a form: (add|sub|set|scale <expr>)",
+            ));
+        };
+        let [SExpr::Atom(Atom::Symbol(op)), operand] = op_items.as_slice() else {
+            return Err(plain("update-op must be (add|sub|set|scale <expr>)"));
+        };
+        charge(fuel, cost::UPDATE_OP_BASE)?;
+        let operand_value =
+            self.numeric_write_value(operand, env, host, fuel, field, "update-hyperedge")?;
+        let (new_value, previous) = match op.as_str() {
+            "set" => (
+                operand_value,
+                self.probe_previous_hyperedge(&*graph, id, field),
+            ),
+            "add" | "sub" | "scale" => {
+                self.refuse_arithmetic_on_enum_field(field, "update-hyperedge")?;
+                let current = graph.hyperedge_attribute(id, field).map_err(from_graph)?;
+                let combined = match op.as_str() {
+                    "add" => current + operand_value,
+                    "sub" => current - operand_value,
+                    _ => current * operand_value,
+                };
+                if !combined.is_finite() {
+                    return Err(EvalError::coded(
+                        EvalCode::NonFinite,
+                        format!("({op} …) on {field} produced a non-finite value"),
+                    ));
+                }
+                (combined, Some(current))
+            }
+            other => {
+                return Err(plain(format!(
+                    "unknown update-op ({other} …) — the set is add|sub|set|scale (§2.8)"
+                )))
+            }
+        };
+        let new_value = canonical_zero(new_value);
+        self.store_range_check(field, new_value)?;
+        graph
+            .update_hyperedge_attribute(id, field, new_value)
+            .map_err(from_graph)?;
+        self.record(Write::HyperedgeAttribute {
+            id,
+            field: field.clone(),
+            previous,
+            value: new_value,
+        });
+        Ok(())
+    }
+
+    /// The collect side's previous-value probe for the hyperedge lane —
+    /// `write_log` discipline 3, through `hyperedge_attribute` exactly as
+    /// [`Self::probe_previous_edge`] reads through `edge_attribute`.
+    fn probe_previous_hyperedge(
+        &self,
+        graph: &dyn GraphSubstrate,
+        id: HyperedgeId,
+        field: &str,
+    ) -> Option<f64> {
+        self.observer.as_ref()?;
+        graph.hyperedge_attribute(id, field).ok()
+    }
+
     // ---- Task 12: the pre-state law — collect-then-apply ----
 
     /// COLLECT phase (§2.8 chapter C6 + §4.2 chapter C4): evaluate
@@ -996,13 +1084,11 @@ impl<'a> EffectExecutor<'a> {
                 pending.push(write);
                 Ok(())
             }
-            "update-hyperedge" => Err(plain(
-                "(update-hyperedge …) has no substrate storage: GraphSubstrate gives a \
-                 hyperedge no attributes at all. Widening that state widens the canonical \
-                 state_hash field set, which is a declared substrate decision (Constitution \
-                 III.7), never a silently-dropped write"
-                    .to_owned(),
-            )),
+            "update-hyperedge" => {
+                let write = self.collect_update_hyperedge(items, env, host, fuel)?;
+                pending.push(write);
+                Ok(())
+            }
             other => Err(plain(format!(
                 "unknown effect head ({other} …) — the §2.8 verb set is closed"
             ))),
@@ -1153,6 +1239,68 @@ impl<'a> EffectExecutor<'a> {
         };
         Ok(PendingWrite {
             target: WriteTarget::Edge(key),
+            field: field.clone(),
+            op: update_op,
+            operand: WriteOperand::Real(operand_value),
+        })
+    }
+
+    /// `(update-hyperedge <expr> <qname> <update-op>)`, the collect half —
+    /// mirrors [`Self::collect_update_edge`] exactly; the write applies in
+    /// the APPLY phase against `WriteTarget::Hyperedge` (the pre-state law,
+    /// §4.2 chapter C4, holds for this lane exactly as for the other two).
+    fn collect_update_hyperedge(
+        &mut self,
+        items: &[SExpr],
+        env: &EvalEnv<'_>,
+        host: &dyn IntrinsicHost,
+        fuel: &mut u64,
+    ) -> Result<PendingWrite, EvalError> {
+        charge(fuel, cost::STRUCTURAL_VERB_BASE)?;
+        let [_, hyperedge, SExpr::Atom(Atom::QName(field)), op_form] = items else {
+            return Err(plain(
+                "(update-hyperedge <expr> <qname> <update-op>) — unrecognized shape",
+            ));
+        };
+        let id = self.resolve_hyperedge(hyperedge, env, host, fuel)?;
+        // The referent check reads the pre-state (collect holds an
+        // immutable reborrow) — the same law as every other collect_*.
+        crate::evaluator::check_hyperedge_referent_type(
+            id,
+            field,
+            "update-hyperedge",
+            env.graph
+                .expect("collect needs the pre-state graph (the driver always passes one)"),
+        )?;
+        let SExpr::List(op_items) = op_form else {
+            return Err(plain(
+                "update-op must be a form: (add|sub|set|scale <expr>)",
+            ));
+        };
+        let [SExpr::Atom(Atom::Symbol(op)), operand] = op_items.as_slice() else {
+            return Err(plain("update-op must be (add|sub|set|scale <expr>)"));
+        };
+        charge(fuel, cost::UPDATE_OP_BASE)?;
+        let operand_value =
+            self.numeric_write_value(operand, env, host, fuel, field, "update-hyperedge")?;
+        let update_op = match op.as_str() {
+            "set" => UpdateOp::Set,
+            "add" | "sub" | "scale" => {
+                self.refuse_arithmetic_on_enum_field(field, "update-hyperedge")?;
+                match op.as_str() {
+                    "add" => UpdateOp::Add,
+                    "sub" => UpdateOp::Sub,
+                    _ => UpdateOp::Scale,
+                }
+            }
+            other => {
+                return Err(plain(format!(
+                    "unknown update-op ({other} …) — the set is add|sub|set|scale (§2.8)"
+                )))
+            }
+        };
+        Ok(PendingWrite {
+            target: WriteTarget::Hyperedge(id),
             field: field.clone(),
             op: update_op,
             operand: WriteOperand::Real(operand_value),
@@ -1317,7 +1465,63 @@ impl<'a> EffectExecutor<'a> {
                 });
                 Ok(())
             }
+            WriteTarget::Hyperedge(id) => self.apply_pending_hyperedge_write(*id, write, graph),
         }
+    }
+
+    /// The hyperedge half of [`Self::apply_pending_write`] (Community port
+    /// train, Task 6, E2b), extracted so that function stays under the
+    /// ≤100-line bound (Power-of-10 rule 3) — the same reason
+    /// [`Self::apply_pending_currency_write`] gives for its own extraction.
+    /// Mirrors the Edge arm exactly: no hyperedge-scoped Currency lane
+    /// exists, so a Currency operand here is the same collect/apply
+    /// wiring-bug shape the edge arm names.
+    fn apply_pending_hyperedge_write(
+        &mut self,
+        id: HyperedgeId,
+        write: &PendingWrite,
+        graph: &mut dyn GraphSubstrate,
+    ) -> Result<(), EvalError> {
+        let WriteOperand::Real(operand) = write.operand else {
+            return Err(plain(format!(
+                "update-hyperedge {}: a Currency operand reached apply — there is no \
+                 hyperedge-scoped Currency lane; collect_update_hyperedge should never \
+                 have produced this (wiring bug, not content)",
+                write.field
+            )));
+        };
+        let (new_value, previous) = match write.op {
+            UpdateOp::Set => (
+                operand,
+                self.probe_previous_hyperedge(&*graph, id, &write.field),
+            ),
+            UpdateOp::Add | UpdateOp::Sub | UpdateOp::Scale => {
+                self.refuse_arithmetic_on_enum_field(&write.field, "update-hyperedge")?;
+                let current = graph
+                    .hyperedge_attribute(id, &write.field)
+                    .map_err(from_graph)?;
+                let combined = combine_and_check_finite(
+                    write.op,
+                    current,
+                    operand,
+                    &write.field,
+                    "update-hyperedge",
+                )?;
+                (combined, Some(current))
+            }
+        };
+        let new_value = canonical_zero(new_value);
+        self.store_range_check(&write.field, new_value)?;
+        graph
+            .update_hyperedge_attribute(id, &write.field, new_value)
+            .map_err(from_graph)?;
+        self.record(Write::HyperedgeAttribute {
+            id,
+            field: write.field.clone(),
+            previous,
+            value: new_value,
+        });
+        Ok(())
     }
 
     /// `(add-node <enum-ref> <expr> <field-init>*)`.
@@ -1529,11 +1733,15 @@ impl<'a> EffectExecutor<'a> {
         };
         if !field_inits.is_empty() {
             // §2.8's ruling already names the adjacent gap (per-membership
-            // payload, hyperedge field mutation); initial hyperedge fields
-            // have no trait storage either — loud, not dropped.
+            // payload, hyperedge field mutation); mint-time field-inits are
+            // a DISTINCT unserved lane — the own-field storage exists since
+            // Task 5 (E2a) and `update-hyperedge`/`(hyperedge-attr …)` are
+            // its two landed writers (Task 6), but the init sugar on THIS
+            // verb is not routed to it in this train. Loud, not dropped.
             return Err(plain(
-                "hyperedge <field-init> has no substrate storage in Phase 1 — \
-                 a declared Phase-2 gap (§2.8 draft ruling), never silently dropped",
+                "hyperedge <field-init> is not served at mint time — write the field \
+                 after minting through update-hyperedge (or seed it in the scenario \
+                 with (hyperedge-attr …)); never silently dropped",
             ));
         }
         let hyperedge_type = self.enum_member_checked(type_ref, "add-hyperedge")?;
@@ -2732,6 +2940,10 @@ mod tests {
 
     #[test]
     fn hyperedge_field_inits_are_a_loud_phase_2_gap() {
+        // The mint-time init lane STAYS refused after Task 6 — with the
+        // reason corrected: the own-field storage exists (Task 5) and
+        // `update-hyperedge`/`(hyperedge-attr …)` are its writers, but the
+        // init sugar on `add-hyperedge` itself is not routed to it.
         let mut fixture = Fixture::new();
         let mut fuel = 128;
         let err = fixture
@@ -2741,7 +2953,7 @@ mod tests {
                 &mut fuel,
             )
             .unwrap_err();
-        assert!(err.message.contains("Phase-2 gap"), "{err}");
+        assert!(err.message.contains("not served at mint time"), "{err}");
     }
 
     // ---- the ADR182 R1 write log ----
@@ -4834,19 +5046,46 @@ mod tests {
         );
     }
 
-    /// The retired refusal's other half STAYS refused — with a corrected
-    /// message that no longer claims an edge is one f64 strength (that
-    /// stopped being true at T3 PR A) and still names the constitutional
-    /// reason a hyperedge's own-field storage cannot be improvised here.
+    /// A COMMUNITY hyperedge over two classes, with its id returned for the
+    /// `h` binding — the hyperedge half of [`edge_fixture`]'s pattern.
+    fn hyperedge_fixture() -> (MemoryGraph, HyperedgeId) {
+        let mut graph = MemoryGraph::new();
+        let a = graph.add_node("SOCIAL_CLASS").unwrap();
+        let b = graph.add_node("SOCIAL_CLASS").unwrap();
+        let cell = graph.add_hyperedge("COMMUNITY", &[a, b]).unwrap();
+        (graph, cell)
+    }
+
+    fn hyperedge_types() -> TypeEnv {
+        TypeEnv {
+            fields: HashMap::from([(
+                "community/heat".to_owned(),
+                FieldDecl {
+                    ty: BslType::Coefficient,
+                    kind: FieldKind::Intensive,
+                },
+            )]),
+            exemptions: &[],
+        }
+    }
+
+    /// Task 6 (Community port train, E2b): `update-hyperedge` WRITES on
+    /// BOTH dispatch sites — the refusal this test's predecessor pinned
+    /// ("no substrate storage … III.7") was discharged by Task 5's
+    /// `GraphSubstrate::update_hyperedge_attribute`, so the pin inverts:
+    /// the execute path writes and records `Write::HyperedgeAttribute`,
+    /// and the collect-then-apply path lands the combined value through
+    /// the APPLY phase. (The M4 lesson: each site owes its own proof.)
     #[test]
-    fn update_hyperedge_still_refuses_with_a_hyperedge_only_message() {
-        let (mut graph, _a, _b) = edge_fixture();
-        let types = edge_types();
+    fn update_hyperedge_writes_a_declared_hyperedge_field_on_both_dispatch_sites() {
+        // Site 1 — the execute path, observed so the write log is visible.
+        let (mut graph, cell) = hyperedge_fixture();
+        let types = hyperedge_types();
         let enums = enums();
         let mut sink = CollectingSink::default();
-        let mut executor = EffectExecutor::new(&types, &enums, None);
+        let mut log = CollectingWriteLog::new();
         let env = EvalEnv {
-            bindings: HashMap::new(),
+            bindings: HashMap::from([("h".to_owned(), Value::HyperedgeRef(cell))]),
             intrinsic_costs: &IntrinsicCosts::default(),
             graph: None,
             types: None,
@@ -4854,40 +5093,58 @@ mod tests {
             elements: Vec::new(),
             draw_context: None,
         };
-        let (form, _) = read("(effects (update-hyperedge h sector/output (set 1)))")
+        let (form, _) = read("(effects (update-hyperedge h community/heat (set 0.5c)))")
             .expect("effects source must parse");
         let SExpr::List(items) = form else {
             unreachable!()
         };
         let mut fuel = 128;
-        let err = executor
-            .execute_effects(
-                &items[1..],
-                &env,
-                &EmptyIntrinsicHost,
-                &mut graph,
-                &mut sink,
-                &mut fuel,
-            )
-            .unwrap_err();
-        assert!(err.message.contains("Constitution III.7"), "{err}");
+        {
+            let mut executor =
+                EffectExecutor::observed(&types, &enums, None, "community/probe", &mut log);
+            executor
+                .execute_effects(
+                    &items[1..],
+                    &env,
+                    &EmptyIntrinsicHost,
+                    &mut graph,
+                    &mut sink,
+                    &mut fuel,
+                )
+                .expect("update-hyperedge must serve on the execute path");
+        }
+        let stored = graph.hyperedge_attribute(cell, "community/heat").unwrap();
+        assert!((stored - 0.5).abs() < 1e-12, "set to 0.5, stored: {stored}");
         assert!(
-            !err.message.contains("one f64 strength"),
-            "the retained refusal must stop describing pre-T3 edge storage: {err}"
+            log.writes().iter().any(|w| matches!(
+                w,
+                Write::HyperedgeAttribute {
+                    field,
+                    previous: None,
+                    value,
+                    ..
+                } if field == "community/heat" && (*value - 0.5).abs() < 1e-12
+            )),
+            "one HyperedgeAttribute record with no prior value, after the store accepted it"
         );
-        // The collect path's copy, likewise.
+
+        // Site 2 — collect-then-apply: `add` reads the pre-state (0.5 from
+        // site 1's write), combines, and lands 0.75 through the APPLY phase.
         let mut fuel = 128;
-        let err = collect_only(
-            &graph,
+        collect_then_apply(
+            &mut graph,
             &types,
             &enums,
-            HashMap::new(),
-            "(effects (update-hyperedge h sector/output (set 1)))",
+            HashMap::from([("h".to_owned(), Value::HyperedgeRef(cell))]),
+            "(effects (update-hyperedge h community/heat (add 0.25c)))",
             &mut fuel,
         )
-        .unwrap_err();
-        assert!(err.message.contains("Constitution III.7"), "{err}");
-        assert!(!err.message.contains("one f64 strength"), "{err}");
+        .expect("update-hyperedge must serve on the collect path");
+        let stored = graph.hyperedge_attribute(cell, "community/heat").unwrap();
+        assert!(
+            (stored - 0.75).abs() < 1e-12,
+            "0.5 + 0.25 through collect-then-apply, stored: {stored}"
+        );
     }
 
     /// `sub` — the fourth op — on a deffield-declared edge field, completing

--- a/rust/crates/babylon-bsl/src/tick.rs
+++ b/rust/crates/babylon-bsl/src/tick.rs
@@ -163,11 +163,42 @@ pub(crate) fn namespace_to_node_type(namespace: &str) -> String {
 }
 
 /// The subject type a rule's `:field` bindings agree on.
-fn subject_type_of(bindings: &[BindingDecl]) -> Result<String, TickError> {
+///
+/// **D29 filter (Community port train, Task 6, E2b):** a `:field` binding
+/// is node-scoped and stays node-scoped — an edge's or a hyperedge's field
+/// is read by the `field-of` accessor, never by a binding (§2.5's draft
+/// ruling, `bsl-language.rst` D29). When the closed vocabulary is in
+/// force, a binding whose qname owns off an `EdgeType`/`HyperedgeType`
+/// member is therefore INVISIBLE to this derivation — exactly the filter
+/// `domain.rs::self_scoped_segments` already applies at load, kept in
+/// agreement with it so the load-time domain and the tick-time population
+/// can never fork. A rule whose only `:field` bindings are hyperedge-owned
+/// then names no subject type at all — the same refusal a binding-free
+/// rule gets, which is the mechanism §8c of the Community port plan cites
+/// (`no_field_binding_uses_the_community_namespace` quotes this function).
+/// Without a vocabulary (`None` — the registry-free unit-test lane) the
+/// owner kind is unknowable and every namespace counts, exactly as before.
+fn subject_type_of(
+    bindings: &[BindingDecl],
+    vocabulary: Option<&crate::vocabulary::ClosedVocabulary>,
+) -> Result<String, TickError> {
     let mut namespaces: Vec<&str> = Vec::new();
     for binding in bindings {
         if let BindSource::Field(qname) = &binding.source {
             let namespace = qname.split('/').next().unwrap_or_default();
+            if let Some(vocabulary) = vocabulary {
+                // Filter ONLY on a POSITIVE owner-kind answer: a segment the
+                // vocabulary does not know (`Err(UnknownFieldOwner)`) is
+                // E-LOAD-023's lane at load, not this filter's — a scenario
+                // may declare a partial vocabulary (e.g. HyperedgeType
+                // members only), and treating its unknown node namespaces as
+                // filtered would empty every subject population.
+                if let Ok((kind, _)) = vocabulary.owner_of(namespace) {
+                    if kind != crate::vocabulary::EnumKind::NodeType {
+                        continue;
+                    }
+                }
+            }
             if !namespaces.contains(&namespace) {
                 namespaces.push(namespace);
             }
@@ -614,9 +645,15 @@ pub fn run_tick(
     rule_id: &str,
     node_content_ids: Option<&HashMap<NodeId, String>>,
     session: &SessionId,
+    // The scenario's closed vocabulary, when one was declared — the D29
+    // owner-kind filter `subject_type_of` applies (Community port train,
+    // Task 6). `None` is the registry-free unit-test lane, where the
+    // filter cannot run and every binding namespace counts, exactly as
+    // before this parameter existed.
+    vocabulary: Option<&crate::vocabulary::ClosedVocabulary>,
 ) -> Result<TickOutcome, TickError> {
     check_sources_servable(&loaded.bindings, defines)?;
-    let subject_type = subject_type_of(&loaded.bindings)?;
+    let subject_type = subject_type_of(&loaded.bindings, vocabulary)?;
     let (guard, effects) = guard_and_effects(&loaded.rule)?;
     let subjects = graph.nodes(&subject_type);
 
@@ -987,7 +1024,7 @@ mod tests {
             field("wages", "social-class/wages"),
             field("value-produced", "social-class/value-produced"),
         ];
-        assert_eq!(subject_type_of(&bindings).unwrap(), "SOCIAL_CLASS");
+        assert_eq!(subject_type_of(&bindings, None).unwrap(), "SOCIAL_CLASS");
     }
 
     #[test]
@@ -998,18 +1035,98 @@ mod tests {
             field("wages", "social-class/wages"),
             field("budget", "organization/budget"),
         ];
-        let err = subject_type_of(&bindings).unwrap_err();
+        let err = subject_type_of(&bindings, None).unwrap_err();
         assert!(err.message.contains("ambiguous"), "{}", err.message);
     }
 
     #[test]
     fn a_rule_with_no_field_binding_names_no_population() {
-        let err = subject_type_of(&[]).unwrap_err();
+        let err = subject_type_of(&[], None).unwrap_err();
         assert!(
             err.message.contains("names no subject type"),
             "{}",
             err.message
         );
+    }
+
+    // ---- Task 6 (Community port train, E2b): the D29 owner-kind filter.
+    // A `:field` binding is node-scoped and stays node-scoped — an edge's
+    // or a hyperedge's declared field reads through `field-of`, never a
+    // binding — so a non-node-owned binding is INVISIBLE to this
+    // derivation when the closed vocabulary is in force, and a rule with
+    // only such bindings names no subject type (the §8c guard's
+    // mechanism).
+
+    /// A small vocabulary with one member per kind — the filter's truth
+    /// table needs all three kinds present.
+    fn d29_vocabulary() -> crate::vocabulary::ClosedVocabulary {
+        crate::vocabulary::ClosedVocabulary::new([
+            (
+                crate::vocabulary::EnumKind::NodeType,
+                vec!["SOCIAL_CLASS".to_owned()],
+            ),
+            (
+                crate::vocabulary::EnumKind::EdgeType,
+                vec!["SOLIDARITY".to_owned()],
+            ),
+            (
+                crate::vocabulary::EnumKind::HyperedgeType,
+                vec!["COMMUNITY".to_owned()],
+            ),
+        ])
+        .expect("disjoint member sets build")
+    }
+
+    #[test]
+    fn a_hyperedge_owned_field_binding_names_no_subject_type() {
+        let vocabulary = d29_vocabulary();
+        let bindings = vec![field("heat", "community/heat")];
+        let err = subject_type_of(&bindings, Some(&vocabulary)).unwrap_err();
+        assert!(
+            err.message.contains("names no subject type"),
+            "a hyperedge-owned :field binding is invisible to subject \
+             derivation (D29) — the subject-type error, not silence: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn an_edge_owned_field_binding_names_no_subject_type() {
+        // D29 is stated for edge AND hyperedge fields alike; the filter
+        // keeps both kinds out of subject derivation.
+        let vocabulary = d29_vocabulary();
+        let bindings = vec![field("strength", "solidarity/strength")];
+        let err = subject_type_of(&bindings, Some(&vocabulary)).unwrap_err();
+        assert!(
+            err.message.contains("names no subject type"),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn a_hyperedge_owned_binding_is_invisible_next_to_a_node_owned_one() {
+        let vocabulary = d29_vocabulary();
+        let bindings = vec![
+            field("active", "social-class/active"),
+            field("heat", "community/heat"),
+        ];
+        assert_eq!(
+            subject_type_of(&bindings, Some(&vocabulary)).unwrap(),
+            "SOCIAL_CLASS",
+            "the node-owned binding alone derives the subject type — the \
+             hyperedge-owned one must not make the derivation ambiguous"
+        );
+    }
+
+    #[test]
+    fn without_a_vocabulary_every_namespace_still_counts() {
+        // The registry-free lane cannot know an owner kind, so the legacy
+        // behavior is pinned: `community` renders to a (meaningless)
+        // subject type rather than being filtered. Content drivers always
+        // pass `Some`, so this lane is unit-test-only.
+        let bindings = vec![field("heat", "community/heat")];
+        assert_eq!(subject_type_of(&bindings, None).unwrap(), "COMMUNITY");
     }
 
     // ============================================= Task 12 — the pre-state
@@ -1156,6 +1273,7 @@ mod tests {
             "geography/spillover",
             None,
             &test_session(),
+            None,
         )
         .expect("the tick must run");
 
@@ -1263,6 +1381,7 @@ mod tests {
             "geography/pool-contribution",
             None,
             &test_session(),
+            None,
         )
         .expect("the tick must run");
         assert_eq!(outcome.fired, 3, "all three territories fired");
@@ -1362,6 +1481,7 @@ mod tests {
             "organization/kind-probe",
             None,
             &test_session(),
+            None,
         )
         .expect("the tick must run");
         assert_eq!(outcome.considered, 2, "both organizations are subjects");
@@ -1423,6 +1543,7 @@ mod tests {
             "organization/kind-ordering-probe",
             None,
             &test_session(),
+            None,
         )
         .unwrap_err();
         assert!(
@@ -1475,6 +1596,7 @@ mod tests {
             "organization/kind-integrity-probe",
             None,
             &test_session(),
+            None,
         )
         .unwrap_err();
         assert!(err.to_string().contains("organization/kind"), "{err}");
@@ -1592,6 +1714,7 @@ mod tests {
             "organization/field-of-probe",
             None,
             &test_session(),
+            None,
         )
         .expect("the tick must run — field-of over an enum field is no longer refused");
         assert_eq!(outcome.considered, 2, "both organizations are subjects");
@@ -1717,6 +1840,7 @@ mod tests {
             "organization/kind-probe",
             None,
             &test_session(),
+            None,
         )
         .expect("a never-hydrated (None) node_content_ids must still serve the Debug-rendering fallback");
         assert_eq!(outcome.fired, 1);
@@ -1770,6 +1894,7 @@ mod tests {
             "organization/kind-probe",
             Some(&non_empty_but_missing_subject),
             &test_session(),
+            None,
         )
         .unwrap_err();
         assert!(err.to_string().contains("hydration bug"), "{err}");
@@ -1827,6 +1952,7 @@ mod tests {
             "organization/kind-probe",
             Some(&hydrated_but_empty),
             &test_session(),
+            None,
         )
         .unwrap_err();
         assert!(

--- a/rust/crates/babylon-bsl/src/write_log.rs
+++ b/rust/crates/babylon-bsl/src/write_log.rs
@@ -144,6 +144,25 @@ pub enum Write {
         /// The hyperedge that no longer exists.
         id: HyperedgeId,
     },
+    /// A field write on a hyperedge — from `update-hyperedge`, on either
+    /// dispatch site (Community port train, Task 6, E2b). An
+    /// `(hyperedge-attr …)` scenario seed does NOT produce one: hydration
+    /// writes the substrate directly and carries no write log (the same
+    /// convention as `(edge-attr …)`'s direct `update_edge`).
+    /// Mirrors [`Self::EdgeAttribute`]'s shape minus the endpoints — a
+    /// hyperedge's identity is its id alone.
+    HyperedgeAttribute {
+        /// The hyperedge written to.
+        id: HyperedgeId,
+        /// The fully-qualified field name.
+        field: String,
+        /// The value the field held before this write, or `None` where it
+        /// held nothing (the same discipline-3 probe, through
+        /// [`babylon_graph::substrate::GraphSubstrate::hyperedge_attribute`]).
+        previous: Option<f64>,
+        /// The value now stored.
+        value: f64,
+    },
 }
 
 /// A [`Write`] with its attribution: which rule performed it, and where in

--- a/rust/crates/babylon-bsl/tests/fundamental_theorem_tick.rs
+++ b/rust/crates/babylon-bsl/tests/fundamental_theorem_tick.rs
@@ -163,6 +163,7 @@ fn run_one_tick() -> (MemoryGraph, usize, usize) {
         "economics/fundamental-theorem",
         Some(&loaded_scenario.node_content_ids),
         &fixture_session(),
+        None,
     )
     .expect("the tick must run");
 
@@ -276,6 +277,7 @@ fn a_changed_scenario_changes_the_hash() {
         "economics/fundamental-theorem",
         Some(&loaded_scenario.node_content_ids),
         &fixture_session(),
+        None,
     )
     .unwrap();
 
@@ -393,6 +395,7 @@ fn run_expr_tick(rule: &str) -> Result<(MemoryGraph, usize), String> {
         "economics/expr-fixture-rule",
         Some(&loaded_scenario.node_content_ids),
         &fixture_session(),
+        None,
     )
     .map_err(|e| format!("tick: {e}"))?;
     Ok((graph, outcome.fired))

--- a/rust/crates/babylon-bsl/tests/r9_chapters.rs
+++ b/rust/crates/babylon-bsl/tests/r9_chapters.rs
@@ -2821,6 +2821,7 @@ mod c14_rng_draw {
             "demo/rng-keyed-draw",
             Some(&loaded_scenario.node_content_ids),
             &SessionId::new(session).expect("literal is non-empty"),
+            None,
         )
         .expect("the tick must run");
         graph
@@ -3018,6 +3019,7 @@ mod c14_rng_draw {
             "demo/rng-fold-draw",
             Some(&loaded_scenario.node_content_ids),
             &SessionId::new("rng-c14-fold").expect("literal is non-empty"),
+            None,
         )
         .expect("the tick must run");
 
@@ -3176,6 +3178,7 @@ mod c14_rng_draw {
             "demo/rng-edge-type-draw",
             Some(&loaded_scenario.node_content_ids),
             &SessionId::new("rng-c14-edge-type").expect("literal is non-empty"),
+            None,
         )
         .expect("the tick must run");
         graph
@@ -3287,6 +3290,7 @@ mod c14_rng_draw {
             "demo/rng-expr-draw",
             Some(&loaded_scenario.node_content_ids),
             &SessionId::new("rng-c14-expr-position").expect("literal is non-empty"),
+            None,
         )
         .expect(
             "an :expr binding calling rng-draw must RUN clean (I3) — no longer a runtime EvalError",

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -188,6 +188,13 @@ pub(crate) struct PreparedRules {
     /// canonical-state weight — `state_hash` is computed over the substrate
     /// alone.
     pub node_content_ids: HashMap<NodeId, String>,
+    /// The scenario's closed vocabulary, when it declared one —
+    /// `run_tick`'s D29 owner-kind filter (`subject_type_of`, Community
+    /// port train Task 6) reads it so a hyperedge/edge-owned `:field`
+    /// binding can never masquerade as a subject type. `None` for a
+    /// scenario declaring no `defvocabulary` at all, exactly the
+    /// load-side `LoadContext::vocabulary_registry` convention.
+    pub vocabulary: Option<babylon_bsl::vocabulary::ClosedVocabulary>,
 }
 
 /// Why `prepare_rules` (or [`diagnose_content_set`]) refused a content set —
@@ -789,6 +796,7 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
         consts: scenario.consts,
         enums: scenario.enums,
         node_content_ids: scenario.node_content_ids,
+        vocabulary: scenario.vocabulary,
     })
 }
 
@@ -923,6 +931,7 @@ fn run_prepared_tick<G: GraphSubstrate + CanonicalState>(
             id,
             Some(&prepared.node_content_ids),
             session,
+            prepared.vocabulary.as_ref(),
         )
         .map_err(|e| format!("tick failed in rule {id}: {e}"))?;
         per_rule_fired.push((id.clone(), outcome.fired));

--- a/rust/crates/babylon-tick/src/session.rs
+++ b/rust/crates/babylon-tick/src/session.rs
@@ -143,6 +143,7 @@ impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
                 id,
                 Some(&self.prepared.node_content_ids),
                 &self.session,
+                self.prepared.vocabulary.as_ref(),
             )
             .map_err(|e| format!("tick failed in rule {id}: {e}"))?;
             per_rule_fired.push((id.clone(), outcome.fired));

--- a/rust/crates/babylon-tick/tests/hyperedge_surface.rs
+++ b/rust/crates/babylon-tick/tests/hyperedge_surface.rs
@@ -1,0 +1,223 @@
+//! Hyperedge-lane Task 6 (E2b, Community port train, plan
+//! `docs/superpowers/plans/2026-08-18-community-port.md`): the BSL
+//! read/write surface for hyperedge own-fields, proven through the content
+//! driver — `update-hyperedge` on the tick's collect-then-apply path,
+//! `field-of` over a `HyperedgeRef`, `(hyperedge-attr …)` seeding, the
+//! D29 owner-kind filter's subject-type refusal, and the typecheck
+//! coverage in both directions.
+//!
+//! This file began as the RED half: two refusal texts pinned through the
+//! content driver (the III.7 storage refusal and the "not meaningful"
+//! refusal). Task 5's `GraphSubstrate::update_hyperedge_attribute`
+//! discharged the storage gap, so the pins INVERTED — what is pinned now
+//! is the served surface, with the refusals that remain (the §2.10
+//! referent check, the D29 subject-type law, the scalar-type guards)
+//! asserted on their own terms.
+//!
+//! NOTE on file placement (deviation, recorded): the plan's Task 6 names
+//! `tests/hyperedge_lane_e2e.rs` (babylon-bsl), whose harness only loads
+//! scenarios — the same deviation Task 3's pin file records applies here
+//! (these proofs drive the tick).
+
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::hypergraph_store::HypergraphStore;
+use babylon_graph::substrate::{GraphSubstrate, HyperedgeId, NodeId};
+use babylon_tick::run_once_into;
+
+/// Two classes, one COMMUNITY hyperedge over both, `community/heat`
+/// declared. Every proof below seeds from some extension of this shape.
+const SCENARIO: &str = r"
+(scenario ft/hyperedge-surface
+  (defvocabulary HyperedgeType (COMMUNITY))
+  (deffield social-class/active int extensive)
+  (deffield social-class/observed coefficient intensive)
+  (deffield community/heat coefficient intensive)
+  (node alpha NodeType/SOCIAL_CLASS (social-class/active 1))
+  (node beta NodeType/SOCIAL_CLASS (social-class/active 1))
+  (hyperedge cell HyperedgeType/COMMUNITY (members alpha beta)))
+";
+
+/// Step 2, the tick half: `update-hyperedge` inside a `for-each` over
+/// `(hyperedges …)` WRITES through the collect-then-apply path. Two active
+/// subjects each run the body once against the same hyperedge; `set` is
+/// idempotent under that, so the stored value is 0.5 exactly (dyadic).
+#[test]
+fn update_hyperedge_writes_through_the_tick() {
+    let rule = r#"
+(rule community/probe-update-hyperedge
+  :material-basis "Task 6 Step 2 proof: update-hyperedge writes through the tick"
+  :fuel 2048
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (for-each (hyperedges HyperedgeType/COMMUNITY)
+      (update-hyperedge it community/heat (set 0.5c)))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(SCENARIO, rule, &mut graph, &mut sink)
+        .expect("update-hyperedge is served on the tick path");
+    assert_eq!(report.fired, 2, "both active subjects fire the for-each");
+    let stored = graph
+        .hyperedge_attribute(HyperedgeId(0), "community/heat")
+        .expect("the write landed");
+    assert_eq!(stored.to_bits(), (0.5_f64).to_bits());
+}
+
+/// Steps 3+5 in one chain: `(hyperedge-attr …)` seeds the field at
+/// hydration, `field-of` over the `HyperedgeRef` reads it mid-tick, and
+/// the value lands on a node field through `update-node` — the full
+/// seed → read → write circuit.
+#[test]
+fn field_of_reads_a_seeded_hyperedge_field_into_a_node_write() {
+    let scenario = SCENARIO.replace(
+        "(members alpha beta)))",
+        "(members alpha beta))\n  (hyperedge-attr cell community/heat 0.25c))",
+    );
+    let rule = r#"
+(rule community/probe-field-of-hyperedge
+  :material-basis "Task 6 Steps 3+5 proof: field-of reads a hyperedge-attr-seeded field"
+  :fuel 2048
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (for-each (hyperedges HyperedgeType/COMMUNITY)
+      (update-node self social-class/observed (set (field-of it community/heat))))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    run_once_into(&scenario, rule, &mut graph, &mut sink)
+        .expect("field-of over a HyperedgeRef is served");
+    for id in [NodeId(0), NodeId(1)] {
+        let observed = graph
+            .node_attribute(id, "social-class/observed")
+            .expect("the node write landed");
+        assert_eq!(
+            observed.to_bits(),
+            (0.25_f64).to_bits(),
+            "node {id:?} read the seeded 0.25 through field-of"
+        );
+    }
+}
+
+/// §2.10 discipline 1, live: the qname's owning type must match the
+/// referent's declared type, on the write side exactly as on the read
+/// side. Fires BEFORE the field-registry lookup, so the foreign field
+/// needs no declaration.
+#[test]
+fn update_hyperedge_refuses_a_qname_owned_by_another_type() {
+    let rule = r#"
+(rule community/probe-referent-check
+  :material-basis "Task 6 proof: the §2.10 discipline-1 referent check"
+  :fuel 2048
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (for-each (hyperedges HyperedgeType/COMMUNITY)
+      (update-hyperedge it economic-sector/output (set 0.5c)))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(SCENARIO, rule, &mut graph, &mut sink).unwrap_err();
+    assert!(
+        err.contains("the referent is a COMMUNITY hyperedge, not ECONOMIC_SECTOR"),
+        "the referent check names both types: {err}"
+    );
+}
+
+/// Step 4's mechanism behind §8c guard 2: a hyperedge-namespace `:field`
+/// binding is invisible to subject derivation (D29 — a `:field` binding is
+/// node-scoped and stays node-scoped), so a rule whose ONLY field binding
+/// owns off a HyperedgeType refuses with the subject-type error rather
+/// than silently iterating an empty population.
+#[test]
+fn a_hyperedge_owned_field_binding_names_no_subject_type() {
+    let rule = r#"
+(rule community/probe-d29-binding
+  :material-basis "Task 6 Step 4 proof: a hyperedge-owned :field binding names no subject type"
+  :fuel 2048
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding heat :field community/heat))
+  (when (>= heat 0.0c))
+  (effects
+    (emit EventType/ORGANIZATION_SEEDED (probe 1))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(SCENARIO, rule, &mut graph, &mut sink).unwrap_err();
+    assert!(
+        err.contains("names no subject type"),
+        "the subject-type error, not silent inertness: {err}"
+    );
+}
+
+/// Step 6, write direction: a non-numeric write value refuses at the one
+/// funnel every write crosses — `numeric_write_value` — never coerced.
+#[test]
+fn update_hyperedge_refuses_a_wrong_typed_write_value() {
+    let rule = r#"
+(rule community/probe-write-type
+  :material-basis "Task 6 Step 6 proof: a wrong-typed write value refuses"
+  :fuel 2048
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (for-each (hyperedges HyperedgeType/COMMUNITY)
+      (update-hyperedge it community/heat (set #t)))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(SCENARIO, rule, &mut graph, &mut sink).unwrap_err();
+    assert!(
+        err.contains("cannot store") && err.contains("community/heat"),
+        "the write-value type refusal names the field: {err}"
+    );
+}
+
+/// Step 6, read direction: an enum-typed hyperedge field renders
+/// `Value::Enum` through the same `bind_field_value` a `:field` binding
+/// uses (D102's discharge, one element kind over), and arithmetic on it
+/// refuses — Enum<T> supports no arithmetic (§2.13).
+#[test]
+fn field_of_an_enum_typed_hyperedge_field_refuses_arithmetic() {
+    let scenario = r"
+(scenario ft/hyperedge-enum-arith
+  (defvocabulary HyperedgeType (COMMUNITY))
+  (defenum CommunityType (REVOLUTIONARY LIBERAL))
+  (deffield social-class/active int extensive)
+  (deffield social-class/observed coefficient intensive)
+  (deffield community/kind enum CommunityType)
+  (node alpha NodeType/SOCIAL_CLASS (social-class/active 1))
+  (node beta NodeType/SOCIAL_CLASS (social-class/active 1))
+  (hyperedge cell HyperedgeType/COMMUNITY (members alpha beta))
+  (hyperedge-attr cell community/kind CommunityType/REVOLUTIONARY))
+";
+    let rule = r#"
+(rule community/probe-enum-arith
+  :material-basis "Task 6 Step 6 proof: enum field read in arithmetic position refuses"
+  :fuel 2048
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (for-each (hyperedges HyperedgeType/COMMUNITY)
+      (update-node self social-class/observed (set (+ (field-of it community/kind) 1))))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let err = run_once_into(scenario, rule, &mut graph, &mut sink).unwrap_err();
+    assert!(
+        err.contains("no arithmetic is defined on"),
+        "Enum<T> in arithmetic position refuses: {err}"
+    );
+}


### PR DESCRIPTION
## Community port train, Task 6 (E2b)

The Task-5 substrate lane (`GraphSubstrate::update_hyperedge_attribute`, canonical section `0x07`) gets its BSL surface. The two Step-1 refusal pins (the III.7 storage refusal, the "not meaningful" `field-of` refusal) were pinned RED through the content driver first, then inverted into green proofs as the surface landed.

**What lands:**

- **`update-hyperedge` in BOTH dispatch sites** — execute path and collect path (`WriteTarget::Hyperedge`, APPLY-phase against the pre-state law), full `set`/`add`/`sub`/`scale` parity, enum `set` included, `Write::HyperedgeAttribute` recorded. Per the M4 lesson, each site owes its own mutation vector: killing the execute arm reds `evaluator::tests::update_edge_and_update_hyperedge_are_both_served` + the structural_verbs site-1 leg; killing the collect arm reds the site-2 leg + the content-driver `hyperedge_surface.rs::update_hyperedge_writes_through_the_tick`. Both proven at landing.
- **`field-of` over a `HyperedgeRef`** — `field_of_hyperedge` serves the own-field read (retiring the "not meaningful" refusal; the membership-payload lane now cites **#653**, never "slice 4"). The §2.10 discipline-1 referent check is one shared function, `check_hyperedge_referent_type`, on both the read and write sides (E-EVAL-033 on a dangling or mistyped referent).
- **The D29 mechanism** (the plan §8c guard 2's machinery): `tick::subject_type_of` gains the owner-kind filter with the scenario's `ClosedVocabulary` threaded through `run_tick`. An edge/hyperedge-owned `:field` binding is invisible to subject derivation — a rule with only such bindings refuses with the subject-type error instead of silently iterating an empty population. The filter acts on a **positive** owner-kind answer only: unknown segments pass through, so a partial vocabulary (e.g. HyperedgeType-only) cannot empty node populations.
- **`(hyperedge-attr <name> <qname> <literal>)`** hydration seeding, mirroring `(edge-attr …)`: the local name resolves through the name→`HyperedgeId` table Task 1 grew for exactly this consumer; the owner check reads the hyperedge's actual type back via `hyperedge_type_of`; the `(hyperedge, field)` pair is a KEY (`E-LOAD-057`); values convert through `attribute_value`'s one per-type literal law (int/fractional contract + enum-ordinal lane; Currency refuses — no hyperedge-scoped Currency lane, the edge ruling one kind over). Hydration writes carry no write log (same convention as `(edge-attr …)`).
- **Typecheck coverage both directions** (Step 6): wrong-scalar write refuses at `numeric_write_value`; enum-field read in arithmetic position refuses at `apply_arith` (Value::Enum via `bind_field_value`). The static enum-arithmetic check stays `update-node`-only — `update-edge`'s own parity level, deliberately not widened.
- Mint-time `<field-init>`s on `add-hyperedge` STAY refused, with the reason corrected (the storage exists; the init sugar is not routed to it in this train).

**D202** in `docs/reference/bsl-language.rst` records the ruling.

**Gates:** `rust:check` (fmt + clippy -D warnings + workspace tests + doc build), `qa:regression` (12 scenarios byte-identical + two-process determinism leg), `qa:vault-regression-ci` (both goldens byte-identical), `check:quick` — all green. Content corpus digests and the 16 tick pins unmoved (no content-file changes).
