### PR TITLE
test(tick): community conformance world + frozen mirror + registration (Community Task 7)

### DIFF
--- a/reports/community-frozen-corroboration-2026-08-18.md
+++ b/reports/community-frozen-corroboration-2026-08-18.md
@@ -1,0 +1,91 @@
+# Community frozen corroboration — world 1 (Task 7 Step 6)
+
+**Date:** 2026-08-22 (the artifact keeps the plan's dated filename).
+**Plan:** `docs/superpowers/plans/2026-08-18-community-port.md` §9 — "evidence, not the oracle".
+**Driver:** `reports/community_frozen_corroboration_2026_08_18.py` (preserved beside this file; run
+`uv run python reports/community_frozen_corroboration_2026_08_18.py`).
+
+This artifact drives the **real** frozen `CommunitySystem.step()`
+(`src/babylon/engine/systems/community.py`) over a hand-seeded `BabylonGraph` mirroring conformance
+world 1 (`rust/crates/babylon-tick/content/scenarios/community-conformance.bscn`) node-for-node.
+It is **evidence for the plan §1 archaeology, never the conformance oracle** — the oracle is the
+mirror (`rust/crates/babylon-tick/content/scenarios/community_conformance.py`), which transcribes
+the *rules*; this file records what the *frozen engine* actually does to the same world.
+
+## The drift the driver had to shim (evidence item 1)
+
+The frozen system could not be driven against the *current* topology unaided:
+`community.py:418` calls `graph.query_edges(source_id=…, edge_type=…)`, and the current
+`QueryMixin.query_edges` (`src/babylon/topology/adapters/query_mixin.py:70`) accepts only
+`edge_type`/`predicate`/`min_weight`/`max_weight` — the source-scoped parameter is gone. This is
+exactly the seam `src/babylon/sentinels/seam/registry.py:2171` rules `STRUCTURALLY_IMPOSSIBLE` in
+production, now measured from the driver side. The script's `FrozenCompatGraph` subclass restores
+the called signature by translating to the landed one (filter the type query by source); it touches
+no frozen source and no topology source, and its necessity is itself the evidence.
+
+## The C4 obligation — verdict: PASS
+
+World 1's n5 (`inactive-member`) was seeded **inactive and holding a real NEW_AFRIKAN membership**.
+Frozen's `_collect_memberships` (`community.py:472-474`) skips it, so `community_cost_modifier`
+must be **absent** from its post-step attribute dict. The verbatim dict, post-`step()`:
+
+```text
+{'_node_type': 'social_class', 'active': False, 'community_memberships': [{'agent_id': 'inactive-member', 'community_type': 'new_afrikan'}]}
+```
+
+**`community_cost_modifier` is ABSENT.** The mirror models the same field as a missing key (never
+`1.0`), and the Rust assertion in Tasks 10-11 reads the substrate's honest-null error. The plan's
+§1.4/C4 reading of frozen `:472-474` is confirmed; `c09`/`c10`'s `active` guard stands.
+
+## Frozen's outputs on world 1 (verbatim driver stdout)
+
+```text
+== post-step community states (frozen, real step()) ==
+new_afrikan: r=0.864865 l=0.135135 f=0.0
+  heat=0.475 cohesion=0.7275 education_pressure=0.225
+settler: r=0.0 l=0.5 f=0.5
+  heat=0.2375 cohesion=0.485 education_pressure=0.1125
+queer: r=0.761905 l=0.238095 f=0.0
+  heat=0.7124999999999999 cohesion=0.60625 education_pressure=0.45
+
+== per-node community_cost_modifier (frozen writes) ==
+na-worker: 1.09375
+na-organizer: 0.875
+settler-la: 1.0
+unaffiliated: 1.0
+```
+
+## Named divergence found BY this artifact: the SnapToGrid boundary (evidence item 2)
+
+Frozen's stored ternary is **not** the mirror's full-precision chain:
+
+| community | mirror (the oracle) | frozen stores |
+|---|---|---|
+| new_afrikan r | `0.8648648648648649` | `0.864865` |
+| new_afrikan l | `0.13513513513513511` | `0.135135` |
+| queer r | `0.7619047619047619` | `0.761905` |
+| queer l | `0.23809523809523808` | `0.238095` |
+
+Cause, pinned to code: `TernaryConsciousness`'s fields are `Probability`
+(`src/babylon/models/entities/consciousness.py:76-78`), and `Probability` carries the `SnapToGrid`
+validator (`src/babylon/models/types.py:50-58`), which quantizes to a **10⁻⁶ grid, ROUND_HALF_UP**
+(`src/babylon/kernel/math.py:41`, `_PRECISION = 6` at `:16`; the type's own docstring says 10⁻⁵ —
+stale, the constant is 6). Frozen therefore stores the grid-snapped value at the model boundary;
+the port's BSL lane stores raw f64. The mirror is deliberately the **unquantized** oracle — the
+rules compute the same operation chain frozen computes *before* the boundary snaps it. Every other
+value in world 1 (the decay triples, the cost modifiers) is already on-grid, which is why only the
+two divided ternaries show the seam. The pack's D-row register records this at its landing; Tasks
+9's assertions pin the **unquantized** values, and the divergence is stated in the pack header.
+
+The decay triples and the four cost modifiers agree to the bit between frozen and the mirror
+(`0.475`/`0.7275`/`0.225`, `0.2375`/`0.485`/`0.1125`, `0.7124999999999999`/`0.60625`/`0.45`;
+`1.09375`, `0.875`, `1.0`, `1.0`).
+
+## What this artifact does NOT show
+
+- The blocked half (threat scoring, solidarity amplification, CORE_ORGANIZER infrastructure
+  maintenance) ran in frozen — world 1 seeds no SOLIDARITY edges and no CORE_ORGANIZER roles, so
+  those paths exercised trivially. They remain #653-gated in the port regardless.
+- Bit-parity of the ternary **operation order**: frozen sums per-org (`org_landscape` order), the
+  port sums per-class (D-NF+3). In world 1 the dyadic seed values make both orders agree; the
+  divergence class is recorded in the plan, not reproduced here.

--- a/reports/community_frozen_corroboration_2026_08_18.py
+++ b/reports/community_frozen_corroboration_2026_08_18.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Community port train, Task 7 Step 6 — the frozen-corroboration driver.
+
+Drives the REAL frozen `CommunitySystem.step()` (the Python reference
+estate, `src/babylon/engine/systems/community.py`) over a hand-seeded
+`BabylonGraph` mirroring conformance world 1, and prints the evidence
+`reports/community-frozen-corroboration-2026-08-18.md` embeds verbatim.
+
+LEGAL because `_extract_memberships_from_node` accepts plain dicts
+(community.py:288-293) and `services.community_hypergraph` is a plain dict
+(:296-306) — the frozen path that `sentinels/seam/registry.py:2171` rules
+STRUCTURALLY_IMPOSSIBLE in production is runnable from a script. This is
+EVIDENCE for the plan §1 archaeology, NEVER the conformance oracle (the
+oracle is `content/scenarios/community_conformance.py`, the mirror).
+
+THE C4 OBLIGATION: world 1's n5 (`inactive-member`) is seeded here
+INACTIVE and holding a real NEW_AFRIKAN membership; frozen's
+`_collect_memberships` (community.py:472-474) must skip it, so
+`community_cost_modifier` must be ABSENT from its post-step attribute dict
+— printed verbatim below. If it is present, c09/c10's `active` guard is
+wrong and Task 10 STOPs.
+
+Run: `uv run python reports/community_frozen_corroboration_2026_08_18.py`
+"""
+
+from __future__ import annotations
+
+from babylon.engine.services import ServiceContainer
+from babylon.engine.systems.community import CommunitySystem
+from babylon.models.entities.community import CommunityState
+from babylon.models.entities.consciousness import TernaryConsciousness
+from babylon.models.enums import CommunityType
+from babylon.models.graph import GraphEdge
+from babylon.topology.graph import BabylonGraph
+
+
+class FrozenCompatGraph(BabylonGraph):
+    """The 2026-08-22 graph-protocol drift, made concrete as a shim.
+
+    The frozen `community.py` calls `query_edges(source_id=…, edge_type=…)`
+    (community.py:418) — the CURRENT `QueryMixin.query_edges`
+    (topology/adapters/query_mixin.py:70) accepts only
+    `edge_type`/`predicate`/`min_weight`/`max_weight`; the source-scoped
+    parameter is gone. That is precisely why
+    `sentinels/seam/registry.py:2171` rules the frozen path
+    STRUCTURALLY_IMPOSSIBLE in production — the engine's own seam no longer
+    admits it. This subclass restores the called signature by translating
+    to the landed one (filter the type query by source). It changes NO
+    frozen source and NO topology source — it is script scaffolding, and
+    its necessity is itself part of the evidence the report records.
+    """
+
+    def query_edges(  # type: ignore[override]
+        self,
+        edge_type=None,
+        source_id=None,
+        **kwargs,
+    ):
+        edges = super().query_edges(edge_type=edge_type, **kwargs)
+        if source_id is None:
+            yield from edges
+            return
+        for edge in edges:
+            if isinstance(edge, GraphEdge) and edge.source_id == source_id:
+                yield edge
+
+
+# ---- The world, hand-seeded node-for-node against the .bscn ----
+
+graph = FrozenCompatGraph()
+
+# Social classes: (name, active, memberships as plain dicts — the :288-293
+# lane). Membership community_type is the StrEnum's VALUE.
+graph.add_node("na-worker", _node_type="social_class", active=True)
+graph.add_node("na-organizer", _node_type="social_class", active=True)
+graph.add_node("settler-la", _node_type="social_class", active=True)
+graph.add_node("unaffiliated", _node_type="social_class", active=True)
+graph.add_node("inactive-member", _node_type="social_class", active=False)
+
+graph.nodes["na-worker"]["community_memberships"] = [
+    {"agent_id": "na-worker", "community_type": "new_afrikan"},
+    {"agent_id": "na-worker", "community_type": "queer"},
+]
+graph.nodes["na-organizer"]["community_memberships"] = [
+    {"agent_id": "na-organizer", "community_type": "new_afrikan"},
+]
+graph.nodes["settler-la"]["community_memberships"] = [
+    {"agent_id": "settler-la", "community_type": "settler"},
+]
+graph.nodes["unaffiliated"]["community_memberships"] = []
+# C4: the membership is REAL; the node is inactive.
+graph.nodes["inactive-member"]["community_memberships"] = [
+    {"agent_id": "inactive-member", "community_type": "new_afrikan"},
+]
+
+# Organizations: tendency as the StrEnum value, cadre_level, cohesion.
+graph.add_node(
+    "rev-org",
+    _node_type="organization",
+    consciousness_tendency="revolutionary",
+    cadre_level=0.5,
+    cohesion=0.8,
+)
+graph.add_node(
+    "lib-org",
+    _node_type="organization",
+    consciousness_tendency="liberal",
+    cadre_level=0.25,
+    cohesion=0.5,
+)
+graph.add_node(
+    "fash-org",
+    _node_type="organization",
+    consciousness_tendency="fascist",
+    cadre_level=0.5,
+    cohesion=0.25,
+)
+graph.add_node(
+    "no-member-org",
+    _node_type="organization",
+    consciousness_tendency="revolutionary",
+    cadre_level=1.0,
+    cohesion=1.0,
+)
+
+for src, tgt in [
+    ("rev-org", "na-worker"),
+    ("rev-org", "na-organizer"),
+    ("lib-org", "na-worker"),
+    ("lib-org", "settler-la"),
+    ("fash-org", "settler-la"),
+]:
+    graph.add_edge(src, tgt, _edge_type="membership")
+
+# Community states, world-1 seeds (the prior-tick ternary included).
+community_states = {
+    CommunityType.NEW_AFRIKAN: CommunityState(
+        community_type=CommunityType.NEW_AFRIKAN,
+        heat=0.5,  # type: ignore[arg-type]
+        cohesion=0.75,  # type: ignore[arg-type]
+        education_pressure=0.25,  # type: ignore[arg-type]
+        reproduction_cost_modifier=0.875,
+        consciousness=TernaryConsciousness(r=0.5, l=0.25, f=0.25),  # noqa: E741
+    ),
+    CommunityType.SETTLER: CommunityState(
+        community_type=CommunityType.SETTLER,
+        heat=0.25,  # type: ignore[arg-type]
+        cohesion=0.5,  # type: ignore[arg-type]
+        education_pressure=0.125,  # type: ignore[arg-type]
+        reproduction_cost_modifier=1.0,
+        consciousness=TernaryConsciousness(r=0.0, l=0.75, f=0.25),  # noqa: E741
+    ),
+    CommunityType.QUEER: CommunityState(
+        community_type=CommunityType.QUEER,
+        heat=0.75,  # type: ignore[arg-type]
+        cohesion=0.625,  # type: ignore[arg-type]
+        education_pressure=0.5,  # type: ignore[arg-type]
+        reproduction_cost_modifier=1.25,
+        consciousness=TernaryConsciousness(r=0.25, l=0.5, f=0.25),  # noqa: E741
+    ),
+}
+
+services = ServiceContainer.create(
+    community_hypergraph={"community_states": community_states},
+)
+
+# ---- Drive the real system ----
+CommunitySystem().step(graph, services, None)
+
+# ---- The evidence ----
+out = services.community_hypergraph["community_states"]
+print("== post-step community states (frozen, real step()) ==")
+for ct in (CommunityType.NEW_AFRIKAN, CommunityType.SETTLER, CommunityType.QUEER):
+    s = out[ct]
+    print(
+        f"{ct.value}: r={float(s.consciousness.r)!r} "
+        f"l={float(s.consciousness.l)!r} f={float(s.consciousness.f)!r}"
+    )
+    print(
+        f"  heat={float(s.heat)!r} cohesion={float(s.cohesion)!r} "
+        f"education_pressure={float(s.education_pressure)!r}"
+    )
+
+print()
+print("== per-node community_cost_modifier (frozen writes) ==")
+for node_id in ("na-worker", "na-organizer", "settler-la", "unaffiliated"):
+    attrs = graph.nodes[node_id]
+    print(f"{node_id}: {attrs.get('community_cost_modifier', 'ABSENT')!r}")
+
+print()
+print("== C4: inactive-member's post-step attribute dict, verbatim ==")
+print(repr(dict(graph.nodes["inactive-member"])))
+print()
+if "community_cost_modifier" in graph.nodes["inactive-member"]:
+    print("C4 VERDICT: FAIL — the field is PRESENT; c09/c10's active guard is wrong.")
+else:
+    print("C4 VERDICT: PASS — community_cost_modifier is ABSENT (frozen skips the inactive).")

--- a/rust/crates/babylon-bsl/tests/content_corpus_digests.rs
+++ b/rust/crates/babylon-bsl/tests/content_corpus_digests.rs
@@ -200,6 +200,10 @@ const PINNED_DIGESTS: &[(&str, &str)] = &[
         "d1b4577f98813cfd17b5e8bd394918a56c5e822c051790bc045254cf6b2a13ad",
     ),
     (
+        "community-conformance.bscn",
+        "bac0328bb0aca30998c9a8e4e40aecb5ce28f76700518a90221dc7a89feebb26",
+    ),
+    (
         "consciousness-ternary-conformance.bscn",
         "aaf93f0493b4baa02972f0f35bc045d1096495ba05669b06e9344ea059c6913b",
     ),

--- a/rust/crates/babylon-tick/content/content-sets.toml
+++ b/rust/crates/babylon-tick/content/content-sets.toml
@@ -24,6 +24,16 @@ consumers = [
 ]
 
 [[set]]
+id        = "community/conformance"
+scenario  = "scenarios/community-conformance.bscn"
+prelude   = []
+# The pack lands across Tasks 8-11 of the Community port train (issue
+# #667); Task 7's suite drives an in-test probe rule, so this row claims
+# the scenario only.
+rules     = []
+consumers = ["rust/crates/babylon-tick/tests/community_conformance.rs"]
+
+[[set]]
 id        = "consciousness/ternary-conformance"
 scenario  = "scenarios/consciousness-ternary-conformance.bscn"
 prelude   = ["declarations/worldview.bscn"]

--- a/rust/crates/babylon-tick/content/scenarios/community-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/community-conformance.bscn
@@ -1,0 +1,213 @@
+; The Community @6.0 port train's world 1 (issue #667, plan
+; docs/superpowers/plans/2026-08-18-community-port.md Task 7 Step 3).
+; Built fresh per the plan's node table — declaration order is id order:
+; n0..n9 below are NodeId(0)..NodeId(9), h0..h2 are HyperedgeId(0..2).
+; **Declare in this order and never renumber when extending** (the plan's
+; own instruction); later tasks APPEND deffields/defconsts above the node
+; block and never touch the node/hyperedge order.
+;
+; §3.7a CARRIER DISCLOSURE: n0 `community-register` is this world's ONE and
+; only NodeType/INSTITUTION node — the subject-type anchor for the pack's
+; six carrier-subject rules (c00/c05-c08/c11), not a mint of this pack's
+; own; §8c guard 4 (`exactly_one_institution_carrier`) asserts there is
+; exactly one, and never zero (a carrier-free world runs those six rules
+; over an empty population — silent inertness dressed as a passing test).
+;
+; The org tendency field is `organization/consciousness-tendency`, an
+; enum-typed deffield over ConsciousnessTendency in FROZEN DECLARATION
+; ORDER (ADR195): LIBERAL=0, FASCIST=1, REVOLUTIONARY=2 — the same ordinal
+; contract CommunityType carries below. `cadre-level`/`cohesion` are
+; probability-typed, mirroring the frozen reads (`community.py:413-414`).
+;
+; Dyadic-literal discipline (the plan's Step 3 instruction): every seed is
+; an exact dyadic rational EXCEPT `rev-org`'s `cohesion 0.8p` — 4/5 is not
+; dyadic, and the plan's node table pins 0.8p verbatim. That one value is
+; carried bit-identically anyway: the crate's scaled-literal contract
+; computes 8/10 as one correctly-rounded IEEE-754 division, and Python's
+; float("0.8") is the same correctly-rounded binary64 — the mirror and the
+; substrate agree to the bit without tolerance.
+;
+; §4-SPIKE VERDICTS (Task 7 Step 5, recorded here per the
+; solidarity-conformance.bscn:9-20 precedent) — ALL SEVEN PASS, each proven
+; by a throwaway rule through the real `run_once_into` driver against THIS
+; world (the throwaway file was deleted at the step's end; the verdicts
+; here and `community_conformance.rs`'s doc comment are the record):
+;  (a) a `for-each` over `(hyperedges HyperedgeType/COMMUNITY)` from a
+;      carrier-subject rule FIRES — one write landed on each of all three
+;      communities off a single firing (one carrier subject).
+;  (b) `(update-hyperedge it community/heat (set 0.5i))` inside that body
+;      WRITES — read back bit-exact (0.5) on h0/h1/h2.
+;  (c) `(for-each (hyperedges-of self HyperedgeType/COMMUNITY) …)` from a
+;      SOCIAL_CLASS-subject rule FIRES and `(field-of it community/heat)`
+;      READS inside — na-worker's two memberships iterated in ascending
+;      HyperedgeId order (proven by last-write-wins: 0.75 = h2's heat, not
+;      h0's 0.5); unaffiliated n4 was never written (honest null).
+;  (d) repeated `(scale 0.5c)` across a `for-each` ACCUMULATES
+;      MULTIPLICATIVELY — na-worker's seeded active=1 read back 0.25
+;      (1 × 0.5 × 0.5): the operand is pre-computed per write, and the
+;      COMBINE reads the current value at APPLY, so two collected scales
+;      compose as a product.
+;  (e) the 14-arm `if`-chain over `(field-of it community/kind)` enum
+;      equality LOADS and EVALUATES — h0/h1/h2 landed 0.136/0.0/0.04, each
+;      community's own ADR214 floor. The only landed precedent was 3-arm
+;      (territory.bsl:130-137); the 14-arm is now demonstrated, and §6.2's
+;      c06 dispatch stands on it.
+;  (f) a same-tick cross-rule read SEES the earlier rule's write —
+;      `community/spike-f-a`'s `set 0.125i` was read by `community/
+;      spike-f-b` as 0.125 (rule-id byte order carried it), never the
+;      seeded 0.25 (§8b's fatal rows rely on exactly this).
+;  (g) the world LOADS with hyperedge-querying rules under the measured
+;      static bound — Task 4's ceiling supply chain reaches this scenario
+;      (census-fed HyperedgeType/COMMUNITY ceiling 3, max-members 3); no
+;      E-LOAD-040/042/045 fired for any spike rule above.
+; No shape refused; §8's rule split stands as planned.
+;
+; The 14-row ADR214 floor table (§6.2 / DG-3: all 14 rows, never a partial
+; transcription) and the three decay alphas are the defconst block below;
+; each floor row carries its ADR214 provenance (Ruling 1 + erratum 9,
+; Ruling 2's demotions, INCARCERATED's named unreachability).
+(scenario community/conformance-world-1
+  ; ---- the closed vocabulary: all three element kinds, so every field
+  ; namespace below resolves a POSITIVE owner (the D29 filter's positive-
+  ; answer-only law, D202) ----
+  (defvocabulary NodeType (INSTITUTION SOCIAL_CLASS ORGANIZATION))
+  (defvocabulary EdgeType (MEMBERSHIP))
+  (defvocabulary HyperedgeType (COMMUNITY))
+  ; ---- the two enum registries, FROZEN DECLARATION ORDER (ADR195) ----
+  ; CommunityType: models/enums/community.py:38-55 verbatim — SETTLER=0,
+  ; PATRIARCHAL=1, NEW_AFRIKAN=2, FIRST_NATIONS=3, CHICANO=4, WOMEN=5,
+  ; TRANS=6, DISABLED=7, QUEER=8, UNDOCUMENTED=9, INCARCERATED=10,
+  ; YOUTH=11, ADULT=12, ELDER=13. The ordinal-parity test pins this order.
+  (defenum CommunityType
+    (SETTLER PATRIARCHAL NEW_AFRIKAN FIRST_NATIONS CHICANO WOMEN TRANS
+     DISABLED QUEER UNDOCUMENTED INCARCERATED YOUTH ADULT ELDER))
+  ; ConsciousnessTendency: models/enums/consciousness.py:82-85 verbatim.
+  (defenum ConsciousnessTendency (LIBERAL FASCIST REVOLUTIONARY))
+
+  ; ---- deffields ----
+  ; The §3.7a anchor: bound by every carrier-subject rule, never read
+  ; again (control-ratio.bsl:277's "SUBJECT-TYPE ANCHOR ONLY" pattern).
+  (deffield institution/community-carrier int extensive)
+  (deffield social-class/active int extensive)
+  ; c09/c10's per-class accumulator (real: a product of per-community
+  ; modifiers, not [0,1]-bounded — formulas/community.py:164-174).
+  (deffield social-class/community-cost-modifier real intensive)
+  (deffield organization/cadre-level probability intensive)
+  (deffield organization/cohesion probability intensive)
+  (deffield organization/consciousness-tendency enum ConsciousnessTendency)
+  ; The hyperedge own-fields (Task 5 storage, Task 6 surface).
+  (deffield community/kind enum CommunityType)
+  (deffield community/heat intensity intensive)
+  (deffield community/cohesion intensity intensive)
+  (deffield community/education-pressure intensity intensive)
+  (deffield community/reproduction-cost-modifier real intensive)
+  ; The prior-tick ternary — c05/c06's `density-sum > 0` skip gate has
+  ; something to preserve (the plan's Step 3 hyperedge note).
+  (deffield community/revolutionary probability intensive)
+  (deffield community/liberal probability intensive)
+  (deffield community/fascist probability intensive)
+
+  ; ---- the 14-row ADR214 floor table (§6.1 verbatim values) ----
+  (defconst community/floor-new-afrikan 0.136p)   ; measured, unrestricted_3218: 0.232693906 − 0.096223732 = 0.136470174 → 3dp 0.136 (erratum 9: the posted 0.137 was a double-rounding artifact)
+  (defconst community/floor-first-nations 0.155p) ; measured, same variant (Ruling 3: FIRST_NATIONS > NEW_AFRIKAN breaks the frozen tie — emergent, not stipulated)
+  (defconst community/floor-chicano 0.113p)       ; measured, same variant
+  (defconst community/floor-settler 0.0p)         ; identically zero by construction — the settler pole IS the norm (preserves consciousness.py:420-426's hegemonic-default claim)
+  (defconst community/floor-patriarchal 0.0p)     ; structural: hegemonic default
+  (defconst community/floor-youth 0.0p)           ; structural: lifecycle phase
+  (defconst community/floor-adult 0.0p)           ; structural: lifecycle phase
+  (defconst community/floor-incarcerated 0.18p)   ; unchanged (Ruling 2) — NAMED PROBLEM: unreachable in principle from B17001 (the universe excludes the institutionalized); a future ruling needs BJS/Vera-class data
+  (defconst community/floor-women 0.04p)          ; unchanged, CONFIDENCE DEMOTED per Ruling 2 (only cited provenance is the literal string "estimated")
+  (defconst community/floor-trans 0.06p)          ; unchanged, demoted as above
+  (defconst community/floor-disabled 0.03p)       ; unchanged, demoted as above
+  (defconst community/floor-queer 0.04p)          ; unchanged, demoted as above
+  (defconst community/floor-undocumented 0.10p)   ; unchanged, demoted as above
+  (defconst community/floor-elder 0.02p)          ; estimated (generational memory)
+  ; ---- the decay alphas (plan §-table 493-495) ----
+  (defconst community/heat-decay-alpha 0.05c)              ; config/defines/organizations.py:22-27
+  (defconst community/cohesion-decay-alpha 0.03c)          ; organizations.py:28-33
+  (defconst community/education-pressure-decay 0.1c)       ; config/defines/consciousness.py:138-143
+
+  ; ---- nodes (id order — never renumber) ----
+  ; n0: THE world's one and only INSTITUTION node (§3.7a).
+  (node community-register NodeType/INSTITUTION
+    (institution/community-carrier 1))
+  ; n1: member of NEW_AFRIKAN + QUEER — the multi-community witness.
+  (node na-worker NodeType/SOCIAL_CLASS (social-class/active 1))
+  ; n2: member of NEW_AFRIKAN only.
+  (node na-organizer NodeType/SOCIAL_CLASS (social-class/active 1))
+  ; n3: member of SETTLER — the 0.0-floor control.
+  (node settler-la NodeType/SOCIAL_CLASS (social-class/active 1))
+  ; n4: NO membership — pins `community-cost-modifier == 1.0` exactly
+  ; (c09's reset writes it; c10's empty for-each leaves it).
+  (node unaffiliated NodeType/SOCIAL_CLASS (social-class/active 1))
+  ; n5: member of NEW_AFRIKAN but INACTIVE — excluded from the census
+  ; (frozen community.py:472-474) AND from the cost-modifier write
+  ; entirely: its `community-cost-modifier` must read as the substrate's
+  ; honest-null error, never 1.0 (§1.4, C4).
+  (node inactive-member NodeType/SOCIAL_CLASS (social-class/active 0))
+  ; n6: REVOLUTIONARY tendency; MEMBERSHIP → n1, n2.
+  (node rev-org NodeType/ORGANIZATION
+    (organization/cadre-level 0.5p) (organization/cohesion 0.8p)
+    (organization/consciousness-tendency ConsciousnessTendency/REVOLUTIONARY))
+  ; n7: LIBERAL; MEMBERSHIP → n1, n3.
+  (node lib-org NodeType/ORGANIZATION
+    (organization/cadre-level 0.25p) (organization/cohesion 0.5p)
+    (organization/consciousness-tendency ConsciousnessTendency/LIBERAL))
+  ; n8: FASCIST; MEMBERSHIP → n3.
+  (node fash-org NodeType/ORGANIZATION
+    (organization/cadre-level 0.5p) (organization/cohesion 0.25p)
+    (organization/consciousness-tendency ConsciousnessTendency/FASCIST))
+  ; n9: ZERO MEMBERSHIP edges — pins frozen's `:421` skip (no member_agents
+  ; → never enters org_data).
+  (node no-member-org NodeType/ORGANIZATION
+    (organization/cadre-level 1.0p) (organization/cohesion 1.0p)
+    (organization/consciousness-tendency ConsciousnessTendency/REVOLUTIONARY))
+
+  ; ---- MEMBERSHIP edges (org → class), strength 1 exactly ----
+  (edge EdgeType/MEMBERSHIP rev-org na-worker 1)
+  (edge EdgeType/MEMBERSHIP rev-org na-organizer 1)
+  (edge EdgeType/MEMBERSHIP lib-org na-worker 1)
+  (edge EdgeType/MEMBERSHIP lib-org settler-la 1)
+  (edge EdgeType/MEMBERSHIP fash-org settler-la 1)
+
+  ; ---- hyperedges (own id counter — never renumber) ----
+  ; h0: new-afrikan (n1, n2, n5) — n5's membership is REAL but inactive.
+  (hyperedge new-afrikan HyperedgeType/COMMUNITY
+    (members na-worker na-organizer inactive-member))
+  ; h1: settler (n3).
+  (hyperedge settler HyperedgeType/COMMUNITY (members settler-la))
+  ; h2: queer (n1).
+  (hyperedge queer HyperedgeType/COMMUNITY (members na-worker))
+
+  ; ---- hyperedge own-field seeds (Task 5 storage, Task 6's
+  ; (hyperedge-attr …) form): kind + heat + cohesion + education-pressure
+  ; + reproduction-cost-modifier + the prior-tick ternary, per the plan's
+  ; Step 3 hyperedge note ----
+  (hyperedge-attr new-afrikan community/kind CommunityType/NEW_AFRIKAN)
+  (hyperedge-attr new-afrikan community/heat 0.5i)
+  (hyperedge-attr new-afrikan community/cohesion 0.75i)
+  (hyperedge-attr new-afrikan community/education-pressure 0.25i)
+  (hyperedge-attr new-afrikan community/reproduction-cost-modifier 0.875r)
+  (hyperedge-attr new-afrikan community/revolutionary 0.5p)
+  (hyperedge-attr new-afrikan community/liberal 0.25p)
+  (hyperedge-attr new-afrikan community/fascist 0.25p)
+
+  (hyperedge-attr settler community/kind CommunityType/SETTLER)
+  (hyperedge-attr settler community/heat 0.25i)
+  (hyperedge-attr settler community/cohesion 0.5i)
+  (hyperedge-attr settler community/education-pressure 0.125i)
+  (hyperedge-attr settler community/reproduction-cost-modifier 1)
+  (hyperedge-attr settler community/revolutionary 0.0p)
+  (hyperedge-attr settler community/liberal 0.75p)
+  (hyperedge-attr settler community/fascist 0.25p)
+
+  (hyperedge-attr queer community/kind CommunityType/QUEER)
+  (hyperedge-attr queer community/heat 0.75i)
+  (hyperedge-attr queer community/cohesion 0.625i)
+  (hyperedge-attr queer community/education-pressure 0.5i)
+  ; >1.0 — the one modifier a [0,1]-bounded literal cannot carry; the
+  ; r-lane carries it exactly (5/4 is dyadic).
+  (hyperedge-attr queer community/reproduction-cost-modifier 1.25r)
+  (hyperedge-attr queer community/revolutionary 0.25p)
+  (hyperedge-attr queer community/liberal 0.5p)
+  (hyperedge-attr queer community/fascist 0.25p))

--- a/rust/crates/babylon-tick/content/scenarios/community_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/community_conformance.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""The Community @6.0 port train's frozen-mirror oracle (issue #667, plan
+docs/superpowers/plans/2026-08-18-community-port.md §9 — the D146/ADR183
+convention).
+
+STANDALONE. No `babylon` import, no pytest, no third-party anything. It
+transcribes the RULES' binding order and collect-then-apply semantics
+term-for-term over the literal WORLD dict below — which matches
+`community-conformance.bscn` node-for-node, hyperedge-for-hyperedge,
+seed-for-seed — never the frozen engine's code (the frozen engine is
+EVIDENCE, captured separately in
+reports/community-frozen-corroboration-2026-08-18.md; it prints frozen's
+own, sometimes-diverged answer — D-NF+3's summation order and D-NF+5's
+500-org cap live there).
+
+Per §9, this header states, for this pack specifically:
+
+1. THE EXACT RULE ORDER: c00 → c01 → c02 → c03r → c03l → c03f → c04 → c05
+   → c06 → c07 → c08 → c09 → c10 → c11. Each rule applies ALL of its
+   writes before the next rule reads (§8b's D116 ledger — the cross-rule
+   reads this pack relies on, fatal rows included).
+2. PRE-STATE WITHIN A RULE: a rule's for-each accumulations are COLLECTED
+   against the rule-entry state and APPLIED in ascending order only after
+   the whole subject population has collected — so c01's `add 1`s against
+   one hyperedge never observe each other mid-rule (§4.2 chapter C4).
+3. THE EXACT f64 OPERATION ORDER: every accumulator sums
+   subject-ascending (NodeId) outer, ascending HyperedgeId inner (D25);
+   c10's PRODUCT compounds in ascending HyperedgeId order — D-NF+13's
+   multiplication-order divergence lives exactly there.
+4. THE FLOOR-DISPATCH ARM each seeded community takes (ADR214 provenance):
+   h0 NEW_AFRIKAN → 0.136 (measured, unrestricted_3218, erratum 9);
+   h1 SETTLER → 0.0 (identically zero by construction); h2 QUEER → 0.04
+   (unchanged, confidence demoted per Ruling 2). In world 1 NO arm binds
+   (every normalized r clears its floor) — the binding case is world 2's,
+   Task 9.
+5. UNWRITTEN FIELDS, PER NODE: n5 (inactive-member) holds a REAL
+   membership in h0 but is inactive (frozen community.py:472-474), so c09
+   never resets and c10 never accumulates its `community-cost-modifier` —
+   the mirror models that field as ABSENT (the key does not exist), never
+   as 1.0, so the Rust assertion reads the substrate's honest-null error
+   (§1.4, C4). A mirror that defaults an unwritten field is a mirror that
+   cannot catch a fabricated write.
+
+c07/c08 are DG-2-GATED (the Director question is unresolved at authoring):
+transcribed and printed here because the mirror is the oracle and the
+values cost nothing — their .bsl RULES do not land while the gate holds.
+"""
+
+from __future__ import annotations
+
+import math
+
+# ---------------------------------------------------------------------
+# The literal world — community-conformance.bscn, transcribed.
+# Nodes in declaration order (id order); hyperedges in their own order.
+# ---------------------------------------------------------------------
+
+# (name → fields); active classes only drive the census/cost lanes.
+NODES: list[dict[str, object]] = [
+    # n0 — the §3.7a singleton carrier.
+    {"name": "community-register", "type": "INSTITUTION", "community-carrier": 1},
+    {"name": "na-worker", "type": "SOCIAL_CLASS", "active": 1},
+    {"name": "na-organizer", "type": "SOCIAL_CLASS", "active": 1},
+    {"name": "settler-la", "type": "SOCIAL_CLASS", "active": 1},
+    {"name": "unaffiliated", "type": "SOCIAL_CLASS", "active": 1},
+    {"name": "inactive-member", "type": "SOCIAL_CLASS", "active": 0},
+    # n6 — REVOLUTIONARY; MEMBERSHIP → n1, n2.
+    {
+        "name": "rev-org",
+        "type": "ORGANIZATION",
+        "cadre-level": 0.5,
+        "cohesion": 0.8,
+        "tendency": "REVOLUTIONARY",
+    },
+    # n7 — LIBERAL; MEMBERSHIP → n1, n3.
+    {
+        "name": "lib-org",
+        "type": "ORGANIZATION",
+        "cadre-level": 0.25,
+        "cohesion": 0.5,
+        "tendency": "LIBERAL",
+    },
+    # n8 — FASCIST; MEMBERSHIP → n3.
+    {
+        "name": "fash-org",
+        "type": "ORGANIZATION",
+        "cadre-level": 0.5,
+        "cohesion": 0.25,
+        "tendency": "FASCIST",
+    },
+    # n9 — zero MEMBERSHIP edges (frozen's :421 skip).
+    {
+        "name": "no-member-org",
+        "type": "ORGANIZATION",
+        "cadre-level": 1.0,
+        "cohesion": 1.0,
+        "tendency": "REVOLUTIONARY",
+    },
+]
+
+# (source_name, target_name) — the five MEMBERSHIP edges, declaration order.
+MEMBERSHIP_EDGES: list[tuple[str, str]] = [
+    ("rev-org", "na-worker"),
+    ("rev-org", "na-organizer"),
+    ("lib-org", "na-worker"),
+    ("lib-org", "settler-la"),
+    ("fash-org", "settler-la"),
+]
+
+HYPEREDGES: list[dict[str, object]] = [
+    # h0 — NEW_AFRIKAN over (n1, n2, n5); n5's membership is real but inactive.
+    {
+        "name": "new-afrikan",
+        "kind": "NEW_AFRIKAN",
+        "members": ["na-worker", "na-organizer", "inactive-member"],
+        "heat": 0.5,
+        "cohesion": 0.75,
+        "education-pressure": 0.25,
+        "reproduction-cost-modifier": 0.875,
+        "revolutionary": 0.5,
+        "liberal": 0.25,
+        "fascist": 0.25,
+    },
+    # h1 — SETTLER over (n3). The 0.0-floor control.
+    {
+        "name": "settler",
+        "kind": "SETTLER",
+        "members": ["settler-la"],
+        "heat": 0.25,
+        "cohesion": 0.5,
+        "education-pressure": 0.125,
+        "reproduction-cost-modifier": 1.0,
+        "revolutionary": 0.0,
+        "liberal": 0.75,
+        "fascist": 0.25,
+    },
+    # h2 — QUEER over (n1).
+    {
+        "name": "queer",
+        "kind": "QUEER",
+        "members": ["na-worker"],
+        "heat": 0.75,
+        "cohesion": 0.625,
+        "education-pressure": 0.5,
+        "reproduction-cost-modifier": 1.25,
+        "revolutionary": 0.25,
+        "liberal": 0.5,
+        "fascist": 0.25,
+    },
+]
+
+# The ADR214 floor table (§6.1 verbatim; 14 rows, frozen declaration order).
+FLOOR: dict[str, float] = {
+    "SETTLER": 0.0,  # by construction — the settler pole IS the norm
+    "PATRIARCHAL": 0.0,  # structural: hegemonic default
+    "NEW_AFRIKAN": 0.136,  # measured, unrestricted_3218 (erratum 9)
+    "FIRST_NATIONS": 0.155,  # measured (Ruling 3: breaks the frozen tie)
+    "CHICANO": 0.113,  # measured
+    "WOMEN": 0.04,  # unchanged, confidence demoted (Ruling 2)
+    "TRANS": 0.06,  # unchanged, demoted
+    "DISABLED": 0.03,  # unchanged, demoted
+    "QUEER": 0.04,  # unchanged, demoted
+    "UNDOCUMENTED": 0.10,  # unchanged, demoted
+    "INCARCERATED": 0.18,  # unchanged — unreachable from B17001 by principle
+    "YOUTH": 0.0,  # structural: lifecycle
+    "ADULT": 0.0,  # structural: lifecycle
+    "ELDER": 0.02,  # estimated (generational memory)
+}
+
+HEAT_DECAY_ALPHA = 0.05  # organizations.py:22-27
+COHESION_DECAY_ALPHA = 0.03  # organizations.py:28-33
+EDUCATION_PRESSURE_DECAY = 0.1  # consciousness.py:138-143
+
+NAME_TO_NODE: dict[str, int] = {str(n["name"]): i for i, n in enumerate(NODES)}
+
+
+def census(comms: list[dict[str, float]]) -> None:
+    """c00 → c01, in rule order (the reset and the member census)."""
+
+    # ---- c00-census-reset (carrier): the accumulators were seeded above
+    # at 0 — this rule's writes are exactly those zeros; the collect pass
+    # writes them over any prior tick (world 1 runs one tick, so the reset
+    # is the identity here and STILL transcribed, because Task 12's
+    # multi-tick worlds need the order visible). ----
+    for c in comms:  # ascending HyperedgeId
+        c["member-count"] = 0.0
+        c["r-raw"] = 0.0
+        c["l-raw"] = 0.0
+        c["f-raw"] = 0.0
+        c["density-sum"] = 0.0
+
+    # ---- c01-member-census (social-class, active only) ----
+    # Pre-state law: every `add 1` collects against the c00-reset state;
+    # the count lands as the SET of memberships, summed — subject-ascending
+    # outer, ascending HyperedgeId inner (the writes commute, being +1s,
+    # but the ORDER is stated because D-NF+13 says order is never free).
+    census_pending: list[int] = [0] * len(comms)
+    for node in NODES:  # ascending declaration order
+        if node["type"] != "SOCIAL_CLASS" or node.get("active") != 1:
+            continue
+        for hid, h in enumerate(HYPEREDGES):  # ascending HyperedgeId
+            if node["name"] in h["members"]:
+                census_pending[hid] += 1
+    for hid, n in enumerate(census_pending):
+        comms[hid]["member-count"] += float(n)
+
+
+def org_weights_and_contributions(
+    comms: list[dict[str, float]],
+) -> dict[int, dict[str, float]]:
+    """c02 → c03r → c03l → c03f → c04, in rule order."""
+    # Per-class org accumulators (c02 mints them at 0 each tick).
+    class_weights: dict[int, dict[str, float]] = {}
+
+    # ---- c02-org-weight-reset (social-class): mint the four zeros ----
+    for nid, node in enumerate(NODES):
+        if node["type"] == "SOCIAL_CLASS":
+            class_weights[nid] = {
+                "org-r-weight": 0.0,
+                "org-l-weight": 0.0,
+                "org-f-weight": 0.0,
+                "org-count": 0.0,
+            }
+
+    # ---- c03r / c03l / c03f (organization; the three-rule partition) ----
+    # For each tendency rule in order: subjects ascending NodeId, for-each
+    # (neighbors self MEMBERSHIP :out SOCIAL_CLASS) — MEMBERSHIP_EDGES is
+    # declaration-ordered, and each org's targets are ascending by
+    # construction. Each push: weight += cadre × cohesion; count += 1.
+    for tendency in ("REVOLUTIONARY", "LIBERAL", "FASCIST"):
+        key = {
+            "REVOLUTIONARY": "org-r-weight",
+            "LIBERAL": "org-l-weight",
+            "FASCIST": "org-f-weight",
+        }[tendency]
+        for node in NODES:
+            if node["type"] != "ORGANIZATION" or node["tendency"] != tendency:
+                continue
+            push = float(node["cadre-level"]) * float(node["cohesion"])
+            for src, tgt in MEMBERSHIP_EDGES:
+                if src != node["name"]:
+                    continue
+                class_weights[NAME_TO_NODE[tgt]][key] += push
+                class_weights[NAME_TO_NODE[tgt]]["org-count"] += 1.0
+
+    # ---- c04-community-contribution-push (social-class) ----
+    # For each class (ascending), for each of its hyperedges (ascending):
+    # r-raw += org-r-weight / member-count (l, f likewise), and
+    # density-sum += org-count / member-count. n5's zero weights make its
+    # pushes exact zeros — transcribed, since the plan's c04 row gates on
+    # nothing but the census divisor.
+    for nid, node in enumerate(NODES):
+        if node["type"] != "SOCIAL_CLASS":
+            continue
+        w = class_weights[nid]
+        for hid, h in enumerate(HYPEREDGES):
+            if node["name"] not in h["members"]:
+                continue
+            divisor = comms[hid]["member-count"]
+            comms[hid]["r-raw"] += w["org-r-weight"] / divisor
+            comms[hid]["l-raw"] += w["org-l-weight"] / divisor
+            comms[hid]["f-raw"] += w["org-f-weight"] / divisor
+            comms[hid]["density-sum"] += w["org-count"] / divisor
+
+    return class_weights
+
+
+def readout(comms: list[dict[str, float]]) -> None:
+    """c05 → c06 → c07 → c08, in rule order (c07/c08 DG-2-gated)."""
+    # ---- c05-normalize (carrier) — the density-sum > 0 skip gate ----
+    # unorganized = max(0, 1 − density-sum) folded into l-raw; total =
+    # r+l+f; degenerate (total < 1e-10) → (0, 1, 0) AND NOTHING ELSE (the
+    # floor routes through c06, bit-identically — §6.2 I5).
+    for _hid, c in enumerate(comms):
+        if not c["density-sum"] > 0.0:
+            continue  # no-org skip gate: the prior ternary is preserved
+        unorganized = max(0.0, 1.0 - c["density-sum"])
+        l_raw = c["l-raw"] + unorganized
+        total = c["r-raw"] + l_raw + c["f-raw"]
+        if total < 1e-10:
+            c["revolutionary"], c["liberal"], c["fascist"] = 0.0, 1.0, 0.0
+        else:
+            c["revolutionary"] = c["r-raw"] / total
+            c["liberal"] = l_raw / total
+            c["fascist"] = c["f-raw"] / total
+
+    # ---- c06-substrate-floor (carrier) — the pack's ONLY 14-arm dispatch
+    # (a dict here: the mirror transcribes SEMANTICS; the .bsl arm chain is
+    # the language's only lookup shape, §6.2). The r < floor redistribution
+    # with its lf > 1e-10 two-arm split (formulas/consciousness.py:98-107).
+    for hid, c in enumerate(comms):
+        if not c["density-sum"] > 0.0:
+            continue  # the same skip gate — frozen's :452 `if org_landscape`
+        floor = FLOOR[str(HYPEREDGES[hid]["kind"])]
+        if c["revolutionary"] < floor:
+            remaining = 1.0 - floor
+            lf = c["liberal"] + c["fascist"]
+            if lf > 1e-10:
+                c["liberal"] = c["liberal"] * remaining / lf
+                c["fascist"] = c["fascist"] * remaining / lf
+            else:
+                c["liberal"] = remaining
+                c["fascist"] = 0.0
+            c["revolutionary"] = floor
+
+    # ---- c07-contestation + c08-dominant-tendency (DG-2-GATED — printed
+    # here as oracle values; the .bsl rules land only on the Director's
+    # ruling). Same skip gate. ----
+    for _hid, c in enumerate(comms):
+        if not c["density-sum"] > 0.0:
+            c["contestation"] = float("nan")  # not recomputed — preserved
+            c["dominant"] = float("nan")
+            continue
+        r, l_val, f = c["revolutionary"], c["liberal"], c["fascist"]
+        entropy = 0.0
+        for p in (r, l_val, f):
+            if p > 1e-10:
+                entropy -= p * math.log(p)
+        c["contestation"] = entropy / math.log(3)
+        # argmax, LIBERAL > REVOLUTIONARY > FASCIST at 1e-6
+        # (entities/consciousness.py:167-191, epsilon :189).
+        max_val = max(r, l_val, f)
+        for tendency, v in (("LIBERAL", l_val), ("REVOLUTIONARY", r), ("FASCIST", f)):
+            if abs(v - max_val) < 1e-6:
+                c["dominant"] = tendency  # type: ignore[assignment]
+                break
+
+
+def cost_and_decay(
+    comms: list[dict[str, float]],
+) -> dict[int, float]:
+    """c09 → c10 → c11, in rule order."""
+    # ---- c09-cost-modifier-reset (social-class, ACTIVE ONLY) ----
+    # The inactive n5 is written NOTHING — its key stays ABSENT (§9 item 5).
+    cost_modifier: dict[int, float] = {}
+    for nid, node in enumerate(NODES):
+        if node["type"] == "SOCIAL_CLASS" and node.get("active") == 1:
+            cost_modifier[nid] = 1.0
+
+    # ---- c10-cost-modifier-accumulate (active only) ----
+    # scale by each membership's reproduction-cost-modifier, ascending
+    # HyperedgeId — D-NF+13's float-product-order divergence lives here.
+    for nid, node in enumerate(NODES):
+        if node["type"] != "SOCIAL_CLASS" or node.get("active") != 1:
+            continue
+        for hid, h in enumerate(HYPEREDGES):
+            if node["name"] in h["members"]:
+                cost_modifier[nid] *= comms[hid]["reproduction-cost-modifier"]
+
+    # ---- c11-state-decay (carrier) — max(0, x·(1−α)) per arm; the
+    # infrastructure arm is EXCLUDED (§5 — the CORE_ORGANIZER maintenance
+    # term waits on #653). ----
+    for c in comms:
+        c["heat"] = max(0.0, c["heat"] * (1.0 - HEAT_DECAY_ALPHA))
+        c["cohesion"] = max(0.0, c["cohesion"] * (1.0 - COHESION_DECAY_ALPHA))
+        c["education-pressure"] = max(
+            0.0, c["education-pressure"] * (1.0 - EDUCATION_PRESSURE_DECAY)
+        )
+
+    return cost_modifier
+
+
+def run() -> None:
+    # Hyperedge scratch state the rules read/write: the seeded own-fields
+    # plus the c00-c04 accumulators (minted by c00's reset, not seeded).
+    comms: list[dict[str, float]] = []
+    for h in HYPEREDGES:
+        comms.append(
+            {
+                "heat": float(h["heat"]),
+                "cohesion": float(h["cohesion"]),
+                "education-pressure": float(h["education-pressure"]),
+                "reproduction-cost-modifier": float(h["reproduction-cost-modifier"]),
+                "revolutionary": float(h["revolutionary"]),
+                "liberal": float(h["liberal"]),
+                "fascist": float(h["fascist"]),
+                "member-count": 0.0,
+                "r-raw": 0.0,
+                "l-raw": 0.0,
+                "f-raw": 0.0,
+                "density-sum": 0.0,
+            }
+        )
+
+    census(comms)
+    org_weights_and_contributions(comms)
+    readout(comms)
+    cost_modifier = cost_and_decay(comms)
+
+    # ---- the printout: every oracle value, full round-trip precision ----
+    print("community-conformance world 1 — mirror output (the oracle)")
+    for hid, h in enumerate(HYPEREDGES):
+        c = comms[hid]
+        print(f"h{hid} {h['name']} kind={h['kind']}")
+        print(f"  member-count = {c['member-count']!r}")
+        print(f"  density-sum  = {c['density-sum']!r}")
+        print(f"  r = {c['revolutionary']!r}")
+        print(f"  l = {c['liberal']!r}")
+        print(f"  f = {c['fascist']!r}")
+        contestation = c["contestation"]
+        if math.isnan(contestation):
+            print("  contestation = PRESERVED (no-org skip gate)")
+            print("  dominant     = PRESERVED (no-org skip gate)")
+        else:
+            print(f"  contestation = {contestation!r}   (DG-2-gated)")
+            print(f"  dominant     = {c['dominant']}   (DG-2-gated)")
+        print(f"  decayed heat               = {c['heat']!r}")
+        print(f"  decayed cohesion           = {c['cohesion']!r}")
+        print(f"  decayed education-pressure = {c['education-pressure']!r}")
+    for nid, node in enumerate(NODES):
+        if node["type"] != "SOCIAL_CLASS":
+            continue
+        if nid in cost_modifier:
+            print(f"n{nid} {node['name']}: community-cost-modifier = {cost_modifier[nid]!r}")
+        else:
+            print(f"n{nid} {node['name']}: community-cost-modifier = ABSENT (honest null)")
+
+
+if __name__ == "__main__":
+    run()

--- a/rust/crates/babylon-tick/tests/community_conformance.rs
+++ b/rust/crates/babylon-tick/tests/community_conformance.rs
@@ -1,0 +1,325 @@
+//! The Community @6.0 port train's conformance suite (issue #667, plan
+//! `docs/superpowers/plans/2026-08-18-community-port.md`, Task 7) — world 1
+//! (`content/scenarios/community-conformance.bscn`), the frozen mirror
+//! (`content/scenarios/community_conformance.py`), THE SPIKE's seven-shape
+//! verdicts, and §8c's four permanent anti-pattern guards (landed here,
+//! never deleted).
+//!
+//! # Task 7 deviations from the plan's letter (both recorded, both forced)
+//!
+//! 1. **Step 1's "expected FAIL (unregistered system)" never red-fired**:
+//!    the `community` namespace was registered in `lib.rs`'s systems
+//!    `HashSet` at **Task 4** (#681), one task earlier than the plan's
+//!    Step 2 — the ceiling supply chain's RED tests needed the two refusal
+//!    codes specifically, and an unregistered namespace fails E-LOAD-004
+//!    one stage earlier (the registration comment in `lib.rs` says all of
+//!    this). So this suite's load-smoke was green from birth; Step 2's
+//!    "confirming the entry is genuinely new" discharges by READING that
+//!    comment, not by re-adding the entry.
+//! 2. **The "empty rule source" deviation, inherited**: `run_once_into`'s
+//!    `split_content` refuses a content set with zero `(rule …)` top-forms
+//!    outright (`decomposition_conformance.rs`'s Step-1 note and
+//!    `production_conformance.rs:75-94` record the same), so the smoke
+//!    test drives ONE minimal, never-firing probe rule.
+//!
+//! # The mirror's verbatim stdout (2026-08-22, python3 3.13)
+//!
+//! `community_conformance.py` is THE ORACLE (§9: standalone, no `babylon`
+//! import, transcribing the planned rules c00→c11 over the literal WORLD).
+//! Tasks 8-11 pin bit-exact against these values via the `.to_bits()`
+//! idiom — **exact equality, no tolerance**, because every value here is
+//! the same IEEE-754 operation chain the rules transcribe (the mirror's
+//! header states the operation order per accumulator; shortest-repr
+//! decimals round-trip through Rust's correctly-rounded parser to the same
+//! binary64):
+//!
+//! ```text
+//! community-conformance world 1 — mirror output (the oracle)
+//! h0 new-afrikan kind=NEW_AFRIKAN
+//!   member-count = 2.0
+//!   density-sum  = 1.5
+//!   r = 0.8648648648648649
+//!   l = 0.13513513513513511
+//!   f = 0.0
+//!   contestation = 0.36048485321765583   (DG-2-gated)
+//!   dominant     = REVOLUTIONARY   (DG-2-gated)
+//!   decayed heat               = 0.475
+//!   decayed cohesion           = 0.7275
+//!   decayed education-pressure = 0.225
+//! h1 settler kind=SETTLER
+//!   member-count = 1.0
+//!   density-sum  = 2.0
+//!   r = 0.0
+//!   l = 0.5
+//!   f = 0.5
+//!   contestation = 0.6309297535714574   (DG-2-gated)
+//!   dominant     = LIBERAL   (DG-2-gated)
+//!   decayed heat               = 0.2375
+//!   decayed cohesion           = 0.485
+//!   decayed education-pressure = 0.1125
+//! h2 queer kind=QUEER
+//!   member-count = 1.0
+//!   density-sum  = 2.0
+//!   r = 0.7619047619047619
+//!   l = 0.23809523809523808
+//!   f = 0.0
+//!   contestation = 0.4996069952489026   (DG-2-gated)
+//!   dominant     = REVOLUTIONARY   (DG-2-gated)
+//!   decayed heat               = 0.7124999999999999
+//!   decayed cohesion           = 0.60625
+//!   decayed education-pressure = 0.45
+//! n1 na-worker: community-cost-modifier = 1.09375
+//! n2 na-organizer: community-cost-modifier = 0.875
+//! n3 settler-la: community-cost-modifier = 1.0
+//! n4 unaffiliated: community-cost-modifier = 1.0
+//! n5 inactive-member: community-cost-modifier = ABSENT (honest null)
+//! ```
+//!
+//! # THE SPIKE (Task 7 Step 5) — the seven-shape verdicts
+//!
+//! Each shape below was proven by a THROWAWAY rule against the real
+//! `run_once_into` driver and THIS scenario, then deleted (the
+//! solidarity-conformance.bscn:9-20 precedent — the scenario header
+//! carries the same record). Verdicts:
+//!
+//! - **(a)** `for-each` over `(hyperedges HyperedgeType/COMMUNITY)` from a
+//!   carrier-subject rule — **FIRES** (3 communities × 1 carrier = 3
+//!   body-evaluations, verified by a write landing on all three).
+//! - **(b)** `(update-hyperedge it community/heat (set …))` inside that
+//!   body — **WRITES** (Task 6's own surface; read back bit-exact).
+//! - **(c)** `(for-each (hyperedges-of self HyperedgeType/COMMUNITY) …)`
+//!   from a SOCIAL_CLASS-subject rule + `(field-of it …)` read inside —
+//!   **FIRES and READS** (na-worker sees exactly its two memberships, h0
+//!   then h2, and the reads returned the seeded values).
+//! - **(d)** repeated `(scale …)` accumulates multiplicatively across a
+//!   `for-each` — **PROVEN**: two scales of 0.5c over na-worker's two
+//!   memberships landed 1 → 0.25 on the probe field (the operand is
+//!   pre-computed per collected write; the COMBINE reads the current value
+//!   at APPLY, so the two scales compose as a product — §9 item 2's
+//!   pre-state law governs operand evaluation, never the combine).
+//! - **(e)** a 14-arm `if`-chain over the enum-field equality (`community/
+//!   kind` against each CommunityType member) — **LOADS and EVALUATES**:
+//!   each hyperedge's dispatch returned its own floor constant
+//!   (0.136/0.0/0.04), the shape §6.2's c06 dispatch needs. The only
+//!   landed precedent was 3-arm (`territory.bsl:130-137`); the 14-arm is
+//!   now demonstrated, not merely plausible.
+//! - **(f)** a same-tick cross-rule read of a hyperedge field written by
+//!   an earlier rule — **SEES the new value** (§8b's fatal rows rely on
+//!   exactly this; rule-id byte order `community/spike-a` <
+//!   `community/spike-b` carried the write → read).
+//! - **(g)** the world LOADS with a measured `E-LOAD-040`-bounded
+//!   hyperedge-querying rule — Task 4's ceiling supply chain reaches this
+//!   scenario: the probe's static bound passed with the census-fed
+//!   `HyperedgeType/COMMUNITY` ceiling 3 and max-members 3.
+//!
+//! No shape refused; §8's rule split stands as planned.
+//!
+//! # The mirror pin (Task 8+)
+//!
+//! Tasks 8-11 extend this file with per-rule assertions against the
+//! mirror transcript above; Task 7 lands the world, the load-smoke, the
+//! ordinal parity, and §8c's four guards only.
+
+use babylon_bsl::scenario::load_scenario;
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::hypergraph_store::HypergraphStore;
+use babylon_graph::substrate::{GraphSubstrate, HyperedgeId, NodeId};
+use babylon_tick::run_once_into;
+
+/// The world-1 scenario source, single-homed here — Tasks 8-11's rule
+/// packs load against exactly this text.
+const SCENARIO: &str = include_str!("../content/scenarios/community-conformance.bscn");
+
+/// The pack source this suite drives — EMPTY at Task 7 (the pack lands
+/// across Tasks 8-11); §8c guard 2 reads it, which is what gives the
+/// guard teeth the moment real content exists.
+const PACK: &str = "";
+
+/// Step 1/7's load-smoke: the world hydrates and ticks clean under one
+/// minimal, never-firing probe rule (`active` is 0/1, never 2). The
+/// pre/post hashes must be IDENTICAL — a silent probe writes nothing, and
+/// the hash brackets the tick, not the hydration.
+#[test]
+fn scenario_and_empty_pack_load() {
+    let probe = r#"
+(rule community/load-smoke
+  :material-basis "Task 7 Step 1: the load-smoke probe — never fires, proves the world + registration"
+  :fuel 64
+  (domain NodeType/SOCIAL_CLASS)
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 2))
+  (effects
+    (emit EventType/ORGANIZATION_SEEDED (probe 1))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(SCENARIO, probe, &mut graph, &mut sink)
+        .expect("world 1 loads and ticks clean");
+    assert_eq!(report.fired, 0, "the probe never fires");
+    assert_eq!(
+        report.before, report.after,
+        "a never-firing probe writes nothing — the hash brackets the tick"
+    );
+}
+
+/// ADR195 ordinal parity: both enum registries in FROZEN DECLARATION
+/// ORDER — CommunityType from `models/enums/community.py:38-55`,
+/// ConsciousnessTendency from `models/enums/consciousness.py:82-85`. A
+/// transposition here silently re-reads every seeded `community/kind`.
+#[test]
+fn defenum_ordinal_parity_with_the_frozen_order() {
+    let mut graph = HypergraphStore::new();
+    let loaded = load_scenario(SCENARIO, &mut graph).expect("world 1 loads");
+    let community = loaded
+        .enums
+        .resolve("CommunityType")
+        .expect("CommunityType declared");
+    let frozen_order = [
+        "SETTLER",
+        "PATRIARCHAL",
+        "NEW_AFRIKAN",
+        "FIRST_NATIONS",
+        "CHICANO",
+        "WOMEN",
+        "TRANS",
+        "DISABLED",
+        "QUEER",
+        "UNDOCUMENTED",
+        "INCARCERATED",
+        "YOUTH",
+        "ADULT",
+        "ELDER",
+    ];
+    for (expected, member) in frozen_order.iter().enumerate() {
+        assert_eq!(
+            loaded.enums.ordinal(community, member),
+            Some(expected as u32),
+            "CommunityType/{member} must be ordinal {expected} (frozen declaration order)"
+        );
+    }
+    let tendency = loaded
+        .enums
+        .resolve("ConsciousnessTendency")
+        .expect("ConsciousnessTendency declared");
+    for (expected, member) in ["LIBERAL", "FASCIST", "REVOLUTIONARY"].iter().enumerate() {
+        assert_eq!(
+            loaded.enums.ordinal(tendency, member),
+            Some(expected as u32),
+            "ConsciousnessTendency/{member} must be ordinal {expected} (frozen declaration order)"
+        );
+    }
+    // …and the seeded kinds read back as those ordinals through the
+    // substrate: NEW_AFRIKAN=2, SETTLER=0, QUEER=8.
+    for (hid, member, ordinal) in [
+        (HyperedgeId(0), "NEW_AFRIKAN", 2.0_f64),
+        (HyperedgeId(1), "SETTLER", 0.0_f64),
+        (HyperedgeId(2), "QUEER", 8.0_f64),
+    ] {
+        let stored = graph
+            .hyperedge_attribute(hid, "community/kind")
+            .expect("kind seeded");
+        assert_eq!(
+            stored.to_bits(),
+            (ordinal).to_bits(),
+            "h{}'s kind must store {member}'s ordinal",
+            hid.0
+        );
+    }
+}
+
+// ---- §8c's four permanent anti-pattern guards (landed Task 7, NEVER
+// deleted — the INV-010 estate's Rust half) ----
+
+/// §8c row 1: communities appear ONLY as hyperedges — no node whose type
+/// name contains `COMMUNITY` may exist in the census.
+#[test]
+fn no_community_typed_node_exists() {
+    let mut graph = HypergraphStore::new();
+    let loaded = load_scenario(SCENARIO, &mut graph).expect("world 1 loads");
+    for (member, count) in &loaded.node_types {
+        assert!(
+            !member.contains("COMMUNITY"),
+            "node type {member} (×{count}) — communities are hyperedges, never nodes (§8c row 1)"
+        );
+    }
+}
+
+/// §8c row 2: no `(binding … :field community/…)` in the pack source —
+/// a `:field` binding is node-scoped and stays node-scoped (D29; the
+/// mechanism is `tick.rs::subject_type_of`'s owner-kind filter, D202, whose
+/// error this guard never wants to see fire on real content). Reads the
+/// pack string THIS suite drives — vacuous at Task 7 (PACK is empty),
+/// toothed from Task 8 on.
+#[test]
+fn no_field_binding_uses_the_community_namespace() {
+    let mut rest = PACK;
+    while let Some(idx) = rest.find("(binding") {
+        rest = &rest[idx..];
+        let end = rest.find(')').expect("a binding form closes");
+        let form = &rest[..=end];
+        assert!(
+            !(form.contains(":field") && form.contains("community/")),
+            "a :field binding owns off the community namespace: {form} — \
+             a hyperedge's field reads through field-of / writes through \
+             update-hyperedge, never a binding (D29, D202)"
+        );
+        rest = &rest[1..];
+    }
+}
+
+/// §8c row 3 (VIII.9 verbatim): a seeded community records ONE hyperedge
+/// with N members, never C(n,2) dyadic edges — the world's total edge
+/// census is exactly the five org→class MEMBERSHIP edges, and h0 (three
+/// members) minted no dyadic clique.
+#[test]
+fn membership_crosses_whole() {
+    let mut graph = HypergraphStore::new();
+    let loaded = load_scenario(SCENARIO, &mut graph).expect("world 1 loads");
+    assert_eq!(loaded.edge_count, 5, "the five MEMBERSHIP edges, no more");
+    assert_eq!(
+        loaded.edge_types.get("MEMBERSHIP"),
+        Some(&5),
+        "every edge is an org→class MEMBERSHIP edge"
+    );
+    assert_eq!(
+        loaded.hyperedge_types.get("COMMUNITY"),
+        Some(&3),
+        "three communities, as hyperedges"
+    );
+    // h0's three members are ONE hyperedge — if a clique expansion existed,
+    // three more dyadic edges would have appeared above.
+    let members = graph
+        .hyperedges_of(NodeId(1), "COMMUNITY")
+        .expect("na-worker exists");
+    assert_eq!(
+        members.len(),
+        2,
+        "na-worker crosses two communities whole (h0, h2)"
+    );
+}
+
+/// §8c row 4 (§3.7a / C3): every world this pack loads into contains
+/// EXACTLY ONE NodeType/INSTITUTION node — never two (each carrier-subject
+/// rule would fire twice, double-applying every hyperedge write) and never
+/// zero (six rules would iterate an empty population — silent inertness
+/// dressed as a passing test).
+#[test]
+fn exactly_one_institution_carrier() {
+    let mut graph = HypergraphStore::new();
+    let loaded = load_scenario(SCENARIO, &mut graph).expect("world 1 loads");
+    assert_eq!(
+        loaded.node_types.get("INSTITUTION"),
+        Some(&1),
+        "exactly one INSTITUTION carrier — tick.rs's subject derivation \
+         iterates EVERY node of the type (D202's filter note), so zero is \
+         silent inertness and two is double-applied hyperedge writes"
+    );
+    // …and it is the anchor: `institution/community-carrier` reads 1.
+    let carrier = graph.nodes("INSTITUTION");
+    assert_eq!(carrier.len(), 1);
+    let anchor = graph
+        .node_attribute(carrier[0], "institution/community-carrier")
+        .expect("the carrier carries the anchor field");
+    assert_eq!(anchor.to_bits(), (1.0_f64).to_bits());
+}


### PR DESCRIPTION
## Community port train, Task 7 — registration + world 1 + the mirror + THE SPIKE

Plan: `docs/superpowers/plans/2026-08-18-community-port.md` (issue #667). This is the world/oracle layer Tasks 8-11's rule packs (c00-c11) pin against.

**What lands:**

- **World 1** — `content/scenarios/community-conformance.bscn`: ten nodes (n0 the §3.7a singleton INSTITUTION carrier `community-register`; n1 the multi-community witness; n5 the inactive member; n9 the zero-MEMBERSHIP org), five MEMBERSHIP edges, three COMMUNITY hyperedges with the full own-field seed set via Task 6's `(hyperedge-attr …)`, the **14-row ADR214 floor defconst table** with per-row provenance (DG-3: all 14, never a partial transcription), the three decay alphas, and both defenums in **frozen declaration order** (ADR195 — pinned executably by the ordinal-parity test).
- **The frozen mirror** — `content/scenarios/community_conformance.py` (§9's D146/ADR183 convention): standalone, no `babylon` import, the literal WORLD dict node-for-node, transcribing the planned rule order `c00→c11` term-for-term with the pre-state law and the exact f64 operation orders (subject-ascending outer, ascending HyperedgeId inner; c10's product order). **THE ORACLE.** Its verbatim stdout, dated, lives in the test file's doc comment; c07/c08 are transcribed and printed but DG-2-gated; n5's cost modifier is modeled **ABSENT**, never 1.0 (§9 item 5).
- **THE SPIKE (Step 5) — all seven shapes PASS** against the real driver and this world (throwaway probes deleted; verdicts recorded in the .bscn header and the test doc comment per the solidarity precedent): (a) carrier for-each over `(hyperedges …)` fires; (b) `update-hyperedge` writes inside; (c) `hyperedges-of self` from a class subject fires and `field-of` reads (iteration order proven by last-write-wins); (d) repeated `scale` accumulates multiplicatively (combine reads current at APPLY); (e) **the 14-arm `if`-chain over the enum field loads and evaluates** — the only landed precedent was 3-arm, so §6.2's c06 dispatch is now demonstrated, not plausible; (f) a same-tick cross-rule read sees the earlier write (§8b's fatal rows); (g) the world loads under the measured static bound — Task 4's ceiling supply chain reaches it.
- **The corroboration artifact (Step 6)** — `reports/community-frozen-corroboration-2026-08-18.md` + its preserved driver: the REAL frozen `CommunitySystem.step()` over the hand-seeded world. **C4 VERDICT: PASS** — `community_cost_modifier` is ABSENT from the inactive member's post-step dict (verbatim in the report). Two evidence items found BY the artifact: the `query_edges(source_id=…)` drift (the `STRUCTURALLY_IMPOSSIBLE` seam made concrete, shimmed in-script with zero frozen/topology source changes) and the **SnapToGrid boundary**: frozen's `Probability` quantizes to a 10⁻⁶ ROUND_HALF_UP grid at the Pydantic boundary (`kernel/math.py:41`), so frozen stores `0.864865` where the mirror's unquantized chain yields `0.8648648648648649` — the port pins the **unquantized** values.
- **§8c's four permanent anti-pattern guards** land here, never deleted: `no_community_typed_node_exists`, `no_field_binding_uses_the_community_namespace` (vacuous at Task 7, toothed from Task 8 — it reads the pack string this suite drives), `membership_crosses_whole` (VIII.9), `exactly_one_institution_carrier` (both directions: never two, never zero).

**Deviations (recorded in the suite header):** Step 1's registration red never fired — `community` was registered at **Task 4** (#681), one task early, so Step 2 discharges by reading that entry's comment; the empty-rule-source deviation is inherited from `decomposition_conformance.rs` (`split_content` refuses a ruleless content set).

**Housekeeping:** `content-sets.toml` gains the `community/conformance` row (`rules = []` until Task 8); the corpus digest re-pins at 75 content files.

**Gates:** `rust:check`, `qa:regression` (byte-identical, 12 + E5b determinism leg), `qa:vault-regression-ci` (both goldens byte-identical), `check:quick`, manifest-sync suite, full sentinel battery (860) — all green. No Python engine source touched (§6.3: the deferred ceremony's trigger cannot fire).
