### PR TITLE
feat(bsl): execute governed phase anchors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,9 @@ returns an in-memory `TickReport`. The Bevy viewer draws 3,222 counties, moves
 ticks, and shows lenses, causal beats, events, and hash data.
 
 Program 27 froze the Python engine at `p27-python-freeze`. Its 34-system
-`SimulationEngine._DEFAULT_SYSTEMS` and five `EndgameDetector` labels are
-behavioral reference facts, not promised outcomes. Python also owns data tools,
-selected periphery, and persisted replay.
+`SimulationEngine._DEFAULT_SYSTEMS` is the transcription oracle for Rust's
+executable `phase_order.rs` causal spine. Five `EndgameDetector` labels remain
+reference facts, not promised outcomes. Python also owns data tools and periphery.
 
 Reference Parquet and deterministic SQLite are build artifacts. The Python
 `RuntimeDatabase` is separate mutable SQLite. Python also has

--- a/ai/architecture.yaml
+++ b/ai/architecture.yaml
@@ -1,8 +1,8 @@
 ---
 meta:
   name: Babylon v4 architecture truth record
-  version: "4.0.0"
-  updated: "2026-08-22"
+  version: "4.1.0"
+  updated: "2026-08-23"
   role: current_and_planned_architecture
   authority: CONSTITUTION.md v4.0.0
   interpretation: >-
@@ -115,10 +115,17 @@ implementation_status:
         - evaluator
         - content_digests
         - anchor_validation
+        - executable_phase_anchor_total_order
+        - pre_hydration_phase_composition
         - graph_execution
       execution_truth: >-
-        Anchors validate, but the tick prepares all rules with a global
-        rule-ID byte sort. Rules then mutate the held graph in place.
+        The tick compiles rules onto the governed 34-system causal spine.
+        Namespace homes and explicit boundaries determine position; rule-ID
+        bytes break same-position ties only. Rules then mutate the held graph
+        in place.
+      limitation: >-
+        Same-position rules remain sequential and can observe earlier writes.
+        Whole-tick working-copy rollback remains PER-18.
       absent_from_current_content:
         - executable_shocks
         - executable_player_actions
@@ -250,19 +257,25 @@ implementation_status:
           - forbid_legacy_writes
           - retire_duplicates
 
-  planned_gate_2:
+  gate_2_delivery:
     PER-17:
-      status: planned
+      status: implemented_current
       gate: G2
-      component: executable_phase_anchor_total_order_and_same_phase_composition
+      component: executable_phase_anchor_total_order
+      evidence:
+        - rust/crates/babylon-tick/src/phase_order.rs
+        - rust/crates/babylon-tick/tests/phase_anchor_conformance.rs
+        - ai/decisions/ADR222_executable_bsl_phase_order.yaml
     PER-18:
       status: planned
       gate: G2
-      component: whole_tick_working_copy_rollback
+      component: >-
+        whole_tick_working_copy_rollback_and_canonical_big_endian_auxiliary_register_combined_world_hashing
     PER-19:
       status: planned
       gate: G2
-      component: combined_graph_and_auxiliary_register_hash
+      component: >-
+        bsl_causal_composition_provenance_direct_write_whitelist_and_negative_outcome_write_contracts
 
   planned_gate_3:
     PER-20:

--- a/ai/bsl-architecture-standard.md
+++ b/ai/bsl-architecture-standard.md
@@ -26,7 +26,9 @@ historical record against their stated baseline.
 - S-11 whole-tick rollback status: planned
 - S-25 renderer requirement status: retired
 - S-32 writer assignment status: superseded
-- D5/D16 byte-sort ordering status: implemented_current_to_be_replaced
+- D5/D16 phase-ordering status: implemented_executable_PER-17
+- PER-18 rollback and combined-world-hash status: planned
+- PER-19 causal-composition and outcome-write-contract status: planned
 - Persistence writer status: accepted_cutover_law
 - PER-48 status: Done
 - PostgreSQL boundary ADR: ADR220_rust_owned_postgresql_persistence_boundary
@@ -42,12 +44,13 @@ and ADR.
 ### Implemented current path
 
 The Rust estate implements the BSL parser, vocabulary and type checking,
-evaluator, canonical content digests, anchor validation, and graph execution.
-It does not yet use anchors as the tick's executable total order. Rule
-preparation sorts every rule globally by rule-ID bytes, then `TickSession`
-applies each rule to its held graph in place. A failing rule prevents the tick
-counter from advancing, but it does not restore mutations made by earlier
-rules.
+evaluator, canonical content digests, executable anchor placement, and graph
+execution. Rule preparation compiles the frozen 34-system causal spine before
+mutating caller state. Default homes come from the rule-ID namespace; explicit
+anchors select governed boundaries; D16 orders only same-position ties by
+rule-ID bytes. `TickSession` still applies each rule to its held graph in
+place. A failing rule prevents the tick counter from advancing, but it does not
+restore mutations made by earlier rules.
 
 The frozen Python estate's 34 systems, actions, resolvers, observers, and
 persistence remain reference and port sources. They are not a prerequisite for
@@ -55,14 +58,16 @@ starting playable Rust slices. The Bevy client is an unfogged administrative
 viewer; executable BSL shocks, executable player actions, and a player decision
 loop are not current.
 
-### Gate 2 target
+### Gate 2 delivery status
 
-PER-17 replaces the global byte sort with a phase-anchor total order and
-governed same-phase composition. PER-18 adds a whole-tick working copy that
-swaps only after successful adjudication. PER-19 extends canonical hashing over
-the graph and auxiliary registers. Therefore, S-11 must not be cited as proof
-that rollback exists today, and D5/D16 describe the current implementation to
-be replaced rather than the future engine order.
+PER-17 has replaced the global byte sort with an executable phase-anchor total
+order. Same-position rules remain sequential; their shared-prestate repair is
+separate from placement. PER-18 adds a whole-tick working copy that swaps only
+after successful adjudication and extends canonical big-endian hashing across
+auxiliary registers into the combined world hash. PER-19 owns BSL causal
+composition, the provenance/direct-write whitelist, and negative outcome-write
+contracts. Therefore, S-11 must not be cited as proof that rollback exists
+today.
 
 ### Durability and client boundary
 

