### PR TITLE
feat(persistence): add canonical H3 schema epoch

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -7,20 +7,63 @@
 # PostgreSQL 17 via the flake closure (flake.nix postgresql_17.withPackages
 # [postgis pgvector]); dev/CI running 16 left every config value and plan
 # shape unverified against the shipping major (postgres brief, Profile 2).
-# Debian variant paired with one checksum-pinned archived pgvector package.
+# Debian variant paired with checksum-pinned pgvector, h3-pg, and H3 core inputs.
 #
-# THE PIN CEREMONY: the base digest plus the archived package checksum define
-# the runtime/package contract. Derived OCI metadata need not be byte-identical.
-# Changing either pin is a declared change: record the old and new identities
+# THE PIN CEREMONY: the image digests plus all five archive checksums define the
+# runtime/package contract. Derived OCI metadata need not be byte-identical.
+# Changing an input pin is a declared change: record the old and new identities
 # and re-run the applicable PostgreSQL integration gates before merging.
 #
 # Pinned 2026-07-29: tag 17-3.5, digest
 # sha256:77e89c11c4779c394ebeeaac1099dafb77b728abc8cd45dcaf6c4695503a0c37
+FROM postgis/postgis:17-3.5@sha256:77e89c11c4779c394ebeeaac1099dafb77b728abc8cd45dcaf6c4695503a0c37 AS postgres-runtime
+
+FROM gcc:12.2.0-bullseye@sha256:a3e091325c0af43bc9c1c576ddd155351d5b16438124421188bb4b4fcacc1452 AS h3-builder
+
+ADD --checksum=sha256:0dc2e9a6860f06bf10bd8fadc03e35d9eeb4df46e33763a7e480e987758f385c \
+    https://github.com/Kitware/CMake/releases/download/v3.31.12/cmake-3.31.12-linux-x86_64.tar.gz \
+    /tmp/cmake.tar.gz
+ADD --checksum=sha256:9f43e428d4145d3212b68a70970cc5b736ce544b4bec2f1d6f010225787ddef4 \
+    https://apt-archive.postgresql.org/pub/repos/apt/pool/main/p/postgresql-17/postgresql-server-dev-17_17.5-1.pgdg110+1_amd64.deb \
+    /tmp/postgresql-server-dev-17.deb
+
+ADD --checksum=sha256:b7e56fb90d486897be3ccd4fdc007c724fc48abe1ff9bbe24bf351d3b8accc57 \
+    https://github.com/zachasme/h3-pg/archive/ed9a09c834787abb5952318bccef1c4fee119f1d.tar.gz \
+    /tmp/h3-pg.tar.gz
+ADD --checksum=sha256:0da8a392a6ff77e76b60e6a331a49497d0935b6b7b6899da7a3e2786139b0441 \
+    https://github.com/uber/h3/archive/refs/tags/v4.5.0.tar.gz \
+    /tmp/h3-core.tar.gz
+
+COPY --from=postgres-runtime /usr/lib/postgresql/17/bin/pg_config /usr/lib/postgresql/17/bin/pg_config
+
+RUN mkdir /opt/cmake /tmp/h3-pg-source /tmp/h3-core-source \
+    && tar --extract --gzip --file=/tmp/cmake.tar.gz \
+        --directory=/opt/cmake --strip-components=1 \
+    && dpkg-deb --extract /tmp/postgresql-server-dev-17.deb / \
+    && test "$(/usr/lib/postgresql/17/bin/pg_config --version)" = \
+        "PostgreSQL 17.5 (Debian 17.5-1.pgdg110+1)" \
+    && tar --extract --gzip --file=/tmp/h3-pg.tar.gz \
+        --directory=/tmp/h3-pg-source --strip-components=1 \
+    && tar --extract --gzip --file=/tmp/h3-core.tar.gz \
+        --directory=/tmp/h3-core-source --strip-components=1 \
+    && /opt/cmake/bin/cmake -S /tmp/h3-pg-source -B /tmp/h3-pg-build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DFETCHCONTENT_SOURCE_DIR_H3=/tmp/h3-core-source \
+        -DPOSTGRESQL_VERSION=17 \
+    && /opt/cmake/bin/cmake --build /tmp/h3-pg-build --parallel 2 \
+    && DESTDIR=/tmp/h3-pg-install \
+        /opt/cmake/bin/cmake --install /tmp/h3-pg-build --component h3-pg \
+    && test -f /tmp/h3-pg-install/usr/lib/postgresql/17/lib/h3.so \
+    && test -f /tmp/h3-pg-install/usr/share/postgresql/17/extension/h3.control \
+    && test -f /tmp/h3-pg-install/usr/share/postgresql/17/extension/h3--4.5.0.sql
+
 FROM postgis/postgis:17-3.5@sha256:77e89c11c4779c394ebeeaac1099dafb77b728abc8cd45dcaf6c4695503a0c37
 
 ADD --checksum=sha256:ff0e10806fd87268e2dfac6b2d0aaa5fc2c24341188e7c24f3db7fd112c90f87 \
     https://apt-archive.postgresql.org/pub/repos/apt/pool/main/p/pgvector/postgresql-17-pgvector_0.8.5-1.pgdg11+1_amd64.deb \
     /tmp/postgresql-17-pgvector.deb
+
+COPY --from=h3-builder /tmp/h3-pg-install/usr/ /usr/
 
 RUN dpkg --install /tmp/postgresql-17-pgvector.deb \
     && test "$(dpkg-query -W -f='${Version}' postgresql-17)" = "17.5-1.pgdg110+1" \
@@ -28,4 +71,6 @@ RUN dpkg --install /tmp/postgresql-17-pgvector.deb \
         "3.5.2+dfsg-1.pgdg110+1" \
     && test "$(dpkg-query -W -f='${Version}' postgresql-17-pgvector)" = \
         "0.8.5-1.pgdg11+1" \
+    && grep --fixed-strings --line-regexp "default_version = '4.5.0'" \
+        /usr/share/postgresql/17/extension/h3.control \
     && rm /tmp/postgresql-17-pgvector.deb

--- a/rust/crates/babylon-persistence/migrations/0002_h3_cell.sql
+++ b/rust/crates/babylon-persistence/migrations/0002_h3_cell.sql
@@ -1,0 +1,91 @@
+CREATE TABLE babylon_ref.h3_cell (
+    cell_id BIGINT NOT NULL,
+    resolution SMALLINT NOT NULL,
+    immediate_parent BIGINT,
+    ancestor_r4 BIGINT,
+    ancestor_r5 BIGINT,
+    ancestor_r6 BIGINT,
+    ancestor_r7 BIGINT,
+    CONSTRAINT h3_cell_pkey PRIMARY KEY (cell_id),
+    CONSTRAINT h3_cell_id_positive CHECK (cell_id > 0),
+    CONSTRAINT h3_cell_resolution_range CHECK (resolution BETWEEN 0 AND 15),
+    CONSTRAINT h3_cell_resolution_matches_id CHECK (
+        resolution = ((cell_id >> 52) & 15)::SMALLINT
+    ),
+    CONSTRAINT h3_cell_immediate_parent_matches CHECK (
+        CASE
+            WHEN resolution = 0 THEN immediate_parent IS NULL
+            WHEN resolution BETWEEN 1 AND 15 THEN
+                immediate_parent IS NOT NULL
+                AND immediate_parent = (
+                    (cell_id & ~(15::BIGINT << 52))
+                    | ((resolution - 1)::BIGINT << 52)
+                    | ((1::BIGINT << (3 * (16 - resolution))) - 1)
+                )
+            ELSE FALSE
+        END
+    ),
+    CONSTRAINT h3_cell_ancestor_r4_matches CHECK (
+        CASE
+            WHEN resolution BETWEEN 0 AND 3 THEN ancestor_r4 IS NULL
+            WHEN resolution BETWEEN 4 AND 15 THEN
+                ancestor_r4 IS NOT NULL
+                AND ancestor_r4 = (
+                    (cell_id & ~(15::BIGINT << 52))
+                    | (4::BIGINT << 52)
+                    | ((1::BIGINT << 33) - 1)
+                )
+            ELSE FALSE
+        END
+    ),
+    CONSTRAINT h3_cell_ancestor_r5_matches CHECK (
+        CASE
+            WHEN resolution BETWEEN 0 AND 4 THEN ancestor_r5 IS NULL
+            WHEN resolution BETWEEN 5 AND 15 THEN
+                ancestor_r5 IS NOT NULL
+                AND ancestor_r5 = (
+                    (cell_id & ~(15::BIGINT << 52))
+                    | (5::BIGINT << 52)
+                    | ((1::BIGINT << 30) - 1)
+                )
+            ELSE FALSE
+        END
+    ),
+    CONSTRAINT h3_cell_ancestor_r6_matches CHECK (
+        CASE
+            WHEN resolution BETWEEN 0 AND 5 THEN ancestor_r6 IS NULL
+            WHEN resolution BETWEEN 6 AND 15 THEN
+                ancestor_r6 IS NOT NULL
+                AND ancestor_r6 = (
+                    (cell_id & ~(15::BIGINT << 52))
+                    | (6::BIGINT << 52)
+                    | ((1::BIGINT << 27) - 1)
+                )
+            ELSE FALSE
+        END
+    ),
+    CONSTRAINT h3_cell_ancestor_r7_matches CHECK (
+        CASE
+            WHEN resolution BETWEEN 0 AND 6 THEN ancestor_r7 IS NULL
+            WHEN resolution BETWEEN 7 AND 15 THEN
+                ancestor_r7 IS NOT NULL
+                AND ancestor_r7 = (
+                    (cell_id & ~(15::BIGINT << 52))
+                    | (7::BIGINT << 52)
+                    | ((1::BIGINT << 24) - 1)
+                )
+            ELSE FALSE
+        END
+    ),
+    CONSTRAINT h3_cell_immediate_parent_fkey FOREIGN KEY (immediate_parent)
+        REFERENCES babylon_ref.h3_cell(cell_id) DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT h3_cell_ancestor_r4_fkey FOREIGN KEY (ancestor_r4)
+        REFERENCES babylon_ref.h3_cell(cell_id) DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT h3_cell_ancestor_r5_fkey FOREIGN KEY (ancestor_r5)
+        REFERENCES babylon_ref.h3_cell(cell_id) DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT h3_cell_ancestor_r6_fkey FOREIGN KEY (ancestor_r6)
+        REFERENCES babylon_ref.h3_cell(cell_id) DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT h3_cell_ancestor_r7_fkey FOREIGN KEY (ancestor_r7)
+        REFERENCES babylon_ref.h3_cell(cell_id) DEFERRABLE INITIALLY DEFERRED
+);
+REVOKE ALL ON TABLE babylon_ref.h3_cell FROM PUBLIC;

--- a/rust/crates/babylon-persistence/src/fixtures/schema_epoch_owned_census_v2.txt
+++ b/rust/crates/babylon-persistence/src/fixtures/schema_epoch_owned_census_v2.txt
@@ -1,0 +1,7 @@
+# Babylon PER-61 Rust schema epoch owned-object census v2
+# provenance|source|legacy_adopter_census.sql on pinned PostgreSQL 17
+# format|kind|schema|name|sha256
+relation|babylon_ref|h3_cell|a27dec1f45cbc0ab76b73f176b2b85f6fa09404a5510e36ae2808d0e1ab00c0b
+relation|babylon_state|schema_migration|9dab3f0b9141a054202b62a4d52391545fc39c8835e8daa8a8f6299a149fb291
+schema|pg_namespace|babylon_ref|7c2fe2c6f3e9487d43b1e67e182c399cadd5d70087dd445f274de00d502ff45b
+schema|pg_namespace|babylon_state|1dce3b1b7211642bbc8265afb67cdfa1a6781d55d3a2e4b8e616ef8ac1686e7e

--- a/rust/crates/babylon-persistence/src/fixtures/schema_epoch_owned_fresh_census_v2.txt
+++ b/rust/crates/babylon-persistence/src/fixtures/schema_epoch_owned_fresh_census_v2.txt
@@ -1,0 +1,8 @@
+# Babylon PER-61 fresh-origin Rust schema epoch owned-object census v2
+# provenance|source|legacy_adopter_census.sql on pinned PostgreSQL 17
+# format|kind|schema|name|sha256
+relation|babylon_ref|h3_cell|a27dec1f45cbc0ab76b73f176b2b85f6fa09404a5510e36ae2808d0e1ab00c0b
+relation|babylon_state|schema_migration|9dab3f0b9141a054202b62a4d52391545fc39c8835e8daa8a8f6299a149fb291
+schema|pg_namespace|babylon_ref|7c2fe2c6f3e9487d43b1e67e182c399cadd5d70087dd445f274de00d502ff45b
+schema|pg_namespace|babylon_state|1dce3b1b7211642bbc8265afb67cdfa1a6781d55d3a2e4b8e616ef8ac1686e7e
+schema_grant|pg_namespace|babylon_meta|5c0ed6508e7b1598182c8b7440dade9cc39061bb35c672d949b0f3713cf772cc

--- a/rust/crates/babylon-persistence/src/fixtures/schema_epoch_test_v1_shape.sql
+++ b/rust/crates/babylon-persistence/src/fixtures/schema_epoch_test_v1_shape.sql
@@ -1,4 +1,0 @@
-SELECT pg_catalog.obj_description(
-    pg_catalog.to_regnamespace('babylon_ref'),
-    'pg_namespace'
-) IS NULL;

--- a/rust/crates/babylon-persistence/src/fixtures/schema_epoch_test_v2.sql
+++ b/rust/crates/babylon-persistence/src/fixtures/schema_epoch_test_v2.sql
@@ -1,1 +1,0 @@
-COMMENT ON SCHEMA babylon_ref IS 'schema-epoch-test-v2';

--- a/rust/crates/babylon-persistence/src/fixtures/schema_epoch_test_v2_shape.sql
+++ b/rust/crates/babylon-persistence/src/fixtures/schema_epoch_test_v2_shape.sql
@@ -1,4 +1,0 @@
-SELECT pg_catalog.obj_description(
-    pg_catalog.to_regnamespace('babylon_ref'),
-    'pg_namespace'
-) = 'schema-epoch-test-v2';

--- a/rust/crates/babylon-persistence/src/schema_epoch.rs
+++ b/rust/crates/babylon-persistence/src/schema_epoch.rs
@@ -19,12 +19,16 @@ pub const MAX_SCHEMA_MIGRATIONS: usize = 256;
 pub const MAX_COMMIT_ATTEMPTS_PER_VERSION: usize = 2;
 
 const MIGRATION_0001_SQL: &str = include_str!("../migrations/0001_owned_schema_epoch.sql");
+const MIGRATION_0002_SQL: &str = include_str!("../migrations/0002_h3_cell.sql");
 const FRESH_CENSUS: &str = include_str!("fixtures/fresh_schema_epoch_census_v1.txt");
 const FRESH_CENSUS_WITH_INTEL: &str =
     include_str!("fixtures/fresh_schema_epoch_census_with_intel_v1.txt");
-const EPOCH_OWNED_CENSUS: &str = include_str!("fixtures/schema_epoch_owned_census_v1.txt");
-const EPOCH_OWNED_FRESH_CENSUS: &str =
+const EPOCH_OWNED_CENSUS_V1: &str = include_str!("fixtures/schema_epoch_owned_census_v1.txt");
+const EPOCH_OWNED_FRESH_CENSUS_V1: &str =
     include_str!("fixtures/schema_epoch_owned_fresh_census_v1.txt");
+const EPOCH_OWNED_CENSUS_V2: &str = include_str!("fixtures/schema_epoch_owned_census_v2.txt");
+const EPOCH_OWNED_FRESH_CENSUS_V2: &str =
+    include_str!("fixtures/schema_epoch_owned_fresh_census_v2.txt");
 const OWNER_SQL: &str = "SELECT database_row.datdba = role_row.oid \
     FROM pg_catalog.pg_database AS database_row \
     JOIN pg_catalog.pg_roles AS role_row ON role_row.rolname = CURRENT_USER \
@@ -64,7 +68,8 @@ const WRITE_SETTINGS_SQL: &str = "SELECT \
     pg_catalog.current_setting('idle_in_transaction_session_timeout')";
 const WRITE_LOCAL_SETTINGS_SQL: &str = "SET LOCAL search_path TO pg_catalog; \
     SET LOCAL synchronous_commit TO on";
