### PR TITLE
docs(agents): skip full documentation builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,8 +101,8 @@ Use TDD: show RED, make it pass, then refactor. Keep game data typed and
 immutable. Python models use frozen Pydantic types.
 `model_copy(update=...)` skips validation. Pass dependencies explicitly.
 
-Use the repository documentation rules for public Python interfaces. Run Vale
-on changed prose and distinguish live facts from plans.
+Do not run Sphinx or full-documentation tasks unless the Director requests them.
+Run only targeted Vale and format checks on changed prose.
 
 ## Tests and behavior contracts
 


### PR DESCRIPTION
## Summary

- make Sphinx and full-documentation tasks opt-in for agents
- keep targeted Vale and format checks in the normal prose loop
- update the shared CLAUDE.md source; AGENTS.md inherits it through the existing symlink

## Verification

- vale CLAUDE.md: clean
- markdownlint pre-commit hook: clean
- git diff --check: clean
- CLAUDE.md remains 199 lines
- no documentation build was run
- local Python tests were skipped by Director instruction

Co-Authored-By: OpenAI Codex <codex@openai.com>