### PR TITLE
feat(tick): community.bsl c09-c11 — cost modifiers, state decay, the arc, and the carrier-collision world (Community Task 10)

### DIFF
--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -9139,6 +9139,67 @@ consequences are the ordinary kind of review item.
        do not exist until the Director's ruling — §8a row 4's epsilon
        independence (c05's total vs c07's per-component entropy) is stated
        but only c05's half is testable this task.
+   * - D205
+     - §4.2, §1.2
+     - **Cost modifiers, the decay, and the five Task-10 worlds (Community
+       port train, 2026-08-22).** ``c09-cost-modifier-reset`` and
+       ``c10-cost-modifier-accumulate`` BOTH carry the ``(= active 1)``
+       guard frozen's ``_collect_memberships`` imposes
+       (``community.py:472-474``, the C4 law — an inactive class is
+       written NOTHING, the honest-null read, never 1.0); c10's product
+       compounds in ascending ``HyperedgeId`` order (D25, D-NF+13).
+       ``c11-state-decay`` writes heat/cohesion/education-pressure as
+       ``max(0, x·(1−α))`` per community per tick with NO skip gate
+       (frozen's decay loop, ``community.py:648-675``, runs over the whole
+       dict); the infrastructure arm is ABSENT — §5's hard sequencing: its
+       CORE_ORGANIZER maintenance term makes frozen's law non-monotone and
+       waits on #653 (DG-7). **The world-6 divergence, recorded against
+       the plan's own phrasing:** the plan's §1.2 L2 analogue claimed the
+       all-inactive world is "a byte-exact no-op on every community
+       field" — its own c11 row (ungated) and c00's reset writes
+       contradict that. Frozen's early return (``community.py:337-338``)
+       is a GLOBAL control-flow shortcut no per-rule pack reproduces, so
+       the honest pins are the LANES: the census reads 0, the seeded
+       simplex is preserved byte-exactly, no cost modifier is written, AND
+       the decay applies (heat 0.5 → 0.475) — the test is named
+       ``all_inactive_members_skip_every_membership_lane``, not the plan's
+       name, which would assert the contradiction. **L1's analogue** (no
+       config) is a LOAD REFUSAL, not a no-op: a world with no COMMUNITY
+       hyperedge supplies no ceiling, and every carrier rule fails
+       ``E-LOAD-045`` at load — the estate's preferred direction (fail
+       loudly), pinned as a refusal test. **The seam world (5b)** co-loads
+       solidarity.bsl + community.bsl over the landed solidarity world
+       plus the community additions: every SOLIDARITY strength is
+       byte-identical against the solidarity-only run (the amplification
+       half that would move them is #653-blocked), and
+       ``seam_world_community_half_actually_ran`` proves the seam cannot
+       pass vacuously (heat decayed). **The carrier-collision world (5c)**
+       co-loads control-ratio.bsl + community.bsl over ONE INSTITUTION
+       node carrying both packs' anchors — per-rule-id fired arithmetic 37
+       (control-ratio 9 + community 28, measured via ``per_rule_fired``)
+       and the decay-applied-once read (0.475, never 0.45125).
+       **Fuel is per-world** (D-NF+22): measured by ``fuel_bound_report``
+       over ALL EIGHT worlds (the 5c co-load's ceilings included),
+       declared at max+1: c00 104, c01 27, c02 21, c03* 72, c04 151, c05
+       596, c06a 252, c06b 272, c09 8, c10 35, c11 208 (world 2's wider
+       census is the worst case for c00/c01/c04-c06b/c10/c11; world 1 for
+       c03*). **Golden pins: 8 new** (one per content world, before+after
+       in one test; the arc's after is its tick-3 value) — measured, never
+       derived, touching none of the sixteen prior pins. **Mutation
+       vectors (eleven, all proven):** deleting c09 compounds the arc's
+       cost modifier (tick 2 reads 0.765625) — the Task-8-deferred vector;
+       dropping c09's active guard reds the C4 detector; each decay α
+       independently reds the independence pin (heat's swap also reds the
+       worlds pinning heat); each max(0,·) clamp REMOVED stays GREEN (the
+       converse — the clamps are present-but-inert for non-negative
+       intermediates, present because frozen's law carries them); a second
+       INSTITUTION node in world 5c reds §8c guard 4 then the collision
+       arithmetic (37 → 42); removing world 5b's carrier reds guard 4, the
+       seam-ran pin, AND cascades E-EVAL-031 through c01 (the reset's
+       load-bearingness one more way); activating a world-6 member reds
+       the lanes-skipped pin. §8c guards 1 and 4 now iterate every world
+       this pack loads into (the main suite covers worlds 1-4, the arc
+       suite worlds 5-6).
 
 Authoring idioms (non-normative)
 -----------------------------------

--- a/rust/crates/babylon-bsl/tests/content_corpus_digests.rs
+++ b/rust/crates/babylon-bsl/tests/content_corpus_digests.rs
@@ -69,7 +69,7 @@ fn corpus_files() -> Vec<PathBuf> {
 const PINNED_DIGESTS: &[(&str, &str)] = &[
     (
         "community.bsl",
-        "14cb56074a85598b4e945c926f386e0e8cf56f3dbbcf9d71a97782928d27dd3c",
+        "1ce0b5129eb9e34d8ac1e5a963ef4e09a0b8a08813186ceaefd9e785db16ccb8",
     ),
     (
         "consciousness.bsl",
@@ -204,16 +204,36 @@ const PINNED_DIGESTS: &[(&str, &str)] = &[
         "d1b4577f98813cfd17b5e8bd394918a56c5e822c051790bc045254cf6b2a13ad",
     ),
     (
+        "community-carrier-collision-conformance.bscn",
+        "d2399cc98ab913622944c68209e663ba8e07695aaeab0f11e4e85b23f9d08e05",
+    ),
+    (
         "community-conformance.bscn",
         "0e13c145c0398b700952737aaaffeb6a4c575d1894cccfc96a31944fbc0ba984",
+    ),
+    (
+        "community-cost-modifier-conformance.bscn",
+        "03c9fccc01e7a783cf0bdc29f5bbd4cad75d27c7c5e791b89e7c3c004cf0a48b",
+    ),
+    (
+        "community-decay-arc-conformance.bscn",
+        "45e1650e120cfc507ec96d4c46015fd1b53e6ecf9b0085bbc7443fa1b77c4c4b",
     ),
     (
         "community-degenerate-conformance.bscn",
         "b8ad8f7f0472ff8c7baeeee8d3e71653edc43635c19cee7c93048e1035b15ab0",
     ),
     (
+        "community-empty-conformance.bscn",
+        "ca82c8a242c7ef43145dfebb22e3bbc26222edddcbb084f3f1f127961b827af1",
+    ),
+    (
         "community-floor-conformance.bscn",
         "ffabae42ddf3da7667e195cb06dd4e9a5b57f7bdc4ae105358cb4a9f59e77843",
+    ),
+    (
+        "community-solidarity-seam-conformance.bscn",
+        "036bd9f4f3639ae31ba90749d024a467d0b8c1152ed8fe1ce8013e72173f28f2",
     ),
     (
         "consciousness-ternary-conformance.bscn",

--- a/rust/crates/babylon-tick/content/content-sets.toml
+++ b/rust/crates/babylon-tick/content/content-sets.toml
@@ -24,28 +24,88 @@ consumers = [
 ]
 
 [[set]]
+id        = "community/carrier-collision"
+scenario  = "scenarios/community-carrier-collision-conformance.bscn"
+prelude   = []
+rules     = ["rules/control-ratio.bsl", "rules/community.bsl"]
+consumers = [
+    "rust/crates/babylon-tick/tests/community_arc_conformance.rs",
+    "rust/crates/babylon-tick/tests/tick_goldens.rs",
+]
+
+[[set]]
 id        = "community/conformance"
 scenario  = "scenarios/community-conformance.bscn"
 prelude   = []
 # The pack lands across Tasks 8-11 of the Community port train (issue
 # #667); c00-c04 landed at Task 8.
 rules     = ["rules/community.bsl"]
-consumers = ["rust/crates/babylon-tick/tests/community_conformance.rs"]
+consumers = [
+    "rust/crates/babylon-tick/tests/community_conformance.rs",
+    "rust/crates/babylon-tick/tests/tick_goldens.rs",
+]
 
+
+[[set]]
+id        = "community/cost-modifier"
+scenario  = "scenarios/community-cost-modifier-conformance.bscn"
+prelude   = []
+rules     = ["rules/community.bsl"]
+consumers = [
+    "rust/crates/babylon-tick/tests/community_conformance.rs",
+    "rust/crates/babylon-tick/tests/tick_goldens.rs",
+]
+
+[[set]]
+id        = "community/decay-arc"
+scenario  = "scenarios/community-decay-arc-conformance.bscn"
+prelude   = []
+rules     = ["rules/community.bsl"]
+consumers = [
+    "rust/crates/babylon-tick/tests/community_arc_conformance.rs",
+    "rust/crates/babylon-tick/tests/tick_goldens.rs",
+]
 
 [[set]]
 id        = "community/degenerate"
 scenario  = "scenarios/community-degenerate-conformance.bscn"
 prelude   = []
 rules     = ["rules/community.bsl"]
-consumers = ["rust/crates/babylon-tick/tests/community_conformance.rs"]
+consumers = [
+    "rust/crates/babylon-tick/tests/community_conformance.rs",
+    "rust/crates/babylon-tick/tests/tick_goldens.rs",
+]
+
+[[set]]
+id        = "community/empty"
+scenario  = "scenarios/community-empty-conformance.bscn"
+prelude   = []
+rules     = ["rules/community.bsl"]
+consumers = [
+    "rust/crates/babylon-tick/tests/community_arc_conformance.rs",
+    "rust/crates/babylon-tick/tests/tick_goldens.rs",
+]
 
 [[set]]
 id        = "community/floor"
 scenario  = "scenarios/community-floor-conformance.bscn"
 prelude   = []
 rules     = ["rules/community.bsl"]
-consumers = ["rust/crates/babylon-tick/tests/community_conformance.rs"]
+consumers = [
+    "rust/crates/babylon-tick/tests/community_conformance.rs",
+    "rust/crates/babylon-tick/tests/tick_goldens.rs",
+]
+
+
+[[set]]
+id        = "community/solidarity-seam"
+scenario  = "scenarios/community-solidarity-seam-conformance.bscn"
+prelude   = []
+rules     = ["rules/solidarity.bsl", "rules/community.bsl"]
+consumers = [
+    "rust/crates/babylon-tick/tests/community_arc_conformance.rs",
+    "rust/crates/babylon-tick/tests/tick_goldens.rs",
+]
 
 [[set]]
 id        = "consciousness/ternary-conformance"

--- a/rust/crates/babylon-tick/content/rules/community.bsl
+++ b/rust/crates/babylon-tick/content/rules/community.bsl
@@ -316,3 +316,44 @@
                 0.0p)))
           (update-hyperedge it community/revolutionary
             (set (field-of it community/substrate-floor))))))))
