### PR TITLE
feat(tick): community.bsl c05+c06 — normalization and the ADR214 floor table (Community Task 9)

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -9082,7 +9082,63 @@ consequences are the ordinary kind of review item.
        Per-rule fuel, measured by `bsl-fuel-report` over world 1 and
        declared at bound+1 (D-NF+22 — per-world bounds, since
        `:max-members` is census-derived): c00 81, c01 22, c02 21,
-       c03f/c03l/c03r 72 each, c04 115.
+       c03f/c03l/c03r 72 each, c04 115. (c00 was re-measured to **79** at
+       #688's harvest: the anchor's comparison guard dropped to `#t`, so
+       the computed bound fell to 78.)
+   * - D204
+     - §4.2, §2.8, §6.2
+     - **The c06 split and the ADR214 floor's landing (Community port
+       train, Task 9, 2026-08-22).** The plan's c06 was ONE rule — "the
+       pack's ONLY 14-arm dispatch" driving the ``r < floor``
+       redistribution — but the pre-state law (§4.2 C4) makes a
+       write-then-read WITHIN one rule's body impossible: a floor written
+       by ``update-hyperedge`` is invisible to a later operand's
+       ``field-of`` in the same collect pass. The dispatch therefore lands
+       as TWO rules: ``c06a-floor-dispatch`` (the pack's only 14-arm
+       ``community/kind`` chain, writing the per-community
+       ``community/substrate-floor`` cache) and ``c06b-floor-redistribute``
+       (reading it the same tick — a cross-rule read, the §8b shape spike
+       (f) proved at Task 7). The math is frozen's
+       (``formulas/consciousness.py:98-107``) unchanged; the pack's rule
+       count moves 14 -> 15, and DG-2's "12 if no-publish" becomes 13.
+       §8a gains a row: c05's total/unorganized expressions are inlined
+       per write (no ``defexpr`` exists) — the bit-exact mirror assertions
+       are the copies-agree mechanism. §8b gains a row: c06b reads c06a's
+       cache (the skip gate keeps a skipped community's cache UNWRITTEN,
+       honest-null — §9 item 5's law one field over). **The landing
+       evidence:** world 2 (``community-floor-conformance.bscn``) binds
+       NEW_AFRIKAN (0.136) and FIRST_NATIONS (0.155) on one tick — ADR214
+       Ruling 3's ordering EXECUTED — with h0's nonzero f arm proving the
+       redistribution's proportionality, and SETTLER as the
+       identically-0.0 control; world 3
+       (``community-degenerate-conformance.bscn``) fires the degenerate
+       branch (zero-cadre org; c05 emits (0,1,0), c06 routes the floor
+       bit-identically to frozen's fused branch — §6.2 I5) and the no-org
+       skip gate (the prior ternary preserved byte-exactly). The
+       ``floor_redistribution_handles_zero_lf`` pin drives c06b's else arm
+       through a test-scoped rig rule (byte-ordered c05 < c05z < c06a):
+       the arm is unreachable from c05's normalized outputs BY
+       CONSTRUCTION (r < floor <= 0.18 forces l+f > 0.82), so the only
+       honest coverage is synthetic. **Fuel is per-world** (D-NF+22 —
+       ``:max-members`` is census-derived): measured by ``bsl-fuel-report``
+       over all three worlds, declared at max+1: c00 104, c01 27, c02 21,
+       c03f/c03l/c03r 72, c04 151, c05 596, c06a 252, c06b 272 (world 2's
+       wider census is the worst case for c00/c01/c04-c06b; world 1 for
+       c03\*). World-1 fired arithmetic after the extension: 21 = 18 +
+       c05:1 + c06a:1 + c06b:1. Mutation vectors (six, all proven): the
+       NEW_AFRIKAN arm swapped to floor-chicano reds both world-2 floor
+       pins; a one-world FN-table typo (0.155 -> 0.145) reds the
+       cross-world parity test AND the ordering pin; the CHICANO arm
+       swapped to floor-elder reds both world-3 pins; the converse —
+       replacing the chain's final else with a 0.99p literal — stays GREEN
+       on all twenty tests (no world seeds ELDER: the unexercised arms
+       provably cannot fire); dropping c06b's ``/ lf`` reds the
+       proportionality pin; gutting the epsilon quotient to ``(< T 0.0c)``
+       fails the degenerate world at the driver (0/0 NaN refused
+       non-finite) and every floor pin with it. c07/c08 are DG-2-GATED and
+       do not exist until the Director's ruling — §8a row 4's epsilon
+       independence (c05's total vs c07's per-component entropy) is stated
+       but only c05's half is testable this task.
 
 Authoring idioms (non-normative)
 -----------------------------------

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -9081,10 +9081,10 @@ consequences are the ordinary kind of review item.
        an empty for-each — frozen's :421 skip is structural) + c04:4.
        Per-rule fuel, measured by `bsl-fuel-report` over world 1 and
        declared at bound+1 (D-NF+22 — per-world bounds, since
-       `:max-members` is census-derived): c00 81, c01 22, c02 21,
-       c03f/c03l/c03r 72 each, c04 115. (c00 was re-measured to **79** at
-       #688's harvest: the anchor's comparison guard dropped to `#t`, so
-       the computed bound fell to 78.)
+       `:max-members` is census-derived): c00 79, c01 22, c02 21,
+       c03f/c03l/c03r 72 each, c04 115. (c00 was 81 at first landing; the
+       #688 harvest dropped the anchor's comparison guard to `#t`, the
+       computed bound fell to 78, and 79 is the declared figure now.)
    * - D204
      - §4.2, §2.8, §6.2
      - **The c06 split and the ADR214 floor's landing (Community port

--- a/rust/crates/babylon-bsl/tests/content_corpus_digests.rs
+++ b/rust/crates/babylon-bsl/tests/content_corpus_digests.rs
@@ -69,7 +69,7 @@ fn corpus_files() -> Vec<PathBuf> {
 const PINNED_DIGESTS: &[(&str, &str)] = &[
     (
         "community.bsl",
-        "9c9599f79f8cd4d92c0dfae36c498d13654d14cc933d90e202beabd81add9557",
+        "14cb56074a85598b4e945c926f386e0e8cf56f3dbbcf9d71a97782928d27dd3c",
     ),
     (
         "consciousness.bsl",
@@ -205,7 +205,15 @@ const PINNED_DIGESTS: &[(&str, &str)] = &[
     ),
     (
         "community-conformance.bscn",
-        "886a948a9e16e7c625a7a75f72e43d4a8c8f6c384b1cc1f126fea9120ec21b32",
+        "0e13c145c0398b700952737aaaffeb6a4c575d1894cccfc96a31944fbc0ba984",
+    ),
+    (
+        "community-degenerate-conformance.bscn",
+        "b8ad8f7f0472ff8c7baeeee8d3e71653edc43635c19cee7c93048e1035b15ab0",
+    ),
+    (
+        "community-floor-conformance.bscn",
+        "ffabae42ddf3da7667e195cb06dd4e9a5b57f7bdc4ae105358cb4a9f59e77843",
     ),
     (
         "consciousness-ternary-conformance.bscn",

--- a/rust/crates/babylon-tick/content/content-sets.toml
+++ b/rust/crates/babylon-tick/content/content-sets.toml
@@ -32,6 +32,21 @@ prelude   = []
 rules     = ["rules/community.bsl"]
 consumers = ["rust/crates/babylon-tick/tests/community_conformance.rs"]
 
+
+[[set]]
+id        = "community/degenerate"
+scenario  = "scenarios/community-degenerate-conformance.bscn"
+prelude   = []
+rules     = ["rules/community.bsl"]
+consumers = ["rust/crates/babylon-tick/tests/community_conformance.rs"]
+
+[[set]]
+id        = "community/floor"
+scenario  = "scenarios/community-floor-conformance.bscn"
+prelude   = []
+rules     = ["rules/community.bsl"]
+consumers = ["rust/crates/babylon-tick/tests/community_conformance.rs"]
+
 [[set]]
 id        = "consciousness/ternary-conformance"
 scenario  = "scenarios/consciousness-ternary-conformance.bscn"

--- a/rust/crates/babylon-tick/content/rules/community.bsl
+++ b/rust/crates/babylon-tick/content/rules/community.bsl
@@ -34,6 +34,20 @@
 ; the mirror transcribes the true order and its output is byte-identical
 ; either way (proven at Task 7). §8b's D116 ledger (the same-tick
 ; cross-rule reads this pack relies on) is reproduced in the plan, §8b.
+; Task 9 extends the map: … < c05-normalize < c06a-floor-dispatch <
+; c06b-floor-redistribute. THE c06 SPLIT (D204): the plan's c06 was ONE
+; rule — "the pack's ONLY 14-arm dispatch" driving the redistribution —
+; but the pre-state law (§4.2 C4) makes a write-then-read WITHIN one
+; rule's body impossible: the floor written by an `update-hyperedge` is
+; not visible to a later operand's `field-of` in the same collect pass.
+; The dispatch therefore lands as c06a (writes the per-community
+; `community/substrate-floor` cache through the pack's only 14-arm chain)
+; and c06b (reads the cache — a same-tick CROSS-RULE read, the §8b shape
+; spike (f) proved at Task 7). The math is unchanged; the pack's rule
+; count moves 14 -> 15 (DG-2's "12 if no-publish" becomes 13), recorded
+; in the D-row register. §8a gains a row: the c05 total/unorganized
+; expressions are inlined per write (no defexpr exists) — the bit-exact
+; mirror assertions are the copies-agree mechanism.
 ;
 ; §5 DISCLOSURE — what does NOT land (the #653-gated half, hard-sequenced):
 ; threat scoring (community.py:579-608), solidarity amplification
@@ -95,7 +109,7 @@
 ; ============================================================ c00 — the reset
 (rule community/c00-census-reset
   :material-basis "The per-tick rebuild (community.py:392-397 mints a fresh community_agents map on every step, and community.py:460-462 writes back via model_copy): every accumulator this pack reads derives from THIS tick's writes, so the tick begins by zeroing them. The institution/community-carrier binding is a SUBJECT-TYPE ANCHOR ONLY (tick.rs::subject_type_of requires >=1 :field binding to derive INSTITUTION) — never read again, never gating anything (`when #t`), so the domain is declared EXPLICITLY: an unreferenced anchor plus a vacuous guard is E-LOAD-004-undeterminable at load (domain.rs's candidate set is reference-fed), and control-ratio.bsl's precedent passes only because its fold bodies feed that set — recorded in the pack header."
-  :fuel 79
+  :fuel 104
   (bindings
     (binding carrier :field institution/community-carrier))
   (domain NodeType/INSTITUTION)
@@ -111,7 +125,7 @@
 ; ============================================================ c01 — the census
 (rule community/c01-member-census
   :material-basis "The member census (community.py:465-479's _collect_memberships + :392-397's community_agents): ACTIVE classes only (the :472-474 gate — an inactive member is excluded from the count AND from every downstream write), one +1 per (class, community) membership. The adds collect against the pre-state and combine at apply, so N active members land N exactly."
-  :fuel 22
+  :fuel 27
   (bindings
     (binding active :field social-class/active))
   (when (= active 1))
@@ -179,7 +193,7 @@
 ; ============================================================ c04 — the contribution push
 (rule community/c04-community-contribution-push
   :material-basis "The density decomposition (plan §1.3, D-NF+3): frozen's per-org weight (overlap/comm_size) x cadre x cohesion re-expressed as per-class sums divided by the census count — each active-in-census class pushes org-weight/member-count onto its communities' raw ternary accumulators and org-count/member-count onto density-sum. The divisor is c01's SAME-TICK census (§8b's D116 ledger row 1: fatal if apply-in-place is ever repaired to collect-across-rules — the Q14 train's acceptance input). The `active` gate is FIDELITY, not caution: frozen's community_agents is built from the active-only membership set (community.py:472-474 -> :392-397), so an inactive class's org weights (c03 pushes to members regardless of the target's active flag) must NEVER enter the sum — gated here, c03's push onto an inactive class stays inert (c02 resets it next tick)."
-  :fuel 115
+  :fuel 151
   (bindings
     (binding active :field social-class/active)
     (binding rw :field social-class/org-r-weight)
@@ -197,3 +211,108 @@
         (add (/ fw (field-of it community/member-count))))
       (update-hyperedge it community/density-sum
         (add (/ orgs (field-of it community/member-count)))))))
+
+; ============================================================ c05 — the normalization
+; (Task 9 Step 2; the §6.2 I5 routing: the degenerate branch emits
+; (0, 1, 0) and NOTHING else — the floor routes through c06a/c06b,
+; bit-identically to frozen's fused branch, formulas/consciousness.py:89-91,
+; because x1.0 and /1.0 are exact in IEEE-754.)
+(rule community/c05-normalize
+  :material-basis "Normalize the raw accumulators to the simplex (formulas/consciousness.py:78-95): unorganized = max(0, 1 - density-sum) folds into l (Jackson: passive acceptance is liberal hegemony); total = (r + (l+u)) + f, frozen's exact association; total < 1e-10 is the degenerate branch -> (0, 1, 0) and NOTHING else (the floor routes through c06a/c06b, bit-identically — 6.2 I5). The density-sum > 0 guard is frozen's community.py:452 skip gate (no org_landscape -> keep the prior ternary). Frozen never stores the unorganized-folded l-raw, so neither does this rule — only the normalized ternary is written. The total/unorganized expressions are inlined per write (no defexpr exists — 8a ledger); the epsilon is the landed (/ 1c 10000000000) quotient (consciousness.bsl's idiom), bit-identical to frozen's 1e-10 literal."
+  :fuel 596
+  (domain NodeType/INSTITUTION)
+  (bindings
+    (binding carrier :field institution/community-carrier))
+  (when #t)
+  (effects
+    (for-each (hyperedges HyperedgeType/COMMUNITY)
+      (guard (> (field-of it community/density-sum) 0.0c)
+        (update-hyperedge it community/revolutionary
+          (set
+            (if (< (+ (+ (field-of it community/r-raw) (+ (field-of it community/l-raw) (if (< (- 1.0c (field-of it community/density-sum)) 0.0c) 0.0c (- 1.0c (field-of it community/density-sum))))) (field-of it community/f-raw)) (/ 1.0c 10000000000))
+              0.0p
+              (/ (field-of it community/r-raw) (+ (+ (field-of it community/r-raw) (+ (field-of it community/l-raw) (if (< (- 1.0c (field-of it community/density-sum)) 0.0c) 0.0c (- 1.0c (field-of it community/density-sum))))) (field-of it community/f-raw))))))
+        (update-hyperedge it community/liberal
+          (set
+            (if (< (+ (+ (field-of it community/r-raw) (+ (field-of it community/l-raw) (if (< (- 1.0c (field-of it community/density-sum)) 0.0c) 0.0c (- 1.0c (field-of it community/density-sum))))) (field-of it community/f-raw)) (/ 1.0c 10000000000))
+              1.0p
+              (/ (+ (field-of it community/l-raw) (if (< (- 1.0c (field-of it community/density-sum)) 0.0c) 0.0c (- 1.0c (field-of it community/density-sum)))) (+ (+ (field-of it community/r-raw) (+ (field-of it community/l-raw) (if (< (- 1.0c (field-of it community/density-sum)) 0.0c) 0.0c (- 1.0c (field-of it community/density-sum))))) (field-of it community/f-raw))))))
+        (update-hyperedge it community/fascist
+          (set
+            (if (< (+ (+ (field-of it community/r-raw) (+ (field-of it community/l-raw) (if (< (- 1.0c (field-of it community/density-sum)) 0.0c) 0.0c (- 1.0c (field-of it community/density-sum))))) (field-of it community/f-raw)) (/ 1.0c 10000000000))
+              0.0p
+              (/ (field-of it community/f-raw) (+ (+ (field-of it community/r-raw) (+ (field-of it community/l-raw) (if (< (- 1.0c (field-of it community/density-sum)) 0.0c) 0.0c (- 1.0c (field-of it community/density-sum))))) (field-of it community/f-raw))))))))))
+
+; ============================================ c06a — the floor dispatch (Task 9 Step 3)
+; THE PACK'S ONLY 14-arm community/kind dispatch (6.2 — no map or lookup
+; construct exists). Writes the per-community floor to the
+; community/substrate-floor cache; c06b reads it the SAME TICK (the
+; pre-state law forces the split — a write inside one rule's collect pass
+; is invisible to a later operand's field-of, so dispatch-and-redistribute
+; cannot be one rule; D204).
+(rule community/c06a-floor-dispatch
+  :material-basis "The 14-row ADR214 floor table, dispatched on community/kind (6.2; the pack's ONLY 14-arm chain — spike shape (e) proved it at Task 7). Values and per-row provenance: the world's .bscn defconst block (ADR214 Ruling 1 + erratum 9 for the measured three; Ruling 2's demotions for the LOW five; INCARCERATED's named unreachability; SETTLER/PATRIARCHAL/YOUTH/ADULT structural zeros; ELDER estimated). The density-sum > 0 guard is the SAME skip gate as c05's — a skipped community's cache is never written, and c06b's guard never reads it (the honest-null discipline, 9 item 5)."
+  :fuel 252
+  (domain NodeType/INSTITUTION)
+  (bindings
+    (binding carrier :field institution/community-carrier)
+    (binding floor-settler :const community/floor-settler)
+    (binding floor-patriarchal :const community/floor-patriarchal)
+    (binding floor-new-afrikan :const community/floor-new-afrikan)
+    (binding floor-first-nations :const community/floor-first-nations)
+    (binding floor-chicano :const community/floor-chicano)
+    (binding floor-women :const community/floor-women)
+    (binding floor-trans :const community/floor-trans)
+    (binding floor-disabled :const community/floor-disabled)
+    (binding floor-queer :const community/floor-queer)
+    (binding floor-undocumented :const community/floor-undocumented)
+    (binding floor-incarcerated :const community/floor-incarcerated)
+    (binding floor-youth :const community/floor-youth)
+    (binding floor-adult :const community/floor-adult)
+    (binding floor-elder :const community/floor-elder))
+  (when #t)
+  (effects
+    (for-each (hyperedges HyperedgeType/COMMUNITY)
+      (guard (> (field-of it community/density-sum) 0.0c)
+        (update-hyperedge it community/substrate-floor
+          (set
+            (if (= (field-of it community/kind) CommunityType/SETTLER) floor-settler
+            (if (= (field-of it community/kind) CommunityType/PATRIARCHAL) floor-patriarchal
+            (if (= (field-of it community/kind) CommunityType/NEW_AFRIKAN) floor-new-afrikan
+            (if (= (field-of it community/kind) CommunityType/FIRST_NATIONS) floor-first-nations
+            (if (= (field-of it community/kind) CommunityType/CHICANO) floor-chicano
+            (if (= (field-of it community/kind) CommunityType/WOMEN) floor-women
+            (if (= (field-of it community/kind) CommunityType/TRANS) floor-trans
+            (if (= (field-of it community/kind) CommunityType/DISABLED) floor-disabled
+            (if (= (field-of it community/kind) CommunityType/QUEER) floor-queer
+            (if (= (field-of it community/kind) CommunityType/UNDOCUMENTED) floor-undocumented
+            (if (= (field-of it community/kind) CommunityType/INCARCERATED) floor-incarcerated
+            (if (= (field-of it community/kind) CommunityType/YOUTH) floor-youth
+            (if (= (field-of it community/kind) CommunityType/ADULT) floor-adult
+              floor-elder)))))))))))))))
+      ))))
+
+; ============================================================ c06b — the redistribution (Task 9 Step 3)
+(rule community/c06b-floor-redistribute
+  :material-basis "The substrate floor, applied post-normalization (formulas/consciousness.py:98-107): if r < floor, r = floor and the remaining (1 - floor) redistributes to l and f PROPORTIONALLY (l x remaining / lf, f x remaining / lf) when lf > 1e-10, else l = remaining and f = 0 (the two-arm split). Reads c06a's cache the SAME TICK (8b's ledger; spike (f) proved the shape). The SETTLER control: floor 0.0 makes r < floor identically false — the 0.0-floor community is untouched (6.2)."
+  :fuel 272
+  (domain NodeType/INSTITUTION)
+  (bindings
+    (binding carrier :field institution/community-carrier))
+  (when #t)
+  (effects
+    (for-each (hyperedges HyperedgeType/COMMUNITY)
+      (guard (> (field-of it community/density-sum) 0.0c)
+        (guard (< (field-of it community/revolutionary) (field-of it community/substrate-floor))
+          (update-hyperedge it community/liberal
+            (set
+              (if (> (+ (field-of it community/liberal) (field-of it community/fascist)) (/ 1.0c 10000000000))
+                (/ (* (field-of it community/liberal) (- 1.0c (field-of it community/substrate-floor))) (+ (field-of it community/liberal) (field-of it community/fascist)))
+                (- 1.0c (field-of it community/substrate-floor)))))
+          (update-hyperedge it community/fascist
+            (set
+              (if (> (+ (field-of it community/liberal) (field-of it community/fascist)) (/ 1.0c 10000000000))
+                (/ (* (field-of it community/fascist) (- 1.0c (field-of it community/substrate-floor))) (+ (field-of it community/liberal) (field-of it community/fascist)))
+                0.0p)))
+          (update-hyperedge it community/revolutionary
+            (set (field-of it community/substrate-floor))))))))

--- a/rust/crates/babylon-tick/content/scenarios/community-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/community-conformance.bscn
@@ -115,6 +115,12 @@
   (deffield community/l-raw real extensive)
   (deffield community/f-raw real extensive)
   (deffield community/density-sum real extensive)
+  ; c06a's cache (Task 9) — written per tick by the pack's only 14-arm
+  ; dispatch, read by c06b the same tick (the pre-state law forces the
+  ; split — D204; a write inside one rule's collect pass is invisible to a
+  ; later operand's field-of, so the floor cannot be computed and consumed
+  ; in one rule).
+  (deffield community/substrate-floor probability intensive)
   (deffield social-class/org-r-weight real extensive)
   (deffield social-class/org-l-weight real extensive)
   (deffield social-class/org-f-weight real extensive)

--- a/rust/crates/babylon-tick/content/scenarios/community-degenerate-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/community-degenerate-conformance.bscn
@@ -1,0 +1,101 @@
+; Community port train world 3 (issue #667, Task 9 Step 6 — plan
+; docs/superpowers/plans/2026-08-18-community-port.md): the DEGENERATE and
+; SKIP-GATE world. h0's only org has ZERO cadre — every org weight is 0,
+; c05's total collapses under 1e-10, the degenerate branch emits
+; (0, 1, 0) AND NOTHING ELSE (§6.2 I5: the floor routes through c06,
+; bit-identically to frozen's fused branch, formulas/consciousness.py:89-91).
+; h1's member has NO org edges at all — density-sum stays 0 and frozen's
+; `:452` skip gate preserves the prior ternary byte-exactly (world 1's
+; no-member-org pins the ORG side; this world pins the COMMUNITY side).
+;
+; Declaration order is id order — never renumber when extending. The
+; 14-row floor table and the decay alphas are re-declared per scenario
+; (§6.2); the cross-world parity test pins all three worlds' tables equal.
+(scenario community/degenerate-conformance
+  (defvocabulary NodeType (INSTITUTION SOCIAL_CLASS ORGANIZATION))
+  (defvocabulary EdgeType (MEMBERSHIP))
+  (defvocabulary HyperedgeType (COMMUNITY))
+  (defenum CommunityType
+    (SETTLER PATRIARCHAL NEW_AFRIKAN FIRST_NATIONS CHICANO WOMEN TRANS
+     DISABLED QUEER UNDOCUMENTED INCARCERATED YOUTH ADULT ELDER))
+  (defenum ConsciousnessTendency (LIBERAL FASCIST REVOLUTIONARY))
+
+  (deffield institution/community-carrier int extensive)
+  (deffield social-class/active int extensive)
+  (deffield social-class/community-cost-modifier real intensive)
+  (deffield organization/cadre-level probability intensive)
+  (deffield organization/cohesion probability intensive)
+  (deffield organization/consciousness-tendency enum ConsciousnessTendency)
+  (deffield community/kind enum CommunityType)
+  (deffield community/heat intensity intensive)
+  (deffield community/cohesion intensity intensive)
+  (deffield community/education-pressure intensity intensive)
+  (deffield community/reproduction-cost-modifier real intensive)
+  (deffield community/revolutionary probability intensive)
+  (deffield community/liberal probability intensive)
+  (deffield community/fascist probability intensive)
+  (deffield community/member-count int extensive)
+  (deffield community/r-raw real extensive)
+  (deffield community/l-raw real extensive)
+  (deffield community/f-raw real extensive)
+  (deffield community/density-sum real extensive)
+  ; c06a's cache — written per tick, read by c06b the same tick (D204).
+  (deffield community/substrate-floor probability intensive)
+  (deffield social-class/org-r-weight real extensive)
+  (deffield social-class/org-l-weight real extensive)
+  (deffield social-class/org-f-weight real extensive)
+  (deffield social-class/org-count int extensive)
+
+  ; ---- the 14-row ADR214 floor table (§6.1 verbatim) ----
+  (defconst community/floor-new-afrikan 0.136p)
+  (defconst community/floor-first-nations 0.155p)
+  (defconst community/floor-chicano 0.113p)
+  (defconst community/floor-settler 0.0p)
+  (defconst community/floor-patriarchal 0.0p)
+  (defconst community/floor-youth 0.0p)
+  (defconst community/floor-adult 0.0p)
+  (defconst community/floor-incarcerated 0.18p)
+  (defconst community/floor-women 0.04p)
+  (defconst community/floor-trans 0.06p)
+  (defconst community/floor-disabled 0.03p)
+  (defconst community/floor-queer 0.04p)
+  (defconst community/floor-undocumented 0.10p)
+  (defconst community/floor-elder 0.02p)
+  (defconst community/heat-decay-alpha 0.05c)
+  (defconst community/cohesion-decay-alpha 0.03c)
+  (defconst community/education-pressure-decay 0.1c)
+
+  ; ---- nodes (id order) ----
+  (node degenerate-register NodeType/INSTITUTION (institution/community-carrier 1))
+  (node d-a NodeType/SOCIAL_CLASS (social-class/active 1))
+  (node d-b NodeType/SOCIAL_CLASS (social-class/active 1))
+  ; The zero-cadre org: its push is 0.0 x 0.5 = 0 — the weight is zero but
+  ; the MEMBERSHIP COUNT is not (org-count reads 1), which is exactly what
+  ; makes the degenerate branch and not the skip gate fire for h0.
+  (node zero-cadre NodeType/ORGANIZATION
+    (organization/cadre-level 0.0p) (organization/cohesion 0.5p)
+    (organization/consciousness-tendency ConsciousnessTendency/REVOLUTIONARY))
+
+  (edge EdgeType/MEMBERSHIP zero-cadre d-a 1)
+
+  ; h0: CHICANO over (d-a) — degenerate, then the floor binds.
+  (hyperedge deg-comm HyperedgeType/COMMUNITY (members d-a))
+  (hyperedge-attr deg-comm community/kind CommunityType/CHICANO)
+  (hyperedge-attr deg-comm community/heat 0.5i)
+  (hyperedge-attr deg-comm community/cohesion 0.75i)
+  (hyperedge-attr deg-comm community/education-pressure 0.25i)
+  (hyperedge-attr deg-comm community/reproduction-cost-modifier 0.75r)
+  (hyperedge-attr deg-comm community/revolutionary 0.25p)
+  (hyperedge-attr deg-comm community/liberal 0.5p)
+  (hyperedge-attr deg-comm community/fascist 0.25p)
+
+  ; h1: QUEER over (d-b) — d-b has NO org edges: the no-org skip gate.
+  (hyperedge no-org-comm HyperedgeType/COMMUNITY (members d-b))
+  (hyperedge-attr no-org-comm community/kind CommunityType/QUEER)
+  (hyperedge-attr no-org-comm community/heat 0.25i)
+  (hyperedge-attr no-org-comm community/cohesion 0.5i)
+  (hyperedge-attr no-org-comm community/education-pressure 0.125i)
+  (hyperedge-attr no-org-comm community/reproduction-cost-modifier 1.125r)
+  (hyperedge-attr no-org-comm community/revolutionary 0.125p)
+  (hyperedge-attr no-org-comm community/liberal 0.75p)
+  (hyperedge-attr no-org-comm community/fascist 0.125p))

--- a/rust/crates/babylon-tick/content/scenarios/community-floor-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/community-floor-conformance.bscn
@@ -1,0 +1,150 @@
+; Community port train world 2 (issue #667, Task 9 Step 6 — plan
+; docs/superpowers/plans/2026-08-18-community-port.md): the FLOOR-BINDING
+; world. NEW_AFRIKAN and FIRST_NATIONS communities seed org landscapes
+; whose normalized r falls BELOW both floors, so both floors bind and the
+; ADR214 Ruling-3 ordering (FIRST_NATIONS 0.155 > NEW_AFRIKAN 0.136 — an
+; emergent output of the chosen measure, never a fresh stipulation) is
+; EXECUTED, not asserted. SETTLER is the identically-0.0 control (the
+; guard `r < floor` is false at floor = 0, §6.2). h0's weak-fash edge
+; gives the redistribution a nonzero f arm, so PROPORTIONALITY (l:f ratio
+; preserved through the remaining/lf scaling) is exercised, not just the
+; l-degenerate arm.
+;
+; Declaration order is id order — never renumber when extending. The
+; 14-row floor table and the decay alphas are re-declared per scenario
+; (§6.2's precedent); the cross-world parity test pins all three worlds'
+; tables equal to the ADR's values. The dyadic-literal discipline and the
+; §3.7a singleton carrier follow world 1's header exactly.
+(scenario community/floor-conformance
+  (defvocabulary NodeType (INSTITUTION SOCIAL_CLASS ORGANIZATION))
+  (defvocabulary EdgeType (MEMBERSHIP))
+  (defvocabulary HyperedgeType (COMMUNITY))
+  (defenum CommunityType
+    (SETTLER PATRIARCHAL NEW_AFRIKAN FIRST_NATIONS CHICANO WOMEN TRANS
+     DISABLED QUEER UNDOCUMENTED INCARCERATED YOUTH ADULT ELDER))
+  (defenum ConsciousnessTendency (LIBERAL FASCIST REVOLUTIONARY))
+
+  (deffield institution/community-carrier int extensive)
+  (deffield social-class/active int extensive)
+  (deffield social-class/community-cost-modifier real intensive)
+  (deffield organization/cadre-level probability intensive)
+  (deffield organization/cohesion probability intensive)
+  (deffield organization/consciousness-tendency enum ConsciousnessTendency)
+  (deffield community/kind enum CommunityType)
+  (deffield community/heat intensity intensive)
+  (deffield community/cohesion intensity intensive)
+  (deffield community/education-pressure intensity intensive)
+  (deffield community/reproduction-cost-modifier real intensive)
+  (deffield community/revolutionary probability intensive)
+  (deffield community/liberal probability intensive)
+  (deffield community/fascist probability intensive)
+  (deffield community/member-count int extensive)
+  (deffield community/r-raw real extensive)
+  (deffield community/l-raw real extensive)
+  (deffield community/f-raw real extensive)
+  (deffield community/density-sum real extensive)
+  ; c06a's cache — written per tick, read by c06b the same tick (the
+  ; pre-state law forces the split; D204).
+  (deffield community/substrate-floor probability intensive)
+  (deffield social-class/org-r-weight real extensive)
+  (deffield social-class/org-l-weight real extensive)
+  (deffield social-class/org-f-weight real extensive)
+  (deffield social-class/org-count int extensive)
+
+  ; ---- the 14-row ADR214 floor table (§6.1 verbatim; per-row provenance
+  ; in world 1's file — the parity test pins this table equal to it) ----
+  (defconst community/floor-new-afrikan 0.136p)
+  (defconst community/floor-first-nations 0.155p)
+  (defconst community/floor-chicano 0.113p)
+  (defconst community/floor-settler 0.0p)
+  (defconst community/floor-patriarchal 0.0p)
+  (defconst community/floor-youth 0.0p)
+  (defconst community/floor-adult 0.0p)
+  (defconst community/floor-incarcerated 0.18p)
+  (defconst community/floor-women 0.04p)
+  (defconst community/floor-trans 0.06p)
+  (defconst community/floor-disabled 0.03p)
+  (defconst community/floor-queer 0.04p)
+  (defconst community/floor-undocumented 0.10p)
+  (defconst community/floor-elder 0.02p)
+  (defconst community/heat-decay-alpha 0.05c)
+  (defconst community/cohesion-decay-alpha 0.03c)
+  (defconst community/education-pressure-decay 0.1c)
+
+  ; ---- nodes (id order) ----
+  (node floor-register NodeType/INSTITUTION (institution/community-carrier 1))
+  (node w2-a NodeType/SOCIAL_CLASS (social-class/active 1))
+  (node w2-b NodeType/SOCIAL_CLASS (social-class/active 1))
+  (node w2-s NodeType/SOCIAL_CLASS (social-class/active 1))
+  ; The weak REVOLUTIONARY org: cadre 1/8 x cohesion 1/4 = 0.03125 per push.
+  (node weak-rev NodeType/ORGANIZATION
+    (organization/cadre-level 0.125p) (organization/cohesion 0.25p)
+    (organization/consciousness-tendency ConsciousnessTendency/REVOLUTIONARY))
+  ; The strong LIBERAL org: 1.0 per push — what puts both r's under floor.
+  (node strong-lib NodeType/ORGANIZATION
+    (organization/cadre-level 1.0p) (organization/cohesion 1.0p)
+    (organization/consciousness-tendency ConsciousnessTendency/LIBERAL))
+  ; The weak FASCIST org: 0.25 x 0.5 = 0.125 — h0's nonzero f arm.
+  (node weak-fash NodeType/ORGANIZATION
+    (organization/cadre-level 0.25p) (organization/cohesion 0.5p)
+    (organization/consciousness-tendency ConsciousnessTendency/FASCIST))
+  ; w2-c/w2-d: the low-density witness's members (h3). w2-c has NO org
+  ; edges, w2-d has exactly one — h3's density-sum is (1+0)/2 = 0.5, so
+  ; c05's unorganized = 0.5 folds into l.
+  (node w2-c NodeType/SOCIAL_CLASS (social-class/active 1))
+  (node w2-d NodeType/SOCIAL_CLASS (social-class/active 1))
+
+  (edge EdgeType/MEMBERSHIP weak-rev w2-a 1)
+  (edge EdgeType/MEMBERSHIP weak-rev w2-b 1)
+  (edge EdgeType/MEMBERSHIP strong-lib w2-a 1)
+  (edge EdgeType/MEMBERSHIP strong-lib w2-b 1)
+  (edge EdgeType/MEMBERSHIP strong-lib w2-s 1)
+  (edge EdgeType/MEMBERSHIP weak-fash w2-b 1)
+  (edge EdgeType/MEMBERSHIP weak-rev w2-d 1)
+
+  ; h0: NEW_AFRIKAN over (w2-a, w2-b) — floor BINDS (normalized r ≈ 0.037).
+  (hyperedge na-comm HyperedgeType/COMMUNITY (members w2-a w2-b))
+  (hyperedge-attr na-comm community/kind CommunityType/NEW_AFRIKAN)
+  (hyperedge-attr na-comm community/heat 0.5i)
+  (hyperedge-attr na-comm community/cohesion 0.75i)
+  (hyperedge-attr na-comm community/education-pressure 0.25i)
+  (hyperedge-attr na-comm community/reproduction-cost-modifier 0.875r)
+  (hyperedge-attr na-comm community/revolutionary 0.5p)
+  (hyperedge-attr na-comm community/liberal 0.25p)
+  (hyperedge-attr na-comm community/fascist 0.25p)
+
+  ; h1: FIRST_NATIONS over (w2-a) — floor BINDS at the HIGHER 0.155 (the
+  ; Ruling-3 ordering observable against h0's 0.136 in one tick).
+  (hyperedge fn-comm HyperedgeType/COMMUNITY (members w2-a))
+  (hyperedge-attr fn-comm community/kind CommunityType/FIRST_NATIONS)
+  (hyperedge-attr fn-comm community/heat 0.25i)
+  (hyperedge-attr fn-comm community/cohesion 0.5i)
+  (hyperedge-attr fn-comm community/education-pressure 0.125i)
+  (hyperedge-attr fn-comm community/reproduction-cost-modifier 1.25r)
+  (hyperedge-attr fn-comm community/revolutionary 0.25p)
+  (hyperedge-attr fn-comm community/liberal 0.5p)
+  (hyperedge-attr fn-comm community/fascist 0.25p)
+
+  ; h2: SETTLER over (w2-s) — the identically-0.0 control.
+  (hyperedge settler-comm HyperedgeType/COMMUNITY (members w2-s))
+  (hyperedge-attr settler-comm community/kind CommunityType/SETTLER)
+  (hyperedge-attr settler-comm community/heat 0.75i)
+  (hyperedge-attr settler-comm community/cohesion 0.625i)
+  (hyperedge-attr settler-comm community/education-pressure 0.5i)
+  (hyperedge-attr settler-comm community/reproduction-cost-modifier 1)
+  (hyperedge-attr settler-comm community/revolutionary 0.0p)
+  (hyperedge-attr settler-comm community/liberal 0.75p)
+  (hyperedge-attr settler-comm community/fascist 0.25p)
+
+  ; h3: SETTLER over (w2-c, w2-d) — the LOW-DENSITY witness: density 0.5,
+  ; unorganized 0.5 defaults to liberal; the 0.0 floor never binds, so the
+  ; pure c05 normalization shape is what the test reads.
+  (hyperedge low-density-comm HyperedgeType/COMMUNITY (members w2-c w2-d))
+  (hyperedge-attr low-density-comm community/kind CommunityType/SETTLER)
+  (hyperedge-attr low-density-comm community/heat 0.5i)
+  (hyperedge-attr low-density-comm community/cohesion 0.25i)
+  (hyperedge-attr low-density-comm community/education-pressure 0.375i)
+  (hyperedge-attr low-density-comm community/reproduction-cost-modifier 1)
+  (hyperedge-attr low-density-comm community/revolutionary 0.5p)
+  (hyperedge-attr low-density-comm community/liberal 0.25p)
+  (hyperedge-attr low-density-comm community/fascist 0.25p))

--- a/rust/crates/babylon-tick/content/scenarios/community_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/community_conformance.py
@@ -5,20 +5,29 @@ convention).
 
 STANDALONE. No `babylon` import, no pytest, no third-party anything. It
 transcribes the RULES' binding order and collect-then-apply semantics
-term-for-term over the literal WORLD dict below — which matches
-`community-conformance.bscn` node-for-node, hyperedge-for-hyperedge,
-seed-for-seed — never the frozen engine's code (the frozen engine is
-EVIDENCE, captured separately in
+term-for-term over the literal WORLD dicts below — each matching its
+`.bscn` node-for-node, hyperedge-for-hyperedge, seed-for-seed — never the
+frozen engine's code (the frozen engine is EVIDENCE, captured separately in
 reports/community-frozen-corroboration-2026-08-18.md; it prints frozen's
-own, sometimes-diverged answer — D-NF+3's summation order and D-NF+5's
-500-org cap live there).
+own, sometimes-diverged answer — D-NF+3's summation order, D-NF+5's
+500-org cap, and the SnapToGrid 10^-6 Pydantic boundary live there).
 
 Per §9, this header states, for this pack specifically:
 
-1. THE EXACT RULE ORDER: c00 → c01 → c02 → c03r → c03l → c03f → c04 → c05
-   → c06 → c07 → c08 → c09 → c10 → c11. Each rule applies ALL of its
-   writes before the next rule reads (§8b's D116 ledger — the cross-rule
-   reads this pack relies on, fatal rows included).
+1. THE EXACT RULE ORDER (byte order, D16): c00 → c01 → c02 → c03f → c03l
+   → c03r → c04 → c05 → c06a → c06b → [c07 → c08, DG-2-gated] → c09 → c10
+   → c11. Each rule applies ALL of its writes before the next rule reads
+   (§8b's D116 ledger — the cross-rule reads this pack relies on, fatal
+   rows included). **THE c06 SPLIT (D204):** the plan's c06 was one rule —
+   "the pack's ONLY 14-arm dispatch" driving the redistribution — but the
+   pre-state law (item 2) makes a write-then-read WITHIN one rule's body
+   impossible: the floor written by an `update-hyperedge` is not visible
+   to a later operand's `field-of` in the same collect pass. The dispatch
+   therefore lands as `c06a-floor-dispatch` (writes the per-community
+   `community/substrate-floor` cache through the pack's only 14-arm chain)
+   and `c06b-floor-redistribute` (reads the cache — a same-tick CROSS-RULE
+   read, the §8b shape spike (f) proved at Task 7). The MATH is unchanged;
+   the rule count moves 14 → 15, recorded in the D-row register.
 2. PRE-STATE WITHIN A RULE: a rule's for-each accumulations are COLLECTED
    against the rule-entry state and APPLIED in ascending order only after
    the whole subject population has collected — so c01's `add 1`s against
@@ -28,18 +37,22 @@ Per §9, this header states, for this pack specifically:
    c10's PRODUCT compounds in ascending HyperedgeId order — D-NF+13's
    multiplication-order divergence lives exactly there.
 4. THE FLOOR-DISPATCH ARM each seeded community takes (ADR214 provenance):
-   h0 NEW_AFRIKAN → 0.136 (measured, unrestricted_3218, erratum 9);
-   h1 SETTLER → 0.0 (identically zero by construction); h2 QUEER → 0.04
-   (unchanged, confidence demoted per Ruling 2). In world 1 NO arm binds
-   (every normalized r clears its floor) — the binding case is world 2's,
-   Task 9.
-5. UNWRITTEN FIELDS, PER NODE: n5 (inactive-member) holds a REAL
-   membership in h0 but is inactive (frozen community.py:472-474), so c09
-   never resets and c10 never accumulates its `community-cost-modifier` —
-   the mirror models that field as ABSENT (the key does not exist), never
-   as 1.0, so the Rust assertion reads the substrate's honest-null error
+   world 1 — h0 NEW_AFRIKAN 0.136, h1 SETTLER 0.0, h2 QUEER 0.04, NONE
+   bind (every normalized r clears its floor). World 2 — NEW_AFRIKAN and
+   FIRST_NATIONS both bind (their landscapes put normalized r below both
+   floors; Ruling 3's 0.155 > 0.136 ordering is EXECUTED, not asserted),
+   SETTLER is the 0.0-floor control. World 3 — CHICANO binds through the
+   DEGENERATE branch (the zero-cadre org), QUEER exercises the no-org skip
+   gate (its prior ternary is preserved byte-exactly).
+5. UNWRITTEN FIELDS, PER NODE: an inactive class (world 1's n5) is
+   excluded from the census AND from the cost-modifier write (frozen
+   community.py:472-474) — the mirror models its
+   `community-cost-modifier` as ABSENT (the key does not exist), never
+   1.0, so the Rust assertion reads the substrate's honest-null error
    (§1.4, C4). A mirror that defaults an unwritten field is a mirror that
-   cannot catch a fabricated write.
+   cannot catch a fabricated write. The same law holds for the no-org
+   SKIPPED community (world 3's h1): c05/c06 write it NOTHING, so its
+   `substrate-floor` cache is absent too.
 
 c07/c08 are DG-2-GATED (the Director question is unresolved at authoring):
 transcribed and printed here because the mirror is the oracle and the
@@ -51,103 +64,247 @@ from __future__ import annotations
 import math
 
 # ---------------------------------------------------------------------
-# The literal world — community-conformance.bscn, transcribed.
-# Nodes in declaration order (id order); hyperedges in their own order.
+# The worlds. Nodes in declaration order (id order); hyperedges in their
+# own counter order. Every literal matches its .bscn seed EXACTLY.
 # ---------------------------------------------------------------------
 
-# (name → fields); active classes only drive the census/cost lanes.
-NODES: list[dict[str, object]] = [
-    # n0 — the §3.7a singleton carrier.
-    {"name": "community-register", "type": "INSTITUTION", "community-carrier": 1},
-    {"name": "na-worker", "type": "SOCIAL_CLASS", "active": 1},
-    {"name": "na-organizer", "type": "SOCIAL_CLASS", "active": 1},
-    {"name": "settler-la", "type": "SOCIAL_CLASS", "active": 1},
-    {"name": "unaffiliated", "type": "SOCIAL_CLASS", "active": 1},
-    {"name": "inactive-member", "type": "SOCIAL_CLASS", "active": 0},
-    # n6 — REVOLUTIONARY; MEMBERSHIP → n1, n2.
-    {
-        "name": "rev-org",
-        "type": "ORGANIZATION",
-        "cadre-level": 0.5,
-        "cohesion": 0.8,
-        "tendency": "REVOLUTIONARY",
-    },
-    # n7 — LIBERAL; MEMBERSHIP → n1, n3.
-    {
-        "name": "lib-org",
-        "type": "ORGANIZATION",
-        "cadre-level": 0.25,
-        "cohesion": 0.5,
-        "tendency": "LIBERAL",
-    },
-    # n8 — FASCIST; MEMBERSHIP → n3.
-    {
-        "name": "fash-org",
-        "type": "ORGANIZATION",
-        "cadre-level": 0.5,
-        "cohesion": 0.25,
-        "tendency": "FASCIST",
-    },
-    # n9 — zero MEMBERSHIP edges (frozen's :421 skip).
-    {
-        "name": "no-member-org",
-        "type": "ORGANIZATION",
-        "cadre-level": 1.0,
-        "cohesion": 1.0,
-        "tendency": "REVOLUTIONARY",
-    },
-]
+WORLD_1: dict[str, object] = {
+    "name": "world 1 (community-conformance.bscn)",
+    "nodes": [
+        {"name": "community-register", "type": "INSTITUTION", "community-carrier": 1},
+        {"name": "na-worker", "type": "SOCIAL_CLASS", "active": 1},
+        {"name": "na-organizer", "type": "SOCIAL_CLASS", "active": 1},
+        {"name": "settler-la", "type": "SOCIAL_CLASS", "active": 1},
+        {"name": "unaffiliated", "type": "SOCIAL_CLASS", "active": 1},
+        {"name": "inactive-member", "type": "SOCIAL_CLASS", "active": 0},
+        {
+            "name": "rev-org",
+            "type": "ORGANIZATION",
+            "cadre-level": 0.5,
+            "cohesion": 0.8,
+            "tendency": "REVOLUTIONARY",
+        },
+        {
+            "name": "lib-org",
+            "type": "ORGANIZATION",
+            "cadre-level": 0.25,
+            "cohesion": 0.5,
+            "tendency": "LIBERAL",
+        },
+        {
+            "name": "fash-org",
+            "type": "ORGANIZATION",
+            "cadre-level": 0.5,
+            "cohesion": 0.25,
+            "tendency": "FASCIST",
+        },
+        {
+            "name": "no-member-org",
+            "type": "ORGANIZATION",
+            "cadre-level": 1.0,
+            "cohesion": 1.0,
+            "tendency": "REVOLUTIONARY",
+        },
+    ],
+    "edges": [
+        ("rev-org", "na-worker"),
+        ("rev-org", "na-organizer"),
+        ("lib-org", "na-worker"),
+        ("lib-org", "settler-la"),
+        ("fash-org", "settler-la"),
+    ],
+    "hyperedges": [
+        {
+            "name": "new-afrikan",
+            "kind": "NEW_AFRIKAN",
+            "members": ["na-worker", "na-organizer", "inactive-member"],
+            "heat": 0.5,
+            "cohesion": 0.75,
+            "education-pressure": 0.25,
+            "reproduction-cost-modifier": 0.875,
+            "revolutionary": 0.5,
+            "liberal": 0.25,
+            "fascist": 0.25,
+        },
+        {
+            "name": "settler",
+            "kind": "SETTLER",
+            "members": ["settler-la"],
+            "heat": 0.25,
+            "cohesion": 0.5,
+            "education-pressure": 0.125,
+            "reproduction-cost-modifier": 1.0,
+            "revolutionary": 0.0,
+            "liberal": 0.75,
+            "fascist": 0.25,
+        },
+        {
+            "name": "queer",
+            "kind": "QUEER",
+            "members": ["na-worker"],
+            "heat": 0.75,
+            "cohesion": 0.625,
+            "education-pressure": 0.5,
+            "reproduction-cost-modifier": 1.25,
+            "revolutionary": 0.25,
+            "liberal": 0.5,
+            "fascist": 0.25,
+        },
+    ],
+}
 
-# (source_name, target_name) — the five MEMBERSHIP edges, declaration order.
-MEMBERSHIP_EDGES: list[tuple[str, str]] = [
-    ("rev-org", "na-worker"),
-    ("rev-org", "na-organizer"),
-    ("lib-org", "na-worker"),
-    ("lib-org", "settler-la"),
-    ("fash-org", "settler-la"),
-]
+# World 2 (community-floor-conformance.bscn, Task 9 Step 6): NEW_AFRIKAN
+# and FIRST_NATIONS communities whose org landscapes put normalized r
+# BELOW both floors (both bind; the Ruling-3 ordering is observable), plus
+# SETTLER as the 0.0-floor control. weak-fash gives h0 a nonzero f so the
+# redistribution's PROPORTIONALITY is exercised (not just the l-only arm).
+WORLD_2: dict[str, object] = {
+    "name": "world 2 (community-floor-conformance.bscn)",
+    "nodes": [
+        {"name": "floor-register", "type": "INSTITUTION", "community-carrier": 1},
+        {"name": "w2-a", "type": "SOCIAL_CLASS", "active": 1},
+        {"name": "w2-b", "type": "SOCIAL_CLASS", "active": 1},
+        {"name": "w2-s", "type": "SOCIAL_CLASS", "active": 1},
+        # w2-c/w2-d: the low-density community's members — h3's density-sum
+        # is (1+0)/2 = 0.5, so c05's unorganized = 0.5 folds into l (the
+        # `unorganized_fraction_defaults_to_liberal` witness). No floor
+        # binds (SETTLER, 0.0), so the pure c05 shape is what shows.
+        {"name": "w2-c", "type": "SOCIAL_CLASS", "active": 1},
+        {"name": "w2-d", "type": "SOCIAL_CLASS", "active": 1},
+        {
+            "name": "weak-rev",
+            "type": "ORGANIZATION",
+            "cadre-level": 0.125,
+            "cohesion": 0.25,
+            "tendency": "REVOLUTIONARY",
+        },
+        {
+            "name": "strong-lib",
+            "type": "ORGANIZATION",
+            "cadre-level": 1.0,
+            "cohesion": 1.0,
+            "tendency": "LIBERAL",
+        },
+        {
+            "name": "weak-fash",
+            "type": "ORGANIZATION",
+            "cadre-level": 0.25,
+            "cohesion": 0.5,
+            "tendency": "FASCIST",
+        },
+    ],
+    "edges": [
+        ("weak-rev", "w2-a"),
+        ("weak-rev", "w2-b"),
+        ("strong-lib", "w2-a"),
+        ("strong-lib", "w2-b"),
+        ("strong-lib", "w2-s"),
+        ("weak-fash", "w2-b"),
+        ("weak-rev", "w2-d"),
+    ],
+    "hyperedges": [
+        {
+            "name": "na-comm",
+            "kind": "NEW_AFRIKAN",
+            "members": ["w2-a", "w2-b"],
+            "heat": 0.5,
+            "cohesion": 0.75,
+            "education-pressure": 0.25,
+            "reproduction-cost-modifier": 0.875,
+            "revolutionary": 0.5,
+            "liberal": 0.25,
+            "fascist": 0.25,
+        },
+        {
+            "name": "fn-comm",
+            "kind": "FIRST_NATIONS",
+            "members": ["w2-a"],
+            "heat": 0.25,
+            "cohesion": 0.5,
+            "education-pressure": 0.125,
+            "reproduction-cost-modifier": 1.25,
+            "revolutionary": 0.25,
+            "liberal": 0.5,
+            "fascist": 0.25,
+        },
+        {
+            "name": "settler-comm",
+            "kind": "SETTLER",
+            "members": ["w2-s"],
+            "heat": 0.75,
+            "cohesion": 0.625,
+            "education-pressure": 0.5,
+            "reproduction-cost-modifier": 1.0,
+            "revolutionary": 0.0,
+            "liberal": 0.75,
+            "fascist": 0.25,
+        },
+        {
+            "name": "low-density-comm",
+            "kind": "SETTLER",
+            "members": ["w2-c", "w2-d"],
+            "heat": 0.5,
+            "cohesion": 0.25,
+            "education-pressure": 0.375,
+            "reproduction-cost-modifier": 1.0,
+            "revolutionary": 0.5,
+            "liberal": 0.25,
+            "fascist": 0.25,
+        },
+    ],
+}
 
-HYPEREDGES: list[dict[str, object]] = [
-    # h0 — NEW_AFRIKAN over (n1, n2, n5); n5's membership is real but inactive.
-    {
-        "name": "new-afrikan",
-        "kind": "NEW_AFRIKAN",
-        "members": ["na-worker", "na-organizer", "inactive-member"],
-        "heat": 0.5,
-        "cohesion": 0.75,
-        "education-pressure": 0.25,
-        "reproduction-cost-modifier": 0.875,
-        "revolutionary": 0.5,
-        "liberal": 0.25,
-        "fascist": 0.25,
-    },
-    # h1 — SETTLER over (n3). The 0.0-floor control.
-    {
-        "name": "settler",
-        "kind": "SETTLER",
-        "members": ["settler-la"],
-        "heat": 0.25,
-        "cohesion": 0.5,
-        "education-pressure": 0.125,
-        "reproduction-cost-modifier": 1.0,
-        "revolutionary": 0.0,
-        "liberal": 0.75,
-        "fascist": 0.25,
-    },
-    # h2 — QUEER over (n1).
-    {
-        "name": "queer",
-        "kind": "QUEER",
-        "members": ["na-worker"],
-        "heat": 0.75,
-        "cohesion": 0.625,
-        "education-pressure": 0.5,
-        "reproduction-cost-modifier": 1.25,
-        "revolutionary": 0.25,
-        "liberal": 0.5,
-        "fascist": 0.25,
-    },
-]
+# World 3 (community-degenerate-conformance.bscn, Task 9 Step 6): the
+# degenerate case (h0's only org has ZERO cadre — every weight is 0, the
+# total collapses, the (0,1,0) branch fires and the floor routes through
+# c06, §6.2 I5) AND the no-org skip gate (h1's member has no org edges —
+# density-sum stays 0, the prior ternary is preserved byte-exactly).
+WORLD_3: dict[str, object] = {
+    "name": "world 3 (community-degenerate-conformance.bscn)",
+    "nodes": [
+        {"name": "degenerate-register", "type": "INSTITUTION", "community-carrier": 1},
+        {"name": "d-a", "type": "SOCIAL_CLASS", "active": 1},
+        {"name": "d-b", "type": "SOCIAL_CLASS", "active": 1},
+        {
+            "name": "zero-cadre",
+            "type": "ORGANIZATION",
+            "cadre-level": 0.0,
+            "cohesion": 0.5,
+            "tendency": "REVOLUTIONARY",
+        },
+    ],
+    "edges": [
+        ("zero-cadre", "d-a"),
+    ],
+    "hyperedges": [
+        {
+            "name": "deg-comm",
+            "kind": "CHICANO",
+            "members": ["d-a"],
+            "heat": 0.5,
+            "cohesion": 0.75,
+            "education-pressure": 0.25,
+            "reproduction-cost-modifier": 0.75,
+            "revolutionary": 0.25,
+            "liberal": 0.5,
+            "fascist": 0.25,
+        },
+        {
+            "name": "no-org-comm",
+            "kind": "QUEER",
+            "members": ["d-b"],
+            "heat": 0.25,
+            "cohesion": 0.5,
+            "education-pressure": 0.125,
+            "reproduction-cost-modifier": 1.125,
+            "revolutionary": 0.125,
+            "liberal": 0.75,
+            "fascist": 0.125,
+        },
+    ],
+}
+
+WORLDS: list[dict[str, object]] = [WORLD_1, WORLD_2, WORLD_3]
 
 # The ADR214 floor table (§6.1 verbatim; 14 rows, frozen declaration order).
 FLOOR: dict[str, float] = {
@@ -171,16 +328,12 @@ HEAT_DECAY_ALPHA = 0.05  # organizations.py:22-27
 COHESION_DECAY_ALPHA = 0.03  # organizations.py:28-33
 EDUCATION_PRESSURE_DECAY = 0.1  # consciousness.py:138-143
 
-NAME_TO_NODE: dict[str, int] = {str(n["name"]): i for i, n in enumerate(NODES)}
 
-
-def census(comms: list[dict[str, float]]) -> None:
+def census(world: dict[str, object], comms: list[dict[str, float]]) -> None:
     """c00 → c01, in rule order (the reset and the member census)."""
-
-    # ---- c00-census-reset (carrier): the accumulators were seeded above
-    # at 0 — this rule's writes are exactly those zeros; the collect pass
-    # writes them over any prior tick (world 1 runs one tick, so the reset
-    # is the identity here and STILL transcribed, because Task 12's
+    # ---- c00-census-reset (carrier): the accumulators were seeded at 0 —
+    # the reset writes those zeros over any prior tick (one tick per world
+    # here, so it is the identity and STILL transcribed: Task 12's
     # multi-tick worlds need the order visible). ----
     for c in comms:  # ascending HyperedgeId
         c["member-count"] = 0.0
@@ -190,30 +343,34 @@ def census(comms: list[dict[str, float]]) -> None:
         c["density-sum"] = 0.0
 
     # ---- c01-member-census (social-class, active only) ----
-    # Pre-state law: every `add 1` collects against the c00-reset state;
-    # the count lands as the SET of memberships, summed — subject-ascending
-    # outer, ascending HyperedgeId inner (the writes commute, being +1s,
-    # but the ORDER is stated because D-NF+13 says order is never free).
+    # Pre-state law: every `add 1` collects against the c00-reset state —
+    # subject-ascending (NodeId) outer, ascending HyperedgeId inner.
+    nodes = world["nodes"]
+    hyperedges = world["hyperedges"]
     census_pending: list[int] = [0] * len(comms)
-    for node in NODES:  # ascending declaration order
-        if node["type"] != "SOCIAL_CLASS" or node.get("active") != 1:
+    for node in nodes:  # type: ignore[union-attr]
+        if node["type"] != "SOCIAL_CLASS" or node.get("active") != 1:  # type: ignore[union-attr]
             continue
-        for hid, h in enumerate(HYPEREDGES):  # ascending HyperedgeId
-            if node["name"] in h["members"]:
+        for hid, h in enumerate(hyperedges):  # type: ignore[union-attr]
+            if node["name"] in h["members"]:  # type: ignore[operator]
                 census_pending[hid] += 1
     for hid, n in enumerate(census_pending):
         comms[hid]["member-count"] += float(n)
 
 
 def org_weights_and_contributions(
+    world: dict[str, object],
     comms: list[dict[str, float]],
 ) -> dict[int, dict[str, float]]:
-    """c02 → c03r → c03l → c03f → c04, in rule order."""
-    # Per-class org accumulators (c02 mints them at 0 each tick).
-    class_weights: dict[int, dict[str, float]] = {}
+    """c02 → c03f → c03l → c03r → c04, in rule order."""
+    nodes = world["nodes"]
+    edges = world["edges"]
+    hyperedges = world["hyperedges"]
+    name_to_node = {str(n["name"]): i for i, n in enumerate(nodes)}  # type: ignore[union-attr]
 
     # ---- c02-org-weight-reset (social-class): mint the four zeros ----
-    for nid, node in enumerate(NODES):
+    class_weights: dict[int, dict[str, float]] = {}
+    for nid, node in enumerate(nodes):  # type: ignore[union-attr]
         if node["type"] == "SOCIAL_CLASS":
             class_weights[nid] = {
                 "org-r-weight": 0.0,
@@ -222,63 +379,55 @@ def org_weights_and_contributions(
                 "org-count": 0.0,
             }
 
-    # ---- c03r / c03l / c03f (organization; the three-rule partition) ----
-    # For each tendency rule in order: subjects ascending NodeId, for-each
-    # (neighbors self MEMBERSHIP :out SOCIAL_CLASS) — MEMBERSHIP_EDGES is
-    # declaration-ordered, and each org's targets are ascending by
-    # construction. Each push: weight += cadre × cohesion; count += 1.
-    # Rule-id byte order is the execution order (D16), so the tick runs
-    # c03f → c03l → c03r — NOT the plan table's reading order. Transcribed
-    # in the TRUE order; the result is order-insensitive (disjoint weight
-    # fields; the shared org-count is integer-exact additive), which the
-    # unchanged output proves.
+    # ---- c03f / c03l / c03r (organization; the three-rule partition) ----
+    # Rule-id byte order is the execution order (D16): c03f → c03l → c03r.
+    # Order-insensitive (disjoint weight fields; the shared org-count is
+    # integer-exact additive) — transcribed in the TRUE order anyway.
     for tendency in ("FASCIST", "LIBERAL", "REVOLUTIONARY"):
         key = {
             "REVOLUTIONARY": "org-r-weight",
             "LIBERAL": "org-l-weight",
             "FASCIST": "org-f-weight",
         }[tendency]
-        for node in NODES:
-            if node["type"] != "ORGANIZATION" or node["tendency"] != tendency:
+        for node in nodes:  # type: ignore[union-attr]
+            if node["type"] != "ORGANIZATION" or node["tendency"] != tendency:  # type: ignore[union-attr]
                 continue
-            push = float(node["cadre-level"]) * float(node["cohesion"])
-            for src, tgt in MEMBERSHIP_EDGES:
+            push = float(node["cadre-level"]) * float(node["cohesion"])  # type: ignore[arg-type]
+            for src, tgt in edges:  # type: ignore[union-attr]
                 if src != node["name"]:
                     continue
-                class_weights[NAME_TO_NODE[tgt]][key] += push
-                class_weights[NAME_TO_NODE[tgt]]["org-count"] += 1.0
+                class_weights[name_to_node[tgt]][key] += push
+                class_weights[name_to_node[tgt]]["org-count"] += 1.0
 
     # ---- c04-community-contribution-push (social-class, ACTIVE ONLY) ----
-    # For each active class (ascending), for each of its hyperedges
-    # (ascending): r-raw += org-r-weight / member-count (l, f likewise),
-    # and density-sum += org-count / member-count. The active gate is
-    # FIDELITY: frozen's community_agents is built from the active-only
-    # membership set (community.py:472-474 -> :392-397), so an inactive
-    # class's org weights never enter the sum. (In world 1 the gate changes
-    # no output: n5's weights are exact zeros either way.)
-    for nid, node in enumerate(NODES):
-        if node["type"] != "SOCIAL_CLASS" or node.get("active") != 1:
+    # The active gate is FIDELITY: frozen's community_agents is built from
+    # the active-only membership set (community.py:472-474 -> :392-397).
+    for nid, node in enumerate(nodes):  # type: ignore[union-attr]
+        if node["type"] != "SOCIAL_CLASS" or node.get("active") != 1:  # type: ignore[union-attr]
             continue
         w = class_weights[nid]
-        for hid, h in enumerate(HYPEREDGES):
-            if node["name"] not in h["members"]:
+        for hid, h in enumerate(hyperedges):  # type: ignore[union-attr]
+            if node["name"] not in h["members"]:  # type: ignore[operator]
                 continue
             divisor = comms[hid]["member-count"]
             comms[hid]["r-raw"] += w["org-r-weight"] / divisor
             comms[hid]["l-raw"] += w["org-l-weight"] / divisor
             comms[hid]["f-raw"] += w["org-f-weight"] / divisor
             comms[hid]["density-sum"] += w["org-count"] / divisor
-
     return class_weights
 
 
-def readout(comms: list[dict[str, float]]) -> None:
-    """c05 → c06 → c07 → c08, in rule order (c07/c08 DG-2-gated)."""
+def normalize(comms: list[dict[str, float]]) -> None:
+    """c05, alone (the normalization and the degenerate branch)."""
+
     # ---- c05-normalize (carrier) — the density-sum > 0 skip gate ----
     # unorganized = max(0, 1 − density-sum) folded into l-raw; total =
-    # r+l+f; degenerate (total < 1e-10) → (0, 1, 0) AND NOTHING ELSE (the
-    # floor routes through c06, bit-identically — §6.2 I5).
-    for _hid, c in enumerate(comms):
+    # r+l+f (LEFT-associated: (r + (l+u)) + f, frozen's exact chain);
+    # degenerate (total < 1e-10) → (0, 1, 0) AND NOTHING ELSE (the floor
+    # routes through c06, bit-identically — §6.2 I5). Frozen never stores
+    # the unorganized-folded l-raw, so neither does the port — only the
+    # normalized ternary is written.
+    for c in comms:
         if not c["density-sum"] > 0.0:
             continue  # no-org skip gate: the prior ternary is preserved
         unorganized = max(0.0, 1.0 - c["density-sum"])
@@ -291,14 +440,30 @@ def readout(comms: list[dict[str, float]]) -> None:
             c["liberal"] = l_raw / total
             c["fascist"] = c["f-raw"] / total
 
-    # ---- c06-substrate-floor (carrier) — the pack's ONLY 14-arm dispatch
-    # (a dict here: the mirror transcribes SEMANTICS; the .bsl arm chain is
-    # the language's only lookup shape, §6.2). The r < floor redistribution
-    # with its lf > 1e-10 two-arm split (formulas/consciousness.py:98-107).
+
+def floor_and_gated_readout(
+    world: dict[str, object],
+    comms: list[dict[str, float]],
+) -> None:
+    """c06a → c06b, then c07/c08 (DG-2-gated), in rule order."""
+    hyperedges = world["hyperedges"]
+    # ---- c06a-floor-dispatch (carrier) — the pack's ONLY 14-arm chain
+    # writes the per-community floor cache. SKIPPED communities are written
+    # NOTHING (the cache stays absent — §9 item 5's law one field over).
+    # (A dict here: the mirror transcribes SEMANTICS; the .bsl arm chain is
+    # the language's only lookup shape, §6.2.)
     for hid, c in enumerate(comms):
         if not c["density-sum"] > 0.0:
-            continue  # the same skip gate — frozen's :452 `if org_landscape`
-        floor = FLOOR[str(HYPEREDGES[hid]["kind"])]
+            continue
+        c["substrate-floor"] = FLOOR[str(hyperedges[hid]["kind"])]  # type: ignore[index]
+
+    # ---- c06b-floor-redistribute (carrier) — reads the cache (the
+    # same-tick cross-rule read, §8b). The r < floor redistribution with
+    # its lf > 1e-10 two-arm split (formulas/consciousness.py:98-107).
+    for c in comms:
+        if "substrate-floor" not in c:
+            continue  # the skip gate, one hop removed
+        floor = c["substrate-floor"]
         if c["revolutionary"] < floor:
             remaining = 1.0 - floor
             lf = c["liberal"] + c["fascist"]
@@ -313,7 +478,7 @@ def readout(comms: list[dict[str, float]]) -> None:
     # ---- c07-contestation + c08-dominant-tendency (DG-2-GATED — printed
     # here as oracle values; the .bsl rules land only on the Director's
     # ruling). Same skip gate. ----
-    for _hid, c in enumerate(comms):
+    for c in comms:
         if not c["density-sum"] > 0.0:
             c["contestation"] = float("nan")  # not recomputed — preserved
             c["dominant"] = float("nan")
@@ -334,44 +499,49 @@ def readout(comms: list[dict[str, float]]) -> None:
 
 
 def cost_and_decay(
+    world: dict[str, object],
     comms: list[dict[str, float]],
 ) -> dict[int, float]:
     """c09 → c10 → c11, in rule order."""
+    nodes = world["nodes"]
+    hyperedges = world["hyperedges"]
+
     # ---- c09-cost-modifier-reset (social-class, ACTIVE ONLY) ----
-    # The inactive n5 is written NOTHING — its key stays ABSENT (§9 item 5).
+    # An inactive class is written NOTHING — its key stays ABSENT (§9
+    # item 5).
     cost_modifier: dict[int, float] = {}
-    for nid, node in enumerate(NODES):
-        if node["type"] == "SOCIAL_CLASS" and node.get("active") == 1:
+    for nid, node in enumerate(nodes):  # type: ignore[union-attr]
+        if node["type"] == "SOCIAL_CLASS" and node.get("active") == 1:  # type: ignore[union-attr]
             cost_modifier[nid] = 1.0
 
     # ---- c10-cost-modifier-accumulate (active only) ----
     # scale by each membership's reproduction-cost-modifier, ascending
     # HyperedgeId — D-NF+13's float-product-order divergence lives here.
-    for nid, node in enumerate(NODES):
-        if node["type"] != "SOCIAL_CLASS" or node.get("active") != 1:
+    for nid, node in enumerate(nodes):  # type: ignore[union-attr]
+        if node["type"] != "SOCIAL_CLASS" or node.get("active") != 1:  # type: ignore[union-attr]
             continue
-        for hid, h in enumerate(HYPEREDGES):
-            if node["name"] in h["members"]:
+        for hid, h in enumerate(hyperedges):  # type: ignore[union-attr]
+            if node["name"] in h["members"]:  # type: ignore[operator]
                 cost_modifier[nid] *= comms[hid]["reproduction-cost-modifier"]
 
-    # ---- c11-state-decay (carrier) — max(0, x·(1−α)) per arm; the
-    # infrastructure arm is EXCLUDED (§5 — the CORE_ORGANIZER maintenance
-    # term waits on #653). ----
+    # ---- c11-state-decay (carrier) — max(0, x·(1−α)) per arm, EVERY
+    # community (frozen's decay has no skip gate — community.py:648-675);
+    # the infrastructure arm is EXCLUDED (§5 — the CORE_ORGANIZER
+    # maintenance term waits on #653). ----
     for c in comms:
         c["heat"] = max(0.0, c["heat"] * (1.0 - HEAT_DECAY_ALPHA))
         c["cohesion"] = max(0.0, c["cohesion"] * (1.0 - COHESION_DECAY_ALPHA))
         c["education-pressure"] = max(
             0.0, c["education-pressure"] * (1.0 - EDUCATION_PRESSURE_DECAY)
         )
-
     return cost_modifier
 
 
-def run() -> None:
-    # Hyperedge scratch state the rules read/write: the seeded own-fields
-    # plus the c00-c04 accumulators (minted by c00's reset, not seeded).
+def run_world(world: dict[str, object]) -> None:
+    """One full tick of the transcribed pack over one world, printed."""
+    hyperedges = world["hyperedges"]
     comms: list[dict[str, float]] = []
-    for h in HYPEREDGES:
+    for h in hyperedges:  # type: ignore[union-attr]
         comms.append(
             {
                 "heat": float(h["heat"]),
@@ -389,14 +559,15 @@ def run() -> None:
             }
         )
 
-    census(comms)
-    weights = org_weights_and_contributions(comms)
-    readout(comms)
-    cost_modifier = cost_and_decay(comms)
+    census(world, comms)
+    weights = org_weights_and_contributions(world, comms)
+    normalize(comms)
+    floor_and_gated_readout(world, comms)
+    cost_modifier = cost_and_decay(world, comms)
 
     # ---- the printout: every oracle value, full round-trip precision ----
-    print("community-conformance world 1 — mirror output (the oracle)")
-    for hid, h in enumerate(HYPEREDGES):
+    print(f"== {world['name']} ==")
+    for hid, h in enumerate(hyperedges):  # type: ignore[union-attr]
         c = comms[hid]
         print(f"h{hid} {h['name']} kind={h['kind']}")
         print(f"  member-count = {c['member-count']!r}")
@@ -404,6 +575,10 @@ def run() -> None:
         print(f"  l-raw = {c['l-raw']!r}")
         print(f"  f-raw = {c['f-raw']!r}")
         print(f"  density-sum  = {c['density-sum']!r}")
+        if "substrate-floor" in c:
+            print(f"  substrate-floor = {c['substrate-floor']!r}")
+        else:
+            print("  substrate-floor = ABSENT (no-org skip gate)")
         print(f"  r = {c['revolutionary']!r}")
         print(f"  l = {c['liberal']!r}")
         print(f"  f = {c['fascist']!r}")
@@ -417,7 +592,8 @@ def run() -> None:
         print(f"  decayed heat               = {c['heat']!r}")
         print(f"  decayed cohesion           = {c['cohesion']!r}")
         print(f"  decayed education-pressure = {c['education-pressure']!r}")
-    for nid, node in enumerate(NODES):
+    nodes = world["nodes"]
+    for nid, node in enumerate(nodes):  # type: ignore[union-attr]
         if node["type"] != "SOCIAL_CLASS":
             continue
         w = weights[nid]
@@ -430,6 +606,13 @@ def run() -> None:
             print(f"n{nid} {node['name']}: community-cost-modifier = {cost_modifier[nid]!r}")
         else:
             print(f"n{nid} {node['name']}: community-cost-modifier = ABSENT (honest null)")
+
+
+def run() -> None:
+    """Drive every world, in WORLDS order."""
+    print("community-conformance — mirror output (the oracle)")
+    for world in WORLDS:
+        run_world(world)
 
 
 if __name__ == "__main__":

--- a/rust/crates/babylon-tick/src/bin/bsl_fuel_report.rs
+++ b/rust/crates/babylon-tick/src/bin/bsl_fuel_report.rs
@@ -174,9 +174,11 @@ const SOLO_PACKS: &[(&str, &str, Option<&str>, &str)] = &[
         include_str!("../../content/rules/vitality-attrition.bsl"),
     ),
     (
-        // Community port train (issue #667), Task 8: the c00-c04 census
-        // pack over conformance world 1. Task 9's worlds join as their own
-        // rows when they land.
+        // Community port train (issue #667), Tasks 8-9: the pack over
+        // conformance world 1. The pack's per-world bounds (worlds 2/3 —
+        // D-NF+22) are measured by the declare-low/read-E-LOAD-040 cycle in
+        // tests/community_conformance.rs, which loads all three worlds at
+        // the declared fuel (a world whose bound exceeds it reds at load).
         "community",
         include_str!("../../content/scenarios/community-conformance.bscn"),
         None,

--- a/rust/crates/babylon-tick/tests/community_conformance.rs
+++ b/rust/crates/babylon-tick/tests/community_conformance.rs
@@ -34,13 +34,15 @@
 //! binary64):
 //!
 //! ```text
-//! community-conformance world 1 — mirror output (the oracle)
+//! community-conformance — mirror output (the oracle)
+//! == world 1 (community-conformance.bscn) ==
 //! h0 new-afrikan kind=NEW_AFRIKAN
 //!   member-count = 2.0
 //!   r-raw = 0.4
 //!   l-raw = 0.0625
 //!   f-raw = 0.0
 //!   density-sum  = 1.5
+//!   substrate-floor = 0.136
 //!   r = 0.8648648648648649
 //!   l = 0.13513513513513511
 //!   f = 0.0
@@ -55,6 +57,7 @@
 //!   l-raw = 0.125
 //!   f-raw = 0.125
 //!   density-sum  = 2.0
+//!   substrate-floor = 0.0
 //!   r = 0.0
 //!   l = 0.5
 //!   f = 0.5
@@ -69,6 +72,7 @@
 //!   l-raw = 0.125
 //!   f-raw = 0.0
 //!   density-sum  = 2.0
+//!   substrate-floor = 0.04
 //!   r = 0.7619047619047619
 //!   l = 0.23809523809523808
 //!   f = 0.0
@@ -87,6 +91,112 @@
 //! n4 unaffiliated: community-cost-modifier = 1.0
 //! n5 inactive-member: org-r-weight = 0.0, org-l-weight = 0.0, org-f-weight = 0.0, org-count = 0.0
 //! n5 inactive-member: community-cost-modifier = ABSENT (honest null)
+//! == world 2 (community-floor-conformance.bscn) ==
+//! h0 na-comm kind=NEW_AFRIKAN
+//!   member-count = 2.0
+//!   r-raw = 0.03125
+//!   l-raw = 1.0
+//!   f-raw = 0.0625
+//!   density-sum  = 2.5
+//!   substrate-floor = 0.136
+//!   r = 0.136
+//!   l = 0.8131764705882352
+//!   f = 0.0508235294117647
+//!   contestation = 0.5378856272512799   (DG-2-gated)
+//!   dominant     = LIBERAL   (DG-2-gated)
+//!   decayed heat               = 0.475
+//!   decayed cohesion           = 0.7275
+//!   decayed education-pressure = 0.225
+//! h1 fn-comm kind=FIRST_NATIONS
+//!   member-count = 1.0
+//!   r-raw = 0.03125
+//!   l-raw = 1.0
+//!   f-raw = 0.0
+//!   density-sum  = 2.0
+//!   substrate-floor = 0.155
+//!   r = 0.155
+//!   l = 0.845
+//!   f = 0.0
+//!   contestation = 0.3925724663663697   (DG-2-gated)
+//!   dominant     = LIBERAL   (DG-2-gated)
+//!   decayed heat               = 0.2375
+//!   decayed cohesion           = 0.485
+//!   decayed education-pressure = 0.1125
+//! h2 settler-comm kind=SETTLER
+//!   member-count = 1.0
+//!   r-raw = 0.0
+//!   l-raw = 1.0
+//!   f-raw = 0.0
+//!   density-sum  = 1.0
+//!   substrate-floor = 0.0
+//!   r = 0.0
+//!   l = 1.0
+//!   f = 0.0
+//!   contestation = 0.0   (DG-2-gated)
+//!   dominant     = LIBERAL   (DG-2-gated)
+//!   decayed heat               = 0.7124999999999999
+//!   decayed cohesion           = 0.60625
+//!   decayed education-pressure = 0.45
+//! h3 low-density-comm kind=SETTLER
+//!   member-count = 2.0
+//!   r-raw = 0.015625
+//!   l-raw = 0.0
+//!   f-raw = 0.0
+//!   density-sum  = 0.5
+//!   substrate-floor = 0.0
+//!   r = 0.030303030303030304
+//!   l = 0.9696969696969697
+//!   f = 0.0
+//!   contestation = 0.12360498799464745   (DG-2-gated)
+//!   dominant     = LIBERAL   (DG-2-gated)
+//!   decayed heat               = 0.475
+//!   decayed cohesion           = 0.2425
+//!   decayed education-pressure = 0.3375
+//! n1 w2-a: org-r-weight = 0.03125, org-l-weight = 1.0, org-f-weight = 0.0, org-count = 2.0
+//! n1 w2-a: community-cost-modifier = 1.09375
+//! n2 w2-b: org-r-weight = 0.03125, org-l-weight = 1.0, org-f-weight = 0.125, org-count = 3.0
+//! n2 w2-b: community-cost-modifier = 0.875
+//! n3 w2-s: org-r-weight = 0.0, org-l-weight = 1.0, org-f-weight = 0.0, org-count = 1.0
+//! n3 w2-s: community-cost-modifier = 1.0
+//! n4 w2-c: org-r-weight = 0.0, org-l-weight = 0.0, org-f-weight = 0.0, org-count = 0.0
+//! n4 w2-c: community-cost-modifier = 1.0
+//! n5 w2-d: org-r-weight = 0.03125, org-l-weight = 0.0, org-f-weight = 0.0, org-count = 1.0
+//! n5 w2-d: community-cost-modifier = 1.0
+//! == world 3 (community-degenerate-conformance.bscn) ==
+//! h0 deg-comm kind=CHICANO
+//!   member-count = 1.0
+//!   r-raw = 0.0
+//!   l-raw = 0.0
+//!   f-raw = 0.0
+//!   density-sum  = 1.0
+//!   substrate-floor = 0.113
+//!   r = 0.113
+//!   l = 0.887
+//!   f = 0.0
+//!   contestation = 0.3210795653730473   (DG-2-gated)
+//!   dominant     = LIBERAL   (DG-2-gated)
+//!   decayed heat               = 0.475
+//!   decayed cohesion           = 0.7275
+//!   decayed education-pressure = 0.225
+//! h1 no-org-comm kind=QUEER
+//!   member-count = 1.0
+//!   r-raw = 0.0
+//!   l-raw = 0.0
+//!   f-raw = 0.0
+//!   density-sum  = 0.0
+//!   substrate-floor = ABSENT (no-org skip gate)
+//!   r = 0.125
+//!   l = 0.75
+//!   f = 0.125
+//!   contestation = PRESERVED (no-org skip gate)
+//!   dominant     = PRESERVED (no-org skip gate)
+//!   decayed heat               = 0.2375
+//!   decayed cohesion           = 0.485
+//!   decayed education-pressure = 0.1125
+//! n1 d-a: org-r-weight = 0.0, org-l-weight = 0.0, org-f-weight = 0.0, org-count = 1.0
+//! n1 d-a: community-cost-modifier = 0.75
+//! n2 d-b: org-r-weight = 0.0, org-l-weight = 0.0, org-f-weight = 0.0, org-count = 0.0
+//! n2 d-b: community-cost-modifier = 1.125
 //! ```
 //!
 //! # THE SPIKE (Task 7 Step 5) — the seven-shape verdicts
@@ -246,16 +356,19 @@ fn defenum_ordinal_parity_with_the_frozen_order() {
 // deleted — the INV-010 estate's Rust half) ----
 
 /// §8c row 1: communities appear ONLY as hyperedges — no node whose type
-/// name contains `COMMUNITY` may exist in the census.
+/// name contains `COMMUNITY` may exist in the census. Every world this
+/// pack loads into (plan §8c: the guards outlive the frozen linter).
 #[test]
 fn no_community_typed_node_exists() {
-    let mut graph = HypergraphStore::new();
-    let loaded = load_scenario(SCENARIO, &mut graph).expect("world 1 loads");
-    for (member, count) in &loaded.node_types {
-        assert!(
-            !member.contains("COMMUNITY"),
-            "node type {member} (×{count}) — communities are hyperedges, never nodes (§8c row 1)"
-        );
+    for scenario in [SCENARIO, SCENARIO_W2, SCENARIO_W3] {
+        let mut graph = HypergraphStore::new();
+        let loaded = load_scenario(scenario, &mut graph).expect("world loads");
+        for (member, count) in &loaded.node_types {
+            assert!(
+                !member.contains("COMMUNITY"),
+                "node type {member} (×{count}) — communities are hyperedges, never nodes (§8c row 1)"
+            );
+        }
     }
 }
 
@@ -320,22 +433,27 @@ fn membership_crosses_whole() {
 /// dressed as a passing test).
 #[test]
 fn exactly_one_institution_carrier() {
-    let mut graph = HypergraphStore::new();
-    let loaded = load_scenario(SCENARIO, &mut graph).expect("world 1 loads");
-    assert_eq!(
-        loaded.node_types.get("INSTITUTION"),
-        Some(&1),
-        "exactly one INSTITUTION carrier — tick.rs's subject derivation \
-         iterates EVERY node of the type (D202's filter note), so zero is \
-         silent inertness and two is double-applied hyperedge writes"
-    );
-    // …and it is the anchor: `institution/community-carrier` reads 1.
-    let carrier = graph.nodes("INSTITUTION");
-    assert_eq!(carrier.len(), 1);
-    let anchor = graph
-        .node_attribute(carrier[0], "institution/community-carrier")
-        .expect("the carrier carries the anchor field");
-    assert_eq!(anchor.to_bits(), (1.0_f64).to_bits());
+    // Every world this pack loads into (§8c row 4's "never zero either" is
+    // the loaded half — a carrier-free world runs the carrier rules over
+    // an empty population, silent inertness dressed as a passing test).
+    for scenario in [SCENARIO, SCENARIO_W2, SCENARIO_W3] {
+        let mut graph = HypergraphStore::new();
+        let loaded = load_scenario(scenario, &mut graph).expect("world loads");
+        assert_eq!(
+            loaded.node_types.get("INSTITUTION"),
+            Some(&1),
+            "exactly one INSTITUTION carrier per world — tick.rs's subject \
+             derivation iterates EVERY node of the type (D202's filter \
+             note), so zero is silent inertness and two is double-applied \
+             hyperedge writes"
+        );
+        let carrier = graph.nodes("INSTITUTION");
+        assert_eq!(carrier.len(), 1);
+        let anchor = graph
+            .node_attribute(carrier[0], "institution/community-carrier")
+            .expect("the carrier carries the anchor field");
+        assert_eq!(anchor.to_bits(), (1.0_f64).to_bits());
+    }
 }
 
 // ---- Task 8: c00-c04 — the census and the org-weight decomposition ----
@@ -349,11 +467,11 @@ fn tick_world_1() -> HypergraphStore {
     let report = run_once_into(SCENARIO, PACK, &mut graph, &mut sink)
         .expect("world 1 + the c00-c04 pack ticks clean");
     assert_eq!(
-        report.fired, 18,
-        "c00:1 (carrier) + c01:4 (active classes) + c02:5 (all classes) + \
-         c03f:1 (fash-org) + c03l:1 (lib-org) + c03r:2 (rev-org AND n9 — \
-         n9 is REVOLUTIONARY too; it FIRES with an empty for-each, frozen's \
-         :421 skip) + c04:4 (active classes)"
+        report.fired, 21,
+        "c00:1 + c01:4 (active classes) + c02:5 (all classes) + c03f:1 + \
+         c03l:1 + c03r:2 (rev-org AND n9 — n9 FIRES with an empty for-each, \
+         frozen's :421 skip is structural) + c04:4 (active classes) + \
+         c05:1 + c06a:1 + c06b:1 (the carrier thrice more, Task 9)"
     );
     graph
 }
@@ -483,4 +601,282 @@ fn density_sum_counts_org_memberships_not_orgs() {
         (2.0_f64).to_bits(),
         "n1's 2 orgs over 1 member"
     );
+}
+
+// ---- Task 9: c05 + c06a/c06b — normalization and the ADR214 floor ----
+// (c07/c08 are DG-2-gated and do not exist until the Director's ruling.)
+// Bit-exact against the mirror transcript (`.to_bits()`), per §9.
+
+/// World 2 and world 3, single-homed beside world 1.
+const SCENARIO_W2: &str = include_str!("../content/scenarios/community-floor-conformance.bscn");
+const SCENARIO_W3: &str =
+    include_str!("../content/scenarios/community-degenerate-conformance.bscn");
+
+fn tick(scenario: &str, pack: &str) -> HypergraphStore {
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    run_once_into(scenario, pack, &mut graph, &mut sink).expect("the world + pack ticks clean");
+    graph
+}
+
+/// Step 1: world 1's normalized ternaries — the pack's c05/c06 output,
+/// bit-exact against the mirror. (No floor binds in world 1.)
+#[test]
+fn world_1_normalizes_to_the_mirror() {
+    let graph = tick(SCENARIO, PACK);
+    // h0: (0.4, 0.0625, 0.0) / 0.4625 — no bind (0.8648… > 0.136).
+    assert_eq!(
+        he(&graph, 0, "community/revolutionary").to_bits(),
+        (0.8648648648648649_f64).to_bits()
+    );
+    assert_eq!(
+        he(&graph, 0, "community/liberal").to_bits(),
+        (0.13513513513513511_f64).to_bits()
+    );
+    assert_eq!(
+        he(&graph, 0, "community/fascist").to_bits(),
+        (0.0_f64).to_bits()
+    );
+    // h1: (0, 0.125, 0.125) / 0.25 — the (0.0, 0.5, 0.5) tie.
+    assert_eq!(
+        he(&graph, 1, "community/liberal").to_bits(),
+        (0.5_f64).to_bits()
+    );
+    assert_eq!(
+        he(&graph, 1, "community/fascist").to_bits(),
+        (0.5_f64).to_bits()
+    );
+    // h2: (0.4, 0.125, 0.0) / 0.525 — no bind (0.7619… > 0.04).
+    assert_eq!(
+        he(&graph, 2, "community/revolutionary").to_bits(),
+        (0.7619047619047619_f64).to_bits()
+    );
+}
+
+/// Step 1: the unorganized fraction defaults to liberal — world 2's h3 has
+/// density-sum 0.5, so unorganized = 0.5 folds into l (Jackson: passive
+/// acceptance is liberal hegemony). The 0.0 SETTLER floor never binds, so
+/// the pure c05 shape is what this reads.
+#[test]
+fn unorganized_fraction_defaults_to_liberal() {
+    let graph = tick(SCENARIO_W2, PACK);
+    assert_eq!(
+        he(&graph, 3, "community/density-sum").to_bits(),
+        (0.5_f64).to_bits()
+    );
+    assert_eq!(
+        he(&graph, 3, "community/liberal").to_bits(),
+        (0.9696969696969697_f64).to_bits(),
+        "(0.0 + 0.5) / 0.515625 — the unorganized 0.5 IS the numerator"
+    );
+    assert_eq!(
+        he(&graph, 3, "community/revolutionary").to_bits(),
+        (0.030303030303030304_f64).to_bits(),
+        "0.015625 / 0.515625"
+    );
+}
+
+/// Step 1: the degenerate branch emits (0, 1, 0) and NOTHING else — the
+/// floor routes through c06, bit-identically (§6.2 I5): world 3's h0 has a
+/// zero-cadre only org, so every weight is 0, total collapses, and c06's
+/// CHICANO arm (0.113) lands r and 1 − 0.113 on l through the lf main arm.
+#[test]
+fn degenerate_total_yields_floor_and_remainder() {
+    let graph = tick(SCENARIO_W3, PACK);
+    assert_eq!(
+        he(&graph, 0, "community/revolutionary").to_bits(),
+        (0.113_f64).to_bits()
+    );
+    assert_eq!(
+        he(&graph, 0, "community/liberal").to_bits(),
+        (0.887_f64).to_bits(),
+        "1.0 x 0.887 / 1.0 — exact"
+    );
+    assert_eq!(
+        he(&graph, 0, "community/fascist").to_bits(),
+        (0.0_f64).to_bits()
+    );
+}
+
+/// Step 1: world 2's h0 — the NEW_AFRIKAN floor binds (normalized r ≈
+/// 0.037 < 0.136) and the remaining 0.864 redistributes to l and f
+/// PROPORTIONALLY (h0's weak-fash edge gives a nonzero f arm).
+#[test]
+fn floor_binds_and_redistributes_proportionally() {
+    let graph = tick(SCENARIO_W2, PACK);
+    assert_eq!(
+        he(&graph, 0, "community/revolutionary").to_bits(),
+        (0.136_f64).to_bits()
+    );
+    assert_eq!(
+        he(&graph, 0, "community/liberal").to_bits(),
+        (0.8131764705882352_f64).to_bits()
+    );
+    assert_eq!(
+        he(&graph, 0, "community/fascist").to_bits(),
+        (0.0508235294117647_f64).to_bits()
+    );
+}
+
+/// Step 1: the lf <= 1e-10 arm — reachable ONLY synthetically (c05's
+/// normalized outputs never produce it: r < floor <= 0.18 forces
+/// l+f > 0.82). A test-scoped rig rule (byte-ordered c05 < c05z < c06a)
+/// overwrites world 3's h0 to (0.05, 0, 0) after c05's normalize; c06b
+/// then takes the else arm: l = remaining, f = 0. Dropping the else arm
+/// reds this test (l stays 0).
+#[test]
+fn floor_redistribution_handles_zero_lf() {
+    let rig = r#"
+(rule community/c05z-rig-zero-lf
+  :material-basis "Task 9 test rig: write the pathological (0.05, 0, 0) ternary onto world 3's h0 between c05 and c06a — the ONLY way lf <= 1e-10 with r < floor exists (c05's normalized outputs never produce it)"
+  :fuel 64
+  (domain NodeType/INSTITUTION)
+  (bindings (binding carrier :field institution/community-carrier))
+  (when #t)
+  (effects
+    (for-each (hyperedges HyperedgeType/COMMUNITY)
+      (guard (= (field-of it community/kind) CommunityType/CHICANO)
+        (update-hyperedge it community/revolutionary (set 0.05p))
+        (update-hyperedge it community/liberal (set 0.0p))
+        (update-hyperedge it community/fascist (set 0.0p))))))
+"#;
+    let mut pack_with_rig = PACK.to_owned();
+    pack_with_rig.push_str(rig);
+    let graph = tick(SCENARIO_W3, &pack_with_rig);
+    assert_eq!(
+        he(&graph, 0, "community/revolutionary").to_bits(),
+        (0.113_f64).to_bits()
+    );
+    assert_eq!(
+        he(&graph, 0, "community/liberal").to_bits(),
+        (0.887_f64).to_bits(),
+        "the else arm: l = 1 - floor outright (no lf to scale against)"
+    );
+    assert_eq!(
+        he(&graph, 0, "community/fascist").to_bits(),
+        (0.0_f64).to_bits()
+    );
+}
+
+/// Step 1: the SETTLER floor is identically 0.0 — the guard `r < floor`
+/// is false at floor 0, so world 2's h2 keeps its normalized (0, 1, 0)
+/// untouched (§6.2: the settler pole IS the norm).
+#[test]
+fn settler_floor_is_identically_zero() {
+    let graph = tick(SCENARIO_W2, PACK);
+    assert_eq!(
+        he(&graph, 2, "community/substrate-floor").to_bits(),
+        (0.0_f64).to_bits()
+    );
+    assert_eq!(
+        he(&graph, 2, "community/revolutionary").to_bits(),
+        (0.0_f64).to_bits()
+    );
+    assert_eq!(
+        he(&graph, 2, "community/liberal").to_bits(),
+        (1.0_f64).to_bits()
+    );
+    assert_eq!(
+        he(&graph, 2, "community/fascist").to_bits(),
+        (0.0_f64).to_bits()
+    );
+}
+
+/// Step 1: ADR214 Ruling 3 EXECUTED — world 2's FIRST_NATIONS community
+/// lands r = 0.155 ABOVE its NEW_AFRIKAN community's 0.136, the first time
+/// the frozen table's exact tie breaks (an emergent output of the chosen
+/// measure, not a fresh stipulation).
+#[test]
+fn first_nations_floor_exceeds_new_afrikan() {
+    let graph = tick(SCENARIO_W2, PACK);
+    let na = he(&graph, 0, "community/revolutionary");
+    let fn_ = he(&graph, 1, "community/revolutionary");
+    assert_eq!(na.to_bits(), (0.136_f64).to_bits());
+    assert_eq!(fn_.to_bits(), (0.155_f64).to_bits());
+    assert!(
+        fn_ > na,
+        "Ruling 3: FIRST_NATIONS strictly exceeds NEW_AFRIKAN"
+    );
+    assert_eq!(
+        he(&graph, 1, "community/liberal").to_bits(),
+        (0.845_f64).to_bits()
+    );
+}
+
+/// Step 1: frozen's `:452` skip gate — world 3's h1 (no org edges on its
+/// member) keeps its seeded prior ternary BYTE-EXACTLY, and c06a's cache
+/// write is skipped too (the field stays ABSENT — §9 item 5's law one
+/// field over).
+#[test]
+fn community_without_orgs_keeps_its_prior_consciousness() {
+    let graph = tick(SCENARIO_W3, PACK);
+    assert_eq!(
+        he(&graph, 1, "community/revolutionary").to_bits(),
+        (0.125_f64).to_bits()
+    );
+    assert_eq!(
+        he(&graph, 1, "community/liberal").to_bits(),
+        (0.75_f64).to_bits()
+    );
+    assert_eq!(
+        he(&graph, 1, "community/fascist").to_bits(),
+        (0.125_f64).to_bits()
+    );
+    assert!(
+        graph
+            .hyperedge_attribute(HyperedgeId(1), "community/substrate-floor")
+            .is_err(),
+        "a skipped community's floor cache is never written — honest null, never 0.0"
+    );
+}
+
+/// Step 3's cross-world parity (DG-3's mechanism): every world's 14 floor
+/// constants (and the three decay alphas) are equal to each other and to
+/// the ADR214 values — a typo in one world cannot pass.
+#[test]
+fn the_floor_table_is_byte_identical_across_all_three_worlds() {
+    let expected: [(&str, f64); 14] = [
+        ("community/floor-settler", 0.0),
+        ("community/floor-patriarchal", 0.0),
+        ("community/floor-new-afrikan", 0.136),
+        ("community/floor-first-nations", 0.155),
+        ("community/floor-chicano", 0.113),
+        ("community/floor-women", 0.04),
+        ("community/floor-trans", 0.06),
+        ("community/floor-disabled", 0.03),
+        ("community/floor-queer", 0.04),
+        ("community/floor-undocumented", 0.1),
+        ("community/floor-incarcerated", 0.18),
+        ("community/floor-youth", 0.0),
+        ("community/floor-adult", 0.0),
+        ("community/floor-elder", 0.02),
+    ];
+    for scenario in [SCENARIO, SCENARIO_W2, SCENARIO_W3] {
+        let mut graph = HypergraphStore::new();
+        let loaded = load_scenario(scenario, &mut graph).expect("world loads");
+        for (name, value) in &expected {
+            let actual = loaded
+                .consts
+                .get(*name)
+                .unwrap_or_else(|| panic!("{name} missing from a world"));
+            let babylon_bsl::evaluator::Value::Real(bits) = actual else {
+                panic!("{name} must be a probability literal")
+            };
+            assert_eq!(
+                bits.to_bits(),
+                value.to_bits(),
+                "{name} diverges from the ADR214 value in a world"
+            );
+        }
+        for (name, value) in [
+            ("community/heat-decay-alpha", 0.05),
+            ("community/cohesion-decay-alpha", 0.03),
+            ("community/education-pressure-decay", 0.1),
+        ] {
+            assert!(
+                loaded.consts.contains_key(name),
+                "{name} missing from a world (value {value})"
+            );
+        }
+    }
 }

--- a/rust/crates/babylon-tick/tests/community_conformance.rs
+++ b/rust/crates/babylon-tick/tests/community_conformance.rs
@@ -869,13 +869,21 @@ fn the_floor_table_is_byte_identical_across_all_three_worlds() {
             );
         }
         for (name, value) in [
-            ("community/heat-decay-alpha", 0.05),
-            ("community/cohesion-decay-alpha", 0.03),
-            ("community/education-pressure-decay", 0.1),
+            ("community/heat-decay-alpha", 0.05_f64),
+            ("community/cohesion-decay-alpha", 0.03_f64),
+            ("community/education-pressure-decay", 0.1_f64),
         ] {
-            assert!(
-                loaded.consts.contains_key(name),
-                "{name} missing from a world (value {value})"
+            let actual = loaded
+                .consts
+                .get(name)
+                .unwrap_or_else(|| panic!("{name} missing from a world"));
+            let babylon_bsl::evaluator::Value::Real(bits) = actual else {
+                panic!("{name} must be a coefficient literal")
+            };
+            assert_eq!(
+                bits.to_bits(),
+                value.to_bits(),
+                "{name} diverges from the frozen defines value in a world"
             );
         }
     }


### PR DESCRIPTION
## Community port train, Task 9 — c05 + c06 (c06a/c06b), worlds 2+3

Plan: `docs/superpowers/plans/2026-08-18-community-port.md` (issue #667). **DG-2 has not arrived, so per the plan's own gate this lands Steps 1–3 + 6–8 for c05/c06 and STOPS** — c07 (entropy), c08 (tie-break), and the `consciousness.bsl` theory-line amendment are NOT in this PR. The plan's Step-8 commit message is adjusted accordingly (no c07/c08 claim).

**The c06 split (D204)** — the plan's one-rule c06 cannot exist: the pre-state law (§4.2 C4) makes a write-then-read within one collect pass invisible, so the pack's only 14-arm `community/kind` dispatch lands as `c06a-floor-dispatch` (writing the per-community `community/substrate-floor` cache) + `c06b-floor-redistribute` (the same-tick cross-rule read, spike-(f)-proven). Math unchanged; rule count 14 → 15 (DG-2's "12" becomes 13).

**Worlds:**

- **World 2** (`community-floor-conformance.bscn`): NEW_AFRIKAN (0.136) and FIRST_NATIONS (0.155) both bind below their floors on one tick — **ADR214 Ruling 3's ordering EXECUTED**, never just asserted — h0's weak-fash edge proves the redistribution's proportionality, SETTLER is the identically-0.0 control, and the low-density h3 (density 0.5) witnesses the unorganized→liberal fold.
- **World 3** (`community-degenerate-conformance.bscn`): the zero-cadre degenerate (c05 emits `(0,1,0)`, the CHICANO floor routes to `(0.113, 0.887, 0)` bit-identically to frozen's fused branch — §6.2 I5) AND the no-org skip gate (h1's prior ternary preserved byte-exactly; its floor cache stays ABSENT — §9 item 5 one field over).

**Tests (+9, all bit-exact via `.to_bits()` against the mirror):** the Step-1 list minus the DG-2-gated pair, including `floor_redistribution_handles_zero_lf` through a test-scoped rig rule (byte-ordered `c05 < c05z < c06a` — the else arm is unreachable from c05's outputs *by construction*: r < floor ≤ 0.18 forces l+f > 0.82 — so synthetic coverage is the only honest coverage) and the cross-world floor-table parity pin (DG-3's mechanism). §8c guards 1 and 4 now iterate all three worlds.

**The mirror** is world-parameterized over three literal WORLD dicts, transcribes the true byte order, prints `substrate-floor` per community; world 1's transcript rows are byte-identical across the refactor (md5-pinned at authoring).

**Fuel (Step 8), per-world measured (D-NF+22), declared at max+1:** c00 104, c01 27, c02 21, c03* 72, c04 151, c05 596, c06a 252, c06b 272 (world 2's wider census is the worst case for most; world 1 for c03*). World-1 fired arithmetic re-measured: **21** = 18 + c05:1 + c06a:1 + c06b:1.

**Mutation vectors (six, all proven):** NA arm swap reds both world-2 floor pins; a one-world FN-table typo (0.155→0.145) reds parity AND ordering; CHICANO arm swap reds both world-3 pins; the converse (else arm → `0.99p` literal) stays **GREEN** on all twenty tests — the unexercised arms provably cannot fire; dropping c06b's `/lf` reds the proportionality pin; gutting the epsilon quotient fails the degenerate world at the driver (0/0 NaN refused non-finite).

**Housekeeping:** two new content-sets rows; corpus digest re-pinned at 78 content files; the citation sentinel caught one out-of-bounds cite at authoring (fixed); D203's c00 fuel figure corrected (re-measured at #688's harvest).

**Gates:** `rust:check`, `qa:regression` (byte-identical 12 + E5b), `qa:vault-regression-ci` (both goldens byte-identical), `check:quick`, manifest-sync — all green. No Python engine source touched.
