### PR TITLE
docs(state): Community port train Tasks 1-6 landed (#680-#685)

### DIFF
--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -3,8 +3,34 @@
 
 meta:
   version: "2.70.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
-  updated: "2026-08-21"
+  updated: "2026-08-22"
   truth_status: |
+    (2026-08-22 COMMUNITY PORT TRAIN — TASKS 1-6 LANDED ON dev, #680-#685)
+    The hyperedge lane of the Community port (plan
+    docs/superpowers/plans/2026-08-18-community-port.md) is complete through
+    Task 6: T6 Grinding Attrition (#680 — vitality/subsistence-mortality,
+    κ = 1.0c derived at the named calibration fixture, D198/D199, the
+    POPULATION_ATTRITION tier1 row); Task 4 E1d (#681 — the ceiling map
+    chains scenario.hyperedge_types and the :max-members axis feeds from
+    max_members_seen, D200); Task 5 E2a (#682 — the seventh canonical
+    listing all_hyperedge_attributes, state_hash section 0x07,
+    CANONICAL_LAYOUT_VERSION = 4) plus its harvest fix (#683 — remove_node's
+    implicit hyperedge drops sweep own-field rows on both backends);
+    Task 3 E1c slice 3 (#684 — query::materialize serves hyperedges/
+    hyperedges-of/members-of, Element::Hyperedge THIRD with the ruled Ord,
+    E-EVAL-032 actually raised via hyperedge_type_of, D201); Task 6 E2b
+    (#685 — update-hyperedge in BOTH dispatch sites with per-site mutation
+    vectors, field-of over HyperedgeRef, (hyperedge-attr …) seeding through
+    the Task-1 name→HyperedgeId table, the D29 owner-kind filter in
+    tick::subject_type_of threaded the scenario vocabulary through run_tick
+    — the §8c guard 2 mechanism, D202). Every merge via mise run pr:merge
+    with the Copilot harvest; dev post-merge CI green each landing. NEXT:
+    Task 7 (world 1 .bscn + the Python mirror + the seven-shape spike, all
+    now reachable), then Tasks 8-11 (the community.bsl rule packs c00-c11)
+    and Task 12's records. The blocked half (threat scoring, solidarity
+    amplification, the CORE_ORGANIZER maintenance term) waits on #653 — the
+    AG(i) attributed-membership ceremony, a Director act.
+    PREVIOUS:
     (2026-08-21 WORKTREE SWEEP — EIGHT LOCAL TRAINS INTEGRATED AS ONE GREEN
     TREE, ON integration/worktree-sweep-2026-08-21, PR PENDING) All nine
     /media/data worktrees swept: bsl-hygiene-knockout (#671 Phase 0, the port


### PR DESCRIPTION
The `truth_status` ledger entry for the six Task-1…6 landings of the Community port train (hyperedge lane complete through Task 6 / E2b, D198-D202), with the Task-7+ outlook and the #653 blocked half named. Docs-only; no code, no content, no baselines.