### PR TITLE
feat(tick): make whole ticks rollback-safe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,11 @@ to the reserved theory line. Do not infer live authority from an old ADR.
 <!-- Vale: these paragraphs preserve literal crate, schema, and Linear identifiers. -->
 <!-- vale ste.UnapprovedWords = NO -->
 <!-- vale ste.NounClusters = NO -->
-The live Rust path is `babylon-kernel`, `babylon-graph`, `babylon-bsl`,
-`babylon-tick`, and `babylon-client`. Live BSL rules execute, but executable
-shocks do not exist. `TickSession` holds a world across weekly advances and
-returns an in-memory `TickReport`. The Bevy viewer draws 3,222 counties, moves
-ticks, and shows lenses, causal beats, events, and hash data.
+The live Rust path is `babylon-kernel`, `babylon-graph`, `babylon-bsl`, `babylon-tick`,
+and `babylon-client`. Live BSL rules execute, but executable shocks do not exist.
+`TickSession` adjudicates each tick on a detached graph and publishes graph, buffered
+events, completed time, and `NominalWorldHash` only after every rule and hash succeeds.
+`GraphStateHash` remains graph-only. The Bevy viewer shows the committed world hash.
 
 Program 27 froze the Python engine at `p27-python-freeze`. Its 34-system
 `SimulationEngine._DEFAULT_SYSTEMS` is the transcription oracle for Rust's

--- a/ai/architecture.yaml
+++ b/ai/architecture.yaml
@@ -1,7 +1,7 @@
 ---
 meta:
   name: Babylon v4 architecture truth record
-  version: "4.1.0"
+  version: "4.2.0"
   updated: "2026-08-23"
   role: current_and_planned_architecture
   authority: CONSTITUTION.md v4.0.0
@@ -121,11 +121,12 @@ implementation_status:
       execution_truth: >-
         The tick compiles rules onto the governed 34-system causal spine.
         Namespace homes and explicit boundaries determine position; rule-ID
-        bytes break same-position ties only. Rules then mutate the held graph
-        in place.
+        bytes break same-position ties only. Rules then execute against one
+        detached working graph and buffer events. The graph and events publish
+        only after every rule and both hash boundaries succeed.
       limitation: >-
         Same-position rules remain sequential and can observe earlier writes.
-        Whole-tick working-copy rollback remains PER-18.
+        PER-19 owns the shared-prestate and causal-composition repair.
       absent_from_current_content:
         - executable_shocks
         - executable_player_actions
@@ -138,10 +139,12 @@ implementation_status:
       scope:
         - persistent_in_memory_graph
         - sequential_rule_execution
+        - detached_whole_tick_working_copy
+        - buffered_event_publication
         - tick_increment_after_success
       limitation: >-
-        There is no working-copy swap. A later rule failure can leave earlier
-        rule mutations in the held graph even though the tick does not advance.
+        Atomicity is in memory only. PostgreSQL durability, crash recovery, and
+        the CommittedTickEnvelope remain Gate 3 work.
       evidence:
         - rust/crates/babylon-tick/src/session.rs
 
@@ -150,9 +153,25 @@ implementation_status:
       scope:
         - canonical_graph_sections
         - unsigned_u64_big_endian_fields
-      limitation: auxiliary political-economy registers are not yet hash-covered
+      limitation: graph_only_diagnostic_not_complete_tick_identity
       evidence:
         - rust/crates/babylon-graph/src/state_hash.rs
+
+    nominal_world_hash:
+      status: implemented_current
+      scope:
+        - canonical_graph_hash
+        - completed_weekly_tick
+        - node_and_hyperedge_allocator_cursors
+        - governed_phase_schedule_digest
+        - versioned_tagged_big_endian_layout
+      limitation: >-
+        This covers every auxiliary register that currently exists in the Rust
+        tick. It is not the future TickContentHash and does not include content,
+        reference, seed, action, or durable campaign-envelope identity.
+      evidence:
+        - rust/crates/babylon-tick/src/world_hash.rs
+        - rust/crates/babylon-tick/src/session.rs
 
     bevy_admin_viewer:
       status: implemented_current
@@ -267,10 +286,16 @@ implementation_status:
         - rust/crates/babylon-tick/tests/phase_anchor_conformance.rs
         - ai/decisions/ADR222_executable_bsl_phase_order.yaml
     PER-18:
-      status: planned
+      status: implemented_current
       gate: G2
       component: >-
         whole_tick_working_copy_rollback_and_canonical_big_endian_auxiliary_register_combined_world_hashing
+      evidence:
+        - rust/crates/babylon-graph/src/working_copy.rs
+        - rust/crates/babylon-tick/src/lib.rs
+        - rust/crates/babylon-tick/src/session.rs
+        - rust/crates/babylon-tick/src/world_hash.rs
+        - ai/decisions/ADR223_whole_tick_atomicity_world_hash.yaml
     PER-19:
       status: planned
       gate: G2

--- a/ai/bsl-architecture-standard.md
+++ b/ai/bsl-architecture-standard.md
@@ -23,11 +23,11 @@ historical record against their stated baseline.
 
 - v3/Amendment AE authority table status: historical
 - S-4/S-5/S-22 vocabulary-amendment reading status: superseded
-- S-11 whole-tick rollback status: planned
+- S-11 whole-tick rollback status: implemented_current_PER-18
 - S-25 renderer requirement status: retired
 - S-32 writer assignment status: superseded
 - D5/D16 phase-ordering status: implemented_executable_PER-17
-- PER-18 rollback and combined-world-hash status: planned
+- PER-18 rollback and combined-world-hash status: implemented_current
 - PER-19 causal-composition and outcome-write-contract status: planned
 - Persistence writer status: accepted_cutover_law
 - PER-48 status: Done
@@ -48,9 +48,17 @@ evaluator, canonical content digests, executable anchor placement, and graph
 execution. Rule preparation compiles the frozen 34-system causal spine before
 mutating caller state. Default homes come from the rule-ID namespace; explicit
 anchors select governed boundaries; D16 orders only same-position ties by
-rule-ID bytes. `TickSession` still applies each rule to its held graph in
-place. A failing rule prevents the tick counter from advancing, but it does not
-restore mutations made by earlier rules.
+rule-ID bytes. `TickSession` applies the ordered rules to a detached working
+graph and buffers their events. It publishes graph state, allocator cursors,
+events, and completed time only after every rule and both hash boundaries
+succeed. Any failure leaves the prior in-memory world byte-identical.
+
+The canonical graph hash remains a graph-only diagnostic. The version-1
+nominal world hash adds the completed weekly tick, the node and hyperedge
+allocator cursors, and the governed phase-schedule digest in a tagged,
+big-endian layout. It covers every auxiliary Rust tick register that exists
+today. It is not Gate 3's complete `TickContentHash` and does not claim durable
+PostgreSQL publication.
 
 The frozen Python estate's 34 systems, actions, resolvers, observers, and
 persistence remain reference and port sources. They are not a prerequisite for
@@ -62,12 +70,13 @@ loop are not current.
 
 PER-17 has replaced the global byte sort with an executable phase-anchor total
 order. Same-position rules remain sequential; their shared-prestate repair is
-separate from placement. PER-18 adds a whole-tick working copy that swaps only
-after successful adjudication and extends canonical big-endian hashing across
-auxiliary registers into the combined world hash. PER-19 owns BSL causal
-composition, the provenance/direct-write whitelist, and negative outcome-write
-contracts. Therefore, S-11 must not be cited as proof that rollback exists
-today.
+separate from placement. PER-18 has landed a whole-tick working copy that swaps
+only after successful adjudication and extends canonical big-endian hashing
+across current auxiliary registers into the nominal world hash. PER-19 owns
+BSL causal composition, the provenance/direct-write whitelist, and negative
+outcome-write contracts. Therefore, S-11 may cite in-memory rollback through
+PER-18 and ADR223, but it cannot claim database durability or shared-prestate
+composition.
 
 ### Durability and client boundary
 

--- a/ai/decisions/ADR223_whole_tick_atomicity_world_hash.yaml
+++ b/ai/decisions/ADR223_whole_tick_atomicity_world_hash.yaml
@@ -1,0 +1,100 @@
+ADR223_whole_tick_atomicity_world_hash:
+  status: "accepted"
+  date: "2026-08-23"
+  title: >
+    Rust adjudicates each weekly tick on a detached world, publishes graph,
+    events, allocator state, and completed time only after total success, and
+    names current in-memory identity with a versioned nominal world hash
+  context: |
+    The Rust tick driver executed governed BSL rules in order against the held
+    graph. A later rule failure could expose earlier mutations even though the
+    session counter did not advance. The graph-state hash also omitted two
+    monotonic identity allocators and completed weekly time. Those values affect
+    later identities and outcomes even when the live graph facts match.
+
+    PER-17 and ADR222 made causal phase placement executable and assigned
+    PER-18 the next Gate 2 obligation: whole-tick rollback and canonical
+    big-endian hashing for every auxiliary Rust tick register that exists.
+    Gate 3 separately owns PostgreSQL durability, the CommittedTickEnvelope,
+    campaign and content identity, and crash recovery. This decision cannot
+    claim that later boundary early.
+
+    Adversarial review found three places where a narrow implementation would
+    have lied: bare Clone does not promise detached mutable backing; one-shot
+    preparation hydrated caller state before the working-copy boundary; and a
+    graph-only or all-zero hash golden could not prove the whole byte layout.
+  decision: |
+    1. DETACHED-COPY CONTRACT. `babylon-graph` exposes `DetachedCopy` as an
+       explicit behavioral contract with no blanket Clone implementation.
+       MemoryGraph and HypergraphStore implement it. Conformance proves that
+       nodes, binary64 and Currency attributes, dyadic edges and attributes,
+       hyperedges and attributes, type indexes, membership queries, and both
+       identity cursors are independently mutable in either direction.
+
+    2. ATOMIC PREPARATION AND ADJUDICATION. A public one-shot call detaches the
+       caller world before scenario preparation. Preparation, scenario
+       hydration, every ordered rule, graph hashing, nominal-world hashing, and
+       event-batch reservation all complete on staged state. Only then may the
+       graph swap and the already-reserved event append occur. TickSession uses
+       the same adjudication boundary and advances its completed-tick counter
+       only after success. Any returned error leaves canonical graph bytes,
+       allocator cursors, prior events, and completed time unchanged.
+
+    3. EXPLICIT FAILURE. Node, hyperedge, and completed-tick arithmetic uses
+       checked operations. The u64 value MAX is the reserved exhausted cursor
+       sentinel; MAX-1 is the last mintable identity. Non-finite graph data,
+       pre-hash failure, post-hash failure, rule failure in any causal
+       partition, and event-reservation refusal all abort before publication.
+
+    4. TWO HASH NAMES. GraphStateHash remains the canonical graph-only
+       diagnostic and its established byte layout does not change.
+       NominalWorldHash names the current mutable graph-and-tick registers at
+       this gate. It covers GraphStateHash, completed weekly time,
+       next-node and next-hyperedge cursors, and the governed static
+       phase-schedule digest. The Bevy tick readout shows the committed
+       NominalWorldHash. Diagnostic CLI output labels graph and world hashes
+       separately.
+
+    5. NOMINAL WORLD HASH VERSION 1. The SHA-256 preimage is exactly the ASCII
+       domain `babylon.world-state` plus NUL, u32 big-endian layout version 1,
+       then these tagged sections in order: 0x01 plus the 32-byte graph hash;
+       0x02 plus i64 big-endian completed tick; 0x03 plus u64 big-endian node
+       cursor and u64 big-endian hyperedge cursor; 0x04 plus the 32-byte phase
+       schedule digest. Negative completed time refuses. A hand-written,
+       asymmetric, nonzero 116-byte vector pins every tag, position, and byte
+       order before pinning its SHA-256.
+
+    6. DETERMINISM EVIDENCE. A real multi-rule TickSession advance compares
+       both graph hashes, both nominal world hashes, total and per-rule firing,
+       and exact typed event payloads across parent and child processes,
+       insertion permutations, and both graph stores. A separate component
+       test proves equal live graph facts with different allocator histories
+       have different nominal world hashes.
+
+    7. NAMED LIMITS. Same-position BSL rules remain sequential; PER-19 owns
+       shared-prestate causal composition and direct-write law. This decision
+       adds no PostgreSQL connection, persistence envelope, campaign identity,
+       reference digest, content digest, RNG seed, action log, checkpoint, or
+       future political-economy register. ADR220 reserves TickContentHash for
+       that complete constitutional identity and makes it a writer-cutover
+       gate.
+  consequences: |
+    - Failure after representative Material Base, Action, or Consequence work
+      rolls back exact graph bytes, cursors, completed time, and prior events on
+      both graph stores.
+    - One-shot scenario hydration is now part of the same atomic operation as
+      its tick. A failed call cannot leave scenario nodes or consumed IDs in a
+      caller-owned world.
+    - A tick that emits events without moving graph facts still changes
+      NominalWorldHash because completed time is state. Graph and world hashes
+      therefore remain separately named in code, tests, CLI output, and docs.
+    - The current boundary protects in-process consistency but cannot
+      acknowledge durable progress. Gate 3 must wrap a successful adjudication
+      result in its own transactional database protocol without weakening this
+      rollback law.
+  supersedes: []
+  related:
+    - ADR179_topology_spine_director_rulings
+    - ADR220_rust_owned_postgresql_persistence_boundary
+    - ADR221_game_first_refoundation_v4
+    - ADR222_executable_bsl_phase_order

--- a/ai/decisions/ADR223_whole_tick_atomicity_world_hash.yaml
+++ b/ai/decisions/ADR223_whole_tick_atomicity_world_hash.yaml
@@ -1,7 +1,7 @@
 ADR223_whole_tick_atomicity_world_hash:
   status: "accepted"
   date: "2026-08-23"
-  title: >
+  title: >-
     Rust adjudicates each weekly tick on a detached world, publishes graph,
     events, allocator state, and completed time only after total success, and
     names current in-memory identity with a versioned nominal world hash

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -1,6 +1,6 @@
 meta:
-  version: 1.75.0
-  updated: '2026-08-22'
+  version: 1.76.0
+  updated: '2026-08-23'
   description: Architecture Decision Records Index
   format: See individual ADR files in this directory
   # ADR NUMBER ALLOCATION (controller ruling 2026-07-21, v1.0.0 parallel lanes —

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -1025,3 +1025,8 @@ decisions:
     status: accepted
     date: '2026-08-23'
     file: ADR222_executable_bsl_phase_order.yaml
+  ADR223_whole_tick_atomicity_world_hash:
+    title: 'Rust adjudicates each weekly tick on a detached world, publishes graph, events, allocator state, and completed time only after total success, and names current in-memory identity with a versioned nominal world hash'
+    status: accepted
+    date: '2026-08-23'
+    file: ADR223_whole_tick_atomicity_world_hash.yaml

--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -79,7 +79,7 @@ meta:
     TickContentHash, and CommittedTickEnvelope remain Gate 3 work.
     PREVIOUS:
     (2026-08-23 GATE 2 — PER-17 EXECUTABLE BSL PHASE ORDER IMPLEMENTED,
-    MERGED AS PR #701) `babylon-tick` now compiles every admitted rule onto
+    REVIEW/PR PENDING) `babylon-tick` now compiles every admitted rule onto
     the frozen 34-system causal spine (15 Material Base, one Action, 18
     Consequence) instead of globally sorting the content set by rule-ID
     bytes. Namespace defaults and explicit before/after boundaries are

--- a/ai/state.yaml
+++ b/ai/state.yaml
@@ -2,7 +2,7 @@
 # What exists vs what's planned - KEEP THIS UPDATED
 
 meta:
-  version: "2.71.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
+  version: "2.72.0"  # 2.28.0 lives on feature/19-emergent-class-partition (Program 19 Phase 0+1)
   updated: "2026-08-23"
   role: historical_implementation_ledger
   history_policy: append_or_prepend_only
@@ -17,7 +17,7 @@ meta:
       url: >-
         https://linear.app/percy-raskova/document/babylon-v4-roadmap-charter-2c67d2898306
   v4_governance_snapshot:
-    as_of: "2026-08-22"
+    as_of: "2026-08-23"
     implementation_truth: ai/architecture.yaml
     lower_entries: dated_snapshots_only
     current_status_queries: Linear
@@ -27,12 +27,17 @@ meta:
       adr: ADR220_rust_owned_postgresql_persistence_boundary
       completion_commit: 9b4c9b2e
     bsl_phase_order:
-      status: implemented_on_PER-17_branch
+      status: implemented_on_dev
       issue: PER-17
       adr: ADR222_executable_bsl_phase_order
-      branch: codex/per-17-executable-phase-anchors
+      merge_commit: 5a0ef2a9
+    whole_tick_atomicity:
+      status: implemented_on_PER-18_branch
+      issue: PER-18
+      adr: ADR223_whole_tick_atomicity_world_hash
+      branch: codex/per-18-whole-tick-atomicity
+      scope: in_memory_only
       remaining_gate_2:
-        - PER-18
         - PER-19
     attributed_membership_payload:
       status: planned
@@ -54,8 +59,27 @@ meta:
       work or override Linear status, priority, dependencies, Horizon,
       milestones, or schedule.
   truth_status: |
+    (2026-08-23 GATE 2 — PER-18 WHOLE-TICK ATOMICITY AND NOMINAL WORLD HASH
+    IMPLEMENTED, REVIEW/PR PENDING) `babylon-graph` now exposes an explicit
+    detached-copy contract for both stores and rejects node, hyperedge, and
+    tick-counter exhaustion before mutation. `babylon-tick` stages one-shot
+    preparation, hydration, ordered rules, hashes, and event reservation before
+    publishing graph, allocator cursors, events, or completed time. Failure
+    vectors cover all three causal partitions on both backends, both public
+    one-shot variants, event refusal, pre-hash failure, and a real StateEncoder
+    NaN rejection. A parent/child multi-rule proof compares graph hashes,
+    nominal world hashes, total and per-rule firing, and exact typed event
+    payloads across insertion permutations and both stores. NominalWorldHash v1
+    covers GraphStateHash, completed weekly time, both allocator cursors, and
+    the static governed phase-schedule digest with an exact 116-byte asymmetric
+    big-endian vector. Bevy shows the committed nominal world hash. ADR223
+    records the in-memory transaction and hash law. Gate 2 remains open only on
+    PER-19 causal composition, provenance/direct-write constraints, and
+    negative outcome-write contracts. PostgreSQL durability, the complete
+    TickContentHash, and CommittedTickEnvelope remain Gate 3 work.
+    PREVIOUS:
     (2026-08-23 GATE 2 — PER-17 EXECUTABLE BSL PHASE ORDER IMPLEMENTED,
-    REVIEW/PR PENDING) `babylon-tick` now compiles every admitted rule onto
+    MERGED AS PR #701) `babylon-tick` now compiles every admitted rule onto
     the frozen 34-system causal spine (15 Material Base, one Action, 18
     Consequence) instead of globally sorting the content set by rule-ID
     bytes. Namespace defaults and explicit before/after boundaries are

--- a/docs/concepts/architecture.rst
+++ b/docs/concepts/architecture.rst
@@ -40,14 +40,23 @@ The Rust workspace contains the shipping engine path:
    The BSL lexer, parser, checker, loader, and evaluator.
 
 ``babylon-tick``
-   The weekly tick, ``TickSession``, and in-memory ``TickReport``.
+   The weekly tick, atomic ``TickSession``, and in-memory ``TickReport``.
 
 ``babylon-client``
    The Bevy administrative viewer.
 
-The Bevy client draws the county atlas and moves ticks forward. It has lenses,
-events, causal beats, and hash diagnostics. Committed BSL has no player action.
-The client does not complete a game decision cycle.
+Each weekly tick runs on a detached graph and buffers its events. The session
+publishes graph state, allocator cursors, events, and completed time only after
+all rules and hash boundaries succeed. ``GraphStateHash`` identifies graph
+bytes only. ``NominalWorldHash`` adds completed time, allocator cursors, and the
+governed phase-schedule digest. It is the hash the Bevy viewer shows after a
+committed tick.
+
+This boundary provides in-memory rollback. It is not the planned Gate 3
+``CommittedTickEnvelope`` or a PostgreSQL durability acknowledgment. The Bevy
+client draws the county atlas and moves ticks forward. It has lenses, events,
+causal beats, and hash diagnostics. Committed BSL has no player action. The
+client does not complete a game decision cycle.
 
 Frozen Python reference
 -----------------------
@@ -166,7 +175,8 @@ Invariants
 ----------
 
 Tick identity
-   Equal inputs and reference digests produce equal bytes and hashes.
+   Equal inputs produce equal graph and nominal-world bytes and hashes. Gate 3
+   will add the complete content, reference, seed, action, and campaign identity.
 
 Pure judgment
    The relation, BSL, and tick crates have no database dependency. Storage starts

--- a/docs/reference/determinism-contract.rst
+++ b/docs/reference/determinism-contract.rst
@@ -1,16 +1,19 @@
 Determinism Contract
 =====================
 
-The language-agnostic, byte-level specification of Babylon's implemented and
-reserved identity hashes. This document exists so that a reimplementation of
-the engine in another language could reproduce these hashes without reading
-their implementation —
-the **rewrite test** of Constitution III.12 ("Behavioral Contracts",
-Amendment Q, corollary (a); see ``CONSTITUTION.md``). It is a reference document: it describes what
-the current implementation *does*, byte for byte, not what an idealized
-implementation *should* do. Where the implementation's behavior surprises its
-own naming or docstrings, this document says so explicitly (see the
-*Known Discrepancies* section below) rather than papering over the gap.
+This reference inventories Babylon's implemented and reserved identities. It
+provides complete, language-agnostic byte layouts for the frozen Python
+artifacts that say so and for the outer ``NominalWorldHash`` composition given
+two authoritative 32-byte inputs. It does not yet specify the inner
+``GraphStateHash`` or phase-schedule encoding. ``TickContentHash`` remains a
+reserved taxonomy name; no byte layout is implemented or specified.
+
+Current constitutional authority is Article V for deterministic identity and
+rewrite-surviving behavioral contracts, with Article VIII governing redundant
+validation evidence. ADR221 maps the historical v3 predecessors to those
+articles. This document describes what the current implementation *does*, not
+what an idealized implementation should do. It names incomplete rewrite
+contracts instead of claiming that code is a sufficient specification.
 
 Program 27 Phase 0
 (``docs/superpowers/specs/2026-07-28-program-27-refoundation-design.md``)
@@ -27,8 +30,7 @@ Scope: What "Deterministic" Guarantees
 ---------------------------------------
 
 Babylon makes two different determinism claims, and conflating them is a
-category error the codebase itself warns against (Constitution III.7,
-``CONSTITUTION.md:250``):
+category error under Constitution Article V:
 
 **Intra-implementation (byte-identical replay).** Given the same CPython
 interpreter, the same platform libm, the same random seed, and the same
@@ -41,8 +43,7 @@ because:
   machines.
 - CPython's ``random`` module (Mersenne Twister) is itself deterministic
   given a seed, and the engine's RNG usage is threaded through explicit
-  seeds (Constitution III.7 / the worktree's ``rng_seed`` convention) rather
-  than reseeded from wall-clock time.
+  seeds under Article V rather than reseeded from wall-clock time.
 - Dict and set iteration in CPython 3.7+ is insertion-ordered for dicts
   (sets remain unordered by the language spec, but this codebase's hot
   paths canonicalize via ``sorted()`` before hashing — see below).
@@ -67,15 +68,16 @@ Catalog of Constitutional Hashes
 The frozen Python estate has three older identities in its live and reference
 paths. Rust adds a graph-only diagnostic and a current in-memory nominal-world
 identity. The complete durable ``TickContentHash`` remains reserved. These
-values are not interchangeable. This section and the PER-18 section below
-specify their exact roles and byte constructions.
+values are not interchangeable. The older entries specify their byte
+constructions. The PER-18 entry specifies the nominal hash's outer composition
+and names its two still-Rust-authoritative inputs.
 
 ``defines_hash`` — GameDefines fingerprint
 +++++++++++++++++++++++++++++++++++++++++++
 
 **Purpose:** detect when the tunable-coefficient space (``GameDefines`` /
 ``defines.yaml``) has moved between a checkpoint baseline's authoring time
-and a comparison run. Per Constitution III.7, a ``defines_hash`` mismatch
+and a comparison run. Under Constitution Article V, a ``defines_hash`` mismatch
 alone is **input-hash drift** — expected and benign, resolved by
 regenerating the baseline — as distinct from **behavioral drift** (a
 checkpoint value moved), which is the actual failure the ``qa:regression``
@@ -91,7 +93,7 @@ gate exists to catch.
    sort_keys=True, separators=(",", ":"), ensure_ascii=True)`` → UTF-8
    encode → SHA-256 → **full 64-char lowercase hex digest** (no
    truncation, no ``default=`` fallback — a non-JSON-native field raises
-   ``TypeError`` loudly per III.11). Note the canonical layout sorts keys
+   ``TypeError`` loudly under Article V). Note the canonical layout sorts keys
    alphabetically via stdlib ``json.dumps``, unlike the retired layout
    below. The remainder of this entry (including its worked examples)
    describes the **retired pre-Task-1 layout** — pydantic-core
@@ -232,8 +234,9 @@ lowercase hex, e.g. ``"4ad75b08-0258-48a4-a29a-61cab92d7d13"`` — a decimal
 ``str.encode()`` (UTF-8), then SHA-256, **full 64 hex-character digest, no
 truncation**.
 
-**Chaining:** **none in the cryptographic sense.** Despite the migration
-comment calling this "the queryable Constitution-III.7 hash chain"
+**Chaining:** **none in the cryptographic sense.** The migration comment
+assigns this marker to historical v3 clause III.7 and calls it a queryable
+hash chain
 (``src/babylon/persistence/migrations/0029_tick_commit.sql:9``), each row's
 hash does **not** incorporate the previous tick's hash (there is no
 ``H_n = H(H_{n-1} || data_n)`` construction anywhere in this codebase). "Chain"
@@ -268,22 +271,22 @@ between two independent runs sharing a seed — not by hash comparison. A
 reimplementation's test harness should adopt the same pattern: don't try to
 reproduce this hash across sessions; diff the persisted values instead.
 
-``conservation_audit_log.hex_frame_hash`` — the III.7 content hash
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+``conservation_audit_log.hex_frame_hash`` — historical v3 clause III.7 content hash
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. note::
    **Renamed from ``determinism_hash`` (migration 0044, ADR179 T2,
    2026-07-30)** — the honest name says what it covers: the 15-field
    ``DynamicHexState`` frame, not the full world state.
 
-**Purpose:** this is the hash that actually matches Constitution III.7's
-literal definition — *"a deterministic SHA-256 hash of its inputs (World
-state + player actions + random seed)"* (``CONSTITUTION.md:250``) — because
+**Purpose:** this is the hash that actually matches historical v3 clause
+III.7's literal definition — *"a deterministic SHA-256 hash of its inputs
+(World state + player actions + random seed)"* — because
 it is the only hash in the codebase whose bytes depend on the tick's