+
+; ============================================ c09/c10 — the cost modifier (Task 10 Step 2)
+(rule community/c09-cost-modifier-reset
+  :material-basis "formulas/community.py:164-165's per-tick reset to 1, gated ACTIVE-ONLY by community.py:472-474 (1.4/C4): an INACTIVE class is written NOTHING — its social-class/community-cost-modifier reads the substrate's honest-null error, never 1.0. The reset is what makes c10's product per-tick rather than compounding across ticks (the Task-8-deferred vector, proven in Task 10's arc world)."
+  :fuel 8
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (update-node self social-class/community-cost-modifier (set 1))))
+
+(rule community/c10-cost-modifier-accumulate
+  :material-basis "formulas/community.py:166-174: the modifier is the PRODUCT of the member communities' reproduction-cost-modifier — one `scale` per membership, ascending HyperedgeId (D25; D-NF+13 records the float-product-order divergence: frozen iterates a dict, this pack's order is the substrate's). The active guard is community.py:472-474's (C4). Spike shape (d) verdict, cited: `scale` accumulates multiplicatively across a for-each because the combine reads the current value at APPLY (the operand is pre-computed per collected write)."
+  :fuel 35
+  (bindings
+    (binding active :field social-class/active))
+  (when (= active 1))
+  (effects
+    (for-each (hyperedges-of self HyperedgeType/COMMUNITY)
+      (update-node self social-class/community-cost-modifier
+        (scale (field-of it community/reproduction-cost-modifier))))))
+
+; ============================================================ c11 — the state decay (Task 10 Step 3)
+(rule community/c11-state-decay
+  :material-basis "community.py:648-675: per tick per community, heat/cohesion/education-pressure each decay max(0, x·(1−α)) (the three-arm triplication is 8a row 2 — decay_arms_are_independent carries the three mutation vectors). Frozen computes x·(1−α) then clamps at the model_copy (:668-674); the if-form here is max(0, ·) exactly. THE INFRASTRUCTURE ARM IS ABSENT — 5: its CORE_ORGANIZER maintenance term makes frozen's law NON-MONOTONE, and landing x·(1−α) alone would be a DIFFERENT law (monotone decay); port-as-is (ADR183) forbids it. The term waits on #653 (the AG(i) ceremony), DG-7's call. The decay has NO skip gate — frozen decays every community_state (:648's loop over the whole dict), including a no-org-skipped one."
+  :fuel 208
+  (domain NodeType/INSTITUTION)
+  (bindings
+    (binding carrier :field institution/community-carrier)
+    (binding heat-alpha :const community/heat-decay-alpha)
+    (binding cohesion-alpha :const community/cohesion-decay-alpha)
+    (binding edu-alpha :const community/education-pressure-decay))
+  (when #t)
+  (effects
+    (for-each (hyperedges HyperedgeType/COMMUNITY)
+      (update-hyperedge it community/heat
+        (set (if (< (* (field-of it community/heat) (- 1.0c heat-alpha)) 0.0c) 0.0c (* (field-of it community/heat) (- 1.0c heat-alpha)))))
+      (update-hyperedge it community/cohesion
+        (set (if (< (* (field-of it community/cohesion) (- 1.0c cohesion-alpha)) 0.0c) 0.0c (* (field-of it community/cohesion) (- 1.0c cohesion-alpha)))))
+      (update-hyperedge it community/education-pressure
+        (set (if (< (* (field-of it community/education-pressure) (- 1.0c edu-alpha)) 0.0c) 0.0c (* (field-of it community/education-pressure) (- 1.0c edu-alpha))))))))

--- a/rust/crates/babylon-tick/content/scenarios/community-carrier-collision-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/community-carrier-collision-conformance.bscn
@@ -1,0 +1,287 @@
+; DERIVATIVE WORLD — Community port train world 5c (issue #667, Task 10
+; Step 4, plan docs/superpowers/plans/2026-08-18-community-port.md §3.7a):
+; the landed `control-ratio-conformance.bscn`'s FULL shape verbatim, with
+; its ONE INSTITUTION node (`carceral-register`) ADDITIONALLY carrying
+; `institution/community-carrier 1` — the two packs' anchors on ONE node,
+; never two carriers (a second INSTITUTION node double-fires every
+; carrier-subject rule in BOTH packs; §8c guard 4 is the bar). The
+; co-loaded packs are community.bsl + control-ratio.bsl; the assertion is
+; per-rule-id fired arithmetic (the carceral_arc_conformance style) plus
+; the decay-applied-once read. The original header follows verbatim.
+;
+; The PRIMARY conformance world for `control-ratio/*` (Pack B, Material
+; Base @12.0), Task 5 of the joint Decomposition (@11.0) + ControlRatio
+; (@12.0) port train (`docs/superpowers/plans/2026-08-17-decomposition-
+; controlratio-port.md`; frozen source: `src/babylon/engine/systems/
+; control_ratio.py`, 248 lines).
+;
+; **Task 5 scope.** This is Pack B's PR — branched off MERGED dev (never
+; stacked on PR A, #193), so it ships NO Rust source edits (Task 1 already
+; registered `"control-ratio"` in `lib.rs`'s system `HashSet`) and this
+; scenario carries only `control-ratio/*` fields, never `decomposition/*`'s
+; own LA-census fields — Pack A's own `decomposition.bsl` rule set is never
+; loaded against this world at all. This file, and its three siblings
+; (`-revolution-conformance.bscn`, `-within-capacity-conformance.bscn`,
+; `-zero-enforcer-conformance.bscn`), are the ONLY scenario edits this whole
+; Pack B lands: Tasks 6-7 (`c03-crisis`/`c04-terminal`, not this task's
+; scope) run against these SAME four files unmodified, so every field either
+; c01/c02 (this task) OR c03/c04 (later) reads must be declared and seeded
+; here now.
+;
+; **Seeds a POST-DECOMPOSITION carrier state directly** (plan §5's own
+; byte-order-hazard note) — `decomposition-fire-tick 0`,
+; `decomposition-fired-known 1`, `decomposition-complete 1` — so Pack B is
+; exercised end to end WITHOUT Pack A ever running. This is also why a
+; ZERO `control-ratio-delay` is safe here: the frozen coupling key
+; (`_class_decomposition_tick`) is SEEDED, never written the same tick by a
+; co-loaded `decomposition/*` rule, so §5's cross-pack byte-order inversion
+; (`control-ratio/*` sorts before `decomposition/*`) never has anything to
+; race.
+;
+; **Enum order is a hash-bearing transcription of the frozen Python
+; declaration order (ADR195)** — do not reorder (same roster as
+; `decomposition-conformance.bscn`'s own header cites):
+;   `src/babylon/models/enums/social.py:34-41` — SocialRole.
+;
+; **The carrier.** One `NodeType/INSTITUTION` node, `carceral-register` —
+; the only node of that type this scenario mints, giving it ceiling 1 (plan
+; §2), the same singleton-carrier idiom Pack A's own scenario established.
+;
+; **`social-class/organization` is `coefficient intensive`**
+; (`territory-conformance.bscn:104`'s precedent, NOT `query-lane-e2e.bscn`'s
+; `int extensive` — see `decomposition-conformance.bscn`'s own header for
+; the full deviation note; this file inherits that same ruling since it
+; needs the identical fractional-seed capability for `organization`).
+;
+; **THIS SCENARIO'S SINGLE MUTATION-PROVABLE CONSTANT (Task 5 scope):**
+; `social-class/active` on BOTH the enforcer and the prisoner side of the
+; census. `enforcer-inactive` (population 999, a value large enough that a
+; dropped active-gate would be impossible to miss) and `prisoner-inactive`
+; (population 888, organization 0.9) are seeded SPECIFICALLY so `c01`'s
+; `(= active 1)` conjunct — on both its enforcer branch and its two-role
+; prisoner branch — is mutation-provable in THIS commit, not deferred.
+; `bourgeois` is the ROLE-gate witness (belongs to neither branch of
+; either gate). Forward-looking (Tasks 6-7, not exercised here): with
+; `carceral/control-ratio-delay 0`/`carceral/terminal-decision-delay 0`,
+; active enforcer population 10 and active prisoner population 30+20=50
+; (`enforcer-population * carceral/control-capacity` = 10*4 = 40 <
+; 50 — `c03`'s crisis fires), organization 0.2 on both active prisoner
+; nodes (weighted average 0.2, below `carceral/revolution-threshold`
+; 0.5 — `c04`'s GENOCIDE branch) is this file's own differentiator from
+; `control-ratio-revolution-conformance.bscn`.
+;
+; **No defaults (scenario.rs's own contract): every field every rule in
+; THIS PACK (c01-c04, the whole train's Pack B) will read is seeded on
+; every node of its namespace** — a leaner roster than
+; `decomposition-conformance.bscn`'s, since `control-ratio.bsl` never reads
+; a class's `wealth`/`subsistence-threshold`/`s-bio`/`s-class`/LA-census
+; fields at all (`control_ratio.py`'s own two census helpers read only
+; `role`, `active`, `population`, `organization`) — declaring those unused
+; fields here would be dead content, the inverse of the discipline
+; `decomposition-conformance.bscn`'s roster exists to serve for ITS pack.
+;
+; Six social classes, one carrier (declaration order fixes NodeId,
+; `production-conformance.bscn:207-209`'s own precedent — never renumber
+; when extending):
+;
+;   enforcer-active   CARCERAL_ENFORCER, active, population 10 — the
+;                     enforcer census's sole active contributor.
+;   enforcer-inactive CARCERAL_ENFORCER, INACTIVE, population 999 — the
+;                     active-gate mutation witness: a dropped `(= active 1)`
+;                     conjunct on `c01`'s enforcer branch would inflate
+;                     `enforcer-census-population` by 999, impossible to
+;                     miss against the active branch's 10.
+;   prisoner-ip       INTERNAL_PROLETARIAT, active, population 30,
+;                     organization 0.2 — the frozen `_PRISONER_ROLES`
+;                     frozenset's FIRST role (`control_ratio.py:32-37`).
+;   prisoner-lumpen   LUMPENPROLETARIAT, active, population 20,
+;                     organization 0.2 — `_PRISONER_ROLES`'s SECOND role;
+;                     both active prisoner nodes present together is what
+;                     proves `c01`'s `(or …)` gate reads BOTH disjuncts,
+;                     not merely one.
+;   prisoner-inactive INTERNAL_PROLETARIAT, INACTIVE, population 888,
+;                     organization 0.9 — the prisoner-side active-gate
+;                     mutation witness, mirroring `enforcer-inactive`.
+;   bourgeois         CORE_BOURGEOISIE, active, population 50,
+;                     organization 0.0 — the ROLE-gate witness: neither
+;                     `CARCERAL_ENFORCER` nor either prisoner role, so
+;                     every published census-contribution field on this
+;                     node must stay 0.
+;   carceral-register INSTITUTION — the carrier; every latch/aggregate
+;                     seeded per the "post-decomposition" state above.
+;
+; **`carceral/*` defconsts this pack needs** (`src/babylon/data/
+; defines.yaml:293-300`) — a SUBSET of Pack A's eight: `control-ratio.bsl`
+; never reads `enforcer-fraction`/`proletariat-fraction`/
+; `decomposition-delay`/`approaching-consumption-multiple` (all Pack-A-only
+; coefficients), so this scenario declares neither — the same
+; declare-only-what-the-pack-reads discipline as the field roster above.
+(scenario community/carrier-collision-conformance
+  (defvocabulary NodeType (SOCIAL_CLASS INSTITUTION ORGANIZATION))
+  (defvocabulary EdgeType (MEMBERSHIP))
+  (defvocabulary HyperedgeType (COMMUNITY))
+  (defenum CommunityType
+    (SETTLER PATRIARCHAL NEW_AFRIKAN FIRST_NATIONS CHICANO WOMEN TRANS
+     DISABLED QUEER UNDOCUMENTED INCARCERATED YOUTH ADULT ELDER))
+  (defenum ConsciousnessTendency (LIBERAL FASCIST REVOLUTIONARY))
+  (defenum SocialRole (CORE_BOURGEOISIE PERIPHERY_PROLETARIAT LABOR_ARISTOCRACY PETTY_BOURGEOISIE LUMPENPROLETARIAT COMPRADOR_BOURGEOISIE INTERNAL_PROLETARIAT CARCERAL_ENFORCER))
+
+  (deffield social-class/role enum SocialRole)
+  (deffield social-class/active int extensive)
+  (deffield social-class/population int extensive)
+  (deffield social-class/organization coefficient intensive)
+  (deffield social-class/enforcer-census-population int extensive)
+  (deffield social-class/prisoner-census-population int extensive)
+  (deffield social-class/prisoner-census-org-weighted real extensive)
+
+  (deffield institution/decomposition-fire-tick int extensive)
+  (deffield institution/decomposition-fired-known int extensive)
+  (deffield institution/decomposition-complete int extensive)
+  (deffield institution/control-crisis-emitted int extensive)
+  (deffield institution/control-crisis-tick int extensive)
+  (deffield institution/terminal-decision-emitted int extensive)
+  (deffield institution/enforcer-population int extensive)
+  (deffield institution/prisoner-population int extensive)
+  (deffield institution/prisoner-org-weighted real extensive)
+
+  ; ---- the community pack's field surface (Task 10 world 5c) ----
+  (deffield institution/community-carrier int extensive)
+  (deffield social-class/community-cost-modifier real intensive)
+  (deffield organization/cadre-level probability intensive)
+  (deffield organization/cohesion probability intensive)
+  (deffield organization/consciousness-tendency enum ConsciousnessTendency)
+  (deffield community/kind enum CommunityType)
+  (deffield community/heat intensity intensive)
+  (deffield community/cohesion intensity intensive)
+  (deffield community/education-pressure intensity intensive)
+  (deffield community/reproduction-cost-modifier real intensive)
+  (deffield community/revolutionary probability intensive)
+  (deffield community/liberal probability intensive)
+  (deffield community/fascist probability intensive)
+  (deffield community/member-count int extensive)
+  (deffield community/r-raw real extensive)
+  (deffield community/l-raw real extensive)
+  (deffield community/f-raw real extensive)
+  (deffield community/density-sum real extensive)
+  (deffield community/substrate-floor probability intensive)
+  (deffield social-class/org-r-weight real extensive)
+  (deffield social-class/org-l-weight real extensive)
+  (deffield social-class/org-f-weight real extensive)
+  (deffield social-class/org-count int extensive)
+
+  ; CarceralDefines, src/babylon/data/defines.yaml:293-300 (the four
+  ; control-ratio.bsl reads).
+  (defconst carceral/control-capacity 4)
+  (defconst carceral/revolution-threshold 0.5c)
+  ; Companion-varied to 0 (Global Constraints: "MAY vary a delay/fraction
+  ; to make a branch reachable at tick 1") — paired with the SEEDED
+  ; decomposition-fire-tick 0 below, this makes the c03 readiness gate
+  ; clear at tick 1 with no delay window to wait out (Task 6 scope).
+  (defconst carceral/control-ratio-delay 0)
+  (defconst carceral/terminal-decision-delay 0)
+
+  ; ---- the 14-row ADR214 floor table (§6.1 verbatim) + decay alphas ----
+  (defconst community/floor-new-afrikan 0.136p)
+  (defconst community/floor-first-nations 0.155p)
+  (defconst community/floor-chicano 0.113p)
+  (defconst community/floor-settler 0.0p)
+  (defconst community/floor-patriarchal 0.0p)
+  (defconst community/floor-youth 0.0p)
+  (defconst community/floor-adult 0.0p)
+  (defconst community/floor-incarcerated 0.18p)
+  (defconst community/floor-women 0.04p)
+  (defconst community/floor-trans 0.06p)
+  (defconst community/floor-disabled 0.03p)
+  (defconst community/floor-queer 0.04p)
+  (defconst community/floor-undocumented 0.10p)
+  (defconst community/floor-elder 0.02p)
+  (defconst community/heat-decay-alpha 0.05c)
+  (defconst community/cohesion-decay-alpha 0.03c)
+  (defconst community/education-pressure-decay 0.1c)
+
+  (node enforcer-active NodeType/SOCIAL_CLASS
+    (social-class/role SocialRole/CARCERAL_ENFORCER)
+    (social-class/active 1)
+    (social-class/population 10)
+    (social-class/organization 0.0c)
+    (social-class/enforcer-census-population 0)
+    (social-class/prisoner-census-population 0)
+    (social-class/prisoner-census-org-weighted 0))
+
+  (node enforcer-inactive NodeType/SOCIAL_CLASS
+    (social-class/role SocialRole/CARCERAL_ENFORCER)
+    (social-class/active 0)
+    (social-class/population 999)
+    (social-class/organization 0.0c)
+    (social-class/enforcer-census-population 0)
+    (social-class/prisoner-census-population 0)
+    (social-class/prisoner-census-org-weighted 0))
+
+  (node prisoner-ip NodeType/SOCIAL_CLASS
+    (social-class/role SocialRole/INTERNAL_PROLETARIAT)
+    (social-class/active 1)
+    (social-class/population 30)
+    (social-class/organization 0.2c)
+    (social-class/enforcer-census-population 0)
+    (social-class/prisoner-census-population 0)
+    (social-class/prisoner-census-org-weighted 0))
+
+  (node prisoner-lumpen NodeType/SOCIAL_CLASS
+    (social-class/role SocialRole/LUMPENPROLETARIAT)
+    (social-class/active 1)
+    (social-class/population 20)
+    (social-class/organization 0.2c)
+    (social-class/enforcer-census-population 0)
+    (social-class/prisoner-census-population 0)
+    (social-class/prisoner-census-org-weighted 0))
+
+  (node prisoner-inactive NodeType/SOCIAL_CLASS
+    (social-class/role SocialRole/INTERNAL_PROLETARIAT)
+    (social-class/active 0)
+    (social-class/population 888)
+    (social-class/organization 0.9c)
+    (social-class/enforcer-census-population 0)
+    (social-class/prisoner-census-population 0)
+    (social-class/prisoner-census-org-weighted 0))
+
+  (node bourgeois NodeType/SOCIAL_CLASS
+    (social-class/role SocialRole/CORE_BOURGEOISIE)
+    (social-class/active 1)
+    (social-class/population 50)
+    (social-class/organization 0.0c)
+    (social-class/enforcer-census-population 0)
+    (social-class/prisoner-census-population 0)
+    (social-class/prisoner-census-org-weighted 0))
+
+  (node carceral-register NodeType/INSTITUTION
+    (institution/decomposition-fire-tick 0)
+    (institution/decomposition-fired-known 1)
+    (institution/decomposition-complete 1)
+    (institution/control-crisis-emitted 0)
+    (institution/control-crisis-tick 0)
+    (institution/terminal-decision-emitted 0)
+    (institution/enforcer-population 0)
+    (institution/prisoner-population 0)
+    (institution/prisoner-org-weighted 0)
+    (institution/community-carrier 1))
+
+  ; ---- world 5c's additions (Task 10 Step 4): ONE org + one MEMBERSHIP
+  ; edge (the load law — c03's fold needs a MEMBERSHIP ceiling) + one
+  ; COMMUNITY hyperedge. The org's member is NOT in the community, so the
+  ; community's density-sum stays 0 (the seeded ternary preserved through
+  ; the no-org skip gate); the heat decay still moves it — the "decay
+  ; applied ONCE" assertion reads 0.475, never 0.45125 (the
+  ; double-application a second carrier would cause). ----
+  (node collision-org NodeType/ORGANIZATION
+    (organization/cadre-level 0.5p) (organization/cohesion 0.5p)
+    (organization/consciousness-tendency ConsciousnessTendency/LIBERAL))
+  (edge EdgeType/MEMBERSHIP collision-org bourgeois 1)
+  (hyperedge collision-comm HyperedgeType/COMMUNITY (members prisoner-ip))
+  (hyperedge-attr collision-comm community/kind CommunityType/QUEER)
+  (hyperedge-attr collision-comm community/heat 0.5i)
+  (hyperedge-attr collision-comm community/cohesion 0.75i)
+  (hyperedge-attr collision-comm community/education-pressure 0.25i)
+  (hyperedge-attr collision-comm community/reproduction-cost-modifier 1)
+  (hyperedge-attr collision-comm community/revolutionary 0.25p)
+  (hyperedge-attr collision-comm community/liberal 0.5p)
+  (hyperedge-attr collision-comm community/fascist 0.25p))

--- a/rust/crates/babylon-tick/content/scenarios/community-cost-modifier-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/community-cost-modifier-conformance.bscn
@@ -1,0 +1,114 @@
+; Community port train world 4 (issue #667, Task 10 Step 4 — plan
+; docs/superpowers/plans/2026-08-18-community-port.md): the COST-MODIFIER
+; world. Two communities with DISTINCT reproduction-cost-modifiers (0.75
+; and 1.25), so the per-class product is distinguishable from either
+; factor: w4-both reads 0.75 x 1.25 = 0.9375, w4-one reads 0.75, w4-none
+; reads exactly 1.0 (c09's reset with an empty c10 for-each), and
+; w4-inactive is written NOTHING — the C4 detector's second home (world
+; 1's n5 is the first).
+;
+; The world carries ONE org with ONE membership edge not because the cost
+; modifier reads it (it does not) but because the LOAD law requires it:
+; c03's neighbors fold bounds by the MEMBERSHIP edge-type ceiling, and a
+; scenario minting zero MEMBERSHIP edges supplies no ceiling — the pack
+; would refuse at load (E-LOAD-045). The same law is why a world with no
+; COMMUNITY hyperedge cannot load this pack (the L1 analogue, pinned as a
+; refusal test rather than a world).
+;
+; Declaration order is id order — never renumber when extending. The
+; 14-row floor table and the decay alphas are re-declared per scenario
+; (§6.2); the cross-world parity test pins every world's table equal.
+(scenario community/cost-modifier-conformance
+  (defvocabulary NodeType (INSTITUTION SOCIAL_CLASS ORGANIZATION))
+  (defvocabulary EdgeType (MEMBERSHIP))
+  (defvocabulary HyperedgeType (COMMUNITY))
+  (defenum CommunityType
+    (SETTLER PATRIARCHAL NEW_AFRIKAN FIRST_NATIONS CHICANO WOMEN TRANS
+     DISABLED QUEER UNDOCUMENTED INCARCERATED YOUTH ADULT ELDER))
+  (defenum ConsciousnessTendency (LIBERAL FASCIST REVOLUTIONARY))
+
+  (deffield institution/community-carrier int extensive)
+  (deffield social-class/active int extensive)
+  (deffield social-class/community-cost-modifier real intensive)
+  (deffield organization/cadre-level probability intensive)
+  (deffield organization/cohesion probability intensive)
+  (deffield organization/consciousness-tendency enum ConsciousnessTendency)
+  (deffield community/kind enum CommunityType)
+  (deffield community/heat intensity intensive)
+  (deffield community/cohesion intensity intensive)
+  (deffield community/education-pressure intensity intensive)
+  (deffield community/reproduction-cost-modifier real intensive)
+  (deffield community/revolutionary probability intensive)
+  (deffield community/liberal probability intensive)
+  (deffield community/fascist probability intensive)
+  (deffield community/member-count int extensive)
+  (deffield community/r-raw real extensive)
+  (deffield community/l-raw real extensive)
+  (deffield community/f-raw real extensive)
+  (deffield community/density-sum real extensive)
+  (deffield community/substrate-floor probability intensive)
+  (deffield social-class/org-r-weight real extensive)
+  (deffield social-class/org-l-weight real extensive)
+  (deffield social-class/org-f-weight real extensive)
+  (deffield social-class/org-count int extensive)
+
+  ; ---- the 14-row ADR214 floor table (§6.1 verbatim) + the decay alphas ----
+  (defconst community/floor-new-afrikan 0.136p)
+  (defconst community/floor-first-nations 0.155p)
+  (defconst community/floor-chicano 0.113p)
+  (defconst community/floor-settler 0.0p)
+  (defconst community/floor-patriarchal 0.0p)
+  (defconst community/floor-youth 0.0p)
+  (defconst community/floor-adult 0.0p)
+  (defconst community/floor-incarcerated 0.18p)
+  (defconst community/floor-women 0.04p)
+  (defconst community/floor-trans 0.06p)
+  (defconst community/floor-disabled 0.03p)
+  (defconst community/floor-queer 0.04p)
+  (defconst community/floor-undocumented 0.10p)
+  (defconst community/floor-elder 0.02p)
+  (defconst community/heat-decay-alpha 0.05c)
+  (defconst community/cohesion-decay-alpha 0.03c)
+  (defconst community/education-pressure-decay 0.1c)
+
+  ; ---- nodes (id order) ----
+  (node cost-register NodeType/INSTITUTION (institution/community-carrier 1))
+  ; member of h0 AND h1 — the product witness (0.75 x 1.25 = 0.9375).
+  (node w4-both NodeType/SOCIAL_CLASS (social-class/active 1))
+  ; member of h0 only — the single-factor witness (0.75).
+  (node w4-one NodeType/SOCIAL_CLASS (social-class/active 1))
+  ; NO memberships — c09's reset writes 1 and c10's empty for-each leaves
+  ; it: exactly 1.0 (the plan's n4 pin, one world over).
+  (node w4-none NodeType/SOCIAL_CLASS (social-class/active 1))
+  ; member of h1 but INACTIVE — written NOTHING (C4's detector, second
+  ; world; the honest-null assertion, never 1.0).
+  (node w4-inactive NodeType/SOCIAL_CLASS (social-class/active 0))
+  ; The load-law org (see the header): one edge, into w4-one.
+  (node w4-org NodeType/ORGANIZATION
+    (organization/cadre-level 0.5p) (organization/cohesion 0.5p)
+    (organization/consciousness-tendency ConsciousnessTendency/LIBERAL))
+
+  (edge EdgeType/MEMBERSHIP w4-org w4-one 1)
+
+  ; h0: QUEER over (w4-both, w4-one) — the 0.75 factor.
+  (hyperedge low-cost HyperedgeType/COMMUNITY (members w4-both w4-one))
+  (hyperedge-attr low-cost community/kind CommunityType/QUEER)
+  (hyperedge-attr low-cost community/heat 0.5i)
+  (hyperedge-attr low-cost community/cohesion 0.75i)
+  (hyperedge-attr low-cost community/education-pressure 0.25i)
+  (hyperedge-attr low-cost community/reproduction-cost-modifier 0.75r)
+  (hyperedge-attr low-cost community/revolutionary 0.25p)
+  (hyperedge-attr low-cost community/liberal 0.5p)
+  (hyperedge-attr low-cost community/fascist 0.25p)
+
+  ; h1: NEW_AFRIKAN over (w4-both, w4-inactive) — the 1.25 factor; the
+  ; inactive membership is real but never counted.
+  (hyperedge high-cost HyperedgeType/COMMUNITY (members w4-both w4-inactive))
+  (hyperedge-attr high-cost community/kind CommunityType/NEW_AFRIKAN)
+  (hyperedge-attr high-cost community/heat 0.75i)
+  (hyperedge-attr high-cost community/cohesion 0.625i)
+  (hyperedge-attr high-cost community/education-pressure 0.5i)
+  (hyperedge-attr high-cost community/reproduction-cost-modifier 1.25r)
+  (hyperedge-attr high-cost community/revolutionary 0.5p)
+  (hyperedge-attr high-cost community/liberal 0.25p)
+  (hyperedge-attr high-cost community/fascist 0.25p))

--- a/rust/crates/babylon-tick/content/scenarios/community-decay-arc-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/community-decay-arc-conformance.bscn
@@ -1,0 +1,89 @@
+; Community port train world 5 (issue #667, Task 10 Step 4 — plan
+; docs/superpowers/plans/2026-08-18-community-port.md): the DECAY-ARC
+; world. One carrier, one active class, one org (the load law — c03's
+; neighbors fold needs a MEMBERSHIP ceiling), one community with
+; DISTINCT heat/cohesion/education-pressure seeds so the three decay arms
+; read independently across a three-tick arc (the TickSession idiom,
+; control_ratio_conformance.rs:1172-1181). The arc's mirror is
+; community_decay_arc_conformance.py; the arc's golden pin is its tick-3
+; `after` hash (Task 10 Step 6).
+;
+; Declaration order is id order — never renumber when extending. The
+; 14-row floor table and the decay alphas are re-declared per scenario
+; (§6.2); the cross-world parity test pins every world's table equal.
+(scenario community/decay-arc-conformance
+  (defvocabulary NodeType (INSTITUTION SOCIAL_CLASS ORGANIZATION))
+  (defvocabulary EdgeType (MEMBERSHIP))
+  (defvocabulary HyperedgeType (COMMUNITY))
+  (defenum CommunityType
+    (SETTLER PATRIARCHAL NEW_AFRIKAN FIRST_NATIONS CHICANO WOMEN TRANS
+     DISABLED QUEER UNDOCUMENTED INCARCERATED YOUTH ADULT ELDER))
+  (defenum ConsciousnessTendency (LIBERAL FASCIST REVOLUTIONARY))
+
+  (deffield institution/community-carrier int extensive)
+  (deffield social-class/active int extensive)
+  (deffield social-class/community-cost-modifier real intensive)
+  (deffield organization/cadre-level probability intensive)
+  (deffield organization/cohesion probability intensive)
+  (deffield organization/consciousness-tendency enum ConsciousnessTendency)
+  (deffield community/kind enum CommunityType)
+  (deffield community/heat intensity intensive)
+  (deffield community/cohesion intensity intensive)
+  (deffield community/education-pressure intensity intensive)
+  (deffield community/reproduction-cost-modifier real intensive)
+  (deffield community/revolutionary probability intensive)
+  (deffield community/liberal probability intensive)
+  (deffield community/fascist probability intensive)
+  (deffield community/member-count int extensive)
+  (deffield community/r-raw real extensive)
+  (deffield community/l-raw real extensive)
+  (deffield community/f-raw real extensive)
+  (deffield community/density-sum real extensive)
+  (deffield community/substrate-floor probability intensive)
+  (deffield social-class/org-r-weight real extensive)
+  (deffield social-class/org-l-weight real extensive)
+  (deffield social-class/org-f-weight real extensive)
+  (deffield social-class/org-count int extensive)
+
+  ; ---- the 14-row ADR214 floor table (§6.1 verbatim) + the decay alphas
+  ; (the ARC's alphas are the load-bearing rows this world reads) ----
+  (defconst community/floor-new-afrikan 0.136p)
+  (defconst community/floor-first-nations 0.155p)
+  (defconst community/floor-chicano 0.113p)
+  (defconst community/floor-settler 0.0p)
+  (defconst community/floor-patriarchal 0.0p)
+  (defconst community/floor-youth 0.0p)
+  (defconst community/floor-adult 0.0p)
+  (defconst community/floor-incarcerated 0.18p)
+  (defconst community/floor-women 0.04p)
+  (defconst community/floor-trans 0.06p)
+  (defconst community/floor-disabled 0.03p)
+  (defconst community/floor-queer 0.04p)
+  (defconst community/floor-undocumented 0.10p)
+  (defconst community/floor-elder 0.02p)
+  (defconst community/heat-decay-alpha 0.05c)
+  (defconst community/cohesion-decay-alpha 0.03c)
+  (defconst community/education-pressure-decay 0.1c)
+
+  ; ---- nodes (id order) ----
+  (node arc-register NodeType/INSTITUTION (institution/community-carrier 1))
+  (node arc-worker NodeType/SOCIAL_CLASS (social-class/active 1))
+  ; The load-law org (world 4's header names why): one edge, into
+  ; arc-worker. cadre 0.5 x cohesion 0.5 = 0.25 r-weight — the ternary
+  ; recomputes to (1.0, 0.0, 0.0) every tick (r clears the 0.136 floor).
+  (node arc-org NodeType/ORGANIZATION
+    (organization/cadre-level 0.5p) (organization/cohesion 0.5p)
+    (organization/consciousness-tendency ConsciousnessTendency/REVOLUTIONARY))
+
+  (edge EdgeType/MEMBERSHIP arc-org arc-worker 1)
+
+  ; h0: NEW_AFRIKAN over (arc-worker) — the arc's community.
+  (hyperedge arc-comm HyperedgeType/COMMUNITY (members arc-worker))
+  (hyperedge-attr arc-comm community/kind CommunityType/NEW_AFRIKAN)
+  (hyperedge-attr arc-comm community/heat 0.5i)
+  (hyperedge-attr arc-comm community/cohesion 0.75i)
+  (hyperedge-attr arc-comm community/education-pressure 0.25i)
+  (hyperedge-attr arc-comm community/reproduction-cost-modifier 0.875r)
+  (hyperedge-attr arc-comm community/revolutionary 0.5p)
+  (hyperedge-attr arc-comm community/liberal 0.25p)
+  (hyperedge-attr arc-comm community/fascist 0.25p))

--- a/rust/crates/babylon-tick/content/scenarios/community-empty-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/community-empty-conformance.bscn
@@ -1,0 +1,96 @@
+; Community port train world 6 (issue #667, Task 10 Step 4 — plan
+; docs/superpowers/plans/2026-08-18-community-port.md §1.2): frozen law
+; L2's analogue — one carrier, one community whose members are ALL
+; inactive classes. Frozen's `step()` EARLY-RETURNS on zero memberships
+; (community.py:337-338) — a GLOBAL control-flow shortcut no per-rule pack
+; reproduces — so the honest pins are the LANES, not a blanket no-op:
+; c01's census skips the inactive (member-count 0), c04 pushes nothing,
+; c05/c06a's density gate preserves the seeded simplex byte-exactly, and
+; c09/c10 write no cost modifier (the active guard, §1.4). The two
+; divergences FROM the plan's own "byte-exact no-op" phrase are recorded
+; in D205: c00's reset WRITES the accumulator zeros (they exist
+; post-tick), and c11's decay is ungated (heat moves 0.5 -> 0.475) —
+; frozen's early return suppresses both, and the port's per-rule
+; structure cannot express a cross-rule early return.
+;
+; Declaration order is id order — never renumber when extending. The
+; 14-row floor table and the decay alphas are re-declared per scenario
+; (§6.2); the cross-world parity test pins every world's table equal.
+(scenario community/empty-conformance
+  (defvocabulary NodeType (INSTITUTION SOCIAL_CLASS ORGANIZATION))
+  (defvocabulary EdgeType (MEMBERSHIP))
+  (defvocabulary HyperedgeType (COMMUNITY))
+  (defenum CommunityType
+    (SETTLER PATRIARCHAL NEW_AFRIKAN FIRST_NATIONS CHICANO WOMEN TRANS
+     DISABLED QUEER UNDOCUMENTED INCARCERATED YOUTH ADULT ELDER))
+  (defenum ConsciousnessTendency (LIBERAL FASCIST REVOLUTIONARY))
+
+  (deffield institution/community-carrier int extensive)
+  (deffield social-class/active int extensive)
+  (deffield social-class/community-cost-modifier real intensive)
+  (deffield organization/cadre-level probability intensive)
+  (deffield organization/cohesion probability intensive)
+  (deffield organization/consciousness-tendency enum ConsciousnessTendency)
+  (deffield community/kind enum CommunityType)
+  (deffield community/heat intensity intensive)
+  (deffield community/cohesion intensity intensive)
+  (deffield community/education-pressure intensity intensive)
+  (deffield community/reproduction-cost-modifier real intensive)
+  (deffield community/revolutionary probability intensive)
+  (deffield community/liberal probability intensive)
+  (deffield community/fascist probability intensive)
+  (deffield community/member-count int extensive)
+  (deffield community/r-raw real extensive)
+  (deffield community/l-raw real extensive)
+  (deffield community/f-raw real extensive)
+  (deffield community/density-sum real extensive)
+  (deffield community/substrate-floor probability intensive)
+  (deffield social-class/org-r-weight real extensive)
+  (deffield social-class/org-l-weight real extensive)
+  (deffield social-class/org-f-weight real extensive)
+  (deffield social-class/org-count int extensive)
+
+  ; ---- the 14-row ADR214 floor table (§6.1 verbatim) + the decay alphas ----
+  (defconst community/floor-new-afrikan 0.136p)
+  (defconst community/floor-first-nations 0.155p)
+  (defconst community/floor-chicano 0.113p)
+  (defconst community/floor-settler 0.0p)
+  (defconst community/floor-patriarchal 0.0p)
+  (defconst community/floor-youth 0.0p)
+  (defconst community/floor-adult 0.0p)
+  (defconst community/floor-incarcerated 0.18p)
+  (defconst community/floor-women 0.04p)
+  (defconst community/floor-trans 0.06p)
+  (defconst community/floor-disabled 0.03p)
+  (defconst community/floor-queer 0.04p)
+  (defconst community/floor-undocumented 0.10p)
+  (defconst community/floor-elder 0.02p)
+  (defconst community/heat-decay-alpha 0.05c)
+  (defconst community/cohesion-decay-alpha 0.03c)
+  (defconst community/education-pressure-decay 0.1c)
+
+  ; ---- nodes (id order) ----
+  (node empty-register NodeType/INSTITUTION (institution/community-carrier 1))
+  ; The two all-inactive members.
+  (node idle-a NodeType/SOCIAL_CLASS (social-class/active 0))
+  (node idle-b NodeType/SOCIAL_CLASS (social-class/active 0))
+  ; The load-law org (world 4's header names why): one edge, into idle-a —
+  ; c03 pushes its weight onto the INACTIVE class, where it stays inert
+  ; (c04's active gate never reads it; c02's ungated reset zeroes it next
+  ; tick).
+  (node idle-org NodeType/ORGANIZATION
+    (organization/cadre-level 0.5p) (organization/cohesion 0.5p)
+    (organization/consciousness-tendency ConsciousnessTendency/REVOLUTIONARY))
+
+  (edge EdgeType/MEMBERSHIP idle-org idle-a 1)
+
+  ; h0: NEW_AFRIKAN over (idle-a, idle-b) — every member inactive.
+  (hyperedge idle-comm HyperedgeType/COMMUNITY (members idle-a idle-b))
+  (hyperedge-attr idle-comm community/kind CommunityType/NEW_AFRIKAN)
+  (hyperedge-attr idle-comm community/heat 0.5i)
+  (hyperedge-attr idle-comm community/cohesion 0.75i)
+  (hyperedge-attr idle-comm community/education-pressure 0.25i)
+  (hyperedge-attr idle-comm community/reproduction-cost-modifier 0.875r)
+  (hyperedge-attr idle-comm community/revolutionary 0.5p)
+  (hyperedge-attr idle-comm community/liberal 0.25p)
+  (hyperedge-attr idle-comm community/fascist 0.25p))

--- a/rust/crates/babylon-tick/content/scenarios/community-solidarity-seam-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/community-solidarity-seam-conformance.bscn
@@ -1,0 +1,321 @@
+; DERIVATIVE WORLD — Community port train world 5b (issue #667, Task 10
+; Step 4, plan docs/superpowers/plans/2026-08-18-community-port.md §2.1):
+; the landed `solidarity-conformance.bscn`'s FULL shape (its 22 classes
+; and SOLIDARITY edges verbatim, so the seam assertion compares against
+; the solidarity-only run of the same content) PLUS one
+; `seam-register` INSTITUTION carrier (§3.7a), one `seam-org` ORGANIZATION
+; with one MEMBERSHIP edge (the load law — c03's neighbors fold needs a
+; MEMBERSHIP ceiling; a zero-edge world refuses the pack at load,
+; E-LOAD-045), and one `seam-comm` COMMUNITY hyperedge over `plain-target`
+; (NOT the org's member — its density-sum stays 0, the seeded ternary is
+; preserved through the no-org skip gate, and the heat decay moving proves
+; the community half actually RAN). The original file's "this world seeds
+; no ORGANIZATION nodes at all" claim applies to the SOURCE world, not
+; this derivative — the derivative's org exists by the load law. The
+; original header follows verbatim for the witness arithmetic.
+;
+; The Solidarity @8.0 port train's conformance world (issue #557 umbrella,
+; Wave C, Task 1 — docs/superpowers/plans/2026-08-17-solidarity-port.md).
+; Neither `edge-write-lane-e2e.bscn` (no consciousness surface, uses a
+; `social-class/shape` discriminator this port must not imitate, plan §2.2)
+; nor `consciousness-ternary-conformance.bscn` (right shape, values tuned
+; for the routing law, would entangle two packs' fixtures) is reusable —
+; built fresh per plan §8, copying the header/declaration DISCIPLINE only.
+;
+; §4.2 SPIKE VERDICT (Task 1 step 2, recorded here per the plan's own
+; instruction): PASS, no fallback needed. After adding "solidarity" to
+; `lib.rs`'s registered `systems` HashSet, a throwaway
+; `solidarity/`-namespaced rule bound to a throwaway
+; `solidarity/`-namespaced defconst loaded and ran cleanly through
+; `run_once` — no `E-LOAD-*` collision between `load_defconst`'s `consts`
+; map and the rule-id anchor/`:field` resolution paths sharing the
+; `solidarity/` prefix, exactly as reading `scenario.rs:517-545` predicted.
+; The fallback this verdict makes unnecessary — reusing the landed
+; `consciousness/solidarity-activation-threshold` /
+; `consciousness/negligible-transmission` const names — is NOT taken; this
+; file declares its own `solidarity/*` defconsts below.
+;
+; ONE rule, ONE subject type (plan §2.1): `(defvocabulary NodeType
+; (SOCIAL_CLASS))` only — org-sourced solidarity is PROVABLY always inert
+; (`Organization.ideology` is a `str`, so `class_consciousness_from_node`
+; returns 0.0 for every org source, failing the >0.3 gate every tick;
+; D-record 5), so this world seeds no ORGANIZATION nodes at all.
+;
+; `social-class/revolutionary` (probability, intensive) is the SAME qname
+; and type `consciousness-ternary-conformance.bscn` declares — deffield
+; registries are scenario-local, so no collision (plan §1: the frozen
+; engine's own `class_consciousness <- revolutionary (delta_r)` mapping,
+; `ideology.py:382-386,410`, is the port's re-point; D-record 1).
+; `social-class/active` (int, intensive) is the 0/1 latch convention
+; (`field_of_node` returns `Value::Real` unconditionally, so `(= (field-of
+; it social-class/active) 1)` is the only expressible liveness read) —
+; seeded on EVERY node below (D-record 6: frozen defaults absent `active`
+; to `True`, but an unwritten attribute is an honest-null error here, so
+; the port's content must seed it, even though the rule's own SOURCE-side
+; read keeps frozen's permissive default via `:optional :default 1`).
+;
+; `solidarity/strength` is DELIBERATELY NOT deffield-declared — it stays
+; implicit (D32): declaring it would be `E-LOAD-001`. It seeds via the
+; `(edge EdgeType/SOLIDARITY <from> <to> <strength>)` 4th slot, kind-blind
+; (any int or p/i/c literal), exactly as `consciousness.bsl`'s own
+; `p2-org-solidarity-push` / `p3-class-solidarity-push` read it.
+;
+; The three defconsts (plan §2.7, verified against `defines.yaml:182-187`
+; and `config/defines/consciousness.py:23-39`):
+;   solidarity/activation-threshold      0.3c  (activation_threshold)
+;   solidarity/mass-awakening-threshold  0.6c  (mass_awakening_threshold)
+;   solidarity/negligible-transmission   0.01c (negligible_transmission)
+; `scaling_factor` (0.5) and `superwage_impact` (1.0) are on the same
+; `SolidarityDefines` model but have ZERO call sites in `solidarity.py` —
+; not declared here (D-record 7).
+;
+; Every strength literal is an exact dyadic rational, c-suffixed EXCEPT
+; two witnesses whose values a p/i/c literal cannot legally carry: the
+; multi-inbound group (which deliberately mirrors the frozen fixture's own
+; 0.9/0.8/0.1/0.3 so the D-record's 0.478-vs-0.31 numbers are EXECUTED,
+; not asserted in prose — plan §7 row 2) and the clamp witness (strength
+; 2, a bare Int — a p/i/c-suffixed literal is lexer-bounded to [0,1]
+; regardless of the field it seeds, `reader.rs`'s `classify_unit_interval`,
+; E-LEX-024, so a >1 coefficient must widen in kind-blind via the Int
+; arm). Every OTHER strength is exact in binary64 (the
+; `edge-write-lane-e2e.bscn` discipline). The one exception to "dyadic
+; rational" among the REVOLUTIONARY-share seeds is the exact-0.6 witness
+; below, whose exactness comes from a different, deliberate trick (see its
+; own comment) rather than from a dyadic fraction.
+;
+; Node census, in declaration order (which fixes the store ids — every
+; later task's `NodeId` literals follow this order):
+;    0  plain-source                witness 1 (plain transmission), source
+;    1  plain-target                witness 1, target
+;    2  awaken-source               witness 2a+2b, shared source
+;    3  mass-awaken-cross-target    witness 2a (crosses PAST 0.6)
+;    4  mass-awaken-stays-target    witness 2b (rises, stays below 0.6)
+;    5  mass-awaken-exact-source    witness 2c, source
+;    6  mass-awaken-exact-target    witness 2c (lands EXACTLY at 0.6)
+;    7  zero-strength-source        witness 3a, source
+;    8  zero-strength-target        witness 3a (strength <= 0 skip)
+;    9  at-threshold-source         witness 3b (source at threshold skip)
+;   10  at-threshold-target         witness 3b, target
+;   11  negligible-source           witness 3c, source
+;   12  negligible-target           witness 3c (|delta| < negligible skip)
+;   13  multi-source-a              witness 4, source A (0.9, fires first)
+;   14  multi-source-b              witness 4, source B (0.8, fires LAST —
+;                                   its write wins under `set`)
+;   15  multi-target                witness 4, shared target
+;   16  inactive-source             extra: inactive-source skip, source
+;   17  inactive-source-target      extra: inactive-source skip, target
+;   18  inactive-target-source      extra: inactive-target skip, source
+;   19  inactive-target             extra: inactive-target skip, target
+;   20  clamp-source                extra: clamp witness, source
+;   21  clamp-target                extra: clamp witness, target
+; See each node group's own comment above the `(node …)` forms for its
+; exact literal values and the arithmetic the witness proves — kept in
+; ONE place (there, not duplicated here) so the numbers cannot drift out
+; of sync with the content that seeds them.
+;
+; delta = strength * (source_r - target_r); new = clamp01(target_r + delta)
+; (plan §2.6). Task 1 asserts only that this world LOADS with the declared
+; census; Tasks 2-3 extend `solidarity_conformance.rs` with the per-witness
+; value/event assertions these shapes exist to prove.
+(scenario community/solidarity-seam-conformance
+  (defvocabulary NodeType (SOCIAL_CLASS INSTITUTION ORGANIZATION))
+  (defvocabulary EdgeType (SOLIDARITY MEMBERSHIP))
+  (defvocabulary HyperedgeType (COMMUNITY))
+  (defenum CommunityType
+    (SETTLER PATRIARCHAL NEW_AFRIKAN FIRST_NATIONS CHICANO WOMEN TRANS
+     DISABLED QUEER UNDOCUMENTED INCARCERATED YOUTH ADULT ELDER))
+  (defenum ConsciousnessTendency (LIBERAL FASCIST REVOLUTIONARY))
+
+  (deffield social-class/revolutionary probability intensive)
+  (deffield social-class/active int intensive)
+  ; ---- the community pack's field surface (world 1's set, verbatim) ----
+  (deffield institution/community-carrier int extensive)
+  (deffield social-class/community-cost-modifier real intensive)
+  (deffield organization/cadre-level probability intensive)
+  (deffield organization/cohesion probability intensive)
+  (deffield organization/consciousness-tendency enum ConsciousnessTendency)
+  (deffield community/kind enum CommunityType)
+  (deffield community/heat intensity intensive)
+  (deffield community/cohesion intensity intensive)
+  (deffield community/education-pressure intensity intensive)
+  (deffield community/reproduction-cost-modifier real intensive)
+  (deffield community/revolutionary probability intensive)
+  (deffield community/liberal probability intensive)
+  (deffield community/fascist probability intensive)
+  (deffield community/member-count int extensive)
+  (deffield community/r-raw real extensive)
+  (deffield community/l-raw real extensive)
+  (deffield community/f-raw real extensive)
+  (deffield community/density-sum real extensive)
+  (deffield community/substrate-floor probability intensive)
+  (deffield social-class/org-r-weight real extensive)
+  (deffield social-class/org-l-weight real extensive)
+  (deffield social-class/org-f-weight real extensive)
+  (deffield social-class/org-count int extensive)
+
+  (defconst solidarity/activation-threshold 0.3c)     ; config/defines/consciousness.py:23-28
+  (defconst solidarity/mass-awakening-threshold 0.6c) ; config/defines/consciousness.py:29-34
+  (defconst solidarity/negligible-transmission 0.01c) ; config/defines/consciousness.py:35-39
+
+  ; ---- the 14-row ADR214 floor table (§6.1 verbatim) + decay alphas ----
+  (defconst community/floor-new-afrikan 0.136p)
+  (defconst community/floor-first-nations 0.155p)
+  (defconst community/floor-chicano 0.113p)
+  (defconst community/floor-settler 0.0p)
+  (defconst community/floor-patriarchal 0.0p)
+  (defconst community/floor-youth 0.0p)
+  (defconst community/floor-adult 0.0p)
+  (defconst community/floor-incarcerated 0.18p)
+  (defconst community/floor-women 0.04p)
+  (defconst community/floor-trans 0.06p)
+  (defconst community/floor-disabled 0.03p)
+  (defconst community/floor-queer 0.04p)
+  (defconst community/floor-undocumented 0.10p)
+  (defconst community/floor-elder 0.02p)
+  (defconst community/heat-decay-alpha 0.05c)
+  (defconst community/cohesion-decay-alpha 0.03c)
+  (defconst community/education-pressure-decay 0.1c)
+
+  ; ---- Witness 1: plain transmission (source above threshold, target
+  ; below, differing r -> nonzero delta, no clamp, no mass awakening) ----
+  ; delta = 0.5*(0.5-0.25) = 0.125; new = 0.25+0.125 = 0.375.
+  (node plain-source NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.5p) (social-class/active 1))
+  (node plain-target NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.25p) (social-class/active 1))
+
+  ; ---- Witness 2: MASS_AWAKENING crossing (3 sub-cases sharing one
+  ; source where two of the three can) ----
+  ; 2a CROSSES past 0.6 (strict >, not the boundary): delta =
+  ;    0.5*(0.875-0.5625) = 0.15625; new = 0.5625+0.15625 = 0.71875.
+  ; 2b RISES but STAYS below 0.6 (the negative case): delta =
+  ;    0.125*(0.875-0.5) = 0.046875; new = 0.5+0.046875 = 0.546875.
+  (node awaken-source NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.875p) (social-class/active 1))
+  (node mass-awaken-cross-target NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.5625p) (social-class/active 1))
+  (node mass-awaken-stays-target NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.5p) (social-class/active 1))
+  ; 2c LANDS EXACTLY at 0.6 (the frozen `<=` arm, not `<`): source r is the
+  ; SAME literal ("0.6") the mass-awakening-threshold defconst parses, so
+  ; both go through the identical `unscaled/10^scale` division and produce
+  ; the identical double. strength=1c makes delta = 1.0*(0.6d-0.5), and
+  ; Sterbenz's lemma makes that subtraction EXACT (0.5 and 0.6d share one
+  ; binade, [0.5,1.0)) — so `target_r + delta` re-sums to exactly 0.6d,
+  ; bit-for-bit, not merely "close to 0.6". old(0.5) < 0.6d, new(0.6d) <=
+  ; 0.6d: the boundary case a strict `<` would miss.
+  (node mass-awaken-exact-source NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.6p) (social-class/active 1))
+  (node mass-awaken-exact-target NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.5p) (social-class/active 1))
+
+  ; ---- Witness 3: the three skip gates, each isolated from the other two
+  ; ----
+  ; 3a strength <= 0: source qualifies, target is active, but the edge
+  ;    itself carries no infrastructure (frozen's "Fascist Bifurcation: no
+  ;    infrastructure, no transmission").
+  (node zero-strength-source NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.75p) (social-class/active 1))
+  (node zero-strength-target NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.25p) (social-class/active 1))
+  ; 3b source at/below threshold (0.3 is NOT > 0.3 — the strict gate):
+  ;    the whole subject never fires, so even a well-formed edge to an
+  ;    active target never transmits.
+  (node at-threshold-source NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.3p) (social-class/active 1))
+  (node at-threshold-target NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.25p) (social-class/active 1))
+  ; 3c |delta| < negligible-transmission (0.01): delta =
+  ;    0.125*(0.5-0.4375) = 0.0078125 < 0.01 — every OTHER gate passes
+  ;    (source above threshold, strength positive, target active), only
+  ;    the negligible-transmission floor fires.
+  (node negligible-source NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.5p) (social-class/active 1))
+  (node negligible-target NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.4375p) (social-class/active 1))
+
+  ; ---- Witness 4: multi-inbound divergence (2 sources -> 1 target),
+  ; mirroring the frozen fixture's own shape EXACTLY
+  ; (test_multiple_solidarity_edges,
+  ; tests/unit/engine/systems/test_solidarity_system.py:347-392) so the
+  ; D-record's 0.478 (frozen, sequential: 0.1 -> 0.34 -> 0.478) vs 0.31
+  ; (port, collect-then-apply + `set` last-write-wins: only
+  ; 0.1+0.3*(0.8-0.1)=0.31 survives) numbers are EXECUTED here, not
+  ; asserted in prose. Declaration order matters: `multi-source-a` (0.9)
+  ; is declared, hence iterated, FIRST; `multi-source-b` (0.8) SECOND —
+  ; subjects apply in ascending node-id order (`tick.rs`'s own contract),
+  ; so source-b's write against the UNCHANGED pre-tick target (0.1) is the
+  ; one that survives `set`. ----
+  (node multi-source-a NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.9p) (social-class/active 1))
+  (node multi-source-b NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.8p) (social-class/active 1))
+  (node multi-target NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.1p) (social-class/active 1))
+
+  ; ---- Extra: the inactive-source skip (the subject-side `active`
+  ; latch) — an otherwise-qualifying source (r=0.9 > threshold) that is
+  ; itself dead never even reaches its own edges. ----
+  (node inactive-source NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.9p) (social-class/active 0))
+  (node inactive-source-target NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.25p) (social-class/active 1))
+
+  ; ---- Extra: the inactive-target skip (the for-each's own inner
+  ; `active` guard) — a qualifying, live source whose only neighbour is
+  ; dead: the subject fires (it passes its own gate) but produces no
+  ; write. ----
+  (node inactive-target-source NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.9p) (social-class/active 1))
+  (node inactive-target NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.25p) (social-class/active 0))
+
+  ; ---- Extra: the clamp witness — target + delta would overshoot 1.0
+  ; without the verbatim frozen clamp (plan §2.3: `probability`'s
+  ; [0,1] store law is `E-EVAL-020`, NEVER a clamp, so the rule's own
+  ; `if`-expressed clamp is what keeps this write lawful at all). delta =
+  ; 2*(1.0-0.875) = 0.25; raw new = 0.875+0.25 = 1.125 -> clamped to 1.0.
+  ; strength=2 is a BARE Int literal, not `2c` — a p/i/c-suffixed literal
+  ; is lexer-bounded to [0,1] regardless of the field it seeds
+  ; (`reader.rs`'s `classify_unit_interval`, E-LEX-024), so a strength
+  ; above 1 must widen in kind-blind via the Int arm (verdict 1's "any int
+  ; or p/i/c literal" — the Int half is what a >1 coefficient needs). ----
+  (node clamp-source NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 1.0p) (social-class/active 1))
+  (node clamp-target NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.875p) (social-class/active 1))
+
+  (edge EdgeType/SOLIDARITY plain-source plain-target 0.5c)
+  (edge EdgeType/SOLIDARITY awaken-source mass-awaken-cross-target 0.5c)
+  (edge EdgeType/SOLIDARITY awaken-source mass-awaken-stays-target 0.125c)
+  (edge EdgeType/SOLIDARITY mass-awaken-exact-source mass-awaken-exact-target 1c)
+  (edge EdgeType/SOLIDARITY zero-strength-source zero-strength-target 0c)
+  (edge EdgeType/SOLIDARITY at-threshold-source at-threshold-target 0.5c)
+  (edge EdgeType/SOLIDARITY negligible-source negligible-target 0.125c)
+  (edge EdgeType/SOLIDARITY multi-source-a multi-target 0.3c)
+  (edge EdgeType/SOLIDARITY multi-source-b multi-target 0.3c)
+  (edge EdgeType/SOLIDARITY inactive-source inactive-source-target 0.5c)
+  (edge EdgeType/SOLIDARITY inactive-target-source inactive-target 0.5c)
+  (edge EdgeType/SOLIDARITY clamp-source clamp-target 2)
+  ; ---- the community half's additions (Task 10 Step 4, world 5b): ONE
+  ; carrier (§3.7a), one org with one MEMBERSHIP edge (the load law —
+  ; c03's fold needs a MEMBERSHIP ceiling), one community hyperedge whose
+  ; members are NOT the org's member (so its density-sum stays 0 and the
+  ; seeded ternary is preserved through the no-org skip gate; the heat
+  ; decay still moves it — the seam test's "the community half actually
+  ; ran" witness) ----
+  (node seam-register NodeType/INSTITUTION (institution/community-carrier 1))
+  (node seam-org NodeType/ORGANIZATION
+    (organization/cadre-level 0.5p) (organization/cohesion 0.5p)
+    (organization/consciousness-tendency ConsciousnessTendency/LIBERAL))
+  (edge EdgeType/MEMBERSHIP seam-org plain-source 1)
+  (hyperedge seam-comm HyperedgeType/COMMUNITY (members plain-target))
+  (hyperedge-attr seam-comm community/kind CommunityType/QUEER)
+  (hyperedge-attr seam-comm community/heat 0.5i)
+  (hyperedge-attr seam-comm community/cohesion 0.75i)
+  (hyperedge-attr seam-comm community/education-pressure 0.25i)
+  (hyperedge-attr seam-comm community/reproduction-cost-modifier 1)
+  (hyperedge-attr seam-comm community/revolutionary 0.25p)
+  (hyperedge-attr seam-comm community/liberal 0.5p)
+  (hyperedge-attr seam-comm community/fascist 0.25p)
+)

