### PR TITLE
test(tick): class-dynamics registration, declaration surface, world 1 and the frozen mirror (TickDynamics Task 2, PR A)

### DIFF
--- a/rust/crates/babylon-bsl/tests/content_corpus_digests.rs
+++ b/rust/crates/babylon-bsl/tests/content_corpus_digests.rs
@@ -68,6 +68,10 @@ fn corpus_files() -> Vec<PathBuf> {
 /// `read_all`'s parsed-tree shape moved. Either is a STOP.
 const PINNED_DIGESTS: &[(&str, &str)] = &[
     (
+        "class-dynamics.bsl",
+        "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+    ),
+    (
         "community.bsl",
         "8b955851e3dec97a89e73b951ba96609713e81a1db36315d0cbf9493b3175384",
     ),
@@ -202,6 +206,10 @@ const PINNED_DIGESTS: &[(&str, &str)] = &[
     (
         "carceral-arc-conformance.bscn",
         "d1b4577f98813cfd17b5e8bd394918a56c5e822c051790bc045254cf6b2a13ad",
+    ),
+    (
+        "class-dynamics-conformance.bscn",
+        "864fb0ade8cfd61c0fdaa32db4569b6443e6cd8ce225812cbed24d28f5481c28",
     ),
     (
         "community-carrier-collision-conformance.bscn",

--- a/rust/crates/babylon-tick/content/content-sets.toml
+++ b/rust/crates/babylon-tick/content/content-sets.toml
@@ -24,6 +24,15 @@ consumers = [
 ]
 
 [[set]]
+id        = "class-dynamics/conformance"
+scenario  = "scenarios/class-dynamics-conformance.bscn"
+prelude   = []
+rules     = ["rules/class-dynamics.bsl"]
+consumers = [
+    "rust/crates/babylon-tick/tests/class_dynamics_conformance.rs",
+]
+
+[[set]]
 id        = "community/carrier-collision"
 scenario  = "scenarios/community-carrier-collision-conformance.bscn"
 prelude   = []

--- a/rust/crates/babylon-tick/content/rules/class-dynamics.bsl
+++ b/rust/crates/babylon-tick/content/rules/class-dynamics.bsl
@@ -1,0 +1,194 @@
+; `class-dynamics/*` rule pack — Feature-016 Class Dynamics Engine
+; (Material Base @4.0), port train `docs/superpowers/plans/2026-08-18-
+; tickdynamics-port.md`.
+;
+; **§0.1 boundary.** This pack ports ONLY the class-dynamics engine — the
+; seven modules under `src/babylon/domain/economics/dynamics/` and the single
+; caller at `src/babylon/domain/economics/tick/system/__init__.py:2346-2458`.
+; It does NOT port all of TickDynamicsSystem @4.0.
+;
+; **Header-only at Task 2.** The 13 rules (a01-a13) and the `economics/phi-
+; savings-coupling` edit land in later tasks. This file today carries only the
+; SPIKE RESULTS block from Task 0's dossier (§10), copied here per the plan's
+; instruction that the pack header owns the surviving spike record.
+;
+; D-NF+1: the "Step 5b executes after Step 6" doc comment numbering in
+; transition_engine.py is stale relative to actual call order; this pack's
+; rule-id byte order is the contract.
+;
+; ---- SPIKE RESULTS (Task 1, 2026-08-18) ----
+;
+; Task 1's own spike, executed against temporary content
+; (`content/rules/class-dynamics.bsl`, `content/scenarios/class-dynamics-
+; spike.bscn`, `tests/class_dynamics_spike.rs` — all three deleted at Step 6;
+; this section is the authoritative surviving record. Rule ids used the
+; already-registered `social-class`/`territory` namespaces (babylon-tick's
+; `lib.rs` registered-systems set) rather than `class-dynamics` — Task 1
+; touches no production code; `class-dynamics` registration is Task 2's own
+; job. All 6 spike tests passed; verbatim evidence below.
+;
+; **Three CONFIRMATIONS (source-answered, cited first — never upgraded back
+; into open questions):**
+;
+; 1. **Step 1 — BLOCKER-6, retired (I5).** Source: `rule_pipeline.rs:744-760`
+;    reduces the `:weight` operand through `field_ref_for` exactly as the fold
+;    body. Loaded a rule with `(fold mean (nodes NodeType/SOCIAL_CLASS)
+;    (field-of it social-class/wealth) :weight (field-of it social-class/
+;    population))` — **loads and fires** (`fired == 2`, both class-a and
+;    class-b). No fallback branch, no two-`fold sum` alternative needed.
+;    **Verdict: CONFIRMED.**
+; 2. **Step 2 — BLOCKER-7, retired.** Source: `session.rs:60-66,120-124`
+;    (`TickSession::new` starts `tick: 0`; `advance` computes `next_tick =
+;    self.tick + 1`) and `lib.rs:517-531` (`run_once`/`run_prepared_tick`
+;    hard-code tick `1`) — tick 0 never executes, the first boundary is tick
+;    52. Executed a `(binding phase-of-year :tick-in-cycle 52)` +
+;    `(when (= phase-of-year 0))` rule over a 105-tick `TickSession`.
+;    **Measured `fired` series (ticks 1..=105, this rule's own `per_rule_fired`
+;    count each tick):** zero for ticks 1-51, **2 at tick 52**, zero for ticks
+;    53-103, **2 at tick 104**, zero for tick 105 — exactly: `[0×51, 2, 0×51,
+;    2, 0]`. This is the arithmetic every world's boundary pin inherits.
+;    **Verdict: CONFIRMED.**
+; 3. **Step 5 — M11, already answered.** Source: `rg -n 'defvocabulary EventType'
+;    rust/crates/babylon-tick/content/` returns zero hits — no landed `.bscn`
+;    opts into an `EventType` vocabulary. Executed `(emit EventType/
+;    DISPOSSESSION_CASCADE (fips 1) (decline 0.05c))` verbatim (the brief's
+;    own literal), no `defvocabulary EventType` declared anywhere in the spike
+;    scenario. **Loaded and fired clean** — 2 `DISPOSSESSION_CASCADE` events
+;    (one per SOCIAL_CLASS subject, both carrying the same literal payload),
+;    `fips` read back as `Value::Int(1)`, `decline` read back as `Value::Real`
+;    with `.to_bits() == 0.05_f64.to_bits()` bit-exact.
+;    **Verdict: CONFIRMED — a world need not opt in.**
+;
+; **Four REAL spikes (actually run; observed evidence recorded verbatim):**
+;
+; 4. **Step 2b (NEW) — the session-driven golden convention.** Drove
+;    `TickSession::advance` ×52 over a throwaway world (the same content set
+;    as Step 2/5b), read `hex(&report.before)`/`hex(&report.after)` at tick
+;    52. **Same-process stability:** two independent, freshly constructed
+;    `TickSession`s (same content, same `SessionId`) produced byte-identical
+;    tick-52 hashes:
+;    `before=5c2b5dbc01023ab10a1aa38115d8e8b1bb45009c1a99c1c00f799ffaa48a7af1`,
+;    `after=b666db12f811dfad8757240335ddfe22accb823c9ac102235613d9e29d5b9bac`.
+;    **Cross-process stability:** ran `cargo test -p babylon-tick --test
+;    class_dynamics_spike step2_boundary_series_step2b_session_golden_and_
+;    step5b_positive -- --nocapture` as two genuinely separate OS process
+;    invocations, each capturing the printed tick-52 hash lines to a file;
+;    `diff`'d byte for byte — **identical, zero diff output** across both
+;    processes. This is exactly the shape Task 6 Step 4 will land as the
+;    file's first multi-tick pin. **Verdict: SPIKED AND PROVEN — the mechanism
+;    is safe to build the real pin on.**
+; 5. **Step 3 — BLOCKER-2, in the legal form.** `(defconst class-dynamics/
+;    deep-precaritization-x1e6 3500000)` bound as the defines-environment
+;    coefficient `class-dynamics/deep-precaritization-x1e6`, promoted before
+;    the divide with `(binding m :expr (/ (- deep-precaritization-x1e6 0c)
+;    1000000))` (the brief's own verbatim spelling — `Int ÷ Int` is a loud
+;    error, rev 1's spelling could not have loaded, I9). **Measured: `m`
+;    reads back bit-exactly `3.5_f64`** (3500000/1000000 is a terminating
+;    binary fraction, so this promote-then-divide order introduces ZERO
+;    rounding of its own — confirmed by `m.to_bits() == 3.5_f64.to_bits()`,
+;    not merely `m == 3.5`). **`product` (= `m * rate`) reads back BIT-EXACTLY
+;    equal to the mirror** — computed as `m_readback * rate_readback` natively
+;    in Rust from the SAME f64 values the engine itself emitted
+;    (`product.to_bits() == (m*rate).to_bits()`), never re-derived from an
+;    independent decimal-string parse (which is not guaranteed bit-identical
+;    to the engine's own `unscaled as f64 / 10^scale` conversion — the cross-
+;    implementation-tolerance discipline). The value reads back bit-exact —
+;    this spike needed no fallback (a different scale, or a declared
+;    tolerance).
+;    **The deliberate operand-order deviation from `metabolism.bsl:386-387`,
+;    with its one-rounding-vs-two derivation:** metabolism's D-1 pattern
+;    multiplies a per-node, generically inexact field value by the scaled-Int
+;    constant FIRST (`raw-extraction * entropy-factor-x1e6`), THEN divides by
+;    `1000000` — two operations, each rounding a generically-inexact
+;    intermediate (metabolism's own header measures up to 2^15 ULP of
+;    divergence from the frozen engine as a consequence). THIS spike's order
+;    instead descales the **constant alone** first — a division of two exact
+;    integers-as-reals whose quotient terminates in binary here
+;    (`3500000/1000000 = 3.5` exactly) — before the result ever touches per-
+;    node data. Only the FINAL multiply by `rate` then rounds: **one rounding,
+;    in general, for THIS operand order, versus metabolism's generically
+;    two.** This is a property of *this specific pattern* (divide the constant
+;    alone, independent of any field read, before combining with anything
+;    else) — it does **not** generalize to every scaled-Int constant: a
+;    constant whose descaled decimal has no exact base-2 expansion would still
+;    round at the constant-alone division step, so a future author reusing
+;    this pattern should not assume zero-rounding without checking their own
+;    constant the same way this spike checked `3500000`.
+;    **Verdict: SPIKED — bit-exact for this constant, order documented, no
+;    fallback needed.**
+; 6. **Step 4 — D102's discharge (enum seed + read pair).** Seeded `(node
+;    county-deep NodeType/TERRITORY (territory/crisis-phase CrisisPhase/DEEP)
+;    …)` (the seeding path, `E-LOAD-056`'s member-only rule — the scenario
+;    loads clean, confirming the seed is legal) and read it back via `(binding
+;    phase :field territory/crisis-phase)` + `(if (= phase CrisisPhase/DEEP)
+;    …)` (the read path). **Measured:** the rule fires for `county-deep` alone
+;    (`fired == 1`; `county-tenanted`/`county-empty` are both `NORMAL` and do
+;    not fire), and the emitted `phase` payload value reads back as
+;    `Value::Enum { enum_type: "CrisisPhase", member: "DEEP" }`.
+;    **`defenum` ordinal parity (hash-bearing, ADR195), asserted directly
+;    against the registry:** `NORMAL=0, ONSET=1, EARLY=2, DEEP=3, RECOVERY=4`
+;    — declaration order is the storage ordinal, confirmed exact.
+;    **Verdict: SPIKED AND CONFIRMED.**
+; 7. **Step 5b (NEW) — the empty-TENANCY fold protector (C5).** `county-empty`
+;    is a TERRITORY with **zero** incoming-TENANCY SOCIAL_CLASS neighbours.
+;    **WITHOUT the `exists` protector** (isolated inline rule, never co-loaded
+;    with anything else — it kills every tick of any content set holding it):
+;    ran tick 1 (`(when (= phase-of-year 0))` is **false** at tick 1,
+;    `phase-of-year == 1`). **The tick still died.** Exact verbatim error
+;    text:
+;    ```
+;    tick failed in rule territory/spike-step5b-without-protector: E-EVAL-021:
+;    mean over an empty query (§4.4) — there is no element to average
+;    ```
+;    This is the whole point: bindings evaluate before the `when` guard, so
+;    the boundary gate protects nothing against an empty fold.
+;    **WITH the protector** (`territory.bsl:168-172`'s `exists` idiom copied
+;    verbatim ahead of the fold, plus a guarded write — `(guard has-classes
+;    (update-node self territory/spike-score (set score)))`): drove the SAME
+;    content set to tick 52. **The tick survived.**
+;    `county-tenanted/territory/spike-score` became **220.0** exactly
+;    (`(100*40 + 300*60)/(40+60)`, the population-weighted mean, confirmed
+;    via `assert_eq!` against the raw f64 value the tick itself wrote).
+;    `county-empty/territory/spike-score` **stayed at its 42 sentinel,
+;    untouched** — no score at all, not a fabricated zero (III.11).
+;    **Verdict: SPIKED AND PROVEN — this ONE refusal is the evidence for the
+;    C5 repair; without it the protector would read as defensive decoration.**
+;
+; **One INCIDENTAL FINDING (not one of the six named spikes, but load-bearing
+; for Task 8's `a12`/`a13` and every future emit-only/constant-only/expr-only
+; rule in this pack):**
+; `(domain NodeType/…)` is **not** what `run_tick` uses to pick a rule's
+; subject population at this engine slice. `babylon-bsl/src/tick.rs::
+; subject_type_of` derives the subject type from the rule's own `:field`
+; bindings ALONE — it does not consult an explicit `(domain …)` declaration,
+; does not look at `update-node` targets, and does not look at `field-of self
+; …` accessors. A rule declaring `(domain NodeType/SOCIAL_CLASS)` with zero
+; `:field` bindings refuses **at run time** (not load time) with: `"the rule
+; declares no :field binding, so it names no subject type — slice 1 runs
+; rules over a population, not over the graph as a whole"` — confirmed
+; empirically this task (Steps 1/2/3/5's first draft all hit this exactly).
+; This independently reproduces `metabolism.bsl`'s own D-4 finding word for
+; word (`"tick.rs::run_tick NEVER reads loaded.domain"`) from the content-
+; author's side rather than the engine-reader's. **Consequence for this
+; train's own plan text:** `a13`, **as literally quoted in the plan
+; (`docs/superpowers/plans/2026-08-18-tickdynamics-port.md:1137`), carries
+; ZERO `:field` bindings** — both `has-classes` and `score` are `:expr`
+; -sourced, and `a13`'s own `update-node` target (`territory/bifurcation-
+; score`) does **not** count toward subject-type inference either. **As
+; literally written, `a13` would refuse at run time with the same "no :field
+; binding" error the protector spike above hit before its own fix.** Task 8
+; must add a genuine self-scoped `:field` binding to `a13` (any already-
+; declared `territory/*` field the rule can legitimately read, even if only
+; to anchor the subject type) before landing it — this spike's own `spike-
+; step5b-with-protector` rule (`(binding subject-anchor :field territory/
+; crisis-phase)`, unused beyond anchoring) is the minimal worked fix, and
+; `crisis-phase` is not a `class-dynamics`-owned field so `a13`'s own author
+; should pick a real anchor from among its OWN pack's `territory/*` fields
+; instead (e.g. whichever field this train's plan already has `a13` reading
+; for real, or a field `a01`-`a11` already publish onto `territory/*`, if any
+; exist — worth checking at Task 8 time, not re-derived here).
+;
+; **Step 6 discharged:** this task's own commit deletes every spike artifact
+; (the temporary `.bsl`/`.bscn`/`tests/*.rs` triple) — see the commit message
+; for the disclosed test-support delta this spike legitimately needed (none
+; beyond the three deleted files: no production code changed).

--- a/rust/crates/babylon-tick/content/scenarios/class-dynamics-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/class-dynamics-conformance.bscn
@@ -1,0 +1,243 @@
+; The PRIMARY conformance world for `class-dynamics/*` (Feature-016 Class
+; Dynamics Engine, Material Base @4.0), Task 2 of the TickDynamics port
+; train (`docs/superpowers/plans/2026-08-18-tickdynamics-port.md`).
+;
+; **Scope boundary (§0.1).** This pack ports ONLY Feature-016 — the seven
+; modules under `src/babylon/domain/economics/dynamics/` plus the single
+; `system/__init__.py:2346-2458` caller — NOT all of TickDynamicsSystem.
+; The residual @4.0 computations (external-service boundary, opaque object
+; metadata, reserve-army sigmoid) remain outside this train.
+;
+; **Declaration order is NodeId order (D96) — never renumber when extending.**
+;   wayne        NodeId(0)  TERRITORY — primary county, bootstrap shares.
+;   oakland      NodeId(1)  TERRITORY — different shares/rates, proves no
+;                              global flattening.
+;   wayne-prole  NodeId(2)  SOCIAL_CLASS — TENANCY→wayne; ternary rest (0,1,0).
+;   wayne-la     NodeId(3)  SOCIAL_CLASS — TENANCY→wayne; non-zero fascist
+;                              so `a13`'s readout is non-zero.
+;   shared-class NodeId(4)  SOCIAL_CLASS — TENANCY→wayne AND oakland;
+;                              the D136 dual-membership mean vector.
+;   orphan-class NodeId(5)  SOCIAL_CLASS — no TENANCY edge; contributes to
+;                              no county.
+;
+; **Seeding discipline.** Every declared field is seeded on every node of its
+; namespace (scenario.rs's no-defaults contract, §4.3). Fractional seeds are
+; legal on `real`/`probability`/`intensity`/`coefficient`; `int` fields refuse
+; them. Fields written ONLY by the pack are seeded to their neutral zero so
+; the no-defaults law stays visible and the first boundary's writes are
+; mutation-provable.
+;
+; **Which seeded value proves which gate, by name:**
+;   - `wayne` bootstrap shares (0.01/0.09/0.40/0.35/0.15) — R5 five-class seed.
+;   - `oakland` different shares + higher unemployment (0.10) — no global
+;     flattening across counties.
+;   - `wayne/median-wage 21.0` (hourly) — the F11 accumulation mirror's wage
+;     base; `phi-hour 0.0` — zero-Φ baseline.
+;   - `wayne-prole` ternary (r=0, f=0) vs `wayne-la` f=0.1p — non-zero a13.
+;   - `shared-class` dual TENANCY — D136 mean (not sum) attribution.
+;   - `orphan-class` no TENANCY — must not enter any county fold.
+;   - `wayne/baseline-la-known 0` — a10's run-start latch is initially open.
+;   - default rates 0.006/0.006/0.063 — dispossession fallback values.
+;
+; **The SPIKE RESULTS block (Task 1, 2026-08-18) lands in the header of
+; `content/rules/class-dynamics.bsl` — the dossier's §10 verbatim copy.**
+;
+; **CrisisPhase enum order is hash-bearing (ADR195)** — frozen declaration
+; order: NORMAL=0, ONSET=1, EARLY=2, DEEP=3, RECOVERY=4.
+(scenario class-dynamics/conformance
+  (defvocabulary NodeType (SOCIAL_CLASS TERRITORY))
+  (defvocabulary EdgeType (TENANCY))
+  (defenum CrisisPhase (NORMAL ONSET EARLY DEEP RECOVERY))
+
+  ; ---- territory fields: the 17-field roster + 7 staging fields (§4.2) ----
+  ; Five externally-fixed bootstrap shares — probability intensive.
+  (deffield territory/share-bourgeoisie probability intensive)
+  (deffield territory/share-petit-bourgeoisie probability intensive)
+  (deffield territory/share-labor-aristocracy probability intensive)
+  (deffield territory/share-proletariat probability intensive)
+  (deffield territory/share-lumpenproletariat probability intensive)
+  ; The distribution year, incremented once per boundary (D-NF+3/D-NF+4).
+  (deffield territory/dist-year int extensive)
+  ; R10 cumulative baseline and its III.11 loud-absence latch.
+  (deffield territory/baseline-la-share probability intensive)
+  (deffield territory/baseline-la-known int extensive)
+  ; Economic conditions inputs.
+  (deffield territory/unemployment-rate probability intensive)
+  (deffield territory/median-wage real intensive)
+  (deffield territory/phi-hour real intensive)
+  ; Dispossession fallback rates (frozen defaults).
+  (deffield territory/foreclosure-rate probability intensive)
+  (deffield territory/bankruptcy-rate probability intensive)
+  (deffield territory/eviction-rate probability intensive)
+  ; Crisis phase — declared input until the crisis-detector train lands
+  ; (BLOCKER-4, D-NF+27).
+  (deffield territory/crisis-phase enum CrisisPhase)
+  ; R9's published coupling, written by `economics/phi-savings-coupling`
+  ; (D-NF+18); seeded to zero because the rule runs every tick.
+  (deffield territory/phi-savings-adjustment coefficient intensive)
+  ; R6 readout range [−1,+1] by construction, so `real` (D-NF+17).
+  (deffield territory/bifurcation-score real intensive)
+  ; Staging fields: four rate constructors and three raw flow outputs.
+  (deffield territory/rate-accumulation probability intensive)
+  (deffield territory/rate-dispossession probability intensive)
+  (deffield territory/rate-precaritization probability intensive)
+  (deffield territory/rate-stabilization probability intensive)
+  (deffield territory/raw-share-labor-aristocracy real intensive)
+  (deffield territory/raw-share-proletariat real intensive)
+  (deffield territory/raw-share-lumpenproletariat real intensive)
+
+  ; ---- class-side fields: one net-new publication + three landed reads ----
+  (deffield social-class/ternary-net-fascist real intensive)
+  (deffield social-class/revolutionary probability intensive)
+  (deffield social-class/fascist probability intensive)
+  (deffield social-class/population int extensive)
+
+  ; ---- the 46-constant canonical block (§4.5) ----
+  ; Every constant carries frozen file:line provenance; register citations use
+  ; NEXT-FREE-AT-LANDING placeholders (D-NF+n). The seven multipliers that
+  ; exceed 1.0 use the scaled-Int x1e6 lane (D-NF+5); remaining multipliers
+  ; and all [0,1] rates use scaled literals directly.
+  ;
+  ; Engine parameters — transition_engine.py:51-54.
+  (defconst class-dynamics/wealth-threshold 142000)        ; int
+  (defconst class-dynamics/precaritization-unemployment-weight 0.5c)
+  (defconst class-dynamics/base-stabilization 0.15c)
+  (defconst class-dynamics/max-accumulation-rate 0.08c)
+  ; Phased amplification table — crisis.py:24-55 (20 constants).
+  ; NORMAL is passthrough (1.0); every multiplier > 1.0 is stored x1e6 per
+  ; D-NF+5 so a rule descales once with one rounding. The plan's §4.5 says
+  ; "seven"; the frozen table actually contains eight values > 1.0 (1.2
+  ; appears twice), so this block uses eight x1e6 constants — a plan-citation
+  ; drift adapted to the code.
+  (defconst class-dynamics/amp-normal-dispossession 1.0c)
+  (defconst class-dynamics/amp-normal-precaritization 1.0c)
+  (defconst class-dynamics/amp-normal-accumulation 1.0c)
+  (defconst class-dynamics/amp-normal-stabilization 1.0c)
+  (defconst class-dynamics/amp-onset-dispossession-x1e6 1200000)
+  (defconst class-dynamics/amp-onset-precaritization-x1e6 1500000)
+  (defconst class-dynamics/amp-onset-accumulation 0.8c)
+  (defconst class-dynamics/amp-onset-stabilization 0.7c)
+  (defconst class-dynamics/amp-early-dispossession-x1e6 1800000)
+  (defconst class-dynamics/amp-early-precaritization-x1e6 2500000)
+  (defconst class-dynamics/amp-early-accumulation 0.4c)
+  (defconst class-dynamics/amp-early-stabilization 0.4c)
+  (defconst class-dynamics/amp-deep-dispossession-x1e6 3000000)
+  (defconst class-dynamics/amp-deep-precaritization-x1e6 3500000)
+  (defconst class-dynamics/amp-deep-accumulation 0.1c)
+  (defconst class-dynamics/amp-deep-stabilization 0.2c)
+  (defconst class-dynamics/amp-recovery-dispossession-x1e6 1300000)
+  (defconst class-dynamics/amp-recovery-precaritization-x1e6 1200000)
+  (defconst class-dynamics/amp-recovery-accumulation 0.6c)
+  (defconst class-dynamics/amp-recovery-stabilization 0.5c)
+  ; Dispossession composite weights (LA→P only) — dispossession.py:30-36.
+  (defconst class-dynamics/foreclosure-weight-la-to-p 0.6c)
+  (defconst class-dynamics/bankruptcy-weight-la-to-p 0.3c)
+  (defconst class-dynamics/eviction-weight-la-to-p 0.1c)
+  ; Savings schedule — savings_schedule.py:21-31.
+  (defconst class-dynamics/savings-proletariat 0.03c)
+  (defconst class-dynamics/phi-cap 0.05c)
+  ; Dispossession-rate defaults — system/__init__.py:2383-2385.
+  (defconst class-dynamics/default-foreclosure-rate 0.006p)
+  (defconst class-dynamics/default-bankruptcy-rate 0.006p)
+  (defconst class-dynamics/default-eviction-rate 0.063p)
+  ; Wage / subsistence — system/__init__.py:2378-2380, defines.yaml.
+  (defconst class-dynamics/hours-per-year 2080)
+  (defconst class-dynamics/v-reproduction 12)
+  (defconst class-dynamics/accumulation-halt-floor-ratio 0.8c)
+  ; Bootstrap five-class shares — types.py:44-48 / R5.
+  (defconst class-dynamics/bootstrap-bourgeoisie 0.01c)
+  (defconst class-dynamics/bootstrap-petit-bourgeoisie 0.09c)
+  (defconst class-dynamics/bootstrap-labor-aristocracy 0.40c)
+  (defconst class-dynamics/bootstrap-proletariat 0.35c)
+  (defconst class-dynamics/bootstrap-lumpenproletariat 0.15c)
+  ; Cascade milestones + bifurcation threshold — R5 / R6.
+  (defconst class-dynamics/cascade-milestone-1 0.05c)
+  (defconst class-dynamics/cascade-milestone-2 0.10c)
+  (defconst class-dynamics/cascade-milestone-3 0.15c)
+  (defconst class-dynamics/bifurcation-event-threshold 0.5c)
+  ; Year clamp window — transition_engine.py / types.py validators.
+  (defconst class-dynamics/year-min 2007)
+  (defconst class-dynamics/year-max 2030)
+
+  ; ---- nodes (declaration order = NodeId order; never renumber) ----
+  (node wayne NodeType/TERRITORY
+    (territory/share-bourgeoisie 0.01c)
+    (territory/share-petit-bourgeoisie 0.09c)
+    (territory/share-labor-aristocracy 0.40c)
+    (territory/share-proletariat 0.35c)
+    (territory/share-lumpenproletariat 0.15c)
+    (territory/dist-year 2010)
+    (territory/baseline-la-share 0.0p)
+    (territory/baseline-la-known 0)
+    (territory/unemployment-rate 0.05p)
+    (territory/median-wage 21.0r)
+    (territory/phi-hour 0)
+    (territory/foreclosure-rate 0.006p)
+    (territory/bankruptcy-rate 0.006p)
+    (territory/eviction-rate 0.063p)
+    (territory/crisis-phase CrisisPhase/NORMAL)
+    (territory/phi-savings-adjustment 0.0c)
+    (territory/bifurcation-score 0)
+    (territory/rate-accumulation 0.0c)
+    (territory/rate-dispossession 0.0c)
+    (territory/rate-precaritization 0.0c)
+    (territory/rate-stabilization 0.0c)
+    (territory/raw-share-labor-aristocracy 0)
+    (territory/raw-share-proletariat 0)
+    (territory/raw-share-lumpenproletariat 0))
+
+  (node oakland NodeType/TERRITORY
+    (territory/share-bourgeoisie 0.02c)
+    (territory/share-petit-bourgeoisie 0.08c)
+    (territory/share-labor-aristocracy 0.35c)
+    (territory/share-proletariat 0.40c)
+    (territory/share-lumpenproletariat 0.15c)
+    (territory/dist-year 2010)
+    (territory/baseline-la-share 0.0p)
+    (territory/baseline-la-known 0)
+    (territory/unemployment-rate 0.10p)
+    (territory/median-wage 25.0r)
+    (territory/phi-hour 0)
+    (territory/foreclosure-rate 0.006p)
+    (territory/bankruptcy-rate 0.006p)
+    (territory/eviction-rate 0.063p)
+    (territory/crisis-phase CrisisPhase/NORMAL)
+    (territory/phi-savings-adjustment 0.0c)
+    (territory/bifurcation-score 0)
+    (territory/rate-accumulation 0.0c)
+    (territory/rate-dispossession 0.0c)
+    (territory/rate-precaritization 0.0c)
+    (territory/rate-stabilization 0.0c)
+    (territory/raw-share-labor-aristocracy 0)
+    (territory/raw-share-proletariat 0)
+    (territory/raw-share-lumpenproletariat 0))
+
+  (node wayne-prole NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.0p)
+    (social-class/fascist 0.0p)
+    (social-class/population 100)
+    (social-class/ternary-net-fascist 0))
+
+  (node wayne-la NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.0p)
+    (social-class/fascist 0.1p)
+    (social-class/population 50)
+    (social-class/ternary-net-fascist 0))
+
+  (node shared-class NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.05p)
+    (social-class/fascist 0.0p)
+    (social-class/population 80)
+    (social-class/ternary-net-fascist 0))
+
+  (node orphan-class NodeType/SOCIAL_CLASS
+    (social-class/revolutionary 0.0p)
+    (social-class/fascist 0.0p)
+    (social-class/population 30)
+    (social-class/ternary-net-fascist 0))
+
+  ; ---- TENANCY edges (class → territory) ----
+  (edge EdgeType/TENANCY wayne-prole wayne 1)
+  (edge EdgeType/TENANCY wayne-la wayne 1)
+  (edge EdgeType/TENANCY shared-class wayne 1)
+  (edge EdgeType/TENANCY shared-class oakland 1))

--- a/rust/crates/babylon-tick/content/scenarios/class_dynamics_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/class_dynamics_conformance.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""Frozen mirror for the class-dynamics primary conformance world.
+
+Plan: docs/superpowers/plans/2026-08-18-tickdynamics-port.md
+Task: Task 2 Step 4 — the primary mirror.
+Frozen source:
+  - src/babylon/domain/economics/dynamics/transition_engine.py (346 lines)
+  - src/babylon/domain/economics/dynamics/accumulation.py (106 lines)
+  - src/babylon/domain/economics/dynamics/dispossession.py (127 lines)
+  - src/babylon/domain/economics/dynamics/crisis.py (181 lines)
+  - src/babylon/domain/economics/dynamics/savings_schedule.py (95 lines)
+  - src/babylon/domain/economics/dynamics/types.py (321 lines)
+  - src/babylon/domain/economics/dynamics/validation.py (300 lines)
+  - caller: src/babylon/domain/economics/tick/system/__init__.py:2346-2458
+
+Reproduction command (from the repository root):
+  PYTHONPATH="$PWD/src" uv run python \
+      rust/crates/babylon-tick/content/scenarios/class_dynamics_conformance.py
+
+# ADR183 disclaimer
+
+The frozen engine is the contract source for STRUCTURE and ORDERING, not a
+byte oracle. Every numeric value this script prints is the frozen Python
+engine's own output at full `repr` precision. Where the term-for-term
+transcription disagrees with the `DefaultClassTransitionEngine` corroboration
+pass, that disagreement is STOPped and classified against the closed list of
+intended divergences this plan has already declared: F11's `wage·s²` →
+`wage·s` repair, F10's degenerate-arm repair, R10's cumulative baseline — and
+nothing else.
+"""
+
+from __future__ import annotations
+
+from babylon.domain.economics.dynamics import (
+    ClassDistribution,
+    DefaultAccumulationCalculator,
+    DefaultClassTransitionEngine,
+    DefaultDispossessionCalculator,
+    DefaultSavingsRateSchedule,
+    EconomicConditions,
+)
+from babylon.domain.economics.dynamics.crisis import PhasedCrisisAmplifier
+from babylon.domain.economics.tick.types import CrisisPhase
+
+# ---------------------------------------------------------------------------
+# Constants — the 46-constant canonical block (§4.5), mirrored literally.
+# ---------------------------------------------------------------------------
+WEALTH_THRESHOLD = 142_000.0
+PRECARITIZATION_UNEMPLOYMENT_WEIGHT = 0.5
+BASE_STABILIZATION = 0.15
+MAX_ACCUMULATION_RATE = 0.08
+
+HOURS_PER_YEAR = 2080
+V_REPRODUCTION = 12.0
+ACCUMULATION_HALT_FLOOR_RATIO = 0.8
+
+PHI_CAP = 0.05
+SAVINGS_PROLETARIAT = 0.03
+
+DEFAULT_FORECLOSURE_RATE = 0.006
+DEFAULT_BANKRUPTCY_RATE = 0.006
+DEFAULT_EVICTION_RATE = 0.063
+
+# Phased amplification table (crisis.py:24-55).
+PHASED_PROFILES = {
+    CrisisPhase.NORMAL: {
+        "dispossession": 1.0,
+        "precaritization": 1.0,
+        "accumulation": 1.0,
+        "stabilization": 1.0,
+    },
+    CrisisPhase.ONSET: {
+        "dispossession": 1.2,
+        "precaritization": 1.5,
+        "accumulation": 0.8,
+        "stabilization": 0.7,
+    },
+    CrisisPhase.EARLY: {
+        "dispossession": 1.8,
+        "precaritization": 2.5,
+        "accumulation": 0.4,
+        "stabilization": 0.4,
+    },
+    CrisisPhase.DEEP: {
+        "dispossession": 3.0,
+        "precaritization": 3.5,
+        "accumulation": 0.1,
+        "stabilization": 0.2,
+    },
+    CrisisPhase.RECOVERY: {
+        "dispossession": 1.3,
+        "precaritization": 1.2,
+        "accumulation": 0.6,
+        "stabilization": 0.5,
+    },
+}
+
+# World 1 seeds, by county.  Shares sum to 1.0 within each county.
+WORLD = {
+    "wayne": {
+        "fips": "26163",
+        "dist_year": 2010,
+        "shares": {
+            "bourgeoisie": 0.01,
+            "petit_bourgeoisie": 0.09,
+            "labor_aristocracy": 0.40,
+            "proletariat": 0.35,
+            "lumpenproletariat": 0.15,
+        },
+        "median_wage_hourly": 21.0,
+        "phi_hour": 0.0,
+        "unemployment_rate": 0.05,
+        "foreclosure_rate": DEFAULT_FORECLOSURE_RATE,
+        "bankruptcy_rate": DEFAULT_BANKRUPTCY_RATE,
+        "eviction_rate": DEFAULT_EVICTION_RATE,
+        "crisis_phase": CrisisPhase.NORMAL,
+    },
+    "oakland": {
+        "fips": "06001",
+        "dist_year": 2010,
+        "shares": {
+            "bourgeoisie": 0.02,
+            "petit_bourgeoisie": 0.08,
+            "labor_aristocracy": 0.35,
+            "proletariat": 0.40,
+            "lumpenproletariat": 0.15,
+        },
+        "median_wage_hourly": 25.0,
+        "phi_hour": 0.0,
+        "unemployment_rate": 0.10,
+        "foreclosure_rate": DEFAULT_FORECLOSURE_RATE,
+        "bankruptcy_rate": DEFAULT_BANKRUPTCY_RATE,
+        "eviction_rate": DEFAULT_EVICTION_RATE,
+        "crisis_phase": CrisisPhase.NORMAL,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Term-for-term transcription of the frozen arithmetic.
+# ---------------------------------------------------------------------------
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+def _halt_floor_wage(median_wage_hourly: float) -> float:
+    """FR-017 halt: zero effective wage when hourly wage is below floor."""
+    floor = V_REPRODUCTION * ACCUMULATION_HALT_FLOOR_RATIO
+    if median_wage_hourly < floor:
+        return 0.0
+    return median_wage_hourly * HOURS_PER_YEAR
+
+
+def _phi_adjustment(phi_hour: float, effective_wage_annual: float) -> float:
+    """Frozen savings_schedule.py:74-92, with the zero guards."""
+    if effective_wage_annual == 0.0 or phi_hour == 0.0:
+        return 0.0
+    return min(phi_hour * HOURS_PER_YEAR / effective_wage_annual, PHI_CAP)
+
+
+def _annual_accumulation_frozen(
+    effective_wage_annual: float, effective_savings_rate: float
+) -> float:
+    """The frozen F11 bug: wage · s² (accumulation.py:39-41, :89-90)."""
+    consumption = effective_wage_annual * (1.0 - effective_savings_rate)
+    return (effective_wage_annual - consumption) * effective_savings_rate
+
+
+def _annual_accumulation_repaired(
+    effective_wage_annual: float, effective_savings_rate: float
+) -> float:
+    """The F11 repair: wage · s (the intended single application)."""
+    return effective_wage_annual * effective_savings_rate
+
+
+def _accumulation_rate(annual_accumulation: float) -> float:
+    """transition_engine.py:200-217."""
+    if annual_accumulation <= 0.0:
+        return 0.0
+    return min(annual_accumulation / WEALTH_THRESHOLD, MAX_ACCUMULATION_RATE)
+
+
+def _dispossession_rate(county: dict) -> float:
+    """dispossession.py:101-111, LA→P composite."""
+    f = county["foreclosure_rate"]
+    b = county["bankruptcy_rate"]
+    e = county["eviction_rate"]
+    return 0.6 * f + 0.3 * b + 0.1 * e
+
+
+def _precaritization_rate(county: dict) -> float:
+    """transition_engine.py:219-236."""
+    u = county["unemployment_rate"]
+    e = county["eviction_rate"]
+    rate = u * PRECARITIZATION_UNEMPLOYMENT_WEIGHT + e * (1.0 - PRECARITIZATION_UNEMPLOYMENT_WEIGHT)
+    return _clamp(rate, 0.0, 1.0)
+
+
+def _stabilization_rate(county: dict) -> float:
+    """transition_engine.py:238-253."""
+    u = county["unemployment_rate"]
+    rate = BASE_STABILIZATION * (1.0 - u)
+    return _clamp(rate, 0.0, 1.0)
+
+
+def _amplify(rates: dict, crisis_phase: CrisisPhase) -> dict:
+    """Phased amplification (crisis.py:153-178), passthrough for NORMAL."""
+    profile = PHASED_PROFILES[crisis_phase]
+    return {
+        "dispossession": _clamp(rates["dispossession"] * profile["dispossession"], 0.0, 1.0),
+        "precaritization": _clamp(rates["precaritization"] * profile["precaritization"], 0.0, 1.0),
+        "accumulation": _clamp(rates["accumulation"] * profile["accumulation"], 0.0, 1.0),
+        "stabilization": _clamp(rates["stabilization"] * profile["stabilization"], 0.0, 1.0),
+    }
+
+
+def _apply_flows(shares: dict, rates: dict) -> dict:
+    """transition_engine.py:255-289."""
+    la = shares["labor_aristocracy"]
+    prol = shares["proletariat"]
+    lumpen = shares["lumpenproletariat"]
+    new_la = la - rates["dispossession"] * la + rates["accumulation"] * prol
+    new_prol = (
+        prol
+        + rates["dispossession"] * la
+        - rates["accumulation"] * prol
+        - rates["precaritization"] * prol
+        + rates["stabilization"] * lumpen
+    )
+    new_lumpen = lumpen + rates["precaritization"] * prol - rates["stabilization"] * lumpen
+    return {
+        "labor_aristocracy": new_la,
+        "proletariat": new_prol,
+        "lumpenproletariat": new_lumpen,
+    }
+
+
+def _normalize(raw: dict, fixed_share: float) -> dict:
+    """transition_engine.py:291-331."""
+    la = max(raw["labor_aristocracy"], 0.0)
+    prol = max(raw["proletariat"], 0.0)
+    lumpen = max(raw["lumpenproletariat"], 0.0)
+    total_dynamic = la + prol + lumpen
+    target = 1.0 - fixed_share
+    if total_dynamic > 0.0:
+        scale = target / total_dynamic
+        return {
+            "labor_aristocracy": la * scale,
+            "proletariat": prol * scale,
+            "lumpenproletariat": lumpen * scale,
+        }
+    # Degenerate branch (F10): equal-thirds reset in frozen engine.
+    return {
+        "labor_aristocracy": target / 3.0,
+        "proletariat": target / 3.0,
+        "lumpenproletariat": target / 3.0,
+    }
+
+
+def _compute_county_transcription(county: dict, accumulation_variant: str) -> dict:
+    """One full term-for-term transition for a county."""
+    fixed = county["shares"]["bourgeoisie"] + county["shares"]["petit_bourgeoisie"]
+    effective_wage_annual = _halt_floor_wage(county["median_wage_hourly"])
+    phi_adj = _phi_adjustment(county["phi_hour"], effective_wage_annual)
+    s = min(SAVINGS_PROLETARIAT + phi_adj, 1.0)
+
+    if accumulation_variant == "frozen":
+        annual_acc = _annual_accumulation_frozen(effective_wage_annual, s)
+    elif accumulation_variant == "repaired":
+        annual_acc = _annual_accumulation_repaired(effective_wage_annual, s)
+    else:
+        raise ValueError(accumulation_variant)
+
+    acc_rate = _accumulation_rate(annual_acc)
+    disp_rate = _dispossession_rate(county)
+    prec_rate = _precaritization_rate(county)
+    stab_rate = _stabilization_rate(county)
+
+    base_rates = {
+        "dispossession": disp_rate,
+        "accumulation": acc_rate,
+        "precaritization": prec_rate,
+        "stabilization": stab_rate,
+    }
+    amplified = _amplify(base_rates, county["crisis_phase"])
+    raw = _apply_flows(county["shares"], amplified)
+    normalized = _normalize(raw, fixed)
+    return {
+        "county": county["fips"],
+        "variant": accumulation_variant,
+        "wage_hourly": county["median_wage_hourly"],
+        "wage_annual": effective_wage_annual,
+        "phi_per_hour": county["phi_hour"],
+        "phi_adjustment": phi_adj,
+        "effective_savings_rate": s,
+        "annual_accumulation_dollars": annual_acc,
+        "rate_accumulation_per_year": acc_rate,
+        "rate_dispossession_per_year": disp_rate,
+        "rate_precaritization_per_year": prec_rate,
+        "rate_stabilization_per_year": stab_rate,
+        "shares_before": county["shares"],
+        "shares_after": normalized,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Corroboration pass through the frozen DefaultClassTransitionEngine.
+# ---------------------------------------------------------------------------
+class _DefaultDispossessionDataSource:
+    """Returns the scenario-seeded default rates, matching a02's per-node
+    field read rather than the hardcoded national source the frozen caller
+    optionally substitutes."""
+
+    def get_foreclosure_rate(self, _fips: str, _year: int) -> float:
+        return DEFAULT_FORECLOSURE_RATE
+
+    def get_bankruptcy_rate(self, _fips: str, _year: int) -> float:
+        return DEFAULT_BANKRUPTCY_RATE
+
+    def get_eviction_rate(self, _fips: str, _year: int) -> float:
+        return DEFAULT_EVICTION_RATE
+
+
+def _run_engine(county: dict, accumulation_variant: str) -> dict:
+    """Drive the actual frozen engine over the same inputs."""
+    savings = DefaultSavingsRateSchedule(phi_cap=PHI_CAP)
+    accumulation = DefaultAccumulationCalculator(savings, wealth_threshold=WEALTH_THRESHOLD)
+    # The default calculator uses wage·s² in the frozen code.  To obtain the
+    # repaired wage·s result, we monkey-patch its compute method for this
+    # corroboration pass only — the engine's own structure is unchanged.
+    if accumulation_variant == "repaired":
+        original_compute = accumulation.compute
+
+        def repaired_compute(wage, phi_hour, class_position):
+            result = original_compute(wage, phi_hour, class_position)
+            # Replace the double-application with the single one.
+            repaired_annual = wage * result.savings_rate
+            return result.model_copy(update={"annual_accumulation": repaired_annual})
+
+        accumulation.compute = repaired_compute
+
+    dispossession = DefaultDispossessionCalculator(_DefaultDispossessionDataSource())
+    amplifier = PhasedCrisisAmplifier()  # matches the BSL a05 phased table
+    engine = DefaultClassTransitionEngine(
+        accumulation,
+        dispossession,
+        amplifier,
+        wealth_threshold=WEALTH_THRESHOLD,
+        eviction_weight=PRECARITIZATION_UNEMPLOYMENT_WEIGHT,
+        base_stabilization=BASE_STABILIZATION,
+    )
+
+    effective_wage = _halt_floor_wage(county["median_wage_hourly"])
+    conditions = EconomicConditions(
+        fips=county["fips"],
+        year=county["dist_year"],
+        unemployment_rate=county["unemployment_rate"],
+        median_wage=effective_wage,
+        melt=60.0,  # dummy; the dynamics engine does not read melt
+        phi_hour=county["phi_hour"],
+        foreclosure_rate=county["foreclosure_rate"],
+        bankruptcy_rate=county["bankruptcy_rate"],
+        eviction_rate=county["eviction_rate"],
+        crisis=county["crisis_phase"] != CrisisPhase.NORMAL,
+    )
+    dist = ClassDistribution(
+        fips=county["fips"],
+        year=county["dist_year"],
+        bourgeoisie_share=county["shares"]["bourgeoisie"],
+        petit_bourgeoisie_share=county["shares"]["petit_bourgeoisie"],
+        labor_aristocracy_share=county["shares"]["labor_aristocracy"],
+        proletariat_share=county["shares"]["proletariat"],
+        lumpenproletariat_share=county["shares"]["lumpenproletariat"],
+    )
+    result = engine.simulate_transitions(dist, conditions, crisis_phase=county["crisis_phase"])
+    return {
+        "county": county["fips"],
+        "variant": accumulation_variant,
+        "shares_after": {
+            "labor_aristocracy": result.labor_aristocracy_share,
+            "proletariat": result.proletariat_share,
+            "lumpenproletariat": result.lumpenproletariat_share,
+        },
+    }
+
+
+def _print_county(label: str, result: dict) -> None:
+    print(f"== {label} ({result['variant']}) ==")
+    print(f"  county_fips = {result['county']}")
+    if "wage_hourly" in result:
+        print(f"  wage_hourly = {result['wage_hourly']!r}")
+        print(f"  wage_annual = {result['wage_annual']!r}")
+        print(f"  phi_per_hour = {result['phi_per_hour']!r}")
+        print(f"  phi_adjustment = {result['phi_adjustment']!r}")
+        print(f"  effective_savings_rate = {result['effective_savings_rate']!r}")
+        print(f"  annual_accumulation_dollars = {result['annual_accumulation_dollars']!r}")
+        print(f"  rate_accumulation_per_year = {result['rate_accumulation_per_year']!r}")
+        print(f"  rate_dispossession_per_year = {result['rate_dispossession_per_year']!r}")
+        print(f"  rate_precaritization_per_year = {result['rate_precaritization_per_year']!r}")
+        print(f"  rate_stabilization_per_year = {result['rate_stabilization_per_year']!r}")
+    before = result.get("shares_before")
+    if before:
+        print(f"  la_before = {before['labor_aristocracy']!r}")
+        print(f"  prol_before = {before['proletariat']!r}")
+        print(f"  lumpen_before = {before['lumpenproletariat']!r}")
+    after = result["shares_after"]
+    print(f"  la_after = {after['labor_aristocracy']!r}")
+    print(f"  prol_after = {after['proletariat']!r}")
+    print(f"  lumpen_after = {after['lumpenproletariat']!r}")
+    total = (
+        result.get("shares_before", {}).get("bourgeoisie", 0.0)
+        + result.get("shares_before", {}).get("petit_bourgeoisie", 0.0)
+        + after["labor_aristocracy"]
+        + after["proletariat"]
+        + after["lumpenproletariat"]
+    )
+    print(f"  total_share_check = {total!r}")
+
+
+def _assert_agreement(transcription: dict, engine: dict) -> None:
+    """STOP-first agreement check; only declared divergences are allowed."""
+    for key in ("labor_aristocracy", "proletariat", "lumpenproletariat"):
+        t = transcription["shares_after"][key]
+        e = engine["shares_after"][key]
+        if t != e:
+            raise AssertionError(
+                f"{transcription['county']} {transcription['variant']} {key}: "
+                f"transcription {t!r} != engine {e!r}"
+            )
+
+
+def main() -> None:
+    print("class-dynamics-conformance — frozen mirror (world 1)")
+    print()
+    for name, county in WORLD.items():
+        for variant in ("frozen", "repaired"):
+            tx = _compute_county_transcription(county, variant)
+            eng = _run_engine(county, variant)
+            _assert_agreement(tx, eng)
+            _print_county(name, tx)
+            print()
+
+    # F11 headline: the 33× factor at the proletariat's 0.03 savings rate.
+    wayne = WORLD["wayne"]
+    effective_wage = _halt_floor_wage(wayne["median_wage_hourly"])
+    s = SAVINGS_PROLETARIAT  # phi = 0 here
+    frozen_acc = _annual_accumulation_frozen(effective_wage, s)
+    repaired_acc = _annual_accumulation_repaired(effective_wage, s)
+    print("F11 headline (wayne, phi=0, savings=0.03):")
+    print(f"  frozen annual accumulation (wage·s²)   = {frozen_acc!r}")
+    print(f"  repaired annual accumulation (wage·s)  = {repaired_acc!r}")
+    print(f"  ratio repaired/frozen                  = {repaired_acc / frozen_acc!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/crates/babylon-tick/src/bin/bsl_fuel_report.rs
+++ b/rust/crates/babylon-tick/src/bin/bsl_fuel_report.rs
@@ -184,6 +184,16 @@ const SOLO_PACKS: &[(&str, &str, Option<&str>, &str)] = &[
         None,
         include_str!("../../content/rules/community.bsl"),
     ),
+    (
+        // TickDynamics class-dynamics port train (issue #669, Feature-016
+        // @4.0). Task 2 lands the header-only pack; later tasks populate
+        // it with rules. The fuel report row is added now so the
+        // enumeration sentinel stays green as the file lands.
+        "class-dynamics",
+        include_str!("../../content/scenarios/class-dynamics-conformance.bscn"),
+        None,
+        include_str!("../../content/rules/class-dynamics.bsl"),
+    ),
 ];
 
 /// The two committed multi-file co-loads — see the module doc's fix-round

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -395,6 +395,15 @@ fn registered_systems() -> HashSet<String> {
         // (`reports/community-bsl-surface-facts-2026-08-18.md`) confirmed
         // zero prior hits in this HashSet.
         "community".to_owned(),
+        // The class-dynamics/* rule pack (Material Base @4.0's Feature-016
+        // class-dynamics engine — NOT all of @4.0; TickDynamics port train,
+        // issue #669, plan `docs/superpowers/plans/2026-08-18-tickdynamics-
+        // port.md`). Genuinely NEW registration — the Task 0 surface-facts
+        // dossier (`reports/class-dynamics-bsl-surface-facts-2026-08-18.md`)
+        // confirmed zero prior hits in this HashSet for `class-dynamics`/
+        // `tick-dynamics`/`tickdynamics` spellings. Hyphenated spelling
+        // follows the `social-class`/`control-ratio` precedent.
+        "class-dynamics".to_owned(),
     ])
 }
 

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -397,8 +397,9 @@ fn registered_systems() -> HashSet<String> {
         "community".to_owned(),
         // The class-dynamics/* rule pack (Material Base @4.0's Feature-016
         // class-dynamics engine — NOT all of @4.0; TickDynamics port train,
-        // issue #669, plan `docs/superpowers/plans/2026-08-18-tickdynamics-
-        // port.md`). Genuinely NEW registration — the Task 0 surface-facts
+        // issue #669, plan docs/superpowers/plans/2026-08-18-tickdynamics-port.md
+        // — path deliberately unbackticked so the line break cannot render a
+        // split path). Genuinely NEW registration — the Task 0 surface-facts
         // dossier (`reports/class-dynamics-bsl-surface-facts-2026-08-18.md`)
         // confirmed zero prior hits in this HashSet for `class-dynamics`/
         // `tick-dynamics`/`tickdynamics` spellings. Hyphenated spelling

--- a/rust/crates/babylon-tick/tests/class_dynamics_conformance.rs
+++ b/rust/crates/babylon-tick/tests/class_dynamics_conformance.rs
@@ -248,12 +248,13 @@ fn defenum_ordinal_parity_with_the_frozen_order() {
     }
 }
 
-/// Cross-world constant-parity harness (Task 2 lands world 1 only; later
-/// tasks extend the `scenarios` array). Every constant a world does not
-/// deliberately vary must be byte-identical across worlds — a typo in one
-/// world's canonical block cannot pass.
+/// Canonical-table parity (Task 2 lands world 1 only, so this asserts
+/// world 1 against the canonical block; when later worlds land, this
+/// harness extends to a loop over a `scenarios` array — every constant a
+/// world does not deliberately vary must be byte-identical across worlds,
+/// so a typo in one world's canonical block cannot pass).
 #[test]
-fn the_constant_table_is_byte_identical_across_all_worlds() {
+fn world1_constants_match_the_canonical_table_bit_exactly() {
     let expected: [(&str, f64); 46] = [
         // Engine parameters — transition_engine.py:51-54.
         ("class-dynamics/wealth-threshold", 142_000.0),

--- a/rust/crates/babylon-tick/tests/class_dynamics_conformance.rs
+++ b/rust/crates/babylon-tick/tests/class_dynamics_conformance.rs
@@ -1,0 +1,418 @@
+//! Conformance vectors for the `class-dynamics/*` rule pack (Feature-016,
+//! issue #669 — the TickDynamics class-dynamics port train,
+//! `docs/superpowers/plans/2026-08-18-tickdynamics-port.md`).
+//!
+//! # Task 2 scope
+//!
+//! This file lands the registration refusal, the world-1 declaration surface,
+//! the frozen-mirror corroboration, and the permanent anti-pattern guards.
+//! Per-task rule assertions follow in later tasks.
+//!
+//! # Provenance
+//!
+//! The frozen mirror is `content/scenarios/class_dynamics_conformance.py`.
+//! It is the structure/ordering oracle, not a byte oracle (ADR183). Every
+//! numeric value pinned below is measured from the BSL engine's own output.
+//!
+//! # Mirror verbatim stdout (2026-08-22, `uv run python`)
+//!
+//! The mirror's term-for-term transcription and `DefaultClassTransitionEngine`
+//! corroboration pass agree exactly (the `_assert_agreement` STOP-first check
+//! exits 0). The F11 double run shows the frozen `wage·s²` accumulation versus
+//! the repaired `wage·s`:
+//!
+//! ```text
+//! class-dynamics-conformance — frozen mirror (world 1)
+//!
+//! == wayne (frozen) ==
+//!   county_fips = 26163
+//!   wage_hourly = 21.0
+//!   wage_annual = 43680.0
+//!   phi_per_hour = 0.0
+//!   phi_adjustment = 0.0
+//!   effective_savings_rate = 0.03
+//!   annual_accumulation_dollars = 39.31200000000004
+//!   rate_accumulation_per_year = 0.0002768450704225355
+//!   rate_dispossession_per_year = 0.0117
+//!   rate_precaritization_per_year = 0.0565
+//!   rate_stabilization_per_year = 0.1425
+//!   la_before = 0.4
+//!   prol_before = 0.35
+//!   lumpen_before = 0.15
+//!   la_after = 0.3954168957746479
+//!   prol_after = 0.3561831042253521
+//!   lumpen_after = 0.1484
+//!   total_share_check = 0.9999999999999999
+//!
+//! == wayne (repaired) ==
+//!   county_fips = 26163
+//!   wage_hourly = 21.0
+//!   wage_annual = 43680.0
+//!   phi_per_hour = 0.0
+//!   phi_adjustment = 0.0
+//!   effective_savings_rate = 0.03
+//!   annual_accumulation_dollars = 1310.3999999999999
+//!   rate_accumulation_per_year = 0.009228169014084506
+//!   rate_dispossession_per_year = 0.0117
+//!   rate_precaritization_per_year = 0.0565
+//!   rate_stabilization_per_year = 0.1425
+//!   la_before = 0.4
+//!   prol_before = 0.35
+//!   lumpen_before = 0.15
+//!   la_after = 0.3985498591549296
+//!   prol_after = 0.3530501408450704
+//!   lumpen_after = 0.1484
+//!   total_share_check = 0.9999999999999999
+//!
+//! == oakland (frozen) ==
+//!   county_fips = 06001
+//!   wage_hourly = 25.0
+//!   wage_annual = 52000.0
+//!   phi_per_hour = 0.0
+//!   phi_adjustment = 0.0
+//!   effective_savings_rate = 0.03
+//!   annual_accumulation_dollars = 46.8
+//!   rate_accumulation_per_year = 0.00032957746478873236
+//!   rate_dispossession_per_year = 0.0117
+//!   rate_precaritization_per_year = 0.0815
+//!   rate_stabilization_per_year = 0.135
+//!   la_before = 0.35
+//!   prol_before = 0.4
+//!   lumpen_before = 0.15
+//!   la_after = 0.34603683098591553
+//!   prol_after = 0.3916131690140846
+//!   lumpen_after = 0.16235000000000002
+//!   total_share_check = 1.0000000000000002
+//!
+//! == oakland (repaired) ==
+//!   county_fips = 06001
+//!   wage_hourly = 25.0
+//!   wage_annual = 52000.0
+//!   phi_per_hour = 0.0
+//!   phi_adjustment = 0.0
+//!   effective_savings_rate = 0.03
+//!   annual_accumulation_dollars = 1560.0
+//!   rate_accumulation_per_year = 0.010985915492957746
+//!   rate_dispossession_per_year = 0.0117
+//!   rate_precaritization_per_year = 0.0815
+//!   rate_stabilization_per_year = 0.135
+//!   la_before = 0.35
+//!   prol_before = 0.4
+//!   lumpen_before = 0.15
+//!   la_after = 0.3502993661971831
+//!   prol_after = 0.38735063380281703
+//!   lumpen_after = 0.16235000000000002
+//!   total_share_check = 1.0000000000000002
+//!
+//! F11 headline (wayne, phi=0, savings=0.03):
+//!   frozen annual accumulation (wage·s²)   = 39.31200000000004
+//!   repaired annual accumulation (wage·s)  = 1310.3999999999999
+//!   ratio repaired/frozen                  = 33.33333333333329
+//! ```
+//!
+//! # Red-phase evidence
+//!
+//! Before `class-dynamics` was registered in `lib.rs`, the probe rule below
+//! refused with:
+//! `rule class-dynamics/probe rejected: E-LOAD-002: rule class-dynamics/probe
+//! carries no anchor and its first id segment names no registered system —
+//! a rule cannot land nowhere (§2.3)`.
+
+use babylon_bsl::scenario::load_scenario;
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::hypergraph_store::HypergraphStore;
+use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_tick::run_once_into;
+
+const SCENARIO: &str = include_str!("../content/scenarios/class-dynamics-conformance.bscn");
+const PACK: &str = include_str!("../content/rules/class-dynamics.bsl");
+
+// Node ids, fixed by the scenario's own declaration order.
+const WAYNE: NodeId = NodeId(0);
+const OAKLAND: NodeId = NodeId(1);
+const WAYNE_PROLE: NodeId = NodeId(2);
+const WAYNE_LA: NodeId = NodeId(3);
+const SHARED_CLASS: NodeId = NodeId(4);
+const ORPHAN_CLASS: NodeId = NodeId(5);
+
+/// Step 2 green load-smoke: the scenario hydrates and ticks clean under a
+/// minimal `class-dynamics/` probe rule. The probe never fires (`crisis-phase`
+/// is `NORMAL`, not `ONSET`), so the pre/post hashes are identical — the hash
+/// brackets the tick, not the hydration.
+#[test]
+fn scenario_loads_with_a_class_dynamics_probe() {
+    const PROBE_RULE: &str = r#"
+(rule class-dynamics/probe
+  :material-basis "Task 2 Step 2 green load-smoke: prove registration + scenario load"
+  :fuel 8
+  (bindings (binding phase :field territory/crisis-phase))
+  (when (= phase CrisisPhase/ONSET))
+  (effects
+    (update-node self territory/bifurcation-score (set 0))))
+"#;
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    let report = run_once_into(SCENARIO, PROBE_RULE, &mut graph, &mut sink)
+        .expect("the scenario must load and run against a registered class-dynamics probe");
+    assert_eq!(report.fired, 0, "the probe never fires");
+    assert_eq!(
+        report.before, report.after,
+        "a never-firing probe writes nothing"
+    );
+}
+
+/// The scenario's own node/edge census, independent of any rule pack.
+#[test]
+fn the_scenario_loads_clean_with_the_declared_census() {
+    let mut graph = HypergraphStore::new();
+    let loaded = load_scenario(SCENARIO, &mut graph).expect("the scenario must load clean");
+    assert_eq!(loaded.node_count, 6, "2 territories + 4 social classes");
+    assert_eq!(loaded.edge_count, 4, "four TENANCY edges");
+    assert_eq!(loaded.node_types.get("TERRITORY").copied(), Some(2));
+    assert_eq!(loaded.node_types.get("SOCIAL_CLASS").copied(), Some(4));
+    assert_eq!(loaded.edge_types.get("TENANCY").copied(), Some(4));
+}
+
+/// Every field the pack will read is present on every node of its namespace
+/// before any rule exists to touch it (no-defaults contract).
+#[test]
+fn every_node_seeds_all_its_declared_fields() {
+    let mut graph = HypergraphStore::new();
+    load_scenario(SCENARIO, &mut graph).expect("the scenario must load clean");
+    for id in [WAYNE, OAKLAND] {
+        for field in [
+            "territory/share-bourgeoisie",
+            "territory/share-petit-bourgeoisie",
+            "territory/share-labor-aristocracy",
+            "territory/share-proletariat",
+            "territory/share-lumpenproletariat",
+            "territory/dist-year",
+            "territory/baseline-la-share",
+            "territory/baseline-la-known",
+            "territory/unemployment-rate",
+            "territory/median-wage",
+            "territory/phi-hour",
+            "territory/foreclosure-rate",
+            "territory/bankruptcy-rate",
+            "territory/eviction-rate",
+            "territory/crisis-phase",
+            "territory/phi-savings-adjustment",
+            "territory/bifurcation-score",
+            "territory/rate-accumulation",
+            "territory/rate-dispossession",
+            "territory/rate-precaritization",
+            "territory/rate-stabilization",
+            "territory/raw-share-labor-aristocracy",
+            "territory/raw-share-proletariat",
+            "territory/raw-share-lumpenproletariat",
+        ] {
+            graph
+                .node_attribute(id, field)
+                .unwrap_or_else(|e| panic!("node {id:?} field {field}: {}", e.message));
+        }
+    }
+    for id in [WAYNE_PROLE, WAYNE_LA, SHARED_CLASS, ORPHAN_CLASS] {
+        for field in [
+            "social-class/ternary-net-fascist",
+            "social-class/revolutionary",
+            "social-class/fascist",
+            "social-class/population",
+        ] {
+            graph
+                .node_attribute(id, field)
+                .unwrap_or_else(|e| panic!("node {id:?} field {field}: {}", e.message));
+        }
+    }
+}
+
+/// ADR195 ordinal parity: `CrisisPhase` order is the frozen Python declaration
+/// order (`src/babylon/domain/economics/tick/types.py`). A transposition here
+/// silently re-reads every seeded `territory/crisis-phase`.
+#[test]
+fn defenum_ordinal_parity_with_the_frozen_order() {
+    let mut graph = HypergraphStore::new();
+    let loaded = load_scenario(SCENARIO, &mut graph).expect("world 1 loads");
+    let phase = loaded
+        .enums
+        .resolve("CrisisPhase")
+        .expect("CrisisPhase declared");
+    for (expected, member) in ["NORMAL", "ONSET", "EARLY", "DEEP", "RECOVERY"]
+        .iter()
+        .enumerate()
+    {
+        assert_eq!(
+            loaded.enums.ordinal(phase, member),
+            Some(expected as u32),
+            "CrisisPhase/{member} must be ordinal {expected}"
+        );
+    }
+}
+
+/// Cross-world constant-parity harness (Task 2 lands world 1 only; later
+/// tasks extend the `scenarios` array). Every constant a world does not
+/// deliberately vary must be byte-identical across worlds — a typo in one
+/// world's canonical block cannot pass.
+#[test]
+fn the_constant_table_is_byte_identical_across_all_worlds() {
+    let expected: [(&str, f64); 46] = [
+        // Engine parameters — transition_engine.py:51-54.
+        ("class-dynamics/wealth-threshold", 142_000.0),
+        ("class-dynamics/precaritization-unemployment-weight", 0.5),
+        ("class-dynamics/base-stabilization", 0.15),
+        ("class-dynamics/max-accumulation-rate", 0.08),
+        // Phased amplification table — crisis.py:24-55 (20 constants).
+        ("class-dynamics/amp-normal-dispossession", 1.0),
+        ("class-dynamics/amp-normal-precaritization", 1.0),
+        ("class-dynamics/amp-normal-accumulation", 1.0),
+        ("class-dynamics/amp-normal-stabilization", 1.0),
+        ("class-dynamics/amp-onset-dispossession-x1e6", 1_200_000.0),
+        ("class-dynamics/amp-onset-precaritization-x1e6", 1_500_000.0),
+        ("class-dynamics/amp-onset-accumulation", 0.8),
+        ("class-dynamics/amp-onset-stabilization", 0.7),
+        ("class-dynamics/amp-early-dispossession-x1e6", 1_800_000.0),
+        ("class-dynamics/amp-early-precaritization-x1e6", 2_500_000.0),
+        ("class-dynamics/amp-early-accumulation", 0.4),
+        ("class-dynamics/amp-early-stabilization", 0.4),
+        ("class-dynamics/amp-deep-dispossession-x1e6", 3_000_000.0),
+        ("class-dynamics/amp-deep-precaritization-x1e6", 3_500_000.0),
+        ("class-dynamics/amp-deep-accumulation", 0.1),
+        ("class-dynamics/amp-deep-stabilization", 0.2),
+        (
+            "class-dynamics/amp-recovery-dispossession-x1e6",
+            1_300_000.0,
+        ),
+        (
+            "class-dynamics/amp-recovery-precaritization-x1e6",
+            1_200_000.0,
+        ),
+        ("class-dynamics/amp-recovery-accumulation", 0.6),
+        ("class-dynamics/amp-recovery-stabilization", 0.5),
+        // Dispossession composite weights (LA→P) — dispossession.py:30-36.
+        ("class-dynamics/foreclosure-weight-la-to-p", 0.6),
+        ("class-dynamics/bankruptcy-weight-la-to-p", 0.3),
+        ("class-dynamics/eviction-weight-la-to-p", 0.1),
+        // Savings schedule — savings_schedule.py:21-31.
+        ("class-dynamics/savings-proletariat", 0.03),
+        ("class-dynamics/phi-cap", 0.05),
+        // Dispossession-rate defaults — system/__init__.py:2383-2385.
+        ("class-dynamics/default-foreclosure-rate", 0.006),
+        ("class-dynamics/default-bankruptcy-rate", 0.006),
+        ("class-dynamics/default-eviction-rate", 0.063),
+        // Wage / subsistence.
+        ("class-dynamics/hours-per-year", 2_080.0),
+        ("class-dynamics/v-reproduction", 12.0),
+        ("class-dynamics/accumulation-halt-floor-ratio", 0.8),
+        // Bootstrap five-class shares — types.py:44-48 / R5.
+        ("class-dynamics/bootstrap-bourgeoisie", 0.01),
+        ("class-dynamics/bootstrap-petit-bourgeoisie", 0.09),
+        ("class-dynamics/bootstrap-labor-aristocracy", 0.40),
+        ("class-dynamics/bootstrap-proletariat", 0.35),
+        ("class-dynamics/bootstrap-lumpenproletariat", 0.15),
+        // Cascade milestones + bifurcation threshold — R5 / R6.
+        ("class-dynamics/cascade-milestone-1", 0.05),
+        ("class-dynamics/cascade-milestone-2", 0.10),
+        ("class-dynamics/cascade-milestone-3", 0.15),
+        ("class-dynamics/bifurcation-event-threshold", 0.5),
+        // Year clamp window.
+        ("class-dynamics/year-min", 2_007.0),
+        ("class-dynamics/year-max", 2_030.0),
+    ];
+
+    let mut graph = HypergraphStore::new();
+    let loaded = load_scenario(SCENARIO, &mut graph).expect("world 1 loads");
+    for (name, value) in &expected {
+        let actual = loaded
+            .consts
+            .get(*name)
+            .unwrap_or_else(|| panic!("{name} missing from world 1"));
+        let bits = match actual {
+            babylon_bsl::evaluator::Value::Real(r) => *r,
+            babylon_bsl::evaluator::Value::Int(i) => *i as f64,
+            other => panic!("{name} must be a real or int literal, got {other:?}"),
+        };
+        assert_eq!(
+            bits.to_bits(),
+            value.to_bits(),
+            "{name} diverges from the canonical value"
+        );
+    }
+}
+
+// ---- §7c's three permanent anti-pattern guards (landed Task 2, NEVER
+// deleted). ----
+
+/// §7c row 1: no `(binding … :field class-dynamics/…)` in the pack source —
+/// `subject_type_of` would demand a `NodeType/CLASS_DYNAMICS` that does not
+/// exist.
+#[test]
+fn no_rule_binds_a_field_in_the_pack_namespace() {
+    let mut rest = PACK;
+    while let Some(idx) = rest.find("(binding") {
+        rest = &rest[idx..];
+        let end = rest.find(')').expect("a binding form closes");
+        let form = &rest[..=end];
+        assert!(
+            !(form.contains(":field") && form.contains("class-dynamics/")),
+            "a :field binding owns off the class-dynamics namespace: {form}"
+        );
+        rest = &rest[1..];
+    }
+}
+
+/// §7c row 2: the pack declares no intrinsic — protects the duplicate-`floor`
+/// hazard (D-NF+22) and §6's no-transcendental verdict in one line.
+#[test]
+fn the_pack_declares_no_intrinsic() {
+    assert!(
+        !PACK.contains("(intrinsic "),
+        "class-dynamics.bsl must declare no intrinsic (D-NF+22 / §6)"
+    );
+}
+
+/// §7c row 3: the pack writes only `territory/*` fields and the one allowed
+/// class field `social-class/ternary-net-fascist` — pins the §2.3 cross-train
+/// disjointness argument mechanically.
+#[test]
+fn the_pack_writes_only_territory_fields_and_one_class_field() {
+    let allowed: std::collections::HashSet<&str> = [
+        "territory/rate-accumulation",
+        "territory/rate-dispossession",
+        "territory/rate-precaritization",
+        "territory/rate-stabilization",
+        "territory/raw-share-labor-aristocracy",
+        "territory/raw-share-proletariat",
+        "territory/raw-share-lumpenproletariat",
+        "territory/share-labor-aristocracy",
+        "territory/share-proletariat",
+        "territory/share-lumpenproletariat",
+        "territory/dist-year",
+        "territory/baseline-la-share",
+        "territory/baseline-la-known",
+        "territory/bifurcation-score",
+        "social-class/ternary-net-fascist",
+    ]
+    .into_iter()
+    .collect();
+    // Strip comment lines so verbatim spike-result examples are not parsed
+    // as live update-node forms.
+    let live_source: String = PACK
+        .lines()
+        .filter(|line| !line.trim_start().starts_with(';'))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut rest = live_source.as_str();
+    while let Some(idx) = rest.find("(update-node") {
+        rest = &rest[idx..];
+        let end = rest.find(')').expect("an update-node form closes");
+        let form = &rest[..=end];
+        let target = form
+            .split_whitespace()
+            .nth(2)
+            .expect("update-node has a target qname");
+        assert!(
+            allowed.contains(target),
+            "update-node target {target} is not in the allowed set (§7c row 3)"
+        );
+        rest = &rest[1..];
+    }
+}


### PR DESCRIPTION
## Summary

Task 2 of the TickDynamics class-dynamics port train (#669; plan `docs/superpowers/plans/2026-08-18-tickdynamics-port.md` rev 2.1; Tasks 0/1 already landed in dev). Ports **Feature 016 — the class-dynamics engine** (`src/babylon/domain/economics/dynamics/`), explicitly NOT all of @4.0 (the plan §0.1 boundary).

- Registers `class-dynamics` in babylon-tick's systems set (genuinely new — zero prior hits, red-probed: `E-LOAD-002` before, green after)
- World 1 (`class-dynamics-conformance.bscn`): the CrisisPhase defenum in landed order (ADR195 ordinal parity test), the §4.2 field roster, the §4.5 46-defconst canonical block with frozen `file:line` provenance, six nodes incl. the D136 dual-membership vector and the orphan class
- The primary frozen mirror (`class_dynamics_conformance.py`), run twice for F11: frozen `wage·s²` vs repaired `wage·s` — the 33.33× repair factor demonstrated on both counties; `DefaultClassTransitionEngine` corroboration agrees silently
- The header-only `class-dynamics.bsl` pack carrying the SPIKE RESULTS block (the dossier §10's deferred copy)
- `bsl_fuel_report.rs`'s SOLO_PACKS gains the `class-dynamics` entry (enumeration-sentinel parity)
- Content corpus digest re-pinned 84 → 86 (additive only; every pre-existing row byte-identical)

## Drift noted

Plan §4.5 says "seven" amplifier multipliers exceed 1.0; the frozen table contains eight (1.2 twice). Documented in the scenario header.

## Gates

`rust:check` green (fmt/clippy/test/doc incl. the 28 pre-existing tick goldens, all byte-identical); `qa:regression` + vault byte-identical; red-then-green observed per TDD.

Co-Authored-By: Kimi Code <noreply@moonshot.cn>