-computed content. This document identifies it with **"the III.7 tick hash"**
-named in Amendment Q corollary (a) (``CONSTITUTION.md:268``); no source
-comment uses that exact phrase, so this is this document's own reasoned
-mapping, stated explicitly as such.
+computed content. This historical section identifies it with **"the historical
+v3 clause III.7 tick hash"** named in Amendment Q corollary (a). ADR221 maps
+that predecessor clause into Article V. No source comment uses the quoted
+phrase, so this is this document's own reasoned mapping.
 
 **Computed by:** ``compute_hex_frame_hash()`` (renamed with the column),
 ``src/babylon/persistence/conservation_audit.py:70-111``:
@@ -311,8 +314,8 @@ per-tick hex checkpoint frame** (every hex, restamped to the current tick;
 ``bridge.py:492``), not the delta actually persisted to ``dynamic_hex_state``.
 ``action_list`` is **never passed** at this call site (it defaults to
 ``None`` → treated as an empty list) — player/organization actions do not
-currently enter this hash in the wired path, even though III.7's prose names
-them as an input. "World state" here is narrower than the full
+currently enter this hash in the wired path, even though historical v3 clause
+III.7 named them as an input. "World state" here is narrower than the full
 ``WorldState`` model: only the hex economic frame (``c``, ``v``, ``s``,
 ``k``, the three substrate stocks, ``internet_access_pct``,
 ``surveillance_coupling`` plus identity/spatial keys — the 15 fields of
@@ -393,7 +396,7 @@ transaction as ``tick_commit`` (``_spec_062.py:314-318``) but as a
 Behavioral artifact: ``trace.csv``
 +++++++++++++++++++++++++++++++++++
 
-Not a hash, but the other durable artifact Constitution III.12 names
+Not a hash, but another durable artifact named by historical v3 clause III.12
 alongside the three hashes above. ``trace.csv``'s column dictionary is
 pinned in ``specs/064-headless-sim-runner/contracts/trace_csv_schema.yaml``
 (22 columns; format: UTF-8, comma-delimited, RFC 4180 minimal quoting,
@@ -490,8 +493,9 @@ Float and Tolerance Policy
 -----------------------------
 
 Babylon uses **three distinct, independently-derived tolerance regimes** —
-conflating them is a documented anti-pattern (Constitution III.7's
-input-hash-drift vs behavioral-drift distinction generalizes to this too).
+conflating them is a documented anti-pattern. Article V's canonical-input
+identity and Article VIII's behavioral validation keep input drift distinct
+from behavioral drift.
 Each has a written derivation in the codebase, following the pattern
 established in ``specs/053-conservation-invariants/contracts/value_conservation.md``:
 state the invariant, state the tolerance as a function of a size parameter
@@ -501,8 +505,8 @@ where relevant, name the test file, name the failure mode.
    tolerance ``TOLERANCE = 1e-5`` per float field
    (``tools/regression_test.py:61``), applied field-by-field in
    ``compare_checkpoints()`` (``tools/regression_test.py:353-395``,
-   ``if abs(exp_val - act_val) > tolerance``). This is the gate Constitution
-   III.7 names as the falsifiability mechanism — "a prediction is a
+   ``if abs(exp_val - act_val) > tolerance``). Historical v3 clause III.7
+   named this gate as the falsifiability mechanism — "a prediction is a
    checkpointed value, a falsifying observation is a value that drifts
    beyond tolerance." Fixed, not scaled by any size parameter, because a
    checkpoint compares individual scalar fields (wealth, tension,
@@ -534,11 +538,12 @@ where relevant, name the test file, name the failure mode.
    name the growth model (here, summation error), not just a number pulled
    from thin air.
 
-Corollary (b) of Constitution III.12 states this policy's boundary
+Corollary (b) of historical v3 clause III.12 states this policy's boundary
 precisely: *"byte-identical replay is guaranteed only within a single
 implementation and libm; cross-implementation validation is
-tolerance-bounded checkpoint comparison (III.7) with written tolerance
-derivations."* A reimplementation should target regime 1's numbers
+tolerance-bounded checkpoint comparison (historical v3 clause III.7) with
+written tolerance derivations."* A reimplementation should target regime 1's
+numbers
 (checkpoint tolerance) for cross-language validation against
 ``tests/baselines/*.json``, since regimes 2 and 3 are internal engine
 self-consistency checks, not cross-implementation contracts.
@@ -580,10 +585,11 @@ What Stays Valid Under Rewrite
      - A reimplementation targeting the same Postgres runtime must match
        column names/types/constraints exactly; this is verified by test,
        not by hash.
-   * - ``observe()`` / HTTP contracts (Constitution II.8)
-     - Contract test per boundary (Constitution III.12 corollary (c))
+   * - ``observe()`` / HTTP contracts (historical v3 clause II.8)
+     - Contract test per boundary (historical v3 clause III.12 corollary (c))
      - Out of this document's scope; each boundary ships its own contract
-       test per III.12(c)'s redundant-verification requirement.
+       test per historical v3 clause III.12(c)'s redundant-verification
+       requirement.
    * - ``tick_commit.replay_identity_hash``
      - **Not** a cross-run or cross-implementation contract — see
        *Known Discrepancies* below
@@ -646,7 +652,7 @@ added later). Every subsequent tick's row re-derives the entity/edge set
 from the live ``WorldState`` and asserts it still matches the tick-0
 header; a scenario that ever violated this assumption would raise
 ``ValueError`` naming the tick and the topology delta rather than silently
-misaligning columns (Constitution III.11, Loud Failure) — this is
+misaligning columns (Constitution Article V, Loud Failure) — this is
 untested-because-unreachable by the current 5 scenarios, not a
 theoretical-only guard.
 
@@ -743,7 +749,7 @@ from a prior run is removed at the start of a compare, and the file is only
 leaves no misleading report behind. Absence of a dense golden for a scenario
 is **not** a failure (dense goldens are additive, per-scenario; a scenario
 without one is simply not dense-checked yet) — only a byte mismatch against
-an *existing* golden fails the gate, keeping with Constitution III.11's
+an *existing* golden fails the gate, keeping with Constitution Article V's
 distinction between a genuine failure and an empty/not-yet-populated domain.
 
 Determinism verified: the five committed goldens were generated twice, in
@@ -773,6 +779,14 @@ hashes. ADR220 reserves ``TickContentHash`` for the future complete
 seed/content/reference/state/action identity at the PostgreSQL writer cutover.
 ``NominalWorldHash`` must never be stored under that stronger name.
 
+This section specifies only the outer ``NominalWorldHash`` composition. It
+treats ``GraphStateHash`` and ``phase_schedule_digest`` as authoritative
+32-byte inputs. Their inner domain strings, tagged sections, omissions, slot
+registry, alias table, and golden digests remain defined only in the cited Rust
+code and tests. An independent implementation still needs those sources. That
+is an explicit rewrite-contract gap, not a claim that this page specifies the
+complete Rust world identity.
+
 Canonical layout
 ++++++++++++++++
 
@@ -791,10 +805,11 @@ layout version, and four tagged sections in this exact order:
 
 The completed tick cannot be negative. The allocator value ``u64::MAX`` is
 the reserved exhausted sentinel; ``u64::MAX - 1`` is the last identity either
-allocator can mint. The schedule digest is separately versioned and hashes all
-34 canonical slots plus the byte-sorted compatibility aliases, including each
-partition, ordinal, and resolved default rank. Content order does not enter the
-schedule digest or this nominal identity.
+allocator can mint. The current Rust schedule digest is separately versioned
+and hashes all 34 canonical slots plus the byte-sorted compatibility aliases.
+It includes each partition, ordinal, and resolved default rank. Content order
+does not enter the schedule digest or this nominal identity. This paragraph is
+descriptive; it is not a complete schedule-digest byte specification.
 
 Exact asymmetric vector
 +++++++++++++++++++++++
@@ -837,10 +852,10 @@ The P27 Tick Hash (Frozen Python Reference)
 **Status: implemented as a frozen Python reference serializer, but not wired as
 the current Rust tick identity or the future durable writer hash.** This
 chapter originally named a single canonical per-tick content hash for the
-Program 27 kernel (Constitution III.7's literal definition —
+Program 27 kernel under historical v3 clause III.7's literal definition:
 *"a deterministic SHA-256 hash of its inputs: World state + player actions
-+ random seed"*, ``CONSTITUTION.md:250``) that the Rust port is required to
-compute, replacing the three-hash tangle documented in *Catalog of
++ random seed"*. The historical target required the Rust port to compute it,
+replacing the three-hash tangle documented in *Catalog of
 Constitutional Hashes* above (``defines_hash``, ``tick_commit.replay_identity_hash``,
 ``conservation_audit_log.hex_frame_hash`` — both named ``determinism_hash``
 pre-0044) with **one unambiguously named value** — resolving the naming
@@ -864,8 +879,8 @@ reading aid):**
      - The current tick index.
    * - ``rng_seed``
      - ``u64``
-     - The session's fixed RNG seed (Constitution III.7's ``random seed``
-       input). **Not** the session UUID — the session identifier never
+     - The session's fixed RNG seed (historical v3 clause III.7's
+       ``random seed`` input). **Not** the session UUID — the session identifier never
        enters this hash, keeping it independent of run identity, unlike
        ``tick_commit.replay_identity_hash`` today.
    * - ``nodes``
@@ -961,7 +976,7 @@ reading aid):**
 - **Ban on stringly fallbacks:** a field encountered during serialization
   that has no encoding rule above (i.e. not one of int / ``i128`` / ``f64``
   / bool / enum-or-string / array / nested record) is a **hash-time load
-  failure** (Constitution III.11, Loud Failure) — it MUST NOT fall back to
+  failure** (Constitution Article V, Loud Failure) — it MUST NOT fall back to
   a generic ``str(obj)``/``Debug``-style rendering. This explicitly bans
   the pattern ``conservation_audit.py``'s ``compute_hex_frame_hash()``
   uses today (``json.dumps(..., default=str)``, ``conservation_audit.py:110``)
@@ -1062,10 +1077,10 @@ benefit from mirroring a 39-category Pydantic model's declaration order:
 
 **``rules_hash`` — canonical AST serialization (CAS): specified in the BSL
 Language Reference.** Purpose: a rule-file edit that only reformats
-whitespace or adds/removes a comment must **not** move ``rules_hash``
-(Constitution III.7's input-hash-drift-vs-behavioral-drift distinction,
-generalized to rule content — see *Content pipeline*,
-``docs/superpowers/specs/2026-07-28-program-27-refoundation-design.md:404-406``);
+whitespace or adds/removes a comment must **not** move ``rules_hash``.
+Article V's canonical-input identity applies here to rule content. See
+*Content pipeline*
+(``docs/superpowers/specs/2026-07-28-program-27-refoundation-design.md:404-406``);
 a rule edit that changes the parsed AST must move it.
 
 The byte-level serialization behind ``rules_hash`` is normatively defined in
@@ -1130,7 +1145,7 @@ Rationale, ratified from that module's own text: (1) it takes an exact
 32-byte seed — a SHA-256 digest's width, so the derivation needs no
 truncation or expansion step; (2) it is a pure-Rust, no-``unsafe``,
 platform-independent stream-cipher construction, fully deterministic from
-its seed with no OS-entropy dependency (III.7); (3) 8 rounds is the "fast,
+its seed with no OS-entropy dependency under Article V; (3) 8 rounds is the "fast,
 still no known practical distinguisher" configuration — this is not a
 cryptographic-security use case, so ``ChaCha8`` over ``ChaCha20`` is pure
 speed with no correctness cost. Constructed only per ``(session_id, tick)``
@@ -1248,9 +1263,9 @@ non-reproducibility the *Scope* chapter above names (lines 53-66) — so a
 per-build determinism claim would be strictly weaker than the ruling
 requires and would silently make the tick hash platform-dependent.
 Consequence: **the Rust engine's tick hash is byte-identical across OS,
-libc, and CPU architecture** — a *stronger* claim than Constitution
-III.12 corollary (b), which continues to govern comparisons against the
-frozen Python engine (glibc) and nothing else.
+libc, and CPU architecture** — a *stronger* claim than historical v3 clause
+III.12 corollary (b), which continues as the recorded comparison policy
+against the frozen Python engine (glibc) and nothing else.
 
 **Why ``libm 0.2.16`` satisfies "pinned soft-float," verified in the
 vendored source** (already present transitively via Bevy/glam/naga before
@@ -1309,8 +1324,8 @@ this train promotes it from a transitive to a *direct* dependency of
    never ``abs(a - b) < eps``. Any drift is a red gate: a ``libm`` bump, a
    feature flip, or an accidental ``f64::exp`` all fail the golden
    vectors.
-2. **Against the frozen Python engine: tolerance is the III.12
-   corollary-(b) regime** (*Float and Tolerance Policy* above, regime 1).
+2. **Against the frozen Python engine: tolerance is the historical v3 clause
+   III.12 corollary-(b) regime** (*Float and Tolerance Policy* above, regime 1).
    CPython's ``math.exp``/``math.log`` call glibc; glibc and MUSL
    disagree in the last 1-2 ULPs (lines 53-66 above). Derivation: a bound
    of ``2 ulp(result)`` covers the crossing error per call — glibc
@@ -1349,7 +1364,7 @@ The four spec-pinned operators (refoundation design §6.1):
      - Rule
    * - ``Currency ± Currency``
      - ``Currency``
-     - checked i128 add/sub; overflow is a loud III.11 failure, never
+     - checked i128 add/sub; overflow is a loud Article V failure, never
        wrapping or saturating
    * - ``Currency × Coefficient``
      - ``Currency``
@@ -1416,9 +1431,9 @@ this document** (doc-only lane).
    owner-queue item 31). The original finding, kept as history:
    **``PerTickTransactionEnvelope.determinism_hash`` is not "a single ...
    shared across all rows."** The docstring
-   (``src/babylon/persistence/envelope.py:42-43``) states: *"A single
-   ``determinism_hash`` is shared across all rows in the tick (GATE-1 /
-   Constitution III.7)."* In the live wiring
+   (``src/babylon/persistence/envelope.py:42-43``) states that one
+   ``determinism_hash`` is shared across every row and attributes the claim to
+   historical v3 clause III.7. In the live wiring
    (``bridge.py:544-563``), this is **false**: ``envelope.determinism_hash``
    (the trivial ``session_id:tick:seed`` identity string, destined for
    ``tick_commit``) and each ``ConservationAuditRow.determinism_hash``
@@ -1436,19 +1451,20 @@ this document** (doc-only lane).
    to be a determinism hash; ``0029``'s comment stands as history and
    ``0044`` records the correction.] Original finding: **The ``tick_commit``
    migration's own comment overstates what it stores.**
-   ``0029_tick_commit.sql:9`` calls the column "the queryable
-   Constitution-III.7 hash chain," but per III.7's own text
-   (``CONSTITUTION.md:250``, "hash of its inputs: World state + player
-   actions + random seed"), the stored value contains none of those three
+   ``0029_tick_commit.sql:9`` calls the column a queryable hash chain under
+   historical v3 clause III.7. That clause described a hash of world state,
+   player actions, and random seed, but the stored value contains none of those three
    things — it is a session/tick/seed identity string with no dependency on
-   engine output. The value that *does* match III.7's definition
+   engine output. The value that *does* match historical v3 clause III.7's
+   definition
    (``compute_determinism_hash()``) is stored elsewhere
    (``conservation_audit_log``), not in ``tick_commit``.
-3. **Player actions are not currently threaded into the III.7 content
-   hash.** ``bridge.py:544-549`` calls ``audit_end_of_tick()`` without an
+3. **Player actions are not currently threaded into the historical v3 clause
+   III.7 content hash.** ``bridge.py:544-549`` calls ``audit_end_of_tick()``
+   without an
    ``action_list`` argument, so ``compute_determinism_hash()``'s ``actions``
-   input is always ``[]`` in the live path — even though both III.7's prose
-   and the function's own parameter exist to accommodate them. This is a
+   input is always ``[]`` in the live path — even though historical v3 clause
+   III.7 and the function's own parameter exist to accommodate them. This is a
    gap between the mechanism's design surface and its current wiring, not a
    correctness bug (there is no current caller with actions to pass), but a
    reimplementation should not assume actions are exercised by any existing
@@ -1456,8 +1472,8 @@ this document** (doc-only lane).
 
 None of the above required a code change to observe or document; they are
 reported per this document's scope as facts about the current
-implementation, for the orchestrator to weigh against Constitution III.12
-corollary (a)'s ``[PENDING CODE]`` marker and Program 13 item 2 (dense
+implementation, for the orchestrator to weigh against historical v3 clause
+III.12 corollary (a)'s ``[PENDING CODE]`` marker and Program 13 item 2 (dense
 goldens).
 
 See Also
@@ -1471,8 +1487,10 @@ See Also
   related but distinct drift-prevention mechanism (grid-snapping engine
   values at the type boundary, independent of this document's
   hash/tolerance policy).
-- ``CONSTITUTION.md`` III.7 (Determinism and Replayability), III.12
-  (Behavioral Contracts, Amendment Q).
+- ``CONSTITUTION.md`` Articles V and VIII — current deterministic architecture
+  and behavioral-validation authority.
+- ``ai/decisions/ADR221_game_first_refoundation_v4.yaml`` — transition mapping
+  for historical v3 clause III.7 and historical v3 clause III.12.
 - ``specs/053-conservation-invariants/contracts/value_conservation.md`` —
   the tolerance-derivation pattern this document's *Float and Tolerance
   Policy* section follows.

--- a/docs/reference/determinism-contract.rst
+++ b/docs/reference/determinism-contract.rst
@@ -1,9 +1,10 @@
 Determinism Contract
 =====================
 
-The language-agnostic, byte-level specification of every constitutional hash
-in Babylon. This document exists so that a reimplementation of the engine in
-another language could reproduce these hashes without reading the Python —
+The language-agnostic, byte-level specification of Babylon's implemented and
+reserved identity hashes. This document exists so that a reimplementation of
+the engine in another language could reproduce these hashes without reading
+their implementation —
 the **rewrite test** of Constitution III.12 ("Behavioral Contracts",
 Amendment Q, corollary (a); see ``CONSTITUTION.md``). It is a reference document: it describes what
 the current implementation *does*, byte for byte, not what an idealized
@@ -11,16 +12,12 @@ implementation *should* do. Where the implementation's behavior surprises its
 own naming or docstrings, this document says so explicitly (see the
 *Known Discrepancies* section below) rather than papering over the gap.
 
-Program 27 Phase 0 (``docs/superpowers/specs/2026-07-28-program-27-refoundation-design.md``)
-adds three chapters below — *The P27 Tick Hash*, *ContentDigest and the
-Canonical BSL AST Serialization*, and *Fuel Cost Model and RNG Seeding* — that
-are a different kind of artifact from the rest of this document: they are
-**forward specifications for the Rust kernel** (``babylon-kernel``,
-``babylon-bsl``) to be built in Program 27 Phase 1, not descriptions of code
-that runs today. Each states plainly, in its own "Today vs. this chapter"
-note, what the live Python implementation does differently — the same
-discipline the rest of this document applies retrospectively, applied here
-prospectively to a not-yet-written implementation.
+Program 27 Phase 0
+(``docs/superpowers/specs/2026-07-28-program-27-refoundation-design.md``)
+added three forward-specification chapters below. Parts later gained frozen
+Python or Rust reference implementations. Each chapter's own status note now
+controls; historical target prose does not override the current identity
+taxonomy or ADR220's reserved ``TickContentHash`` name.
 
 .. contents:: On this page
    :local:
@@ -67,11 +64,11 @@ comparison**, not hash equality — see *Float and Tolerance Policy* below.
 Catalog of Constitutional Hashes
 ----------------------------------
 
-Three genuinely different hashes exist in the codebase, all currently named
-some variant of "determinism hash." They are **not interchangeable** and, as
-of this writing, **not even consistent with each other's docstrings** inside
-the same code path — see *Known Discrepancies* below. This section specifies each
-one's exact byte-level construction.
+The frozen Python estate has three older identities in its live and reference
+paths. Rust adds a graph-only diagnostic and a current in-memory nominal-world
+identity. The complete durable ``TickContentHash`` remains reserved. These
+values are not interchangeable. This section and the PER-18 section below
+specify their exact roles and byte constructions.
 
 ``defines_hash`` — GameDefines fingerprint
 +++++++++++++++++++++++++++++++++++++++++++
@@ -754,12 +751,93 @@ two independent ``uv run python`` processes, and byte-compared
 (``cmp``) identical before being committed — the intra-implementation
 guarantee *Scope* above claims, demonstrated rather than assumed.
 
-The P27 Tick Hash (Rust Kernel Reference)
---------------------------------------------
+Current Rust Nominal World Hash (PER-18)
+----------------------------------------
 
-**Status: forward specification, Program 27 Phase 1 target — not yet
-implemented.** This chapter names the single canonical per-tick content
-hash for ``babylon-kernel`` (Constitution III.7's literal definition —
+**Status: implemented in the Rust tick path.** PER-18 and ADR223 establish two
+separate current identities:
+
+``GraphStateHash``
+   The SHA-256 diagnostic over canonical graph facts. Its existing graph
+   layout remains unchanged. It does not cover elapsed time or allocator
+   history.
+
+``NominalWorldHash``
+   The SHA-256 identity of the current mutable Rust graph-and-tick registers:
+   ``GraphStateHash``, the completed weekly tick, both monotonic graph
+   allocator cursors, and the governed static phase-schedule digest.
+
+The frozen Python P27 tick hash below is a reference implementation over a
+JSON node, edge, action, tick, and seed record. It is neither of these Rust
+hashes. ADR220 reserves ``TickContentHash`` for the future complete
+seed/content/reference/state/action identity at the PostgreSQL writer cutover.
+``NominalWorldHash`` must never be stored under that stronger name.
+
+Canonical layout
+++++++++++++++++
+
+Every integer is big-endian. The 116-byte version-1 preimage is the fixed
+ASCII domain ``babylon.world-state`` followed by NUL, a big-endian ``u32``
+layout version, and four tagged sections in this exact order:
+
+.. code-block:: text
+
+   "babylon.world-state\0"
+   u32(1)
+   0x01 | GraphStateHash[32]
+   0x02 | completed_tick:i64
+   0x03 | next_node:u64 | next_hyperedge:u64
+   0x04 | phase_schedule_digest[32]
+
+The completed tick cannot be negative. The allocator value ``u64::MAX`` is
+the reserved exhausted sentinel; ``u64::MAX - 1`` is the last identity either
+allocator can mint. The schedule digest is separately versioned and hashes all
+34 canonical slots plus the byte-sorted compatibility aliases, including each
+partition, ordinal, and resolved default rank. Content order does not enter the
+schedule digest or this nominal identity.
+
+Exact asymmetric vector
++++++++++++++++++++++++
+
+The executable vector uses graph bytes ``01`` through ``20``, completed tick
+``0x0102030405060708``, node cursor ``0x1112131415161718``, hyperedge cursor
+``0x2122232425262728``, and schedule bytes ``a1`` through ``c0``. Its exact
+116-byte preimage is:
+
+.. code-block:: text
+
+   626162796c6f6e2e776f726c642d73746174650000000001010102030405060708
+   090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20020102030405060708
+   031112131415161718212223242526272804a1a2a3a4a5a6a7a8a9aaabacadaeaf
+   b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0
+
+Its SHA-256 is
+``8ce3e668779b762d26bf3543820775d52d711ffae6076006297c85968fb12751``.
+The test asserts the hand-written bytes before the digest, so a wrong tag,
+field order, or endian choice cannot pass by updating one captured hash.
+
+Atomicity and determinism evidence
+++++++++++++++++++++++++++++++++++
+
+``TickSession`` and both one-shot entry points adjudicate against a detached
+working graph, buffer events, and reserve the complete event batch before
+publication. A returned error leaves graph bytes, cursors, prior events, and
+completed time unchanged. Tests inject failures in Material Base, Action, and
+Consequences on both graph stores, plus pre-hash, post-hash non-finite, event
+publication, allocator-exhaustion, and tick-exhaustion paths.
+
+A real multi-rule tick compares both graph hashes, both nominal-world hashes,
+total and per-rule firing, and exact typed event payloads in parent and child
+processes, under reversed insertion order and both graph backends. These tests
+prove computational identity, not scientific truth or PostgreSQL durability.
+
+The P27 Tick Hash (Frozen Python Reference)
+-------------------------------------------
+
+**Status: implemented as a frozen Python reference serializer, but not wired as
+the current Rust tick identity or the future durable writer hash.** This
+chapter originally named a single canonical per-tick content hash for the
+Program 27 kernel (Constitution III.7's literal definition —
 *"a deterministic SHA-256 hash of its inputs: World state + player actions
 + random seed"*, ``CONSTITUTION.md:250``) that the Rust port is required to
 compute, replacing the three-hash tangle documented in *Catalog of
@@ -931,8 +1009,13 @@ Postgres ``EXCEPT`` row-diff pattern this document already documents (see
 ``tick_commit.replay_identity_hash`` above), and this hash's job is a single
 unambiguous per-tick content fingerprint, not a chain.
 
-**Today vs. this chapter — what changes:** all three of today's hashes
-must be reconciled into this one at cutover. Concretely: (1)
+**Current disposition:** ``babylon.kernel.tick_hash`` implements this
+language-neutral reference layout and its tests preserve the rewrite artifact.
+The shipping Rust tick does not call it. Gate 3 must decide which parts survive
+inside the complete ``TickContentHash`` while adding all current Rust auxiliary
+registers, content and reference digests, and the durable action/campaign
+contract. The original transition analysis follows: all three older Python
+hashes needed reconciliation at cutover. Concretely: (1)
 ``defines_hash`` is unaffected (it stays a separate, independent hash —
 see the *ContentDigest* chapter below); (2) ``tick_commit.replay_identity_hash``
 today carries **no world state at all** (just

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -113,8 +113,8 @@ concrete implementations (``PostgresRuntime``, ``RuntimeDatabase``,
 ``PgVectorStore``, ``TraceRecorder``), database schema, and the
 ``PersistenceObserver`` lifecycle hook.
 
-Projection Registry (Program 24, Constitution II.11)
-----------------------------------------------------
+Projection Registry (Program 24)
+--------------------------------
 
 .. toctree::
    :maxdepth: 1
@@ -123,20 +123,22 @@ Projection Registry (Program 24, Constitution II.11)
 
 The declared-view registry behind the transport-neutral projection layer
 (``babylon.projection``): per-view ownership, frozen view-models, explicit
-``ORDER BY`` determinism, and FTS columns. The mandated II.11 spec.
+``ORDER BY`` determinism, and FTS columns. ADR221 re-homes historical v3
+clause II.11 here and in the architecture record.
 
-Determinism Contract (Constitution III.12)
--------------------------------------------
+Determinism Contract (Constitution Article V)
+----------------------------------------------
 
 .. toctree::
    :maxdepth: 1
 
    determinism-contract
 
-The language-agnostic, byte-level identity taxonomy and hash specification:
-the legacy Python replay marker and hex-frame hash, ``GraphStateHash``, the
-current Rust ``NominalWorldHash``, and the future complete
-``TickContentHash``. It records canonical serialization, worked examples,
+The identity taxonomy and selected byte layouts: the legacy Python replay
+marker and hex-frame hash, the roles of ``GraphStateHash`` and the current Rust
+``NominalWorldHash``, and the reserved ``TickContentHash`` name. The nominal
+section specifies its outer composition but records the graph and schedule
+inputs as a rewrite-contract gap. The page also records worked examples,
 float-tolerance regimes, and historical naming discrepancies.
 
 BSL Language Reference (Program 27)
@@ -154,8 +156,8 @@ evaluation and fuel accounting, the canonical AST serialization behind
 ``rules_hash``, and the conformance-vector contract. Phase-1 draft under
 the Program 27 refoundation design.
 
-Declared Synthetic Data (Constitution III.11 / VIII.12)
----------------------------------------------------------
+Declared Synthetic Data (Constitution Article V)
+-------------------------------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -133,11 +133,11 @@ Determinism Contract (Constitution III.12)
 
    determinism-contract
 
-The language-agnostic, byte-level specification of every constitutional
-hash (``defines_hash``, ``tick_commit.determinism_hash``,
-``conservation_audit_log.determinism_hash``): canonical serialization,
-worked examples, the three float-tolerance regimes, and documented
-discrepancies between hash naming/docstrings and actual behavior.
+The language-agnostic, byte-level identity taxonomy and hash specification:
+the legacy Python replay marker and hex-frame hash, ``GraphStateHash``, the
+current Rust ``NominalWorldHash``, and the future complete
+``TickContentHash``. It records canonical serialization, worked examples,
+float-tolerance regimes, and historical naming discrepancies.
 
 BSL Language Reference (Program 27)
 -------------------------------------

--- a/docs/reference/phase-1-exit-checklist.md
+++ b/docs/reference/phase-1-exit-checklist.md
@@ -14,7 +14,10 @@ tests, workspace clippy `-D warnings`, per-crate pedantic clippy on
 `RUSTDOCFLAGS='-D warnings' cargo doc` — **zero errors on every leg**.
 
 Current follow-through (2026-08-23): the deferred anchor total order and
-E-LOAD-003 item landed in `babylon-tick` through PER-17 and ADR222. The table
+E-LOAD-003 item landed in `babylon-tick` through PER-17 and ADR222. PER-18 and
+ADR223 then added detached whole-tick rollback, checked allocator exhaustion,
+buffered event publication, and the versioned nominal world hash. These are
+in-memory contracts; the durable Gate 3 envelope remains planned. The table
 below remains the Phase 1 handoff snapshot rather than rewriting its history.
 
 ## DONE — merged, tested, gate-clean

--- a/docs/superpowers/specs/2026-07-29-game-design-standard-design.md
+++ b/docs/superpowers/specs/2026-07-29-game-design-standard-design.md
@@ -33,6 +33,7 @@ service of play. It must never masquerade as an empirical observation.
 - Ratatui/TUI status: retired
 - Article V vocabulary authority status: superseded
 - NarrationEnvelope status: superseded_proposal
+- In-memory whole-tick rollback status: implemented_current_PER-18
 - CommittedTickEnvelope status: planned
 - DecisionSurfaceContract executable status: planned
 - Persistence writer status: accepted_cutover_law
@@ -61,8 +62,10 @@ cannot satisfy gameplay milestones. PER-24 owns the executable Rust contract
 and surface inventory at Gate 3; this addendum does not claim that code exists.
 
 The historical `NarrationEnvelope` proposal below is not an implemented v4
-boundary. Gate 3 plans `CommittedTickEnvelope`, durable state, and the Archive
-outbox. Durability begins after deterministic adjudication. PER-48 is Done;
+boundary. PER-18 implements detached in-memory adjudication and publishes a
+tick only after rules, event preparation, and hashes succeed. Gate 3 still
+plans `CommittedTickEnvelope`, durable state, and the Archive outbox.
+Durability begins after deterministic adjudication. PER-48 is Done;
 `ADR220_rust_owned_postgresql_persistence_boundary` records the accepted law.
 Python remains the sole live PostgreSQL writer before cutover. The one-way
 cutover disables Python migration and runtime-write entry points before Rust

--- a/rust/crates/babylon-client/src/loop_ui.rs
+++ b/rust/crates/babylon-client/src/loop_ui.rs
@@ -286,7 +286,7 @@ fn spawn_engine_session_and_hud(
 
 fn refresh_readouts(
     counter: Res<TickCounter>,
-    session: Res<EngineSession>,
+    last_report: Res<crate::ui::admin::LastTickReport>,
     mut tick_text: Query<&mut Text, (With<TickCounterReadout>, Without<HashReadout>)>,
     mut hash_text: Query<&mut Text, With<HashReadout>>,
 ) {
@@ -297,15 +297,10 @@ fn refresh_readouts(
         t.0 = format!("tick {}", counter.0);
     }
     if let Ok(mut h) = hash_text.single_mut() {
-        // The last hash this session computed — sink carries no hash, so
-        // read it back off the session's own last report by re-deriving
-        // from the graph directly (state_hash is cheap at this scale, see
-        // the Global Constraints Scale Note — 18 nodes, 0 hyperedges).
-        if let Ok(hash) =
-            babylon_graph::state_hash::CanonicalState::state_hash(session.inner.graph())
-        {
-            h.0 = format!("hash: {}", babylon_tick::hex(&hash));
-        }
+        h.0 = match last_report.0.as_ref() {
+            Some(report) => format!("hash: {}", babylon_tick::hex(&report.world_after)),
+            None => "hash: (not yet run)".to_owned(),
+        };
     }
 }
 

--- a/rust/crates/babylon-client/src/ui/admin.rs
+++ b/rust/crates/babylon-client/src/ui/admin.rs
@@ -171,6 +171,8 @@ mod tests {
         let report = babylon_tick::TickReport {
             before: [0u8; 32],
             after: [1u8; 32],
+            world_before: [2u8; 32],
+            world_after: [3u8; 32],
             fired: 18,
             per_rule_fired: vec![
                 ("lifecycle/dpd-circuit".to_owned(), 12),

--- a/rust/crates/babylon-client/tests/determinism.rs
+++ b/rust/crates/babylon-client/tests/determinism.rs
@@ -15,8 +15,8 @@ fn same_content_same_tick_count_yields_the_same_hash() {
         let ra = a.advance().expect("a advances");
         let rb = b.advance().expect("b advances");
         assert_eq!(
-            ra.after, rb.after,
-            "tick {tick}: two independent EngineSessions over the same content must hash identically"
+            ra.world_after, rb.world_after,
+            "tick {tick}: two independent EngineSessions over the same content must have identical world hashes"
         );
         assert_eq!(
             ra.per_rule_fired, rb.per_rule_fired,
@@ -34,11 +34,11 @@ fn five_ticks_produce_five_distinct_hashes() {
     let mut hashes = std::collections::HashSet::new();
     for _ in 0..5 {
         let report = session.advance().expect("advance");
-        hashes.insert(report.after);
+        hashes.insert(report.world_after);
     }
     assert_eq!(
         hashes.len(),
         5,
-        "each tick must produce a distinct state hash"
+        "each completed tick must produce a distinct nominal world hash"
     );
 }

--- a/rust/crates/babylon-client/tests/projection.rs
+++ b/rust/crates/babylon-client/tests/projection.rs
@@ -280,6 +280,8 @@ fn the_admin_panel_renders_the_per_rule_breakdown_from_a_seeded_tick_report() {
         .0 = Some(babylon_tick::TickReport {
         before: [0u8; 32],
         after: [1u8; 32],
+        world_before: [2u8; 32],
+        world_after: [3u8; 32],
         fired: 7,
         per_rule_fired: vec![
             ("lifecycle/dpd-circuit".to_owned(), 5),

--- a/rust/crates/babylon-client/tests/tick_loop.rs
+++ b/rust/crates/babylon-client/tests/tick_loop.rs
@@ -34,15 +34,11 @@ fn press_key_via_real_event(app: &mut App, key: bevy::input::keyboard::KeyCode) 
 /// `TickCounter` — hardcoding `refresh_readouts`' hash text to
 /// `"hash: deadbeefdeadbeef"` left this test fully green (mutation-proven).
 /// Now the test reads the ACTUAL rendered `HashReadout` text and checks it
-/// against the session's own real post-tick `state_hash`, so the name is
-/// no longer an overclaim.
+/// against the session's own committed nominal world hash, so the name is
+/// no longer an overclaim and the shipped readout cannot regress to graph-only
+/// identity.
 #[test]
 fn pressing_space_advances_the_tick_and_updates_the_hash_text() {
-    // Needed below to call `.state_hash()`; hoisted to the top of the
-    // function (clippy::items_after_statements) rather than left inline
-    // where it was first used.
-    use babylon_graph::state_hash::CanonicalState;
-
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, AssetPlugin::default()));
     app.add_plugins(babylon_client::map::MapPlugin);
@@ -68,16 +64,16 @@ fn pressing_space_advances_the_tick_and_updates_the_hash_text() {
         .resource::<babylon_client::loop_ui::TickCounter>();
     assert_eq!(counter.0, 1);
 
-    // The ACTUAL rendered hash text must match the session's own real
-    // post-tick state_hash — not a placeholder, not a stale value.
-    let session = app
+    // The ACTUAL rendered hash text must match the last committed report's
+    // nominal world identity — not a placeholder, stale value, or graph-only
+    // recomputation that omits completed time and allocator state.
+    let expected_hash = app
         .world()
-        .resource::<babylon_client::engine_link::EngineSession>();
-    let expected_hash = session
-        .inner
-        .graph()
-        .state_hash()
-        .expect("post-tick state hashes");
+        .resource::<babylon_client::ui::admin::LastTickReport>()
+        .0
+        .as_ref()
+        .expect("tick one produced a committed report")
+        .world_after;
     let expected_text = format!("hash: {}", babylon_tick::hex(&expected_hash));
 
     let world = app.world_mut();
@@ -89,6 +85,6 @@ fn pressing_space_advances_the_tick_and_updates_the_hash_text() {
         .clone();
     assert_eq!(
         hash_text, expected_text,
-        "the rendered hash readout must equal the session's own real post-tick state_hash"
+        "the rendered hash readout must equal the last committed nominal world hash"
     );
 }

--- a/rust/crates/babylon-client/tests/time_controls.rs
+++ b/rust/crates/babylon-client/tests/time_controls.rs
@@ -9,6 +9,7 @@
 //! Row numbering below matches `task-2-brief.md` §2.2 verbatim (rows 1-8).
 use babylon_client::engine_link::EngineSession;
 use babylon_client::loop_ui::TickCounter;
+use babylon_client::ui::admin::LastTickReport;
 use babylon_client::ui::time::{ticks_due, AutopauseMode, RunState, SPEEDS_PER_SECOND};
 use bevy::asset::AssetPlugin;
 use bevy::input::keyboard::{Key, KeyboardInput, NativeKey};
@@ -240,7 +241,7 @@ fn ten_discrete_advances_and_a_ticks_due_batch_of_ten_hash_identically() {
     let mut stepped_hashes = Vec::new();
     for _ in 0..10 {
         let report = stepped.advance().expect("stepped advance");
-        stepped_hashes.push(report.after);
+        stepped_hashes.push(report.world_after);
     }
 
     let interval = 1.0 / SPEEDS_PER_SECOND[0];
@@ -259,7 +260,7 @@ fn ten_discrete_advances_and_a_ticks_due_batch_of_ten_hash_identically() {
         accumulator = remainder;
         for _ in 0..due {
             let report = batched.advance().expect("batched advance");
-            batched_hashes.push(report.after);
+            batched_hashes.push(report.world_after);
         }
     }
 
@@ -275,11 +276,9 @@ fn ten_discrete_advances_and_a_ticks_due_batch_of_ten_hash_identically() {
 /// The wiring-level half of the claim: the REAL `advance_ticks` system,
 /// driven once by ten real `Space` presses and once by real injected
 /// `Time` durations (never a keypress), must reach the identical tick
-/// count and state hash at tick 10.
+/// count and nominal world hash at tick 10.
 #[test]
 fn ten_space_presses_and_an_auto_run_batch_reach_the_same_wired_tick_and_hash() {
-    use babylon_graph::state_hash::CanonicalState;
-
     let mut stepped_app = new_app();
     stepped_app.update(); // Startup
     press_key_via_real_event(&mut stepped_app, KeyCode::KeyP);
@@ -293,11 +292,11 @@ fn ten_space_presses_and_an_auto_run_batch_reach_the_same_wired_tick_and_hash() 
     let stepped_tick = stepped_app.world().resource::<TickCounter>().0;
     let stepped_hash = stepped_app
         .world()
-        .resource::<EngineSession>()
-        .inner
-        .graph()
-        .state_hash()
-        .expect("stepped hash");
+        .resource::<LastTickReport>()
+        .0
+        .as_ref()
+        .expect("stepped tick ten report")
+        .world_after;
 
     let mut batched_app = new_app();
     batched_app.update(); // Startup
@@ -312,18 +311,18 @@ fn ten_space_presses_and_an_auto_run_batch_reach_the_same_wired_tick_and_hash() 
     let batched_tick = batched_app.world().resource::<TickCounter>().0;
     let batched_hash = batched_app
         .world()
-        .resource::<EngineSession>()
-        .inner
-        .graph()
-        .state_hash()
-        .expect("batched hash");
+        .resource::<LastTickReport>()
+        .0
+        .as_ref()
+        .expect("batched tick ten report")
+        .world_after;
 
     assert_eq!(stepped_tick, 10);
     assert_eq!(batched_tick, 10);
     assert_eq!(
         stepped_hash, batched_hash,
         "10 discrete Space presses and one auto-run batch of 10 must reach \
-         byte-identical state at tick 10"
+         byte-identical nominal world identity at tick 10"
     );
 }
 

--- a/rust/crates/babylon-graph/src/allocator_state.rs
+++ b/rust/crates/babylon-graph/src/allocator_state.rs
@@ -21,3 +21,11 @@ pub trait AllocatorState {
     /// Return both next-id cursors without advancing either allocator.
     fn allocator_cursors(&self) -> AllocatorCursors;
 }
+
+/// Narrow test-only control for proving allocator exhaustion behavior. No
+/// production caller may set monotonic identity cursors.
+#[cfg(test)]
+pub(crate) trait AllocatorTestControl {
+    /// Set both cursors to an otherwise unreachable boundary fixture.
+    fn set_allocator_cursors_for_test(&mut self, cursors: AllocatorCursors);
+}

--- a/rust/crates/babylon-graph/src/allocator_state.rs
+++ b/rust/crates/babylon-graph/src/allocator_state.rs
@@ -7,11 +7,18 @@
 //! contract without changing the established graph-state byte layout.
 
 /// The next identities each monotonic graph allocator will mint.
+///
+/// `u64::MAX` is the reserved exhausted-cursor sentinel for either lane. It
+/// is never a mintable identity. The last mintable identity is therefore
+/// `u64::MAX - 1`; a successful mint there advances its cursor to the
+/// sentinel, and every later mint refuses without mutation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AllocatorCursors {
-    /// The next [`crate::substrate::NodeId`] value.
+    /// The next [`crate::substrate::NodeId`] value, or `u64::MAX` when the
+    /// node allocator is exhausted.
     pub next_node: u64,
-    /// The next [`crate::substrate::HyperedgeId`] value.
+    /// The next [`crate::substrate::HyperedgeId`] value, or `u64::MAX` when
+    /// the hyperedge allocator is exhausted.
     pub next_hyperedge: u64,
 }
 

--- a/rust/crates/babylon-graph/src/allocator_state.rs
+++ b/rust/crates/babylon-graph/src/allocator_state.rs
@@ -1,0 +1,23 @@
+//! Allocator state that is real world state but not graph content.
+//!
+//! [`crate::state_hash::CanonicalState`] deliberately hashes live graph
+//! facts only. Monotonic identity cursors are different: removing an object
+//! does not rewind them, and the next minted identity affects every later
+//! reference. Tick-level world hashing therefore consumes this sibling
+//! contract without changing the established graph-state byte layout.
+
+/// The next identities each monotonic graph allocator will mint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AllocatorCursors {
+    /// The next [`crate::substrate::NodeId`] value.
+    pub next_node: u64,
+    /// The next [`crate::substrate::HyperedgeId`] value.
+    pub next_hyperedge: u64,
+}
+
+/// Read-only access to identity allocator state for transaction and hash
+/// boundaries.
+pub trait AllocatorState {
+    /// Return both next-id cursors without advancing either allocator.
+    fn allocator_cursors(&self) -> AllocatorCursors;
+}

--- a/rust/crates/babylon-graph/src/allocator_state.rs
+++ b/rust/crates/babylon-graph/src/allocator_state.rs
@@ -6,7 +6,7 @@
 //! reference. Tick-level world hashing therefore consumes this sibling
 //! contract without changing the established graph-state byte layout.
 
-/// The next identities each monotonic graph allocator will mint.
+/// The cursor state of each monotonic graph identity allocator.
 ///
 /// `u64::MAX` is the reserved exhausted-cursor sentinel for either lane. It
 /// is never a mintable identity. The last mintable identity is therefore

--- a/rust/crates/babylon-graph/src/conformance.rs
+++ b/rust/crates/babylon-graph/src/conformance.rs
@@ -1193,6 +1193,10 @@ where
     let mut working = source.detached_copy();
     assert_eq!(working.encode_state().unwrap().as_bytes(), source_bytes);
     assert_eq!(working.allocator_cursors(), source_cursors);
+    assert_eq!(source.hyperedges("COALITION"), vec![cell]);
+    assert_eq!(source.hyperedges_of(a, "COALITION").unwrap(), vec![cell]);
+    assert_eq!(working.hyperedges("COALITION"), vec![cell]);
+    assert_eq!(working.hyperedges_of(a, "COALITION").unwrap(), vec![cell]);
 
     exercise_every_mutable_lane(&mut working, a, b, c, cell);
 
@@ -1222,12 +1226,44 @@ where
     );
     assert_ne!(working.encode_state().unwrap().as_bytes(), source_bytes);
     assert_ne!(working.allocator_cursors(), source_cursors);
+    assert_eq!(source.hyperedges("COALITION"), vec![cell]);
+    assert_eq!(source.hyperedges_of(a, "COALITION").unwrap(), vec![cell]);
+    assert_eq!(source.members_of(cell).unwrap(), vec![a, b, c]);
+    assert_eq!(working.hyperedges("COALITION"), vec![HyperedgeId(1)]);
+    assert_eq!(
+        working.hyperedges_of(a, "COALITION").unwrap(),
+        vec![HyperedgeId(1)]
+    );
+    assert_eq!(working.members_of(HyperedgeId(1)).unwrap(), vec![a, b]);
 
     assert_eq!(source.add_node("BUSINESS").unwrap(), NodeId(3));
     assert_eq!(
-        source.add_hyperedge("COALITION", &[a, b]).unwrap(),
+        source.add_hyperedge("COALITION", &[b, c]).unwrap(),
         HyperedgeId(1)
     );
+    assert_eq!(source.hyperedges("COALITION"), vec![cell, HyperedgeId(1)]);
+    assert_eq!(
+        source.hyperedges_of(b, "COALITION").unwrap(),
+        vec![cell, HyperedgeId(1)]
+    );
+    assert_eq!(source.hyperedges_of(a, "COALITION").unwrap(), vec![cell]);
+    assert_eq!(source.members_of(HyperedgeId(1)).unwrap(), vec![b, c]);
+    assert_eq!(working.hyperedges("COALITION"), vec![HyperedgeId(1)]);
+    assert_eq!(
+        working.hyperedges_of(a, "COALITION").unwrap(),
+        vec![HyperedgeId(1)]
+    );
+    assert_eq!(working.members_of(HyperedgeId(1)).unwrap(), vec![a, b]);
+
+    source.remove_hyperedge(cell).unwrap();
+    assert_eq!(source.hyperedges("COALITION"), vec![HyperedgeId(1)]);
+    assert!(source.hyperedges_of(a, "COALITION").unwrap().is_empty());
+    assert_eq!(source.members_of(HyperedgeId(1)).unwrap(), vec![b, c]);
+    assert_eq!(
+        working.hyperedges_of(a, "COALITION").unwrap(),
+        vec![HyperedgeId(1)]
+    );
+    assert_eq!(working.members_of(HyperedgeId(1)).unwrap(), vec![a, b]);
 }
 
 #[cfg(test)]
@@ -1272,8 +1308,9 @@ fn exercise_every_mutable_lane<G: GraphSubstrate>(
     working.remove_node(c).unwrap();
 }
 
-/// Both identity allocators must reject exhaustion before changing graph
-/// bytes or either cursor.
+/// Both identity allocators mint `u64::MAX - 1`, advance to the reserved
+/// `u64::MAX` exhausted sentinel, then refuse before changing graph bytes or
+/// either cursor.
 #[cfg(test)]
 pub(crate) fn run_allocator_exhaustion_conformance<G, F>(make: F)
 where
@@ -1286,15 +1323,22 @@ where
     graph.add_hyperedge("COALITION", &[a, b]).unwrap();
 
     graph.set_allocator_cursors_for_test(AllocatorCursors {
-        next_node: u64::MAX,
+        next_node: u64::MAX - 1,
         next_hyperedge: 1,
     });
+    assert_eq!(graph.add_node("BUSINESS").unwrap(), NodeId(u64::MAX - 1));
+    assert_eq!(graph.allocator_cursors().next_node, u64::MAX);
     assert_exhausted_node_allocator_is_atomic(&mut graph);
 
     graph.set_allocator_cursors_for_test(AllocatorCursors {
-        next_node: 2,
-        next_hyperedge: u64::MAX,
+        next_node: u64::MAX,
+        next_hyperedge: u64::MAX - 1,
     });
+    assert_eq!(
+        graph.add_hyperedge("COALITION", &[a, b]).unwrap(),
+        HyperedgeId(u64::MAX - 1)
+    );
+    assert_eq!(graph.allocator_cursors().next_hyperedge, u64::MAX);
     assert_exhausted_hyperedge_allocator_is_atomic(&mut graph, a, b);
 }
 

--- a/rust/crates/babylon-graph/src/conformance.rs
+++ b/rust/crates/babylon-graph/src/conformance.rs
@@ -1172,6 +1172,30 @@ where
     F: Fn() -> G,
 {
     let mut source = make();
+    let witness = seed_detached_copy_source(&mut source);
+    let mut working = source.detached_copy();
+    assert_detached_copy_matches_source(&source, &working, &witness);
+    exercise_every_mutable_lane(&mut working, witness.a, witness.b, witness.c, witness.cell);
+    assert_source_unchanged(&source, &witness);
+    assert_working_changed_independently(&working, &witness);
+    exercise_source_after_copy(&mut source, &working, &witness);
+}
+
+#[cfg(test)]
+struct DetachedCopyWitness {
+    a: NodeId,
+    b: NodeId,
+    c: NodeId,
+    cell: HyperedgeId,
+    source_bytes: Vec<u8>,
+    source_cursors: AllocatorCursors,
+}
+
+#[cfg(test)]
+fn seed_detached_copy_source<G>(source: &mut G) -> DetachedCopyWitness
+where
+    G: GraphSubstrate + CanonicalState + AllocatorState,
+{
     let a = source.add_node("SOCIAL_CLASS").unwrap();
     let b = source.add_node("TERRITORY").unwrap();
     let c = source.add_node("ORGANIZATION").unwrap();
@@ -1187,83 +1211,163 @@ where
     source
         .update_hyperedge_attribute(cell, "coalition/cohesion", 0.625)
         .unwrap();
+    DetachedCopyWitness {
+        a,
+        b,
+        c,
+        cell,
+        source_bytes: source.encode_state().unwrap().as_bytes().to_vec(),
+        source_cursors: source.allocator_cursors(),
+    }
+}
 
-    let source_bytes = source.encode_state().unwrap().as_bytes().to_vec();
-    let source_cursors = source.allocator_cursors();
-    let mut working = source.detached_copy();
-    assert_eq!(working.encode_state().unwrap().as_bytes(), source_bytes);
-    assert_eq!(working.allocator_cursors(), source_cursors);
-    assert_eq!(source.hyperedges("COALITION"), vec![cell]);
-    assert_eq!(source.hyperedges_of(a, "COALITION").unwrap(), vec![cell]);
-    assert_eq!(working.hyperedges("COALITION"), vec![cell]);
-    assert_eq!(working.hyperedges_of(a, "COALITION").unwrap(), vec![cell]);
-
-    exercise_every_mutable_lane(&mut working, a, b, c, cell);
-
-    assert_eq!(source.encode_state().unwrap().as_bytes(), source_bytes);
-    assert_eq!(source.allocator_cursors(), source_cursors);
+#[cfg(test)]
+fn assert_detached_copy_matches_source<G>(source: &G, working: &G, witness: &DetachedCopyWitness)
+where
+    G: GraphSubstrate + CanonicalState + AllocatorState,
+{
     assert_eq!(
-        source.node_attribute(a, "class/power").unwrap().to_bits(),
+        working.encode_state().unwrap().as_bytes(),
+        witness.source_bytes
+    );
+    assert_eq!(working.allocator_cursors(), witness.source_cursors);
+    assert_eq!(source.hyperedges("COALITION"), vec![witness.cell]);
+    assert_eq!(
+        source.hyperedges_of(witness.a, "COALITION").unwrap(),
+        vec![witness.cell]
+    );
+    assert_eq!(working.hyperedges("COALITION"), vec![witness.cell]);
+    assert_eq!(
+        working.hyperedges_of(witness.a, "COALITION").unwrap(),
+        vec![witness.cell]
+    );
+}
+
+#[cfg(test)]
+fn assert_source_unchanged<G>(source: &G, witness: &DetachedCopyWitness)
+where
+    G: GraphSubstrate + CanonicalState + AllocatorState,
+{
+    assert_eq!(
+        source.encode_state().unwrap().as_bytes(),
+        witness.source_bytes
+    );
+    assert_eq!(source.allocator_cursors(), witness.source_cursors);
+    assert_eq!(
+        source
+            .node_attribute(witness.a, "class/power")
+            .unwrap()
+            .to_bits(),
         0.25f64.to_bits()
     );
     assert_eq!(
-        source.node_attribute_currency(a, "class/cash").unwrap(),
+        source
+            .node_attribute_currency(witness.a, "class/cash")
+            .unwrap(),
         Currency::from_micro_units(12_345)
     );
     assert_eq!(
         source
-            .edge_attribute("PRESENCE", a, b, "presence/friction")
+            .edge_attribute("PRESENCE", witness.a, witness.b, "presence/friction")
             .unwrap()
             .to_bits(),
         0.125f64.to_bits()
     );
     assert_eq!(
         source
-            .hyperedge_attribute(cell, "coalition/cohesion")
+            .hyperedge_attribute(witness.cell, "coalition/cohesion")
             .unwrap()
             .to_bits(),
         0.625f64.to_bits()
     );
-    assert_ne!(working.encode_state().unwrap().as_bytes(), source_bytes);
-    assert_ne!(working.allocator_cursors(), source_cursors);
-    assert_eq!(source.hyperedges("COALITION"), vec![cell]);
-    assert_eq!(source.hyperedges_of(a, "COALITION").unwrap(), vec![cell]);
-    assert_eq!(source.members_of(cell).unwrap(), vec![a, b, c]);
+    assert_eq!(source.hyperedges("COALITION"), vec![witness.cell]);
+    assert_eq!(
+        source.hyperedges_of(witness.a, "COALITION").unwrap(),
+        vec![witness.cell]
+    );
+    assert_eq!(
+        source.members_of(witness.cell).unwrap(),
+        vec![witness.a, witness.b, witness.c]
+    );
+}
+
+#[cfg(test)]
+fn assert_working_changed_independently<G>(working: &G, witness: &DetachedCopyWitness)
+where
+    G: GraphSubstrate + CanonicalState + AllocatorState,
+{
+    assert_ne!(
+        working.encode_state().unwrap().as_bytes(),
+        witness.source_bytes
+    );
+    assert_ne!(working.allocator_cursors(), witness.source_cursors);
     assert_eq!(working.hyperedges("COALITION"), vec![HyperedgeId(1)]);
     assert_eq!(
-        working.hyperedges_of(a, "COALITION").unwrap(),
+        working.hyperedges_of(witness.a, "COALITION").unwrap(),
         vec![HyperedgeId(1)]
     );
-    assert_eq!(working.members_of(HyperedgeId(1)).unwrap(), vec![a, b]);
+    assert_eq!(
+        working.members_of(HyperedgeId(1)).unwrap(),
+        vec![witness.a, witness.b]
+    );
+}
 
+#[cfg(test)]
+fn exercise_source_after_copy<G>(source: &mut G, working: &G, witness: &DetachedCopyWitness)
+where
+    G: GraphSubstrate,
+{
     assert_eq!(source.add_node("BUSINESS").unwrap(), NodeId(3));
     assert_eq!(
-        source.add_hyperedge("COALITION", &[b, c]).unwrap(),
+        source
+            .add_hyperedge("COALITION", &[witness.b, witness.c])
+            .unwrap(),
         HyperedgeId(1)
     );
-    assert_eq!(source.hyperedges("COALITION"), vec![cell, HyperedgeId(1)]);
     assert_eq!(
-        source.hyperedges_of(b, "COALITION").unwrap(),
-        vec![cell, HyperedgeId(1)]
+        source.hyperedges("COALITION"),
+        vec![witness.cell, HyperedgeId(1)]
     );
-    assert_eq!(source.hyperedges_of(a, "COALITION").unwrap(), vec![cell]);
-    assert_eq!(source.members_of(HyperedgeId(1)).unwrap(), vec![b, c]);
+    assert_eq!(
+        source.hyperedges_of(witness.b, "COALITION").unwrap(),
+        vec![witness.cell, HyperedgeId(1)]
+    );
+    assert_eq!(
+        source.hyperedges_of(witness.a, "COALITION").unwrap(),
+        vec![witness.cell]
+    );
+    assert_eq!(
+        source.members_of(HyperedgeId(1)).unwrap(),
+        vec![witness.b, witness.c]
+    );
     assert_eq!(working.hyperedges("COALITION"), vec![HyperedgeId(1)]);
     assert_eq!(
-        working.hyperedges_of(a, "COALITION").unwrap(),
+        working.hyperedges_of(witness.a, "COALITION").unwrap(),
         vec![HyperedgeId(1)]
     );
-    assert_eq!(working.members_of(HyperedgeId(1)).unwrap(), vec![a, b]);
-
-    source.remove_hyperedge(cell).unwrap();
-    assert_eq!(source.hyperedges("COALITION"), vec![HyperedgeId(1)]);
-    assert!(source.hyperedges_of(a, "COALITION").unwrap().is_empty());
-    assert_eq!(source.members_of(HyperedgeId(1)).unwrap(), vec![b, c]);
     assert_eq!(
-        working.hyperedges_of(a, "COALITION").unwrap(),
+        working.members_of(HyperedgeId(1)).unwrap(),
+        vec![witness.a, witness.b]
+    );
+
+    source.remove_hyperedge(witness.cell).unwrap();
+    assert_eq!(source.hyperedges("COALITION"), vec![HyperedgeId(1)]);
+    assert!(source
+        .hyperedges_of(witness.a, "COALITION")
+        .unwrap()
+        .is_empty());
+    assert_eq!(
+        source.members_of(HyperedgeId(1)).unwrap(),
+        vec![witness.b, witness.c]
+    );
+    assert_eq!(
+        working.hyperedges_of(witness.a, "COALITION").unwrap(),
         vec![HyperedgeId(1)]
     );
-    assert_eq!(working.members_of(HyperedgeId(1)).unwrap(), vec![a, b]);
+    assert_eq!(
+        working.members_of(HyperedgeId(1)).unwrap(),
+        vec![witness.a, witness.b]
+    );
 }
 
 #[cfg(test)]

--- a/rust/crates/babylon-graph/src/conformance.rs
+++ b/rust/crates/babylon-graph/src/conformance.rs
@@ -21,6 +21,11 @@ use crate::state_hash::CanonicalState;
 use crate::substrate::{Direction, GraphSubstrate, HyperedgeId, NodeId};
 use babylon_kernel::Currency;
 
+#[cfg(test)]
+use crate::allocator_state::{AllocatorCursors, AllocatorState, AllocatorTestControl};
+#[cfg(test)]
+use crate::working_copy::DetachedCopy;
+
 /// Run every invariant in this module against a fresh store from `make`.
 ///
 /// `make` is called many times — once per invariant block, each starting
@@ -1154,6 +1159,171 @@ where
             .is_err(),
         "a non-finite write refuses"
     );
+}
+
+/// Prove that a transactional working copy owns every mutable graph lane and
+/// both identity cursors. This is deliberately stronger than a type-level
+/// `Clone` bound: it exercises the behavioral promise the tick transaction
+/// relies on against each concrete backend.
+#[cfg(test)]
+pub(crate) fn run_detached_working_copy_conformance<G, F>(make: F)
+where
+    G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy,
+    F: Fn() -> G,
+{
+    let mut source = make();
+    let a = source.add_node("SOCIAL_CLASS").unwrap();
+    let b = source.add_node("TERRITORY").unwrap();
+    let c = source.add_node("ORGANIZATION").unwrap();
+    source.update_node(a, "class/power", 0.25).unwrap();
+    source
+        .update_node_currency(a, "class/cash", Currency::from_micro_units(12_345))
+        .unwrap();
+    source.add_edge("PRESENCE", a, b, 0.75).unwrap();
+    source
+        .update_edge("PRESENCE", a, b, "presence/friction", 0.125)
+        .unwrap();
+    let cell = source.add_hyperedge("COALITION", &[c, a, b]).unwrap();
+    source
+        .update_hyperedge_attribute(cell, "coalition/cohesion", 0.625)
+        .unwrap();
+
+    let source_bytes = source.encode_state().unwrap().as_bytes().to_vec();
+    let source_cursors = source.allocator_cursors();
+    let mut working = source.detached_copy();
+    assert_eq!(working.encode_state().unwrap().as_bytes(), source_bytes);
+    assert_eq!(working.allocator_cursors(), source_cursors);
+
+    exercise_every_mutable_lane(&mut working, a, b, c, cell);
+
+    assert_eq!(source.encode_state().unwrap().as_bytes(), source_bytes);
+    assert_eq!(source.allocator_cursors(), source_cursors);
+    assert_eq!(
+        source.node_attribute(a, "class/power").unwrap().to_bits(),
+        0.25f64.to_bits()
+    );
+    assert_eq!(
+        source.node_attribute_currency(a, "class/cash").unwrap(),
+        Currency::from_micro_units(12_345)
+    );
+    assert_eq!(
+        source
+            .edge_attribute("PRESENCE", a, b, "presence/friction")
+            .unwrap()
+            .to_bits(),
+        0.125f64.to_bits()
+    );
+    assert_eq!(
+        source
+            .hyperedge_attribute(cell, "coalition/cohesion")
+            .unwrap()
+            .to_bits(),
+        0.625f64.to_bits()
+    );
+    assert_ne!(working.encode_state().unwrap().as_bytes(), source_bytes);
+    assert_ne!(working.allocator_cursors(), source_cursors);
+
+    assert_eq!(source.add_node("BUSINESS").unwrap(), NodeId(3));
+    assert_eq!(
+        source.add_hyperedge("COALITION", &[a, b]).unwrap(),
+        HyperedgeId(1)
+    );
+}
+
+#[cfg(test)]
+fn exercise_every_mutable_lane<G: GraphSubstrate>(
+    working: &mut G,
+    a: NodeId,
+    b: NodeId,
+    c: NodeId,
+    cell: HyperedgeId,
+) {
+    working.update_node(a, "class/power", 0.5).unwrap();
+    working
+        .update_node_currency(a, "class/cash", Currency::from_micro_units(54_321))
+        .unwrap();
+    working
+        .update_edge("PRESENCE", a, b, "presence/friction", 0.875)
+        .unwrap();
+    assert_eq!(
+        working
+            .edge_attribute("PRESENCE", a, b, "presence/friction")
+            .unwrap()
+            .to_bits(),
+        0.875f64.to_bits()
+    );
+    working
+        .update_hyperedge_attribute(cell, "coalition/cohesion", 0.25)
+        .unwrap();
+    assert_eq!(
+        working
+            .hyperedge_attribute(cell, "coalition/cohesion")
+            .unwrap()
+            .to_bits(),
+        0.25f64.to_bits()
+    );
+    assert_eq!(working.add_node("BUSINESS").unwrap(), NodeId(3));
+    assert_eq!(
+        working.add_hyperedge("COALITION", &[a, b]).unwrap(),
+        HyperedgeId(1)
+    );
+    working.remove_edge("PRESENCE", a, b).unwrap();
+    working.remove_hyperedge(cell).unwrap();
+    working.remove_node(c).unwrap();
+}
+
+/// Both identity allocators must reject exhaustion before changing graph
+/// bytes or either cursor.
+#[cfg(test)]
+pub(crate) fn run_allocator_exhaustion_conformance<G, F>(make: F)
+where
+    G: GraphSubstrate + CanonicalState + AllocatorState + AllocatorTestControl,
+    F: Fn() -> G,
+{
+    let mut graph = make();
+    let a = graph.add_node("SOCIAL_CLASS").unwrap();
+    let b = graph.add_node("TERRITORY").unwrap();
+    graph.add_hyperedge("COALITION", &[a, b]).unwrap();
+
+    graph.set_allocator_cursors_for_test(AllocatorCursors {
+        next_node: u64::MAX,
+        next_hyperedge: 1,
+    });
+    assert_exhausted_node_allocator_is_atomic(&mut graph);
+
+    graph.set_allocator_cursors_for_test(AllocatorCursors {
+        next_node: 2,
+        next_hyperedge: u64::MAX,
+    });
+    assert_exhausted_hyperedge_allocator_is_atomic(&mut graph, a, b);
+}
+
+#[cfg(test)]
+fn assert_exhausted_node_allocator_is_atomic<G>(graph: &mut G)
+where
+    G: GraphSubstrate + CanonicalState + AllocatorState,
+{
+    let before = graph.encode_state().unwrap().as_bytes().to_vec();
+    let cursors = graph.allocator_cursors();
+    let error = graph.add_node("BUSINESS").unwrap_err();
+    assert!(error.message.contains("node identity allocator exhausted"));
+    assert_eq!(graph.encode_state().unwrap().as_bytes(), before);
+    assert_eq!(graph.allocator_cursors(), cursors);
+}
+
+#[cfg(test)]
+fn assert_exhausted_hyperedge_allocator_is_atomic<G>(graph: &mut G, a: NodeId, b: NodeId)
+where
+    G: GraphSubstrate + CanonicalState + AllocatorState,
+{
+    let before = graph.encode_state().unwrap().as_bytes().to_vec();
+    let cursors = graph.allocator_cursors();
+    let error = graph.add_hyperedge("COALITION", &[a, b]).unwrap_err();
+    assert!(error
+        .message
+        .contains("hyperedge identity allocator exhausted"));
+    assert_eq!(graph.encode_state().unwrap().as_bytes(), before);
+    assert_eq!(graph.allocator_cursors(), cursors);
 }
 
 #[cfg(test)]

--- a/rust/crates/babylon-graph/src/hypergraph_store.rs
+++ b/rust/crates/babylon-graph/src/hypergraph_store.rs
@@ -34,6 +34,7 @@
 //! reachable, because no member this adapter would validate can be unknown
 //! to the library.
 
+use crate::allocator_state::{AllocatorCursors, AllocatorState};
 use crate::state_hash::CanonicalState;
 use crate::substrate::{Direction, GraphError, GraphSubstrate, HyperedgeId, NodeId};
 use babylon_kernel::Currency;
@@ -108,6 +109,34 @@ pub struct HypergraphStore {
     inner: Hypergraph<(), String, MembershipPayload>,
     next_id: u64,
     next_hyperedge_id: u64,
+}
+
+impl Clone for HypergraphStore {
+    fn clone(&self) -> Self {
+        Self {
+            nodes: self.nodes.clone(),
+            node_keys: self.node_keys.clone(),
+            attributes: self.attributes.clone(),
+            currency_attributes: self.currency_attributes.clone(),
+            edges: self.edges.clone(),
+            edge_attributes: self.edge_attributes.clone(),
+            hyperedge_attributes: self.hyperedge_attributes.clone(),
+            hyperedge_keys: self.hyperedge_keys.clone(),
+            hyperedge_type_index: self.hyperedge_type_index.clone(),
+            inner: self.inner.copy(),
+            next_id: self.next_id,
+            next_hyperedge_id: self.next_hyperedge_id,
+        }
+    }
+}
+
+impl AllocatorState for HypergraphStore {
+    fn allocator_cursors(&self) -> AllocatorCursors {
+        AllocatorCursors {
+            next_node: self.next_id,
+            next_hyperedge: self.next_hyperedge_id,
+        }
+    }
 }
 
 impl HypergraphStore {
@@ -729,6 +758,7 @@ impl CanonicalState for HypergraphStore {
 #[cfg(test)]
 mod tests {
     use super::HypergraphStore;
+    use crate::allocator_state::{AllocatorCursors, AllocatorState};
     use crate::conformance::run_substrate_conformance;
     use crate::state_hash::CanonicalState;
     use crate::substrate::GraphSubstrate;
@@ -737,6 +767,54 @@ mod tests {
     #[test]
     fn hypergraph_store_passes_the_conformance_suite() {
         run_substrate_conformance(HypergraphStore::new);
+    }
+
+    #[test]
+    fn clone_is_an_independent_world_with_the_same_allocator_position() {
+        let mut original = HypergraphStore::new();
+        let first = original.add_node("SOCIAL_CLASS").unwrap();
+        original.update_node(first, "wealth", 10.0).unwrap();
+        original.add_hyperedge("CLASS", &[first]).unwrap();
+        let before = original.state_hash().unwrap();
+
+        let mut working = original.clone();
+        assert_eq!(working.state_hash().unwrap(), before);
+        assert_eq!(working.add_node("ORGANIZATION").unwrap().0, 1);
+        working.update_node(first, "wealth", 20.0).unwrap();
+        assert_eq!(working.add_hyperedge("CLASS", &[first]).unwrap().0, 1);
+
+        assert_eq!(original.state_hash().unwrap(), before);
+        assert_eq!(
+            original.node_attribute(first, "wealth").unwrap().to_bits(),
+            10.0f64.to_bits()
+        );
+        assert_eq!(
+            original.add_node("ORGANIZATION").unwrap().0,
+            1,
+            "allocating in a clone must not consume the source world's next node identity"
+        );
+        assert_eq!(
+            original.add_hyperedge("CLASS", &[first]).unwrap().0,
+            1,
+            "allocating in a clone must not consume the source world's next hyperedge identity"
+        );
+    }
+
+    #[test]
+    fn allocator_cursors_report_the_next_ids_even_after_removal() {
+        let mut graph = HypergraphStore::new();
+        let first = graph.add_node("SOCIAL_CLASS").unwrap();
+        let second = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph.add_hyperedge("CLASS", &[first, second]).unwrap();
+        graph.remove_node(second).unwrap();
+
+        assert_eq!(
+            graph.allocator_cursors(),
+            AllocatorCursors {
+                next_node: 2,
+                next_hyperedge: 1,
+            }
+        );
     }
 
     /// Task 3's III.7 evidence, not a claim (P27 Phase 2 Slice 1): the

--- a/rust/crates/babylon-graph/src/hypergraph_store.rs
+++ b/rust/crates/babylon-graph/src/hypergraph_store.rs
@@ -37,6 +37,7 @@
 use crate::allocator_state::{AllocatorCursors, AllocatorState};
 use crate::state_hash::CanonicalState;
 use crate::substrate::{Direction, GraphError, GraphSubstrate, HyperedgeId, NodeId};
+use crate::working_copy::DetachedCopy;
 use babylon_kernel::Currency;
 use hypergraph_rs::Hypergraph;
 use std::collections::HashMap;
@@ -139,6 +140,20 @@ impl AllocatorState for HypergraphStore {
     }
 }
 
+impl DetachedCopy for HypergraphStore {
+    fn detached_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+impl crate::allocator_state::AllocatorTestControl for HypergraphStore {
+    fn set_allocator_cursors_for_test(&mut self, cursors: AllocatorCursors) {
+        self.next_id = cursors.next_node;
+        self.next_hyperedge_id = cursors.next_hyperedge;
+    }
+}
+
 impl HypergraphStore {
     /// An empty substrate.
     #[must_use]
@@ -179,14 +194,17 @@ impl HypergraphStore {
 impl GraphSubstrate for HypergraphStore {
     fn add_node(&mut self, node_type: &str) -> Result<NodeId, GraphError> {
         self.check_not_frozen()?;
+        let next_id = self.next_id.checked_add(1).ok_or_else(|| GraphError {
+            message: "node identity allocator exhausted".to_owned(),
+        })?;
         let id = NodeId(self.next_id);
-        self.next_id += 1;
         let key = node_key(id);
         self.nodes.insert(id, node_type.to_owned());
         self.node_keys.insert(key.clone(), id);
         // Covenant 4: mint through the library too, or the existence check
         // below proves nothing about the library's universe.
         self.inner.add_node(&key, ());
+        self.next_id = next_id;
         Ok(id)
     }
 
@@ -512,8 +530,13 @@ impl GraphSubstrate for HypergraphStore {
             });
         }
 
+        let next_id = self
+            .next_hyperedge_id
+            .checked_add(1)
+            .ok_or_else(|| GraphError {
+                message: "hyperedge identity allocator exhausted".to_owned(),
+            })?;
         let id = HyperedgeId(self.next_hyperedge_id);
-        self.next_hyperedge_id += 1;
         let key = hyperedge_key(id);
         let member_keys: Vec<String> = sorted.iter().map(|n| node_key(*n)).collect();
         self.inner
@@ -526,6 +549,7 @@ impl GraphSubstrate for HypergraphStore {
             .entry(hyperedge_type.to_owned())
             .or_default()
             .push(id);
+        self.next_hyperedge_id = next_id;
         Ok(id)
     }
 
@@ -758,10 +782,14 @@ impl CanonicalState for HypergraphStore {
 #[cfg(test)]
 mod tests {
     use super::HypergraphStore;
-    use crate::allocator_state::{AllocatorCursors, AllocatorState};
-    use crate::conformance::run_substrate_conformance;
+    use crate::allocator_state::{AllocatorCursors, AllocatorState, AllocatorTestControl};
+    use crate::conformance::{
+        run_allocator_exhaustion_conformance, run_detached_working_copy_conformance,
+        run_substrate_conformance,
+    };
     use crate::state_hash::CanonicalState;
     use crate::substrate::GraphSubstrate;
+    use crate::working_copy::DetachedCopy;
     use std::fmt::Write as _;
 
     #[test]
@@ -770,34 +798,36 @@ mod tests {
     }
 
     #[test]
-    fn clone_is_an_independent_world_with_the_same_allocator_position() {
-        let mut original = HypergraphStore::new();
-        let first = original.add_node("SOCIAL_CLASS").unwrap();
-        original.update_node(first, "wealth", 10.0).unwrap();
-        original.add_hyperedge("CLASS", &[first]).unwrap();
-        let before = original.state_hash().unwrap();
+    fn detached_working_copy_owns_every_mutable_lane() {
+        run_detached_working_copy_conformance(HypergraphStore::new);
+    }
 
-        let mut working = original.clone();
-        assert_eq!(working.state_hash().unwrap(), before);
-        assert_eq!(working.add_node("ORGANIZATION").unwrap().0, 1);
-        working.update_node(first, "wealth", 20.0).unwrap();
-        assert_eq!(working.add_hyperedge("CLASS", &[first]).unwrap().0, 1);
+    #[test]
+    fn exhausted_allocators_leave_hypergraph_store_unchanged() {
+        run_allocator_exhaustion_conformance(HypergraphStore::new);
+    }
 
-        assert_eq!(original.state_hash().unwrap(), before);
-        assert_eq!(
-            original.node_attribute(first, "wealth").unwrap().to_bits(),
-            10.0f64.to_bits()
-        );
-        assert_eq!(
-            original.add_node("ORGANIZATION").unwrap().0,
-            1,
-            "allocating in a clone must not consume the source world's next node identity"
-        );
-        assert_eq!(
-            original.add_hyperedge("CLASS", &[first]).unwrap().0,
-            1,
-            "allocating in a clone must not consume the source world's next hyperedge identity"
-        );
+    #[test]
+    fn failed_library_hyperedge_insert_does_not_advance_the_cursor() {
+        let mut graph = HypergraphStore::new();
+        let member = graph.add_node("SOCIAL_CLASS").unwrap();
+        graph.add_hyperedge("COALITION", &[member]).unwrap();
+        graph.set_allocator_cursors_for_test(AllocatorCursors {
+            next_node: 1,
+            next_hyperedge: 0,
+        });
+        let before = graph.encode_state().unwrap().as_bytes().to_vec();
+        let cursors = graph.allocator_cursors();
+
+        let error = graph
+            .add_hyperedge("COALITION", &[member])
+            .expect_err("the library must reject the duplicate internal edge key");
+
+        assert!(error.message.contains("hyperedge-half mint"));
+        assert_eq!(graph.encode_state().unwrap().as_bytes(), before);
+        assert_eq!(graph.allocator_cursors(), cursors);
+        let detached = graph.detached_copy();
+        assert_eq!(detached.allocator_cursors(), cursors);
     }
 
     #[test]

--- a/rust/crates/babylon-graph/src/hypergraph_store.rs
+++ b/rust/crates/babylon-graph/src/hypergraph_store.rs
@@ -818,6 +818,9 @@ mod tests {
         });
         let before = graph.encode_state().unwrap().as_bytes().to_vec();
         let cursors = graph.allocator_cursors();
+        let indexed = graph.hyperedges("COALITION");
+        let memberships = graph.hyperedges_of(member, "COALITION").unwrap();
+        let members = graph.members_of(indexed[0]).unwrap();
 
         let error = graph
             .add_hyperedge("COALITION", &[member])
@@ -826,8 +829,32 @@ mod tests {
         assert!(error.message.contains("hyperedge-half mint"));
         assert_eq!(graph.encode_state().unwrap().as_bytes(), before);
         assert_eq!(graph.allocator_cursors(), cursors);
+        assert_eq!(graph.hyperedges("COALITION"), indexed);
+        assert_eq!(
+            graph.hyperedges_of(member, "COALITION").unwrap(),
+            memberships
+        );
+        assert_eq!(graph.members_of(indexed[0]).unwrap(), members);
+
+        graph.set_allocator_cursors_for_test(AllocatorCursors {
+            next_node: 1,
+            next_hyperedge: 1,
+        });
+        let next = graph
+            .add_hyperedge("COALITION", &[member])
+            .expect("a valid mint after the rejected library insert succeeds");
+        assert_eq!(next, crate::substrate::HyperedgeId(1));
+        assert_eq!(
+            graph.hyperedges("COALITION"),
+            vec![indexed[0], crate::substrate::HyperedgeId(1)]
+        );
+        assert_eq!(
+            graph.hyperedges_of(member, "COALITION").unwrap(),
+            vec![indexed[0], crate::substrate::HyperedgeId(1)]
+        );
+        assert_eq!(graph.members_of(next).unwrap(), vec![member]);
         let detached = graph.detached_copy();
-        assert_eq!(detached.allocator_cursors(), cursors);
+        assert_eq!(detached.allocator_cursors(), graph.allocator_cursors());
     }
 
     #[test]

--- a/rust/crates/babylon-graph/src/lib.rs
+++ b/rust/crates/babylon-graph/src/lib.rs
@@ -45,3 +45,4 @@ pub mod induced;
 pub mod memory;
 pub mod state_hash;
 pub mod substrate;
+pub mod working_copy;

--- a/rust/crates/babylon-graph/src/lib.rs
+++ b/rust/crates/babylon-graph/src/lib.rs
@@ -34,6 +34,7 @@
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
 
+pub mod allocator_state;
 pub mod backfire;
 pub mod capacity;
 pub mod conformance;

--- a/rust/crates/babylon-graph/src/memory.rs
+++ b/rust/crates/babylon-graph/src/memory.rs
@@ -33,13 +33,14 @@
 //! hypergraph-rs, all but one absorbed behind `HypergraphStore`'s adapter
 //! covenants. Depend on the TRAIT — every call site that did stayed
 //! unchanged by the swap, which is the entire point of the insulation.
+use crate::allocator_state::{AllocatorCursors, AllocatorState};
 use crate::state_hash::CanonicalState;
 use crate::substrate::{Direction, GraphError, GraphSubstrate, HyperedgeId, NodeId};
 use babylon_kernel::Currency;
 use std::collections::HashMap;
 
 /// The in-memory substrate. See the module documentation.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct MemoryGraph {
     nodes: HashMap<NodeId, String>,
     attributes: HashMap<(NodeId, String), f64>,
@@ -97,6 +98,15 @@ impl MemoryGraph {
     #[must_use]
     pub fn currency_attribute_key_count(&self) -> usize {
         self.currency_attributes.len()
+    }
+}
+
+impl AllocatorState for MemoryGraph {
+    fn allocator_cursors(&self) -> AllocatorCursors {
+        AllocatorCursors {
+            next_node: self.next_id,
+            next_hyperedge: self.next_hyperedge_id,
+        }
     }
 }
 
@@ -570,6 +580,7 @@ impl GraphSubstrate for MemoryGraph {
 #[cfg(test)]
 mod tests {
     use super::{CanonicalState, GraphSubstrate, MemoryGraph, NodeId};
+    use crate::allocator_state::{AllocatorCursors, AllocatorState};
     use crate::substrate::Direction;
 
     #[test]
@@ -612,6 +623,47 @@ mod tests {
         assert!(graph
             .neighbors(doomed, "solidarity", Direction::Any)
             .is_err());
+    }
+
+    #[test]
+    fn clone_is_an_independent_world_with_the_same_allocator_position() {
+        let mut original = MemoryGraph::new();
+        let first = original.add_node("social_class").unwrap();
+        original.update_node(first, "wealth", 10.0).unwrap();
+        let before = original.state_hash().unwrap();
+
+        let mut working = original.clone();
+        assert_eq!(working.state_hash().unwrap(), before);
+        assert_eq!(working.add_node("organization").unwrap(), NodeId(1));
+        working.update_node(first, "wealth", 20.0).unwrap();
+
+        assert_eq!(original.state_hash().unwrap(), before);
+        assert_eq!(
+            original.node_attribute(first, "wealth").unwrap().to_bits(),
+            10.0f64.to_bits()
+        );
+        assert_eq!(
+            original.add_node("organization").unwrap(),
+            NodeId(1),
+            "allocating in a clone must not consume the source world's next identity"
+        );
+    }
+
+    #[test]
+    fn allocator_cursors_report_the_next_ids_even_after_removal() {
+        let mut graph = MemoryGraph::new();
+        let first = graph.add_node("social_class").unwrap();
+        let second = graph.add_node("social_class").unwrap();
+        graph.add_hyperedge("class", &[first, second]).unwrap();
+        graph.remove_node(second).unwrap();
+
+        assert_eq!(
+            graph.allocator_cursors(),
+            AllocatorCursors {
+                next_node: 2,
+                next_hyperedge: 1,
+            }
+        );
     }
 
     /// Build the same world twice, inserting in opposite orders.

--- a/rust/crates/babylon-graph/src/memory.rs
+++ b/rust/crates/babylon-graph/src/memory.rs
@@ -36,6 +36,7 @@
 use crate::allocator_state::{AllocatorCursors, AllocatorState};
 use crate::state_hash::CanonicalState;
 use crate::substrate::{Direction, GraphError, GraphSubstrate, HyperedgeId, NodeId};
+use crate::working_copy::DetachedCopy;
 use babylon_kernel::Currency;
 use std::collections::HashMap;
 
@@ -110,6 +111,20 @@ impl AllocatorState for MemoryGraph {
     }
 }
 
+impl DetachedCopy for MemoryGraph {
+    fn detached_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+impl crate::allocator_state::AllocatorTestControl for MemoryGraph {
+    fn set_allocator_cursors_for_test(&mut self, cursors: AllocatorCursors) {
+        self.next_id = cursors.next_node;
+        self.next_hyperedge_id = cursors.next_hyperedge;
+    }
+}
+
 impl CanonicalState for MemoryGraph {
     /// The sort moved to [`CanonicalState::encode_state`] — this listing
     /// reports storage order, exactly as `HashMap` iteration gives it.
@@ -165,9 +180,12 @@ impl CanonicalState for MemoryGraph {
 
 impl GraphSubstrate for MemoryGraph {
     fn add_node(&mut self, node_type: &str) -> Result<NodeId, GraphError> {
+        let next_id = self.next_id.checked_add(1).ok_or_else(|| GraphError {
+            message: "node identity allocator exhausted".to_owned(),
+        })?;
         let id = NodeId(self.next_id);
-        self.next_id += 1;
         self.nodes.insert(id, node_type.to_owned());
+        self.next_id = next_id;
         Ok(id)
     }
 
@@ -453,10 +471,16 @@ impl GraphSubstrate for MemoryGraph {
                 message: format!("no such member node: {missing:?}"),
             });
         }
+        let next_id = self
+            .next_hyperedge_id
+            .checked_add(1)
+            .ok_or_else(|| GraphError {
+                message: "hyperedge identity allocator exhausted".to_owned(),
+            })?;
         let id = HyperedgeId(self.next_hyperedge_id);
-        self.next_hyperedge_id += 1;
         self.hyperedges
             .insert(id, (hyperedge_type.to_owned(), sorted));
+        self.next_hyperedge_id = next_id;
         Ok(id)
     }
 
@@ -581,6 +605,9 @@ impl GraphSubstrate for MemoryGraph {
 mod tests {
     use super::{CanonicalState, GraphSubstrate, MemoryGraph, NodeId};
     use crate::allocator_state::{AllocatorCursors, AllocatorState};
+    use crate::conformance::{
+        run_allocator_exhaustion_conformance, run_detached_working_copy_conformance,
+    };
     use crate::substrate::Direction;
 
     #[test]
@@ -626,27 +653,13 @@ mod tests {
     }
 
     #[test]
-    fn clone_is_an_independent_world_with_the_same_allocator_position() {
-        let mut original = MemoryGraph::new();
-        let first = original.add_node("social_class").unwrap();
-        original.update_node(first, "wealth", 10.0).unwrap();
-        let before = original.state_hash().unwrap();
+    fn detached_working_copy_owns_every_mutable_lane() {
+        run_detached_working_copy_conformance(MemoryGraph::new);
+    }
 
-        let mut working = original.clone();
-        assert_eq!(working.state_hash().unwrap(), before);
-        assert_eq!(working.add_node("organization").unwrap(), NodeId(1));
-        working.update_node(first, "wealth", 20.0).unwrap();
-
-        assert_eq!(original.state_hash().unwrap(), before);
-        assert_eq!(
-            original.node_attribute(first, "wealth").unwrap().to_bits(),
-            10.0f64.to_bits()
-        );
-        assert_eq!(
-            original.add_node("organization").unwrap(),
-            NodeId(1),
-            "allocating in a clone must not consume the source world's next identity"
-        );
+    #[test]
+    fn exhausted_allocators_leave_memory_graph_unchanged() {
+        run_allocator_exhaustion_conformance(MemoryGraph::new);
     }
 
     #[test]

--- a/rust/crates/babylon-graph/src/substrate.rs
+++ b/rust/crates/babylon-graph/src/substrate.rs
@@ -85,8 +85,9 @@ pub trait GraphSubstrate {
     /// Mint one typed node.
     ///
     /// # Errors
-    /// Returns [`GraphError`] if the implementation cannot allocate the node
-    /// (for example, an exhausted identity space).
+    /// Returns [`GraphError`] if the implementation cannot allocate the node.
+    /// `u64::MAX` is the reserved exhausted-cursor sentinel, so the last
+    /// mintable identity is `NodeId(u64::MAX - 1)`.
     fn add_node(&mut self, node_type: &str) -> Result<NodeId, GraphError>;
 
     /// Remove a node, **cascading** to its incident structure (ADR185 R2).
@@ -269,8 +270,10 @@ pub trait GraphSubstrate {
     /// `members.len()` incidences — never `C(n,2)` edges.
     ///
     /// # Errors
-    /// Returns [`GraphError`] if `members` is empty, contains a duplicate, or
-    /// names a node that does not exist.
+    /// Returns [`GraphError`] if `members` is empty, contains a duplicate,
+    /// names a node that does not exist, or the identity space is exhausted.
+    /// `u64::MAX` is the reserved exhausted-cursor sentinel, so the last
+    /// mintable identity is `HyperedgeId(u64::MAX - 1)`.
     fn add_hyperedge(
         &mut self,
         hyperedge_type: &str,

--- a/rust/crates/babylon-graph/src/working_copy.rs
+++ b/rust/crates/babylon-graph/src/working_copy.rs
@@ -1,0 +1,15 @@
+//! Explicit deep-copy contract for transactional graph work.
+//!
+//! A bare [`Clone`] bound cannot say whether a backend shares mutable
+//! internals. Tick adjudication depends on a stronger behavioral promise:
+//! mutations and allocator advances on the returned value never affect the
+//! source. Implementations are therefore explicit and intentionally have no
+//! blanket `T: Clone` implementation.
+
+/// Construct an independently mutable graph working copy.
+pub trait DetachedCopy: Sized {
+    /// Copy every mutable graph lane and identity cursor into a detached
+    /// value suitable for transactional mutation.
+    #[must_use]
+    fn detached_copy(&self) -> Self;
+}

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -41,6 +41,7 @@ use babylon_graph::allocator_state::AllocatorState;
 use babylon_graph::hypergraph_store::HypergraphStore;
 use babylon_graph::state_hash::CanonicalState;
 use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_graph::working_copy::DetachedCopy;
 use babylon_kernel::SessionId;
 use std::collections::{HashMap, HashSet};
 
@@ -787,15 +788,15 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
 /// **one** implementation of the flow: `run_once`'s signature and
 /// [`TickReport`] are the seam `babylon-client` consumes and neither moves.
 ///
-/// Generic over the substrate. Atomic adjudication requires [`Clone`] for a
-/// disposable working world; [`AllocatorState`] supplies the non-graph
-/// identity cursors covered by the nominal world hash.
+/// Generic over the substrate. Atomic adjudication requires
+/// [`DetachedCopy`] for a disposable working world; [`AllocatorState`]
+/// supplies the non-graph identity cursors covered by the nominal world hash.
 ///
 /// # Errors
 ///
 /// A description of the first failing stage — an intrinsic declaration, a
 /// scenario load, a rule load, a state hash, or the tick itself.
-pub fn run_once_into<G: GraphSubstrate + CanonicalState + AllocatorState + Clone>(
+pub fn run_once_into<G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy>(
     scenario_src: &str,
     rule_src: &str,
     graph: &mut G,
@@ -821,7 +822,9 @@ pub fn run_once_into<G: GraphSubstrate + CanonicalState + AllocatorState + Clone
 /// A description of the first failing stage — the prelude, an intrinsic
 /// declaration, a scenario load, a rule load, a state hash, or the tick
 /// itself.
-pub fn run_once_into_with_prelude<G: GraphSubstrate + CanonicalState + AllocatorState + Clone>(
+pub fn run_once_into_with_prelude<
+    G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy,
+>(
     scenario_src: &str,
     prelude_src: &str,
     rule_src: &str,
@@ -860,7 +863,9 @@ fn run_once_session() -> SessionId {
 /// An invalid tick number, schedule/world/graph hashing, event reservation,
 /// or the tick itself (named to its own rule id). Every error leaves the
 /// caller's graph and existing events unchanged.
-pub(crate) fn run_prepared_tick<G: GraphSubstrate + CanonicalState + AllocatorState + Clone>(
+pub(crate) fn run_prepared_tick<
+    G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy,
+>(
     prepared: &PreparedRules,
     graph: &mut G,
     sink: &mut CollectingSink,
@@ -881,7 +886,7 @@ pub(crate) fn run_prepared_tick<G: GraphSubstrate + CanonicalState + AllocatorSt
         graph.allocator_cursors(),
         schedule_digest,
     )?;
-    let mut working_graph = graph.clone();
+    let mut working_graph = graph.detached_copy();
     let mut working_sink = CollectingSink::default();
 
     // Every rule in `prepared.rules` runs to COMPLETION (every matching

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -37,6 +37,7 @@ use babylon_bsl::tick::run_tick;
 use babylon_bsl::typecheck::TypeEnv;
 use babylon_bsl::types::{EnumRegistry, FieldDecl};
 use babylon_bsl::BindingVocabulary;
+use babylon_graph::allocator_state::AllocatorState;
 use babylon_graph::hypergraph_store::HypergraphStore;
 use babylon_graph::state_hash::CanonicalState;
 use babylon_graph::substrate::{GraphSubstrate, NodeId};
@@ -45,14 +46,21 @@ use std::collections::{HashMap, HashSet};
 
 mod phase_order;
 pub mod session;
+mod world_hash;
 pub use session::TickSession;
 
 /// The result of running one or more rules over one scenario for one tick:
-/// the pre-tick and post-tick state hashes, and how many subjects fired.
+/// graph and nominal-world hashes around the commit, plus firing counts.
 #[derive(Debug)]
 pub struct TickReport {
+    /// Canonical graph-state hash before adjudication.
     pub before: [u8; 32],
+    /// Canonical graph-state hash after successful adjudication.
     pub after: [u8; 32],
+    /// Nominal graph-plus-current-auxiliary world hash before adjudication.
+    pub world_before: [u8; 32],
+    /// Nominal graph-plus-current-auxiliary world hash after commit.
+    pub world_after: [u8; 32],
     /// The TOTAL fired-subject count across every rule this tick ran —
     /// unchanged in meaning and type for a single-rule content set (today
     /// every existing caller: `run_once`, the CLI, B0's engine-link probe,
@@ -779,24 +787,22 @@ pub(crate) fn prepare_rules<G: GraphSubstrate + CanonicalState>(
 /// **one** implementation of the flow: `run_once`'s signature and
 /// [`TickReport`] are the seam `babylon-client` consumes and neither moves.
 ///
-/// Generic over the substrate — the storage-swap plan's entire
-/// production-side change was this one signature (Phase A Task 3) plus one
-/// construction-site swap (Phase D Task 10): `run_once` now constructs
-/// `HypergraphStore` (ADR179 T3) rather than `MemoryGraph`; this function
-/// itself never moved.
+/// Generic over the substrate. Atomic adjudication requires [`Clone`] for a
+/// disposable working world; [`AllocatorState`] supplies the non-graph
+/// identity cursors covered by the nominal world hash.
 ///
 /// # Errors
 ///
 /// A description of the first failing stage — an intrinsic declaration, a
 /// scenario load, a rule load, a state hash, or the tick itself.
-pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
+pub fn run_once_into<G: GraphSubstrate + CanonicalState + AllocatorState + Clone>(
     scenario_src: &str,
     rule_src: &str,
     graph: &mut G,
     sink: &mut CollectingSink,
 ) -> Result<TickReport, String> {
     let prepared = prepare_rules(scenario_src, None, rule_src, graph).map_err(|e| e.to_string())?;
-    run_prepared_tick(&prepared, graph, sink, &run_once_session())
+    run_prepared_tick(&prepared, graph, sink, &run_once_session(), 1)
 }
 
 /// `run_once_into`, with the scenario load routed through a **declaration
@@ -815,7 +821,7 @@ pub fn run_once_into<G: GraphSubstrate + CanonicalState>(
 /// A description of the first failing stage — the prelude, an intrinsic
 /// declaration, a scenario load, a rule load, a state hash, or the tick
 /// itself.
-pub fn run_once_into_with_prelude<G: GraphSubstrate + CanonicalState>(
+pub fn run_once_into_with_prelude<G: GraphSubstrate + CanonicalState + AllocatorState + Clone>(
     scenario_src: &str,
     prelude_src: &str,
     rule_src: &str,
@@ -824,7 +830,7 @@ pub fn run_once_into_with_prelude<G: GraphSubstrate + CanonicalState>(
 ) -> Result<TickReport, String> {
     let prepared = prepare_rules(scenario_src, Some(prelude_src), rule_src, graph)
         .map_err(|e| e.to_string())?;
-    run_prepared_tick(&prepared, graph, sink, &run_once_session())
+    run_prepared_tick(&prepared, graph, sink, &run_once_session(), 1)
 }
 
 /// The `rng-draw` seam's session id for every one-shot driver in this
@@ -841,30 +847,46 @@ fn run_once_session() -> SessionId {
 }
 
 /// `run_once_with_prelude` (this train) and `run_once_into` (above) share
-/// this from the point `prepare_rules` has already returned: run every
-/// prepared rule to completion, in order, against the SAME `graph`, and
-/// assemble the [`TickReport`]. Extracted so a prelude-bearing caller does
-/// not duplicate this loop — `prepare_rules`'s own `prelude_src` parameter
-/// is the only thing that differs between the two callers, and it is fully
+/// this from the point `prepare_rules` has already returned: clone the
+/// committed graph, run every prepared rule to completion against that one
+/// working copy, buffer its events, and publish both only after every rule
+/// and hash succeeds. Extracted so a prelude-bearing caller does not
+/// duplicate this loop — `prepare_rules`'s own `prelude_src` parameter is
+/// the only thing that differs between the two callers, and it is fully
 /// resolved before this function ever runs.
 ///
 /// # Errors
 ///
-/// The tick itself (named to its own rule id), or a pre/post state-hash
-/// failure.
-fn run_prepared_tick<G: GraphSubstrate + CanonicalState>(
+/// An invalid tick number, schedule/world/graph hashing, event reservation,
+/// or the tick itself (named to its own rule id). Every error leaves the
+/// caller's graph and existing events unchanged.
+pub(crate) fn run_prepared_tick<G: GraphSubstrate + CanonicalState + AllocatorState + Clone>(
     prepared: &PreparedRules,
     graph: &mut G,
     sink: &mut CollectingSink,
     session: &SessionId,
+    tick: i64,
 ) -> Result<TickReport, String> {
+    let completed_before = tick
+        .checked_sub(1)
+        .filter(|completed| *completed >= 0)
+        .ok_or_else(|| format!("tick to adjudicate must be positive, got {tick}"))?;
+    let schedule_digest = phase_order::schedule_digest().map_err(|e| e.to_string())?;
     let before = graph
         .state_hash()
         .map_err(|e| format!("pre-tick state: {}", e.message))?;
+    let world_before = world_hash::nominal_world_hash(
+        before,
+        completed_before,
+        graph.allocator_cursors(),
+        schedule_digest,
+    )?;
+    let mut working_graph = graph.clone();
+    let mut working_sink = CollectingSink::default();
 
     // Every rule in `prepared.rules` runs to COMPLETION (every matching
     // subject) before the next rule starts — never interleaved — against
-    // the SAME `graph`, so a later rule sees an EARLIER rule's writes from
+    // the SAME working graph, so a later rule sees an EARLIER rule's writes from
     // the SAME tick. This falls out of calling `run_tick` sequentially
     // against one `&mut G`, and it matches the frozen Python engine's own
     // in-place, strict-order mutation semantics — but it is NOT what §4.2
@@ -888,16 +910,15 @@ fn run_prepared_tick<G: GraphSubstrate + CanonicalState>(
             &prepared.types,
             &prepared.enums,
             &KernelIntrinsicHost,
-            graph,
-            sink,
+            &mut working_graph,
+            &mut working_sink,
             &prepared.intrinsics,
             &prepared.consts,
-            // `run_once` is one tick, and it is tick 1 — the same number the
-            // CLI has always printed. §2.5's `:tick`/`:tick-in-cycle`
-            // bindings read it; `:year`/`:tick-of-year` need an epoch
-            // slice 1 does not pin and are refused by name at `run_tick`
-            // entry.
-            1,
+            // One-shot callers pass tick 1; persistent sessions pass their
+            // checked next tick. §2.5's `:tick`/`:tick-in-cycle` bindings
+            // read it; `:year`/`:tick-of-year` need an epoch slice 1 does
+            // not pin and are refused by name at `run_tick` entry.
+            tick,
             id,
             Some(&prepared.node_content_ids),
             session,
@@ -908,13 +929,26 @@ fn run_prepared_tick<G: GraphSubstrate + CanonicalState>(
     }
     let fired = per_rule_fired.iter().map(|(_, n)| n).sum();
 
-    let after = graph
+    let after = working_graph
         .state_hash()
         .map_err(|e| format!("post-tick state: {}", e.message))?;
+    let world_after = world_hash::nominal_world_hash(
+        after,
+        tick,
+        working_graph.allocator_cursors(),
+        schedule_digest,
+    )?;
+    sink.events
+        .try_reserve(working_sink.events.len())
+        .map_err(|e| format!("event commit refused: {e}"))?;
+    *graph = working_graph;
+    sink.events.extend(working_sink.events);
 
     Ok(TickReport {
         before,
         after,
+        world_before,
+        world_after,
         fired,
         per_rule_fired,
     })

--- a/rust/crates/babylon-tick/src/lib.rs
+++ b/rust/crates/babylon-tick/src/lib.rs
@@ -40,7 +40,7 @@ use babylon_bsl::BindingVocabulary;
 use babylon_graph::allocator_state::AllocatorState;
 use babylon_graph::hypergraph_store::HypergraphStore;
 use babylon_graph::state_hash::CanonicalState;
-use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_graph::substrate::{GraphError, GraphSubstrate, NodeId};
 use babylon_graph::working_copy::DetachedCopy;
 use babylon_kernel::SessionId;
 use std::collections::{HashMap, HashSet};
@@ -78,6 +78,35 @@ pub struct TickReport {
     /// content set (`fired == per_rule_fired[0].1` always holds); length N
     /// for an N-rule content set.
     pub per_rule_fired: Vec<(String, usize)>,
+}
+
+pub(crate) type EventRecord = (String, Vec<(String, Value)>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HashBoundary {
+    Pre,
+    Post,
+}
+
+/// Fallible preparation plus infallible commit for one already-buffered tick
+/// event batch. Implementations must leave their logical event sequence
+/// unchanged when preparation refuses.
+pub(crate) trait PreparedEventBatchSink {
+    fn try_prepare(&mut self, additional: usize) -> Result<(), String>;
+    fn commit_prepared(&mut self, events: Vec<EventRecord>);
+}
+
+impl PreparedEventBatchSink for CollectingSink {
+    fn try_prepare(&mut self, additional: usize) -> Result<(), String> {
+        self.events
+            .try_reserve(additional)
+            .map_err(|error| format!("event commit refused: {error}"))
+    }
+
+    fn commit_prepared(&mut self, events: Vec<EventRecord>) {
+        debug_assert!(self.events.capacity() - self.events.len() >= events.len());
+        self.events.extend(events);
+    }
 }
 
 /// Render a 32-byte hash as lowercase hex — the same format the CLI driver
@@ -802,8 +831,12 @@ pub fn run_once_into<G: GraphSubstrate + CanonicalState + AllocatorState + Detac
     graph: &mut G,
     sink: &mut CollectingSink,
 ) -> Result<TickReport, String> {
-    let prepared = prepare_rules(scenario_src, None, rule_src, graph).map_err(|e| e.to_string())?;
-    run_prepared_tick(&prepared, graph, sink, &run_once_session(), 1)
+    let mut candidate = graph.detached_copy();
+    let prepared =
+        prepare_rules(scenario_src, None, rule_src, &mut candidate).map_err(|e| e.to_string())?;
+    let report = run_prepared_tick(&prepared, &mut candidate, sink, &run_once_session(), 1)?;
+    *graph = candidate;
+    Ok(report)
 }
 
 /// `run_once_into`, with the scenario load routed through a **declaration
@@ -831,9 +864,12 @@ pub fn run_once_into_with_prelude<
     graph: &mut G,
     sink: &mut CollectingSink,
 ) -> Result<TickReport, String> {
-    let prepared = prepare_rules(scenario_src, Some(prelude_src), rule_src, graph)
+    let mut candidate = graph.detached_copy();
+    let prepared = prepare_rules(scenario_src, Some(prelude_src), rule_src, &mut candidate)
         .map_err(|e| e.to_string())?;
-    run_prepared_tick(&prepared, graph, sink, &run_once_session(), 1)
+    let report = run_prepared_tick(&prepared, &mut candidate, sink, &run_once_session(), 1)?;
+    *graph = candidate;
+    Ok(report)
 }
 
 /// The `rng-draw` seam's session id for every one-shot driver in this
@@ -872,13 +908,35 @@ pub(crate) fn run_prepared_tick<
     session: &SessionId,
     tick: i64,
 ) -> Result<TickReport, String> {
+    run_prepared_tick_with(
+        prepared,
+        graph,
+        sink,
+        session,
+        tick,
+        |_boundary, candidate| candidate.state_hash(),
+    )
+}
+
+fn run_prepared_tick_with<G, B, H>(
+    prepared: &PreparedRules,
+    graph: &mut G,
+    sink: &mut B,
+    session: &SessionId,
+    tick: i64,
+    mut state_hash: H,
+) -> Result<TickReport, String>
+where
+    G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy,
+    B: PreparedEventBatchSink,
+    H: FnMut(HashBoundary, &G) -> Result<[u8; 32], GraphError>,
+{
     let completed_before = tick
         .checked_sub(1)
         .filter(|completed| *completed >= 0)
         .ok_or_else(|| format!("tick to adjudicate must be positive, got {tick}"))?;
     let schedule_digest = phase_order::schedule_digest().map_err(|e| e.to_string())?;
-    let before = graph
-        .state_hash()
+    let before = state_hash(HashBoundary::Pre, graph)
         .map_err(|e| format!("pre-tick state: {}", e.message))?;
     let world_before = world_hash::nominal_world_hash(
         before,
@@ -934,8 +992,7 @@ pub(crate) fn run_prepared_tick<
     }
     let fired = per_rule_fired.iter().map(|(_, n)| n).sum();
 
-    let after = working_graph
-        .state_hash()
+    let after = state_hash(HashBoundary::Post, &working_graph)
         .map_err(|e| format!("post-tick state: {}", e.message))?;
     let world_after = world_hash::nominal_world_hash(
         after,
@@ -943,11 +1000,9 @@ pub(crate) fn run_prepared_tick<
         working_graph.allocator_cursors(),
         schedule_digest,
     )?;
-    sink.events
-        .try_reserve(working_sink.events.len())
-        .map_err(|e| format!("event commit refused: {e}"))?;
+    sink.try_prepare(working_sink.events.len())?;
     *graph = working_graph;
-    sink.events.extend(working_sink.events);
+    sink.commit_prepared(working_sink.events);
 
     Ok(TickReport {
         before,
@@ -1060,9 +1115,169 @@ pub fn any_over_budget(rows: &[FuelBoundRow]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{any_over_budget, fuel_bound_report, prepare_rules, run_once, FuelBoundRow};
+    use super::{
+        any_over_budget, fuel_bound_report, prepare_rules, run_once, run_once_into,
+        run_once_into_with_prelude, FuelBoundRow,
+    };
+    use babylon_bsl::structural_verbs::CollectingSink;
+    use babylon_graph::allocator_state::{AllocatorCursors, AllocatorState};
+    use babylon_graph::hypergraph_store::HypergraphStore;
+    use babylon_graph::memory::MemoryGraph;
+    use babylon_graph::state_hash::CanonicalState;
+    use babylon_graph::substrate::{GraphSubstrate, NodeId};
+    use babylon_graph::working_copy::DetachedCopy;
     const SCENARIO: &str = include_str!("../content/scenarios/two-classes.bscn");
     const RULE: &str = include_str!("../content/rules/fundamental-theorem.bsl");
+
+    const ONE_SHOT_FAILURE_SCENARIO: &str = r"
+(scenario tick/one-shot-atomicity
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (deffield social-class/probability probability intensive)
+  (node first NodeType/SOCIAL_CLASS (social-class/probability 0.1p))
+  (node second NodeType/SOCIAL_CLASS (social-class/probability 0.9p)))
+";
+    const ONE_SHOT_PRELUDE: &str = "(defvocabulary NodeType (SOCIAL_CLASS))";
+    const ONE_SHOT_FAILURE_SCENARIO_WITH_PRELUDE: &str = r"
+(scenario tick/one-shot-atomicity
+  (deffield social-class/probability probability intensive)
+  (node first NodeType/SOCIAL_CLASS (social-class/probability 0.1p))
+  (node second NodeType/SOCIAL_CLASS (social-class/probability 0.9p)))
+";
+    const ONE_SHOT_FAILURE_RULE: &str = r#"(rule vitality/one-shot-atomicity
+  :material-basis "PER-18: hydration and adjudication publish as one transaction"
+  :fuel 64
+  (bindings (binding probability :field social-class/probability))
+  (when (> probability 0.0p))
+  (effects
+    (emit EventType/PROBE)
+    (update-node self social-class/probability (add 0.4i))))"#;
+
+    const ONE_SHOT_SUCCESS_SCENARIO: &str = r"
+(scenario tick/one-shot-success
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (deffield social-class/count int extensive)
+  (node only NodeType/SOCIAL_CLASS (social-class/count 1)))
+";
+    const ONE_SHOT_SUCCESS_SCENARIO_WITH_PRELUDE: &str = r"
+(scenario tick/one-shot-success
+  (deffield social-class/count int extensive)
+  (node only NodeType/SOCIAL_CLASS (social-class/count 1)))
+";
+    const ONE_SHOT_SUCCESS_RULE: &str = r#"(rule vitality/one-shot-success
+  :material-basis "PER-18: successful staging preserves caller-relative identity allocation"
+  :fuel 32
+  (bindings (binding count :field social-class/count))
+  (when (= count 1))
+  (effects
+    (emit EventType/COMMITTED)
+    (update-node self social-class/count (add 1))))"#;
+
+    fn prepopulated_graph<G>() -> G
+    where
+        G: GraphSubstrate + Default,
+    {
+        let mut graph = G::default();
+        let prior = graph.add_node("PREEXISTING").unwrap();
+        graph.update_node(prior, "prior/value", 0.375).unwrap();
+        graph.add_hyperedge("PRIOR_GROUP", &[prior]).unwrap();
+        graph
+    }
+
+    fn assert_one_shot_failure_is_atomic<G>(with_prelude: bool)
+    where
+        G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy + Default,
+    {
+        let mut graph = prepopulated_graph::<G>();
+        let before = graph.encode_state().unwrap().as_bytes().to_vec();
+        let cursors = graph.allocator_cursors();
+        let mut sink = CollectingSink {
+            events: vec![("EventType/PRIOR".to_owned(), Vec::new())],
+        };
+        let events = sink.events.clone();
+
+        let result = if with_prelude {
+            run_once_into_with_prelude(
+                ONE_SHOT_FAILURE_SCENARIO_WITH_PRELUDE,
+                ONE_SHOT_PRELUDE,
+                ONE_SHOT_FAILURE_RULE,
+                &mut graph,
+                &mut sink,
+            )
+        } else {
+            run_once_into(
+                ONE_SHOT_FAILURE_SCENARIO,
+                ONE_SHOT_FAILURE_RULE,
+                &mut graph,
+                &mut sink,
+            )
+        };
+
+        let error = result.expect_err("the second probability write must fail");
+        assert!(error.contains("E-EVAL-020"), "{error}");
+        assert_eq!(graph.encode_state().unwrap().as_bytes(), before);
+        assert_eq!(graph.allocator_cursors(), cursors);
+        assert_eq!(sink.events, events);
+    }
+
+    fn assert_one_shot_success_preserves_relative_allocation<G>(with_prelude: bool)
+    where
+        G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy + Default,
+    {
+        let mut graph = prepopulated_graph::<G>();
+        let mut sink = CollectingSink::default();
+        let report = if with_prelude {
+            run_once_into_with_prelude(
+                ONE_SHOT_SUCCESS_SCENARIO_WITH_PRELUDE,
+                ONE_SHOT_PRELUDE,
+                ONE_SHOT_SUCCESS_RULE,
+                &mut graph,
+                &mut sink,
+            )
+        } else {
+            run_once_into(
+                ONE_SHOT_SUCCESS_SCENARIO,
+                ONE_SHOT_SUCCESS_RULE,
+                &mut graph,
+                &mut sink,
+            )
+        }
+        .expect("the staged one-shot tick commits");
+
+        assert_eq!(graph.nodes("SOCIAL_CLASS"), vec![NodeId(1)]);
+        assert_eq!(
+            graph
+                .node_attribute(NodeId(1), "social-class/count")
+                .unwrap()
+                .to_bits(),
+            2.0f64.to_bits()
+        );
+        assert_eq!(
+            graph.allocator_cursors(),
+            AllocatorCursors {
+                next_node: 2,
+                next_hyperedge: 1,
+            }
+        );
+        assert_eq!(report.fired, 1);
+        assert_eq!(sink.events.len(), 1);
+        assert_eq!(sink.events[0].0, "COMMITTED");
+    }
+
+    #[test]
+    fn both_one_shot_variants_roll_back_hydration_on_both_backends() {
+        assert_one_shot_failure_is_atomic::<MemoryGraph>(false);
+        assert_one_shot_failure_is_atomic::<MemoryGraph>(true);
+        assert_one_shot_failure_is_atomic::<HypergraphStore>(false);
+        assert_one_shot_failure_is_atomic::<HypergraphStore>(true);
+    }
+
+    #[test]
+    fn both_one_shot_variants_keep_preexisting_allocation_on_success() {
+        assert_one_shot_success_preserves_relative_allocation::<MemoryGraph>(false);
+        assert_one_shot_success_preserves_relative_allocation::<MemoryGraph>(true);
+        assert_one_shot_success_preserves_relative_allocation::<HypergraphStore>(false);
+        assert_one_shot_success_preserves_relative_allocation::<HypergraphStore>(true);
+    }
 
     // Task W3 (BSL Hygiene Knock-out): the fuel-bound report's smallest
     // possible fixture — one field binding, one comparison, one

--- a/rust/crates/babylon-tick/src/main.rs
+++ b/rust/crates/babylon-tick/src/main.rs
@@ -5,9 +5,9 @@
 //! ```
 //!
 //! Loads a world, loads a rule through every gate, runs one tick, and prints
-//! the state hash. Running it twice on the same inputs must print the same
-//! hash; that is Constitution III.7 made observable from a shell rather than
-//! only from a test.
+//! both the graph-state and nominal world hashes. Running it twice on the
+//! same inputs must print the same hashes; that is Constitution III.7 made
+//! observable from a shell rather than only from a test.
 //!
 //! # Where the content lives
 //!
@@ -36,7 +36,7 @@
 //! now only argument parsing, calling that seam, and printing. The same
 //! `run_once` is what `babylon-client`'s engine link calls in-process.
 
-use babylon_tick::{hex, run_once};
+use babylon_tick::{hex, run_once, TickReport};
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
@@ -63,13 +63,77 @@ fn run(scenario_path: &str, rule_path: &str) -> Result<(), String> {
 
     let report = run_once(&scenario_src, &rule_src)?;
 
-    println!("tick 1    {} subjects fired", report.fired);
-    println!("before    {}", hex(&report.before));
-    println!("after     {}", hex(&report.after));
-    if report.before == report.after {
+    print!("{}", format_report(&report));
+    Ok(())
+}
+
+fn format_report(report: &TickReport) -> String {
+    let unchanged_note = if report.before == report.after {
         // Not an error — a tick where no guard passed is a real outcome, and
         // saying so beats leaving the reader to compare 64 hex digits.
-        println!("note      state unchanged: no subject passed the guard");
+        "note             graph state unchanged: no subject passed the guard\n"
+    } else {
+        ""
+    };
+    format!(
+        "tick 1           {} subjects fired\n\
+         graph-before     {}\n\
+         graph-after      {}\n\
+         world-before     {}\n\
+         world-after      {}\n\
+         {unchanged_note}",
+        report.fired,
+        hex(&report.before),
+        hex(&report.after),
+        hex(&report.world_before),
+        hex(&report.world_after),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_report;
+    use babylon_tick::TickReport;
+
+    #[test]
+    fn cli_labels_graph_and_world_hashes_and_names_graph_only_unchanged_state() {
+        let report = TickReport {
+            before: [0x11; 32],
+            after: [0x11; 32],
+            world_before: [0x22; 32],
+            world_after: [0x33; 32],
+            fired: 0,
+            per_rule_fired: Vec::new(),
+        };
+
+        let output = format_report(&report);
+
+        assert!(output.contains(
+            "graph-before     1111111111111111111111111111111111111111111111111111111111111111"
+        ));
+        assert!(output.contains(
+            "graph-after      1111111111111111111111111111111111111111111111111111111111111111"
+        ));
+        assert!(output.contains(
+            "world-before     2222222222222222222222222222222222222222222222222222222222222222"
+        ));
+        assert!(output.contains(
+            "world-after      3333333333333333333333333333333333333333333333333333333333333333"
+        ));
+        assert!(output.contains("graph state unchanged: no subject passed the guard"));
     }
-    Ok(())
+
+    #[test]
+    fn unchanged_note_compares_the_clearly_named_graph_hashes() {
+        let report = TickReport {
+            before: [0x11; 32],
+            after: [0x12; 32],
+            world_before: [0x22; 32],
+            world_after: [0x22; 32],
+            fired: 1,
+            per_rule_fired: Vec::new(),
+        };
+
+        assert!(!format_report(&report).contains("graph state unchanged"));
+    }
 }

--- a/rust/crates/babylon-tick/src/main.rs
+++ b/rust/crates/babylon-tick/src/main.rs
@@ -69,9 +69,9 @@ fn run(scenario_path: &str, rule_path: &str) -> Result<(), String> {
 
 fn format_report(report: &TickReport) -> String {
     let unchanged_note = if report.before == report.after {
-        // Not an error — a tick where no guard passed is a real outcome, and
-        // saying so beats leaving the reader to compare 64 hex digits.
-        "note             graph state unchanged: no subject passed the guard\n"
+        // Graph equality says nothing by itself about rule eligibility,
+        // emitted events, or the completed-time component of world identity.
+        "note             graph state unchanged; the committed tick may still advance time or emit events\n"
     } else {
         ""
     };
@@ -96,14 +96,14 @@ mod tests {
     use babylon_tick::TickReport;
 
     #[test]
-    fn cli_labels_graph_and_world_hashes_and_names_graph_only_unchanged_state() {
+    fn cli_labels_hashes_and_describes_equal_graph_hashes_without_inferring_no_guard() {
         let report = TickReport {
             before: [0x11; 32],
             after: [0x11; 32],
             world_before: [0x22; 32],
             world_after: [0x33; 32],
-            fired: 0,
-            per_rule_fired: Vec::new(),
+            fired: 2,
+            per_rule_fired: vec![("vitality/emit-only".to_owned(), 2)],
         };
 
         let output = format_report(&report);
@@ -120,7 +120,10 @@ mod tests {
         assert!(output.contains(
             "world-after      3333333333333333333333333333333333333333333333333333333333333333"
         ));
-        assert!(output.contains("graph state unchanged: no subject passed the guard"));
+        assert!(output.contains(
+            "graph state unchanged; the committed tick may still advance time or emit events"
+        ));
+        assert!(!output.contains("no subject passed the guard"));
     }
 
     #[test]

--- a/rust/crates/babylon-tick/src/phase_order.rs
+++ b/rust/crates/babylon-tick/src/phase_order.rs
@@ -5,9 +5,19 @@
 //! explicit `(anchor :before|:after <system>)` selects a boundary around a
 //! governed slot. Rules sharing one resolved position retain D16's ascending
 //! rule-ID byte order. Source and file order are never observable.
+//!
+//! [`schedule_digest`] fingerprints the governed scheduling law, not one
+//! content pack. Its version-1 canonical bytes are: the fixed domain string
+//! `babylon.phase-schedule\0`; a big-endian `u32` layout version; a
+//! big-endian `u32` slot count; then each canonical slot in governed order as
+//! `str name | u8 partition | u8 ordinal | u16 default-rank`; then a
+//! big-endian `u32` alias count and each alias sorted by alias name as
+//! `str alias | str canonical | u16 resolved-default-rank`. Here `str` is a
+//! big-endian `u32` UTF-8 byte length followed by the raw UTF-8 bytes.
 
 use babylon_bsl::mod_anchors::{check_anchor, AnchorDecl, AnchorError, AnchorPosition};
 use babylon_bsl::reader::SExpr;
+use babylon_kernel::sha256_of;
 use std::collections::{BTreeMap, HashSet};
 
 const MATERIAL_BASE_COUNT: usize = 15;
@@ -15,6 +25,8 @@ const ACTION_COUNT: usize = 1;
 const CONSEQUENCE_COUNT: usize = 18;
 const SYSTEM_COUNT: usize = MATERIAL_BASE_COUNT + ACTION_COUNT + CONSEQUENCE_COUNT;
 const AFTER_MATERIAL_BASE_RANK: usize = MATERIAL_BASE_COUNT * 2;
+const SCHEDULE_DIGEST_LAYOUT_VERSION: u32 = 1;
+const SCHEDULE_DIGEST_DOMAIN: &[u8] = b"babylon.phase-schedule\0";
 
 /// The three contiguous causal partitions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -302,6 +314,68 @@ pub(crate) fn registered_systems() -> HashSet<String> {
         .collect()
 }
 
+/// SHA-256 of the versioned, canonical 34-slot scheduling law.
+pub(crate) fn schedule_digest() -> Result<[u8; 32], ScheduleError> {
+    validate_registry()?;
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(SCHEDULE_DIGEST_DOMAIN);
+    bytes.extend_from_slice(&SCHEDULE_DIGEST_LAYOUT_VERSION.to_be_bytes());
+    push_schedule_count(&mut bytes, SYSTEM_SLOTS.len(), "canonical slots")?;
+    for slot in SYSTEM_SLOTS {
+        push_schedule_str(&mut bytes, slot.name)?;
+        bytes.push(partition_tag(slot.partition));
+        bytes.push(slot.ordinal);
+        bytes.extend_from_slice(&default_rank(slot)?.to_be_bytes());
+    }
+
+    let mut aliases: Vec<&SystemAlias> = SYSTEM_ALIASES.iter().collect();
+    aliases.sort_unstable_by(|a, b| a.name.as_bytes().cmp(b.name.as_bytes()));
+    push_schedule_count(&mut bytes, aliases.len(), "system aliases")?;
+    for alias in aliases {
+        push_schedule_str(&mut bytes, alias.name)?;
+        push_schedule_str(&mut bytes, alias.canonical)?;
+        let slot = SYSTEM_SLOTS
+            .iter()
+            .find(|slot| slot.name == alias.canonical)
+            .ok_or_else(|| ScheduleError::Registry {
+                message: format!("system alias {} has no canonical slot", alias.name),
+            })?;
+        bytes.extend_from_slice(&default_rank(*slot)?.to_be_bytes());
+    }
+    Ok(sha256_of(&bytes))
+}
+
+fn push_schedule_count(bytes: &mut Vec<u8>, count: usize, what: &str) -> Result<(), ScheduleError> {
+    let count = u32::try_from(count).map_err(|_| ScheduleError::Registry {
+        message: format!("{what} count {count} exceeds u32"),
+    })?;
+    bytes.extend_from_slice(&count.to_be_bytes());
+    Ok(())
+}
+
+fn push_schedule_str(bytes: &mut Vec<u8>, value: &str) -> Result<(), ScheduleError> {
+    push_schedule_count(bytes, value.len(), "schedule string bytes")?;
+    bytes.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn partition_tag(partition: TickPartition) -> u8 {
+    match partition {
+        TickPartition::MaterialBase => 0,
+        TickPartition::Action => 1,
+        TickPartition::Consequence => 2,
+    }
+}
+
+fn default_rank(slot: SystemSlot) -> Result<u16, ScheduleError> {
+    u16::from(slot.ordinal)
+        .checked_mul(2)
+        .and_then(|rank| rank.checked_add(1))
+        .ok_or_else(|| ScheduleError::Registry {
+            message: format!("default execution rank overflow for system {}", slot.name),
+        })
+}
+
 /// Compile raw rule forms into their total execution order.
 pub(crate) fn compile(rule_forms: &[(String, SExpr)]) -> Result<RuleOrderPlan, ScheduleError> {
     validate_registry()?;
@@ -546,6 +620,14 @@ mod tests {
             ]
         );
         validate_registry().expect("the governed registry is internally valid");
+    }
+
+    #[test]
+    fn schedule_law_digest_pins_slots_partitions_ranks_and_sorted_aliases() {
+        assert_eq!(
+            crate::hex(&schedule_digest().expect("the governed schedule encodes")),
+            "3cb992b960112948023e5fcfa1335f2a6e6270628f27fe758186bc9c4d6b2487"
+        );
     }
 
     #[test]

--- a/rust/crates/babylon-tick/src/session.rs
+++ b/rust/crates/babylon-tick/src/session.rs
@@ -9,10 +9,9 @@
 //! this type. D16's ascending rule-ID byte order breaks ties at one resolved
 //! position.
 
-use crate::{prepare_rules, PreparedRules, TickReport};
-use babylon_bsl::intrinsic_host::KernelIntrinsicHost;
+use crate::{prepare_rules, run_prepared_tick, PreparedRules, TickReport};
 use babylon_bsl::structural_verbs::CollectingSink;
-use babylon_bsl::tick::run_tick;
+use babylon_graph::allocator_state::AllocatorState;
 use babylon_graph::state_hash::CanonicalState;
 use babylon_graph::substrate::GraphSubstrate;
 use babylon_kernel::SessionId;
@@ -32,7 +31,7 @@ pub struct TickSession<G> {
     session: SessionId,
 }
 
-impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
+impl<G: GraphSubstrate + CanonicalState + AllocatorState + Clone> TickSession<G> {
     /// Parse `rule_src` (one or more `(rule …)` forms) and load
     /// `scenario_src` into `graph` once. `prepare_rules` compiles the forms
     /// into governed phase order before this returns — the caller's own
@@ -100,10 +99,10 @@ impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
     /// Run one more tick against the held graph: every rule in the
     /// content set in the governed phase order compiled once at load time
     /// by `prepare_rules`. D16 orders same-position ties by rule-ID bytes.
-    /// Each rule runs to completion before the next starts against the SAME
-    /// graph, so a later rule sees an earlier rule's writes from this same
-    /// tick, matching the frozen engine's own in-place strict-order semantics
-    /// (inherited from calling `run_tick` sequentially against one `&mut G`).
+    /// Each rule runs to completion before the next starts against the same
+    /// disposable working graph, so a later rule sees an earlier rule's
+    /// writes from this tick. The working graph and its buffered events are
+    /// published together only after every rule and hash succeeds.
     ///
     /// **This is a RECORDED GAP, not a design feature.** §4.2 says "rules
     /// within one system position observe the same pre-state"
@@ -120,47 +119,24 @@ impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
     ///
     /// # Errors
     /// The tick itself (named to its own rule id), or a pre/post
-    /// state-hash failure. On any error the session's tick counter does
-    /// NOT advance — `tick()` counts COMPLETED ticks only (a failed tick
-    /// must not look consumed to retry/error-handling callers).
+    /// schedule/world/graph hash failure, event reservation failure, or a
+    /// checked tick-counter overflow. On any error the graph, caller's
+    /// existing events, and session counter stay unchanged — `tick()` counts
+    /// completed ticks only.
     pub fn advance(&mut self, sink: &mut CollectingSink) -> Result<TickReport, String> {
-        let next_tick = self.tick + 1;
-        let before = self
-            .graph
-            .state_hash()
-            .map_err(|e| format!("pre-tick state: {}", e.message))?;
-        let mut per_rule_fired = Vec::with_capacity(self.prepared.rules.len());
-        for (id, loaded) in &self.prepared.rules {
-            let outcome = run_tick(
-                loaded,
-                &self.prepared.types,
-                &self.prepared.enums,
-                &KernelIntrinsicHost,
-                &mut self.graph,
-                sink,
-                &self.prepared.intrinsics,
-                &self.prepared.consts,
-                next_tick,
-                id,
-                Some(&self.prepared.node_content_ids),
-                &self.session,
-                self.prepared.vocabulary.as_ref(),
-            )
-            .map_err(|e| format!("tick failed in rule {id}: {e}"))?;
-            per_rule_fired.push((id.clone(), outcome.fired));
-        }
-        let fired = per_rule_fired.iter().map(|(_, n)| n).sum();
-        let after = self
-            .graph
-            .state_hash()
-            .map_err(|e| format!("post-tick state: {}", e.message))?;
+        let next_tick = self
+            .tick
+            .checked_add(1)
+            .ok_or_else(|| "tick counter overflow before adjudication".to_owned())?;
+        let report = run_prepared_tick(
+            &self.prepared,
+            &mut self.graph,
+            sink,
+            &self.session,
+            next_tick,
+        )?;
         self.tick = next_tick;
-        Ok(TickReport {
-            before,
-            after,
-            fired,
-            per_rule_fired,
-        })
+        Ok(report)
     }
 
     /// The current tick number — 0 before the first `advance()` call.
@@ -181,13 +157,45 @@ impl<G: GraphSubstrate + CanonicalState> TickSession<G> {
 mod tests {
     use crate::session::TickSession;
     use babylon_bsl::structural_verbs::CollectingSink;
+    use babylon_graph::allocator_state::AllocatorState;
     use babylon_graph::hypergraph_store::HypergraphStore;
+    use babylon_graph::state_hash::CanonicalState;
+    use babylon_graph::substrate::{GraphSubstrate, NodeId};
     use babylon_kernel::SessionId;
 
     const SCENARIO: &str =
         include_str!("../content/scenarios/vitality-lifecycle-combined-conformance.bscn");
     const VITALITY: &str = include_str!("../content/rules/vitality.bsl");
     const LIFECYCLE: &str = include_str!("../content/rules/lifecycle.bsl");
+
+    const ATOMICITY_SCENARIO: &str = r"
+(scenario tick/atomicity-probe
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (deffield social-class/probability probability intensive)
+  (node first NodeType/SOCIAL_CLASS (social-class/probability 0.1p))
+  (node second NodeType/SOCIAL_CLASS (social-class/probability 0.9p)))
+";
+    const ATOMICITY_RULE: &str = r#"(rule vitality/atomicity-probe
+  :material-basis "PER-18 E-EVAL-020 rollback probe: one legal write precedes one illegal write"
+  :fuel 64
+  (bindings (binding probability :field social-class/probability))
+  (when (> probability 0.0p))
+  (effects
+    (emit EventType/PROBE)
+    (update-node self social-class/probability (add 0.4i))))"#;
+
+    const CLOCK_SCENARIO: &str = r"
+(scenario tick/world-clock-probe
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (deffield social-class/active int intensive)
+  (node only NodeType/SOCIAL_CLASS (social-class/active 1)))
+";
+    const CLOCK_RULE: &str = r#"(rule vitality/world-clock-probe
+  :material-basis "PER-18 nominal world hash probe: elapsed committed time is world state"
+  :fuel 32
+  (bindings (binding active :field social-class/active))
+  (when (= active 1))
+  (effects (emit EventType/PROBE)))"#;
 
     fn rule_src() -> String {
         format!("{VITALITY}\n{LIFECYCLE}")
@@ -199,6 +207,99 @@ mod tests {
     /// wall-clock one anyway.
     fn test_session() -> SessionId {
         SessionId::new("tick-session-test").expect("literal is non-empty")
+    }
+
+    #[test]
+    fn a_failed_tick_leaves_graph_counter_and_prior_events_unchanged() {
+        let mut session = TickSession::new(
+            ATOMICITY_SCENARIO,
+            ATOMICITY_RULE,
+            HypergraphStore::new(),
+            test_session(),
+        )
+        .expect("the rollback probe loads");
+        let before_hash = session.graph().state_hash().expect("pre-state hashes");
+        let mut sink = CollectingSink {
+            events: vec![("EventType/PRIOR".to_owned(), Vec::new())],
+        };
+        let before_events = sink.events.clone();
+
+        let before_cursors = session.graph().allocator_cursors();
+
+        for _ in 0..2 {
+            let error = session
+                .advance(&mut sink)
+                .expect_err("the second write exceeds one");
+
+            assert!(error.contains("E-EVAL-020"), "{error}");
+            assert_eq!(session.tick(), 0, "a failed tick is not completed");
+            assert_eq!(
+                session
+                    .graph()
+                    .state_hash()
+                    .expect("post-failure state hashes"),
+                before_hash,
+                "the first subject's valid write must roll back with the failed tick"
+            );
+            assert_eq!(session.graph().allocator_cursors(), before_cursors);
+            assert_eq!(
+                sink.events, before_events,
+                "events emitted before the failing write must not escape the tick"
+            );
+        }
+
+        let mut future = session.graph().clone();
+        assert_eq!(future.add_node("SOCIAL_CLASS").unwrap(), NodeId(2));
+    }
+
+    #[test]
+    fn nominal_world_hash_moves_with_completed_time_when_graph_hash_does_not() {
+        let mut session = TickSession::new(
+            CLOCK_SCENARIO,
+            CLOCK_RULE,
+            HypergraphStore::new(),
+            test_session(),
+        )
+        .expect("the world-clock probe loads");
+        let mut sink = CollectingSink::default();
+
+        let first = session.advance(&mut sink).expect("tick one commits");
+        let second = session.advance(&mut sink).expect("tick two commits");
+
+        assert_eq!(
+            first.before, first.after,
+            "an emit-only rule does not move graph state"
+        );
+        assert_eq!(first.after, second.before);
+        assert_ne!(first.world_before, first.world_after);
+        assert_eq!(first.world_after, second.world_before);
+        assert_ne!(second.world_before, second.world_after);
+    }
+
+    #[test]
+    fn completed_tick_overflow_refuses_before_any_world_or_event_mutation() {
+        let mut session = TickSession::new(
+            CLOCK_SCENARIO,
+            CLOCK_RULE,
+            HypergraphStore::new(),
+            test_session(),
+        )
+        .expect("the world-clock probe loads");
+        session.tick = i64::MAX;
+        let before_hash = session.graph().state_hash().unwrap();
+        let before_cursors = session.graph().allocator_cursors();
+        let mut sink = CollectingSink {
+            events: vec![("EventType/PRIOR".to_owned(), Vec::new())],
+        };
+
+        let error = session.advance(&mut sink).unwrap_err();
+
+        assert_eq!(error, "tick counter overflow before adjudication");
+        assert_eq!(session.tick(), i64::MAX);
+        assert_eq!(session.graph().state_hash().unwrap(), before_hash);
+        assert_eq!(session.graph().allocator_cursors(), before_cursors);
+        assert_eq!(sink.events.len(), 1);
+        assert_eq!(sink.events[0].0, "EventType/PRIOR");
     }
 
     #[test]
@@ -268,6 +369,10 @@ mod tests {
             assert_eq!(
                 ra.after, rb.after,
                 "same content + same tick count must hash identically"
+            );
+            assert_eq!(
+                ra.world_after, rb.world_after,
+                "nominal world hashes must be byte-identical too"
             );
         }
     }

--- a/rust/crates/babylon-tick/src/session.rs
+++ b/rust/crates/babylon-tick/src/session.rs
@@ -157,12 +157,16 @@ impl<G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy> TickSes
 #[cfg(test)]
 mod tests {
     use crate::session::TickSession;
+    use crate::{run_prepared_tick_with, EventRecord, HashBoundary, PreparedEventBatchSink};
     use babylon_bsl::structural_verbs::CollectingSink;
     use babylon_graph::allocator_state::AllocatorState;
     use babylon_graph::hypergraph_store::HypergraphStore;
-    use babylon_graph::state_hash::CanonicalState;
-    use babylon_graph::substrate::{GraphSubstrate, NodeId};
+    use babylon_graph::memory::MemoryGraph;
+    use babylon_graph::state_hash::{CanonicalState, StateEncoder};
+    use babylon_graph::substrate::{GraphError, GraphSubstrate, NodeId};
+    use babylon_graph::working_copy::DetachedCopy;
     use babylon_kernel::SessionId;
+    use std::process::Command;
 
     const SCENARIO: &str =
         include_str!("../content/scenarios/vitality-lifecycle-combined-conformance.bscn");
@@ -198,6 +202,107 @@ mod tests {
   (when (= active 1))
   (effects (emit EventType/PROBE)))"#;
 
+    const PHASE_FAULT_SCENARIO: &str = r"
+(scenario tick/phase-fault-matrix
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (deffield social-class/probability probability intensive)
+  (deffield social-class/base int extensive)
+  (deffield social-class/action int extensive)
+  (node first NodeType/SOCIAL_CLASS
+    (social-class/probability 0.1p)
+    (social-class/base 0)
+    (social-class/action 0))
+  (node second NodeType/SOCIAL_CLASS
+    (social-class/probability 0.9p)
+    (social-class/base 0)
+    (social-class/action 0)))
+";
+    const MATERIAL_SUCCESS_RULE: &str = r#"(rule vitality/phase-success
+  :material-basis "PER-18 rollback matrix: representative Material Base work"
+  :fuel 64
+  (bindings (binding value :field social-class/base))
+  (when (>= value 0))
+  (effects
+    (emit EventType/MATERIAL_WORK)
+    (update-node self social-class/base (add 1))))"#;
+    const ACTION_SUCCESS_RULE: &str = r#"(rule ooda/phase-success
+  :material-basis "PER-18 rollback matrix: representative Action work"
+  :fuel 64
+  (bindings (binding value :field social-class/action))
+  (when (>= value 0))
+  (effects
+    (emit EventType/ACTION_WORK)
+    (update-node self social-class/action (add 1))))"#;
+    const MATERIAL_FAILURE_RULE: &str = r#"(rule metabolism/phase-failure
+  :material-basis "PER-18 rollback matrix: fail at the end of Material Base"
+  :fuel 64
+  (bindings (binding probability :field social-class/probability))
+  (when (> probability 0.0p))
+  (effects
+    (emit EventType/MATERIAL_FAILURE)
+    (update-node self social-class/probability (add 0.4i))))"#;
+    const ACTION_FAILURE_RULE: &str = r#"(rule ooda/phase-failure
+  :material-basis "PER-18 rollback matrix: fail after Material Base"
+  :fuel 64
+  (bindings (binding probability :field social-class/probability))
+  (when (> probability 0.0p))
+  (effects
+    (emit EventType/ACTION_FAILURE)
+    (update-node self social-class/probability (add 0.4i))))"#;
+    const CONSEQUENCE_FAILURE_RULE: &str = r#"(rule epistemic-horizon/phase-failure
+  :material-basis "PER-18 rollback matrix: fail after Material Base and Action"
+  :fuel 64
+  (bindings (binding probability :field social-class/probability))
+  (when (> probability 0.0p))
+  (effects
+    (emit EventType/CONSEQUENCE_FAILURE)
+    (update-node self social-class/probability (add 0.4i))))"#;
+
+    const HASH_FAILURE_SCENARIO: &str = r"
+(scenario tick/hash-failure
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (deffield social-class/count int extensive)
+  (node only NodeType/SOCIAL_CLASS (social-class/count 1)))
+";
+    const HASH_FAILURE_RULE: &str = r#"(rule vitality/hash-failure
+  :material-basis "PER-18 hash-boundary rollback mutates before the post hash"
+  :fuel 32
+  (bindings (binding count :field social-class/count))
+  (when (= count 1))
+  (effects
+    (emit EventType/HASH_WORK)
+    (update-node self social-class/count (add 1))))"#;
+
+    const ENVELOPE_SCENARIO: &str = r"
+(scenario tick/process-envelope
+  (defvocabulary NodeType (SOCIAL_CLASS))
+  (deffield social-class/material int extensive)
+  (deffield social-class/action int extensive)
+  (node subject NodeType/SOCIAL_CLASS
+    (social-class/material 1)
+    (social-class/action 10)))
+";
+    const ENVELOPE_RULES: &str = r#"(rule ooda/envelope-action
+  :material-basis "PER-18 real envelope proof: Action rule"
+  :fuel 32
+  (bindings (binding action :field social-class/action))
+  (when (= action 10))
+  (effects
+    (emit EventType/ACTION_ENVELOPE)
+    (update-node self social-class/action (add 2))))
+
+(rule vitality/envelope-material
+  :material-basis "PER-18 real envelope proof: Material Base rule"
+  :fuel 32
+  (bindings (binding material :field social-class/material))
+  (when (= material 1))
+  (effects
+    (emit EventType/MATERIAL_ENVELOPE)
+    (update-node self social-class/material (add 1))))"#;
+
+    const ENVELOPE_CHILD_ENV: &str = "BABYLON_PER18_TICK_ENVELOPE_CHILD";
+    const ENVELOPE_MARKER: &str = "PER18_TICK_ENVELOPE=";
+
     fn rule_src() -> String {
         format!("{VITALITY}\n{LIFECYCLE}")
     }
@@ -208,6 +313,318 @@ mod tests {
     /// wall-clock one anyway.
     fn test_session() -> SessionId {
         SessionId::new("tick-session-test").expect("literal is non-empty")
+    }
+
+    #[derive(Default)]
+    struct RejectingBatchSink {
+        prepare_attempts: usize,
+        commit_attempts: usize,
+    }
+
+    impl PreparedEventBatchSink for RejectingBatchSink {
+        fn try_prepare(&mut self, _additional: usize) -> Result<(), String> {
+            self.prepare_attempts += 1;
+            Err("injected event publication refusal".to_owned())
+        }
+
+        fn commit_prepared(&mut self, _events: Vec<EventRecord>) {
+            self.commit_attempts += 1;
+        }
+    }
+
+    #[test]
+    fn rejecting_event_publication_happens_before_graph_publication() {
+        let mut session = TickSession::new(
+            CLOCK_SCENARIO,
+            CLOCK_RULE,
+            HypergraphStore::new(),
+            test_session(),
+        )
+        .expect("the event publication probe loads");
+        let before = session.graph.encode_state().unwrap().as_bytes().to_vec();
+        let cursors = session.graph.allocator_cursors();
+        let mut publisher = RejectingBatchSink::default();
+
+        let error = run_prepared_tick_with(
+            &session.prepared,
+            &mut session.graph,
+            &mut publisher,
+            &session.session,
+            1,
+            |_boundary: HashBoundary, graph: &HypergraphStore| graph.state_hash(),
+        )
+        .expect_err("publication is injected to fail");
+
+        assert_eq!(error, "injected event publication refusal");
+        assert_eq!(publisher.prepare_attempts, 1);
+        assert_eq!(publisher.commit_attempts, 0);
+        assert_eq!(session.tick, 0);
+        assert_eq!(session.graph.encode_state().unwrap().as_bytes(), before);
+        assert_eq!(session.graph.allocator_cursors(), cursors);
+    }
+
+    fn assert_phase_fault_rolls_back<G>(rules: &str)
+    where
+        G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy + Default,
+    {
+        let mut session =
+            TickSession::new(PHASE_FAULT_SCENARIO, rules, G::default(), test_session())
+                .expect("the phase fault fixture loads");
+        let before = session.graph().encode_state().unwrap().as_bytes().to_vec();
+        let cursors = session.graph().allocator_cursors();
+        let completed_tick = session.tick();
+        let mut sink = CollectingSink {
+            events: vec![("EventType/PRIOR".to_owned(), Vec::new())],
+        };
+        let prior_events = sink.events.clone();
+
+        let error = session
+            .advance(&mut sink)
+            .expect_err("the second probability write exceeds one");
+
+        assert!(error.contains("E-EVAL-020"), "{error}");
+        assert_eq!(session.graph().encode_state().unwrap().as_bytes(), before);
+        assert_eq!(session.graph().allocator_cursors(), cursors);
+        assert_eq!(session.tick(), completed_tick);
+        assert_eq!(sink.events, prior_events);
+    }
+
+    #[test]
+    fn rollback_covers_material_action_and_consequence_faults_on_both_backends() {
+        let material = format!("{MATERIAL_SUCCESS_RULE}\n{MATERIAL_FAILURE_RULE}");
+        let action = format!("{MATERIAL_SUCCESS_RULE}\n{ACTION_FAILURE_RULE}");
+        let consequence =
+            format!("{MATERIAL_SUCCESS_RULE}\n{ACTION_SUCCESS_RULE}\n{CONSEQUENCE_FAILURE_RULE}");
+
+        assert_phase_fault_rolls_back::<MemoryGraph>(&material);
+        assert_phase_fault_rolls_back::<HypergraphStore>(&material);
+        assert_phase_fault_rolls_back::<MemoryGraph>(&action);
+        assert_phase_fault_rolls_back::<HypergraphStore>(&action);
+        assert_phase_fault_rolls_back::<MemoryGraph>(&consequence);
+        assert_phase_fault_rolls_back::<HypergraphStore>(&consequence);
+    }
+
+    fn assert_hash_fault_rolls_back<H>(mut state_hash: H, expected: &str)
+    where
+        H: FnMut(HashBoundary, &HypergraphStore) -> Result<[u8; 32], GraphError>,
+    {
+        let mut session = TickSession::new(
+            HASH_FAILURE_SCENARIO,
+            HASH_FAILURE_RULE,
+            HypergraphStore::new(),
+            test_session(),
+        )
+        .expect("the hash fault fixture loads");
+        let before = session.graph.encode_state().unwrap().as_bytes().to_vec();
+        let cursors = session.graph.allocator_cursors();
+        let mut sink = CollectingSink {
+            events: vec![("EventType/PRIOR".to_owned(), Vec::new())],
+        };
+        let events = sink.events.clone();
+
+        let error = run_prepared_tick_with(
+            &session.prepared,
+            &mut session.graph,
+            &mut sink,
+            &session.session,
+            1,
+            &mut state_hash,
+        )
+        .expect_err("the selected hash boundary refuses");
+
+        assert!(error.contains(expected), "{error}");
+        assert_eq!(session.graph.encode_state().unwrap().as_bytes(), before);
+        assert_eq!(session.graph.allocator_cursors(), cursors);
+        assert_eq!(session.tick, 0);
+        assert_eq!(sink.events, events);
+    }
+
+    #[test]
+    fn pre_hash_failure_leaves_the_whole_tick_unpublished() {
+        assert_hash_fault_rolls_back(
+            |boundary, graph| match boundary {
+                HashBoundary::Pre => Err(GraphError {
+                    message: "injected pre-hash refusal".to_owned(),
+                }),
+                HashBoundary::Post => graph.state_hash(),
+            },
+            "pre-tick state: injected pre-hash refusal",
+        );
+    }
+
+    #[test]
+    fn post_hash_nan_failure_leaves_the_whole_tick_unpublished() {
+        assert_hash_fault_rolls_back(
+            |boundary, graph| match boundary {
+                HashBoundary::Pre => graph.state_hash(),
+                HashBoundary::Post => {
+                    let mut encoder = StateEncoder::new();
+                    encoder.write_attributes(&[(
+                        NodeId(99),
+                        "fault/non-finite".to_owned(),
+                        f64::NAN,
+                    )])?;
+                    Ok(encoder.finish())
+                }
+            },
+            "post-tick state: attribute fault/non-finite on NodeId(99) is NaN",
+        );
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct TickEnvelopeProof {
+        before: [u8; 32],
+        after: [u8; 32],
+        world_before: [u8; 32],
+        world_after: [u8; 32],
+        per_rule_fired: Vec<(String, usize)>,
+        events: Vec<EventRecord>,
+    }
+
+    impl TickEnvelopeProof {
+        fn canonical_text(&self) -> String {
+            let rules = self
+                .per_rule_fired
+                .iter()
+                .map(|(id, fired)| format!("{id}={fired}"))
+                .collect::<Vec<_>>()
+                .join(",");
+            let events = self
+                .events
+                .iter()
+                .map(|(kind, payload)| format!("{kind}#{}", payload.len()))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!(
+                "graph-before={};graph-after={};world-before={};world-after={};rules={rules};events={events}",
+                crate::hex(&self.before),
+                crate::hex(&self.after),
+                crate::hex(&self.world_before),
+                crate::hex(&self.world_after),
+            )
+        }
+    }
+
+    fn envelope_prestate<G>(reverse_writes: bool) -> G
+    where
+        G: GraphSubstrate + Default,
+    {
+        let mut graph = G::default();
+        let territory = graph.add_node("TERRITORY").unwrap();
+        let organization = graph.add_node("ORGANIZATION").unwrap();
+        if reverse_writes {
+            graph
+                .update_node(organization, "organization/power", 0.625)
+                .unwrap();
+            graph
+                .update_node(territory, "territory/pressure", 0.125)
+                .unwrap();
+            graph
+                .add_hyperedge("PRESENCE_GROUP", &[organization, territory])
+                .unwrap();
+            graph
+                .add_edge("PRESENCE", organization, territory, 0.75)
+                .unwrap();
+        } else {
+            graph
+                .add_edge("PRESENCE", organization, territory, 0.75)
+                .unwrap();
+            graph
+                .add_hyperedge("PRESENCE_GROUP", &[territory, organization])
+                .unwrap();
+            graph
+                .update_node(territory, "territory/pressure", 0.125)
+                .unwrap();
+            graph
+                .update_node(organization, "organization/power", 0.625)
+                .unwrap();
+        }
+        graph
+    }
+
+    fn run_tick_envelope<G>(reverse_writes: bool) -> TickEnvelopeProof
+    where
+        G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy + Default,
+    {
+        let graph = envelope_prestate::<G>(reverse_writes);
+        let mut session = TickSession::new(
+            ENVELOPE_SCENARIO,
+            ENVELOPE_RULES,
+            graph,
+            SessionId::new("per18-envelope").unwrap(),
+        )
+        .expect("the real multi-rule envelope fixture loads");
+        let mut sink = CollectingSink::default();
+        let report = session.advance(&mut sink).expect("the real tick commits");
+        let expected_events = vec![
+            ("MATERIAL_ENVELOPE".to_owned(), Vec::new()),
+            ("ACTION_ENVELOPE".to_owned(), Vec::new()),
+        ];
+        assert_eq!(
+            report.per_rule_fired,
+            vec![
+                ("vitality/envelope-material".to_owned(), 1),
+                ("ooda/envelope-action".to_owned(), 1),
+            ]
+        );
+        assert_eq!(sink.events, expected_events);
+        TickEnvelopeProof {
+            before: report.before,
+            after: report.after,
+            world_before: report.world_before,
+            world_after: report.world_after,
+            per_rule_fired: report.per_rule_fired,
+            events: sink.events,
+        }
+    }
+
+    fn child_tick_envelope(mode: &str) -> String {
+        let executable = std::env::current_exe().expect("the test executable has a path");
+        let output = Command::new(executable)
+            .env(ENVELOPE_CHILD_ENV, mode)
+            .args([
+                "--exact",
+                "session::tests::real_tick_envelope_child_probe",
+                "--nocapture",
+            ])
+            .output()
+            .expect("the child test process starts");
+        let stdout = String::from_utf8(output.stdout).expect("child stdout is UTF-8");
+        let stderr = String::from_utf8(output.stderr).expect("child stderr is UTF-8");
+        assert!(
+            output.status.success(),
+            "child process failed\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        stdout
+            .lines()
+            .find_map(|line| line.strip_prefix(ENVELOPE_MARKER))
+            .expect("child stdout carries the real tick envelope marker")
+            .to_owned()
+    }
+
+    #[test]
+    fn real_tick_envelope_child_probe() {
+        let Some(mode) = std::env::var_os(ENVELOPE_CHILD_ENV) else {
+            return;
+        };
+        let mode = mode.to_string_lossy();
+        let envelope = match mode.as_ref() {
+            "memory-reverse" => run_tick_envelope::<MemoryGraph>(true),
+            "hypergraph-forward" => run_tick_envelope::<HypergraphStore>(false),
+            other => panic!("unknown PER-18 child envelope mode: {other}"),
+        };
+        println!("{ENVELOPE_MARKER}{}", envelope.canonical_text());
+    }
+
+    #[test]
+    fn real_tick_envelope_is_identical_across_process_order_and_backend() {
+        let memory_parent = run_tick_envelope::<MemoryGraph>(false);
+        let hypergraph_parent = run_tick_envelope::<HypergraphStore>(true);
+        assert_eq!(memory_parent, hypergraph_parent);
+        let expected = memory_parent.canonical_text();
+
+        assert_eq!(child_tick_envelope("memory-reverse"), expected);
+        assert_eq!(child_tick_envelope("hypergraph-forward"), expected);
     }
 
     #[test]

--- a/rust/crates/babylon-tick/src/session.rs
+++ b/rust/crates/babylon-tick/src/session.rs
@@ -14,6 +14,7 @@ use babylon_bsl::structural_verbs::CollectingSink;
 use babylon_graph::allocator_state::AllocatorState;
 use babylon_graph::state_hash::CanonicalState;
 use babylon_graph::substrate::GraphSubstrate;
+use babylon_graph::working_copy::DetachedCopy;
 use babylon_kernel::SessionId;
 
 /// One content set, loaded once, advanced tick by tick against ONE held
@@ -31,7 +32,7 @@ pub struct TickSession<G> {
     session: SessionId,
 }
 
-impl<G: GraphSubstrate + CanonicalState + AllocatorState + Clone> TickSession<G> {
+impl<G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy> TickSession<G> {
     /// Parse `rule_src` (one or more `(rule …)` forms) and load
     /// `scenario_src` into `graph` once. `prepare_rules` compiles the forms
     /// into governed phase order before this returns — the caller's own

--- a/rust/crates/babylon-tick/src/session.rs
+++ b/rust/crates/babylon-tick/src/session.rs
@@ -158,6 +158,7 @@ impl<G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy> TickSes
 mod tests {
     use crate::session::TickSession;
     use crate::{run_prepared_tick_with, EventRecord, HashBoundary, PreparedEventBatchSink};
+    use babylon_bsl::evaluator::Value;
     use babylon_bsl::structural_verbs::CollectingSink;
     use babylon_graph::allocator_state::AllocatorState;
     use babylon_graph::hypergraph_store::HypergraphStore;
@@ -165,7 +166,8 @@ mod tests {
     use babylon_graph::state_hash::{CanonicalState, StateEncoder};
     use babylon_graph::substrate::{GraphError, GraphSubstrate, NodeId};
     use babylon_graph::working_copy::DetachedCopy;
-    use babylon_kernel::SessionId;
+    use babylon_kernel::{Currency, SessionId};
+    use std::fmt::Write as _;
     use std::process::Command;
 
     const SCENARIO: &str =
@@ -288,7 +290,7 @@ mod tests {
   (bindings (binding action :field social-class/action))
   (when (= action 10))
   (effects
-    (emit EventType/ACTION_ENVELOPE)
+    (emit EventType/ACTION_ENVELOPE (authorized #t) (budget 7.5$))
     (update-node self social-class/action (add 2))))
 
 (rule vitality/envelope-material
@@ -297,7 +299,7 @@ mod tests {
   (bindings (binding material :field social-class/material))
   (when (= material 1))
   (effects
-    (emit EventType/MATERIAL_ENVELOPE)
+    (emit EventType/MATERIAL_ENVELOPE (ordinal 101) (pressure 0.125c))
     (update-node self social-class/material (add 1))))"#;
 
     const ENVELOPE_CHILD_ENV: &str = "BABYLON_PER18_TICK_ENVELOPE_CHILD";
@@ -477,32 +479,125 @@ mod tests {
         after: [u8; 32],
         world_before: [u8; 32],
         world_after: [u8; 32],
+        fired: usize,
         per_rule_fired: Vec<(String, usize)>,
         events: Vec<EventRecord>,
     }
 
     impl TickEnvelopeProof {
-        fn canonical_text(&self) -> String {
-            let rules = self
-                .per_rule_fired
-                .iter()
-                .map(|(id, fired)| format!("{id}={fired}"))
-                .collect::<Vec<_>>()
-                .join(",");
-            let events = self
-                .events
-                .iter()
-                .map(|(kind, payload)| format!("{kind}#{}", payload.len()))
-                .collect::<Vec<_>>()
-                .join(",");
-            format!(
-                "graph-before={};graph-after={};world-before={};world-after={};rules={rules};events={events}",
-                crate::hex(&self.before),
-                crate::hex(&self.after),
-                crate::hex(&self.world_before),
-                crate::hex(&self.world_after),
-            )
+        fn canonical_bytes(&self) -> Vec<u8> {
+            let mut bytes = b"babylon.per18.tick-envelope\0".to_vec();
+            bytes.extend_from_slice(&self.before);
+            bytes.extend_from_slice(&self.after);
+            bytes.extend_from_slice(&self.world_before);
+            bytes.extend_from_slice(&self.world_after);
+            push_usize(&mut bytes, self.fired);
+            push_count(&mut bytes, self.per_rule_fired.len());
+            for (id, fired) in &self.per_rule_fired {
+                push_str(&mut bytes, id);
+                push_usize(&mut bytes, *fired);
+            }
+            push_count(&mut bytes, self.events.len());
+            for (kind, payload) in &self.events {
+                push_str(&mut bytes, kind);
+                push_count(&mut bytes, payload.len());
+                for (key, value) in payload {
+                    push_str(&mut bytes, key);
+                    push_value(&mut bytes, value);
+                }
+            }
+            bytes
         }
+    }
+
+    fn push_count(bytes: &mut Vec<u8>, count: usize) {
+        let count = u32::try_from(count).expect("the bounded proof fixture fits a u32 count");
+        bytes.extend_from_slice(&count.to_be_bytes());
+    }
+
+    fn push_usize(bytes: &mut Vec<u8>, value: usize) {
+        let value = u64::try_from(value).expect("the proof count fits canonical u64");
+        bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn push_str(bytes: &mut Vec<u8>, value: &str) {
+        push_count(bytes, value.len());
+        bytes.extend_from_slice(value.as_bytes());
+    }
+
+    fn push_f64(bytes: &mut Vec<u8>, value: f64) {
+        assert!(value.is_finite(), "event payload values must be finite");
+        let canonical = if value == 0.0 { 0.0 } else { value };
+        bytes.extend_from_slice(&canonical.to_bits().to_be_bytes());
+    }
+
+    fn push_optional_ratio(bytes: &mut Vec<u8>, value: Option<babylon_kernel::Ratio>) {
+        match value {
+            Some(ratio) => {
+                bytes.push(1);
+                push_f64(bytes, ratio.get());
+            }
+            None => bytes.push(0),
+        }
+    }
+
+    /// Canonical test-envelope tags: Int=1, Currency=2, Real=3, Ratio=4,
+    /// Bool=5, Enum=6, NodeRef=7, HyperedgeRef=8, EdgeRef=9. Every numeric
+    /// payload is big-endian; strings are u32-length-prefixed UTF-8.
+    fn push_value(bytes: &mut Vec<u8>, value: &Value) {
+        match value {
+            Value::Int(integer) => {
+                bytes.push(1);
+                bytes.extend_from_slice(&integer.to_be_bytes());
+            }
+            Value::Currency(currency) => {
+                bytes.push(2);
+                bytes.extend_from_slice(&currency.micro_units().to_be_bytes());
+            }
+            Value::Real(real) => {
+                bytes.push(3);
+                push_f64(bytes, *real);
+            }
+            Value::Ratio { value, floor, cap } => {
+                bytes.push(4);
+                push_f64(bytes, value.get());
+                push_optional_ratio(bytes, *floor);
+                push_optional_ratio(bytes, *cap);
+            }
+            Value::Bool(boolean) => {
+                bytes.push(5);
+                bytes.push(u8::from(*boolean));
+            }
+            Value::Enum { enum_type, member } => {
+                bytes.push(6);
+                push_str(bytes, enum_type);
+                push_str(bytes, member);
+            }
+            Value::NodeRef(id) => {
+                bytes.push(7);
+                bytes.extend_from_slice(&id.0.to_be_bytes());
+            }
+            Value::HyperedgeRef(id) => {
+                bytes.push(8);
+                bytes.extend_from_slice(&id.0.to_be_bytes());
+            }
+            Value::EdgeRef(edge) => {
+                bytes.push(9);
+                bytes.extend_from_slice(&edge.source.0.to_be_bytes());
+                bytes.extend_from_slice(&edge.target.0.to_be_bytes());
+                push_str(bytes, &edge.edge_type);
+            }
+        }
+    }
+
+    fn byte_hex(bytes: &[u8]) -> String {
+        bytes.iter().fold(
+            String::with_capacity(bytes.len() * 2),
+            |mut output, byte| {
+                write!(&mut output, "{byte:02x}").expect("writing to String cannot fail");
+                output
+            },
+        )
     }
 
     fn envelope_prestate<G>(reverse_writes: bool) -> G
@@ -557,9 +652,25 @@ mod tests {
         let mut sink = CollectingSink::default();
         let report = session.advance(&mut sink).expect("the real tick commits");
         let expected_events = vec![
-            ("MATERIAL_ENVELOPE".to_owned(), Vec::new()),
-            ("ACTION_ENVELOPE".to_owned(), Vec::new()),
+            (
+                "MATERIAL_ENVELOPE".to_owned(),
+                vec![
+                    ("ordinal".to_owned(), Value::Int(101)),
+                    ("pressure".to_owned(), Value::Real(0.125)),
+                ],
+            ),
+            (
+                "ACTION_ENVELOPE".to_owned(),
+                vec![
+                    ("authorized".to_owned(), Value::Bool(true)),
+                    (
+                        "budget".to_owned(),
+                        Value::Currency(Currency::from_micro_units(7_500_000)),
+                    ),
+                ],
+            ),
         ];
+        assert_eq!(report.fired, 2);
         assert_eq!(
             report.per_rule_fired,
             vec![
@@ -573,6 +684,7 @@ mod tests {
             after: report.after,
             world_before: report.world_before,
             world_after: report.world_after,
+            fired: report.fired,
             per_rule_fired: report.per_rule_fired,
             events: sink.events,
         }
@@ -613,7 +725,7 @@ mod tests {
             "hypergraph-forward" => run_tick_envelope::<HypergraphStore>(false),
             other => panic!("unknown PER-18 child envelope mode: {other}"),
         };
-        println!("{ENVELOPE_MARKER}{}", envelope.canonical_text());
+        println!("{ENVELOPE_MARKER}{}", byte_hex(&envelope.canonical_bytes()));
     }
 
     #[test]
@@ -621,7 +733,7 @@ mod tests {
         let memory_parent = run_tick_envelope::<MemoryGraph>(false);
         let hypergraph_parent = run_tick_envelope::<HypergraphStore>(true);
         assert_eq!(memory_parent, hypergraph_parent);
-        let expected = memory_parent.canonical_text();
+        let expected = byte_hex(&memory_parent.canonical_bytes());
 
         assert_eq!(child_tick_envelope("memory-reverse"), expected);
         assert_eq!(child_tick_envelope("hypergraph-forward"), expected);

--- a/rust/crates/babylon-tick/src/world_hash.rs
+++ b/rust/crates/babylon-tick/src/world_hash.rs
@@ -31,6 +31,21 @@ pub(crate) fn nominal_world_hash(
     cursors: AllocatorCursors,
     schedule_digest: [u8; 32],
 ) -> Result<[u8; 32], String> {
+    Ok(sha256_of(&encode_nominal_world_state(
+        graph_hash,
+        completed_tick,
+        cursors,
+        schedule_digest,
+    )?))
+}
+
+/// Encode the versioned nominal world identity before hashing it.
+fn encode_nominal_world_state(
+    graph_hash: [u8; 32],
+    completed_tick: i64,
+    cursors: AllocatorCursors,
+    schedule_digest: [u8; 32],
+) -> Result<Vec<u8>, String> {
     if completed_tick < 0 {
         return Err(format!(
             "completed tick must be non-negative, got {completed_tick}"
@@ -48,17 +63,59 @@ pub(crate) fn nominal_world_hash(
     bytes.extend_from_slice(&cursors.next_hyperedge.to_be_bytes());
     bytes.push(0x04);
     bytes.extend_from_slice(&schedule_digest);
-    Ok(sha256_of(&bytes))
+    Ok(bytes)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::nominal_world_hash;
+    use super::{encode_nominal_world_state, nominal_world_hash};
     use crate::phase_order::schedule_digest;
     use babylon_graph::allocator_state::{AllocatorCursors, AllocatorState};
     use babylon_graph::hypergraph_store::HypergraphStore;
+    use babylon_graph::memory::MemoryGraph;
     use babylon_graph::state_hash::CanonicalState;
     use babylon_graph::substrate::GraphSubstrate;
+    use babylon_kernel::sha256_of;
+
+    fn seeded_world<G: GraphSubstrate + Default>(reverse_writes: bool) -> G {
+        let mut graph = G::default();
+        let worker = graph.add_node("SOCIAL_CLASS").unwrap();
+        let organizer = graph.add_node("ORGANIZATION").unwrap();
+        if reverse_writes {
+            graph
+                .update_node(organizer, "organization/cadre", 0.25)
+                .unwrap();
+            graph
+                .update_node(worker, "social-class/wealth", 0.75)
+                .unwrap();
+            graph.add_hyperedge("CLASS", &[organizer, worker]).unwrap();
+            graph
+                .add_edge("SOLIDARITY", worker, organizer, 0.5)
+                .unwrap();
+        } else {
+            graph
+                .update_node(worker, "social-class/wealth", 0.75)
+                .unwrap();
+            graph
+                .update_node(organizer, "organization/cadre", 0.25)
+                .unwrap();
+            graph
+                .add_edge("SOLIDARITY", worker, organizer, 0.5)
+                .unwrap();
+            graph.add_hyperedge("CLASS", &[worker, organizer]).unwrap();
+        }
+        graph
+    }
+
+    fn seeded_world_hash<G: CanonicalState + AllocatorState>(graph: &G) -> [u8; 32] {
+        nominal_world_hash(
+            graph.state_hash().unwrap(),
+            17,
+            graph.allocator_cursors(),
+            schedule_digest().unwrap(),
+        )
+        .unwrap()
+    }
 
     #[test]
     fn empty_tick_zero_world_hash_pins_the_version_one_layout() {
@@ -73,6 +130,51 @@ mod tests {
         assert_eq!(
             crate::hex(&hash),
             "bb1fd62f9053807b13fe00a45fc7f2c032dc9d23a4d778e8c5c016bbb59c2932"
+        );
+    }
+
+    #[test]
+    fn asymmetric_world_state_vector_pins_every_canonical_byte_and_its_sha() {
+        let graph_hash = core::array::from_fn(|index| u8::try_from(index + 1).unwrap());
+        let schedule_digest = core::array::from_fn(|index| u8::try_from(index).unwrap() + 0xa1);
+        let cursors = AllocatorCursors {
+            next_node: 0x1112_1314_1516_1718,
+            next_hyperedge: 0x2122_2324_2526_2728,
+        };
+        let bytes =
+            encode_nominal_world_state(graph_hash, 0x0102_0304_0506_0708, cursors, schedule_digest)
+                .unwrap();
+
+        #[rustfmt::skip]
+        let expected: &[u8] = &[
+            // Domain + u32 layout version 1.
+            b'b', b'a', b'b', b'y', b'l', b'o', b'n', b'.',
+            b'w', b'o', b'r', b'l', b'd', b'-', b's', b't', b'a', b't', b'e', 0x00,
+            0x00, 0x00, 0x00, 0x01,
+            // Section 0x01: asymmetric 32-byte graph hash.
+            0x01,
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+            0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+            0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+            0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+            // Section 0x02: signed completed tick, big-endian.
+            0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+            // Section 0x03: node cursor followed by hyperedge cursor.
+            0x03,
+            0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+            0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+            // Section 0x04: asymmetric 32-byte governed-schedule digest.
+            0x04,
+            0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8,
+            0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0,
+            0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8,
+            0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0xc0,
+        ];
+
+        assert_eq!(bytes, expected);
+        assert_eq!(
+            crate::hex(&sha256_of(&bytes)),
+            "8ce3e668779b762d26bf3543820775d52d711ffae6076006297c85968fb12751"
         );
     }
 
@@ -103,6 +205,19 @@ mod tests {
         )
         .unwrap();
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn insertion_order_and_graph_store_do_not_move_nominal_world_identity() {
+        let memory = seeded_world::<MemoryGraph>(false);
+        let hypergraph = seeded_world::<HypergraphStore>(true);
+
+        assert_eq!(
+            memory.state_hash().unwrap(),
+            hypergraph.state_hash().unwrap()
+        );
+        assert_eq!(memory.allocator_cursors(), hypergraph.allocator_cursors());
+        assert_eq!(seeded_world_hash(&memory), seeded_world_hash(&hypergraph));
     }
 
     #[test]

--- a/rust/crates/babylon-tick/src/world_hash.rs
+++ b/rust/crates/babylon-tick/src/world_hash.rs
@@ -1,0 +1,122 @@
+//! Nominal whole-world hashing above the established graph-state hash.
+//!
+//! The graph hash remains its own stable contract. This layer adds only
+//! auxiliary state that exists today: completed weekly time, both monotonic
+//! graph allocator cursors, and the versioned static phase-schedule digest.
+//! It does not invent future economic registers or persistence-envelope
+//! fields.
+//!
+//! # Canonical byte layout — version 1
+//!
+//! Every integer is big-endian. The encoding is the fixed domain string
+//! `babylon.world-state\0`, then `u32` layout version 1, followed by:
+//!
+//! ```text
+//! 0x01 | 32-byte graph hash
+//! 0x02 | i64 completed tick
+//! 0x03 | u64 next-node cursor | u64 next-hyperedge cursor
+//! 0x04 | 32-byte governed phase-schedule digest
+//! ```
+
+use babylon_graph::allocator_state::AllocatorCursors;
+use babylon_kernel::sha256_of;
+
+const WORLD_HASH_LAYOUT_VERSION: u32 = 1;
+const WORLD_HASH_DOMAIN: &[u8] = b"babylon.world-state\0";
+
+/// Hash one graph hash plus the real auxiliary state that names its world.
+pub(crate) fn nominal_world_hash(
+    graph_hash: [u8; 32],
+    completed_tick: i64,
+    cursors: AllocatorCursors,
+    schedule_digest: [u8; 32],
+) -> Result<[u8; 32], String> {
+    if completed_tick < 0 {
+        return Err(format!(
+            "completed tick must be non-negative, got {completed_tick}"
+        ));
+    }
+    let mut bytes = Vec::with_capacity(116);
+    bytes.extend_from_slice(WORLD_HASH_DOMAIN);
+    bytes.extend_from_slice(&WORLD_HASH_LAYOUT_VERSION.to_be_bytes());
+    bytes.push(0x01);
+    bytes.extend_from_slice(&graph_hash);
+    bytes.push(0x02);
+    bytes.extend_from_slice(&completed_tick.to_be_bytes());
+    bytes.push(0x03);
+    bytes.extend_from_slice(&cursors.next_node.to_be_bytes());
+    bytes.extend_from_slice(&cursors.next_hyperedge.to_be_bytes());
+    bytes.push(0x04);
+    bytes.extend_from_slice(&schedule_digest);
+    Ok(sha256_of(&bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::nominal_world_hash;
+    use crate::phase_order::schedule_digest;
+    use babylon_graph::allocator_state::{AllocatorCursors, AllocatorState};
+    use babylon_graph::hypergraph_store::HypergraphStore;
+    use babylon_graph::state_hash::CanonicalState;
+    use babylon_graph::substrate::GraphSubstrate;
+
+    #[test]
+    fn empty_tick_zero_world_hash_pins_the_version_one_layout() {
+        let graph = HypergraphStore::new();
+        let hash = nominal_world_hash(
+            graph.state_hash().unwrap(),
+            0,
+            graph.allocator_cursors(),
+            schedule_digest().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            crate::hex(&hash),
+            "bb1fd62f9053807b13fe00a45fc7f2c032dc9d23a4d778e8c5c016bbb59c2932"
+        );
+    }
+
+    #[test]
+    fn allocator_history_moves_world_hash_when_live_graph_facts_match() {
+        let untouched = HypergraphStore::new();
+        let mut allocated = HypergraphStore::new();
+        let transient = allocated.add_node("SOCIAL_CLASS").unwrap();
+        allocated.remove_node(transient).unwrap();
+        assert_eq!(
+            untouched.state_hash().unwrap(),
+            allocated.state_hash().unwrap()
+        );
+
+        let schedule = schedule_digest().unwrap();
+        let a = nominal_world_hash(
+            untouched.state_hash().unwrap(),
+            0,
+            untouched.allocator_cursors(),
+            schedule,
+        )
+        .unwrap();
+        let b = nominal_world_hash(
+            allocated.state_hash().unwrap(),
+            0,
+            allocated.allocator_cursors(),
+            schedule,
+        )
+        .unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn negative_completed_time_refuses_loudly() {
+        let error = nominal_world_hash(
+            [0; 32],
+            -1,
+            AllocatorCursors {
+                next_node: 0,
+                next_hyperedge: 0,
+            },
+            [0; 32],
+        )
+        .unwrap_err();
+        assert_eq!(error, "completed tick must be non-negative, got -1");
+    }
+}

--- a/rust/crates/babylon-tick/tests/support/mod.rs
+++ b/rust/crates/babylon-tick/tests/support/mod.rs
@@ -35,6 +35,7 @@
 //! identical — same fixture, same assertions, same pass/fail contract).
 
 use babylon_bsl::structural_verbs::CollectingSink;
+use babylon_graph::allocator_state::AllocatorState;
 use babylon_graph::state_hash::CanonicalState;
 use babylon_graph::substrate::{GraphSubstrate, NodeId};
 use babylon_tick::{run_once, run_once_into, TickReport};
@@ -94,7 +95,7 @@ pub fn attribute<G: GraphSubstrate>(graph: &G, id: impl IntoNodeId, field: &str)
 /// `metabolism_entropy_high_conformance.rs`,
 /// `metabolism_entropy_low_conformance.rs`) — the majority shape among the
 /// three `run_*` variants genuinely found (the other two below).
-pub fn run_conformance<G: GraphSubstrate + CanonicalState + Default>(
+pub fn run_conformance<G: GraphSubstrate + CanonicalState + AllocatorState + Clone + Default>(
     scenario: &str,
     rule: &str,
 ) -> G {
@@ -111,7 +112,9 @@ pub fn run_conformance<G: GraphSubstrate + CanonicalState + Default>(
 /// `dispossession_*_conformance.rs` files, `lifecycle_conformance.rs`,
 /// `lifecycle_crisis_conformance.rs`, `vitality_conformance.rs`, and
 /// `decomposition_conformance.rs`'s own `HypergraphStore` variant.
-pub fn run_conformance_with_sink<G: GraphSubstrate + CanonicalState + Default>(
+pub fn run_conformance_with_sink<
+    G: GraphSubstrate + CanonicalState + AllocatorState + Clone + Default,
+>(
     scenario: &str,
     rule: &str,
 ) -> (G, CollectingSink) {
@@ -126,7 +129,9 @@ pub fn run_conformance_with_sink<G: GraphSubstrate + CanonicalState + Default>(
 /// TickReport)` / `fn run_territory() -> (HypergraphStore, TickReport)`
 /// shape shared by `production_conformance.rs` and
 /// `territory_conformance.rs`, the third `run_*` variant genuinely found.
-pub fn run_conformance_with_report<G: GraphSubstrate + CanonicalState + Default>(
+pub fn run_conformance_with_report<
+    G: GraphSubstrate + CanonicalState + AllocatorState + Clone + Default,
+>(
     scenario: &str,
     rule: &str,
 ) -> (G, TickReport) {

--- a/rust/crates/babylon-tick/tests/support/mod.rs
+++ b/rust/crates/babylon-tick/tests/support/mod.rs
@@ -38,6 +38,7 @@ use babylon_bsl::structural_verbs::CollectingSink;
 use babylon_graph::allocator_state::AllocatorState;
 use babylon_graph::state_hash::CanonicalState;
 use babylon_graph::substrate::{GraphSubstrate, NodeId};
+use babylon_graph::working_copy::DetachedCopy;
 use babylon_tick::{run_once, run_once_into, TickReport};
 
 /// Accepts either a raw `u64` (the majority shape across existing
@@ -95,7 +96,9 @@ pub fn attribute<G: GraphSubstrate>(graph: &G, id: impl IntoNodeId, field: &str)
 /// `metabolism_entropy_high_conformance.rs`,
 /// `metabolism_entropy_low_conformance.rs`) — the majority shape among the
 /// three `run_*` variants genuinely found (the other two below).
-pub fn run_conformance<G: GraphSubstrate + CanonicalState + AllocatorState + Clone + Default>(
+pub fn run_conformance<
+    G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy + Default,
+>(
     scenario: &str,
     rule: &str,
 ) -> G {
@@ -113,7 +116,7 @@ pub fn run_conformance<G: GraphSubstrate + CanonicalState + AllocatorState + Clo
 /// `lifecycle_crisis_conformance.rs`, `vitality_conformance.rs`, and
 /// `decomposition_conformance.rs`'s own `HypergraphStore` variant.
 pub fn run_conformance_with_sink<
-    G: GraphSubstrate + CanonicalState + AllocatorState + Clone + Default,
+    G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy + Default,
 >(
     scenario: &str,
     rule: &str,
@@ -130,7 +133,7 @@ pub fn run_conformance_with_sink<
 /// shape shared by `production_conformance.rs` and
 /// `territory_conformance.rs`, the third `run_*` variant genuinely found.
 pub fn run_conformance_with_report<
-    G: GraphSubstrate + CanonicalState + AllocatorState + Clone + Default,
+    G: GraphSubstrate + CanonicalState + AllocatorState + DetachedCopy + Default,
 >(
     scenario: &str,
     rule: &str,

--- a/tests/unit/governance/test_v4_portfolio_alignment.py
+++ b/tests/unit/governance/test_v4_portfolio_alignment.py
@@ -72,6 +72,7 @@ _CURRENT_COMPONENTS: Final[tuple[str, ...]] = (
     "bsl_pipeline",
     "rust_tick_session",
     "canonical_graph_hash",
+    "nominal_world_hash",
     "bevy_admin_viewer",
     "frozen_python_engine",
     "legacy_python_persistence",
@@ -85,6 +86,10 @@ _CURRENT_EVIDENCE: Final[dict[str, tuple[str, ...]]] = {
     ),
     "rust_tick_session": ("rust/crates/babylon-tick/src/session.rs",),
     "canonical_graph_hash": ("rust/crates/babylon-graph/src/state_hash.rs",),
+    "nominal_world_hash": (
+        "rust/crates/babylon-tick/src/world_hash.rs",
+        "rust/crates/babylon-tick/src/session.rs",
+    ),
     "bevy_admin_viewer": ("rust/crates/babylon-client/src/ui/admin.rs",),
     "frozen_python_engine": (
         "src/babylon/engine/simulation_engine.py",
@@ -109,7 +114,7 @@ _H3_EVIDENCE: Final[tuple[str, ...]] = (
 )
 _GATE_2_STATUSES: Final[dict[str, str]] = {
     "PER-17": "implemented_current",
-    "PER-18": "planned",
+    "PER-18": "implemented_current",
     "PER-19": "planned",
 }
 _GATE_2_COMPONENTS: Final[dict[str, str]] = {
@@ -123,6 +128,13 @@ _GATE_2_COMPONENTS: Final[dict[str, str]] = {
         "negative_outcome_write_contracts"
     ),
 }
+_PER_18_EVIDENCE: Final[tuple[str, ...]] = (
+    "rust/crates/babylon-graph/src/working_copy.rs",
+    "rust/crates/babylon-tick/src/lib.rs",
+    "rust/crates/babylon-tick/src/session.rs",
+    "rust/crates/babylon-tick/src/world_hash.rs",
+    "ai/decisions/ADR223_whole_tick_atomicity_world_hash.yaml",
+)
 _GATE_3_ISSUES: Final[tuple[str, ...]] = (
     "PER-20",
     "PER-21",
@@ -211,6 +223,8 @@ def test_architecture_records_current_components_and_gate_delivery_status() -> N
     assert tuple(gate_3) == _GATE_3_ISSUES
     assert {issue: gate_2[issue]["status"] for issue in _GATE_2_STATUSES} == _GATE_2_STATUSES
     assert {issue: gate_2[issue]["component"] for issue in _GATE_2_COMPONENTS} == _GATE_2_COMPONENTS
+    assert tuple(gate_2["PER-18"]["evidence"]) == _PER_18_EVIDENCE
+    assert all((_ROOT / evidence).is_file() for evidence in _PER_18_EVIDENCE)
     assert all(gate_3[issue]["status"] == "planned" for issue in _GATE_3_ISSUES)
 
 
@@ -435,7 +449,7 @@ def test_state_is_one_historical_ledger_not_a_status_authority() -> None:
     assert authority["project"] == _LINEAR_PROJECT
     assert authority["charter"] == _LINEAR_CHARTER
     snapshot = meta["v4_governance_snapshot"]
-    assert snapshot["as_of"] == "2026-08-22"
+    assert snapshot["as_of"] == "2026-08-23"
     assert snapshot["implementation_truth"] == "ai/architecture.yaml"
     assert snapshot["lower_entries"] == "dated_snapshots_only"
     assert snapshot["current_status_queries"] == "Linear"
@@ -513,6 +527,7 @@ def test_standard_addenda_classify_current_and_superseded_surfaces() -> None:
         "Ratatui/TUI status: retired",
         "Article V vocabulary authority status: superseded",
         "NarrationEnvelope status: superseded_proposal",
+        "In-memory whole-tick rollback status: implemented_current_PER-18",
         "CommittedTickEnvelope status: planned",
         "DecisionSurfaceContract executable status: planned",
         "Persistence writer status: accepted_cutover_law",
@@ -523,11 +538,11 @@ def test_standard_addenda_classify_current_and_superseded_surfaces() -> None:
     ):
         assert phrase in game_design
     for phrase in (
-        "S-11 whole-tick rollback status: planned",
+        "S-11 whole-tick rollback status: implemented_current_PER-18",
         "S-25 renderer requirement status: retired",
         "S-32 writer assignment status: superseded",
         "D5/D16 phase-ordering status: implemented_executable_PER-17",
-        "PER-18 rollback and combined-world-hash status: planned",
+        "PER-18 rollback and combined-world-hash status: implemented_current",
         "PER-19 causal-composition and outcome-write-contract status: planned",
         "Persistence writer status: accepted_cutover_law",
         "PER-48 status: Done",

--- a/tests/unit/governance/test_v4_portfolio_alignment.py
+++ b/tests/unit/governance/test_v4_portfolio_alignment.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Final
+from typing import Any, Final
 
 import pytest
 import yaml
@@ -16,6 +16,11 @@ _ARCHITECTURE: Final[Path] = _ROOT / "ai" / "architecture.yaml"
 _STATE: Final[Path] = _ROOT / "ai" / "state.yaml"
 _TUNING: Final[Path] = _ROOT / "ai" / "tuning-standard.yaml"
 _ROADMAP: Final[Path] = _ROOT / "project" / "roadmap.md"
+_ADR_INDEX: Final[Path] = _ROOT / "ai" / "decisions" / "index.yaml"
+_PER_18_ADR: Final[Path] = (
+    _ROOT / "ai" / "decisions" / "ADR223_whole_tick_atomicity_world_hash.yaml"
+)
+_DETERMINISM_REFERENCE: Final[Path] = _ROOT / "docs" / "reference" / "determinism-contract.rst"
 
 _LINEAR_PROJECT: Final[dict[str, str]] = {
     "id": "ebab3603-e391-4110-97e2-97422bc2037e",
@@ -174,9 +179,15 @@ _ROADMAP_DELIVERY_ROOT_PATTERN: Final[re.Pattern[str]] = re.compile(
     re.MULTILINE,
 )
 _POSTGRESQL_ADR: Final[str] = "ADR220_rust_owned_postgresql_persistence_boundary"
+_PER_18_ADR_KEY: Final[str] = "ADR223_whole_tick_atomicity_world_hash"
+_PER_18_ADR_TITLE: Final[str] = (
+    "Rust adjudicates each weekly tick on a detached world, publishes graph, "
+    "events, allocator state, and completed time only after total success, and "
+    "names current in-memory identity with a versioned nominal world hash"
+)
 
 
-def _yaml_document(path: Path) -> dict[str, object]:
+def _yaml_document(path: Path) -> dict[str, Any]:
     """Load one required YAML mapping."""
     document = yaml.safe_load(path.read_text(encoding="utf-8"))
     assert isinstance(document, dict), path
@@ -459,12 +470,73 @@ def test_state_is_one_historical_ledger_not_a_status_authority() -> None:
         "adr": _POSTGRESQL_ADR,
         "completion_commit": "9b4c9b2e",
     }
+    assert snapshot["bsl_phase_order"] == {
+        "status": "implemented_on_dev",
+        "issue": "PER-17",
+        "adr": "ADR222_executable_bsl_phase_order",
+        "merge_commit": "5a0ef2a9",
+    }
+    assert snapshot["whole_tick_atomicity"] == {
+        "status": "implemented_on_PER-18_branch",
+        "issue": "PER-18",
+        "adr": _PER_18_ADR_KEY,
+        "branch": "codex/per-18-whole-tick-atomicity",
+        "scope": "in_memory_only",
+        "remaining_gate_2": ["PER-19"],
+    }
     assert snapshot["attributed_membership_payload"] == {
         "status": "planned",
         "horizon": "Research",
         "issue": "PER-44",
         "current_truth": "empty_unhashed_unwritten_unconsumed",
     }
+    history = " ".join(meta["truth_status"].split())
+    assert (
+        "(2026-08-23 GATE 2 — PER-17 EXECUTABLE BSL PHASE ORDER IMPLEMENTED, REVIEW/PR PENDING)"
+    ) in history
+
+
+def test_per_18_adr_and_catalog_are_exact() -> None:
+    """The accepted decision and catalog row cannot pass as an empty placeholder."""
+    catalog = _yaml_document(_ADR_INDEX)
+    assert catalog["meta"] == {
+        "version": "1.76.0",
+        "updated": "2026-08-23",
+        "description": "Architecture Decision Records Index",
+        "format": "See individual ADR files in this directory",
+    }
+    assert catalog["decisions"][_PER_18_ADR_KEY] == {
+        "title": _PER_18_ADR_TITLE,
+        "status": "accepted",
+        "date": "2026-08-23",
+        "file": "ADR223_whole_tick_atomicity_world_hash.yaml",
+    }
+    document = _yaml_document(_PER_18_ADR)
+    assert tuple(document) == (_PER_18_ADR_KEY,)
+    decision = document[_PER_18_ADR_KEY]
+    assert decision["status"] == "accepted"
+    assert decision["date"] == "2026-08-23"
+    assert decision["title"] == _PER_18_ADR_TITLE
+    assert tuple(decision["related"]) == (
+        "ADR179_topology_spine_director_rulings",
+        _POSTGRESQL_ADR,
+        "ADR221_game_first_refoundation_v4",
+        "ADR222_executable_bsl_phase_order",
+    )
+
+
+def test_determinism_reference_uses_v4_authority_and_honest_scope() -> None:
+    """Current hash guidance cannot cite superseded law or promise missing layouts."""
+    reference = _DETERMINISM_REFERENCE.read_text(encoding="utf-8")
+    index = (_ROOT / "docs" / "reference" / "index.rst").read_text(encoding="utf-8")
+    assert "Determinism Contract (Constitution Article V)" in index
+    assert "Current constitutional authority is Article V" in reference
+    assert "outer ``NominalWorldHash`` composition" in reference
+    assert "no byte layout is implemented or specified" in reference
+    assert "CONSTITUTION.md:250" not in reference
+    combined = " ".join(f"{reference}\n{index}".lower().split())
+    stale_clause = re.search(r"(?<!historical v3 clause )\b[IVX]+\.\d+(?:\.\d+)?\b", combined)
+    assert stale_clause is None, stale_clause.group() if stale_clause else ""
 
 
 def test_project_corpus_publishes_the_bounded_catchup_path() -> None:


### PR DESCRIPTION
## Summary

- adjudicate every weekly tick on a detached working copy
- publish graph, events, allocator state, and completed time only after total success
- add a versioned NominalWorldHash over the graph hash and real auxiliary identity
- distinguish graph-only and world hashes in the CLI and Bevy client
- record ADR223 and align the v4 determinism reference without rewriting historical snapshots

## Behavioral contracts

- failure injection proves no partial graph, event, cursor, or tick publication
- u64::MAX is a reserved exhausted allocator sentinel across both graph stores
- backend rejection cannot leak side-index or cursor mutation
- insertion permutations, both stores, retries, and two independent processes produce the same world identity
- the exact 116-byte asymmetric hash vector is pinned

## Verification

- mise run rust:check
- mise run check: 14,246 passed, 55 skipped, 1 expected failure
- mise run qa:regression: 12 scenarios plus two-process determinism passed
- mise run qa:vault-regression-ci: both scenarios byte-identical
- mise run check:gate-coverage
- mise run check:gate-coverage-truth: 13 scenarios verified
- pre-push CI mirror, including the full Rust gate

## Tracking

- Linear: https://linear.app/percy-raskova/issue/PER-18/make-the-whole-tick-rollback-safe-and-hash-auxiliary-registers
- GitHub delivery bridge: #503
- Gate 2 remaining after this PR: PER-19