-const EPOCH_SHAPE_SQL: &str = include_str!("schema_epoch_shape.sql");
+const EPOCH_V1_SHAPE_SQL: &str = include_str!("schema_epoch_shape.sql");
+const EPOCH_V2_SHAPE_SQL: &str = include_str!("schema_epoch_v2_shape.sql");
 
 /// Database lane selected under the schema advisory lock.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -384,10 +389,18 @@ const PREFIX_V1: SchemaPrefixContract = SchemaPrefixContract {
     verify_client: verify_v1_prefix_client,
     verify_transaction: verify_v1_prefix_transaction,
 };
+const PREFIX_V2: SchemaPrefixContract = SchemaPrefixContract {
+    verify_client: verify_v2_prefix_client,
+    verify_transaction: verify_v2_prefix_transaction,
+};
 
-fn compiled_schema_epoch_migrations() -> Result<[SchemaEpochMigration; 1], SchemaMigrationError> {
-    let migration = SchemaMigration::new(MigrationVersion::try_from(1)?, MIGRATION_0001_SQL)?;
-    Ok([SchemaEpochMigration::new(migration, PREFIX_V1)])
+fn compiled_schema_epoch_migrations() -> Result<[SchemaEpochMigration; 2], SchemaMigrationError> {
+    let migration_v1 = SchemaMigration::new(MigrationVersion::try_from(1)?, MIGRATION_0001_SQL)?;
+    let migration_v2 = SchemaMigration::new(MigrationVersion::try_from(2)?, MIGRATION_0002_SQL)?;
+    Ok([
+        SchemaEpochMigration::new(migration_v1, PREFIX_V1),
+        SchemaEpochMigration::new(migration_v2, PREFIX_V2),
+    ])
 }
 
 /// Build the checked-in migration registry from exact SQL bytes.
@@ -395,9 +408,9 @@ fn compiled_schema_epoch_migrations() -> Result<[SchemaEpochMigration; 1], Schem
 /// # Errors
 /// Returns [`SchemaMigrationError`] if a checked-in migration violates its
 /// bounded byte contract.
-pub fn compiled_schema_migrations() -> Result<[SchemaMigration; 1], SchemaMigrationError> {
+pub fn compiled_schema_migrations() -> Result<[SchemaMigration; 2], SchemaMigrationError> {
     let compiled = compiled_schema_epoch_migrations()?;
-    Ok([compiled[0].migration])
+    Ok([compiled[0].migration, compiled[1].migration])
 }
 
 /// Verify that persisted rows are an exact prefix of contiguous migrations.
@@ -804,53 +817,73 @@ fn verify_v1_prefix_client(
     client: &mut Client,
     legacy_origin: bool,
 ) -> Result<(), SchemaEpochError> {
-    verify_epoch_shape_client(client)?;
-    verify_post_epoch_census_client(client, legacy_origin)
+    verify_epoch_shape_client(client, EPOCH_V1_SHAPE_SQL)?;
+    verify_post_epoch_census_client(client, legacy_origin, SchemaEpochPrefix::V1)
 }
 
 fn verify_v1_prefix_transaction(
     transaction: &mut Transaction<'_>,
     legacy_origin: bool,
 ) -> Result<(), SchemaEpochError> {
-    verify_epoch_shape_transaction(transaction)?;
-    verify_post_epoch_census_transaction(transaction, legacy_origin)
+    verify_epoch_shape_transaction(transaction, EPOCH_V1_SHAPE_SQL)?;
+    verify_post_epoch_census_transaction(transaction, legacy_origin, SchemaEpochPrefix::V1)
+}
+
+fn verify_v2_prefix_client(
+    client: &mut Client,
+    legacy_origin: bool,
+) -> Result<(), SchemaEpochError> {
+    verify_epoch_shape_client(client, EPOCH_V2_SHAPE_SQL)?;
+    verify_post_epoch_census_client(client, legacy_origin, SchemaEpochPrefix::V2)
+}
+
+fn verify_v2_prefix_transaction(
+    transaction: &mut Transaction<'_>,
+    legacy_origin: bool,
+) -> Result<(), SchemaEpochError> {
+    verify_epoch_shape_transaction(transaction, EPOCH_V2_SHAPE_SQL)?;
+    verify_post_epoch_census_transaction(transaction, legacy_origin, SchemaEpochPrefix::V2)
 }
 
 fn verify_post_epoch_census_client(
     client: &mut Client,
     legacy_origin: bool,
+    prefix: SchemaEpochPrefix,
 ) -> Result<(), SchemaEpochError> {
     verify_authority_sentinels_client(client)?;
     let actual = catalog_census_under_lock(client, false).map_err(SchemaEpochError::Census)?;
-    verify_post_epoch_census(actual.as_slice(), legacy_origin)
+    verify_post_epoch_census(actual.as_slice(), legacy_origin, prefix)
 }
 
 fn verify_post_epoch_census_transaction(
     transaction: &mut Transaction<'_>,
     legacy_origin: bool,
+    prefix: SchemaEpochPrefix,
 ) -> Result<(), SchemaEpochError> {
     verify_authority_sentinels_transaction(transaction)?;
     let actual = read_census_rows(transaction).map_err(SchemaEpochError::Census)?;
-    verify_post_epoch_census(actual.as_slice(), legacy_origin)
+    verify_post_epoch_census(actual.as_slice(), legacy_origin, prefix)
 }
 
 fn verify_post_epoch_census(
     actual: &[LegacyCensusEntry],
     legacy_origin: bool,
+    prefix: SchemaEpochPrefix,
 ) -> Result<(), SchemaEpochError> {
     let mut baseline = Vec::with_capacity(actual.len());
-    let mut epoch = Vec::with_capacity(4);
+    let mut epoch = Vec::with_capacity(5);
     for entry in actual.iter().take(MAX_LEGACY_CENSUS_ROWS) {
-        if is_epoch_entry(entry, legacy_origin) {
+        if is_epoch_entry(entry, legacy_origin, prefix) {
             epoch.push(entry.clone());
         } else {
             baseline.push(entry.clone());
         }
     }
-    let epoch_fixture = if legacy_origin {
-        EPOCH_OWNED_CENSUS
-    } else {
-        EPOCH_OWNED_FRESH_CENSUS
+    let epoch_fixture = match (prefix, legacy_origin) {
+        (SchemaEpochPrefix::V1, true) => EPOCH_OWNED_CENSUS_V1,
+        (SchemaEpochPrefix::V1, false) => EPOCH_OWNED_FRESH_CENSUS_V1,
+        (SchemaEpochPrefix::V2, true) => EPOCH_OWNED_CENSUS_V2,
+        (SchemaEpochPrefix::V2, false) => EPOCH_OWNED_FRESH_CENSUS_V2,
     };
     let expected_epoch = parse_legacy_census_fixture(epoch_fixture)?;
     compare_legacy_census(&expected_epoch, epoch.as_slice())
@@ -865,11 +898,25 @@ fn verify_post_epoch_census(
     }
 }
 
-fn is_epoch_entry(entry: &LegacyCensusEntry, legacy_origin: bool) -> bool {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SchemaEpochPrefix {
+    V1,
+    V2,
+}
+
+fn is_epoch_entry(
+    entry: &LegacyCensusEntry,
+    legacy_origin: bool,
+    prefix: SchemaEpochPrefix,
+) -> bool {
     let key = entry.key();
-    let owned_relation = key.kind() == LegacyObjectKind::Relation
+    let migration_relation = key.kind() == LegacyObjectKind::Relation
         && key.schema() == "babylon_state"
         && key.name() == "schema_migration";
+    let h3_relation = prefix == SchemaEpochPrefix::V2
+        && key.kind() == LegacyObjectKind::Relation
+        && key.schema() == "babylon_ref"
+        && key.name() == "h3_cell";
     let owned_schema = key.kind() == LegacyObjectKind::Schema
         && key.schema() == "pg_namespace"
         && matches!(key.name(), "babylon_ref" | "babylon_state");
@@ -877,7 +924,7 @@ fn is_epoch_entry(entry: &LegacyCensusEntry, legacy_origin: bool) -> bool {
         && key.kind() == LegacyObjectKind::SchemaGrant
         && key.schema() == "pg_namespace"
         && key.name() == "babylon_meta";
-    owned_relation || owned_schema || fresh_meta
+    migration_relation || h3_relation || owned_schema || fresh_meta
 }
 
 fn verify_authority_sentinels_client(client: &mut Client) -> Result<(), SchemaEpochError> {
@@ -1028,18 +1075,19 @@ fn insert_ledger_marker(
     }
 }
 
-fn verify_epoch_shape_client(client: &mut Client) -> Result<(), SchemaEpochError> {
+fn verify_epoch_shape_client(client: &mut Client, shape_sql: &str) -> Result<(), SchemaEpochError> {
     let row = client
-        .query_one(EPOCH_SHAPE_SQL, &[])
+        .query_one(shape_sql, &[])
         .map_err(|_| database_error(SchemaEpochOperation::VerifyEpochShape))?;
     require_epoch_shape(&row)
 }
 
 fn verify_epoch_shape_transaction(
     transaction: &mut Transaction<'_>,
+    shape_sql: &str,
 ) -> Result<(), SchemaEpochError> {
     let row = transaction
-        .query_one(EPOCH_SHAPE_SQL, &[])
+        .query_one(shape_sql, &[])
         .map_err(|_| database_error(SchemaEpochOperation::VerifyEpochShape))?;
     require_epoch_shape(&row)
 }
@@ -1072,8 +1120,9 @@ mod pure_tests {
     fn compiled_registry_binds_each_migration_to_a_prefix_contract() {
         let compiled = compiled_schema_epoch_migrations().unwrap();
 
-        assert_eq!(compiled.len(), 1);
+        assert_eq!(compiled.len(), 2);
         assert_eq!(compiled[0].migration.version().as_i64(), 1);
+        assert_eq!(compiled[1].migration.version().as_i64(), 2);
     }
 
     #[test]
@@ -1175,17 +1224,6 @@ mod live_rollback_tests {
     const ACK_ENV: &str = "BABYLON_LEGACY_ADOPTER_DISPOSABLE_ACK";
     const ACK: &str = "I_UNDERSTAND_PER20_DROPS_SCRATCH_DATABASES_ROLES_AND_CREATED_BABYLON_INTEL";
     const CANARY_ENV: &str = "BABYLON_LEGACY_ADOPTER_DISPOSABLE_CANARY";
-    const TEST_V2_SQL: &str = include_str!("fixtures/schema_epoch_test_v2.sql");
-    const TEST_V1_SHAPE_SQL: &str = include_str!("fixtures/schema_epoch_test_v1_shape.sql");
-    const TEST_V2_SHAPE_SQL: &str = include_str!("fixtures/schema_epoch_test_v2_shape.sql");
-    const TEST_PREFIX_V1: SchemaPrefixContract = SchemaPrefixContract {
-        verify_client: verify_test_v1_prefix_client,
-        verify_transaction: verify_test_v1_prefix_transaction,
-    };
-    const TEST_PREFIX_V2: SchemaPrefixContract = SchemaPrefixContract {
-        verify_client: verify_test_v2_prefix_client,
-        verify_transaction: verify_test_v2_prefix_transaction,
-    };
 
     #[test]
     #[ignore = "requires the task-owned disposable PER-20 PostgreSQL runtime"]
@@ -1224,7 +1262,8 @@ mod live_rollback_tests {
         drop(client);
         let retry = migrate_schema_epoch(&config).unwrap();
         assert_eq!(retry.origin, SchemaEpochOrigin::Fresh);
-        assert_eq!(retry.final_applied, 1);
+        assert_eq!(retry.final_applied, 2);
+        assert_eq!(retry.applied_versions.len(), 2);
         database.cleanup();
     }
 
@@ -1291,7 +1330,9 @@ mod live_rollback_tests {
             vec![compiled[0].migration.version()]
         );
         assert!(report.reconciled_versions.is_empty());
-        assert_eq!(migrate_schema_epoch(&config).unwrap().prior_applied, 1);
+        let completed = migrate_schema_epoch(&config).unwrap();
+        assert_eq!(completed.prior_applied, 1);
+        assert_eq!(completed.final_applied, 2);
         database.cleanup();
     }
 
@@ -1329,7 +1370,9 @@ mod live_rollback_tests {
             report.reconciled_versions,
             vec![compiled[0].migration.version()]
         );
-        assert_eq!(migrate_schema_epoch(&config).unwrap().prior_applied, 1);
+        let completed = migrate_schema_epoch(&config).unwrap();
+        assert_eq!(completed.prior_applied, 1);
+        assert_eq!(completed.final_applied, 2);
         database.cleanup();
     }
 
@@ -1337,10 +1380,10 @@ mod live_rollback_tests {
         let database = TestDatabase::create(base, "vupgrade");
         let config = database.config(base);
         establish_v1(&config);
-        let registry = two_version_registry();
+        let registry = production_registry();
         assert_v1_prefix(&config, &registry);
 
-        let first = migrate_with_registry(&config, &registry).unwrap();
+        let first = migrate_schema_epoch(&config).unwrap();
         assert_eq!(first.origin, SchemaEpochOrigin::ExistingRustPrefix);
         assert_eq!(first.prior_applied, 1);
         assert_eq!(first.final_applied, 2);
@@ -1349,14 +1392,14 @@ mod live_rollback_tests {
             vec![registry[1].migration.version()]
         );
         assert!(first.reconciled_versions.is_empty());
-        let before = test_v2_snapshot(&config, &registry);
+        let before = v2_snapshot(&config, &registry);
 
-        let second = migrate_with_registry(&config, &registry).unwrap();
+        let second = migrate_schema_epoch(&config).unwrap();
         assert_eq!(second.prior_applied, 2);
         assert_eq!(second.final_applied, 2);
         assert!(second.applied_versions.is_empty());
         assert!(second.reconciled_versions.is_empty());
-        assert_eq!(test_v2_snapshot(&config, &registry), before);
+        assert_eq!(v2_snapshot(&config, &registry), before);
         database.cleanup();
     }
 
@@ -1364,7 +1407,7 @@ mod live_rollback_tests {
         let database = TestDatabase::create(base, "vprerollback");
         let config = database.config(base);
         establish_v1(&config);
-        let registry = two_version_registry();
+        let registry = production_registry();
         let bounded = bounded_config(&config);
         let mut session = LockedSession::connect(&bounded).unwrap();
         let mut transaction = begin_migration_transaction(session.client()).unwrap();
@@ -1374,12 +1417,7 @@ mod live_rollback_tests {
         session.finish(Ok(())).unwrap();
 
         assert_v1_prefix(&config, &registry);
-        assert_eq!(
-            migrate_with_registry(&config, &registry)
-                .unwrap()
-                .final_applied,
-            2
-        );
+        assert_eq!(migrate_schema_epoch(&config).unwrap().final_applied, 2);
         database.cleanup();
     }
 
@@ -1387,7 +1425,7 @@ mod live_rollback_tests {
         let database = TestDatabase::create(base, "vmarkerrollback");
         let config = database.config(base);
         establish_v1(&config);
-        let registry = two_version_registry();
+        let registry = production_registry();
         let bounded = bounded_config(&config);
         let mut session = LockedSession::connect(&bounded).unwrap();
         let mut transaction = begin_migration_transaction(session.client()).unwrap();
@@ -1398,12 +1436,7 @@ mod live_rollback_tests {
         session.finish(Ok(())).unwrap();
 
         assert_v1_prefix(&config, &registry);
-        assert_eq!(
-            migrate_with_registry(&config, &registry)
-                .unwrap()
-                .final_applied,
-            2
-        );
+        assert_eq!(migrate_schema_epoch(&config).unwrap().final_applied, 2);
         database.cleanup();
     }
 
@@ -1411,7 +1444,7 @@ mod live_rollback_tests {
         let database = TestDatabase::create(base, "vkilled");
         let config = database.config(base);
         establish_v1(&config);
-        let registry = two_version_registry();
+        let registry = production_registry();
         let bounded = bounded_config(&config);
         let mut session = LockedSession::connect(&bounded).unwrap();
         let mut report = v2_report();
@@ -1440,12 +1473,7 @@ mod live_rollback_tests {
             vec![registry[1].migration.version()]
         );
         assert!(report.reconciled_versions.is_empty());
-        assert_eq!(
-            migrate_with_registry(&config, &registry)
-                .unwrap()
-                .prior_applied,
-            2
-        );
+        assert_eq!(migrate_schema_epoch(&config).unwrap().prior_applied, 2);
         database.cleanup();
     }
 
@@ -1453,7 +1481,7 @@ mod live_rollback_tests {
         let database = TestDatabase::create(base, "vreconciled");
         let config = database.config(base);
         establish_v1(&config);
-        let registry = two_version_registry();
+        let registry = production_registry();
         let bounded = bounded_config(&config);
         let mut session = LockedSession::connect(&bounded).unwrap();
         let mut report = v2_report();
@@ -1484,19 +1512,14 @@ mod live_rollback_tests {
             report.reconciled_versions,
             vec![registry[1].migration.version()]
         );
-        assert_eq!(
-            migrate_with_registry(&config, &registry)
-                .unwrap()
-                .prior_applied,
-            2
-        );
+        assert_eq!(migrate_schema_epoch(&config).unwrap().prior_applied, 2);
         database.cleanup();
     }
 
     fn verify_leap_ahead_reconciliation(base: &Config) {
         let database = TestDatabase::create(base, "vleapahead");
         let config = database.config(base);
-        let registry = two_version_registry();
+        let registry = production_registry();
         let leap_registry = registry;
         let bounded = bounded_config(&config);
         let mut session = LockedSession::connect(&bounded).unwrap();
@@ -1528,15 +1551,20 @@ mod live_rollback_tests {
             report.reconciled_versions,
             vec![registry[0].migration.version()]
         );
-        test_v2_snapshot(&config, &registry);
+        v2_snapshot(&config, &registry);
         database.cleanup();
     }
 
     fn establish_v1(config: &Config) {
-        let report = migrate_schema_epoch(config).unwrap();
-        assert_eq!(report.origin, SchemaEpochOrigin::Fresh);
-        assert_eq!(report.prior_applied, 0);
-        assert_eq!(report.final_applied, 1);
+        let registry = production_registry();
+        let bounded = bounded_config(config);
+        let mut session = LockedSession::connect(&bounded).unwrap();
+        assert_eq!(
+            attempt_migration(session.client(), registry[0], false).unwrap(),
+            MigrationAttempt::Committed
+        );
+        session.finish(Ok(())).unwrap();
+        assert_v1_prefix(config, &registry);
     }
 
     fn assert_v1_prefix(config: &Config, registry: &[SchemaEpochMigration]) {
@@ -1551,29 +1579,13 @@ mod live_rollback_tests {
         session.finish(Ok(())).unwrap();
     }
 
-    fn migrate_with_registry(
-        config: &Config,
-        registry: &[SchemaEpochMigration],
-    ) -> Result<SchemaEpochReport, SchemaEpochError> {
-        validate_legacy_connection_target(config).map_err(SchemaEpochError::ConnectionTarget)?;
-        let bounded = bounded_config(config);
-        let mut session = LockedSession::connect(&bounded)?;
-        let result = migrate_locked_with_registry(&bounded, &mut session, registry);
-        session.finish(result)
-    }
-
     fn force_transaction_rollback(transaction: &mut Transaction<'_>) {
         let failure = transaction.batch_execute("SELECT 1 / 0").unwrap_err();
         assert_eq!(failure.code(), Some(&SqlState::DIVISION_BY_ZERO));
     }
 
-    fn two_version_registry() -> [SchemaEpochMigration; 2] {
-        let migration_v1 = compiled_schema_epoch_migrations().unwrap()[0].migration;
-        let v2 = SchemaMigration::new(MigrationVersion::try_from(2).unwrap(), TEST_V2_SQL).unwrap();
-        [
-            SchemaEpochMigration::new(migration_v1, TEST_PREFIX_V1),
-            SchemaEpochMigration::new(v2, TEST_PREFIX_V2),
-        ]
+    fn production_registry() -> [SchemaEpochMigration; 2] {
+        compiled_schema_epoch_migrations().unwrap()
     }
 
     fn v2_report() -> SchemaEpochReport {
@@ -1587,73 +1599,23 @@ mod live_rollback_tests {
         }
     }
 
-    fn verify_test_v1_prefix_client(
-        client: &mut Client,
-        legacy_origin: bool,
-    ) -> Result<(), SchemaEpochError> {
-        verify_v1_prefix_client(client, legacy_origin)?;
-        let row = client
-            .query_one(TEST_V1_SHAPE_SQL, &[])
-            .map_err(|_| database_error(SchemaEpochOperation::VerifyEpochShape))?;
-        require_test_prefix_shape(&row)
-    }
-
-    fn verify_test_v1_prefix_transaction(
-        transaction: &mut Transaction<'_>,
-        legacy_origin: bool,
-    ) -> Result<(), SchemaEpochError> {
-        verify_v1_prefix_transaction(transaction, legacy_origin)?;
-        let row = transaction
-            .query_one(TEST_V1_SHAPE_SQL, &[])
-            .map_err(|_| database_error(SchemaEpochOperation::VerifyEpochShape))?;
-        require_test_prefix_shape(&row)
-    }
-
-    fn verify_test_v2_prefix_client(
-        client: &mut Client,
-        legacy_origin: bool,
-    ) -> Result<(), SchemaEpochError> {
-        verify_v1_prefix_client(client, legacy_origin)?;
-        let row = client
-            .query_one(TEST_V2_SHAPE_SQL, &[])
-            .map_err(|_| database_error(SchemaEpochOperation::VerifyEpochShape))?;
-        require_test_prefix_shape(&row)
-    }
-
-    fn verify_test_v2_prefix_transaction(
-        transaction: &mut Transaction<'_>,
-        legacy_origin: bool,
-    ) -> Result<(), SchemaEpochError> {
-        verify_v1_prefix_transaction(transaction, legacy_origin)?;
-        let row = transaction
-            .query_one(TEST_V2_SHAPE_SQL, &[])
-            .map_err(|_| database_error(SchemaEpochOperation::VerifyEpochShape))?;
-        require_test_prefix_shape(&row)
-    }
-
-    fn require_test_prefix_shape(row: &Row) -> Result<(), SchemaEpochError> {
-        if decode_bool(row, 0, SchemaEpochOperation::VerifyEpochShape)? {
-            Ok(())
-        } else {
-            Err(SchemaEpochError::EpochShapeMismatch)
-        }
-    }
-
-    fn test_v2_snapshot(
-        config: &Config,
-        registry: &[SchemaEpochMigration; 2],
-    ) -> Vec<(i64, Vec<u8>)> {
+    fn v2_snapshot(config: &Config, registry: &[SchemaEpochMigration; 2]) -> Vec<(i64, Vec<u8>)> {
         let mut client = config.connect(NoTls).unwrap();
-        let comment: Option<String> = client
+        let relation: Option<String> = client
             .query_one(
-                "SELECT pg_catalog.obj_description(\
-                    pg_catalog.to_regnamespace('babylon_ref'), 'pg_namespace')",
+                "SELECT pg_catalog.to_regclass('babylon_ref.h3_cell')::pg_catalog.text",
                 &[],
             )
             .unwrap()
             .try_get(0)
             .unwrap();
-        assert_eq!(comment.as_deref(), Some("schema-epoch-test-v2"));
+        assert_eq!(relation.as_deref(), Some("babylon_ref.h3_cell"));
+        let h3_rows: i64 = client
+            .query_one("SELECT pg_catalog.count(*) FROM babylon_ref.h3_cell", &[])
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+        assert_eq!(h3_rows, 0);
         let rows = client
             .query(
                 "SELECT version, checksum FROM babylon_state.schema_migration \

--- a/rust/crates/babylon-persistence/src/schema_epoch_v2_shape.sql
+++ b/rust/crates/babylon-persistence/src/schema_epoch_v2_shape.sql
@@ -1,0 +1,305 @@
+WITH database_owner AS MATERIALIZED (
+    SELECT database_row.datdba AS owner_oid
+    FROM pg_catalog.pg_database AS database_row
+    WHERE database_row.datname = pg_catalog.current_database()
+),
+owned_schemas AS MATERIALIZED (
+    SELECT namespace.oid, namespace.nspname, namespace.nspowner, namespace.nspacl
+    FROM pg_catalog.pg_namespace AS namespace
+    WHERE namespace.nspname IN ('babylon_ref', 'babylon_state', 'babylon_meta')
+    ORDER BY namespace.nspname
+    LIMIT 4
+),
+owned_relations AS MATERIALIZED (
+    SELECT relation.oid, namespace.nspname, relation.relname, relation.relowner,
+           relation.relacl, relation.reltype
+    FROM pg_catalog.pg_class AS relation
+    JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+    WHERE (
+        (namespace.nspname = 'babylon_ref' AND relation.relname = 'h3_cell')
+        OR (namespace.nspname = 'babylon_state' AND relation.relname = 'schema_migration')
+    )
+      AND relation.relkind = 'r'
+      AND relation.relpersistence = 'p'
+    ORDER BY namespace.nspname, relation.relname
+    LIMIT 3
+),
+ledger AS MATERIALIZED (
+    SELECT relation.oid
+    FROM owned_relations AS relation
+    WHERE relation.nspname = 'babylon_state' AND relation.relname = 'schema_migration'
+    LIMIT 2
+),
+h3_cell AS MATERIALIZED (
+    SELECT relation.oid
+    FROM owned_relations AS relation
+    WHERE relation.nspname = 'babylon_ref' AND relation.relname = 'h3_cell'
+    LIMIT 2
+),
+intel_role AS MATERIALIZED (
+    SELECT role_row.oid
+    FROM pg_catalog.pg_roles AS role_row
+    WHERE role_row.rolname = 'babylon_intel'
+    LIMIT 2
+),
+relation_columns AS MATERIALIZED (
+    SELECT relation.relname, attribute.attnum, attribute.attname, attribute.atttypid,
+           attribute.attnotnull, attribute.attidentity, attribute.attgenerated,
+           attribute.attacl, default_row.oid IS NOT NULL AS has_default
+    FROM owned_relations AS relation
+    JOIN pg_catalog.pg_attribute AS attribute ON attribute.attrelid = relation.oid
+    LEFT JOIN pg_catalog.pg_attrdef AS default_row
+      ON default_row.adrelid = attribute.attrelid
+     AND default_row.adnum = attribute.attnum
+    WHERE attribute.attnum > 0 AND NOT attribute.attisdropped
+    ORDER BY relation.relname, attribute.attnum
+    LIMIT 10
+),
+ledger_constraints AS MATERIALIZED (
+    SELECT constraint_row.contype,
+           pg_catalog.pg_get_constraintdef(constraint_row.oid, true) AS definition
+    FROM ledger
+    JOIN pg_catalog.pg_constraint AS constraint_row
+      ON constraint_row.conrelid = ledger.oid
+    ORDER BY constraint_row.contype, constraint_row.conname
+    LIMIT 4
+),
+h3_constraints AS MATERIALIZED (
+    SELECT constraint_row.conname::pg_catalog.text AS conname,
+           constraint_row.contype, constraint_row.convalidated,
+           constraint_row.condeferrable, constraint_row.condeferred,
+           constraint_row.confrelid
+    FROM h3_cell
+    JOIN pg_catalog.pg_constraint AS constraint_row
+      ON constraint_row.conrelid = h3_cell.oid
+    ORDER BY constraint_row.conname
+    LIMIT 15
+),
+relation_indexes AS MATERIALIZED (
+    SELECT parent.relname AS parent_name, index_relation.relname AS index_name,
+           index_row.indisprimary, index_row.indisunique, index_row.indisvalid,
+           index_row.indisready, index_row.indpred, index_row.indexprs
+    FROM owned_relations AS parent
+    JOIN pg_catalog.pg_index AS index_row ON index_row.indrelid = parent.oid
+    JOIN pg_catalog.pg_class AS index_relation ON index_relation.oid = index_row.indexrelid
+    ORDER BY parent.relname, index_relation.relname
+    LIMIT 3
+),
+allowed_types AS MATERIALIZED (
+    SELECT type_row.oid, type_row.typarray
+    FROM owned_relations AS relation
+    JOIN pg_catalog.pg_type AS type_row ON type_row.oid = relation.reltype
+),
+owned_classes AS MATERIALIZED (
+    SELECT namespace.nspname, relation.relname, relation.relkind
+    FROM pg_catalog.pg_class AS relation
+    JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+    WHERE namespace.nspname IN ('babylon_ref', 'babylon_state')
+    ORDER BY namespace.nspname, relation.relname
+    LIMIT 5
+)
+SELECT
+    (SELECT pg_catalog.count(*) = 3 FROM owned_schemas)
+    AND (SELECT pg_catalog.bool_and(schema_row.nspowner = owner_row.owner_oid)
+         FROM owned_schemas AS schema_row CROSS JOIN database_owner AS owner_row)
+    AND NOT EXISTS (
+        SELECT 1
+        FROM owned_schemas AS schema_row
+        CROSS JOIN LATERAL pg_catalog.aclexplode(
+            coalesce(schema_row.nspacl, pg_catalog.acldefault('n', schema_row.nspowner))
+        ) AS acl
+        WHERE acl.grantee = 0
+        LIMIT 1
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM intel_role AS intel
+        CROSS JOIN owned_schemas AS schema_row
+        WHERE pg_catalog.has_schema_privilege(intel.oid, schema_row.oid, 'USAGE')
+           OR pg_catalog.has_schema_privilege(intel.oid, schema_row.oid, 'CREATE')
+        LIMIT 1
+    )
+    AND (SELECT pg_catalog.count(*) = 2 FROM owned_relations)
+    AND (SELECT pg_catalog.count(*) = 1 FROM ledger)
+    AND (SELECT pg_catalog.count(*) = 1 FROM h3_cell)
+    AND (SELECT pg_catalog.bool_and(relation.relowner = owner_row.owner_oid)
+         FROM owned_relations AS relation CROSS JOIN database_owner AS owner_row)
+    AND NOT EXISTS (
+        SELECT 1
+        FROM owned_relations AS relation
+        CROSS JOIN LATERAL pg_catalog.aclexplode(
+            coalesce(relation.relacl, pg_catalog.acldefault('r', relation.relowner))
+        ) AS acl
+        WHERE acl.grantee = 0
+        LIMIT 1
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM intel_role AS intel
+        CROSS JOIN owned_relations AS relation
+        WHERE pg_catalog.has_table_privilege(intel.oid, relation.oid, 'SELECT')
+           OR pg_catalog.has_table_privilege(intel.oid, relation.oid, 'INSERT')
+           OR pg_catalog.has_table_privilege(intel.oid, relation.oid, 'UPDATE')
+           OR pg_catalog.has_table_privilege(intel.oid, relation.oid, 'DELETE')
+           OR pg_catalog.has_table_privilege(intel.oid, relation.oid, 'TRUNCATE')
+           OR pg_catalog.has_table_privilege(intel.oid, relation.oid, 'REFERENCES')
+           OR pg_catalog.has_table_privilege(intel.oid, relation.oid, 'TRIGGER')
+           OR pg_catalog.has_table_privilege(intel.oid, relation.oid, 'MAINTAIN')
+        LIMIT 1
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM relation_columns AS column_row
+        CROSS JOIN LATERAL pg_catalog.aclexplode(column_row.attacl) AS acl
+        WHERE acl.grantee = 0
+        LIMIT 1
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM intel_role AS intel
+        CROSS JOIN owned_relations AS relation
+        JOIN pg_catalog.pg_attribute AS attribute ON attribute.attrelid = relation.oid
+        WHERE attribute.attnum > 0 AND NOT attribute.attisdropped
+          AND (
+              pg_catalog.has_column_privilege(
+                  intel.oid, relation.oid, attribute.attnum, 'SELECT'
+              )
+              OR pg_catalog.has_column_privilege(
+                  intel.oid, relation.oid, attribute.attnum, 'INSERT'
+              )
+              OR pg_catalog.has_column_privilege(
+                  intel.oid, relation.oid, attribute.attnum, 'UPDATE'
+              )
+              OR pg_catalog.has_column_privilege(
+                  intel.oid, relation.oid, attribute.attnum, 'REFERENCES'
+              )
+          )
+        LIMIT 1
+    )
+    AND (SELECT pg_catalog.count(*) = 9 FROM relation_columns)
+    AND EXISTS (
+        SELECT 1 FROM relation_columns
+        WHERE relname = 'schema_migration' AND attnum = 1 AND attname = 'version'
+          AND atttypid = 'pg_catalog.int8'::pg_catalog.regtype
+          AND attnotnull AND attidentity = '' AND attgenerated = '' AND NOT has_default
+    )
+    AND EXISTS (
+        SELECT 1 FROM relation_columns
+        WHERE relname = 'schema_migration' AND attnum = 2 AND attname = 'checksum'
+          AND atttypid = 'pg_catalog.bytea'::pg_catalog.regtype
+          AND attnotnull AND attidentity = '' AND attgenerated = '' AND NOT has_default
+    )
+    AND EXISTS (
+        SELECT 1 FROM relation_columns
+        WHERE relname = 'h3_cell' AND attnum = 1 AND attname = 'cell_id'
+          AND atttypid = 'pg_catalog.int8'::pg_catalog.regtype
+          AND attnotnull AND attidentity = '' AND attgenerated = '' AND NOT has_default
+    )
+    AND EXISTS (
+        SELECT 1 FROM relation_columns
+        WHERE relname = 'h3_cell' AND attnum = 2 AND attname = 'resolution'
+          AND atttypid = 'pg_catalog.int2'::pg_catalog.regtype
+          AND attnotnull AND attidentity = '' AND attgenerated = '' AND NOT has_default
+    )
+    AND NOT EXISTS (
+        SELECT 1 FROM relation_columns
+        WHERE relname = 'h3_cell' AND attnum BETWEEN 3 AND 7
+          AND NOT (
+              attname = (ARRAY[
+                  'immediate_parent', 'ancestor_r4', 'ancestor_r5',
+                  'ancestor_r6', 'ancestor_r7'
+              ]::pg_catalog.text[])[attnum - 2]
+              AND atttypid = 'pg_catalog.int8'::pg_catalog.regtype
+              AND NOT attnotnull AND attidentity = '' AND attgenerated = '' AND NOT has_default
+          )
+        LIMIT 1
+    )
+    AND (SELECT pg_catalog.count(*) = 3 FROM ledger_constraints)
+    AND EXISTS (
+        SELECT 1 FROM ledger_constraints
+        WHERE contype = 'p' AND definition = 'PRIMARY KEY (version)'
+    )
+    AND EXISTS (
+        SELECT 1 FROM ledger_constraints
+        WHERE contype = 'c' AND definition = 'CHECK (version > 0)'
+    )
+    AND EXISTS (
+        SELECT 1 FROM ledger_constraints
+        WHERE contype = 'c' AND definition = 'CHECK (octet_length(checksum) = 32)'
+    )
+    AND (SELECT pg_catalog.count(*) = 14 FROM h3_constraints)
+    AND (SELECT pg_catalog.count(*) = 8 FROM h3_constraints WHERE contype = 'c')
+    AND (SELECT pg_catalog.count(*) = 5 FROM h3_constraints WHERE contype = 'f')
+    AND (SELECT pg_catalog.count(*) = 1 FROM h3_constraints WHERE contype = 'p')
+    AND (SELECT pg_catalog.bool_and(convalidated) FROM h3_constraints)
+    AND NOT EXISTS (
+        SELECT 1 FROM h3_constraints
+        WHERE (contype = 'f' AND NOT (
+                   condeferrable AND condeferred
+                   AND confrelid = (SELECT oid FROM h3_cell)
+               ))
+           OR (contype <> 'f' AND (condeferrable OR condeferred))
+        LIMIT 1
+    )
+    AND (SELECT pg_catalog.array_agg(conname ORDER BY conname) = ARRAY[
+        'h3_cell_ancestor_r4_fkey',
+        'h3_cell_ancestor_r4_matches',
+        'h3_cell_ancestor_r5_fkey',
+        'h3_cell_ancestor_r5_matches',
+        'h3_cell_ancestor_r6_fkey',
+        'h3_cell_ancestor_r6_matches',
+        'h3_cell_ancestor_r7_fkey',
+        'h3_cell_ancestor_r7_matches',
+        'h3_cell_id_positive',
+        'h3_cell_immediate_parent_fkey',
+        'h3_cell_immediate_parent_matches',
+        'h3_cell_pkey',
+        'h3_cell_resolution_matches_id',
+        'h3_cell_resolution_range'
+    ]::pg_catalog.text[] FROM h3_constraints)
+    AND (SELECT pg_catalog.count(*) = 2 FROM relation_indexes)
+    AND NOT EXISTS (
+        SELECT 1 FROM relation_indexes
+        WHERE NOT (
+            index_name = parent_name || '_pkey'
+            AND indisprimary AND indisunique AND indisvalid AND indisready
+            AND indpred IS NULL AND indexprs IS NULL
+        )
+        LIMIT 1
+    )
+    AND (SELECT pg_catalog.count(*) = 4 FROM owned_classes)
+    AND NOT EXISTS (
+        SELECT 1 FROM owned_classes
+        WHERE NOT (
+            (nspname = 'babylon_ref' AND relname = 'h3_cell' AND relkind = 'r')
+            OR (nspname = 'babylon_ref' AND relname = 'h3_cell_pkey' AND relkind = 'i')
+            OR (
+                nspname = 'babylon_state'
+                AND relname = 'schema_migration'
+                AND relkind = 'r'
+            )
+            OR (
+                nspname = 'babylon_state'
+                AND relname = 'schema_migration_pkey'
+                AND relkind = 'i'
+            )
+        )
+        LIMIT 1
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_proc AS routine
+        JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = routine.pronamespace
+        WHERE namespace.nspname IN ('babylon_ref', 'babylon_state')
+        LIMIT 1
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_type AS type_row
+        JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = type_row.typnamespace
+        LEFT JOIN allowed_types AS allowed
+          ON type_row.oid = allowed.oid OR type_row.oid = allowed.typarray
+        WHERE namespace.nspname IN ('babylon_ref', 'babylon_state')
+          AND allowed.oid IS NULL
+        LIMIT 1
+    ) AS epoch_shape_matches;

--- a/rust/crates/babylon-persistence/tests/h3_cell_id_contract.rs
+++ b/rust/crates/babylon-persistence/tests/h3_cell_id_contract.rs
@@ -2,52 +2,76 @@
 
 use babylon_persistence::{H3CellId, H3CellIdError};
 use std::mem::size_of;
+use std::path::Path;
 use std::str::FromStr;
 
-#[derive(Debug)]
-struct ValidVector {
-    label: String,
-    resolution: u8,
-    text: String,
-    raw_u64: u64,
-    sql_i64: i64,
-    bytes_be: [u8; 8],
-    immediate_parent: Option<String>,
-    ancestor_chain_r0_to_self: Vec<String>,
+#[path = "support/h3_cell_vectors.rs"]
+mod h3_cell_vectors;
+
+use h3_cell_vectors::{
+    load_fixture, INVALID_ANCESTOR_VECTOR_COUNT, INVALID_RAW_VECTOR_COUNT,
+    INVALID_SQL_VECTOR_COUNT, INVALID_TEXT_VECTOR_COUNT, PENTAGON_VECTOR_COUNT, VALID_VECTOR_COUNT,
+};
+
+const POSTGRES_DOCKERFILE: &str = include_str!("../../../../docker/postgres/Dockerfile");
+const POSTGRES_INITDB: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../docker/postgres/initdb"
+);
+const MAX_INITDB_ENTRIES: usize = 64;
+
+#[test]
+fn postgres_test_image_pins_h3_pg_without_activating_it() {
+    assert!(POSTGRES_DOCKERFILE.starts_with("# syntax=docker/dockerfile:1.6\n"));
+    for required in [
+        "gcc:12.2.0-bullseye@sha256:a3e091325c0af43bc9c1c576ddd155351d5b16438124421188bb4b4fcacc1452",
+        "https://github.com/Kitware/CMake/releases/download/v3.31.12/cmake-3.31.12-linux-x86_64.tar.gz",
+        "sha256:0dc2e9a6860f06bf10bd8fadc03e35d9eeb4df46e33763a7e480e987758f385c",
+        "postgresql-server-dev-17_17.5-1.pgdg110+1_amd64.deb",
+        "sha256:9f43e428d4145d3212b68a70970cc5b736ce544b4bec2f1d6f010225787ddef4",
+        "https://github.com/zachasme/h3-pg/archive/ed9a09c834787abb5952318bccef1c4fee119f1d.tar.gz",
+        "sha256:b7e56fb90d486897be3ccd4fdc007c724fc48abe1ff9bbe24bf351d3b8accc57",
+        "https://github.com/uber/h3/archive/refs/tags/v4.5.0.tar.gz",
+        "sha256:0da8a392a6ff77e76b60e6a331a49497d0935b6b7b6899da7a3e2786139b0441",
+        "--component h3-pg",
+    ] {
+        assert!(
+            POSTGRES_DOCKERFILE.contains(required),
+            "PostgreSQL test image lost pinned H3 build input {required:?}"
+        );
+    }
+    assert!(!POSTGRES_DOCKERFILE
+        .to_ascii_uppercase()
+        .contains("CREATE EXTENSION H3"));
+    assert_initdb_does_not_activate_h3(Path::new(POSTGRES_INITDB));
 }
 
-#[derive(Debug)]
-struct InvalidRawVector {
-    label: String,
-    raw_u64: u64,
-}
-
-#[derive(Debug)]
-struct InvalidSqlVector {
-    label: String,
-    sql_i64: i64,
-}
-
-#[derive(Debug)]
-struct InvalidTextVector {
-    label: String,
-    text: String,
-}
-
-#[derive(Debug)]
-struct InvalidAncestorVector {
-    label: String,
-    text: String,
-    requested_resolution: u8,
-}
-
-#[derive(Debug, Default)]
-struct VectorFixture {
-    valid: Vec<ValidVector>,
-    invalid_raw: Vec<InvalidRawVector>,
-    invalid_sql: Vec<InvalidSqlVector>,
-    invalid_text: Vec<InvalidTextVector>,
-    invalid_ancestor: Vec<InvalidAncestorVector>,
+fn assert_initdb_does_not_activate_h3(initdb: &Path) {
+    let entries = std::fs::read_dir(initdb)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", initdb.display()))
+        .take(MAX_INITDB_ENTRIES + 1)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap_or_else(|error| panic!("failed to enumerate {}: {error}", initdb.display()));
+    assert!(
+        entries.len() <= MAX_INITDB_ENTRIES,
+        "initdb entry count exceeds the static test bound"
+    );
+    for entry in entries.iter().take(MAX_INITDB_ENTRIES) {
+        assert!(
+            entry
+                .file_type()
+                .expect("initdb file type must resolve")
+                .is_file(),
+            "initdb contract remains a bounded flat file set"
+        );
+        let body = std::fs::read_to_string(entry.path())
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", entry.path().display()));
+        assert!(
+            !body.to_ascii_uppercase().contains("CREATE EXTENSION H3"),
+            "initdb file {} must not activate the test-only H3 oracle",
+            entry.path().display()
+        );
+    }
 }
 
 #[test]
@@ -56,6 +80,7 @@ fn h3_cell_id_layout_and_order_follow_unsigned_identity() {
     let ordinary = fixture
         .valid
         .iter()
+        .take(VALID_VECTOR_COUNT)
         .filter(|vector| vector.label.starts_with("ordinary_"))
         .collect::<Vec<_>>();
     assert_eq!(ordinary.len(), 16);
@@ -63,14 +88,20 @@ fn h3_cell_id_layout_and_order_follow_unsigned_identity() {
 
     let mut ids = ordinary
         .iter()
+        .take(16)
         .rev()
         .map(|vector| H3CellId::try_from(vector.raw_u64).expect("fixture cell should validate"))
         .collect::<Vec<_>>();
     ids.sort_unstable();
 
-    let sorted_raws = ids.iter().map(|cell| cell.as_u64()).collect::<Vec<_>>();
+    let sorted_raws = ids
+        .iter()
+        .take(16)
+        .map(|cell| cell.as_u64())
+        .collect::<Vec<_>>();
     let expected_raws = ordinary
         .iter()
+        .take(16)
         .map(|vector| vector.raw_u64)
         .collect::<Vec<_>>();
     assert_eq!(sorted_raws, expected_raws);
@@ -82,11 +113,12 @@ fn h3_cell_id_round_trips_display_bytes_sql_and_semantic_parents_from_vectors() 
     let pentagons = fixture
         .valid
         .iter()
+        .take(VALID_VECTOR_COUNT)
         .filter(|vector| vector.label.starts_with("pentagon_"))
         .count();
-    assert_eq!(pentagons, 12 * 16);
+    assert_eq!(pentagons, PENTAGON_VECTOR_COUNT);
 
-    for vector in &fixture.valid {
+    for vector in fixture.valid.iter().take(VALID_VECTOR_COUNT) {
         let from_raw =
             H3CellId::try_from(vector.raw_u64).expect("fixture raw cell should validate");
         assert_eq!(from_raw.as_u64(), vector.raw_u64);
@@ -101,11 +133,16 @@ fn h3_cell_id_round_trips_display_bytes_sql_and_semantic_parents_from_vectors() 
             usize::from(vector.resolution) + 1
         );
         for (requested_resolution, expected_ancestor) in
-            vector.ancestor_chain_r0_to_self.iter().enumerate()
+            vector.ancestor_chain_r0_to_self.iter().take(16).enumerate()
         {
+            let requested_resolution = u8::try_from(requested_resolution).unwrap();
+            assert_eq!(
+                vector.ancestor_at(requested_resolution),
+                Some(expected_ancestor.as_str())
+            );
             assert_eq!(
                 from_raw
-                    .ancestor_at(u8::try_from(requested_resolution).unwrap())
+                    .ancestor_at(requested_resolution)
                     .unwrap()
                     .to_string(),
                 *expected_ancestor
@@ -131,7 +168,7 @@ fn h3_cell_id_round_trips_display_bytes_sql_and_semantic_parents_from_vectors() 
 fn h3_cell_id_validation_rejects_invalid_raw_vectors() {
     let fixture = load_fixture();
 
-    for vector in &fixture.invalid_raw {
+    for vector in fixture.invalid_raw.iter().take(INVALID_RAW_VECTOR_COUNT) {
         assert_eq!(
             H3CellId::try_from(vector.raw_u64),
             Err(H3CellIdError::InvalidCellIndex {
@@ -147,7 +184,7 @@ fn h3_cell_id_validation_rejects_invalid_raw_vectors() {
 fn h3_cell_id_validation_rejects_invalid_sql_and_text_vectors() {
     let fixture = load_fixture();
 
-    for vector in &fixture.invalid_sql {
+    for vector in fixture.invalid_sql.iter().take(INVALID_SQL_VECTOR_COUNT) {
         assert_eq!(
             H3CellId::try_from(vector.sql_i64),
             Err(H3CellIdError::NegativeSqlValue {
@@ -158,7 +195,7 @@ fn h3_cell_id_validation_rejects_invalid_sql_and_text_vectors() {
         );
     }
 
-    for vector in &fixture.invalid_text {
+    for vector in fixture.invalid_text.iter().take(INVALID_TEXT_VECTOR_COUNT) {
         let expected = match vector.label.as_str() {
             "upper_case" => H3CellIdError::NonLowercaseHexText,
             "prefixed" => H3CellIdError::InvalidTextLength { actual_bytes: 17 },
@@ -180,7 +217,11 @@ fn h3_cell_id_validation_rejects_invalid_sql_and_text_vectors() {
 fn h3_cell_id_ancestor_requests_reject_too_fine_or_out_of_range_resolution() {
     let fixture = load_fixture();
 
-    for vector in &fixture.invalid_ancestor {
+    for vector in fixture
+        .invalid_ancestor
+        .iter()
+        .take(INVALID_ANCESTOR_VECTOR_COUNT)
+    {
         let cell = H3CellId::from_str(&vector.text).expect("fixture ancestor cell is valid");
         let error = cell.ancestor_at(vector.requested_resolution).unwrap_err();
         match vector.label.as_str() {
@@ -197,84 +238,4 @@ fn h3_cell_id_ancestor_requests_reject_too_fine_or_out_of_range_resolution() {
             other => panic!("unexpected invalid ancestor vector {other}"),
         }
     }
-}
-
-fn load_fixture() -> VectorFixture {
-    let mut fixture = VectorFixture::default();
-
-    for line in include_str!("fixtures/h3_cell_id_vectors_v1.txt")
-        .lines()
-        .filter(|line| !line.is_empty() && !line.starts_with('#'))
-    {
-        let fields = line.split('|').collect::<Vec<_>>();
-        match fields.first().copied().unwrap_or_default() {
-            "valid" => fixture.valid.push(parse_valid(&fields)),
-            "invalid_raw" => fixture.invalid_raw.push(parse_invalid_raw(&fields)),
-            "invalid_sql" => fixture.invalid_sql.push(parse_invalid_sql(&fields)),
-            "invalid_text" => fixture.invalid_text.push(parse_invalid_text(&fields)),
-            "invalid_ancestor" => fixture
-                .invalid_ancestor
-                .push(parse_invalid_ancestor(&fields)),
-            other => panic!("unexpected fixture record kind {other}"),
-        }
-    }
-
-    fixture
-}
-
-fn parse_valid(fields: &[&str]) -> ValidVector {
-    assert_eq!(fields.len(), 9);
-    ValidVector {
-        label: fields[1].to_owned(),
-        resolution: fields[2].parse().unwrap(),
-        text: fields[3].to_owned(),
-        raw_u64: u64::from_str_radix(fields[4], 16).unwrap(),
-        sql_i64: fields[5].parse().unwrap(),
-        bytes_be: parse_hex_bytes(fields[6]),
-        immediate_parent: (!fields[7].is_empty()).then(|| fields[7].to_owned()),
-        ancestor_chain_r0_to_self: fields[8].split(',').map(str::to_owned).collect(),
-    }
-}
-
-fn parse_invalid_raw(fields: &[&str]) -> InvalidRawVector {
-    assert_eq!(fields.len(), 3);
-    InvalidRawVector {
-        label: fields[1].to_owned(),
-        raw_u64: u64::from_str_radix(fields[2], 16).unwrap(),
-    }
-}
-
-fn parse_invalid_sql(fields: &[&str]) -> InvalidSqlVector {
-    assert_eq!(fields.len(), 3);
-    InvalidSqlVector {
-        label: fields[1].to_owned(),
-        sql_i64: fields[2].parse().unwrap(),
-    }
-}
-
-fn parse_invalid_text(fields: &[&str]) -> InvalidTextVector {
-    assert_eq!(fields.len(), 3);
-    InvalidTextVector {
-        label: fields[1].to_owned(),
-        text: fields[2].to_owned(),
-    }
-}
-
-fn parse_invalid_ancestor(fields: &[&str]) -> InvalidAncestorVector {
-    assert_eq!(fields.len(), 4);
-    InvalidAncestorVector {
-        label: fields[1].to_owned(),
-        text: fields[2].to_owned(),
-        requested_resolution: fields[3].parse().unwrap(),
-    }
-}
-
-fn parse_hex_bytes(raw_hex16: &str) -> [u8; 8] {
-    assert_eq!(raw_hex16.len(), 16);
-    let mut bytes = [0_u8; 8];
-    for (index, chunk) in raw_hex16.as_bytes().chunks(2).enumerate() {
-        let pair = std::str::from_utf8(chunk).unwrap();
-        bytes[index] = u8::from_str_radix(pair, 16).unwrap();
-    }
-    bytes
 }

--- a/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
+++ b/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
@@ -2366,6 +2366,7 @@ fn live_matrix_receipts_survive_one_fixed_diagnostic_ceiling() {
         "sequence_acl_default",
         "canonical_after_cleanup",
         "schema_epoch_matrix",
+        "h3_pg_oracle",
         "cleanup_first_database",
         "cleanup_second_database",
         "cleanup_owner_role",

--- a/rust/crates/babylon-persistence/tests/legacy_adopter_postgres.rs
+++ b/rust/crates/babylon-persistence/tests/legacy_adopter_postgres.rs
@@ -20,6 +20,10 @@ use std::process::{Command, Stdio};
 use std::str::FromStr;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+#[path = "support/h3_cell_vectors.rs"]
+mod h3_cell_vectors;
+#[path = "support/h3_pg_oracle.rs"]
+mod h3_pg_oracle;
 #[path = "support/schema_epoch_postgres.rs"]
 mod schema_epoch_postgres;
 
@@ -168,6 +172,11 @@ fn live_adopter_contract_against_independent_builds_and_disposable_mutations() {
             "schema_epoch_matrix",
             schema_epoch_postgres::verify_schema_epoch_matrix(&base, &template, owner.name())
         );
+        live_phase!(
+            phases,
+            "h3_pg_oracle",
+            verify_h3_pg_oracle_in_scratch(&base, owner.name())
+        );
     }
     live_phase!(phases, "cleanup_first_database", first.cleanup());
     live_phase!(phases, "cleanup_second_database", second.cleanup());
@@ -213,6 +222,7 @@ fn run_first_live_phases(
             Some("schema_epoch_matrix") => {
                 schema_epoch_postgres::verify_schema_epoch_matrix(base, template, owner);
             }
+            Some("h3_pg_oracle") => verify_h3_pg_oracle_in_scratch(base, owner),
             _ => panic!("unknown bounded live focus"),
         }
         return false;
@@ -272,6 +282,14 @@ fn run_first_live_phases(
         verify_effective_authority_refusals(base, template)
     );
     true
+}
+
+fn verify_h3_pg_oracle_in_scratch(base: &Config, owner: &str) {
+    let database = ScratchDatabase::empty(base, "h3_pg_oracle", owner);
+    let owner_config = database.config_as(base, owner, OWNER_PASSWORD);
+    let admin_config = database.config(base);
+    h3_pg_oracle::verify_h3_pg_oracle(&owner_config, &admin_config);
+    database.cleanup();
 }
 
 fn run_second_live_phases(
@@ -2679,6 +2697,8 @@ fn preflight_disposable_harness(config: &Config) {
                      AS available WHERE available.name = 'postgis'), \
                     (SELECT available.default_version FROM pg_catalog.pg_available_extensions \
                      AS available WHERE available.name = 'vector'), \
+                    (SELECT available.default_version FROM pg_catalog.pg_available_extensions \
+                     AS available WHERE available.name = 'h3'), \
                     pg_catalog.current_setting('transaction_read_only') \
              FROM pg_catalog.pg_roles AS role_row WHERE role_row.rolname = current_user",
             &[],
@@ -2700,7 +2720,9 @@ fn preflight_disposable_harness(config: &Config) {
             .map_err(|_| DisposableHarnessRejection::Runtime),
         row.try_get::<_, Option<String>>(6)
             .map_err(|_| DisposableHarnessRejection::Runtime),
-        row.try_get::<_, String>(7)
+        row.try_get::<_, Option<String>>(7)
+            .map_err(|_| DisposableHarnessRejection::Runtime),
+        row.try_get::<_, String>(8)
             .map_err(|_| DisposableHarnessRejection::Runtime),
     );
     assert_eq!(
@@ -2713,6 +2735,7 @@ fn preflight_disposable_harness(config: &Config) {
             Ok(true),
             Ok(Some("3.5.2".into())),
             Ok(Some("0.8.5".into())),
+            Ok(Some("4.5.0".into())),
             Ok("on".into()),
         ),
         "disposable harness runtime profile must match the pinned oracle"

--- a/rust/crates/babylon-persistence/tests/schema_epoch_contract.rs
+++ b/rust/crates/babylon-persistence/tests/schema_epoch_contract.rs
@@ -9,18 +9,29 @@ const SQL_ONE: &str = "SELECT 1;\n";
 const SQL_TWO: &str = "SELECT 2;\n";
 
 #[test]
-fn compiled_registry_is_one_contiguous_exact_migration() {
+fn compiled_registry_is_two_contiguous_exact_migrations() {
     let compiled = compiled_schema_migrations().expect("checked-in migration bytes are valid");
 
-    assert_eq!(compiled.len(), 1);
+    assert_eq!(compiled.len(), 2);
     assert_eq!(compiled[0].version().as_i64(), 1);
+    assert_eq!(compiled[1].version().as_i64(), 2);
     assert_eq!(
         compiled[0].sql(),
         include_str!("../migrations/0001_owned_schema_epoch.sql")
     );
+    let migration_two = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/migrations/0002_h3_cell.sql"
+    ))
+    .expect("epoch-2 H3 migration must exist");
+    assert_eq!(compiled[1].sql(), migration_two);
     assert_eq!(
         compiled[0].checksum().as_bytes(),
         &hex_checksum("4fc40761ed3b9a2bfab574d14ce65d24e828d1d51ca3f953a515b18f6f2667d4")
+    );
+    assert_eq!(
+        compiled[1].checksum().as_bytes(),
+        &hex_checksum("1f749f1519196c81c911fff619c42daccbf36d6566442ca66015dadd281ab4cd")
     );
 }
 
@@ -135,6 +146,7 @@ fn production_epoch_has_no_runtime_activation_or_caller_supplied_sql_path() {
 
     assert!(production.contains("pub fn migrate_schema_epoch(config: &Config)"));
     assert!(production.contains("include_str!(\"../migrations/0001_owned_schema_epoch.sql\")"));
+    assert!(production.contains("include_str!(\"../migrations/0002_h3_cell.sql\")"));
     for stage in [
         "map_err(SchemaEpochError::ConnectionTarget)",
         "map_err(SchemaEpochError::Lock)",
@@ -157,7 +169,6 @@ fn production_epoch_has_no_runtime_activation_or_caller_supplied_sql_path() {
         "CommittedTickEnvelope",
         "tick_commit",
         "archive_outbox",
-        "h3_cell",
     ] {
         assert!(
             !production.contains(forbidden),
@@ -189,15 +200,34 @@ fn migration_executes_exact_ddl_verification_marker_then_commit() {
 }
 
 #[test]
+fn v2_prefix_has_an_independent_shape_and_census_contract() {
+    let source = include_str!("../src/schema_epoch.rs");
+    let v2_verifier = source
+        .split_once("fn verify_v2_prefix_client(")
+        .unwrap()
+        .1
+        .split_once("fn verify_post_epoch_census_client(")
+        .unwrap()
+        .0;
+
+    assert!(v2_verifier.contains("EPOCH_V2_SHAPE_SQL"));
+    assert!(v2_verifier.contains("SchemaEpochPrefix::V2"));
+    assert!(!v2_verifier.contains("verify_v1_prefix"));
+    assert!(!v2_verifier.contains("EPOCH_V1_SHAPE_SQL"));
+}
+
+#[test]
 fn fresh_and_owned_census_fixtures_are_bounded_and_exactly_sorted() {
     let fixtures = [
         include_str!("../src/fixtures/fresh_schema_epoch_census_v1.txt"),
         include_str!("../src/fixtures/fresh_schema_epoch_census_with_intel_v1.txt"),
         include_str!("../src/fixtures/schema_epoch_owned_census_v1.txt"),
         include_str!("../src/fixtures/schema_epoch_owned_fresh_census_v1.txt"),
+        include_str!("../src/fixtures/schema_epoch_owned_census_v2.txt"),
+        include_str!("../src/fixtures/schema_epoch_owned_fresh_census_v2.txt"),
     ];
-    let expected_counts = [7, 8, 3, 4];
-    for (fixture, expected) in fixtures.iter().zip(expected_counts).take(4) {
+    let expected_counts = [7, 8, 3, 4, 4, 5];
+    for (fixture, expected) in fixtures.iter().zip(expected_counts).take(6) {
         let parsed = babylon_persistence::parse_legacy_census_fixture(fixture).unwrap();
         assert_eq!(parsed.entries().len(), expected);
         assert!(fixture.len() <= 65_536);

--- a/rust/crates/babylon-persistence/tests/schema_epoch_v2_shape_contract.rs
+++ b/rust/crates/babylon-persistence/tests/schema_epoch_v2_shape_contract.rs
@@ -1,0 +1,48 @@
+//! Static guards for the exact epoch-2 shape verifier.
+
+const SHAPE_SQL: &str = include_str!("../src/schema_epoch_v2_shape.sql");
+
+#[test]
+fn v2_shape_verifier_is_bounded_and_checks_the_closed_authority_surface() {
+    assert!(SHAPE_SQL.ends_with('\n'));
+    assert!(SHAPE_SQL.len() <= 65_536);
+
+    for required in [
+        "babylon_ref",
+        "babylon_state",
+        "babylon_meta",
+        "h3_cell",
+        "schema_migration",
+        "h3_cell_resolution_matches_id",
+        "h3_cell_immediate_parent_matches",
+        "h3_cell_ancestor_r7_matches",
+        "h3_cell_immediate_parent_fkey",
+        "pg_catalog.has_table_privilege",
+        "'MAINTAIN'",
+        "pg_catalog.has_column_privilege",
+        "pg_catalog.aclexplode(column_row.attacl)",
+        "LIMIT 15",
+        "LIMIT 10",
+        "LIMIT 5",
+    ] {
+        assert!(
+            SHAPE_SQL.contains(required),
+            "v2 shape verifier omits governed contract {required:?}"
+        );
+    }
+
+    let lowercase = SHAPE_SQL.to_ascii_lowercase();
+    for prohibited in [
+        "h3index",
+        "h3_is_valid_cell",
+        "h3_cell_to_parent",
+        "create extension",
+        "gist",
+        "spgist",
+    ] {
+        assert!(
+            !lowercase.contains(prohibited),
+            "v2 shape verifier depends on prohibited H3 surface {prohibited:?}"
+        );
+    }
+}

--- a/rust/crates/babylon-persistence/tests/schema_epoch_v2_sql_contract.rs
+++ b/rust/crates/babylon-persistence/tests/schema_epoch_v2_sql_contract.rs
@@ -1,0 +1,148 @@
+//! Exact static contract for the epoch-2 canonical H3 identity relation.
+
+use std::path::Path;
+
+const MIGRATION_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/migrations/0002_h3_cell.sql");
+
+const EXPECTED_SQL: &str = "\
+CREATE TABLE babylon_ref.h3_cell (
+    cell_id BIGINT NOT NULL,
+    resolution SMALLINT NOT NULL,
+    immediate_parent BIGINT,
+    ancestor_r4 BIGINT,
+    ancestor_r5 BIGINT,
+    ancestor_r6 BIGINT,
+    ancestor_r7 BIGINT,
+    CONSTRAINT h3_cell_pkey PRIMARY KEY (cell_id),
+    CONSTRAINT h3_cell_id_positive CHECK (cell_id > 0),
+    CONSTRAINT h3_cell_resolution_range CHECK (resolution BETWEEN 0 AND 15),
+    CONSTRAINT h3_cell_resolution_matches_id CHECK (
+        resolution = ((cell_id >> 52) & 15)::SMALLINT
+    ),
+    CONSTRAINT h3_cell_immediate_parent_matches CHECK (
+        CASE
+            WHEN resolution = 0 THEN immediate_parent IS NULL
+            WHEN resolution BETWEEN 1 AND 15 THEN
+                immediate_parent IS NOT NULL
+                AND immediate_parent = (
+                    (cell_id & ~(15::BIGINT << 52))
+                    | ((resolution - 1)::BIGINT << 52)
+                    | ((1::BIGINT << (3 * (16 - resolution))) - 1)
+                )
+            ELSE FALSE
+        END
+    ),
+    CONSTRAINT h3_cell_ancestor_r4_matches CHECK (
+        CASE
+            WHEN resolution BETWEEN 0 AND 3 THEN ancestor_r4 IS NULL
+            WHEN resolution BETWEEN 4 AND 15 THEN
+                ancestor_r4 IS NOT NULL
+                AND ancestor_r4 = (
+                    (cell_id & ~(15::BIGINT << 52))
+                    | (4::BIGINT << 52)
+                    | ((1::BIGINT << 33) - 1)
+                )
+            ELSE FALSE
+        END
+    ),
+    CONSTRAINT h3_cell_ancestor_r5_matches CHECK (
+        CASE
+            WHEN resolution BETWEEN 0 AND 4 THEN ancestor_r5 IS NULL
+            WHEN resolution BETWEEN 5 AND 15 THEN
+                ancestor_r5 IS NOT NULL
+                AND ancestor_r5 = (
+                    (cell_id & ~(15::BIGINT << 52))
+                    | (5::BIGINT << 52)
+                    | ((1::BIGINT << 30) - 1)
+                )
+            ELSE FALSE
+        END
+    ),
+    CONSTRAINT h3_cell_ancestor_r6_matches CHECK (
+        CASE
+            WHEN resolution BETWEEN 0 AND 5 THEN ancestor_r6 IS NULL
+            WHEN resolution BETWEEN 6 AND 15 THEN
+                ancestor_r6 IS NOT NULL
+                AND ancestor_r6 = (
+                    (cell_id & ~(15::BIGINT << 52))
+                    | (6::BIGINT << 52)
+                    | ((1::BIGINT << 27) - 1)
+                )
+            ELSE FALSE
+        END
+    ),
+    CONSTRAINT h3_cell_ancestor_r7_matches CHECK (
+        CASE
+            WHEN resolution BETWEEN 0 AND 6 THEN ancestor_r7 IS NULL
+            WHEN resolution BETWEEN 7 AND 15 THEN
+                ancestor_r7 IS NOT NULL
+                AND ancestor_r7 = (
+                    (cell_id & ~(15::BIGINT << 52))
+                    | (7::BIGINT << 52)
+                    | ((1::BIGINT << 24) - 1)
+                )
+            ELSE FALSE
+        END
+    ),
+    CONSTRAINT h3_cell_immediate_parent_fkey FOREIGN KEY (immediate_parent)
+        REFERENCES babylon_ref.h3_cell(cell_id) DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT h3_cell_ancestor_r4_fkey FOREIGN KEY (ancestor_r4)
+        REFERENCES babylon_ref.h3_cell(cell_id) DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT h3_cell_ancestor_r5_fkey FOREIGN KEY (ancestor_r5)
+        REFERENCES babylon_ref.h3_cell(cell_id) DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT h3_cell_ancestor_r6_fkey FOREIGN KEY (ancestor_r6)
+        REFERENCES babylon_ref.h3_cell(cell_id) DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT h3_cell_ancestor_r7_fkey FOREIGN KEY (ancestor_r7)
+        REFERENCES babylon_ref.h3_cell(cell_id) DEFERRABLE INITIALLY DEFERRED
+);
+REVOKE ALL ON TABLE babylon_ref.h3_cell FROM PUBLIC;
+";
+
+fn migration_sql() -> String {
+    std::fs::read_to_string(Path::new(MIGRATION_PATH)).unwrap_or_else(|error| {
+        panic!("failed to read {MIGRATION_PATH}: {error}");
+    })
+}
+
+#[test]
+fn h3_cell_epoch_sql_is_exact_and_additive_only() {
+    let sql = migration_sql();
+    assert_eq!(sql, EXPECTED_SQL);
+    assert_eq!(sql.as_bytes().last(), Some(&b'\n'));
+
+    let uppercase = sql.to_ascii_uppercase();
+    for prohibited in [
+        "BEGIN",
+        "COMMIT",
+        "ROLLBACK",
+        "START TRANSACTION",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "CREATE EXTENSION",
+        "H3INDEX",
+        "CREATE INDEX",
+        "CREATE VIEW",
+        "BRIDGE",
+        "CAMPAIGN",
+        "OUTBOX",
+        "WRITER",
+        "BABYLON_INTEL",
+        "GRANT",
+    ] {
+        assert!(
+            !uppercase.contains(prohibited),
+            "epoch-2 migration contains prohibited surface {prohibited}"
+        );
+    }
+}
+
+#[test]
+fn parent_construction_rewrites_resolution_and_trailing_digits() {
+    let sql = migration_sql();
+    assert!(sql.contains("& ~(15::BIGINT << 52)"));
+    assert!(sql.contains("| ((resolution - 1)::BIGINT << 52)"));
+    assert!(sql.contains("| ((1::BIGINT << (3 * (16 - resolution))) - 1)"));
+    assert!(!sql.to_ascii_lowercase().contains("descendant"));
+    assert!(!sql.to_ascii_lowercase().contains("between cell_id"));
+}

--- a/rust/crates/babylon-persistence/tests/support/h3_cell_vectors.rs
+++ b/rust/crates/babylon-persistence/tests/support/h3_cell_vectors.rs
@@ -1,0 +1,319 @@
+//! Shared bounded parser for the language-neutral H3 identity vectors.
+
+use std::collections::BTreeSet;
+
+pub(super) const VALID_VECTOR_COUNT: usize = 208;
+pub(super) const PENTAGON_VECTOR_COUNT: usize = 12 * 16;
+pub(super) const INVALID_RAW_VECTOR_COUNT: usize = 6;
+pub(super) const INVALID_SQL_VECTOR_COUNT: usize = 1;
+pub(super) const INVALID_TEXT_VECTOR_COUNT: usize = 6;
+pub(super) const INVALID_ANCESTOR_VECTOR_COUNT: usize = 2;
+const MAX_VECTOR_LINES: usize = 256;
+
+#[derive(Debug)]
+pub(super) struct ValidVector {
+    pub(super) label: String,
+    pub(super) resolution: u8,
+    pub(super) text: String,
+    pub(super) raw_u64: u64,
+    pub(super) sql_i64: i64,
+    pub(super) bytes_be: [u8; 8],
+    pub(super) immediate_parent: Option<String>,
+    pub(super) ancestor_chain_r0_to_self: Vec<String>,
+}
+
+impl ValidVector {
+    pub(super) fn ancestor_at(&self, resolution: u8) -> Option<&str> {
+        self.ancestor_chain_r0_to_self
+            .get(usize::from(resolution))
+            .map(String::as_str)
+    }
+
+    pub(super) fn is_pentagon(&self) -> bool {
+        self.label.starts_with("pentagon_")
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct InvalidRawVector {
+    pub(super) label: String,
+    pub(super) raw_u64: u64,
+}
+
+#[derive(Debug)]
+pub(super) struct InvalidSqlVector {
+    pub(super) label: String,
+    pub(super) sql_i64: i64,
+}
+
+#[derive(Debug)]
+pub(super) struct InvalidTextVector {
+    pub(super) label: String,
+    pub(super) text: String,
+}
+
+#[derive(Debug)]
+pub(super) struct InvalidAncestorVector {
+    pub(super) label: String,
+    pub(super) text: String,
+    pub(super) requested_resolution: u8,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct VectorFixture {
+    pub(super) valid: Vec<ValidVector>,
+    pub(super) invalid_raw: Vec<InvalidRawVector>,
+    pub(super) invalid_sql: Vec<InvalidSqlVector>,
+    pub(super) invalid_text: Vec<InvalidTextVector>,
+    pub(super) invalid_ancestor: Vec<InvalidAncestorVector>,
+}
+
+pub(super) fn load_fixture() -> VectorFixture {
+    let source = include_str!("../fixtures/h3_cell_id_vectors_v1.txt");
+    let lines = source
+        .lines()
+        .take(MAX_VECTOR_LINES + 1)
+        .collect::<Vec<_>>();
+    assert!(
+        lines.len() <= MAX_VECTOR_LINES,
+        "H3 fixture exceeds the static line bound"
+    );
+
+    let mut fixture = VectorFixture::default();
+    for line in lines.iter().take(MAX_VECTOR_LINES) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let fields = line.split('|').take(10).collect::<Vec<_>>();
+        match fields.first().copied().unwrap_or_default() {
+            "valid" => fixture.valid.push(parse_valid(&fields)),
+            "invalid_raw" => fixture.invalid_raw.push(parse_invalid_raw(&fields)),
+            "invalid_sql" => fixture.invalid_sql.push(parse_invalid_sql(&fields)),
+            "invalid_text" => fixture.invalid_text.push(parse_invalid_text(&fields)),
+            "invalid_ancestor" => fixture
+                .invalid_ancestor
+                .push(parse_invalid_ancestor(&fields)),
+            other => panic!("unexpected fixture record kind {other}"),
+        }
+    }
+    assert_fixture_cardinality(&fixture);
+    fixture
+}
+
+fn assert_fixture_cardinality(fixture: &VectorFixture) {
+    assert_eq!(fixture.valid.len(), VALID_VECTOR_COUNT);
+    assert_eq!(
+        fixture
+            .valid
+            .iter()
+            .take(VALID_VECTOR_COUNT)
+            .filter(|vector| vector.is_pentagon())
+            .count(),
+        PENTAGON_VECTOR_COUNT
+    );
+    assert_eq!(fixture.invalid_raw.len(), INVALID_RAW_VECTOR_COUNT);
+    assert_eq!(fixture.invalid_sql.len(), INVALID_SQL_VECTOR_COUNT);
+    assert_eq!(fixture.invalid_text.len(), INVALID_TEXT_VECTOR_COUNT);
+    assert_eq!(
+        fixture.invalid_ancestor.len(),
+        INVALID_ANCESTOR_VECTOR_COUNT
+    );
+    assert_unique_valid_identities(fixture);
+    assert_unique_invalid_cases(fixture);
+    assert_exact_resolution_shape(fixture);
+}
+
+fn assert_unique_valid_identities(fixture: &VectorFixture) {
+    let mut labels = BTreeSet::new();
+    let mut raw_identities = BTreeSet::new();
+    let mut text_identities = BTreeSet::new();
+    for vector in fixture.valid.iter().take(VALID_VECTOR_COUNT) {
+        assert!(
+            labels.insert(vector.label.as_str()),
+            "duplicate H3 vector label"
+        );
+        assert!(
+            raw_identities.insert(vector.raw_u64),
+            "duplicate H3 raw identity"
+        );
+        assert!(
+            text_identities.insert(vector.text.as_str()),
+            "duplicate H3 text identity"
+        );
+    }
+    assert_eq!(labels.len(), VALID_VECTOR_COUNT);
+    assert_eq!(raw_identities.len(), VALID_VECTOR_COUNT);
+    assert_eq!(text_identities.len(), VALID_VECTOR_COUNT);
+}
+
+fn assert_unique_invalid_cases(fixture: &VectorFixture) {
+    let mut labels = BTreeSet::new();
+    let mut raw_identities = BTreeSet::new();
+    for vector in fixture.invalid_raw.iter().take(INVALID_RAW_VECTOR_COUNT) {
+        assert!(
+            labels.insert(vector.label.as_str()),
+            "duplicate invalid label"
+        );
+        assert!(
+            raw_identities.insert(vector.raw_u64),
+            "duplicate invalid raw identity"
+        );
+    }
+    let mut sql_values = BTreeSet::new();
+    for vector in fixture.invalid_sql.iter().take(INVALID_SQL_VECTOR_COUNT) {
+        assert!(
+            labels.insert(vector.label.as_str()),
+            "duplicate invalid label"
+        );
+        assert!(
+            sql_values.insert(vector.sql_i64),
+            "duplicate invalid SQL identity"
+        );
+    }
+    let mut text_cases = BTreeSet::new();
+    for vector in fixture.invalid_text.iter().take(INVALID_TEXT_VECTOR_COUNT) {
+        assert!(
+            labels.insert(vector.label.as_str()),
+            "duplicate invalid label"
+        );
+        assert!(
+            text_cases.insert(vector.text.as_str()),
+            "duplicate invalid text case"
+        );
+    }
+    let mut ancestor_cases = BTreeSet::new();
+    for vector in fixture
+        .invalid_ancestor
+        .iter()
+        .take(INVALID_ANCESTOR_VECTOR_COUNT)
+    {
+        assert!(
+            labels.insert(vector.label.as_str()),
+            "duplicate invalid label"
+        );
+        assert!(
+            ancestor_cases.insert((vector.text.as_str(), vector.requested_resolution)),
+            "duplicate invalid ancestor case"
+        );
+    }
+    assert_eq!(labels.len(), 15);
+}
+
+fn assert_exact_resolution_shape(fixture: &VectorFixture) {
+    for resolution in 0..16 {
+        let resolution = u8::try_from(resolution).expect("bounded H3 resolution must fit");
+        let level = fixture
+            .valid
+            .iter()
+            .take(VALID_VECTOR_COUNT)
+            .filter(|vector| vector.resolution == resolution)
+            .collect::<Vec<_>>();
+        assert_eq!(level.len(), 13, "resolution {resolution} vector count");
+        assert_eq!(
+            level
+                .iter()
+                .take(13)
+                .filter(|vector| vector.is_pentagon())
+                .count(),
+            12,
+            "resolution {resolution} pentagon count"
+        );
+        let ordinary = level
+            .iter()
+            .take(13)
+            .filter(|vector| !vector.is_pentagon())
+            .take(2)
+            .copied()
+            .collect::<Vec<_>>();
+        assert_eq!(ordinary.len(), 1, "resolution {resolution} ordinary count");
+        assert_ordinary_lineage(fixture, ordinary[0], resolution);
+    }
+}
+
+fn assert_ordinary_lineage(fixture: &VectorFixture, current: &ValidVector, resolution: u8) {
+    assert_eq!(current.label, format!("ordinary_r{resolution}"));
+    assert_eq!(
+        current.ancestor_chain_r0_to_self.len(),
+        usize::from(resolution) + 1
+    );
+    assert_eq!(current.ancestor_at(resolution), Some(current.text.as_str()));
+    if resolution == 0 {
+        assert_eq!(current.immediate_parent, None);
+        return;
+    }
+    let prior_label = format!("ordinary_r{}", resolution - 1);
+    let prior = fixture
+        .valid
+        .iter()
+        .take(VALID_VECTOR_COUNT)
+        .find(|vector| vector.label == prior_label)
+        .expect("ordinary H3 lineage must contain its prior resolution");
+    assert_eq!(
+        current.immediate_parent.as_deref(),
+        Some(prior.text.as_str())
+    );
+    assert_eq!(
+        &current.ancestor_chain_r0_to_self[..usize::from(resolution)],
+        prior.ancestor_chain_r0_to_self.as_slice()
+    );
+}
+
+fn parse_valid(fields: &[&str]) -> ValidVector {
+    assert_eq!(fields.len(), 9);
+    ValidVector {
+        label: fields[1].to_owned(),
+        resolution: fields[2].parse().expect("valid resolution must parse"),
+        text: fields[3].to_owned(),
+        raw_u64: u64::from_str_radix(fields[4], 16).expect("valid raw identity must parse"),
+        sql_i64: fields[5].parse().expect("valid SQL identity must parse"),
+        bytes_be: parse_hex_bytes(fields[6]),
+        immediate_parent: (!fields[7].is_empty()).then(|| fields[7].to_owned()),
+        ancestor_chain_r0_to_self: fields[8].split(',').take(17).map(str::to_owned).collect(),
+    }
+}
+
+fn parse_invalid_raw(fields: &[&str]) -> InvalidRawVector {
+    assert_eq!(fields.len(), 3);
+    InvalidRawVector {
+        label: fields[1].to_owned(),
+        raw_u64: u64::from_str_radix(fields[2], 16).expect("invalid raw identity bytes must parse"),
+    }
+}
+
+fn parse_invalid_sql(fields: &[&str]) -> InvalidSqlVector {
+    assert_eq!(fields.len(), 3);
+    InvalidSqlVector {
+        label: fields[1].to_owned(),
+        sql_i64: fields[2].parse().expect("invalid SQL identity must parse"),
+    }
+}
+
+fn parse_invalid_text(fields: &[&str]) -> InvalidTextVector {
+    assert_eq!(fields.len(), 3);
+    InvalidTextVector {
+        label: fields[1].to_owned(),
+        text: fields[2].to_owned(),
+    }
+}
+
+fn parse_invalid_ancestor(fields: &[&str]) -> InvalidAncestorVector {
+    assert_eq!(fields.len(), 4);
+    InvalidAncestorVector {
+        label: fields[1].to_owned(),
+        text: fields[2].to_owned(),
+        requested_resolution: fields[3]
+            .parse()
+            .expect("invalid ancestor resolution must parse"),
+    }
+}
+
+fn parse_hex_bytes(raw_hex16: &str) -> [u8; 8] {
+    assert_eq!(raw_hex16.len(), 16);
+    let mut bytes = [0_u8; 8];
+    for (index, byte) in bytes.iter_mut().enumerate().take(8) {
+        let start = index * 2;
+        *byte = u8::from_str_radix(&raw_hex16[start..start + 2], 16)
+            .expect("big-endian vector byte must parse");
+    }
+    bytes
+}

--- a/rust/crates/babylon-persistence/tests/support/h3_pg_oracle.rs
+++ b/rust/crates/babylon-persistence/tests/support/h3_pg_oracle.rs
@@ -1,0 +1,445 @@
+//! Test-only h3-pg semantic oracle for the canonical H3 identity relation.
+
+use super::h3_cell_vectors::{
+    load_fixture, ValidVector, VectorFixture, INVALID_RAW_VECTOR_COUNT, PENTAGON_VECTOR_COUNT,
+    VALID_VECTOR_COUNT,
+};
+use babylon_persistence::migrate_schema_epoch;
+use postgres::error::SqlState;
+use postgres::types::ToSql;
+use postgres::{Client, Config, NoTls, Transaction};
+
+const H3_PG_VERSION: &str = "4.5.0";
+const H3_RESOLUTION_COUNT: usize = 16;
+const PENTAGONS_PER_RESOLUTION: usize = 12;
+
+pub(super) fn verify_h3_pg_oracle(owner: &Config, admin: &Config) {
+    let first = migrate_schema_epoch(owner).expect("H3 oracle scratch database must migrate");
+    assert_eq!((first.prior_applied, first.final_applied), (0, 2));
+    assert_eq!(first.applied_versions.len(), 2);
+
+    let fixture = load_fixture();
+    assert_shared_fixture_transport(&fixture);
+    let mut client = admin.connect(NoTls).expect("H3 oracle admin must connect");
+    assert_pre_activation_state(&mut client);
+    client
+        .batch_execute("CREATE EXTENSION h3")
+        .expect("test-only H3 oracle extension must activate");
+    assert_active_extension_identity(&mut client);
+
+    let mut transaction = client
+        .transaction()
+        .expect("H3 oracle comparison transaction must begin");
+    insert_valid_vectors(&mut transaction, &fixture);
+    compare_valid_vectors(&mut transaction, &fixture);
+    compare_invalid_raw_vectors(&mut transaction, &fixture);
+    compare_exact_pentagon_sets(&mut transaction, &fixture);
+    assert_persisted_projection_matches(&mut transaction);
+    transaction
+        .commit()
+        .expect("H3 oracle comparison transaction must commit");
+    assert_relational_metadata_rejections(&mut client, &fixture);
+
+    client
+        .batch_execute("DROP EXTENSION h3 RESTRICT")
+        .expect("production BIGINT relation must not depend on test-only h3-pg");
+    assert_post_drop_independence(&mut client);
+    drop(client);
+
+    let second = migrate_schema_epoch(owner).expect("post-oracle epoch must remain valid");
+    assert_eq!((second.prior_applied, second.final_applied), (2, 2));
+    assert!(second.applied_versions.is_empty());
+    assert!(second.reconciled_versions.is_empty());
+}
+
+fn assert_shared_fixture_transport(fixture: &VectorFixture) {
+    for vector in fixture.valid.iter().take(VALID_VECTOR_COUNT) {
+        assert_eq!(
+            i64::try_from(vector.raw_u64).expect("valid H3 identity must fit positive BIGINT"),
+            vector.sql_i64,
+            "{} SQL transport",
+            vector.label
+        );
+        assert_eq!(
+            vector.raw_u64.to_be_bytes(),
+            vector.bytes_be,
+            "{} bytes",
+            vector.label
+        );
+    }
+    for vector in fixture.invalid_sql.iter().take(1) {
+        assert!(!vector.label.is_empty());
+        assert!(vector.sql_i64 < 0);
+    }
+    for vector in fixture.invalid_text.iter().take(6) {
+        assert!(!vector.label.is_empty());
+        assert!(!vector.text.is_empty());
+    }
+    for vector in fixture.invalid_ancestor.iter().take(2) {
+        assert!(!vector.label.is_empty());
+        assert!(!vector.text.is_empty());
+        match vector.label.as_str() {
+            "too_fine_parent" => assert_eq!(vector.requested_resolution, 11),
+            "resolution_above_15" => assert_eq!(vector.requested_resolution, 16),
+            other => panic!("unexpected invalid ancestor fixture {other}"),
+        }
+    }
+}
+
+fn assert_pre_activation_state(client: &mut Client) {
+    let row = client
+        .query_one(
+            "SELECT (SELECT pg_catalog.count(*) FROM babylon_state.schema_migration), \
+                    (SELECT installed_version FROM pg_catalog.pg_available_extensions \
+                     WHERE name = 'h3'), \
+                    (SELECT default_version FROM pg_catalog.pg_available_extensions \
+                     WHERE name = 'h3')",
+            &[],
+        )
+        .expect("pre-activation H3 state must query");
+    assert_eq!(row.get::<_, i64>(0), 2);
+    assert_eq!(row.get::<_, Option<String>>(1), None);
+    assert_eq!(
+        row.get::<_, Option<String>>(2).as_deref(),
+        Some(H3_PG_VERSION)
+    );
+}
+
+fn assert_active_extension_identity(client: &mut Client) {
+    let row = client
+        .query_one(
+            "SELECT extension.extversion::pg_catalog.text, \
+                    namespace.nspname::pg_catalog.text \
+             FROM pg_catalog.pg_extension AS extension \
+             JOIN pg_catalog.pg_namespace AS namespace \
+               ON namespace.oid = extension.extnamespace \
+             WHERE extension.extname = 'h3'",
+            &[],
+        )
+        .expect("active H3 extension identity must query");
+    assert_eq!(row.get::<_, String>(0), H3_PG_VERSION);
+    assert_eq!(row.get::<_, String>(1), "public");
+}
+
+fn insert_valid_vectors(transaction: &mut Transaction<'_>, fixture: &VectorFixture) {
+    let statement = transaction
+        .prepare(
+            "INSERT INTO babylon_ref.h3_cell ( \
+                 cell_id, resolution, immediate_parent, ancestor_r4, ancestor_r5, \
+                 ancestor_r6, ancestor_r7 \
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        )
+        .expect("H3 vector insert must prepare");
+    for vector in fixture.valid.iter().take(VALID_VECTOR_COUNT) {
+        let resolution = i16::from(vector.resolution);
+        let immediate_parent = optional_text_identity(vector.immediate_parent.as_deref());
+        let ancestor_r4 = optional_text_identity(vector.ancestor_at(4));
+        let ancestor_r5 = optional_text_identity(vector.ancestor_at(5));
+        let ancestor_r6 = optional_text_identity(vector.ancestor_at(6));
+        let ancestor_r7 = optional_text_identity(vector.ancestor_at(7));
+        assert_eq!(
+            transaction
+                .execute(
+                    &statement,
+                    &[
+                        &vector.sql_i64,
+                        &resolution,
+                        &immediate_parent,
+                        &ancestor_r4,
+                        &ancestor_r5,
+                        &ancestor_r6,
+                        &ancestor_r7,
+                    ],
+                )
+                .expect("valid H3 vector must insert"),
+            1,
+            "valid H3 vector {} must insert exactly once",
+            vector.label
+        );
+    }
+}
+
+fn compare_valid_vectors(transaction: &mut Transaction<'_>, fixture: &VectorFixture) {
+    let statement = transaction
+        .prepare(
+            "SELECT (($1::pg_catalog.int8)::public.h3index)::pg_catalog.text, \
+                    public.h3_get_resolution(($1::pg_catalog.int8)::public.h3index), \
+                    public.h3_is_valid_cell(($1::pg_catalog.int8)::public.h3index), \
+                    public.h3_is_pentagon(($1::pg_catalog.int8)::public.h3index), \
+                    CASE WHEN $2::pg_catalog.int4 = 0 THEN NULL \
+                         ELSE public.h3_cell_to_parent( \
+                             ($1::pg_catalog.int8)::public.h3index \
+                         )::pg_catalog.int8 END, \
+                    CASE WHEN $2 >= 4 THEN public.h3_cell_to_parent( \
+                         ($1::pg_catalog.int8)::public.h3index, 4 \
+                    )::pg_catalog.int8 END, \
+                    CASE WHEN $2 >= 5 THEN public.h3_cell_to_parent( \
+                         ($1::pg_catalog.int8)::public.h3index, 5 \
+                    )::pg_catalog.int8 END, \
+                    CASE WHEN $2 >= 6 THEN public.h3_cell_to_parent( \
+                         ($1::pg_catalog.int8)::public.h3index, 6 \
+                    )::pg_catalog.int8 END, \
+                    CASE WHEN $2 >= 7 THEN public.h3_cell_to_parent( \
+                         ($1::pg_catalog.int8)::public.h3index, 7 \
+                    )::pg_catalog.int8 END",
+        )
+        .expect("H3 semantic comparison must prepare");
+    for vector in fixture.valid.iter().take(VALID_VECTOR_COUNT) {
+        let resolution = i32::from(vector.resolution);
+        let row = transaction
+            .query_one(&statement, &[&vector.sql_i64, &resolution])
+            .unwrap_or_else(|error| panic!("H3 vector {} must query: {error}", vector.label));
+        assert_vector_projection(&row, vector);
+    }
+}
+
+fn assert_vector_projection(row: &postgres::Row, vector: &ValidVector) {
+    assert_eq!(
+        row.get::<_, String>(0),
+        vector.text,
+        "{} text",
+        vector.label
+    );
+    assert_eq!(
+        row.get::<_, i32>(1),
+        i32::from(vector.resolution),
+        "{} resolution",
+        vector.label
+    );
+    assert!(row.get::<_, bool>(2), "{} validity", vector.label);
+    assert_eq!(
+        row.get::<_, bool>(3),
+        vector.is_pentagon(),
+        "{} pentagon",
+        vector.label
+    );
+    assert_eq!(
+        row.get::<_, Option<i64>>(4),
+        optional_text_identity(vector.immediate_parent.as_deref()),
+        "{} parent",
+        vector.label
+    );
+    for (column, resolution) in [(5, 4_u8), (6, 5_u8), (7, 6_u8), (8, 7_u8)] {
+        assert_eq!(
+            row.get::<_, Option<i64>>(column),
+            optional_text_identity(vector.ancestor_at(resolution)),
+            "{} ancestor r{resolution}",
+            vector.label
+        );
+    }
+}
+
+fn compare_invalid_raw_vectors(transaction: &mut Transaction<'_>, fixture: &VectorFixture) {
+    let statement = transaction
+        .prepare(
+            "SELECT public.h3_is_valid_cell( \
+                 ($1::pg_catalog.int8)::public.h3index \
+             )",
+        )
+        .expect("invalid H3 comparison must prepare");
+    for vector in fixture.invalid_raw.iter().take(INVALID_RAW_VECTOR_COUNT) {
+        let raw = i64::try_from(vector.raw_u64).expect("invalid vector must fit positive BIGINT");
+        let row = transaction
+            .query_one(&statement, &[&raw])
+            .unwrap_or_else(|error| {
+                panic!("invalid H3 vector {} must query: {error}", vector.label)
+            });
+        assert!(!row.get::<_, bool>(0), "{} must stay invalid", vector.label);
+    }
+}
+
+fn compare_exact_pentagon_sets(transaction: &mut Transaction<'_>, fixture: &VectorFixture) {
+    assert_eq!(
+        fixture
+            .valid
+            .iter()
+            .take(VALID_VECTOR_COUNT)
+            .filter(|vector| vector.is_pentagon())
+            .count(),
+        PENTAGON_VECTOR_COUNT
+    );
+    let statement = transaction
+        .prepare(
+            "SELECT pentagon::pg_catalog.int8 \
+             FROM public.h3_get_pentagons($1) AS pentagon ORDER BY 1 LIMIT 13",
+        )
+        .expect("pentagon oracle query must prepare");
+    for resolution in 0..H3_RESOLUTION_COUNT {
+        let resolution_u8 = u8::try_from(resolution).expect("bounded H3 resolution must fit");
+        let resolution_i32 = i32::from(resolution_u8);
+        let mut expected = fixture
+            .valid
+            .iter()
+            .take(VALID_VECTOR_COUNT)
+            .filter(|vector| vector.is_pentagon() && vector.resolution == resolution_u8)
+            .map(|vector| vector.sql_i64)
+            .collect::<Vec<_>>();
+        expected.sort_unstable();
+        assert_eq!(expected.len(), PENTAGONS_PER_RESOLUTION);
+        let rows = transaction
+            .query(&statement, &[&resolution_i32])
+            .expect("pentagon oracle set must query");
+        assert_eq!(
+            rows.len(),
+            PENTAGONS_PER_RESOLUTION,
+            "resolution {resolution} oracle must return exactly 12 pentagons"
+        );
+        let actual = rows
+            .iter()
+            .take(PENTAGONS_PER_RESOLUTION + 1)
+            .map(|row| row.get::<_, i64>(0))
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected, "resolution {resolution} pentagon set");
+    }
+}
+
+fn assert_persisted_projection_matches(transaction: &mut Transaction<'_>) {
+    let row = transaction
+        .query_one(
+            "SELECT pg_catalog.count(*)::pg_catalog.int8, \
+                    pg_catalog.count(*) FILTER (WHERE \
+                        resolution <> public.h3_get_resolution(cell_id::public.h3index) \
+                        OR immediate_parent IS DISTINCT FROM CASE WHEN resolution = 0 \
+                           THEN NULL ELSE public.h3_cell_to_parent( \
+                               cell_id::public.h3index \
+                           )::pg_catalog.int8 END \
+                        OR ancestor_r4 IS DISTINCT FROM CASE WHEN resolution >= 4 \
+                           THEN public.h3_cell_to_parent( \
+                               cell_id::public.h3index, 4 \
+                           )::pg_catalog.int8 END \
+                        OR ancestor_r5 IS DISTINCT FROM CASE WHEN resolution >= 5 \
+                           THEN public.h3_cell_to_parent( \
+                               cell_id::public.h3index, 5 \
+                           )::pg_catalog.int8 END \
+                        OR ancestor_r6 IS DISTINCT FROM CASE WHEN resolution >= 6 \
+                           THEN public.h3_cell_to_parent( \
+                               cell_id::public.h3index, 6 \
+                           )::pg_catalog.int8 END \
+                        OR ancestor_r7 IS DISTINCT FROM CASE WHEN resolution >= 7 \
+                           THEN public.h3_cell_to_parent( \
+                               cell_id::public.h3index, 7 \
+                           )::pg_catalog.int8 END \
+                    )::pg_catalog.int8 \
+             FROM babylon_ref.h3_cell",
+            &[],
+        )
+        .expect("persisted H3 projection must query");
+    assert_eq!(
+        row.get::<_, i64>(0),
+        i64::try_from(VALID_VECTOR_COUNT).unwrap()
+    );
+    assert_eq!(row.get::<_, i64>(1), 0);
+}
+
+fn assert_post_drop_independence(client: &mut Client) {
+    let row = client
+        .query_one(
+            "SELECT NOT EXISTS (SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'h3'), \
+                    pg_catalog.to_regclass('babylon_ref.h3_cell') IS NOT NULL, \
+                    (SELECT pg_catalog.count(*) FROM babylon_ref.h3_cell)",
+            &[],
+        )
+        .expect("post-drop H3 independence must query");
+    assert!(row.get::<_, bool>(0));
+    assert!(row.get::<_, bool>(1));
+    assert_eq!(
+        row.get::<_, i64>(2),
+        i64::try_from(VALID_VECTOR_COUNT).unwrap()
+    );
+}
+
+fn assert_relational_metadata_rejections(client: &mut Client, fixture: &VectorFixture) {
+    let zero = 0_i64;
+    let resolution_zero = 0_i16;
+    assert_constraint_rejection(
+        client,
+        "INSERT INTO babylon_ref.h3_cell (cell_id, resolution) VALUES ($1, $2)",
+        &[&zero, &resolution_zero],
+        &SqlState::CHECK_VIOLATION,
+        "h3_cell_id_positive",
+    );
+
+    let ordinary_r0 = identity_by_label(fixture, "ordinary_r0");
+    let ordinary_r1 = identity_by_label(fixture, "ordinary_r1");
+    let ordinary_r8 = identity_by_label(fixture, "ordinary_r8");
+    let pentagon_r4 = fixture
+        .valid
+        .iter()
+        .take(VALID_VECTOR_COUNT)
+        .find(|vector| vector.resolution == 4 && vector.is_pentagon())
+        .expect("fixture must contain an r4 pentagon")
+        .sql_i64;
+    assert_constraint_rejection(
+        client,
+        "UPDATE babylon_ref.h3_cell SET immediate_parent = NULL WHERE cell_id = $1",
+        &[&ordinary_r1],
+        &SqlState::CHECK_VIOLATION,
+        "h3_cell_immediate_parent_matches",
+    );
+    assert_constraint_rejection(
+        client,
+        "UPDATE babylon_ref.h3_cell SET ancestor_r4 = $1 WHERE cell_id = $1",
+        &[&ordinary_r0],
+        &SqlState::CHECK_VIOLATION,
+        "h3_cell_ancestor_r4_matches",
+    );
+    assert_constraint_rejection(
+        client,
+        "UPDATE babylon_ref.h3_cell SET ancestor_r4 = $1 WHERE cell_id = $2",
+        &[&pentagon_r4, &ordinary_r8],
+        &SqlState::CHECK_VIOLATION,
+        "h3_cell_ancestor_r4_matches",
+    );
+    assert_constraint_rejection(
+        client,
+        "DELETE FROM babylon_ref.h3_cell WHERE cell_id = $1",
+        &[&ordinary_r0],
+        &SqlState::FOREIGN_KEY_VIOLATION,
+        "h3_cell_immediate_parent_fkey",
+    );
+}
+
+fn assert_constraint_rejection(
+    client: &mut Client,
+    statement: &str,
+    parameters: &[&(dyn ToSql + Sync)],
+    expected_code: &SqlState,
+    expected_constraint: &str,
+) {
+    let mut transaction = client
+        .transaction()
+        .expect("H3 negative-case transaction must begin");
+    transaction
+        .batch_execute("SET CONSTRAINTS ALL IMMEDIATE")
+        .expect("H3 negative-case constraints must become immediate");
+    let error = transaction
+        .execute(statement, parameters)
+        .expect_err("invalid H3 relational metadata must be rejected");
+    assert_eq!(error.code(), Some(expected_code));
+    assert_eq!(
+        error
+            .as_db_error()
+            .and_then(postgres::error::DbError::constraint),
+        Some(expected_constraint)
+    );
+    transaction
+        .rollback()
+        .expect("H3 negative-case transaction must roll back");
+}
+
+fn identity_by_label(fixture: &VectorFixture, label: &str) -> i64 {
+    fixture
+        .valid
+        .iter()
+        .take(VALID_VECTOR_COUNT)
+        .find(|vector| vector.label == label)
+        .unwrap_or_else(|| panic!("fixture must contain {label}"))
+        .sql_i64
+}
+
+fn optional_text_identity(text: Option<&str>) -> Option<i64> {
+    text.map(|value| {
+        let raw = u64::from_str_radix(value, 16).expect("fixture hierarchy identity must parse");
+        i64::try_from(raw).expect("fixture hierarchy identity must fit positive BIGINT")
+    })
+}

--- a/rust/crates/babylon-persistence/tests/support/schema_epoch_postgres.rs
+++ b/rust/crates/babylon-persistence/tests/support/schema_epoch_postgres.rs
@@ -17,16 +17,18 @@ pub(super) fn verify_fresh_migration(base: &Config) {
     let first = migrate_schema_epoch(&config).expect("pinned fresh template must migrate");
     assert_eq!(first.origin, SchemaEpochOrigin::Fresh);
     assert_eq!(first.prior_applied, 0);
-    assert_eq!(first.final_applied, 1);
-    assert_eq!(first.applied_versions.len(), 1);
+    assert_eq!(first.final_applied, 2);
+    assert_eq!(first.applied_versions.len(), 2);
+    assert_eq!(first.applied_versions[0].as_i64(), 1);
+    assert_eq!(first.applied_versions[1].as_i64(), 2);
     assert!(first.reconciled_versions.is_empty());
     assert!(first.legacy_adoption.is_none());
 
     let before = epoch_snapshot(&config);
     let second = migrate_schema_epoch(&config).expect("exact Rust prefix must be idempotent");
     assert_eq!(second.origin, SchemaEpochOrigin::ExistingRustPrefix);
-    assert_eq!(second.prior_applied, 1);
-    assert_eq!(second.final_applied, 1);
+    assert_eq!(second.prior_applied, 2);
+    assert_eq!(second.final_applied, 2);
     assert!(second.applied_versions.is_empty());
     assert!(second.reconciled_versions.is_empty());
     assert_eq!(epoch_snapshot(&config), before);
@@ -48,6 +50,7 @@ pub(super) fn verify_schema_epoch_matrix(base: &Config, legacy_template: &str, o
     assert_epoch_authority(&fresh_config);
 
     verify_non_superuser_owner(base, owner);
+    verify_v1_to_v2_upgrade(base);
     verify_lock_refusal(base);
     verify_legacy_epoch(base, legacy_template);
     verify_bad_ledgers(base, fresh.name());
@@ -100,6 +103,46 @@ fn verify_non_superuser_owner(base: &Config, owner: &str) {
     database.cleanup();
 }
 
+fn verify_v1_to_v2_upgrade(base: &Config) {
+    let database = ScratchDatabase::empty(base, "epoch_v1_upgrade", database_user(base));
+    let config = database.config(base);
+    establish_v1_prefix(&config);
+    let before = raw_epoch_snapshot(&config);
+    assert_eq!(before.len(), 4);
+    assert!(before.iter().any(|row| row.0 == "ledger" && row.1 == "1"));
+    assert!(!before.iter().any(|row| row.1 == "2"));
+
+    let upgraded = migrate_schema_epoch(&config).expect("exact epoch 1 must upgrade to epoch 2");
+    assert_eq!(upgraded.origin, SchemaEpochOrigin::ExistingRustPrefix);
+    assert_eq!(upgraded.prior_applied, 1);
+    assert_eq!(upgraded.final_applied, 2);
+    assert_eq!(upgraded.applied_versions.len(), 1);
+    assert_eq!(upgraded.applied_versions[0].as_i64(), 2);
+    assert!(upgraded.reconciled_versions.is_empty());
+    assert_epoch_authority(&config);
+    let snapshot = epoch_snapshot(&config);
+    assert_idempotent(&config, &snapshot);
+    assert_lock_released(&config);
+    database.cleanup();
+}
+
+fn establish_v1_prefix(config: &Config) {
+    let compiled = compiled_schema_migrations().expect("compiled registry must be valid");
+    let version = compiled[0].version().as_i64();
+    let checksum = compiled[0].checksum();
+    let checksum_bytes = checksum.as_bytes().as_slice();
+    let mut client = config.connect(NoTls).unwrap();
+    let mut transaction = client.transaction().unwrap();
+    transaction.batch_execute(compiled[0].sql()).unwrap();
+    transaction
+        .execute(
+            "INSERT INTO babylon_state.schema_migration (version, checksum) VALUES ($1, $2)",
+            &[&version, &checksum_bytes],
+        )
+        .unwrap();
+    transaction.commit().unwrap();
+}
+
 fn verify_legacy_epoch(base: &Config, template: &str) {
     let database = ScratchDatabase::from_template(base, template, "epoch_legacy");
     let config = database.config(base);
@@ -111,7 +154,8 @@ fn verify_legacy_epoch(base: &Config, template: &str) {
     let first = migrate_schema_epoch(&config).unwrap();
     assert_eq!(first.origin, SchemaEpochOrigin::ExactLegacy);
     assert_eq!(first.prior_applied, 0);
-    assert_eq!(first.final_applied, 1);
+    assert_eq!(first.final_applied, 2);
+    assert_eq!(first.applied_versions.len(), 2);
     assert_eq!(first.legacy_adoption, Some(adoption));
     assert_eq!(legacy_meta_snapshot(&config), before);
     assert_epoch_authority(&config);
@@ -152,19 +196,36 @@ fn verify_bad_ledgers(base: &Config, migrated_template: &str) {
     assert_lock_released(&checksum_config);
     checksum.cleanup();
 
+    let checksum_v2 =
+        ScratchDatabase::from_template(base, migrated_template, "epoch_checksum_vtwo");
+    let checksum_v2_config = checksum_v2.config(base);
+    mutate(
+        &checksum_v2_config,
+        "UPDATE babylon_state.schema_migration SET checksum = decode(repeat('66', 32), 'hex') \
+         WHERE version = 2",
+    );
+    let before = raw_epoch_snapshot(&checksum_v2_config);
+    assert_eq!(
+        migrate_schema_epoch(&checksum_v2_config),
+        Err(SchemaEpochError::LedgerChecksumMismatch { version: 2 })
+    );
+    assert_eq!(raw_epoch_snapshot(&checksum_v2_config), before);
+    assert_lock_released(&checksum_v2_config);
+    checksum_v2.cleanup();
+
     let future = ScratchDatabase::from_template(base, migrated_template, "epoch_future");
     let future_config = future.config(base);
     mutate(
         &future_config,
         "INSERT INTO babylon_state.schema_migration (version, checksum) \
-         VALUES (2, decode(repeat('22', 32), 'hex'))",
+         VALUES (3, decode(repeat('33', 32), 'hex'))",
     );
     let before = raw_epoch_snapshot(&future_config);
     assert_eq!(
         migrate_schema_epoch(&future_config),
         Err(SchemaEpochError::UnknownFutureVersion {
-            actual: 2,
-            latest_compiled: 1,
+            actual: 3,
+            latest_compiled: 2,
         })
     );
     assert_eq!(raw_epoch_snapshot(&future_config), before);
@@ -312,8 +373,28 @@ fn verify_authority_refusals(base: &Config, migrated_template: &str, owner: &str
             "epoch_extra_object",
             "CREATE TABLE babylon_ref.unexpected_epoch_object (id BIGINT)",
         ),
+        (
+            "epoch_hthree_owner",
+            "ALTER TABLE babylon_ref.h3_cell OWNER TO babylon_intel",
+        ),
+        (
+            "epoch_hthree_public",
+            "GRANT SELECT ON babylon_ref.h3_cell TO PUBLIC",
+        ),
+        (
+            "epoch_hthree_intel",
+            "GRANT SELECT ON babylon_ref.h3_cell TO babylon_intel",
+        ),
+        (
+            "epoch_hthree_column",
+            "GRANT SELECT (resolution) ON babylon_ref.h3_cell TO babylon_intel",
+        ),
+        (
+            "epoch_hthree_drift",
+            "ALTER TABLE babylon_ref.h3_cell DROP CONSTRAINT h3_cell_resolution_matches_id",
+        ),
     ];
-    for (label, mutation) in cases.iter().take(8) {
+    for (label, mutation) in cases.iter().take(13) {
         let database = ScratchDatabase::from_template(base, migrated_template, label);
         let config = database.config(base);
         mutate(&config, mutation);
@@ -336,8 +417,10 @@ fn verify_authority_refusals(base: &Config, migrated_template: &str, owner: &str
 fn assert_fresh_receipt(report: &babylon_persistence::SchemaEpochReport) {
     assert_eq!(report.origin, SchemaEpochOrigin::Fresh);
     assert_eq!(report.prior_applied, 0);
-    assert_eq!(report.final_applied, 1);
-    assert_eq!(report.applied_versions.len(), 1);
+    assert_eq!(report.final_applied, 2);
+    assert_eq!(report.applied_versions.len(), 2);
+    assert_eq!(report.applied_versions[0].as_i64(), 1);
+    assert_eq!(report.applied_versions[1].as_i64(), 2);
     assert!(report.reconciled_versions.is_empty());
     assert!(report.legacy_adoption.is_none());
 }
@@ -345,8 +428,8 @@ fn assert_fresh_receipt(report: &babylon_persistence::SchemaEpochReport) {
 fn assert_idempotent(config: &Config, expected_snapshot: &[(String, String, String)]) {
     let second = migrate_schema_epoch(config).unwrap();
     assert_eq!(second.origin, SchemaEpochOrigin::ExistingRustPrefix);
-    assert_eq!(second.prior_applied, 1);
-    assert_eq!(second.final_applied, 1);
+    assert_eq!(second.prior_applied, 2);
+    assert_eq!(second.final_applied, 2);
     assert!(second.applied_versions.is_empty());
     assert!(second.reconciled_versions.is_empty());
     assert_eq!(epoch_snapshot(config), expected_snapshot);
@@ -371,13 +454,25 @@ fn assert_epoch_authority(config: &Config) {
                     NOT EXISTS (SELECT 1 FROM schemas CROSS JOIN intel \
                       WHERE pg_catalog.has_schema_privilege(intel.oid, schemas.oid, 'USAGE') \
                          OR pg_catalog.has_schema_privilege(intel.oid, schemas.oid, 'CREATE')), \
+                    (SELECT pg_catalog.count(*) = 2 \
+                     FROM pg_catalog.pg_class AS relation \
+                     JOIN pg_catalog.pg_namespace AS namespace \
+                       ON namespace.oid = relation.relnamespace \
+                     WHERE (namespace.nspname, relation.relname) IN (\
+                       ('babylon_ref', 'h3_cell'), \
+                       ('babylon_state', 'schema_migration')) \
+                       AND relation.relkind = 'r' AND relation.relpersistence = 'p'), \
                     NOT EXISTS (SELECT 1 FROM intel \
                       WHERE pg_catalog.has_table_privilege( \
-                        intel.oid, 'babylon_state.schema_migration', 'SELECT,INSERT,UPDATE,DELETE'))",
+                        intel.oid, 'babylon_state.schema_migration', \
+                        'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER,MAINTAIN') \
+                         OR pg_catalog.has_table_privilege( \
+                        intel.oid, 'babylon_ref.h3_cell', \
+                        'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER,MAINTAIN'))",
             &[],
         )
         .unwrap();
-    for index in 0..4 {
+    for index in 0..5 {
         assert!(row.try_get::<_, bool>(index).unwrap());
     }
 }
@@ -424,11 +519,16 @@ fn marker_snapshot(config: &Config) -> Vec<(String, String)> {
 
 fn epoch_snapshot(config: &Config) -> Vec<(String, String, String)> {
     let snapshot = raw_epoch_snapshot(config);
-    assert_eq!(snapshot.len(), 4);
-    let checksum = compiled_schema_migrations().unwrap()[0].checksum();
-    assert!(snapshot.iter().any(|row| {
-        row.0 == "ledger" && row.1 == "1" && row.2 == lower_hex(checksum.as_bytes())
-    }));
+    assert_eq!(snapshot.len(), 5);
+    let compiled = compiled_schema_migrations().unwrap();
+    for (index, migration) in compiled.iter().enumerate().take(2) {
+        let version = (index + 1).to_string();
+        assert!(snapshot.iter().any(|row| {
+            row.0 == "ledger"
+                && row.1 == version
+                && row.2 == lower_hex(migration.checksum().as_bytes())
+        }));
+    }
     snapshot
 }
 


### PR DESCRIPTION
## Summary

- add exact-checksum schema epoch 2 with `babylon_ref.h3_cell` as positive `BIGINT` plus resolution, immediate-parent, and r4-r7 ancestor contracts
- preserve independent v1/v2 census, ownership, ACL, rollback, and prefix verification
- pin h3-pg/H3 4.5.0 as a disposable semantic oracle without production activation or correctness dependency
- cross-check 208 cells, invalid identities, every pentagon at resolutions 0-15, hierarchy metadata, negative CHECK/FK mutations, and `DROP EXTENSION h3 RESTRICT`

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p babylon-persistence --locked`
- `cargo clippy -p babylon-persistence --all-targets --locked -- -D warnings`
- `tools/run_rust_legacy_adopter_pg.sh`
- pre-commit and non-documentation/non-pytest pre-push policy hooks
- independent adversarial review: no remaining findings

## Governance

Linear: PER-61

Part of PER-21

Closes #720

## Commits

### feat

- **(persistence)** add canonical H3 schema epoch (`cf2daa14`)

## Provenance

- **Co-Authored-By:** `OpenAI Codex <codex@openai.com>`

---
*Generated from the repository-standard PR body and extended with verification evidence.*