--- a/ai/decisions/ADR222_executable_bsl_phase_order.yaml
+++ b/ai/decisions/ADR222_executable_bsl_phase_order.yaml
@@ -1,0 +1,111 @@
+ADR222_executable_bsl_phase_order:
+  status: "accepted"
+  date: "2026-08-23"
+  title: >
+    BSL rules execute on the governed 34-system causal spine: namespace homes
+    and explicit boundary anchors compile before caller-state mutation, D16
+    orders only same-position ties, and the former global rule-ID sort retires
+  context: |
+    The Rust tick driver admitted multiple rules but sorted the complete content
+    set globally by rule-ID bytes. That inverted real causal dependencies. In
+    particular, control-ratio/* ran before decomposition/* even though the
+    frozen engine places Decomposition before ControlRatio. The landed estate
+    documented those inversions as tolerable, but the safety depended on
+    disjoint fields, seeded carrier state, or delays. It was not a causal
+    scheduler.
+
+    BSL already parsed and validated `(anchor :before|:after <system>)`, while
+    the language reserved E-LOAD-003 for an anchor that cuts through Material
+    Base. No execution path consumed that declaration. PER-17 requires the
+    phase anchors and the frozen weekly causal spine to become executable before
+    Gate 2 adds whole-tick rollback and combined state hashing.
+
+    The first implementation preflighted anchors before scenario and rule
+    validation. Adversarial review found that this inverted the existing load
+    error-class contract: an illegal anchor could hide an earlier malformed
+    scenario, invalid fuel value, or type error. The accepted implementation
+    validates on a disposable graph in the established order and compiles
+    placement only after every rule has independently loaded.
+  decision: |
+    1. REGISTRY. `babylon-tick` owns one ordered registry transcribed from the
+       frozen 34-system engine: 15 Material Base slots, one Action slot, and 18
+       Consequence slots. The exact order is pinned by a full-list test, not
+       sampled endpoints. The compatibility namespaces `class-dynamics`,
+       `economics`, `organization`, and `social-class` resolve to
+       `tick-dynamics`, `contradiction`, `ooda`, and `solidarity` respectively.
+
+    2. PLACEMENT. For canonical slot ordinal i, `:before` resolves to rank 2i,
+       the namespace default to 2i+1, and `:after` to 2i+2. Therefore `:after`
+       one slot and `:before` the next name the same boundary. Rules at one
+       resolved rank use ascending rule-ID bytes as D16 requires. Source, file,
+       directory, and map iteration order remain unobservable. Phase
+       validation also visits rule IDs in byte order, so invalid source
+       permutations name the same offending rule.
+
+    3. MATERIAL BASE. Explicit pre-base and post-base boundaries are legal:
+       `:before vitality` and `:after metabolism`. Every explicit rank strictly
+       inside that partition is E-LOAD-003. Namespace-default rules continue to
+       occupy their governed Material Base homes; the restriction prevents mods
+       from splicing incidental work between the fixed causal stages.
+
+    4. LOAD ORDER AND MUTATION. `prepare_rules` first loads the scenario into a
+       disposable `HypergraphStore`, builds the real declarations, and loads
+       every rule through the existing parser, type, fuel, vocabulary, and
+       anchor gates. It then compiles and applies the phase plan. Only after all
+       non-mutating checks pass does it hydrate the caller graph. This preserves
+       scenario -> rule -> composition failure precedence while proving an
+       invalid phase composition cannot mutate caller state. The final hydration
+       supplies content-to-node identities, because a non-empty caller graph may
+       allocate different node IDs than the disposable graph. The diagnostics
+       seam applies the same aggregate rule-id uniqueness check after joining
+       independently parsed sources. Duplicate rule IDs therefore remain typed
+       E-LOAD-001 data even when a file boundary separates them.
+
+    5. DECLARATIVE MEANING. An explicit anchor names the immediate boundary,
+       not an inequality. The old Lifecycle declaration `(anchor :after
+       vitality)` is removed: Lifecycle's namespace already places it at slot 7,
+       while the literal boundary after Vitality would illegally cut Material
+       Base.
+
+    6. DEFERRED, NAMED GAPS. Rules at the same resolved position still execute
+       sequentially and may observe earlier same-position writes. This ADR does
+       not claim the language target's shared-prestate composition. PER-18 owns
+       whole-tick working-copy rollback, including graph, session counters, and
+       buffered events, plus the combined state hash. That hash must cover a
+       schedule/layout version or equivalent registry digest so an engine-order
+       change cannot masquerade behind an unchanged content digest. PER-19 owns
+       BSL causal composition, the provenance/direct-write whitelist, and
+       negative outcome-write contracts. The gated E-LOAD-058/059 analyzer
+       still compares raw IDs globally; it MUST remain disabled until it
+       consumes resolved phase ranks, uses D16 only within one rank, and runs
+       over the post-concatenation aggregate content set so a file boundary
+       cannot hide a cross-rule hazard.
+
+    7. HASH COMPATIBILITY. `rules_hash_of` remains the canonical content hash
+       and retains its rule-ID byte sort. Execution order is a separate derived
+       contract. Existing graph-state hashes and byte goldens do not move merely
+       because schedule metadata became executable; behavior changes only where
+       cross-rule writes make causal order observable.
+  consequences: |
+    - Decomposition now writes before ControlRatio reads in the same tick. The
+      zero-delay conformance vector emits its crisis at tick 1 and proves the
+      latch prevents a duplicate at tick 2.
+    - Vitality runs before Lifecycle even though their rule IDs sort in the
+      opposite order. File-order permutation tests produce identical reports.
+    - Missing, duplicate, unknown, and illegal anchors refuse before caller
+      hydration without stealing precedence from scenario or rule failures.
+      Invalid source permutations select the same byte-least rule identity.
+      Duplicate rule IDs split across source files cannot produce a false-clean
+      diagnostics result.
+    - Successful preparation performs one disposable validation hydration and
+      one caller hydration. A future declaration-only scenario compiler may
+      remove that cost only if it preserves identical validation and identity
+      behavior.
+    - Historical D100, D172, and D190 records remain readable and are marked as
+      superseded for execution rather than rewritten as though the old hazard
+      never existed.
+  supersedes: []
+  related:
+    - ADR172_amendment_ae_refoundation_ratified
+    - ADR212_decomposition_controlratio_port_handoff
+    - ADR221_game_first_refoundation_v4

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -1020,3 +1020,8 @@ decisions:
     status: accepted
     date: '2026-08-22'
     file: ADR221_game_first_refoundation_v4.yaml
+  ADR222_executable_bsl_phase_order:
+    title: 'BSL rules execute on the governed 34-system causal spine: namespace homes and explicit boundary anchors compile before caller-state mutation, D16 orders only same-position ties, and the former global rule-ID sort retires'
+    status: accepted
+    date: '2026-08-23'
+    file: ADR222_executable_bsl_phase_order.yaml

--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -2,8 +2,8 @@
 # What exists vs what's planned - KEEP THIS UPDATED
 
 meta:
-  version: "2.70.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
-  updated: "2026-08-22"
+  version: "2.71.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
+  updated: "2026-08-23"
   role: historical_implementation_ledger
   history_policy: append_or_prepend_only
   current_work_authority:
@@ -26,6 +26,14 @@ meta:
       issue: PER-48
       adr: ADR220_rust_owned_postgresql_persistence_boundary
       completion_commit: 9b4c9b2e
+    bsl_phase_order:
+      status: implemented_on_PER-17_branch
+      issue: PER-17
+      adr: ADR222_executable_bsl_phase_order
+      branch: codex/per-17-executable-phase-anchors
+      remaining_gate_2:
+        - PER-18
+        - PER-19
     attributed_membership_payload:
       status: planned
       horizon: Research
@@ -46,6 +54,26 @@ meta:
       work or override Linear status, priority, dependencies, Horizon,
       milestones, or schedule.
   truth_status: |
+    (2026-08-23 GATE 2 — PER-17 EXECUTABLE BSL PHASE ORDER IMPLEMENTED,
+    REVIEW/PR PENDING) `babylon-tick` now compiles every admitted rule onto
+    the frozen 34-system causal spine (15 Material Base, one Action, 18
+    Consequence) instead of globally sorting the content set by rule-ID
+    bytes. Namespace defaults and explicit before/after boundaries are
+    executable; D16 remains the same-position tie-break only; the four
+    compatibility namespaces resolve to governed canonical homes. Interior
+    Material Base anchors refuse as E-LOAD-003. Validation uses a disposable
+    graph in the established scenario -> rule -> composition error order and
+    hydrates caller state only after phase composition succeeds. Seven
+    integration vectors cover explicit placement, file permutations, missing
+    and duplicate anchors, E-LOAD-003, diagnostic parity, mixed-error
+    precedence, and mutation absence. The full babylon-tick crate suite and
+    all-target Clippy are green. ADR222 records the registry, rank law,
+    lifecycle anchor correction, unchanged CAS content hashing, and the named
+    same-position gap. Gate 2 remains open: PER-18 owns whole-tick working-copy
+    rollback plus canonical big-endian auxiliary-register hashing and the
+    combined world hash. PER-19 owns BSL causal composition, the
+    provenance/direct-write whitelist, and negative outcome-write contracts.
+    PREVIOUS:
     (2026-08-22 COMMUNITY PORT TRAIN — TASKS 1-6 LANDED ON dev, #680-#685)
     The hyperedge lane of the Community port (plan
     docs/superpowers/plans/2026-08-18-community-port.md) is complete through

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -687,13 +687,26 @@ source order; the canonical serialization sorts them (§5.3).
 rule that means "always" writes ``(when #t)`` or omits the clause. This is one
 of the four deliberate III.11 corrections (§6.3).
 
-**[draft ruling — Phase 1 review]** *Anchor default.* A rule with no
-``<anchor>`` belongs to the system named by the first segment of its rule id
-and takes that system's declared position. A rule whose first id segment names
-no registered system, and which carries no anchor, is ``E-LOAD-002``. Mods
-therefore cannot land a rule "nowhere", and cannot express a raw position
-float. Interleaving an anchor into the Material Base partition is
-``E-LOAD-003`` (design §5, modding boundary).
+*Executable anchor placement (PER-17, ADR222).* A rule with no ``<anchor>``
+belongs to the system named by the first segment of its rule id and takes that
+system's governed position. A rule whose first id segment names no registered
+system, and which carries no anchor, is ``E-LOAD-002``. An explicit anchor
+selects the boundary immediately before or after its named system; ``:after``
+one slot and ``:before`` the next share one boundary. Rules at one resolved
+position use D16's rule-id byte order.
+
+The registry follows the frozen 34-system causal spine: 15 Material Base
+slots, one Action slot, and 18 Consequence slots. Four compatibility names
+retain governed homes: ``class-dynamics`` maps to ``tick-dynamics``,
+``economics`` to ``contradiction``, ``organization`` to ``ooda``, and
+``social-class`` to ``solidarity``. Mods therefore cannot land a rule
+"nowhere" and cannot express a raw position float. The boundary before
+Vitality and the boundary after Metabolism are legal; an explicit anchor that
+cuts through the interior of Material Base is ``E-LOAD-003``. Placement
+compiles for the complete content set before caller-owned hydration or
+mutation. Validation may hydrate a disposable graph first to preserve the
+established scenario-error precedence, but an invalid composition never
+touches caller-owned world state.
 
 **[draft ruling — Phase 1 review, R9 chapter C4]** *The rule domain — what a
 rule fires over, and how many times.* §4.2 says a rule evaluates against "the
@@ -3871,12 +3884,16 @@ the defines environment (coefficients), the current tick, the subject node, and
 the fuel meter. Bindings resolve first, in declaration order — the external
 sources by lookup, the ``:expr`` bindings (§2.5) by evaluation against the
 bindings already resolved. Effects are applied only after the whole condition
-has been evaluated. **A rule can never observe its own effects**, and rules within one
-system position observe the same pre-state.
+has been evaluated. **A rule can never observe its own effects.** The language
+target says rules within one system position share a pre-state; the current
+Rust driver instead applies same-position rules sequentially, so a later rule
+can observe an earlier rule's write (D116). This recorded divergence remains a
+separate composition repair, not a property supplied by phase ordering.
 
-Rules at the same anchor position evaluate in **ascending rule-id byte order**
-**[draft ruling — Phase 1 review]**, and their effects apply in that same
-order. File order and load order are never observable.
+Rules execute in the 34-slot causal order defined in §2.3. Rules at the same
+resolved position evaluate in **ascending rule-id byte order** (D16), and
+their effects apply in that same order. File order and load order are never
+observable.
 
 **[draft ruling — Phase 1 review, R9 chapter C4]** *Subject enumeration order,
 which this document had not specified.* A rule whose domain is a node type
@@ -3895,16 +3912,14 @@ chapter held. Currency's exact integer lane is immune; the bounded scalars are
 not, which is why the order is stated rather than left to the executor.
 
 **Task W2 (BSL Hygiene Knock-out, 2026-08-18) — same-tick ordering as LOAD
-REFUSALS.** Ascending rule-id byte order (above) and D116's recorded
-cross-rule same-tick visibility (a second rule at one anchor position
-observes the first rule's already-applied writes, not the tick's shared
-pre-state) together make a rule's read order *content-visible*: whether an
-``:optional :default`` binding's declared default is ever actually
-observed depends on where its field's writers happen to sort. Two load
-refusals make that dependency a checked property of the content set
+REFUSALS.** The resolved phase order, D16's same-position rule-id tie-break,
+and D116's recorded cross-rule same-tick visibility make a rule's read order
+*content-visible*: whether an ``:optional :default`` binding's declared
+default is ever observed depends on where its field's writers execute. Two
+load refusals make that dependency a checked property of the content set
 rather than a silent hazard, in the same family as ``E-LOAD-001``
-(content-set-wide, checked at load, over whatever set is actually
-loaded — never a hypothetical wider one).
+(content-set-wide, checked at load, over whatever set is actually loaded —
+never a hypothetical wider one).
 
 *Refusal 1 —* ``E-LOAD-058`` *, stale-default read.* For a binding
 ``(binding b :field f :optional :default d)`` in rule ``R``, the *writer
@@ -3919,9 +3934,9 @@ effects" **and** "all firings of one rule observe the same pre-state";
 the second is the operative one when the read and write targets differ,
 which is exactly ``solidarity/p0-transmit``'s shape: it reads ``self``
 and writes a neighbour ``it``, one rule, still self-excluded). If any
-rule in the writer set does not sort strictly before ``R`` (ascending
-rule-id byte order), the load is refused, naming both rules and the
-field.
+rule in the writer set does not execute strictly before ``R`` under the
+resolved phase rank and D16 tie-break, the load is refused, naming both rules
+and the field.
 
 *Refusal 2 —* ``E-LOAD-059`` *, unreset fan-in.* A field written by two or
 more distinct rules in the content set (via ``set``, or via fan-in
@@ -3930,43 +3945,36 @@ more distinct rules in the content set (via ``set``, or via fan-in
 literal ``#t``; nothing finer, no guard-dominance analysis between a
 reset and its fan-in writers — or the D127 unconditional-recompute shape
 (a writer meeting the same unconditional test whose ``:material-basis``
-cites D127). Concretely: among the field's distinct writers sorted by
-ascending rule-id byte order, the byte-earliest must satisfy one of the
-two tests above, or the load is refused, naming the field and its writer
-rules.
+cites D127). Concretely: among the field's distinct writers sorted by resolved
+execution rank and then D16 rule-id bytes, the earliest must satisfy one of the
+two tests above, or the load is refused, naming the field and its writer rules.
 
-**Enforcement is gated, not implemented-but-inert.** Both refusals are
-computable from existing declarations — no new author-facing grammar —
-so this is loader hardening, ADR-recorded, under the same boundary
-ruling that put same-tick coherence in the language rather than an
-external lint. But ``consciousness.bsl`` ships 13 deliberate same-tick
-reads (mitigated by guard structure or a documented one-tick-lag idiom
-the loader does not yet verify) that refusal 1 as stated above would
-refuse outright. The Director's ruling (R-W2a, the 2026-08-18 evening
-sitting): mint a per-binding author declaration (working name
-``:prior-tick``) via constitutional amendment, narrowing refusal 1's
-final semantics to *every UNDECLARED exposed read*. **This section's two
-rows describe that POST-RATIFICATION enforcement.** Until a Director
-sitting ratifies the declaration, both refusals are implemented and
-load-bearing in ``babylon-bsl``'s own fixture tests but gated OFF for the
-landed corpus by ``babylon_bsl::same_tick_order::
-ENFORCE_SAME_TICK_ORDERING`` — see that constant's doc and
-``ai/_inbox/amendment-prior-tick-draft.md`` (Amendment AI, DRAFT).
+**Enforcement is gated.** The semantic refusals are computable from existing
+declarations plus the resolved schedule; they need no new ordering grammar.
+However, ``consciousness.bsl`` ships 13 deliberate same-tick reads that the
+loader cannot yet distinguish from hazards. The Director's ruling (R-W2a, the
+2026-08-18 evening sitting) requires a per-binding author declaration (working
+name ``:prior-tick``), narrowing refusal 1's final semantics to every
+undeclared exposed read.
 
-**Refusing a composed load is intended, not a regression.** No committed
-load path co-loads ``consciousness.bsl`` with ``solidarity.bsl`` today —
-each loads solo — but should a future content set compose them, refusal
-1 fires on ``solidarity/p0-transmit``'s write to
-``social-class/revolutionary``: every ``consciousness/*`` writer of that
-field sorts before ``solidarity/*`` in rule-id byte order, so the
-composed load's own byte order runs ``consciousness/p6-route``'s simplex
-closure strictly *before* ``solidarity/p0-transmit``'s write, reopening
-the off-simplex window ``solidarity.bsl``'s own header already files as
-a non-blocking Director-gate question (issue #646 names the same
-co-load-hazard class for ``territory.bsl``/``decomposition.bsl``).
-Refusal 1 refusing that composition is the check doing exactly its job —
-mechanizing what #646 was filed for — not a false positive to work
-around.
+PER-17 adds a second gate. The fixture analyzer in
+``babylon_bsl::same_tick_order`` predates executable phase placement and still
+compares raw rule IDs globally. That comparison is correct only within one
+resolved position. ``ENFORCE_SAME_TICK_ORDERING`` therefore remains ``false``
+until the declaration is ratified *and* the analyzer consumes resolved phase
+ranks from ``babylon-tick`` over the post-concatenation aggregate content set.
+Its current per-source fixture tests preserve the historical W2 logic; they do
+not prove cross-phase or cross-file enforcement is ready. See the constant's
+documentation and ``ai/_inbox/amendment-prior-tick-draft.md`` (Amendment AI,
+DRAFT).
+
+**The former Consciousness/Solidarity example is superseded.** Global rule-ID
+order placed ``consciousness/*`` before ``solidarity/*`` and made the composed
+load look stale. The executable registry instead runs Solidarity in Material
+Base before Consciousness in Consequences. A rank-aware analyzer must accept
+that ordering case. Same-position multi-writer packs and genuine later-phase
+writers remain the load-refusal consumers; a raw-ID analyzer must not decide
+them across phases.
 
 4.3 Arithmetic
 ~~~~~~~~~~~~~~~~
@@ -4204,16 +4212,21 @@ the same rule.
 of allocation, per the same rule; full normative text at §4.2's own end
 (same-tick evaluation order is that section's subject). **Both rows
 describe POST-RATIFICATION enforcement.** The check is computable from
-existing declarations (no new author-facing grammar), so it is loader
-hardening under the same boundary ruling §4.2 records for the check's own
-motivation — but landed content includes 13 deliberate same-tick reads in
-``consciousness.bsl`` that need a per-binding author declaration (working
-name ``:prior-tick``) an amendment mints, not yet ratified. Both refusals
-are therefore implemented and load-bearing in this crate's own tests, but
-gated OFF for the landed corpus by ``babylon_bsl::same_tick_order::
-ENFORCE_SAME_TICK_ORDERING`` until a Director sitting ratifies the
-declaration; see that constant's own doc and the amendment draft it cites
-for the ratification ceremony.
+existing declarations plus the resolved phase schedule (no new ordering
+grammar), so it is loader hardening under the same boundary ruling §4.2
+records for the check's own motivation — but landed content includes 13
+deliberate same-tick reads in ``consciousness.bsl`` that need a per-binding
+author declaration (working name ``:prior-tick``) an amendment mints, not
+yet ratified. Both refusals therefore remain gated OFF for the landed corpus
+by ``babylon_bsl::same_tick_order::ENFORCE_SAME_TICK_ORDERING`` until two
+conditions hold: a Director sitting ratifies that declaration, and the
+fixture analyzer consumes ``babylon-tick``'s resolved phase ranks. Its
+current raw global rule-ID comparison is correct only within one resolved
+position. The replacement must also analyze the post-concatenation aggregate
+content set, not each source file independently. The tests preserve the
+historical W2 logic but cannot establish cross-phase readiness. See §4.2's
+PER-17 correction, the constant's own documentation, ADR222, and the amendment
+draft for the required ceremonies.
 
 **The #576 intrinsic-host train (Task 2) continues** ``E-EVAL``.
 ``E-EVAL-043`` — ``TranscendentalOutOfDomain``: a non-finite ``exp``/``log``
@@ -6219,7 +6232,12 @@ consequences are the ordinary kind of review item.
        ``rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs``.
    * - D100
      - §2.2, §4.2
-     - **The content-set loader admits more than one** ``(rule …)``
+     - **Historical implementation record, superseded for scheduling by
+       ADR222/PER-17.** The multi-rule admission and duplicate-id refusal
+       remain; the global byte-order fallback and inert-anchor clauses below
+       describe the pre-ADR222 driver.
+
+       **The content-set loader admits more than one** ``(rule …)``
        **top-form, executed in ascending rule-id byte order (register row
        D16, §4.2), duplicate ids refused** — a driver-level fix (Program 28
        B2), not a spec change. §2.2's grammar (``<top-form>*``) and prose
@@ -8251,7 +8269,13 @@ consequences are the ordinary kind of review item.
    * - D172
      - N/A (D100's class — the global rule-id byte-order sort inverting a frozen
        tick-position order; not a new construct)
-     - ``control-ratio/*`` sorts BEFORE ``decomposition/*`` in ascending rule-id byte
+     - **Historical implementation record, superseded by ADR222/PER-17.**
+       The executable registry now runs Decomposition before ControlRatio;
+       the zero-delay acceptance test requires the same-tick crisis at tick
+       1. The text below records the former global-byte-order hazard and why
+       it was accepted at the time.
+
+       ``control-ratio/*`` sorts BEFORE ``decomposition/*`` in ascending rule-id byte
        order (D100's class — the comparison resolves at the NAMESPACE segment,
        ``'c'`` (``control-ratio/``) < ``'d'`` (``decomposition/``), before ever
        reaching the rule-local ``c01`` vs ``p01`` prefixes), inverting the frozen

--- a/docs/reference/bsl-language.rst
+++ b/docs/reference/bsl-language.rst
@@ -697,11 +697,11 @@ position use D16's rule-id byte order.
 
 The registry follows the frozen 34-system causal spine: 15 Material Base
 slots, one Action slot, and 18 Consequence slots. Four compatibility names
-retain governed homes: ``class-dynamics`` maps to ``tick-dynamics``,
+keep governed homes: ``class-dynamics`` maps to ``tick-dynamics``,
 ``economics`` to ``contradiction``, ``organization`` to ``ooda``, and
-``social-class`` to ``solidarity``. Mods therefore cannot land a rule
+``social-class`` to ``solidarity``. Mods cannot land a rule
 "nowhere" and cannot express a raw position float. The boundary before
-Vitality and the boundary after Metabolism are legal; an explicit anchor that
+Vitality and the boundary after Metabolism are legal. An explicit anchor that
 cuts through the interior of Material Base is ``E-LOAD-003``. Placement
 compiles for the complete content set before caller-owned hydration or
 mutation. Validation may hydrate a disposable graph first to preserve the
@@ -3883,17 +3883,16 @@ A rule evaluates against: the graph (read-only during condition evaluation),
 the defines environment (coefficients), the current tick, the subject node, and
 the fuel meter. Bindings resolve first, in declaration order — the external
 sources by lookup, the ``:expr`` bindings (§2.5) by evaluation against the
-bindings already resolved. Effects are applied only after the whole condition
-has been evaluated. **A rule can never observe its own effects.** The language
-target says rules within one system position share a pre-state; the current
-Rust driver instead applies same-position rules sequentially, so a later rule
-can observe an earlier rule's write (D116). This recorded divergence remains a
-separate composition repair, not a property supplied by phase ordering.
+bindings already resolved. The engine applies effects after it evaluates the
+complete condition. **A rule cannot observe its own effects.** The language
+target requires rules at one system position to share a pre-state. The current
+Rust driver applies same-position rules in sequence. A later rule can observe
+an earlier rule's write (D116). Phase ordering does not repair this separate
+composition divergence.
 
-Rules execute in the 34-slot causal order defined in §2.3. Rules at the same
-resolved position evaluate in **ascending rule-id byte order** (D16), and
-their effects apply in that same order. File order and load order are never
-observable.
+Rules execute in the 34-slot causal order from §2.3. D16 orders rules at one
+resolved position by rule-id bytes. The engine applies their effects in that
+order. File order and load order cannot affect execution.
 
 **[draft ruling — Phase 1 review, R9 chapter C4]** *Subject enumeration order,
 which this document had not specified.* A rule whose domain is a node type
@@ -3934,9 +3933,9 @@ effects" **and** "all firings of one rule observe the same pre-state";
 the second is the operative one when the read and write targets differ,
 which is exactly ``solidarity/p0-transmit``'s shape: it reads ``self``
 and writes a neighbour ``it``, one rule, still self-excluded). If any
-rule in the writer set does not execute strictly before ``R`` under the
-resolved phase rank and D16 tie-break, the load is refused, naming both rules
-and the field.
+writer does not execute before ``R`` under the resolved phase rank and D16
+tie-break, the loader refuses the content. The error names the field and both
+rules.
 
 *Refusal 2 —* ``E-LOAD-059`` *, unreset fan-in.* A field written by two or
 more distinct rules in the content set (via ``set``, or via fan-in
@@ -3945,36 +3944,35 @@ more distinct rules in the content set (via ``set``, or via fan-in
 literal ``#t``; nothing finer, no guard-dominance analysis between a
 reset and its fan-in writers — or the D127 unconditional-recompute shape
 (a writer meeting the same unconditional test whose ``:material-basis``
-cites D127). Concretely: among the field's distinct writers sorted by resolved
-execution rank and then D16 rule-id bytes, the earliest must satisfy one of the
-two tests above, or the load is refused, naming the field and its writer rules.
+cites D127). Sort the writers first by resolved execution rank and then by D16
+rule-id bytes. The first writer must pass one of the two tests above.
+Otherwise, the loader refuses the content and names the field and writer rules.
 
-**Enforcement is gated.** The semantic refusals are computable from existing
-declarations plus the resolved schedule; they need no new ordering grammar.
-However, ``consciousness.bsl`` ships 13 deliberate same-tick reads that the
-loader cannot yet distinguish from hazards. The Director's ruling (R-W2a, the
-2026-08-18 evening sitting) requires a per-binding author declaration (working
-name ``:prior-tick``), narrowing refusal 1's final semantics to every
-undeclared exposed read.
+**The loader does not enforce these rules yet.** Existing declarations and the
+resolved schedule supply the required data. The rules need no new ordering
+grammar. ``consciousness.bsl`` has 13 deliberate same-tick reads. The loader
+cannot yet distinguish those reads from hazards. The Director's ruling
+(R-W2a, 2026-08-18) requires a per-binding author declaration named
+``:prior-tick``. That declaration narrows refusal 1 to undeclared exposed
+reads.
 
 PER-17 adds a second gate. The fixture analyzer in
 ``babylon_bsl::same_tick_order`` predates executable phase placement and still
-compares raw rule IDs globally. That comparison is correct only within one
-resolved position. ``ENFORCE_SAME_TICK_ORDERING`` therefore remains ``false``
-until the declaration is ratified *and* the analyzer consumes resolved phase
-ranks from ``babylon-tick`` over the post-concatenation aggregate content set.
-Its current per-source fixture tests preserve the historical W2 logic; they do
-not prove cross-phase or cross-file enforcement is ready. See the constant's
-documentation and ``ai/_inbox/amendment-prior-tick-draft.md`` (Amendment AI,
-DRAFT).
+compares raw rule IDs globally. That comparison works only within one resolved
+position. ``ENFORCE_SAME_TICK_ORDERING`` remains ``false`` until the Director
+ratifies the declaration. The analyzer must also consume resolved phase ranks
+from ``babylon-tick`` over the aggregate content set after concatenation. The
+current per-source fixture tests preserve the historical W2 logic. They do not
+prove cross-phase or cross-file readiness. See the constant's documentation
+and ``ai/_inbox/amendment-prior-tick-draft.md`` (Amendment AI, DRAFT).
 
-**The former Consciousness/Solidarity example is superseded.** Global rule-ID
-order placed ``consciousness/*`` before ``solidarity/*`` and made the composed
-load look stale. The executable registry instead runs Solidarity in Material
-Base before Consciousness in Consequences. A rank-aware analyzer must accept
-that ordering case. Same-position multi-writer packs and genuine later-phase
-writers remain the load-refusal consumers; a raw-ID analyzer must not decide
-them across phases.
+**The executable registry replaces the former Consciousness and Solidarity
+example.** Global rule-ID order placed ``consciousness/*`` before
+``solidarity/*`` and made the composed load look stale. The executable registry
+runs Solidarity in Material Base before Consciousness in Consequences. A
+rank-aware analyzer must accept that order. Same-position multi-writer packs
+and actual later-phase writers remain the load-refusal consumers. A raw-ID
+analyzer must not decide them across phases.
 
 4.3 Arithmetic
 ~~~~~~~~~~~~~~~~
@@ -4212,21 +4210,17 @@ the same rule.
 of allocation, per the same rule; full normative text at §4.2's own end
 (same-tick evaluation order is that section's subject). **Both rows
 describe POST-RATIFICATION enforcement.** The check is computable from
-existing declarations plus the resolved phase schedule (no new ordering
-grammar), so it is loader hardening under the same boundary ruling §4.2
-records for the check's own motivation — but landed content includes 13
-deliberate same-tick reads in ``consciousness.bsl`` that need a per-binding
-author declaration (working name ``:prior-tick``) an amendment mints, not
-yet ratified. Both refusals therefore remain gated OFF for the landed corpus
-by ``babylon_bsl::same_tick_order::ENFORCE_SAME_TICK_ORDERING`` until two
-conditions hold: a Director sitting ratifies that declaration, and the
-fixture analyzer consumes ``babylon-tick``'s resolved phase ranks. Its
-current raw global rule-ID comparison is correct only within one resolved
-position. The replacement must also analyze the post-concatenation aggregate
-content set, not each source file independently. The tests preserve the
-historical W2 logic but cannot establish cross-phase readiness. See §4.2's
-PER-17 correction, the constant's own documentation, ADR222, and the amendment
-draft for the required ceremonies.
+existing declarations plus the resolved phase schedule. The check needs no new
+ordering grammar. It strengthens the loader under the boundary ruling in §4.2.
+Landed content includes 13 deliberate same-tick reads in
+``consciousness.bsl``. Those reads need the unratified per-binding declaration
+``:prior-tick``. Two conditions keep both refusals off through
+``babylon_bsl::same_tick_order::ENFORCE_SAME_TICK_ORDERING``. The Director must
+ratify the declaration, and the analyzer must consume ``babylon-tick`` phase
+ranks. The replacement must analyze the aggregate content set after
+concatenation, not each source file by itself. Current tests preserve the
+historical W2 logic but cannot prove cross-phase readiness. See §4.2, ADR222,
+the constant documentation, and the amendment draft for the ceremonies.
 
 **The #576 intrinsic-host train (Task 2) continues** ``E-EVAL``.
 ``E-EVAL-043`` — ``TranscendentalOutOfDomain``: a non-finite ``exp``/``log``
@@ -6232,10 +6226,9 @@ consequences are the ordinary kind of review item.
        ``rust/crates/babylon-tick/tests/currency_scale_op_e2e.rs``.
    * - D100
      - §2.2, §4.2
-     - **Historical implementation record, superseded for scheduling by
-       ADR222/PER-17.** The multi-rule admission and duplicate-id refusal
-       remain; the global byte-order fallback and inert-anchor clauses below
-       describe the pre-ADR222 driver.
+     - **ADR222/PER-17 supersedes this scheduling record.** The multi-rule
+       admission and duplicate-id refusal remain. The global byte-order
+       fallback and inert-anchor clauses below describe the pre-ADR222 driver.
 
        **The content-set loader admits more than one** ``(rule …)``
        **top-form, executed in ascending rule-id byte order (register row
@@ -8269,11 +8262,10 @@ consequences are the ordinary kind of review item.
    * - D172
      - N/A (D100's class — the global rule-id byte-order sort inverting a frozen
        tick-position order; not a new construct)
-     - **Historical implementation record, superseded by ADR222/PER-17.**
-       The executable registry now runs Decomposition before ControlRatio;
-       the zero-delay acceptance test requires the same-tick crisis at tick
-       1. The text below records the former global-byte-order hazard and why
-       it was accepted at the time.
+     - **ADR222/PER-17 supersedes this implementation record.** The executable
+       registry now runs Decomposition before ControlRatio. The zero-delay
+       acceptance test requires the same-tick crisis at tick 1. This text
+       records the former global-byte-order hazard and its prior rationale.
 
        ``control-ratio/*`` sorts BEFORE ``decomposition/*`` in ascending rule-id byte
        order (D100's class — the comparison resolves at the NAMESPACE segment,

--- a/docs/reference/event-schema-registry.toml
+++ b/docs/reference/event-schema-registry.toml
@@ -74,7 +74,7 @@ keys = [
 
 [[tier1]]
 event_type = "LIFECYCLE_TRANSITION"
-citations = ["rust/crates/babylon-tick/content/rules/lifecycle.bsl:409"]
+citations = ["rust/crates/babylon-tick/content/rules/lifecycle.bsl:405"]
 keys = [
   { name = "territory-id", required = true, source = "bsl" },
   { name = "pop-d", required = true, source = "bsl" },
@@ -85,7 +85,7 @@ keys = [
 
 [[tier1]]
 event_type = "LEGITIMATION_CRISIS"
-citations = ["rust/crates/babylon-tick/content/rules/lifecycle.bsl:422"]
+citations = ["rust/crates/babylon-tick/content/rules/lifecycle.bsl:418"]
 keys = [
   { name = "territory-id", required = true, source = "bsl" },
   { name = "legitimation-index", required = true, source = "bsl" },
@@ -93,7 +93,7 @@ keys = [
 
 [[tier1]]
 event_type = "LEGITIMATION_RECOVERY"
-citations = ["rust/crates/babylon-tick/content/rules/lifecycle.bsl:426"]
+citations = ["rust/crates/babylon-tick/content/rules/lifecycle.bsl:422"]
 keys = [
   { name = "territory-id", required = true, source = "bsl" },
   { name = "legitimation-index", required = true, source = "bsl" },
@@ -123,12 +123,12 @@ keys = [
 [[tier1]]
 event_type = "CONTROL_RATIO_CRISIS"
 citations = [
-  "rust/crates/babylon-tick/content/rules/control-ratio.bsl:320",
-  "rust/crates/babylon-tick/content/rules/control-ratio.bsl:330",
+  "rust/crates/babylon-tick/content/rules/control-ratio.bsl:321",
+  "rust/crates/babylon-tick/content/rules/control-ratio.bsl:331",
 ]
 # Two-shape payload, D-recorded (control_ratio.py:210-247's frozen origin;
-# ADR183 port-AS-IS): the enforcer-population > 0 branch (:320) emits all 8
-# keys; the = 0 branch (:330) omits actual-ratio and control-ratio. The
+# ADR183 port-AS-IS): the enforcer-population > 0 branch (:321) emits all 8
+# keys; the = 0 branch (:331) omits actual-ratio and control-ratio. The
 # registry lists the UNION with the two branch-specific keys flagged
 # optional, never a forced single shape.
 keys = [
@@ -138,15 +138,15 @@ keys = [
   { name = "max-controllable", required = true, source = "bsl" },
   { name = "over-capacity-by", required = true, source = "bsl" },
   { name = "capacity-threshold", required = true, source = "bsl" },
-  { name = "actual-ratio", required = false, source = "bsl", note = "present only in the enforcer-population > 0 branch (control-ratio.bsl:325); the = 0 branch omits it (deliberate, D-recorded — both are the frozen engine's real shapes, not a defect)." },
-  { name = "control-ratio", required = false, source = "bsl", note = "present only in the enforcer-population > 0 branch (control-ratio.bsl:327); the = 0 branch omits it (same D-record as actual-ratio)." },
+  { name = "actual-ratio", required = false, source = "bsl", note = "present only in the enforcer-population > 0 branch (control-ratio.bsl:326); the = 0 branch omits it (deliberate, D-recorded — both are the frozen engine's real shapes, not a defect)." },
+  { name = "control-ratio", required = false, source = "bsl", note = "present only in the enforcer-population > 0 branch (control-ratio.bsl:328); the = 0 branch omits it (same D-record as actual-ratio)." },
 ]
 
 [[tier1]]
 event_type = "TERMINAL_DECISION"
 citations = [
-  "rust/crates/babylon-tick/content/rules/control-ratio.bsl:366",
-  "rust/crates/babylon-tick/content/rules/control-ratio.bsl:373",
+  "rust/crates/babylon-tick/content/rules/control-ratio.bsl:367",
+  "rust/crates/babylon-tick/content/rules/control-ratio.bsl:374",
 ]
 # Same 5 keys in both branches (outcome 1=revolution / 0=genocide is the only
 # difference) — no optional flag needed, unlike CONTROL_RATIO_CRISIS above.
@@ -186,7 +186,7 @@ keys = [
 
 [[tier1]]
 event_type = "SURPLUS_EXTRACTION"
-citations = ["rust/crates/babylon-tick/content/rules/imperial-rent.bsl:775"]
+citations = ["rust/crates/babylon-tick/content/rules/imperial-rent.bsl:778"]
 keys = [
   { name = "source", required = true, source = "bsl" },
   { name = "target", required = true, source = "bsl" },

--- a/docs/reference/phase-1-exit-checklist.md
+++ b/docs/reference/phase-1-exit-checklist.md
@@ -1,3 +1,5 @@
+<!-- vale off -->
+
 # Program 27 — Phase 1 Exit Checklist
 
 **Status: Phase 1 (Language & Kernel) COMPLETE at this document's merge.**
@@ -10,6 +12,10 @@ Verification battery (Task 18 Step 1), run green 2026-07-30: workspace
 tests, workspace clippy `-D warnings`, per-crate pedantic clippy on
 `babylon-kernel`/`babylon-bsl`/`babylon-graph`, `cargo fmt --check`, and
 `RUSTDOCFLAGS='-D warnings' cargo doc` — **zero errors on every leg**.
+
+Current follow-through (2026-08-23): the deferred anchor total order and
+E-LOAD-003 item landed in `babylon-tick` through PER-17 and ADR222. The table
+below remains the Phase 1 handoff snapshot rather than rewriting its history.
 
 ## DONE — merged, tested, gate-clean
 
@@ -79,3 +85,5 @@ assignment ambiguity (`bindings.rs`).
    content pipeline generalizes.
 5. `ai/decisions/ADR179_*` (T3: hypergraph-rs as storage) and the
    babylon-graph trait docs — the storage decision's constraints.
+
+<!-- vale on -->

--- a/rust/crates/babylon-bsl/src/error_identity.rs
+++ b/rust/crates/babylon-bsl/src/error_identity.rs
@@ -308,6 +308,7 @@ pub fn identity_of(err: &LoadError) -> Option<ErrorIdentity> {
         LoadError::ElementName(e) => Some(element_name_identity(e)),
         LoadError::Bound(e) => bound_identity(e),
         LoadError::Intrinsic(e) => decl_identity(e),
+        LoadError::DuplicateRuleId { rule_id } => Some(ErrorIdentity::RuleId(rule_id.clone())),
         // `Read`: E-LEX is located via `ReadError.position` ->
         // `SpanTable::innermost_at` (§6.2's own table, row 1), never through
         // `ErrorIdentity`. `Type`: `TypeError` is `{code, message}` with no
@@ -359,6 +360,17 @@ mod tests {
             Some(ErrorIdentity::RuleId(
                 "control-ratio/c01-prisoner-census".to_owned()
             ))
+        );
+    }
+
+    #[test]
+    fn identity_of_gives_a_rule_id_for_a_duplicate_rule() {
+        let err = LoadError::DuplicateRuleId {
+            rule_id: "vitality/duplicate".to_owned(),
+        };
+        assert_eq!(
+            identity_of(&err),
+            Some(ErrorIdentity::RuleId("vitality/duplicate".to_owned()))
         );
     }
 

--- a/rust/crates/babylon-bsl/src/lib.rs
+++ b/rust/crates/babylon-bsl/src/lib.rs
@@ -64,8 +64,8 @@ pub use reader::{
     ReadErrorKind, SExpr, ScaledKind, ScaledLit, Span, SpanTable,
 };
 pub use rule_pipeline::{
-    bind_environment, load_rule, load_rule_form, resolve_expr_bindings, split_content, LoadContext,
-    LoadError, LoadedRule,
+    bind_environment, check_unique_rule_ids, load_rule, load_rule_form, resolve_expr_bindings,
+    split_content, LoadContext, LoadError, LoadedRule,
 };
 // `diagnose` re-exported under a qualified name (W2 fix round 1, review
 // Minor 4): `babylon_bsl::diagnose` unqualified reads as "diagnose

--- a/rust/crates/babylon-bsl/src/mod_anchors.rs
+++ b/rust/crates/babylon-bsl/src/mod_anchors.rs
@@ -4,13 +4,11 @@
 //! a rule can never land "nowhere", and a raw position float is not
 //! expressible (§2.2 `:after`/`:before`).
 //!
-//! Scope (Phase 1 Task 16, per the plan): this module validates the
-//! DECLARATION — shape, and the E-LOAD-002 no-system case. Resolving
-//! anchors into a total order belongs to `babylon-engine`'s anchor-based
-//! registry (Phase 3), and the Material Base interleave check
-//! (`E-LOAD-003`) belongs there with it, because the partition boundaries
-//! are engine registry data this crate does not hold — deferred with a
-//! name, not silently.
+//! This module validates the declaration shape and the E-LOAD-002 no-system
+//! case against a caller-supplied registry. `babylon-tick::phase_order` owns
+//! the executable 34-slot registry, total-order compilation, and the
+//! Material Base interleave check (`E-LOAD-003`), because partition
+//! boundaries are engine scheduling data rather than BSL syntax.
 
 use crate::reader::{Atom, SExpr};
 use std::collections::HashSet;

--- a/rust/crates/babylon-bsl/src/rule_pipeline.rs
+++ b/rust/crates/babylon-bsl/src/rule_pipeline.rs
@@ -146,6 +146,14 @@ pub enum LoadError {
     /// [`split_content`]'s discipline, not a §2 grammar production with a
     /// reserved `E-LOAD` number.
     Content(String),
+    /// `E-LOAD-001` — one rule id occurs more than once in the aggregate
+    /// content set. This stays distinct from [`Self::Content`] so callers
+    /// can consume the governed code as structured data instead of parsing
+    /// the display message.
+    DuplicateRuleId {
+        /// The duplicated rule id.
+        rule_id: String,
+    },
     /// No numbered code, same precedent as [`Self::Content`]: a rule using
     /// one of the six graph-shape verbs Task 12's collect-then-apply
     /// pre-state split does not yet defer (§4.2 chapter C4) — every one of
@@ -193,6 +201,7 @@ impl LoadError {
             Self::Bound(e) => e.spec_code(),
             Self::Intrinsic(e) => e.spec_code(),
             Self::SameTickOrder(e) => Some(e.spec_code()),
+            Self::DuplicateRuleId { .. } => Some("E-LOAD-001"),
             Self::Content(_) | Self::DeferredShapeVerb(_) | Self::MintingTypeOperand(_) => None,
         }
     }
@@ -213,6 +222,12 @@ impl std::fmt::Display for LoadError {
             Self::Bound(e) => write!(f, "{e}"),
             Self::Intrinsic(e) => write!(f, "{e}"),
             Self::SameTickOrder(e) => write!(f, "{e}"),
+            Self::DuplicateRuleId { rule_id } => write!(
+                f,
+                "E-LOAD-001: duplicate rule id: {rule_id} (§2.2 — rule ids must be \
+                 content-set-unique, the same duplicate-name discipline \
+                 parse_intrinsic_decls already enforces for intrinsic declarations)"
+            ),
             Self::Content(message)
             | Self::DeferredShapeVerb(message)
             | Self::MintingTypeOperand(message) => write!(f, "{message}"),
@@ -368,8 +383,9 @@ pub fn load_rule_form(rule: SExpr, ctx: &LoadContext<'_>) -> Result<LoadedRule, 
 /// widening makes the driver honor what the grammar always admitted: one or
 /// more `(rule …)` forms, in whatever order the reader encounters them
 /// (this function makes no ordering claim — `babylon-tick::prepare_rules`
-/// sorts into ascending rule-id byte order per §4.2/D16), duplicate ids
-/// across the content set refused as `E-LOAD-001`.
+/// compiles executable phase placement; D16 orders only same-position
+/// ties), with duplicate ids across the content set refused as
+/// `E-LOAD-001`.
 ///
 /// (`deffield` and `manifest` top-forms are not split out here — nothing
 /// in this crate's Slice 1 content path reads them from a rule source yet;
@@ -378,8 +394,9 @@ pub fn load_rule_form(rule: SExpr, ctx: &LoadContext<'_>) -> Result<LoadedRule, 
 /// # Errors
 ///
 /// [`LoadError::Read`] for a parse failure; [`LoadError::Content`] (uncoded)
-/// when the source contains zero `(rule …)` top-forms, or when two rule
-/// forms share the same id (`E-LOAD-001`).
+/// when the source contains zero `(rule …)` top-forms; or
+/// [`LoadError::DuplicateRuleId`] (`E-LOAD-001`) when two rule forms share
+/// the same id.
 // The return type is a plain, un-nested pair of vecs — flagged only because
 // its second element is itself a `Vec` of pairs; a type alias would be one
 // more name to chase for a shape this crate already spells out in the doc
@@ -399,7 +416,11 @@ pub fn split_content(source: &str) -> Result<(Vec<SExpr>, Vec<(String, SExpr)>),
     // channel (its return type carries none). Rejection fires only when
     // `same_tick_order::ENFORCE_SAME_TICK_ORDERING` is `true`, which it is
     // not for the landed corpus (R-W2a) — see that constant's own doc for
-    // the amendment-draft citation. This is the ONE call site: no other
+    // the amendment-draft citation. PER-17 also made the global-ID analysis
+    // inside `diagnose` invalid across resolved phase positions. The gate
+    // MUST remain false until the analyzer accepts the tick driver's resolved
+    // execution ranks; raw ID comparison remains valid only within one rank.
+    // This is the ONE call site: no other
     // production path reaches `E-LOAD-058`/`E-LOAD-059` except through
     // here.
     if same_tick_order::ENFORCE_SAME_TICK_ORDERING {
@@ -454,29 +475,39 @@ pub(crate) fn split_content_unchecked(
                 .to_owned(),
         ));
     }
-    // A set, not a `HashMap<String, ()>` — same duplicate-id-refusal shape
-    // `declarations::parse_intrinsic_decls` uses for intrinsic names
-    // (contains-check before insert, §2.2's duplicate-name discipline), but
-    // with no payload to store per id, so nothing here needs a map's value
-    // slot at all.
-    let mut seen: HashSet<String> = HashSet::with_capacity(rule_forms.len());
     let mut paired = Vec::with_capacity(rule_forms.len());
     for form in rule_forms {
         let id = crate::canonical_ast::rule_id(&form)
             .map_err(|e| LoadError::Content(e.message))?
             .to_owned();
-        if seen.contains(&id) {
-            return Err(LoadError::Content(format!(
-                "E-LOAD-001: duplicate rule id: {id} (§2.2 — rule ids must be \
-                 content-set-unique, the same duplicate-name discipline \
-                 parse_intrinsic_decls already enforces for intrinsic \
-                 declarations)"
-            )));
-        }
-        seen.insert(id.clone());
         paired.push((id, form));
     }
+    check_unique_rule_ids(&paired)?;
     Ok((intrinsic_forms, paired))
+}
+
+/// Refuse a duplicate rule id across an aggregate content set.
+///
+/// File boundaries carry no semantics, so callers that assemble forms from
+/// more than one source must run this over the aggregate, not merely rely on
+/// each source's [`split_content`] call. If several ids are duplicated, the
+/// byte-least id is named so source order cannot select the diagnostic.
+///
+/// # Errors
+///
+/// [`LoadError::DuplicateRuleId`] (`E-LOAD-001`) for the byte-least repeated
+/// id.
+pub fn check_unique_rule_ids(rules: &[(String, SExpr)]) -> Result<(), LoadError> {
+    let mut ids: Vec<&str> = rules.iter().map(|(id, _)| id.as_str()).collect();
+    ids.sort_unstable_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+    let duplicate = ids
+        .windows(2)
+        .find_map(|pair| (pair[0] == pair[1]).then_some(pair[0]));
+    duplicate.map_or(Ok(()), |rule_id| {
+        Err(LoadError::DuplicateRuleId {
+            rule_id: rule_id.to_owned(),
+        })
+    })
 }
 
 /// Whether `expr` is `(intrinsic …)` — the one top-form kind this module's
@@ -906,10 +937,11 @@ mod split_content_tests {
     }
 
     #[test]
-    fn a_source_with_two_rule_forms_is_a_loud_content_error() {
+    fn a_source_with_duplicate_rule_forms_is_a_typed_duplicate_error() {
         let source = format!("{RULE}\n{RULE}");
         let err = split_content(&source).unwrap_err();
-        assert!(matches!(err, LoadError::Content(_)));
+        assert!(matches!(err, LoadError::DuplicateRuleId { .. }));
+        assert_eq!(err.spec_code(), Some("E-LOAD-001"));
     }
 
     #[test]
@@ -969,6 +1001,7 @@ mod split_content_tests {
   (effects (update-node self a/v2 (set v))))
 "#;
         let err = split_content(source).unwrap_err();
+        assert_eq!(err.spec_code(), Some("E-LOAD-001"));
         assert!(err.to_string().contains("E-LOAD-001"));
         assert!(err.to_string().contains("a/dup"));
     }

--- a/rust/crates/babylon-bsl/src/same_tick_order.rs
+++ b/rust/crates/babylon-bsl/src/same_tick_order.rs
@@ -11,6 +11,16 @@
 //! `E-LOAD-001` (content-set-wide, checked at load, over whatever content
 //! set the caller actually loaded — never a hypothetical wider one).
 //!
+//! **PER-17 supersession boundary (ADR222).** This module's fixture analyzer
+//! predates executable phase placement and compares raw rule IDs globally.
+//! That comparison is semantically valid only when both rules share one
+//! resolved position. It is wrong across phase positions. The load gate MUST
+//! remain false until `diagnose` accepts the tick driver's resolved execution
+//! ranks, uses D16 bytes only as a same-rank tie-break, and receives the
+//! post-concatenation aggregate content set rather than one source file at a
+//! time. The refusal descriptions below preserve the historical W2 analyzer;
+//! they do not claim it is ready to enforce the current scheduler.
+//!
 //! **Refusal 1 — `E-LOAD-058`, stale-default read.** For every
 //! `(binding … :field f :optional :default d)` in rule `R`, compute `f`'s
 //! *writer set*: every OTHER rule `W` in the content set with an
@@ -66,11 +76,14 @@ use std::collections::{HashMap, HashSet};
 /// tests and W2.4's audit both prove the refusal's exact behavior against
 /// real content without waiting on ratification.
 ///
-/// Flip this to `true` only as part of the ratification ceremony this
-/// module's doc names: minting the `:prior-tick` declaration (or whatever
-/// name the Director ratifies), teaching refusal 1 to honor it on the 13
-/// rows the amendment draft lists, and re-running the W2.4 audit to prove
-/// the post-ratification inventory is `[]`. Draft:
+/// Flip this to `true` only after both gates close: the ratification ceremony
+/// mints the `:prior-tick` declaration (or the name the Director ratifies),
+/// and the analyzer consumes resolved phase ranks from `babylon-tick` rather
+/// than comparing rule IDs globally. Move the call site after aggregate
+/// source concatenation at the same time, so file boundaries cannot hide a
+/// writer/reader pair. Then teach refusal 1 to honor the declaration on the
+/// 13 draft rows and rerun the W2.4 audit to prove the post-ratification
+/// inventory is `[]`. Draft:
 /// `ai/_inbox/amendment-prior-tick-draft.md` (Amendment AI — reserved
 /// 2026-08-18 against the concurrently-drafted AH/defevent; DRAFT status,
 /// not ratified by this PR).
@@ -78,11 +91,12 @@ pub const ENFORCE_SAME_TICK_ORDERING: bool = false;
 
 /// Refusal 1: rule `reader_rule`'s binding `binding_name` reads field
 /// `field` with a declared `:optional :default`, and `writer_rule` — a
-/// DIFFERENT rule in the same content set — writes `field` and sorts
-/// on/after `reader_rule` in ascending rule-id byte order, so
+/// DIFFERENT rule in the same content set — writes `field` and this legacy
+/// analyzer sorts it on/after `reader_rule` by raw rule-ID bytes, so
 /// `reader_rule` can observe the DECLARED DEFAULT on a tick where
 /// `writer_rule` already ran and left a value from an earlier tick, not
-/// this one's write.
+/// this one's write. Valid only for rules at one resolved phase rank until
+/// ADR222's rank-aware follow-up lands.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StaleDefaultRead {
     /// The rule doing the exposed `:optional :default` read.
@@ -97,10 +111,10 @@ pub struct StaleDefaultRead {
     pub writer_rule: String,
 }
 
-/// Refusal 2: `field` is written by 2+ distinct rules (`writers`, ascending
-/// byte order) in the content set, and the byte-earliest of them is
+/// Refusal 2: `field` is written by 2+ distinct rules (`writers`, raw-ID byte
+/// order) in the content set, and the byte-earliest of them is
 /// neither an unconditional `set` nor the D127 unconditional-recompute
-/// shape.
+/// shape. This legacy ordering is valid only within one resolved phase rank.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnresetFanIn {
     /// The multi-writer field.
@@ -139,8 +153,8 @@ impl std::fmt::Display for SameTickOrderError {
                 f,
                 "E-LOAD-058: stale-default read — rule {reader}'s binding `{binding}` reads \
                  field {field} with :optional :default, but rule {writer} writes {field} and \
-                 does not sort strictly before {reader} in ascending rule-id byte order \
-                 (§4.2/D116 same-tick evaluation order) — {reader} can observe the declared \
+                 does not sort strictly before {reader} in the legacy raw rule-id analysis \
+                 (§4.2/D116; phase ranks required before enforcement) — {reader} can observe the declared \
                  default on a tick where {writer} already ran and left a value from an EARLIER \
                  tick, never this one's write. Refused at load (S-11), content-set-wide, like \
                  E-LOAD-001. Gated by same_tick_order::ENFORCE_SAME_TICK_ORDERING — see that \
@@ -157,7 +171,8 @@ impl std::fmt::Display for SameTickOrderError {
                  content set ({writers}), and the byte-earliest writer is neither an \
                  unconditional `set` (no (when …), or (when #t)) nor the D127 \
                  unconditional-recompute shape (a :material-basis citing D127) — an \
-                 accumulation with no rule-identifiable reset. Refused at load (S-11), \
+                 accumulation with no rule-identifiable reset. This is legacy raw-ID \
+                 analysis; phase ranks are required before load enforcement. Refused at load (S-11), \
                  content-set-wide, like E-LOAD-001.",
                 field = v.field,
                 n = v.writers.len(),
@@ -472,6 +487,14 @@ pub fn diagnose(rules: &[(String, SExpr)]) -> Diagnosis {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn raw_id_analysis_stays_load_gated_until_phase_ranks_are_injected() {
+        // Observe the public contract at runtime so clippy does not discard
+        // this guard as an assertion over a compile-time constant.
+        let enabled = std::hint::black_box(ENFORCE_SAME_TICK_ORDERING);
+        assert!(!enabled);
+    }
 
     /// Parse a multi-rule content set through
     /// `rule_pipeline::split_content_unchecked` — the real production

--- a/rust/crates/babylon-bsl/tests/content_corpus_digests.rs
+++ b/rust/crates/babylon-bsl/tests/content_corpus_digests.rs
@@ -101,7 +101,7 @@ const PINNED_DIGESTS: &[(&str, &str)] = &[
     ),
     (
         "lifecycle.bsl",
-        "e388d4e4f54301e528004a4d3b5233bc4f039928054c4b6c6a4d1774a7614064",
+        "0161f308c352d95f363187853a78968ae8f5359b6fc4517579d999e3e7ca5b4c",
     ),
     (
         "metabolism.bsl",

--- a/rust/crates/babylon-client/src/engine_link.rs
+++ b/rust/crates/babylon-client/src/engine_link.rs
@@ -39,8 +39,9 @@ pub fn engine_link_probe() -> Result<TickReport, String> {
 
 /// The client's own held tick session over the currently-selected
 /// [`crate::story::Story`] — `roster` is that story's territory-fips
-/// pairs, DERIVED (never hand-transcribed), one rule pack running every
-/// tick in ascending rule-id byte order (§4.2, D16/D100). `Resource`:
+/// pairs, DERIVED (never hand-transcribed), with admitted rules running
+/// every tick in governed phase order. D16 orders same-position ties.
+/// `Resource`:
 /// `loop_ui::spawn_engine_session_and_hud` inserts one at Startup, held for
 /// the whole session; `ui/story_card.rs`'s `N`-key restart replaces it with
 /// a fresh one over the catalog's next story.
@@ -128,11 +129,10 @@ impl EngineSession {
             })
             .collect::<Result<_, String>>()?;
 
-        // Concatenation order below is arbitrary — the driver sorts by
-        // rule-id BYTE ORDER (§4.2, D16) regardless of which text comes
-        // first, so this order has no bearing on execution order or on the
-        // resulting TickReport (babylon-tick's own multi_rule_conformance.rs
-        // proves the file-order invariance directly).
+        // Concatenation order below is arbitrary. The driver compiles governed
+        // phase placement and uses D16 bytes only for same-position ties, so
+        // text order has no bearing on execution or the resulting TickReport.
+        // babylon-tick's multi_rule_conformance.rs proves this invariance.
         let rule_src = story.rule_srcs.join("\n");
         // §3.5: the story's own scenario qname, transcribed from its
         // `.bscn`'s `(scenario …)` form — never a UUID, never a wall-clock

--- a/rust/crates/babylon-client/src/story.rs
+++ b/rust/crates/babylon-client/src/story.rs
@@ -339,8 +339,8 @@ const COUNTIES_PREMISE: &str = "\
 ; The Program 28 B2 demo world (Phase B, Task 7): twelve real-FIPS counties
 ; carrying the lifecycle/dpd-circuit rule pack, plus the six
 ; vitality/subsistence-and-death fixture nodes verbatim — one scenario,
-; two node types, both rule packs running together, in ascending rule-id
-; byte order (§4.2, register row D16/D100).";
+; two node types, both rule packs running together in governed phase order:
+; Vitality @1 before Lifecycle @7.";
 
 const CARCERAL_SCENARIO: &str =
     include_str!("../../babylon-tick/content/scenarios/carceral-arc-conformance.bscn");

--- a/rust/crates/babylon-client/src/ui/admin.rs
+++ b/rust/crates/babylon-client/src/ui/admin.rs
@@ -85,12 +85,11 @@ pub fn toggle_admin_panel(keys: Res<ButtonInput<KeyCode>>, mut visible: ResMut<A
 }
 
 /// Renders the per-rule breakdown from a `TickReport` — pure and
-/// independently testable. Ascending rule-id byte order is the ENGINE's
-/// own contract on `per_rule_fired` (`babylon-tick/src/lib.rs`'s own doc,
-/// §4.2/D16) — this function renders the vector AS GIVEN, never
-/// re-sorting it, so the render inherits the engine's own order rather
-/// than a coincidentally-matching reimplementation. Zero new computation:
-/// every number here is a field `TickReport` already carries.
+/// independently testable. Governed phase placement is the engine's contract
+/// on `per_rule_fired`; D16 bytes order same-position ties. This function
+/// renders the vector as given and never re-sorts it, so the display inherits
+/// engine order rather than duplicating the scheduler. Every number here is a
+/// field `TickReport` already carries.
 #[must_use]
 pub fn format_tick_report(report: &babylon_tick::TickReport) -> String {
     let mut lines = vec![format!("tick report \u{2014} {} fired", report.fired)];

--- a/rust/crates/babylon-ls/src/diagnostics.rs
+++ b/rust/crates/babylon-ls/src/diagnostics.rs
@@ -212,6 +212,7 @@ pub fn family_of_load_error(err: &LoadError) -> &'static str {
         // (shape-level, `E-PARSE`) alone.
         LoadError::Anchor(babylon_bsl::AnchorError::UnregisteredAnchorSystem { .. })
         | LoadError::Content(_)
+        | LoadError::DuplicateRuleId { .. }
         | LoadError::DeferredShapeVerb(_)
         // `SameTickOrder` (W2, E-LOAD-058/059) always carries a spec code,
         // so `spec_code()`'s early return classifies it — this pattern

--- a/rust/crates/babylon-ls/tests/diagnostics_conformance.rs
+++ b/rust/crates/babylon-ls/tests/diagnostics_conformance.rs
@@ -360,3 +360,18 @@ fn diagnose_content_set_duplicate_intrinsic_carries_e_load_001() {
     };
     assert_eq!(expected_identity_source.spec_code(), Some("E-LOAD-001"));
 }
+
+#[test]
+fn diagnose_content_set_duplicate_rule_carries_typed_location_data() {
+    let errors = diagnose_content_set(PROBE_SCENARIO, None, &[PROBE_RULE, PROBE_RULE]);
+    assert_eq!(errors.len(), 1, "{errors:?}");
+    assert_eq!(errors[0].spec_code(), Some("E-LOAD-001"));
+
+    let located = Located::from_prepare_error(&errors[0]);
+    assert_eq!(located.code, Some("E-LOAD-001"));
+    assert_eq!(located.family, "E-LOAD");
+    assert!(matches!(
+        located.identity,
+        Some(babylon_bsl::ErrorIdentity::RuleId(ref id)) if id == "vitality/probe"
+    ));
+}

--- a/rust/crates/babylon-tick/content/content-sets.toml
+++ b/rust/crates/babylon-tick/content/content-sets.toml
@@ -2,9 +2,9 @@ schema = 1
 
 # Paths in `scenario` / `prelude` / `rules` are relative to THIS FILE's
 # directory (the content root). `consumers` are repo-relative (D146).
-# The `rules` array is a SET, not a load order: the loader sorts rule ids
-# into ascending byte order before firing (§4.2 / D16,
-# babylon-tick/src/lib.rs:715, `prepare_rules`'s `rules.sort_by`).
+# The `rules` array is a SET, not a load order: the loader compiles each
+# rule onto the governed phase registry before firing. D16's ascending
+# rule-id byte order breaks ties at one resolved position.
 # Presented here in ascending byte order too, for deterministic diffs —
 # not because the loader requires it.
 #
@@ -370,6 +370,13 @@ scenario  = "scenarios/organization-foundation.bscn"
 prelude   = []
 rules     = ["rules/organization.bsl"]
 consumers = ["rust/crates/babylon-tick/tests/tick_goldens.rs"]
+
+[[set]]
+id        = "phase-anchor/conformance"
+scenario  = "scenarios/two-classes.bscn"
+prelude   = []
+rules     = []
+consumers = ["rust/crates/babylon-tick/tests/phase_anchor_conformance.rs"]
 
 [[set]]
 id        = "production/conformance"

--- a/rust/crates/babylon-tick/content/rules/control-ratio.bsl
+++ b/rust/crates/babylon-tick/content/rules/control-ratio.bsl
@@ -230,11 +230,12 @@
 ;      TIGHTEST in this pack at 987/1024 (37 headroom). Recorded here so
 ;      the next editor adding a clause to either string sees the E-LEX-026
 ;      pressure coming instead of hitting a whole-load lexer refusal cold.
-;   6. (global D172) THE CROSS-PACK BYTE-ORDER INVERSION — `control-ratio/*` sorts
+;   6. (global D172, HISTORICAL; superseded by ADR222/PER-17) THE FORMER
+;      CROSS-PACK BYTE-ORDER INVERSION — `control-ratio/*` formerly sorted
 ;      BEFORE `decomposition/*` in ascending rule-id byte order (D100's
 ;      class, `docs/superpowers/plans/2026-08-17-decomposition-
 ;      controlratio-port.md` §5), inverting the frozen @11.0-then-@12.0
-;      system order. Benign here BY CONSTRUCTION, not by luck: every one
+;      system order. It was benign BY CONSTRUCTION, not by luck: every one
 ;      of this whole Pack B's four scenarios SEEDS
 ;      `decomposition-fire-tick`/`-fired-known`/`decomposition-complete`
 ;      directly rather than relying on a co-loaded `decomposition/*`

--- a/rust/crates/babylon-tick/content/rules/imperial-rent.bsl
+++ b/rust/crates/babylon-tick/content/rules/imperial-rent.bsl
@@ -186,7 +186,9 @@
 ; for imperial-rent specifically; the blanket "no single-tick test flips"
 ; sentence above governs rows 1-6 only.
 ;
-; §7's FOUR inter-pack byte-order inversions (plan §7, D190) — this pack's
+; HISTORICAL §7/D190 RECORD, superseded for execution by the governed phase
+; registry (ADR222/PER-17): the former FOUR inter-pack byte-order inversions.
+; This pack's
 ; own namespace, `imperial-rent`, sorts AFTER `consciousness, control-ratio,
 ; decomposition, dispossession, economics` and BEFORE `lifecycle, metabolism,
 ; organization, production, solidarity, territory, vitality` (`economics` <
@@ -397,7 +399,8 @@
 ;      default; `defines.yaml:97` SHIPS 0.7 and `ImperialRentSystem` passes
 ;      the define — the SHIPPED 0.7 governs, the code is the port's oracle,
 ;      not its own docstring).
-;   10. (D190) The inter-pack byte-order inversions — FOUR, each with its
+;   10. (D190, HISTORICAL; superseded by ADR222/PER-17) The inter-pack
+;       byte-order inversions — FOUR, each with its
 ;       own executable constraint. See the §7 disclosure block above (this
 ;       header, immediately before this D-record list) for the full text of
 ;       all four (7.1 production, 7.2 consciousness, 7.3 decomposition, 7.4

--- a/rust/crates/babylon-tick/content/rules/lifecycle.bsl
+++ b/rust/crates/babylon-tick/content/rules/lifecycle.bsl
@@ -248,14 +248,10 @@
 (rule lifecycle/dpd-circuit
   :material-basis "a county's population moves through three material phases every tick — pre-productive (raised out of household labor), productive (sells labor-power), post-productive (lives on the legitimation bargain) — at rates set by birth and mortality data and by the age structure of production; a cohort that dies takes a proportional share of whatever wealth its members held with it; the D' bargain's credibility and the ideology a new productive cohort inherits are computed alongside it every tick"
   :fuel 3072
-  ; Declarative only (Program 28 B2, register row D100/D16) — the frozen
-  ; engine's own tick-position order runs Vitality @1 before Lifecycle @7,
-  ; which this anchor states for the eventual Phase 3 anchor-resolution
-  ; registry. INERT for ordering today: the driver sorts by rule-id byte
-  ; order ('l' < 'v', so lifecycle actually runs FIRST), never reads this
-  ; field. check_anchor still parses and validates the form; nothing
-  ; downstream consumes it yet.
-  (anchor :after vitality)
+  ; No explicit anchor: the executable registry resolves the `lifecycle`
+  ; rule-id namespace to Lifecycle @7. `(anchor :after vitality)` would mean
+  ; the literal boundary immediately after Vitality @1, not "somewhere later
+  ; than vitality," and would illegally cut through Material Base.
   (bindings
     ; --- Block 1: DPD population flow (formulas/lifecycle.py:16-61,
     ; domain/economics/lifecycle/cohort_dynamics.py:129-163) ---

--- a/rust/crates/babylon-tick/content/scenarios/community-carrier-collision-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/community-carrier-collision-conformance.bscn
@@ -28,15 +28,15 @@
 ; c01/c02 (this task) OR c03/c04 (later) reads must be declared and seeded
 ; here now.
 ;
-; **Seeds a POST-DECOMPOSITION carrier state directly** (plan §5's own
-; byte-order-hazard note) — `decomposition-fire-tick 0`,
+; **Seeds a POST-DECOMPOSITION carrier state directly** (the historical
+; plan §5 byte-order hazard is superseded by executable phase ordering) —
+; `decomposition-fire-tick 0`,
 ; `decomposition-fired-known 1`, `decomposition-complete 1` — so Pack B is
 ; exercised end to end WITHOUT Pack A ever running. This is also why a
 ; ZERO `control-ratio-delay` is safe here: the frozen coupling key
 ; (`_class_decomposition_tick`) is SEEDED, never written the same tick by a
-; co-loaded `decomposition/*` rule, so §5's cross-pack byte-order inversion
-; (`control-ratio/*` sorts before `decomposition/*`) never has anything to
-; race.
+; co-loaded `decomposition/*` rule. The seed remains a Pack-B isolation
+; choice; the phase registry now orders Decomposition before ControlRatio.
 ;
 ; **Enum order is a hash-bearing transcription of the frozen Python
 ; declaration order (ADR195)** — do not reorder (same roster as

--- a/rust/crates/babylon-tick/content/scenarios/control-ratio-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/control-ratio-conformance.bscn
@@ -17,15 +17,15 @@
 ; c01/c02 (this task) OR c03/c04 (later) reads must be declared and seeded
 ; here now.
 ;
-; **Seeds a POST-DECOMPOSITION carrier state directly** (plan §5's own
-; byte-order-hazard note) — `decomposition-fire-tick 0`,
+; **Seeds a POST-DECOMPOSITION carrier state directly** (the historical
+; plan §5 byte-order hazard is superseded by executable phase ordering) —
+; `decomposition-fire-tick 0`,
 ; `decomposition-fired-known 1`, `decomposition-complete 1` — so Pack B is
 ; exercised end to end WITHOUT Pack A ever running. This is also why a
 ; ZERO `control-ratio-delay` is safe here: the frozen coupling key
 ; (`_class_decomposition_tick`) is SEEDED, never written the same tick by a
-; co-loaded `decomposition/*` rule, so §5's cross-pack byte-order inversion
-; (`control-ratio/*` sorts before `decomposition/*`) never has anything to
-; race.
+; co-loaded `decomposition/*` rule. The seed remains a Pack-B isolation
+; choice; the phase registry now orders Decomposition before ControlRatio.
 ;
 ; **Enum order is a hash-bearing transcription of the frozen Python
 ; declaration order (ADR195)** — do not reorder (same roster as

--- a/rust/crates/babylon-tick/content/scenarios/decomposition_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/decomposition_conformance.py
@@ -32,9 +32,9 @@ Task 1's own scope: Task 1 ships no `control-ratio/*` rule content yet, so
 there is nothing for a later Rust conformance test to assert against
 ControlRatio's own event path from this run; that arrives in this train's
 Pack B tasks, with a companion scenario that seeds a decomposed world
-directly (matching plan §5's byte-order-hazard constraint: a zero-delay
-control-ratio companion must SEED `decomposition-fire-tick`, never rely on
-Pack A writing it the same tick).
+directly. That seed originally satisfied plan §5's byte-order-hazard
+constraint; executable phase ordering now makes same-tick Pack A writes
+visible to Pack B in the governed Decomposition-then-ControlRatio order.
 """
 
 from __future__ import annotations

--- a/rust/crates/babylon-tick/content/scenarios/us-counties-lifecycle-demo.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/us-counties-lifecycle-demo.bscn
@@ -1,8 +1,8 @@
 ; The Program 28 B2 demo world (Phase B, Task 7): twelve real-FIPS counties
 ; carrying the lifecycle/dpd-circuit rule pack, plus the six
 ; vitality/subsistence-and-death fixture nodes verbatim — one scenario,
-; two node types, both rule packs running together, in ascending rule-id
-; byte order (§4.2, register row D16/D100).
+; two node types, both rule packs running together in governed phase order:
+; Vitality @1 before Lifecycle @7.
 ;
 ; The FIPS codes are the twelve LOWEST-FIPS counties in the committed atlas
 ; (`assets/map/county_atlas.bin`, sorted ascending by B1 Task 1 Step 5) —

--- a/rust/crates/babylon-tick/content/scenarios/vitality-lifecycle-combined-conformance.bscn
+++ b/rust/crates/babylon-tick/content/scenarios/vitality-lifecycle-combined-conformance.bscn
@@ -1,14 +1,10 @@
 ; The multi-rule conformance world for vitality/subsistence-and-death AND
 ; lifecycle/dpd-circuit run together, in ONE content set (Program 28 B2,
-; Phase A Task 5). Proves the mechanism Tasks 2 and 4 built: (1) the loader
-; sorts by rule-id byte order regardless of concatenation order (§4.2,
-; register row D16/D100), and (2) the sorted result reproduces the frozen
-; engine's own combined output for this pair, despite running in the
-; REVERSE of the frozen engine's own tick-position order — safe here only
-; because the two rules' domains are disjoint (the plan's Multi-Rule
-; Decision section), which vitality_lifecycle_combined_conformance.py
-; proves directly by running both engine-order and reverse-order against
-; the same ten-node state and diffing the results.
+; Phase A Task 5). The executable phase registry now restores the frozen
+; Vitality-then-Lifecycle order regardless of concatenation order. The
+; provenance script still runs both engine and reverse order against the
+; same ten-node state, proving this particular pair commutes because its
+; domains are disjoint rather than relying on that fact for scheduling.
 ;
 ; A straight UNION of two already-proven fixtures, transcribed byte-for-byte
 ; — deffield/defconst blocks and every node's field values, no new numbers:

--- a/rust/crates/babylon-tick/content/scenarios/vitality_lifecycle_combined_conformance.py
+++ b/rust/crates/babylon-tick/content/scenarios/vitality_lifecycle_combined_conformance.py
@@ -9,9 +9,9 @@ transcribed byte-for-byte from both scripts) and runs the frozen
 ``VitalitySystem`` and ``LifecycleSystem`` against it TWICE, on two
 independently-built copies of the same state: once in the frozen engine's
 own tick-position order (Vitality @1, then Lifecycle @7 — "engine order"),
-and once in the REVERSE order (Lifecycle, then Vitality — the order the
-Rust driver actually runs in, since it sorts by ascending rule-id byte
-order, and ``'l' < 'v'``).
+and once in the REVERSE order (Lifecycle, then Vitality). The Rust driver
+now uses the engine order through its executable phase registry; the reverse
+run remains a corroborating commutativity proof for this disjoint pair.
 
 The two runs' post-tick fields are compared field-for-field. They must
 match EXACTLY, because this is the empirical proof (not just an inference
@@ -19,9 +19,8 @@ from reading the bindings) that the two rules' domains are disjoint:
 ``VitalitySystem`` touches only ``social-class/*`` fields,
 ``LifecycleSystem`` touches only ``territory/*`` fields, so which one runs
 first cannot matter. If the two runs ever disagree, the disjoint-domain
-premise this whole task's byte-order-is-safe-here argument rests on is
-false, and this script exits loudly rather than printing vectors that
-would silently paper over that.
+premise is false, and this script exits loudly rather than printing vectors
+that would silently paper over that.
 
 Run it from the repository root, single process::
 

--- a/rust/crates/babylon-tick/src/bin/bsl_fuel_report.rs
+++ b/rust/crates/babylon-tick/src/bin/bsl_fuel_report.rs
@@ -238,9 +238,10 @@ fn main() -> ExitCode {
             }
         }
     }
-    // Global sort, byte order — each pack's own rows already arrive sorted
-    // (`prepare_rules`, §4.2/D16), but sorting the WHOLE report again makes
-    // its determinism independent of the table's own declared order, which
+    // Global presentation sort by rule-ID bytes. Each pack's rows arrive in
+    // executable phase order from `prepare_rules`; this report deliberately
+    // re-sorts the WHOLE inventory so its output stays independent of the
+    // table's declared order, which
     // (like any content ordering, §2.2) carries no semantics. `sort_by` is
     // STABLE, so when a rule-id repeats across a solo row and a co-load
     // row (see the module doc), the two keep their relative iteration

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -732,12 +732,16 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
 
     // rule_forms is `Vec<(String, SExpr)>` — each rule's id already paired
     // with its form by split_content (Task 2), so no second extraction
-    // here. Rules load in reader encounter order, then the preflighted plan
-    // places them on the 34-slot causal spine. D16 breaks only same-position
-    // ties by ascending rule-id bytes. This is the one place execution order
-    // gets decided, so every later stage just iterates the compiled order.
+    // here. Validate a temporary reference view by ascending rule-id bytes so
+    // two invalid source permutations name the same first failing identity.
+    // The preflighted plan then places valid rules on the 34-slot causal
+    // spine; D16 breaks only same-position execution ties by rule-id bytes.
+    // Every later stage just iterates that compiled execution order.
+    let mut validation_order: Vec<_> = rule_forms.iter().collect();
+    validation_order
+        .sort_unstable_by(|(left, _), (right, _)| left.as_bytes().cmp(right.as_bytes()));
     let mut rules = Vec::with_capacity(rule_forms.len());
-    for (id, form) in &rule_forms {
+    for (id, form) in validation_order {
         let loaded = load_rule_form(form.clone(), &ctx).map_err(|error| PrepareError::Rule {
             rule_id: Some(id.clone()),
             error,

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -551,9 +551,11 @@ fn build_shared_load_inputs(scenario: &LoadedScenario) -> Result<SharedLoadInput
 ///   INDEPENDENTLY — one rule's rejection never hides a sibling's, matching
 ///   `prepare_rules`'s own "no partial admission, but every unit gets its
 ///   own chance" discipline one radius wider;
+/// - an aggregate duplicate rule ID suppresses phase placement because one
+///   identity cannot own two potentially different anchors;
 /// - phase placement compiles over the independently admitted rule forms after
-///   per-rule loading, so a broken sibling cannot hide an unrelated causal
-///   composition failure.
+///   per-rule loading when their identities are unique, so a broken sibling
+///   cannot hide an unrelated causal composition failure.
 ///
 /// Ordering within the returned `Vec` is: split-stage failures in source
 /// order, an aggregate duplicate-id failure when present, one blocking
@@ -585,12 +587,16 @@ pub fn diagnose_content_set(
             }),
         }
     }
-    if let Err(error) = check_unique_rule_ids(&rule_forms) {
-        errors.push(PrepareError::Rule {
-            rule_id: None,
-            error,
-        });
-    }
+    let unique_rule_ids = match check_unique_rule_ids(&rule_forms) {
+        Ok(()) => true,
+        Err(error) => {
+            errors.push(PrepareError::Rule {
+                rule_id: None,
+                error,
+            });
+            false
+        }
+    };
 
     let declared = match parse_intrinsic_decls(&intrinsic_forms) {
         Ok(declared) => declared,
@@ -643,7 +649,7 @@ pub fn diagnose_content_set(
         }
     }
 
-    if !admitted_rule_forms.is_empty() {
+    if unique_rule_ids && !admitted_rule_forms.is_empty() {
         if let Err(error) = phase_order::compile(&admitted_rule_forms) {
             errors.push(prepare_error_from_schedule(error));
         }

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -27,7 +27,7 @@ use babylon_bsl::fuel::{CardinalityCeilings, IntrinsicCosts};
 use babylon_bsl::intrinsic_host::KernelIntrinsicHost;
 use babylon_bsl::reader::SExpr;
 use babylon_bsl::rule_pipeline::{
-    load_rule_form, split_content, LoadContext, LoadError, LoadedRule,
+    check_unique_rule_ids, load_rule_form, split_content, LoadContext, LoadError, LoadedRule,
 };
 use babylon_bsl::scenario::{
     load_scenario, load_scenario_with_prelude, LoadedScenario, ScenarioError,
@@ -43,6 +43,7 @@ use babylon_graph::substrate::{GraphSubstrate, NodeId};
 use babylon_kernel::SessionId;
 use std::collections::{HashMap, HashSet};
 
+mod phase_order;
 pub mod session;
 pub use session::TickSession;
 
@@ -61,12 +62,12 @@ pub struct TickReport {
     /// this crate's `tests/*_conformance.rs` and `tests/floor_intrinsic_e2e.rs`
     /// keep compiling and keep passing unmodified.
     pub fired: usize,
-    /// Per-rule detail, in ASCENDING RULE-ID BYTE ORDER (§4.2, register row
-    /// D16) — `(rule_id, fired)`. NEVER declaration order or file order;
-    /// §4.2 says those "are never observable", and this field's own order
-    /// is the driver's proof that it honors that. Length 1 for every
-    /// existing single-rule content set (`fired == per_rule_fired[0].1`
-    /// always holds); length N for an N-rule content set.
+    /// Per-rule detail in governed causal order — `(rule_id, fired)`.
+    /// Rules resolve through the 34-slot phase registry; rules sharing one
+    /// position use D16's ascending rule-ID byte order. Declaration and file
+    /// order are never observable. Length 1 for every existing single-rule
+    /// content set (`fired == per_rule_fired[0].1` always holds); length N
+    /// for an N-rule content set.
     pub per_rule_fired: Vec<(String, usize)>,
 }
 
@@ -151,13 +152,13 @@ pub fn run_once_with_prelude(
 /// Everything `run_once_into` does before running a tick: parse the
 /// intrinsic declarations, load the scenario into `graph`, and load every
 /// `(rule …)` form `split_content` returns against the vocabulary/types/
-/// ceilings that scenario declared — sorted into ascending rule-id BYTE
-/// order (§4.2, register row D16) before this returns, so every later
-/// stage (`TickSession::advance`, `run_once_into`) just iterates the
-/// already-correct order. Shared by `run_once_into` (which still runs
-/// exactly tick 1) and, from `session.rs` on, `TickSession::new` (Program
-/// 28 B2, `docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md` Phase A
-/// Task 4).
+/// ceilings that scenario declared — compiled into the governed phase order
+/// before this returns, so every later stage (`TickSession::advance`,
+/// `run_once_into`) just iterates the already-correct order. D16's ascending
+/// rule-ID byte order breaks ties at one resolved position. Shared by
+/// `run_once_into` (which still runs exactly tick 1) and, from `session.rs`
+/// on, `TickSession::new` (Program 28 B2,
+/// `docs/superpowers/plans/2026-08-11-b2-tick-loop-plan.md` Phase A Task 4).
 ///
 /// `Debug` (T2, issue #559): needed so `Result<PreparedRules, PrepareError>`
 /// (`String` before #652 Task 3's `PrepareError`) can be formatted with
@@ -217,9 +218,8 @@ pub enum PrepareError {
     Scenario(ScenarioError),
     /// One `(rule …)` form was rejected. `rule_id` is `None` for a
     /// composition-level [`split_content`] failure (a malformed content
-    /// source, or a duplicate rule id WITHIN one source) raised before any
-    /// individual rule's own id is even in scope; `Some` for a specific
-    /// rule's own load rejection.
+    /// source or duplicate rule id) raised before any individual rule's own
+    /// id is in scope; `Some` for a specific rule's own load rejection.
     Rule {
         /// The rejected rule's id, when the failure is attributable to one.
         rule_id: Option<String>,
@@ -292,120 +292,50 @@ impl std::error::Error for PrepareError {}
 /// The rule-pack namespaces this driver registers before loading any rule
 /// (`LoadContext::systems`) — extracted (Task 3, #652) so `prepare_rules`
 /// and [`diagnose_content_set`] build the IDENTICAL set from one place
-/// rather than two copies drifting apart. Every entry and its own comment
-/// is unchanged from `prepare_rules`'s pre-Task-3 inline literal, just
-/// relocated.
+/// rather than two copies drifting apart. PER-17 replaces the former partial
+/// inline set with the canonical 34-slot registry and its compatibility names.
 fn registered_systems() -> HashSet<String> {
-    HashSet::from([
-        "economics".to_owned(),
-        "vitality".to_owned(),
-        "consciousness".to_owned(),
-        // The lifecycle/* rule pack (Material Base @7.0, the D-P-D' circuit)
-        // — same class of minimal driver-scaffolding addition as "vitality"
-        // above.
-        "lifecycle".to_owned(),
-        // The dispossession/* rule pack (Material Base @10.0, primitive
-        // accumulation as value transfer) — same class of minimal
-        // driver-scaffolding addition as "vitality"/"lifecycle" above.
-        "dispossession".to_owned(),
-        // The metabolism/* rule pack (Material Base @13.0, the per-territory
-        // half of the metabolic rift) — same class of minimal
-        // driver-scaffolding addition as the three above.
-        "metabolism".to_owned(),
-        // The territory/* rule pack (Material Base @2.0, four sequential
-        // phase rules — heat dynamics, eviction pipeline, spillover,
-        // necropolitics; Territory port train, P27 PR B). This entry was
-        // ADDED EARLIER by the query-evaluation train solely so
-        // `query_lane_e2e.rs`'s four synthetic, Territory-SHAPED vectors
-        // had a legal namespace to anchor under, explicitly marked at the
-        // time as "not a Territory-port system... this train ships none" —
-        // the port train now ships the real content this namespace was
-        // reserved for; the string literal itself is unchanged.
-        "territory".to_owned(),
-        // The organization/* rule pack (Task 8, Organization foundation
-        // plan) — same class of minimal driver-scaffolding addition as the
-        // five above; Task 10 ships the first content using this
-        // namespace.
-        "organization".to_owned(),
-        // The production/* rule pack (Material Base @3.0, four rules —
-        // direct production, employed routing, employed fallback,
-        // extraction-intensity broadcast; Production port train, issue
-        // #565). Genuinely NEW registration (unlike territory's own
-        // pre-existing placeholder above) — the scout dossier
-        // (reports/production-bsl-surface-facts-2026-08-12.md §3) confirmed
-        // "production" had zero prior hits in this HashSet on either tree.
-        "production".to_owned(),
-        // The social-class/* namespace (T2 slice-2 edge reads, issue #559).
-        // Added solely so `edge_lane_e2e.rs`'s three synthetic, Solidarity-
-        // SHAPED vectors have a legal namespace to anchor under (E-LOAD-002)
-        // — the SAME class of driver-scaffolding entry "territory" itself
-        // was when the query-evaluation train added it for
-        // `query_lane_e2e.rs`'s vectors (see that entry's own comment
-        // above). NOT a system port: T2 ships no Solidarity content
-        // (Solidarity's PORT is a separate Wave C train), and no engine
-        // system is named "social-class" — this is the e2e fixture's own
-        // subject-type namespace, nothing more.
-        "social-class".to_owned(),
-        // The solidarity/* rule pack (Material Base @8.0, consciousness
-        // transmission over SOLIDARITY edges — Wave C: Solidarity port
-        // train, issue #557 umbrella, Task 1). Same class of minimal
-        // driver-scaffolding addition as "vitality"/"lifecycle"/
-        // "dispossession"/"metabolism"/"production" above: registers the
-        // namespace so `solidarity/p0-transmit`'s rule id resolves under
-        // E-LOAD-002 before the pack itself lands (Task 2).
-        "solidarity".to_owned(),
-        // The decomposition/* rule pack (Material Base @11.0, LA class
-        // breakdown into CARCERAL_ENFORCER/INTERNAL_PROLETARIAT during
-        // terminal crisis; Decomposition+ControlRatio port train, Task 1 of
-        // `docs/superpowers/plans/2026-08-17-decomposition-controlratio-
-        // port.md`). Genuinely NEW registration — the Task 0 surface-facts
-        // dossier confirmed zero prior hits in this HashSet.
-        "decomposition".to_owned(),
-        // The control-ratio/* rule pack (Material Base @12.0, the
-        // guard:prisoner ratio crisis + the ADR070-reserved revolution-vs-
-        // genocide terminal decision; same port train, Task 1). Hyphenated
-        // spelling is the RULED spelling (Task 0 dossier §7, three
-        // independent proofs: `reader.rs::validate_symbol` accepts hyphens,
-        // the landed `"social-class"` precedent immediately above, and
-        // `edge_lane_e2e.rs`'s landed hyphenated rule-id first segments) —
-        // genuinely NEW registration, same class as "decomposition" above.
-        "control-ratio".to_owned(),
-        // The imperial-rent/* rule pack (Material Base @9.0, the 5-phase
-        // Imperial Circuit — Extraction, Tribute, Wages, [Subsidy RESERVED,
-        // Constitution IX.5], Decision; ImperialRent BSL port train, Task 1
-        // of `docs/superpowers/plans/2026-08-18-imperialrent-port.md`).
-        // Genuinely NEW registration — the Task 0 surface-facts dossier
-        // (`reports/imperial-rent-bsl-surface-facts-2026-08-18.md`)
-        // confirmed zero prior hits in this HashSet, same class as
-        // "decomposition"/"control-ratio" above. Hyphenated spelling
-        // follows the same "control-ratio" precedent immediately above.
-        "imperial-rent".to_owned(),
-        // The community/* rule pack (Material Base @6.0, the Community port
-        // train, issue #667, plan
-        // `docs/superpowers/plans/2026-08-18-community-port.md`).
-        // Registered AT TASK 4 (one task earlier than the plan's Task 7
-        // Step 2): the ceiling supply chain's RED tests must observe the
-        // two refusal codes specifically — E-LOAD-045 (MissingCeiling, the
-        // type axis) and E-LOAD-042 (MissingMaxMembers, the
-        // :max-members axis) — and a rule under an
-        // unregistered namespace fails E-LOAD-004 (undeterminable domain)
-        // one stage earlier — the registration is the precondition for the
-        // probe to reach the check it pins. Genuinely NEW registration —
-        // the Task 0 surface-facts dossier
-        // (`reports/community-bsl-surface-facts-2026-08-18.md`) confirmed
-        // zero prior hits in this HashSet.
-        "community".to_owned(),
-        // The class-dynamics/* rule pack (Material Base @4.0's Feature-016
-        // class-dynamics engine — NOT all of @4.0; TickDynamics port train,
-        // issue #669, plan docs/superpowers/plans/2026-08-18-tickdynamics-port.md
-        // — path deliberately unbackticked so the line break cannot render a
-        // split path). Genuinely NEW registration — the Task 0 surface-facts
-        // dossier (`reports/class-dynamics-bsl-surface-facts-2026-08-18.md`)
-        // confirmed zero prior hits in this HashSet for `class-dynamics`/
-        // `tick-dynamics`/`tickdynamics` spellings. Hyphenated spelling
-        // follows the `social-class`/`control-ratio` precedent.
-        "class-dynamics".to_owned(),
-    ])
+    phase_order::registered_systems()
+}
+
+fn prepare_error_from_schedule(error: phase_order::ScheduleError) -> PrepareError {
+    let message = error.to_string();
+    match error {
+        phase_order::ScheduleError::Anchor { rule_id, source } => PrepareError::Rule {
+            rule_id: Some(rule_id),
+            error: LoadError::Anchor(source),
+        },
+        phase_order::ScheduleError::MaterialBaseInterleave { rule_id, .. } => {
+            PrepareError::Composition {
+                code: Some("E-LOAD-003"),
+                identity: Some(ErrorIdentity::RuleId(rule_id)),
+                message,
+            }
+        }
+        phase_order::ScheduleError::Registry { .. } => PrepareError::Composition {
+            code: None,
+            identity: None,
+            message,
+        },
+        phase_order::ScheduleError::Plan { rule_id, .. } => PrepareError::Composition {
+            code: None,
+            identity: rule_id.map(ErrorIdentity::RuleId),
+            message,
+        },
+    }
+}
+
+fn hydrate_scenario<G: GraphSubstrate>(
+    scenario_src: &str,
+    prelude_src: Option<&str>,
+    graph: &mut G,
+) -> Result<LoadedScenario, PrepareError> {
+    match prelude_src {
+        Some(prelude) => {
+            load_scenario_with_prelude(prelude, scenario_src, graph).map_err(PrepareError::Scenario)
+        }
+        None => load_scenario(scenario_src, graph).map_err(PrepareError::Scenario),
+    }
 }
 
 /// The D32 implicit-`<edge-type>/strength` collision check (D32,
@@ -458,8 +388,8 @@ fn seed_implicit_edge_strength_fields(
             .type_env_fields()
             .into_iter()
             .collect();
-        // Byte order, the same convention `rules.sort_by` uses in
-        // `prepare_rules`: the Err/Ok verdict never depended on
+        // Byte order, the same convention D16 uses for same-position rule
+        // ties: the Err/Ok verdict never depended on
         // `type_env_fields()`'s HashMap iteration order, but the refusal
         // TEXT did — with two or more colliding qnames it
         // nondeterministically named a different field per process.
@@ -604,13 +534,15 @@ fn build_shared_load_inputs(scenario: &LoadedScenario) -> Result<SharedLoadInput
 ///   malformed source cannot hide the forms a SIBLING source parses
 ///   cleanly, so a failure here is recorded and the NEXT source still gets
 ///   its own chance;
+/// - aggregate rule-id uniqueness is checked after splitting, because file
+///   boundaries carry no semantics; a duplicate split across sources is one
+///   structured `E-LOAD-001` diagnostic rather than a false-clean result;
 /// - intrinsic-declaration parsing runs once, over every collected
 ///   `(intrinsic …)` form — a failure here BLOCKS rule loading, because
 ///   every rule's static fuel-bound check needs `IntrinsicCosts` to exist
 ///   at all;
-/// - scenario hydration BLOCKS rule loading on failure too — a scenario
-///   that never hydrated leaves no field/vocabulary/ceiling registries to
-///   load a rule against;
+/// - scenario validation hydrates a disposable graph and BLOCKS rule loading
+///   on failure — caller-owned state is never in scope here;
 /// - the D32 implicit-`<edge-type>/strength` collision check (the same one
 ///   `prepare_rules` runs, `seed_implicit_edge_strength_fields`) BLOCKS
 ///   rule loading on failure — the seeded field registry would be
@@ -618,17 +550,17 @@ fn build_shared_load_inputs(scenario: &LoadedScenario) -> Result<SharedLoadInput
 /// - every `(rule …)` form collected across every source then loads
 ///   INDEPENDENTLY — one rule's rejection never hides a sibling's, matching
 ///   `prepare_rules`'s own "no partial admission, but every unit gets its
-///   own chance" discipline one radius wider.
+///   own chance" discipline one radius wider;
+/// - phase placement compiles over the independently admitted rule forms after
+///   per-rule loading, so a broken sibling cannot hide an unrelated causal
+///   composition failure.
 ///
-/// Ordering within the returned `Vec` is: split-stage failures (source
-/// order), then a single blocking intrinsic/scenario/composition failure,
-/// then per-rule failures in `rule_forms`' own order — the SAME ascending
-/// rule-id byte order `prepare_rules` sorts into (§4.2, register row D16,
-/// `prepare_rules`'s own `rules.sort_by` — this function reads that same
-/// pre-sorted-by-`split_content`-encounter-order sequence, since a
-/// diagnostic report has no tick to run and therefore no reason to commit
-/// to the byte-order sort `prepare_rules` performs solely for `run_tick`'s
-/// own iteration).
+/// Ordering within the returned `Vec` is: split-stage failures in source
+/// order, an aggregate duplicate-id failure when present, one blocking
+/// intrinsic/scenario/composition failure when present, then per-rule failures
+/// in encounter order, then a phase-composition failure over admitted
+/// siblings. Executable phase ordering applies to admitted rules, not
+/// diagnostic display order.
 ///
 /// An empty return means the content set loads clean end to end — the SAME
 /// success condition `prepare_rules` reports as `Ok`.
@@ -653,6 +585,12 @@ pub fn diagnose_content_set(
             }),
         }
     }
+    if let Err(error) = check_unique_rule_ids(&rule_forms) {
+        errors.push(PrepareError::Rule {
+            rule_id: None,
+            error,
+        });
+    }
 
     let declared = match parse_intrinsic_decls(&intrinsic_forms) {
         Ok(declared) => declared,
@@ -669,14 +607,10 @@ pub fn diagnose_content_set(
     );
 
     let mut graph = HypergraphStore::new();
-    let loaded = match prelude_src {
-        Some(prelude) => load_scenario_with_prelude(prelude, scenario_src, &mut graph),
-        None => load_scenario(scenario_src, &mut graph),
-    };
-    let scenario = match loaded {
+    let scenario = match hydrate_scenario(scenario_src, prelude_src, &mut graph) {
         Ok(scenario) => scenario,
         Err(e) => {
-            errors.push(PrepareError::Scenario(e));
+            errors.push(e);
             return errors;
         }
     };
@@ -698,12 +632,20 @@ pub fn diagnose_content_set(
         rule_file: "rule",
     };
 
-    for (id, form) in rule_forms {
-        if let Err(error) = load_rule_form(form, &ctx) {
-            errors.push(PrepareError::Rule {
-                rule_id: Some(id),
+    let mut admitted_rule_forms = Vec::with_capacity(rule_forms.len());
+    for (id, form) in &rule_forms {
+        match load_rule_form(form.clone(), &ctx) {
+            Ok(_) => admitted_rule_forms.push((id.clone(), form.clone())),
+            Err(error) => errors.push(PrepareError::Rule {
+                rule_id: Some(id.clone()),
                 error,
-            });
+            }),
+        }
+    }
+
+    if !admitted_rule_forms.is_empty() {
+        if let Err(error) = phase_order::compile(&admitted_rule_forms) {
+            errors.push(prepare_error_from_schedule(error));
         }
     }
 
@@ -742,11 +684,12 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
             .collect(),
     );
 
-    let scenario = match prelude_src {
-        Some(prelude) => load_scenario_with_prelude(prelude, scenario_src, graph)
-            .map_err(PrepareError::Scenario)?,
-        None => load_scenario(scenario_src, graph).map_err(PrepareError::Scenario)?,
-    };
+    // Validate scenario declarations and rule surfaces against a disposable
+    // graph first. This preserves the established scenario -> rule ->
+    // composition error order while ensuring a phase-composition refusal
+    // cannot partially hydrate the caller-owned graph.
+    let mut validation_graph = HypergraphStore::new();
+    let validation_scenario = hydrate_scenario(scenario_src, prelude_src, &mut validation_graph)?;
 
     // The scenario's `deffield` forms ARE the registries for slice 1. When
     // Phase 2's content registries land they replace this wholesale; until
@@ -755,7 +698,7 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
     // `<edge-type>/strength` seeding (and its own duplicate-declaration
     // refusal) is [`seed_implicit_edge_strength_fields`]'s own doc — shared
     // with [`diagnose_content_set`] via [`build_shared_load_inputs`].
-    let inputs = build_shared_load_inputs(&scenario)?;
+    let inputs = build_shared_load_inputs(&validation_scenario)?;
 
     // ONE shared LoadContext for every rule in the content set — the
     // vocabulary/types/ceilings come from the SCENARIO, not from any one
@@ -777,27 +720,33 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
         // enforcement live — whatever the scenario declared (`Some`, or
         // `None` for a scenario declaring none at all, exactly today's
         // unchecked behavior) is what every rule loads against.
-        vocabulary_registry: scenario.vocabulary.as_ref(),
+        vocabulary_registry: validation_scenario.vocabulary.as_ref(),
         rule_file: "rule",
     };
 
     // rule_forms is `Vec<(String, SExpr)>` — each rule's id already paired
     // with its form by split_content (Task 2), so no second extraction
-    // here. Loaded in WHATEVER order split_content returned them (reader-
-    // encounter order, unspecified) — then SORTED by id, ascending byte
-    // order, before returning. This is the one place execution order gets
-    // decided (§4.2, register row D16): sorting here, once, at load time,
-    // means every later stage (TickSession::advance, run_once_into) just
-    // iterates the already-correct order and never re-derives it.
+    // here. Rules load in reader encounter order, then the preflighted plan
+    // places them on the 34-slot causal spine. D16 breaks only same-position
+    // ties by ascending rule-id bytes. This is the one place execution order
+    // gets decided, so every later stage just iterates the compiled order.
     let mut rules = Vec::with_capacity(rule_forms.len());
-    for (id, form) in rule_forms {
-        let loaded = load_rule_form(form, &ctx).map_err(|error| PrepareError::Rule {
+    for (id, form) in &rule_forms {
+        let loaded = load_rule_form(form.clone(), &ctx).map_err(|error| PrepareError::Rule {
             rule_id: Some(id.clone()),
             error,
         })?;
-        rules.push((id, loaded));
+        rules.push((id.clone(), loaded));
     }
-    rules.sort_by(|(a, _), (b, _)| a.as_bytes().cmp(b.as_bytes()));
+    let rule_order = phase_order::compile(&rule_forms).map_err(prepare_error_from_schedule)?;
+    let rules = rule_order
+        .apply(rules)
+        .map_err(prepare_error_from_schedule)?;
+
+    // All non-mutating validation has succeeded. Hydrate the caller graph
+    // exactly once and retain this pass's content-to-node identities, which
+    // may differ from the disposable graph when the caller was non-empty.
+    let scenario = hydrate_scenario(scenario_src, prelude_src, graph)?;
 
     Ok(PreparedRules {
         rules,
@@ -915,12 +864,13 @@ fn run_prepared_tick<G: GraphSubstrate + CanonicalState>(
     // (D-row Q1) repaired the within-rule half via `run_tick`'s
     // collect-then-apply split; this cross-rule half is a SEPARATE,
     // RECORDED gap — D-row Q14 (the query-evaluation plan's draft-ruling
-    // register) — latent today because every landed rule pack keeps its
-    // system position to exactly one rule (see `vitality.bsl`'s own
-    // header). This is a divergence to fix in its own train, not a
-    // design feature "inherited for free". The ORDER `prepared.rules`
-    // iterates in is rule-id byte order (`prepare_rules`'s sort), not the
-    // frozen engine's tick-position order.
+    // register). This behavior is live and observable: Community,
+    // Consciousness, ControlRatio, and other multi-rule packs intentionally
+    // exchange same-position writes. A shared-prestate repair therefore needs
+    // explicit content dispositions and new behavioral contracts; it is not
+    // supplied by PER-17. The ORDER `prepared.rules`
+    // iterates in is the executable phase registry's causal order; D16
+    // applies only to rules at the same resolved position.
     let mut per_rule_fired = Vec::with_capacity(prepared.rules.len());
     for (id, loaded) in &prepared.rules {
         let outcome = run_tick(
@@ -1005,8 +955,8 @@ impl std::fmt::Display for FuelBoundRow {
 /// Load one content set (scenario, optional declaration prelude, rule
 /// source) through the REAL production pipeline (`prepare_rules` — the same
 /// function `run_once`/`TickSession::new` use) and report its fuel bounds,
-/// one row per rule, in the SAME ascending rule-id byte order
-/// `prepare_rules` already sorts into (§4.2/D16).
+/// one row per rule, in the SAME governed phase order `prepare_rules`
+/// compiles. D16's ascending rule-ID byte order breaks same-position ties.
 ///
 /// This is a REPORT, not a gate: it runs no tick and changes no load
 /// behavior. The "same content the loader loads" guarantee is structural,

--- a/rust/crates/babylon-tick/src/phase_order.rs
+++ b/rust/crates/babylon-tick/src/phase_order.rs
@@ -14,7 +14,7 @@ const MATERIAL_BASE_COUNT: usize = 15;
 const ACTION_COUNT: usize = 1;
 const CONSEQUENCE_COUNT: usize = 18;
 const SYSTEM_COUNT: usize = MATERIAL_BASE_COUNT + ACTION_COUNT + CONSEQUENCE_COUNT;
-const AFTER_MATERIAL_BASE_RANK: u16 = 30;
+const AFTER_MATERIAL_BASE_RANK: usize = MATERIAL_BASE_COUNT * 2;
 
 /// The three contiguous causal partitions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -424,7 +424,8 @@ fn system_index(name: &str) -> Option<usize> {
 }
 
 fn is_material_base_interior(key: ExecutionKey) -> bool {
-    key.0 > 0 && key.0 < AFTER_MATERIAL_BASE_RANK
+    let rank = usize::from(key.0);
+    rank > 0 && rank < AFTER_MATERIAL_BASE_RANK
 }
 
 fn validate_registry() -> Result<(), ScheduleError> {
@@ -647,6 +648,15 @@ mod tests {
 
     #[test]
     fn material_base_boundary_anchors_are_legal_but_interior_anchors_are_not() {
+        let post_base = execution_key(
+            "mods/after-base",
+            Some(&AnchorDecl {
+                position: AnchorPosition::After,
+                system: "metabolism".to_owned(),
+            }),
+        )
+        .expect("the post-base boundary has a rank");
+        assert_eq!(usize::from(post_base.0), AFTER_MATERIAL_BASE_RANK);
         compile(&[rule("mods/before-base", "(anchor :before vitality)")])
             .expect("the pre-base boundary is legal");
         compile(&[rule("mods/after-base", "(anchor :after metabolism)")])

--- a/rust/crates/babylon-tick/src/phase_order.rs
+++ b/rust/crates/babylon-tick/src/phase_order.rs
@@ -1,0 +1,660 @@
+//! Executable BSL phase ordering (PER-17).
+//!
+//! The frozen Python registry is the transcription oracle for the 34-slot
+//! causal spine. BSL rule IDs inherit one governed system home, while an
+//! explicit `(anchor :before|:after <system>)` selects a boundary around a
+//! governed slot. Rules sharing one resolved position retain D16's ascending
+//! rule-ID byte order. Source and file order are never observable.
+
+use babylon_bsl::mod_anchors::{check_anchor, AnchorDecl, AnchorError, AnchorPosition};
+use babylon_bsl::reader::SExpr;
+use std::collections::{BTreeMap, HashSet};
+
+const MATERIAL_BASE_COUNT: usize = 15;
+const ACTION_COUNT: usize = 1;
+const CONSEQUENCE_COUNT: usize = 18;
+const SYSTEM_COUNT: usize = MATERIAL_BASE_COUNT + ACTION_COUNT + CONSEQUENCE_COUNT;
+const AFTER_MATERIAL_BASE_RANK: u16 = 30;
+
+/// The three contiguous causal partitions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TickPartition {
+    MaterialBase,
+    Action,
+    Consequence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SystemSlot {
+    name: &'static str,
+    partition: TickPartition,
+    ordinal: u8,
+}
+
+const SYSTEM_SLOTS: [SystemSlot; SYSTEM_COUNT] = [
+    SystemSlot {
+        name: "vitality",
+        partition: TickPartition::MaterialBase,
+        ordinal: 0,
+    },
+    SystemSlot {
+        name: "territory",
+        partition: TickPartition::MaterialBase,
+        ordinal: 1,
+    },
+    SystemSlot {
+        name: "substrate",
+        partition: TickPartition::MaterialBase,
+        ordinal: 2,
+    },
+    SystemSlot {
+        name: "production",
+        partition: TickPartition::MaterialBase,
+        ordinal: 3,
+    },
+    SystemSlot {
+        name: "tick-dynamics",
+        partition: TickPartition::MaterialBase,
+        ordinal: 4,
+    },
+    SystemSlot {
+        name: "reserve-army",
+        partition: TickPartition::MaterialBase,
+        ordinal: 5,
+    },
+    SystemSlot {
+        name: "community",
+        partition: TickPartition::MaterialBase,
+        ordinal: 6,
+    },
+    SystemSlot {
+        name: "lifecycle",
+        partition: TickPartition::MaterialBase,
+        ordinal: 7,
+    },
+    SystemSlot {
+        name: "solidarity",
+        partition: TickPartition::MaterialBase,
+        ordinal: 8,
+    },
+    SystemSlot {
+        name: "imperial-rent",
+        partition: TickPartition::MaterialBase,
+        ordinal: 9,
+    },
+    SystemSlot {
+        name: "transport",
+        partition: TickPartition::MaterialBase,
+        ordinal: 10,
+    },
+    SystemSlot {
+        name: "dispossession",
+        partition: TickPartition::MaterialBase,
+        ordinal: 11,
+    },
+    SystemSlot {
+        name: "decomposition",
+        partition: TickPartition::MaterialBase,
+        ordinal: 12,
+    },
+    SystemSlot {
+        name: "control-ratio",
+        partition: TickPartition::MaterialBase,
+        ordinal: 13,
+    },
+    SystemSlot {
+        name: "metabolism",
+        partition: TickPartition::MaterialBase,
+        ordinal: 14,
+    },
+    SystemSlot {
+        name: "ooda",
+        partition: TickPartition::Action,
+        ordinal: 15,
+    },
+    SystemSlot {
+        name: "faction-influence",
+        partition: TickPartition::Consequence,
+        ordinal: 16,
+    },
+    SystemSlot {
+        name: "doctrine",
+        partition: TickPartition::Consequence,
+        ordinal: 17,
+    },
+    SystemSlot {
+        name: "survival",
+        partition: TickPartition::Consequence,
+        ordinal: 18,
+    },
+    SystemSlot {
+        name: "struggle",
+        partition: TickPartition::Consequence,
+        ordinal: 19,
+    },
+    SystemSlot {
+        name: "consciousness",
+        partition: TickPartition::Consequence,
+        ordinal: 20,
+    },
+    SystemSlot {
+        name: "fascist-faction",
+        partition: TickPartition::Consequence,
+        ordinal: 21,
+    },
+    SystemSlot {
+        name: "allegiance",
+        partition: TickPartition::Consequence,
+        ordinal: 22,
+    },
+    SystemSlot {
+        name: "electoral",
+        partition: TickPartition::Consequence,
+        ordinal: 23,
+    },
+    SystemSlot {
+        name: "policy",
+        partition: TickPartition::Consequence,
+        ordinal: 24,
+    },
+    SystemSlot {
+        name: "sovereignty",
+        partition: TickPartition::Consequence,
+        ordinal: 25,
+    },
+    SystemSlot {
+        name: "market-scissors",
+        partition: TickPartition::Consequence,
+        ordinal: 26,
+    },
+    SystemSlot {
+        name: "contradiction",
+        partition: TickPartition::Consequence,
+        ordinal: 27,
+    },
+    SystemSlot {
+        name: "contradiction-field",
+        partition: TickPartition::Consequence,
+        ordinal: 28,
+    },
+    SystemSlot {
+        name: "field-derivative",
+        partition: TickPartition::Consequence,
+        ordinal: 29,
+    },
+    SystemSlot {
+        name: "collapse-transition",
+        partition: TickPartition::Consequence,
+        ordinal: 30,
+    },
+    SystemSlot {
+        name: "edge-transition",
+        partition: TickPartition::Consequence,
+        ordinal: 31,
+    },
+    SystemSlot {
+        name: "wealth-distribution",
+        partition: TickPartition::Consequence,
+        ordinal: 32,
+    },
+    SystemSlot {
+        name: "epistemic-horizon",
+        partition: TickPartition::Consequence,
+        ordinal: 33,
+    },
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SystemAlias {
+    name: &'static str,
+    canonical: &'static str,
+}
+
+/// Compatibility homes for already-landed content and conformance fixtures.
+const SYSTEM_ALIASES: [SystemAlias; 4] = [
+    SystemAlias {
+        name: "class-dynamics",
+        canonical: "tick-dynamics",
+    },
+    SystemAlias {
+        name: "economics",
+        canonical: "contradiction",
+    },
+    SystemAlias {
+        name: "organization",
+        canonical: "ooda",
+    },
+    SystemAlias {
+        name: "social-class",
+        canonical: "solidarity",
+    },
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct ExecutionKey(u16);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlannedRule {
+    id: String,
+    key: ExecutionKey,
+}
+
+/// A validated, deterministic content-set order compiled before hydration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuleOrderPlan {
+    rules: Vec<PlannedRule>,
+}
+
+/// A loud phase-registry or composition failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ScheduleError {
+    Anchor {
+        rule_id: String,
+        source: AnchorError,
+    },
+    MaterialBaseInterleave {
+        rule_id: String,
+        position: AnchorPosition,
+        system: String,
+    },
+    Registry {
+        message: String,
+    },
+    Plan {
+        rule_id: Option<String>,
+        message: String,
+    },
+}
+
+impl std::fmt::Display for ScheduleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Anchor { source, .. } => write!(f, "{source}"),
+            Self::MaterialBaseInterleave {
+                rule_id,
+                position,
+                system,
+            } => write!(
+                f,
+                "E-LOAD-003: rule {rule_id}'s explicit anchor :{} {system} cuts through the \
+                 interior of the Material Base partition — mods may target the boundary \
+                 before vitality or after metabolism, but cannot splice incidental order \
+                 into the governed material causal spine (§2.3)",
+                match position {
+                    AnchorPosition::Before => "before",
+                    AnchorPosition::After => "after",
+                }
+            ),
+            Self::Registry { message } => write!(f, "invalid phase registry: {message}"),
+            Self::Plan { message, .. } => write!(f, "invalid phase-order plan: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for ScheduleError {}
+
+/// Every canonical and compatibility system name accepted by BSL loading.
+pub(crate) fn registered_systems() -> HashSet<String> {
+    SYSTEM_SLOTS
+        .iter()
+        .map(|slot| slot.name.to_owned())
+        .chain(SYSTEM_ALIASES.iter().map(|alias| alias.name.to_owned()))
+        .collect()
+}
+
+/// Compile raw rule forms into their total execution order.
+pub(crate) fn compile(rule_forms: &[(String, SExpr)]) -> Result<RuleOrderPlan, ScheduleError> {
+    validate_registry()?;
+    let systems = registered_systems();
+    let mut planned = Vec::with_capacity(rule_forms.len());
+    let mut validation_order: Vec<_> = rule_forms.iter().collect();
+    validation_order.sort_by(|(a, _), (b, _)| a.as_bytes().cmp(b.as_bytes()));
+    for (id, form) in validation_order {
+        let anchor = check_anchor(form, &systems).map_err(|source| ScheduleError::Anchor {
+            rule_id: id.clone(),
+            source,
+        })?;
+        let key = execution_key(id, anchor.as_ref())?;
+        if let Some(anchor) = anchor {
+            if is_material_base_interior(key) {
+                return Err(ScheduleError::MaterialBaseInterleave {
+                    rule_id: id.clone(),
+                    position: anchor.position,
+                    system: anchor.system,
+                });
+            }
+        }
+        planned.push(PlannedRule {
+            id: id.clone(),
+            key,
+        });
+    }
+    planned.sort_by(|a, b| {
+        a.key
+            .cmp(&b.key)
+            .then_with(|| a.id.as_bytes().cmp(b.id.as_bytes()))
+    });
+    Ok(RuleOrderPlan { rules: planned })
+}
+
+impl RuleOrderPlan {
+    /// Apply this already-validated order to the corresponding loaded rules.
+    pub(crate) fn apply<T>(
+        self,
+        rules: Vec<(String, T)>,
+    ) -> Result<Vec<(String, T)>, ScheduleError> {
+        if self.rules.len() != rules.len() {
+            return Err(ScheduleError::Plan {
+                rule_id: None,
+                message: format!(
+                    "compiled {} rule ids but loading produced {} rules",
+                    self.rules.len(),
+                    rules.len()
+                ),
+            });
+        }
+        let mut by_id = BTreeMap::new();
+        for (id, loaded) in rules {
+            if by_id.insert(id.clone(), loaded).is_some() {
+                return Err(ScheduleError::Plan {
+                    rule_id: Some(id),
+                    message: "one loaded rule id appeared twice".to_owned(),
+                });
+            }
+        }
+        let mut ordered = Vec::with_capacity(self.rules.len());
+        for row in self.rules {
+            let Some(loaded) = by_id.remove(&row.id) else {
+                return Err(ScheduleError::Plan {
+                    rule_id: Some(row.id),
+                    message: "a compiled rule id was absent after loading".to_owned(),
+                });
+            };
+            ordered.push((row.id, loaded));
+        }
+        if let Some((id, _)) = by_id.into_iter().next() {
+            return Err(ScheduleError::Plan {
+                rule_id: Some(id),
+                message: "a loaded rule id was absent from the compiled order".to_owned(),
+            });
+        }
+        Ok(ordered)
+    }
+}
+
+fn execution_key(
+    rule_id: &str,
+    anchor: Option<&AnchorDecl>,
+) -> Result<ExecutionKey, ScheduleError> {
+    let (system, offset) = match anchor {
+        Some(anchor) => (
+            anchor.system.as_str(),
+            match anchor.position {
+                AnchorPosition::Before => 0_u16,
+                AnchorPosition::After => 2_u16,
+            },
+        ),
+        None => (rule_id.split('/').next().unwrap_or_default(), 1_u16),
+    };
+    let index = system_index(system).ok_or_else(|| ScheduleError::Plan {
+        rule_id: Some(rule_id.to_owned()),
+        message: format!("registered system {system:?} has no governed slot"),
+    })?;
+    let ordinal = u16::try_from(index).map_err(|_| ScheduleError::Registry {
+        message: format!("system index {index} exceeds u16"),
+    })?;
+    let rank = ordinal
+        .checked_mul(2)
+        .and_then(|base| base.checked_add(offset))
+        .ok_or_else(|| ScheduleError::Registry {
+            message: format!("execution rank overflow for system {system}"),
+        })?;
+    Ok(ExecutionKey(rank))
+}
+
+fn system_index(name: &str) -> Option<usize> {
+    if let Some(index) = SYSTEM_SLOTS.iter().position(|slot| slot.name == name) {
+        return Some(index);
+    }
+    let canonical = SYSTEM_ALIASES
+        .iter()
+        .find(|alias| alias.name == name)?
+        .canonical;
+    SYSTEM_SLOTS.iter().position(|slot| slot.name == canonical)
+}
+
+fn is_material_base_interior(key: ExecutionKey) -> bool {
+    key.0 > 0 && key.0 < AFTER_MATERIAL_BASE_RANK
+}
+
+fn validate_registry() -> Result<(), ScheduleError> {
+    let mut names = HashSet::with_capacity(SYSTEM_COUNT + SYSTEM_ALIASES.len());
+    for (index, slot) in SYSTEM_SLOTS.iter().enumerate() {
+        let expected_ordinal = u8::try_from(index).map_err(|_| ScheduleError::Registry {
+            message: format!("system index {index} exceeds u8"),
+        })?;
+        if slot.ordinal != expected_ordinal {
+            return Err(ScheduleError::Registry {
+                message: format!(
+                    "system {} declares ordinal {} at index {index}",
+                    slot.name, slot.ordinal
+                ),
+            });
+        }
+        let expected_partition = partition_at(index);
+        if slot.partition != expected_partition {
+            return Err(ScheduleError::Registry {
+                message: format!("system {} breaks the 15/1/18 partition blocks", slot.name),
+            });
+        }
+        if !names.insert(slot.name) {
+            return Err(ScheduleError::Registry {
+                message: format!("duplicate canonical system name {}", slot.name),
+            });
+        }
+    }
+    for alias in SYSTEM_ALIASES {
+        if !names.insert(alias.name) {
+            return Err(ScheduleError::Registry {
+                message: format!("duplicate or colliding system alias {}", alias.name),
+            });
+        }
+        if !SYSTEM_SLOTS.iter().any(|slot| slot.name == alias.canonical) {
+            return Err(ScheduleError::Registry {
+                message: format!(
+                    "system alias {} names missing canonical target {}",
+                    alias.name, alias.canonical
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn partition_at(index: usize) -> TickPartition {
+    if index < MATERIAL_BASE_COUNT {
+        TickPartition::MaterialBase
+    } else if index < MATERIAL_BASE_COUNT + ACTION_COUNT {
+        TickPartition::Action
+    } else {
+        TickPartition::Consequence
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use babylon_bsl::reader::read;
+
+    fn form(source: &str) -> SExpr {
+        read(source).expect("phase-order fixture parses").0
+    }
+
+    fn rule(id: &str, anchor: &str) -> (String, SExpr) {
+        let source = format!(
+            "(rule {id} :material-basis \"x\" :fuel 8 {anchor} \
+             (bindings) (effects (emit EventType/RUPTURE)))"
+        );
+        (id.to_owned(), form(&source))
+    }
+
+    fn ids(plan: &RuleOrderPlan) -> Vec<&str> {
+        plan.rules.iter().map(|row| row.id.as_str()).collect()
+    }
+
+    #[test]
+    fn registry_matches_the_frozen_34_slot_spine() {
+        let names: Vec<&str> = SYSTEM_SLOTS.iter().map(|slot| slot.name).collect();
+        assert_eq!(
+            names,
+            [
+                "vitality",
+                "territory",
+                "substrate",
+                "production",
+                "tick-dynamics",
+                "reserve-army",
+                "community",
+                "lifecycle",
+                "solidarity",
+                "imperial-rent",
+                "transport",
+                "dispossession",
+                "decomposition",
+                "control-ratio",
+                "metabolism",
+                "ooda",
+                "faction-influence",
+                "doctrine",
+                "survival",
+                "struggle",
+                "consciousness",
+                "fascist-faction",
+                "allegiance",
+                "electoral",
+                "policy",
+                "sovereignty",
+                "market-scissors",
+                "contradiction",
+                "contradiction-field",
+                "field-derivative",
+                "collapse-transition",
+                "edge-transition",
+                "wealth-distribution",
+                "epistemic-horizon",
+            ]
+        );
+        validate_registry().expect("the governed registry is internally valid");
+    }
+
+    #[test]
+    fn partitions_are_contiguous_fifteen_one_eighteen() {
+        let base = SYSTEM_SLOTS
+            .iter()
+            .filter(|slot| slot.partition == TickPartition::MaterialBase)
+            .count();
+        let action = SYSTEM_SLOTS
+            .iter()
+            .filter(|slot| slot.partition == TickPartition::Action)
+            .count();
+        let consequence = SYSTEM_SLOTS
+            .iter()
+            .filter(|slot| slot.partition == TickPartition::Consequence)
+            .count();
+        assert_eq!((base, action, consequence), (15, 1, 18));
+    }
+
+    #[test]
+    fn default_homes_put_decomposition_before_control_ratio() {
+        let input = vec![rule("control-ratio/z", ""), rule("decomposition/a", "")];
+        assert_eq!(
+            ids(&compile(&input).unwrap()),
+            ["decomposition/a", "control-ratio/z"]
+        );
+    }
+
+    #[test]
+    fn an_explicit_anchor_overrides_the_rule_id_namespace() {
+        let input = vec![
+            rule("vitality/z", ""),
+            rule("mods/a", "(anchor :before survival)"),
+        ];
+        assert_eq!(ids(&compile(&input).unwrap()), ["vitality/z", "mods/a"]);
+    }
+
+    #[test]
+    fn one_position_ties_by_rule_id_bytes() {
+        let input = vec![rule("vitality/z", ""), rule("vitality/a", "")];
+        assert_eq!(ids(&compile(&input).unwrap()), ["vitality/a", "vitality/z"]);
+    }
+
+    #[test]
+    fn after_previous_and_before_next_share_one_boundary() {
+        let after = execution_key(
+            "mods/z",
+            Some(&AnchorDecl {
+                position: AnchorPosition::After,
+                system: "ooda".to_owned(),
+            }),
+        )
+        .unwrap();
+        let before = execution_key(
+            "mods/a",
+            Some(&AnchorDecl {
+                position: AnchorPosition::Before,
+                system: "faction-influence".to_owned(),
+            }),
+        )
+        .unwrap();
+        assert_eq!(after, before);
+    }
+
+    #[test]
+    fn source_permutations_compile_to_the_same_order() {
+        let a = rule("vitality/z", "");
+        let b = rule("mods/a", "(anchor :before survival)");
+        let forward = compile(&[a.clone(), b.clone()]).unwrap();
+        let reversed = compile(&[b, a]).unwrap();
+        assert_eq!(forward, reversed);
+    }
+
+    #[test]
+    fn invalid_source_permutations_name_the_same_byte_least_rule() {
+        let a = rule("mods/a-illegal", "(anchor :after vitality)");
+        let z = rule("mods/z-illegal", "(anchor :before metabolism)");
+        let forward = compile(&[z.clone(), a.clone()]).unwrap_err();
+        let reversed = compile(&[a, z]).unwrap_err();
+
+        assert_eq!(forward, reversed);
+        assert!(matches!(
+            forward,
+            ScheduleError::MaterialBaseInterleave { ref rule_id, .. }
+                if rule_id == "mods/a-illegal"
+        ));
+    }
+
+    #[test]
+    fn compatibility_names_have_governed_canonical_homes() {
+        for (alias, canonical) in [
+            ("class-dynamics", "tick-dynamics"),
+            ("economics", "contradiction"),
+            ("organization", "ooda"),
+            ("social-class", "solidarity"),
+        ] {
+            assert_eq!(system_index(alias), system_index(canonical));
+        }
+    }
+
+    #[test]
+    fn material_base_boundary_anchors_are_legal_but_interior_anchors_are_not() {
+        compile(&[rule("mods/before-base", "(anchor :before vitality)")])
+            .expect("the pre-base boundary is legal");
+        compile(&[rule("mods/after-base", "(anchor :after metabolism)")])
+            .expect("the post-base boundary is legal");
+        let error = compile(&[rule("mods/interior", "(anchor :after vitality)")]).unwrap_err();
+        assert!(matches!(
+            error,
+            ScheduleError::MaterialBaseInterleave { .. }
+        ));
+    }
+}

--- a/rust/crates/babylon-tick/src/session.rs
+++ b/rust/crates/babylon-tick/src/session.rs
@@ -5,9 +5,9 @@
 //! loop needs the split this type provides instead: parse and load cost
 //! paid ONCE in `new`, the SAME `PreparedRules` and the SAME graph reused
 //! by every `advance()` call, every rule in the content set run once per
-//! call, in ascending rule-id byte order (§4.2, register row D16/D100 —
-//! `prepare_rules` sorts once at load time), with `tick` incremented by
-//! this type.
+//! call in the governed 34-slot causal order, with `tick` incremented by
+//! this type. D16's ascending rule-ID byte order breaks ties at one resolved
+//! position.
 
 use crate::{prepare_rules, PreparedRules, TickReport};
 use babylon_bsl::intrinsic_host::KernelIntrinsicHost;
@@ -34,9 +34,9 @@ pub struct TickSession<G> {
 
 impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
     /// Parse `rule_src` (one or more `(rule …)` forms) and load
-    /// `scenario_src` into `graph` once. `prepare_rules` sorts the forms
-    /// into ascending rule-id byte order (§4.2, D16/D100) before this
-    /// returns — the caller's own concatenation order is never observable.
+    /// `scenario_src` into `graph` once. `prepare_rules` compiles the forms
+    /// into governed phase order before this returns — the caller's own
+    /// concatenation order is never observable.
     ///
     /// `session` is this session's `rng-draw` identity (plan §3.5) — a
     /// caller-supplied, deterministic id (III.7: never a UUID, never a
@@ -98,12 +98,12 @@ impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
     }
 
     /// Run one more tick against the held graph: every rule in the
-    /// content set, in ASCENDING RULE-ID BYTE ORDER (§4.2, D16/D100 —
-    /// sorted once, at load time, by `prepare_rules`), each to completion
-    /// before the next starts, against the SAME graph — so a later rule
-    /// sees an earlier rule's writes from this same tick, matching the
-    /// frozen engine's own in-place strict-order semantics (inherited
-    /// from calling `run_tick` sequentially against one `&mut G`).
+    /// content set in the governed phase order compiled once at load time
+    /// by `prepare_rules`. D16 orders same-position ties by rule-ID bytes.
+    /// Each rule runs to completion before the next starts against the SAME
+    /// graph, so a later rule sees an earlier rule's writes from this same
+    /// tick, matching the frozen engine's own in-place strict-order semantics
+    /// (inherited from calling `run_tick` sequentially against one `&mut G`).
     ///
     /// **This is a RECORDED GAP, not a design feature.** §4.2 says "rules
     /// within one system position observe the same pre-state"
@@ -112,10 +112,11 @@ impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
     /// (D-row Q1) repaired the within-rule half (`run_tick`'s
     /// collect-then-apply split); this cross-rule half is a separate,
     /// still-open divergence — D-row Q14 (the query-evaluation plan's
-    /// draft-ruling register) — latent today because every landed rule
-    /// pack keeps its system position to exactly one rule. The first call
-    /// runs tick 1 (matching `run_once`'s own numbering), the second tick
-    /// 2, and so on.
+    /// draft-ruling register). It is live and observable in multi-rule packs
+    /// that exchange same-position writes. PER-17 preserves that behavior;
+    /// repairing it needs explicit content dispositions and behavioral
+    /// contracts. The first call runs tick 1 (matching `run_once`'s own
+    /// numbering), the second tick 2, and so on.
     ///
     /// # Errors
     /// The tick itself (named to its own rule id), or a pre/post

--- a/rust/crates/babylon-tick/tests/carceral_arc_conformance.rs
+++ b/rust/crates/babylon-tick/tests/carceral_arc_conformance.rs
@@ -36,7 +36,8 @@
 //! tick from 1 to 112, sharing ONE `TickContext.persistent_data` (matching
 //! the frozen engine's own single `context` threaded through every system
 //! every tick — the composition this whole arc proves the ported estate
-//! reproduces despite §5's byte-order inversion, below). Run from the
+//! reproduces. The historical §5 byte-order inversion is superseded by the
+//! executable phase registry below. Run from the
 //! repository root:
 //!
 //! ```text
@@ -74,31 +75,14 @@
 //! ORDERING oracle, never a byte oracle; every numeric assertion below is
 //! measured from THIS engine's own run).
 //!
-//! # The cross-pack byte-order inversion (§5) — why the schedule still
-//! holds
+//! # Executable phase ordering
 //!
-//! `control-ratio/*` sorts BEFORE `decomposition/*` in ascending rule-id
-//! byte order (`'c' < 'd'` at the NAMESPACE segment — `control-ratio/`
-//! vs `decomposition/` — the comparison already resolves there and never
-//! reaches the rule-local `c01` vs `p01` prefixes), inverting the frozen
-//! @11.0-then-@12.0 system order: within EVERY tick, `c01`-`c04` run to
-//! completion before
-//! `p01`-`p06` start. The only cross-pack datum `control-ratio/*` reads is
-//! the carrier's `institution/decomposition-fire-tick`/`-fired-known`
-//! (written by `decomposition/p03-trigger`) — so on the tick decomposition
-//! ACTUALLY fires (tick 53 here), `c03`'s readiness gate reads THOSE
-//! fields' PRE-tick-53 values (still 0, since `p03` has not run yet this
-//! tick), one rule-order "behind". This is invisible to this arc's own
-//! schedule because `control_ratio_delay` is the SHIPPED 52, not 0 — the
-//! earliest `c03` could possibly fire is `53 + 52 = 105` regardless of
-//! whether it sees `fired-known` become 1 on tick 53 or tick 54 (one
-//! rule-order later than the write, but 51 ticks before the delay clears
-//! either way). `the_byte_order_inversion_delays_a_same_tick_race_by_
-//! exactly_one_tick` below is this constraint's EXECUTABLE form (plan §5's
-//! own instruction: "a test that fails if the constraint is violated") —
-//! an isolated, minimal fixture with `control-ratio-delay 0` and an
-//! UNSEEDED fire tick, where the one-rule-order lag is the ONLY thing
-//! standing between "no crisis" and "a crisis" on the firing tick.
+//! The governed registry places Decomposition @11 before ControlRatio @12.
+//! The ordinary 52-tick delay keeps the full arc's milestone schedule at
+//! 1/53/105/106. The zero-delay fixture below makes the ordering observable:
+//! ControlRatio must see Decomposition's same-tick carrier write and emit its
+//! crisis on tick 1. A global rule-id sort would invert the packs because
+//! `'c' < 'd'` and delay that crisis to tick 2.
 
 use babylon_bsl::evaluator::Value;
 use babylon_bsl::structural_verbs::CollectingSink;
@@ -125,9 +109,9 @@ const LUMPEN: NodeId = NodeId(3);
 const BOURGEOIS: NodeId = NodeId(4);
 const CARCERAL_REGISTER: NodeId = NodeId(5);
 
-/// Both packs, concatenated — `TickSession::new`/`prepare_rules` sorts by
-/// ascending rule-id byte order regardless of concatenation order
-/// (§4.2/D16/D100), so this order is arbitrary, matching
+/// Both packs, concatenated — `TickSession::new`/`prepare_rules` resolves
+/// the governed phase order regardless of concatenation order, so this
+/// order is arbitrary, matching
 /// `us_counties_lifecycle_demo_hashes_are_pinned`'s own `format!` idiom
 /// (`tick_goldens.rs`).
 fn joint_rule_src() -> String {
@@ -364,14 +348,12 @@ fn the_arc_post_session_class_states_match_the_frozen_mirror() {
 }
 
 // ---------------------------------------------------------------------
-// Step 4 — the byte-order constraint, made executable (plan §5's own
-// instruction: "a test that fails if the constraint is violated").
+// Step 4 — the governed phase order, made executable.
 // ---------------------------------------------------------------------
 
-/// `control-ratio/*` sorts BEFORE `decomposition/*` (`'c' < 'd'` at the
-/// NAMESPACE segment, ascending rule-id byte order), so within any ONE tick every
-/// `control-ratio/*` rule completes before any `decomposition/*` rule
-/// starts. This fixture isolates the ONE cross-pack datum that matters
+/// The registry places `decomposition/*` before `control-ratio/*`, despite
+/// the opposite global rule-id byte order. This fixture isolates the ONE
+/// cross-pack datum that matters
 /// (`institution/decomposition-fire-tick`/`-fired-known`) from every other
 /// variable: `control-ratio-delay` is 0 (so if `c03` could see
 /// `fired-known` become 1 on the SAME tick it is written, its readiness
@@ -508,22 +490,15 @@ const BOR_LA_DYING: NodeId = NodeId(0);
 const BOR_LUMPEN: NodeId = NodeId(1);
 const BOR_CARCERAL_REGISTER: NodeId = NodeId(2);
 
-/// **The byte-order constraint's executable form.** At tick 1
+/// **The phase-order contract's executable form.** At tick 1
 /// (`decomposition/p03-trigger`'s fallback fires and writes
 /// `decomposition-fire-tick 1`/`decomposition-fired-known 1` for the FIRST
-/// time, THIS tick), `control-ratio/c03-crisis` — which ran BEFORE `p03`
-/// this same tick, byte order — must NOT see those writes yet: its
-/// readiness gate reads the PRE-tick-1 seeded values (both 0), so `ready`
-/// is false and NO `CONTROL_RATIO_CRISIS` fires, even though the census
-/// (0 enforcers, 100 prisoners, the zero-enforcer branch's "any nonzero
-/// prisoner population is over capacity" shape) would otherwise clear
-/// every other gate. At tick 2, `fired-known`/`fire-tick` are readable (the
-/// writes are visible from the NEXT tick onward), `control-ratio-delay 0`
-/// clears the delay check immediately (`2 >= 1 + 0`), and the crisis DOES
-/// fire — proving the hazard is a benign ONE-TICK LAG, not a permanent
-/// block (§5's own claim, made executable rather than asserted in prose).
+/// time, THIS tick), `control-ratio/c03-crisis` runs afterward and must see
+/// those writes. With zero enforcers, 100 prisoners, and delay 0, every gate
+/// clears and `CONTROL_RATIO_CRISIS` fires on tick 1. Its latch prevents a
+/// duplicate crisis on tick 2.
 #[test]
-fn the_byte_order_inversion_delays_a_same_tick_race_by_exactly_one_tick() {
+fn governed_phase_order_exposes_decomposition_to_control_ratio_in_the_same_tick() {
     let rule_src = joint_rule_src();
     let mut session = TickSession::new(
         BYTE_ORDER_SCENARIO,
@@ -560,9 +535,8 @@ fn the_byte_order_inversion_delays_a_same_tick_race_by_exactly_one_tick() {
         .collect();
     assert_eq!(
         crises_tick1.len(),
-        0,
-        "tick 1: NO CONTROL_RATIO_CRISIS — c03 (byte order 'c' < 'd', namespace segment) ran BEFORE p03 wrote \
-         decomposition-fired-known this tick, so it read the SEEDED 0, not the tick-1 write"
+        1,
+        "tick 1: Decomposition @11 writes before ControlRatio @12 reads, so the zero-delay crisis fires now"
     );
 
     let mut sink2 = CollectingSink::default();
@@ -574,9 +548,8 @@ fn the_byte_order_inversion_delays_a_same_tick_race_by_exactly_one_tick() {
         .collect();
     assert_eq!(
         crises_tick2.len(),
-        1,
-        "tick 2: decomposition-fired-known (written at tick 1) is now readable — the crisis \
-         fires exactly one tick later, proving the hazard is benign, not a permanent block"
+        0,
+        "tick 2: the crisis latch prevents a duplicate after the phase-ordered tick-1 emission"
     );
     assert_eq!(
         attribute(
@@ -591,7 +564,6 @@ fn the_byte_order_inversion_delays_a_same_tick_race_by_exactly_one_tick() {
     assert_eq!(
         attribute(session.graph(), BOR_LA_DYING, "social-class/active"),
         0.0,
-        "la-dying: deactivated by p06 at tick 1 — its own decomposition is unaffected by \
-         the byte-order race, only control-ratio's downstream read of it is"
+        "la-dying: deactivated by p06 at tick 1 before ControlRatio's downstream read"
     );
 }

--- a/rust/crates/babylon-tick/tests/diagnose_seam.rs
+++ b/rust/crates/babylon-tick/tests/diagnose_seam.rs
@@ -103,6 +103,14 @@ const ILLEGAL_PHASE_RULE: &str = r#"(rule mods/illegal-material-base-interleave
   (bindings)
   (effects (emit EventType/PROBE)))"#;
 
+const DUPLICATE_ID_WITH_ILLEGAL_PHASE: &str = r#"(rule economics/fundamental-theorem
+  :material-basis "duplicate identity makes phase placement undefined"
+  :fuel 64
+  (domain :graph)
+  (anchor :after vitality)
+  (bindings)
+  (effects (emit EventType/PROBE)))"#;
+
 #[test]
 fn a_clean_content_set_diagnoses_empty() {
     let errors = diagnose_content_set(SCENARIO, None, &[RULE]);
@@ -150,4 +158,17 @@ fn duplicate_rule_ids_across_sources_are_one_structured_e_load_001() {
     assert_eq!(errors.len(), 1, "{errors:?}");
     assert_eq!(errors[0].spec_code(), Some("E-LOAD-001"));
     assert!(errors[0].to_string().contains("fundamental-theorem"));
+}
+
+#[test]
+fn duplicate_rule_ids_suppress_phase_diagnostics_in_both_source_orders() {
+    for sources in [
+        [RULE, DUPLICATE_ID_WITH_ILLEGAL_PHASE],
+        [DUPLICATE_ID_WITH_ILLEGAL_PHASE, RULE],
+    ] {
+        let errors = diagnose_content_set(SCENARIO, None, &sources);
+
+        assert_eq!(errors.len(), 1, "{errors:?}");
+        assert_eq!(errors[0].spec_code(), Some("E-LOAD-001"));
+    }
 }

--- a/rust/crates/babylon-tick/tests/diagnose_seam.rs
+++ b/rust/crates/babylon-tick/tests/diagnose_seam.rs
@@ -95,6 +95,14 @@ const BROKEN_RULE_MATERIAL_BASIS: &str = r#"(rule vitality/broken-material-basis
   (when (> wages 0))
   (effects (emit EventType/PROBE)))"#;
 
+const ILLEGAL_PHASE_RULE: &str = r#"(rule mods/illegal-material-base-interleave
+  :material-basis "an independent causal-composition refusal"
+  :fuel 64
+  (domain :graph)
+  (anchor :after vitality)
+  (bindings)
+  (effects (emit EventType/PROBE)))"#;
+
 #[test]
 fn a_clean_content_set_diagnoses_empty() {
     let errors = diagnose_content_set(SCENARIO, None, &[RULE]);
@@ -124,4 +132,22 @@ fn a_scenario_that_redeclares_an_implicit_strength_field_yields_a_structured_cod
     assert_eq!(errors.len(), 1, "{errors:?}");
     assert_ne!(errors[0].spec_code(), None, "{errors:?}");
     assert_eq!(errors[0].spec_code(), Some("E-LOAD-001"));
+}
+
+#[test]
+fn a_bad_rule_does_not_hide_an_independent_phase_composition_failure() {
+    let errors = diagnose_content_set(SCENARIO, None, &[BROKEN_RULE_FUEL, ILLEGAL_PHASE_RULE]);
+
+    assert_eq!(errors.len(), 2, "{errors:?}");
+    assert_eq!(errors[0].spec_code(), Some("E-PARSE-012"));
+    assert_eq!(errors[1].spec_code(), Some("E-LOAD-003"));
+}
+
+#[test]
+fn duplicate_rule_ids_across_sources_are_one_structured_e_load_001() {
+    let errors = diagnose_content_set(SCENARIO, None, &[RULE, RULE]);
+
+    assert_eq!(errors.len(), 1, "{errors:?}");
+    assert_eq!(errors[0].spec_code(), Some("E-LOAD-001"));
+    assert!(errors[0].to_string().contains("fundamental-theorem"));
 }

--- a/rust/crates/babylon-tick/tests/multi_rule_conformance.rs
+++ b/rust/crates/babylon-tick/tests/multi_rule_conformance.rs
@@ -4,21 +4,14 @@
 //!
 //! # What this proves
 //!
-//! 1. **The driver sorts by ascending rule-id byte order** (§4.2, register
-//!    row D16/D100), not by declaration/concatenation order — `'l' < 'v'`,
-//!    so `per_rule_fired[0]` is always `lifecycle/dpd-circuit` and
-//!    `per_rule_fired[1]` is always `vitality/subsistence-and-death`,
-//!    REGARDLESS of which order the caller concatenates the two `.bsl`
-//!    files in (`byte_order_sort_reproduces_the_frozen_engine_despite_
-//!    running_reversed` builds `rule_src` vitality-first; `file_order_is_
-//!    never_observable_per_section_4_2` proves the OTHER concatenation
-//!    order produces a byte-identical `TickReport`, including
-//!    `per_rule_fired`'s own order — the actual property §4.2 promises).
-//! 2. **The sorted (reverse-of-engine-order) result reproduces the frozen
-//!    engine's own combined output** for this pair, despite running
-//!    backwards from the frozen engine's Vitality-@1-before-Lifecycle-@7 —
-//!    safe here only because the two rules' domains are disjoint (the
-//!    plan's Multi-Rule Decision section), which
+//! 1. **The executable phase registry orders rules by governed system slot,**
+//!    not by declaration order or global rule-id bytes. Vitality @1 runs
+//!    before Lifecycle @7 even though `'l' < 'v'`. The second test proves
+//!    both source permutations produce a byte-identical `TickReport`,
+//!    including `per_rule_fired`'s resolved order.
+//! 2. **The phase-ordered result reproduces the frozen engine's own combined
+//!    output** for this pair. The rules' domains are disjoint (the plan's
+//!    Multi-Rule Decision section), which
 //!    `vitality_lifecycle_combined_conformance.py` proves EMPIRICALLY (not
 //!    just by reading the bindings): it runs both engine-order and
 //!    reverse-order against two independently-built copies of the same
@@ -220,7 +213,7 @@ fn assert_post_tick_state_matches(graph: &HypergraphStore) {
 }
 
 #[test]
-fn byte_order_sort_reproduces_the_frozen_engine_despite_running_reversed() {
+fn governed_phase_order_reproduces_the_frozen_engine() {
     // Concatenation order here is arbitrary on purpose (vitality text
     // first) — the second test below proves the OTHER concatenation order
     // gives an identical report, which is the actual claim this task makes.
@@ -229,23 +222,21 @@ fn byte_order_sort_reproduces_the_frozen_engine_despite_running_reversed() {
     let mut sink = CollectingSink::default();
     let report = run_once_into(SCENARIO, &rule_src, &mut graph, &mut sink).expect("tick");
 
-    // THE ORDER PROOF — ascending rule-id byte order puts lifecycle FIRST
-    // ('l' < 'v'), the reverse of the frozen engine's Vitality-@1-before-
-    // Lifecycle-@7. Per the Multi-Rule Decision section, the final hash
-    // would not, by itself, distinguish "sorts by id" from "preserves file
-    // order" for this pair, so per_rule_fired's own order is the
-    // load-bearing assertion.
+    // THE ORDER PROOF — the phase registry puts Vitality @1 before
+    // Lifecycle @7 even though the rule ids sort in the opposite order.
+    // The final hash would not distinguish the two for this disjoint pair,
+    // so per_rule_fired's own order is the load-bearing assertion.
     assert_eq!(report.per_rule_fired.len(), 2);
-    assert_eq!(report.per_rule_fired[0].0, "lifecycle/dpd-circuit");
-    assert_eq!(report.per_rule_fired[1].0, "vitality/subsistence-and-death");
+    assert_eq!(report.per_rule_fired[0].0, "vitality/subsistence-and-death");
+    assert_eq!(report.per_rule_fired[1].0, "lifecycle/dpd-circuit");
     // Exact counts, pinned from the Python reference: lifecycle fires
     // unconditionally on every territory (no `(when …)` guard on the
     // rule); vitality fires on 5 of 6 social classes (`dissolved` fails
     // the `(and (= active 1) (> population 0))` guard) — the SAME counts
     // vitality-conformance.bscn's and lifecycle-conformance.bscn's own
     // individually-pinned tests already assert, unchanged by union.
-    assert_eq!(report.per_rule_fired[0].1, 4, "lifecycle fired count");
-    assert_eq!(report.per_rule_fired[1].1, 5, "vitality fired count");
+    assert_eq!(report.per_rule_fired[0].1, 5, "vitality fired count");
+    assert_eq!(report.per_rule_fired[1].1, 4, "lifecycle fired count");
 
     // Per-node field values match the Python reference's printed output —
     // proven order-invariant by that script's own engine-order vs.
@@ -259,8 +250,8 @@ fn file_order_is_never_observable_per_section_4_2() {
     // sets built from the SAME two rules in DIFFERENT concatenation order
     // must produce BYTE-IDENTICAL TickReports — not merely the same hash,
     // the same report in full, including per_rule_fired's order (which
-    // must be IDENTICAL, not flipped, because the driver sorts rather
-    // than preserving file order).
+    // must be IDENTICAL, not flipped, because the driver resolves the
+    // governed phase order rather than preserving file order).
     let forward = format!("{VITALITY}\n{LIFECYCLE}");
     let reversed = format!("{LIFECYCLE}\n{VITALITY}");
 

--- a/rust/crates/babylon-tick/tests/phase_anchor_conformance.rs
+++ b/rust/crates/babylon-tick/tests/phase_anchor_conformance.rs
@@ -1,0 +1,161 @@
+//! Executable phase-anchor acceptance vectors (PER-17).
+
+use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::hypergraph_store::HypergraphStore;
+use babylon_graph::state_hash::CanonicalState;
+use babylon_tick::{diagnose_content_set, run_once_into};
+
+const SCENARIO: &str = include_str!("../content/scenarios/two-classes.bscn");
+
+const VITALITY_RULE: &str = r#"
+(rule vitality/z-default-home
+  :material-basis "biological reproduction is resolved in the vitality phase"
+  :fuel 16
+  (bindings (binding wages :field social-class/wages))
+  (effects (emit EventType/RUPTURE (probe 1))))
+"#;
+
+const BEFORE_SURVIVAL_RULE: &str = r#"
+(rule mods/a-before-survival
+  :material-basis "a consequence-phase probe runs at its declared governed boundary"
+  :fuel 16
+  (anchor :before survival)
+  (bindings (binding wages :field social-class/wages))
+  (effects (emit EventType/RUPTURE (probe 2))))
+"#;
+
+fn run(rule_src: &str) -> babylon_tick::TickReport {
+    let mut graph = HypergraphStore::new();
+    let mut sink = CollectingSink::default();
+    run_once_into(SCENARIO, rule_src, &mut graph, &mut sink).expect("phase-ordered tick")
+}
+
+#[test]
+fn an_explicit_anchor_uses_the_governed_system_spine_not_global_rule_id_order() {
+    let forward = format!("{BEFORE_SURVIVAL_RULE}\n{VITALITY_RULE}");
+    let reversed = format!("{VITALITY_RULE}\n{BEFORE_SURVIVAL_RULE}");
+    let report_a = run(&forward);
+    let report_b = run(&reversed);
+
+    let expected = vec![
+        ("vitality/z-default-home".to_owned(), 2),
+        ("mods/a-before-survival".to_owned(), 2),
+    ];
+    assert_eq!(report_a.per_rule_fired, expected);
+    assert_eq!(report_b.per_rule_fired, expected);
+    assert_eq!(report_a.before, report_b.before);
+    assert_eq!(report_a.after, report_b.after);
+}
+
+fn assert_rejected_before_hydration(rule_src: &str, code: Option<&str>, text: &str) {
+    let mut graph = HypergraphStore::new();
+    let before = graph.state_hash().expect("empty hash");
+    let mut sink = CollectingSink::default();
+    let error = run_once_into(SCENARIO, rule_src, &mut graph, &mut sink)
+        .expect_err("invalid phase composition must fail");
+    let after = graph.state_hash().expect("post-refusal hash");
+
+    if let Some(code) = code {
+        assert!(error.contains(code), "expected {code}, got {error}");
+    }
+    assert!(error.contains(text), "expected {text:?}, got {error}");
+    assert_eq!(after, before, "composition failure must precede hydration");
+    assert!(sink.events.is_empty(), "composition failure emits nothing");
+}
+
+#[test]
+fn an_anchor_that_cuts_through_material_base_is_e_load_003_before_hydration() {
+    let rule = r#"
+(rule mods/illegal-interleave
+  :material-basis "a mod cannot splice incidental work into the material causal spine"
+  :fuel 16
+  (domain :graph)
+  (anchor :after vitality)
+  (bindings)
+  (effects (emit EventType/RUPTURE)))
+"#;
+    assert_rejected_before_hydration(rule, Some("E-LOAD-003"), "Material Base");
+}
+
+#[test]
+fn diagnostic_loading_reports_the_same_phase_composition_refusal() {
+    let rule = r#"
+(rule mods/illegal-diagnostic-interleave
+  :material-basis "diagnostics and execution share one causal-placement compiler"
+  :fuel 16
+  (domain :graph)
+  (anchor :after vitality)
+  (bindings)
+  (effects (emit EventType/RUPTURE)))
+"#;
+    let errors = diagnose_content_set(SCENARIO, None, &[rule]);
+
+    assert_eq!(errors.len(), 1, "{errors:?}");
+    assert_eq!(errors[0].spec_code(), Some("E-LOAD-003"));
+    assert!(errors[0].to_string().contains("Material Base"));
+}
+
+#[test]
+fn rule_surface_failure_precedes_phase_composition_without_hydration() {
+    let rule = r#"
+(rule mods/invalid-fuel-and-placement
+  :material-basis "surface validation remains earlier than causal composition"
+  :fuel 0
+  (domain :graph)
+  (anchor :after vitality)
+  (bindings)
+  (effects (emit EventType/RUPTURE)))
+"#;
+    assert_rejected_before_hydration(rule, Some("E-PARSE-012"), ":fuel");
+}
+
+#[test]
+fn scenario_failure_precedes_phase_composition_without_hydration() {
+    let rule = r#"
+(rule mods/invalid-placement-after-bad-scenario
+  :material-basis "scenario validation remains earlier than causal composition"
+  :fuel 16
+  (domain :graph)
+  (anchor :after vitality)
+  (bindings)
+  (effects (emit EventType/RUPTURE)))
+"#;
+    let mut graph = HypergraphStore::new();
+    let before = graph.state_hash().expect("empty hash");
+    let mut sink = CollectingSink::default();
+    let error = run_once_into("(", rule, &mut graph, &mut sink)
+        .expect_err("the malformed scenario must fail first");
+
+    assert!(!error.contains("E-LOAD-003"), "{error}");
+    assert!(error.contains("scenario"), "{error}");
+    assert_eq!(graph.state_hash().expect("refused hash"), before);
+    assert!(sink.events.is_empty());
+}
+
+#[test]
+fn an_anchorless_rule_with_no_system_home_is_e_load_002_before_hydration() {
+    let rule = r#"
+(rule nowhere/no-home
+  :material-basis "an unplaced rule has no causal meaning"
+  :fuel 16
+  (domain :graph)
+  (bindings)
+  (effects (emit EventType/RUPTURE)))
+"#;
+    assert_rejected_before_hydration(rule, Some("E-LOAD-002"), "cannot land nowhere");
+}
+
+#[test]
+fn duplicate_anchor_forms_fail_before_hydration() {
+    let rule = r#"
+(rule mods/duplicate-anchor
+  :material-basis "one rule has one causal placement"
+  :fuel 16
+  (domain :graph)
+  (anchor :before survival)
+  (anchor :after doctrine)
+  (bindings)
+  (effects (emit EventType/RUPTURE)))
+"#;
+    assert_rejected_before_hydration(rule, None, "at most one");
+}

--- a/rust/crates/babylon-tick/tests/phase_anchor_conformance.rs
+++ b/rust/crates/babylon-tick/tests/phase_anchor_conformance.rs
@@ -48,6 +48,15 @@ fn an_explicit_anchor_uses_the_governed_system_spine_not_global_rule_id_order() 
 }
 
 fn assert_rejected_before_hydration(rule_src: &str, code: Option<&str>, text: &str) {
+    let error = rejection_before_hydration(rule_src);
+
+    if let Some(code) = code {
+        assert!(error.contains(code), "expected {code}, got {error}");
+    }
+    assert!(error.contains(text), "expected {text:?}, got {error}");
+}
+
+fn rejection_before_hydration(rule_src: &str) -> String {
     let mut graph = HypergraphStore::new();
     let before = graph.state_hash().expect("empty hash");
     let mut sink = CollectingSink::default();
@@ -55,12 +64,9 @@ fn assert_rejected_before_hydration(rule_src: &str, code: Option<&str>, text: &s
         .expect_err("invalid phase composition must fail");
     let after = graph.state_hash().expect("post-refusal hash");
 
-    if let Some(code) = code {
-        assert!(error.contains(code), "expected {code}, got {error}");
-    }
-    assert!(error.contains(text), "expected {text:?}, got {error}");
     assert_eq!(after, before, "composition failure must precede hydration");
     assert!(sink.events.is_empty(), "composition failure emits nothing");
+    error
 }
 
 #[test]
@@ -158,4 +164,30 @@ fn duplicate_anchor_forms_fail_before_hydration() {
   (effects (emit EventType/RUPTURE)))
 "#;
     assert_rejected_before_hydration(rule, None, "at most one");
+}
+
+#[test]
+fn invalid_rule_permutations_name_the_same_byte_least_identity() {
+    let byte_least = r#"
+(rule aaa/no-home
+  :material-basis "an unplaced rule must fail deterministically"
+  :fuel 16
+  (domain :graph)
+  (bindings)
+  (effects (emit EventType/RUPTURE)))
+"#;
+    let byte_greater = r#"
+(rule zzz/no-home
+  :material-basis "another unplaced rule must not win by source order"
+  :fuel 16
+  (domain :graph)
+  (bindings)
+  (effects (emit EventType/RUPTURE)))
+"#;
+    let forward = rejection_before_hydration(&format!("{byte_least}\n{byte_greater}"));
+    let reversed = rejection_before_hydration(&format!("{byte_greater}\n{byte_least}"));
+
+    assert_eq!(forward, reversed);
+    assert!(forward.contains("E-LOAD-002"), "{forward}");
+    assert!(forward.contains("rule aaa/no-home"), "{forward}");
 }

--- a/rust/crates/babylon-tick/tests/tick_goldens.rs
+++ b/rust/crates/babylon-tick/tests/tick_goldens.rs
@@ -96,8 +96,8 @@ fn vitality_conformance_hashes_are_pinned() {
 /// left every other test in this crate and `babylon-client` green
 /// (mutation-proven, this fix round). `run_once` composes the two rule
 /// packs the same way `EngineSession::start`/`us_counties_demo.rs` do —
-/// concatenation order is arbitrary (`prepare_rules` sorts by rule-id byte
-/// order, §4.2/D16, regardless of it) — and runs tick 1.
+/// concatenation order is arbitrary because `prepare_rules` compiles the
+/// governed phase order — and runs tick 1.
 #[test]
 fn us_counties_lifecycle_demo_hashes_are_pinned() {
     let rule_src = format!("{DEMO_VITALITY_RULE}\n{DEMO_LIFECYCLE_RULE}");

--- a/rust/crates/babylon-tick/tests/us_counties_demo.rs
+++ b/rust/crates/babylon-tick/tests/us_counties_demo.rs
@@ -22,10 +22,10 @@ fn the_demo_scenario_loads_and_ticks_both_packs() {
     let report = session.advance(&mut sink).expect("tick 1");
     assert_ne!(report.before, report.after);
     assert_eq!(report.per_rule_fired.len(), 2);
-    // Ascending rule-id byte order (§4.2, D16/D100) — lifecycle before
-    // vitality, regardless of the rule_src concatenation order above.
-    assert_eq!(report.per_rule_fired[0].0, "lifecycle/dpd-circuit");
-    assert_eq!(report.per_rule_fired[1].0, "vitality/subsistence-and-death");
+    // Governed phase order — Vitality @1 before Lifecycle @7, regardless
+    // of the rule_src concatenation order above.
+    assert_eq!(report.per_rule_fired[0].0, "vitality/subsistence-and-death");
+    assert_eq!(report.per_rule_fired[1].0, "lifecycle/dpd-circuit");
     // lifecycle fires unconditionally on all twelve territories; vitality
     // fires on 5 of 6 social classes (`dissolved` fails the guard) — the
     // same per-pack counts the individually-pinned conformance tests
@@ -33,11 +33,11 @@ fn the_demo_scenario_loads_and_ticks_both_packs() {
     // them; the scenario mints no territory that fails any guard) and
     // unchanged for the six untouched vitality fixture nodes.
     assert_eq!(
-        report.per_rule_fired[0].1, 12,
+        report.per_rule_fired[1].1, 12,
         "all twelve territories fire"
     );
     assert_eq!(
-        report.per_rule_fired[1].1, 5,
+        report.per_rule_fired[0].1, 5,
         "five of six social classes fire"
     );
     // The recovering-county archetype (county-01013/01015/01017) fires

--- a/rust/crates/bsl-lint/src/namespace_unique.rs
+++ b/rust/crates/bsl-lint/src/namespace_unique.rs
@@ -57,6 +57,7 @@ const ALLOWLIST: &[(&str, &[&str], &str)] = &[
         &[
             "babylon-bsl/src/declarations.rs",
             "babylon-bsl/src/metrics.rs",
+            "babylon-bsl/src/rule_pipeline.rs",
             "babylon-bsl/src/scenario.rs",
             "babylon-tick/src/lib.rs",
         ],
@@ -66,7 +67,9 @@ const ALLOWLIST: &[(&str, &[&str], &str)] = &[
          babylon-tick/src/lib.rs joined the set in the 2026-08-21 worktree sweep: the D32 \
          implicit-<edge-type>/strength collision check (#652 T2) refuses a deffield \
          re-declaring an implicit field — the same generic duplicate-declaration class, \
-         returned as PrepareError::Composition with the code carried as data.",
+         returned as PrepareError::Composition with the code carried as data. \
+         rule_pipeline.rs joined under ADR222/PER-17: duplicate rule ids now carry the \
+         same governed code as typed data across aggregate source boundaries.",
     ),
     (
         "E-LOAD-011",

--- a/tests/unit/governance/test_v4_portfolio_alignment.py
+++ b/tests/unit/governance/test_v4_portfolio_alignment.py
@@ -107,7 +107,22 @@ _H3_EVIDENCE: Final[tuple[str, ...]] = (
     "src/babylon/models/entities/territory.py",
     "src/babylon/persistence/hex_state.py",
 )
-_GATE_2_ISSUES: Final[tuple[str, ...]] = ("PER-17", "PER-18", "PER-19")
+_GATE_2_STATUSES: Final[dict[str, str]] = {
+    "PER-17": "implemented_current",
+    "PER-18": "planned",
+    "PER-19": "planned",
+}
+_GATE_2_COMPONENTS: Final[dict[str, str]] = {
+    "PER-17": "executable_phase_anchor_total_order",
+    "PER-18": (
+        "whole_tick_working_copy_rollback_and_canonical_big_endian_"
+        "auxiliary_register_combined_world_hashing"
+    ),
+    "PER-19": (
+        "bsl_causal_composition_provenance_direct_write_whitelist_and_"
+        "negative_outcome_write_contracts"
+    ),
+}
 _GATE_3_ISSUES: Final[tuple[str, ...]] = (
     "PER-20",
     "PER-21",
@@ -176,12 +191,12 @@ def test_v4_yaml_records_are_mappings() -> None:
         assert _yaml_document(path)
 
 
-def test_architecture_separates_current_components_from_planned_gates() -> None:
-    """Current evidence and planned work occupy separate machine-readable estates."""
+def test_architecture_records_current_components_and_gate_delivery_status() -> None:
+    """Current evidence and per-issue gate status remain machine-readable."""
     architecture = _yaml_document(_ARCHITECTURE)
     status = architecture["implementation_status"]
     assert isinstance(status, dict)
-    assert {"implemented_current", "planned_gate_2", "planned_gate_3"} <= set(status)
+    assert {"implemented_current", "gate_2_delivery", "planned_gate_3"} <= set(status)
     current = status["implemented_current"]
     assert isinstance(current, dict)
     for component in _CURRENT_COMPONENTS:
@@ -190,11 +205,12 @@ def test_architecture_separates_current_components_from_planned_gates() -> None:
         expected_evidence = _CURRENT_EVIDENCE[component]
         assert tuple(record["evidence"]) == expected_evidence
         assert all((_ROOT / evidence).is_file() for evidence in expected_evidence)
-    gate_2 = status["planned_gate_2"]
+    gate_2 = status["gate_2_delivery"]
     gate_3 = status["planned_gate_3"]
-    assert tuple(gate_2) == _GATE_2_ISSUES
+    assert tuple(gate_2) == tuple(_GATE_2_STATUSES)
     assert tuple(gate_3) == _GATE_3_ISSUES
-    assert all(gate_2[issue]["status"] == "planned" for issue in _GATE_2_ISSUES)
+    assert {issue: gate_2[issue]["status"] for issue in _GATE_2_STATUSES} == _GATE_2_STATUSES
+    assert {issue: gate_2[issue]["component"] for issue in _GATE_2_COMPONENTS} == _GATE_2_COMPONENTS
     assert all(gate_3[issue]["status"] == "planned" for issue in _GATE_3_ISSUES)
 
 
@@ -510,7 +526,9 @@ def test_standard_addenda_classify_current_and_superseded_surfaces() -> None:
         "S-11 whole-tick rollback status: planned",
         "S-25 renderer requirement status: retired",
         "S-32 writer assignment status: superseded",
-        "D5/D16 byte-sort ordering status: implemented_current_to_be_replaced",
+        "D5/D16 phase-ordering status: implemented_executable_PER-17",
+        "PER-18 rollback and combined-world-hash status: planned",
+        "PER-19 causal-composition and outcome-write-contract status: planned",
         "Persistence writer status: accepted_cutover_law",
         "PER-48 status: Done",
         _POSTGRESQL_ADR,


### PR DESCRIPTION
## What does this PR do?

Implements Linear PER-17 as the first executable-causality slice:

- compiles the frozen 34-system causal spine into deterministic phase ranks;
- resolves default rule homes and governed before/after anchors before caller-owned hydration;
- uses rule-ID bytes only for same-position D16 ties;
- rejects missing homes, duplicate rule IDs, and illegal Material Base cuts with stable load errors;
- preserves scenario → rule → composition diagnostic precedence on a disposable graph;
- removes the inert Lifecycle anchor and restores Decomposition-before-ControlRatio behavior;
- records ADR222 and the still-open same-position shared-prestate gap.

## Related Issue

- Linear: https://linear.app/percy-raskova/issue/PER-17/implement-executable-bsl-phase-anchors-and-phase-local-ordering
- GitHub bridge: #503

This PR completes the phase-anchor part of #503. It does not close #503 because whole-tick rollback and the combined world hash remain in PER-18.

## Verification

- `mise run check`: 14,241 passed, 55 skipped, 1 xfailed
- `mise run rust:check`
- `mise run check:gate-coverage`
- `mise run check:gate-coverage-truth`
- `mise run qa:regression`
- `mise run qa:vault-regression-ci`
- focused phase-anchor, BSL, language-server, governance, citation, and grammar suites
- `cargo fmt --all -- --check`, `rstcheck`, `doc8`, and diff checks
- full pre-push CI mirror after rebasing onto merged PR #699

## Checklist

- [x] Tested locally
- [x] Existing style and bounded-control-flow rules preserved
- [x] Documentation and ADR updated
- [x] No baseline ceremony required

## Questions for Reviewers

Please focus on the governed alias homes, the legal outer Material Base boundaries, and the preserved scenario/rule/composition error precedence.