--- a/rust/crates/babylon-tick/content/scenarios/community_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/community_conformance.py
@@ -304,7 +304,59 @@ WORLD_3: dict[str, object] = {
     ],
 }
 
-WORLDS: list[dict[str, object]] = [WORLD_1, WORLD_2, WORLD_3]
+# World 4 (community-cost-modifier-conformance.bscn, Task 10 Step 4): the
+# cost-modifier world — two communities with DISTINCT modifiers (0.75,
+# 1.25) so the product is distinguishable from either factor, and an
+# inactive member so the C4 detector runs in two worlds (world 1's n5 is
+# the first).
+WORLD_4: dict[str, object] = {
+    "name": "world 4 (community-cost-modifier-conformance.bscn)",
+    "nodes": [
+        {"name": "cost-register", "type": "INSTITUTION", "community-carrier": 1},
+        {"name": "w4-both", "type": "SOCIAL_CLASS", "active": 1},
+        {"name": "w4-one", "type": "SOCIAL_CLASS", "active": 1},
+        {"name": "w4-none", "type": "SOCIAL_CLASS", "active": 1},
+        {"name": "w4-inactive", "type": "SOCIAL_CLASS", "active": 0},
+        {
+            "name": "w4-org",
+            "type": "ORGANIZATION",
+            "cadre-level": 0.5,
+            "cohesion": 0.5,
+            "tendency": "LIBERAL",
+        },
+    ],
+    "edges": [
+        ("w4-org", "w4-one"),
+    ],
+    "hyperedges": [
+        {
+            "name": "low-cost",
+            "kind": "QUEER",
+            "members": ["w4-both", "w4-one"],
+            "heat": 0.5,
+            "cohesion": 0.75,
+            "education-pressure": 0.25,
+            "reproduction-cost-modifier": 0.75,
+            "revolutionary": 0.25,
+            "liberal": 0.5,
+            "fascist": 0.25,
+        },
+        {
+            "name": "high-cost",
+            "kind": "NEW_AFRIKAN",
+            "members": ["w4-both", "w4-inactive"],
+            "heat": 0.75,
+            "cohesion": 0.625,
+            "education-pressure": 0.5,
+            "reproduction-cost-modifier": 1.25,
+            "revolutionary": 0.5,
+            "liberal": 0.25,
+            "fascist": 0.25,
+        },
+    ],
+}
+
+WORLDS: list[dict[str, object]] = [WORLD_1, WORLD_2, WORLD_3, WORLD_4]
 
 # The ADR214 floor table (§6.1 verbatim; 14 rows, frozen declaration order).
 FLOOR: dict[str, float] = {

--- a/rust/crates/babylon-tick/content/scenarios/community_decay_arc_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/community_decay_arc_conformance.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""The Community @6.0 port train's DECAY-ARC mirror (issue #667, Task 10
+Step 5 — plan docs/superpowers/plans/2026-08-18-community-port.md §9, the
+D146/ADR183 convention).
+
+STANDALONE, like every mirror: no `babylon` import, no pytest, no import
+of the sibling mirror (`community_conformance.py` is the term-for-term
+oracle for worlds 1-4; this file transcribes the SAME rules over the arc
+world for THREE ticks — the multi-tick half, which is where c00's reset
+and c09's reset stop being the identity and start being load-bearing).
+
+Transcription notes specific to the arc:
+
+1. The rule order within each tick is the main mirror's (c00 → … → c11);
+   across ticks, the tick boundary is a full write-flush — every write a
+   tick makes is visible to the next tick's FIRST read.
+2. THE RESETS ARE THE POINT: c00 zeroes the per-tick accumulators and c09
+   resets the cost modifier to 1 — deleting c09 makes c10's scale compound
+   (tick 2 would read 0.875^2 = 0.765625; the arc proves 0.875 again).
+3. The ternary recomputes from the static org landscape EVERY tick to
+   (1.0, 0.0, 0.0) — idempotent, r = 1.0 clears the 0.136 floor — while
+   heat/cohesion/education-pressure decay by their own α each tick:
+   x_k = max(0, x_{k-1}·(1−α)) with x_0 the seed.
+4. Unwritten fields: none in this world (its one class is active).
+"""
+
+from __future__ import annotations
+
+# The arc world — community-decay-arc-conformance.bscn, transcribed.
+SEED = {
+    "heat": 0.5,
+    "cohesion": 0.75,
+    "education-pressure": 0.25,
+    "reproduction-cost-modifier": 0.875,
+    "revolutionary": 0.5,
+    "liberal": 0.25,
+    "fascist": 0.25,
+}
+# The static org landscape: one REVOLUTIONARY org, cadre 0.5 x cohesion
+# 0.5 = 0.25 pushed onto the one active class, density 1.0.
+ORG_WEIGHT = 0.25
+FLOOR_NEW_AFRIKAN = 0.136  # ADR214 (measured; erratum 9)
+HEAT_DECAY_ALPHA = 0.05
+COHESION_DECAY_ALPHA = 0.03
+EDUCATION_PRESSURE_DECAY = 0.1
+
+TICKS = 3
+
+
+def run() -> None:
+    heat = SEED["heat"]
+    cohesion = SEED["cohesion"]
+    edu = SEED["education-pressure"]
+    rcm = SEED["reproduction-cost-modifier"]
+
+    print("community-decay-arc — mirror output (the three-tick oracle)")
+    print(f"tick 0 (seed): heat = {heat!r} cohesion = {cohesion!r} edu = {edu!r}")
+    for tick in range(1, TICKS + 1):
+        # c00-c04: the census and the org-weight decomposition rebuild —
+        # the world's content is static, so the accumulators land on the
+        # same values every tick: member-count 1, r-raw 0.25, density 1.0.
+        member_count = 1.0
+        r_raw = ORG_WEIGHT / member_count  # the one class's push
+        density_sum = 1.0 / member_count  # org-count 1 / member-count 1
+
+        # c05: unorganized = max(0, 1 - 1.0) = 0; total = 0.25; normalize.
+        unorganized = max(0.0, 1.0 - density_sum)
+        l_raw = 0.0 + unorganized
+        total = r_raw + l_raw + 0.0
+        r, l_val, f = r_raw / total, l_raw / total, 0.0  # (1.0, 0.0, 0.0)
+
+        # c06a/c06b: floor 0.136 never binds (r = 1.0) — a loud guard, not
+        # an assert (S101): if the arc's ternary ever dips under the floor,
+        # the world's own design broke.
+        if r < FLOOR_NEW_AFRIKAN:
+            raise ValueError(f"arc r {r!r} under the NEW_AFRIKAN floor — the world's design broke")
+
+        # c09 + c10: reset to 1, then scale by the ONE membership's rcm —
+        # per-tick, never compounding.
+        cost_modifier = 1.0 * rcm
+
+        # c11: the decay (the only cross-tick state that MOVES).
+        heat = max(0.0, heat * (1.0 - HEAT_DECAY_ALPHA))
+        cohesion = max(0.0, cohesion * (1.0 - COHESION_DECAY_ALPHA))
+        edu = max(0.0, edu * (1.0 - EDUCATION_PRESSURE_DECAY))
+
+        print(
+            f"tick {tick}: heat = {heat!r} cohesion = {cohesion!r} edu = {edu!r} | "
+            f"r = {r!r} l = {l_val!r} f = {f!r} | "
+            f"cost-modifier = {cost_modifier!r} | member-count = {member_count!r} "
+            f"density-sum = {density_sum!r}"
+        )
+
+
+if __name__ == "__main__":
+    run()

--- a/rust/crates/babylon-tick/tests/community_arc_conformance.rs
+++ b/rust/crates/babylon-tick/tests/community_arc_conformance.rs
@@ -1,0 +1,408 @@
+//! The decay-arc conformance suite (Community port train, Task 10 — plan
+//! `docs/superpowers/plans/2026-08-18-community-port.md`): the three-tick
+//! arc over world 5 (`content/scenarios/community-decay-arc-conformance.bscn`)
+//! via `TickSession` (the `control_ratio_conformance.rs:1172-1181` idiom,
+//! with `SessionId::new`'s deterministic-identity law, D179).
+//!
+//! # The arc mirror's verbatim stdout (2026-08-22, python3 3.13)
+//!
+//! `community_decay_arc_conformance.py` is the arc's oracle (standalone,
+//! transcribing the SAME rules as the main mirror over three ticks — the
+//! multi-tick half, where c00's and c09's resets stop being the identity).
+//! Exact equality, no tolerance, per §9:
+//!
+//! ```text
+//! community-decay-arc — mirror output (the three-tick oracle)
+//! tick 0 (seed): heat = 0.5 cohesion = 0.75 edu = 0.25
+//! tick 1: heat = 0.475 cohesion = 0.7275 edu = 0.225 | r = 1.0 l = 0.0 f = 0.0 | cost-modifier = 0.875 | member-count = 1.0 density-sum = 1.0
+//! tick 2: heat = 0.45125 cohesion = 0.705675 edu = 0.2025 | r = 1.0 l = 0.0 f = 0.0 | cost-modifier = 0.875 | member-count = 1.0 density-sum = 1.0
+//! tick 3: heat = 0.42868749999999994 cohesion = 0.68450475 edu = 0.18225000000000002 | r = 1.0 l = 0.0 f = 0.0 | cost-modifier = 0.875 | member-count = 1.0 density-sum = 1.0
+//! ```
+
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::hypergraph_store::HypergraphStore;
+use babylon_graph::substrate::{GraphSubstrate, HyperedgeId, NodeId};
+use babylon_kernel::SessionId;
+use babylon_tick::TickSession;
+
+const SCENARIO: &str = include_str!("../content/scenarios/community-decay-arc-conformance.bscn");
+const PACK: &str = include_str!("../content/rules/community.bsl");
+
+/// The session id — `SessionId::new`'s deterministic-identity law (D179).
+fn arc_session() -> SessionId {
+    SessionId::new("community-decay-arc").expect("literal is non-empty")
+}
+
+/// Drive three ticks, returning the session (the graph lives in it).
+fn run_arc() -> TickSession<HypergraphStore> {
+    let mut session = TickSession::new(SCENARIO, PACK, HypergraphStore::new(), arc_session())
+        .expect("world 5 + the pack loads into a session");
+    let mut sink = CollectingSink::default();
+    session.advance(&mut sink).expect("tick 1");
+    session.advance(&mut sink).expect("tick 2");
+    session.advance(&mut sink).expect("tick 3");
+    session
+}
+
+fn heat(session: &TickSession<HypergraphStore>) -> f64 {
+    session
+        .graph()
+        .hyperedge_attribute(HyperedgeId(0), "community/heat")
+        .expect("heat written")
+}
+
+fn at(session: &TickSession<HypergraphStore>, field: &str) -> f64 {
+    session
+        .graph()
+        .hyperedge_attribute(HyperedgeId(0), field)
+        .unwrap_or_else(|e| panic!("{field}: {}", e.message))
+}
+
+/// Step 1: the three decay arms are INDEPENDENT (§8a row 2) — tick 3 reads
+/// three DISTINCT values, each its own α compounded three times
+/// (0.5·0.95³, 0.75·0.97³, 0.25·0.9³), bit-exact against the arc mirror.
+#[test]
+fn heat_cohesion_education_decay_independently() {
+    let session = run_arc();
+    assert_eq!(
+        at(&session, "community/heat").to_bits(),
+        (0.42868749999999994_f64).to_bits()
+    );
+    assert_eq!(
+        at(&session, "community/cohesion").to_bits(),
+        (0.68450475_f64).to_bits()
+    );
+    assert_eq!(
+        at(&session, "community/education-pressure").to_bits(),
+        (0.18225000000000002_f64).to_bits()
+    );
+}
+
+/// Step 1: frozen law L4's ported half (`test_law_community_system.py:221`
+/// — heat/cohesion never increase per tick): per-tick reads are monotone
+/// non-increasing across the arc.
+#[test]
+fn decay_is_monotone_non_increasing() {
+    let mut session = TickSession::new(SCENARIO, PACK, HypergraphStore::new(), arc_session())
+        .expect("session loads");
+    let mut sink = CollectingSink::default();
+    let mut prev = f64::INFINITY;
+    for _tick in 1..=3 {
+        session.advance(&mut sink).expect("tick");
+        let current = heat(&session);
+        assert!(
+            current <= prev,
+            "heat must not increase: {prev} -> {current}"
+        );
+        prev = current;
+    }
+}
+
+/// Step 1 (the Task-8-deferred vector's proof home): c09's reset makes the
+/// cost modifier PER-TICK — tick 3 reads 0.875 again, never 0.875³
+/// (0.669…). Deleting c09 reds this at tick 2 (0.765625).
+#[test]
+fn cost_modifier_does_not_compound_across_ticks() {
+    let session = run_arc();
+    let value = session
+        .graph()
+        .node_attribute(NodeId(1), "social-class/community-cost-modifier")
+        .expect("the active class is written every tick");
+    assert_eq!(
+        value.to_bits(),
+        (0.875_f64).to_bits(),
+        "the reset + the scale, per tick — never compounding"
+    );
+}
+
+/// The ternary recomputes identically from the static org landscape every
+/// tick: (1.0, 0.0, 0.0), r = 1.0 clearing the 0.136 floor.
+#[test]
+fn the_ternary_is_idempotent_across_the_arc() {
+    let session = run_arc();
+    assert_eq!(
+        at(&session, "community/revolutionary").to_bits(),
+        (1.0_f64).to_bits()
+    );
+    assert_eq!(
+        at(&session, "community/liberal").to_bits(),
+        (0.0_f64).to_bits()
+    );
+    assert_eq!(
+        at(&session, "community/fascist").to_bits(),
+        (0.0_f64).to_bits()
+    );
+}
+
+// ---- World 5b: the solidarity seam (§2.1) ----
+
+/// World 5b: the landed solidarity world PLUS the community half's
+/// additions (carrier, load-law org, one community).
+const SEAM_SCENARIO: &str =
+    include_str!("../content/scenarios/community-solidarity-seam-conformance.bscn");
+const SOLIDARITY_PACK: &str = include_str!("../content/rules/solidarity.bsl");
+
+/// Step 1, first half (§2.1): co-loading the community pack moves NO
+/// SOLIDARITY edge's strength — byte-identical against the
+/// solidarity-only run of the SAME world. (The amplification half that
+/// WOULD move them is #653-blocked and not in this pack.)
+#[test]
+fn community_tick_leaves_solidarity_strength_byte_identical() {
+    let mut solo = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    babylon_tick::run_once_into(SEAM_SCENARIO, SOLIDARITY_PACK, &mut solo, &mut sink)
+        .expect("the solidarity-only run ticks");
+
+    let co_loaded = format!("{SOLIDARITY_PACK}\n{PACK}");
+    let mut both = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    babylon_tick::run_once_into(SEAM_SCENARIO, &co_loaded, &mut both, &mut sink)
+        .expect("the co-loaded run ticks");
+
+    for (from, to) in solo.edges("SOLIDARITY") {
+        let solo_strength = solo
+            .edge_attribute("SOLIDARITY", from, to, "solidarity/strength")
+            .expect("the strength slot");
+        let both_strength = both
+            .edge_attribute("SOLIDARITY", from, to, "solidarity/strength")
+            .expect("the strength slot");
+        assert_eq!(
+            solo_strength.to_bits(),
+            both_strength.to_bits(),
+            "SOLIDARITY {from:?}->{to:?} moved under the co-load"
+        );
+    }
+    // and the worlds' edge censuses agree (the co-load mints no edges).
+    assert_eq!(
+        solo.edges("SOLIDARITY").len(),
+        both.edges("SOLIDARITY").len()
+    );
+}
+
+/// Step 1, second half: the seam proof cannot pass VACUOUSLY — the
+/// co-loaded run's community half actually RAN (the seam community's heat
+/// decayed 0.5 -> 0.475 through c11) AND its carrier rules fired. The
+/// mutation vector (remove world 5b's carrier) reds this AND §8c guard 4.
+#[test]
+fn seam_world_community_half_actually_ran() {
+    let co_loaded = format!("{SOLIDARITY_PACK}\n{PACK}");
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = babylon_tick::run_once_into(SEAM_SCENARIO, &co_loaded, &mut graph, &mut sink)
+        .expect("the co-loaded run ticks");
+    assert!(
+        report.fired > 0,
+        "the carrier rules fired (the fired arithmetic is the per-rule-id ledger)"
+    );
+    let heat = graph
+        .hyperedge_attribute(HyperedgeId(0), "community/heat")
+        .expect("the seam community's heat");
+    assert_eq!(
+        heat.to_bits(),
+        (0.475_f64).to_bits(),
+        "0.5 x (1 - 0.05) — the community half RAN (c11's decay moved it)"
+    );
+}
+
+// ---- World 5c: the carrier collision (§3.7a) ----
+
+/// World 5c: the landed carceral world with its ONE institution node
+/// carrying BOTH packs' anchor fields.
+const COLLISION_SCENARIO: &str =
+    include_str!("../content/scenarios/community-carrier-collision-conformance.bscn");
+const CONTROL_RATIO_PACK: &str = include_str!("../content/rules/control-ratio.bsl");
+
+/// Step 1 (§3.7a): the two packs co-loaded over ONE carrier fire once
+/// each — the per-rule-id fired arithmetic (the carceral_arc_conformance
+/// style) and the decay-applied-ONCE read (0.475, never the
+/// double-application 0.45125). The mutation vector (a SECOND institution
+/// node in this world) reds §8c guard 4 first, then this arithmetic.
+#[test]
+fn co_loaded_packs_fire_once_each_on_one_carrier() {
+    let co_loaded = format!("{CONTROL_RATIO_PACK}\n{PACK}");
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = babylon_tick::run_once_into(COLLISION_SCENARIO, &co_loaded, &mut graph, &mut sink)
+        .expect("the co-loaded world ticks");
+    let heat = graph
+        .hyperedge_attribute(HyperedgeId(0), "community/heat")
+        .expect("the collision community's heat");
+    assert_eq!(
+        heat.to_bits(),
+        (0.475_f64).to_bits(),
+        "c11's decay applied ONCE (0.5 x 0.95) — a second carrier would \
+         double-apply it (0.45125)"
+    );
+    // The fired arithmetic (breakdown in the failure message).
+    assert_eq!(
+        report.fired, 37,
+        "control-ratio: c01:6 (every SOCIAL_CLASS subject) + c02:1 + c03:1 \
+         + c04:1 = 9; community: c00:1 + c01:4 (the four ACTIVE carceral \
+         classes — enforcer-inactive and prisoner-inactive are excluded) + \
+         c02:6 (all six) + c03f:0 + c03l:1 (collision-org is LIBERAL) + \
+         c03r:0 + c04:4 + c05:1 + c06a:1 + c06b:1 + c09:4 + c10:4 + c11:1 \
+         = 28 (per-rule-id, measured via per_rule_fired) — each pack's \
+         carrier rules fire ONCE on the shared carrier"
+    );
+}
+
+// ---- World 6 + the L1 analogue (§1.2) ----
+
+/// World 6: one carrier, one all-inactive community.
+const EMPTY_SCENARIO: &str = include_str!("../content/scenarios/community-empty-conformance.bscn");
+
+/// Step 1 (§1.2's L2 analogue, per the plan's OWN repinning in D205): with
+/// every member inactive, every MEMBERSHIP lane is skipped — the census
+/// reads 0, the seeded simplex is preserved byte-exactly (the c05/c06
+/// skip gate), and no cost modifier is ever written (the honest-null
+/// read) — while the carrier rules DO fire and c11's ungated decay still
+/// moves heat (0.5 -> 0.475). Frozen's global early return
+/// (community.py:337-338) suppresses the decay; the port's per-rule
+/// structure cannot express a cross-rule early return, so the decay
+/// applying is the recorded divergence — NOT the plan's "byte-exact
+/// no-op" phrasing, which its own ungated c11 row contradicts.
+#[test]
+fn all_inactive_members_skip_every_membership_lane() {
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = babylon_tick::run_once_into(EMPTY_SCENARIO, PACK, &mut graph, &mut sink)
+        .expect("every rule loads and the world ticks");
+    // The carrier rules fire; the class rules fire on nobody active.
+    let per_rule: std::collections::HashMap<&str, usize> = report
+        .per_rule_fired
+        .iter()
+        .map(|(id, n)| (id.as_str(), *n))
+        .collect();
+    assert_eq!(per_rule["community/c00-census-reset"], 1);
+    assert_eq!(
+        per_rule["community/c11-state-decay"], 1,
+        "the carrier decay rule fires"
+    );
+    assert_eq!(
+        per_rule["community/c01-member-census"], 0,
+        "no active class"
+    );
+    assert_eq!(
+        per_rule["community/c09-cost-modifier-reset"], 0,
+        "the active guard"
+    );
+    assert_eq!(
+        per_rule["community/c10-cost-modifier-accumulate"], 0,
+        "the active guard"
+    );
+    // The census is zero and the simplex is preserved byte-exactly.
+    assert_eq!(
+        graph
+            .hyperedge_attribute(HyperedgeId(0), "community/member-count")
+            .expect("c00's reset landed")
+            .to_bits(),
+        (0.0_f64).to_bits()
+    );
+    assert_eq!(
+        graph
+            .hyperedge_attribute(HyperedgeId(0), "community/revolutionary")
+            .expect("the seeded ternary")
+            .to_bits(),
+        (0.5_f64).to_bits(),
+        "the skip gate preserves the seed"
+    );
+    // No cost modifier is ever written on either inactive class.
+    for nid in [1_u64, 2] {
+        assert!(
+            graph
+                .node_attribute(NodeId(nid), "social-class/community-cost-modifier")
+                .is_err(),
+            "n{nid}: honest null, never 1.0"
+        );
+    }
+    // The recorded divergence: c11's ungated decay DOES apply.
+    assert_eq!(
+        graph
+            .hyperedge_attribute(HyperedgeId(0), "community/heat")
+            .expect("heat")
+            .to_bits(),
+        (0.475_f64).to_bits(),
+        "the decay applies — the port has no cross-rule early return (D205)"
+    );
+}
+
+/// Step 1 (§1.2's L1 analogue): a world with NO COMMUNITY hyperedge
+/// REFUSES the pack at load — MissingCeiling (E-LOAD-045), the driver's
+/// documented "fail loudly at load rather than quietly iterate nothing"
+/// (lib.rs:250-252) — where frozen silently no-ops. A refusal test, never
+/// a golden-pinned world.
+#[test]
+fn a_world_with_no_community_hyperedge_refuses_at_load() {
+    // One carrier, one active class, one org, one MEMBERSHIP edge — every
+    // load law satisfied EXCEPT the community ceiling.
+    let scenario = r"
+(scenario community/no-community-refusal
+  (defvocabulary NodeType (INSTITUTION SOCIAL_CLASS ORGANIZATION))
+  (defvocabulary EdgeType (MEMBERSHIP))
+  (defvocabulary HyperedgeType (COMMUNITY))
+  (deffield institution/community-carrier int extensive)
+  (deffield social-class/active int extensive)
+  (deffield organization/cadre-level probability intensive)
+  (deffield organization/cohesion probability intensive)
+  (defenum ConsciousnessTendency (LIBERAL FASCIST REVOLUTIONARY))
+  (deffield organization/consciousness-tendency enum ConsciousnessTendency)
+  (deffield social-class/community-cost-modifier real intensive)
+  (deffield social-class/org-r-weight real extensive)
+  (deffield social-class/org-l-weight real extensive)
+  (deffield social-class/org-f-weight real extensive)
+  (deffield social-class/org-count int extensive)
+  (node lone-register NodeType/INSTITUTION (institution/community-carrier 1))
+  (node lone-class NodeType/SOCIAL_CLASS (social-class/active 1))
+  (node lone-org NodeType/ORGANIZATION
+    (organization/cadre-level 0.5p) (organization/cohesion 0.5p)
+    (organization/consciousness-tendency ConsciousnessTendency/LIBERAL))
+  (edge EdgeType/MEMBERSHIP lone-org lone-class 1))
+";
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let err = babylon_tick::run_once_into(scenario, PACK, &mut graph, &mut sink)
+        .expect_err("a community-free world refuses the pack at load");
+    assert!(
+        err.contains("E-LOAD-045"),
+        "MissingCeiling, named by code: {err}"
+    );
+}
+
+// ---- §8c guards 1 and 4 over the Task-10 worlds (the same law, the arc
+// file's own instances — the guards are never deleted and they cover
+// every world this pack loads into) ----
+
+/// §8c row 1 over the arc/seam/collision/empty worlds: no node whose type
+/// name contains `COMMUNITY`.
+#[test]
+fn no_community_typed_node_exists_in_the_arc_worlds() {
+    for scenario in [SCENARIO, SEAM_SCENARIO, COLLISION_SCENARIO, EMPTY_SCENARIO] {
+        let mut graph = HypergraphStore::new();
+        let loaded =
+            babylon_bsl::scenario::load_scenario(scenario, &mut graph).expect("world loads");
+        for (member, count) in &loaded.node_types {
+            assert!(
+                !member.contains("COMMUNITY"),
+                "node type {member} (x{count}) — communities are hyperedges, never nodes"
+            );
+        }
+    }
+}
+
+/// §8c row 4 over the arc/seam/collision/empty worlds: exactly ONE
+/// INSTITUTION carrier each. The 5c collision world is the row's
+/// load-bearing case — its one carrier carries BOTH packs' anchors.
+#[test]
+fn exactly_one_institution_carrier_in_the_arc_worlds() {
+    for scenario in [SCENARIO, SEAM_SCENARIO, COLLISION_SCENARIO, EMPTY_SCENARIO] {
+        let mut graph = HypergraphStore::new();
+        let loaded =
+            babylon_bsl::scenario::load_scenario(scenario, &mut graph).expect("world loads");
+        assert_eq!(
+            loaded.node_types.get("INSTITUTION"),
+            Some(&1),
+            "exactly one INSTITUTION carrier — two double-applies every \
+             carrier rule's hyperedge writes; zero is silent inertness"
+        );
+    }
+}

--- a/rust/crates/babylon-tick/tests/community_conformance.rs
+++ b/rust/crates/babylon-tick/tests/community_conformance.rs
@@ -360,7 +360,7 @@ fn defenum_ordinal_parity_with_the_frozen_order() {
 /// pack loads into (plan §8c: the guards outlive the frozen linter).
 #[test]
 fn no_community_typed_node_exists() {
-    for scenario in [SCENARIO, SCENARIO_W2, SCENARIO_W3] {
+    for scenario in [SCENARIO, SCENARIO_W2, SCENARIO_W3, SCENARIO_W4] {
         let mut graph = HypergraphStore::new();
         let loaded = load_scenario(scenario, &mut graph).expect("world loads");
         for (member, count) in &loaded.node_types {
@@ -436,7 +436,7 @@ fn exactly_one_institution_carrier() {
     // Every world this pack loads into (§8c row 4's "never zero either" is
     // the loaded half — a carrier-free world runs the carrier rules over
     // an empty population, silent inertness dressed as a passing test).
-    for scenario in [SCENARIO, SCENARIO_W2, SCENARIO_W3] {
+    for scenario in [SCENARIO, SCENARIO_W2, SCENARIO_W3, SCENARIO_W4] {
         let mut graph = HypergraphStore::new();
         let loaded = load_scenario(scenario, &mut graph).expect("world loads");
         assert_eq!(
@@ -467,11 +467,12 @@ fn tick_world_1() -> HypergraphStore {
     let report = run_once_into(SCENARIO, PACK, &mut graph, &mut sink)
         .expect("world 1 + the c00-c04 pack ticks clean");
     assert_eq!(
-        report.fired, 21,
+        report.fired, 30,
         "c00:1 + c01:4 (active classes) + c02:5 (all classes) + c03f:1 + \
          c03l:1 + c03r:2 (rev-org AND n9 — n9 FIRES with an empty for-each, \
          frozen's :421 skip is structural) + c04:4 (active classes) + \
-         c05:1 + c06a:1 + c06b:1 (the carrier thrice more, Task 9)"
+         c05:1 + c06a:1 + c06b:1 (Task 9) + c09:4 + c10:4 (active classes) \
+         + c11:1 (the carrier — Task 10)"
     );
     graph
 }
@@ -887,4 +888,64 @@ fn the_floor_table_is_byte_identical_across_all_three_worlds() {
             );
         }
     }
+}
+
+// ---- Task 10: c09-c11 — cost modifiers and the state decay ----
+
+/// World 4 (the cost-modifier world), single-homed beside worlds 1-3.
+const SCENARIO_W4: &str =
+    include_str!("../content/scenarios/community-cost-modifier-conformance.bscn");
+
+/// Step 1: the modifier is the PRODUCT over the class's communities —
+/// w4-both reads 0.75 x 1.25 = 0.9375, in ascending HyperedgeId order
+/// (D25; D-NF+13's product-order note).
+#[test]
+fn cost_modifier_is_the_product_over_communities() {
+    let graph = tick(SCENARIO_W4, PACK);
+    assert_eq!(
+        node(&graph, 1, "social-class/community-cost-modifier").to_bits(),
+        (0.9375_f64).to_bits(),
+        "w4-both: 0.75 x 1.25"
+    );
+    assert_eq!(
+        node(&graph, 2, "social-class/community-cost-modifier").to_bits(),
+        (0.75_f64).to_bits(),
+        "w4-one: the single factor"
+    );
+}
+
+/// Step 1: no memberships → c09's reset writes 1 and c10's empty for-each
+/// leaves it — exactly 1.0, never a defaulted absence.
+#[test]
+fn cost_modifier_without_membership_is_exactly_one() {
+    let graph = tick(SCENARIO_W4, PACK);
+    assert_eq!(
+        node(&graph, 3, "social-class/community-cost-modifier").to_bits(),
+        (1.0_f64).to_bits(),
+        "w4-none: the reset's value, untouched"
+    );
+}
+
+/// Step 1 (C4's detector, the SECOND world): an inactive class is written
+/// NOTHING — the field reads the substrate's honest-null ERROR, never 1.0
+/// (the landed `.is_err()` shape of consciousness_ternary_conformance.rs:
+/// 244-245). Mutation vector: deleting c09's active guard reds this.
+#[test]
+fn inactive_class_receives_no_cost_modifier_write() {
+    // World 4's w4-inactive (n4) …
+    let graph = tick(SCENARIO_W4, PACK);
+    assert!(
+        graph
+            .node_attribute(NodeId(4), "social-class/community-cost-modifier")
+            .is_err(),
+        "w4-inactive: honest null, never 1.0"
+    );
+    // … and world 1's n5, the first home (one tick of the full pack).
+    let graph = tick(SCENARIO, PACK);
+    assert!(
+        graph
+            .node_attribute(NodeId(5), "social-class/community-cost-modifier")
+            .is_err(),
+        "world 1's n5: honest null, never 1.0"
+    );
 }

--- a/rust/crates/babylon-tick/tests/tick_goldens.rs
+++ b/rust/crates/babylon-tick/tests/tick_goldens.rs
@@ -847,3 +847,188 @@ fn carceral_arc_conformance_hashes_are_pinned() {
          p06:0 (fire-tick never reaches tick 1 on the delay path)"
     );
 }
+
+// ---------------------------------------------------------------------
+// The Community port train's eight content-world pins (issue #667, Task
+// 10 Step 6) — one per world (1, 2, 3, 4, 5, 5b, 5c, 6), each pinning
+// `before` and `after` in one test as the landed pins do (the arc's
+// `after` is its tick-3 value). Every one carries the triad: what it
+// summarizes that the conformance suites already pin; that it is
+// MEASURED, never derived — new in this train, so this is a measurement,
+// not a ceremony (III.13 applies to tests/baselines/**, not this crate's
+// own goldens); and that it touches none of the sixteen prior pins.
+// ---------------------------------------------------------------------
+
+const COMMUNITY_W1: &str = include_str!("../content/scenarios/community-conformance.bscn");
+const COMMUNITY_W2: &str = include_str!("../content/scenarios/community-floor-conformance.bscn");
+const COMMUNITY_W3: &str =
+    include_str!("../content/scenarios/community-degenerate-conformance.bscn");
+const COMMUNITY_W4: &str =
+    include_str!("../content/scenarios/community-cost-modifier-conformance.bscn");
+const COMMUNITY_W5: &str =
+    include_str!("../content/scenarios/community-decay-arc-conformance.bscn");
+const COMMUNITY_W5B: &str =
+    include_str!("../content/scenarios/community-solidarity-seam-conformance.bscn");
+const COMMUNITY_W5C: &str =
+    include_str!("../content/scenarios/community-carrier-collision-conformance.bscn");
+const COMMUNITY_W6: &str = include_str!("../content/scenarios/community-empty-conformance.bscn");
+const COMMUNITY_PACK: &str = include_str!("../content/rules/community.bsl");
+const COMMUNITY_SOLIDARITY: &str = include_str!("../content/rules/solidarity.bsl");
+const COMMUNITY_CONTROL_RATIO: &str = include_str!("../content/rules/control-ratio.bsl");
+
+/// World 1 — summarizes `community_conformance.rs`'s census/weights/
+/// normalization/floor pins (already bit-exact against the mirror).
+/// Measured, never derived; touches none of the sixteen prior pins.
+#[test]
+fn community_world_1_hashes_are_pinned() {
+    let report = run_once(COMMUNITY_W1, COMMUNITY_PACK).expect("world 1 tick");
+    assert_eq!(
+        hex(&report.before),
+        "855f6f9b92a47b909f7d470aa84556c9ac48a319fff0905c142ee58199a392ba",
+        "pre-tick hash moved — the substrate's load of community-conformance.bscn"
+    );
+    assert_eq!(
+        hex(&report.after),
+        "d4fc962cc33ab551fa06494dddd61302ac2c9867f315714df401a231662136f5",
+        "post-tick hash moved — the full c00-c11 pack over world 1"
+    );
+}
+
+/// World 2 — summarizes the floor-binding pins (Ruling 3's ordering
+/// executed, the proportionality read). Measured, never derived; touches
+/// none of the sixteen prior pins.
+#[test]
+fn community_world_2_hashes_are_pinned() {
+    let report = run_once(COMMUNITY_W2, COMMUNITY_PACK).expect("world 2 tick");
+    assert_eq!(
+        hex(&report.before),
+        "74c94d50d41bbe816d3f0de17956162d9698aad36a39f2ecf006b169e17eeb6b",
+        "pre-tick hash moved — the substrate's load of community-floor-conformance.bscn"
+    );
+    assert_eq!(
+        hex(&report.after),
+        "9945301783754de8f54a10317fb4d227b5b931aa7e640f2db135cddba31fa09c",
+        "post-tick hash moved — the floor world after one tick"
+    );
+}
+
+/// World 3 — summarizes the degenerate + skip-gate pins. Measured, never
+/// derived; touches none of the sixteen prior pins.
+#[test]
+fn community_world_3_hashes_are_pinned() {
+    let report = run_once(COMMUNITY_W3, COMMUNITY_PACK).expect("world 3 tick");
+    assert_eq!(
+        hex(&report.before),
+        "cbc85aab2f12b2858ae215e896fe72e2343471b7e40f3e79b4360f321b40c83d",
+        "pre-tick hash moved — the substrate's load of community-degenerate-conformance.bscn"
+    );
+    assert_eq!(
+        hex(&report.after),
+        "bba7959911fe1a40c016e6caddf072944fd84beba3400b02e82bebd3b82aaec5",
+        "post-tick hash moved — the degenerate world after one tick"
+    );
+}
+
+/// World 4 — summarizes the cost-modifier pins (the product, the exact
+/// 1.0, the honest-null inactive). Measured, never derived; touches none
+/// of the sixteen prior pins.
+#[test]
+fn community_world_4_hashes_are_pinned() {
+    let report = run_once(COMMUNITY_W4, COMMUNITY_PACK).expect("world 4 tick");
+    assert_eq!(
+        hex(&report.before),
+        "3a021222a3c3d9a5606305feed76e5d20dd0e1a14dd712309ca0f0578e0107b7",
+        "pre-tick hash moved — the substrate's load of community-cost-modifier-conformance.bscn"
+    );
+    assert_eq!(
+        hex(&report.after),
+        "41f8dccba9366eba6fc870cf5630882a90f4eb494df29c015d60b310c0f46b05",
+        "post-tick hash moved — the cost-modifier world after one tick"
+    );
+}
+
+/// World 5 — the arc's tick-3 `after` (the three-tick decay chain the arc
+/// mirror oracles). Measured, never derived; touches none of the sixteen
+/// prior pins.
+#[test]
+fn community_world_5_arc_hashes_are_pinned() {
+    let mut session = babylon_tick::TickSession::new(
+        COMMUNITY_W5,
+        COMMUNITY_PACK,
+        HypergraphStore::new(),
+        babylon_kernel::SessionId::new("community-decay-arc").expect("literal"),
+    )
+    .expect("world 5 session");
+    let mut sink = babylon_bsl::structural_verbs::CollectingSink::default();
+    let mut last = None;
+    for _ in 0..3 {
+        last = Some(session.advance(&mut sink).expect("tick"));
+    }
+    let report = last.expect("three ticks ran");
+    assert_eq!(
+        hex(&report.before),
+        "18fbf163dc93898cbb6276e4c1f28c3378d72400e286d540e57d6b9be1dbecea",
+        "tick-3 pre-hash moved — the arc world's state entering tick 3"
+    );
+    assert_eq!(
+        hex(&report.after),
+        "b8018b5daa3c6624a477abb16409f593219c345b9365aa642c5f1b81e1ea8325",
+        "tick-3 post-hash moved — the decay arc's third link"
+    );
+}
+
+/// World 5b — summarizes the seam pins (SOLIDARITY strengths byte-
+/// identical under the co-load; the community half actually ran).
+/// Measured, never derived; touches none of the sixteen prior pins.
+#[test]
+fn community_world_5b_seam_hashes_are_pinned() {
+    let rules = format!("{COMMUNITY_SOLIDARITY}\n{COMMUNITY_PACK}");
+    let report = run_once(COMMUNITY_W5B, &rules).expect("world 5b tick");
+    assert_eq!(
+        hex(&report.before),
+        "43c36eece2e8250410e7730467b2cb48b5e67d8c279391bf29ffd6c2d77acf3b",
+        "pre-tick hash moved — the seam world's load"
+    );
+    assert_eq!(
+        hex(&report.after),
+        "fa6297254a13c5c9ff9786e7599ce84e2e95ae09ed109f6d8ff7c98f9f147c52",
+        "post-tick hash moved — solidarity + community co-loaded, one tick"
+    );
+}
+
+/// World 5c — summarizes the carrier-collision pins (per-rule-id fired
+/// arithmetic, the decay-applied-once read). Measured, never derived;
+/// touches none of the sixteen prior pins.
+#[test]
+fn community_world_5c_collision_hashes_are_pinned() {
+    let rules = format!("{COMMUNITY_CONTROL_RATIO}\n{COMMUNITY_PACK}");
+    let report = run_once(COMMUNITY_W5C, &rules).expect("world 5c tick");
+    assert_eq!(
+        hex(&report.before),
+        "1ad177425e34ed4f972d8f530cec9cfe3122ab6bd3c14902ee282cfd71106d4f",
+        "pre-tick hash moved — the collision world's load"
+    );
+    assert_eq!(
+        hex(&report.after),
+        "d018323568b2d910d643fd1fb79a30315b19d8629401213b12c8a12e602c4b14",
+        "post-tick hash moved — control-ratio + community over ONE carrier"
+    );
+}
+
+/// World 6 — summarizes the all-inactive lanes-skipped pins (and the
+/// recorded decay divergence, D205). Measured, never derived; touches
+/// none of the sixteen prior pins.
+#[test]
+fn community_world_6_hashes_are_pinned() {
+    let report = run_once(COMMUNITY_W6, COMMUNITY_PACK).expect("world 6 tick");
+    assert_eq!(
+        hex(&report.before),
+        "0d10526ca3a6a14eb1e2bac27c63c0e4716d4f9189fc990c07bbd9226d70d946",
+        "pre-tick hash moved — the substrate's load of community-empty-conformance.bscn"
+    );
+    assert_eq!(
+        hex(&report.after),
+        "d808eb25330cc3f680d45ae9ee458c515c2abb207b08eb18b88427d821fe3c8e",
+        "post-tick hash moved — the all-inactive world after one tick"
+    );
+}


### PR DESCRIPTION
Community port train Task 10 (issue #667, plan `docs/superpowers/plans/2026-08-18-community-port.md`).

**Rules:** `c09`/`c10` both carry the `(= active 1)` guard (frozen `community.py:472-474`, §1.4/C4 — an inactive class is written NOTHING, the honest-null read, never 1.0); c10's product compounds in ascending HyperedgeId order (D25/D-NF+13). `c11-state-decay` writes the three `max(0, x·(1−α))` arms with NO skip gate; the infrastructure arm is ABSENT (§5 + DG-7: non-monotone maintenance waits on #653; a monotone-only port would be a different law, ADR183).

**Worlds (five new):** world 4 (cost-modifier witnesses incl. the second C4 home); world 5 (the three-tick TickSession arc + its own mirror, verbatim stdout in the test doc); world 5b (the solidarity seam — strengths byte-identical under the co-load, and the community half provably ran); world 5c (the carrier collision — community.bsl + control-ratio.bsl over ONE institution node carrying both anchors; per-rule-id fired 37, decay applied once); world 6 (all-inactive — pins the LANES honestly; D205 records the plan's "byte-exact no-op" phrasing as self-contradictory since frozen's global early return is inexpressible per-rule) + the L1 refusal test (a no-community world refuses at load, E-LOAD-045).

**Golden pins:** 8 new (one per world, before+after; the arc's after is tick-3) — measured, never derived; none of the 16 prior pins touched.

**Mutation vectors (eleven, all proven):** c09 deleted (compounding reds at tick 2); c09's active guard dropped (the C4 vector); each decay α independently; each max(0,·) clamp REMOVED stays green (converses — present-but-inert); a second carrier in 5c (guard 4 then 37→42); 5b's carrier removed (guard 4 + seam-ran + the E-EVAL-031 cascade through c01); a world-6 member activated.

**Fuel:** per-world measured over all eight worlds via `fuel_bound_report`, declared at max+1 (c00 104 … c11 208).

**Gates:** rust:check, qa:regression (byte-identical 12 + E5b), qa:vault-regression-ci (both goldens byte-identical), check:quick, manifest-sync (five new rows), corpus digest re-pinned at 83. No Python engine source touched. D205 in the register.