### PR TITLE
docs(governance): record accepted Linear delivery flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,8 +12,8 @@ three gates. Do not say that a planned system is complete.
 <!-- vale ste.UnapprovedWords = NO -->
 <!-- vale ste.NounClusters = NO -->
 Linear is canonical for current work. GitHub owns source control, pull
-requests, reviews, and historical evidence. Project #7 and Project #8 in GitHub
-are transitional inputs. The migration is not complete. See
+requests, reviews, and historical evidence. The team closed GitHub Project #7
+and Project #8. They are historical inputs. The migration is complete. See
 [`docs/agents/governance.md`](../docs/agents/governance.md) for scope or status
 disputes.
 <!-- vale ste.NounClusters = YES -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,15 +135,16 @@ its ceremony, trailer, and `tools/generate_ceremony_message.py` record.
 <!-- vale ste.NounClusters = NO -->
 Linear alone owns current issue identity, scope, status, priority, dependencies,
 horizon, milestones, schedule, and work. GitHub owns source, PRs, reviews, and
-historical evidence. Project #7 and Project #8 are transitional inputs. Archive
-them only after full PER-15 acceptance. The migration is not complete.
+historical evidence. The team closed GitHub Project #7 and Project #8. They are
+historical inputs. The migration is complete, and PER-15 is complete. Neither board is live.
+
 `ai/state.yaml` is historical
 implementation evidence, and `project/` is non-live context.
 
 Create regular lanes from `dev` and target `dev`. Use `feature/`, `fix/`, `docs/`,
 `refactor/`, `test/`, or a `codex/PER-123-short-name` lane. Link the PER identity
-manually as `docs/agents/governance.md` directs. Never commit directly to
-`dev` or `main`.
+as `docs/agents/governance.md` directs: `Part of PER-N` for partial delivery and
+`Fixes PER-N` only for final acceptance. Never commit directly to `dev` or `main`.
 
 A critical hotfix alone can branch from and target `main`. Its merge is
 Director-only, and a backport PR to `dev` is mandatory.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -53,10 +53,10 @@ to `dev` or `main`.
 <!-- vale ste.UnapprovedWords = NO -->
 <!-- vale ste.NounClusters = NO -->
 Linear is canonical for current work. GitHub owns source control, pull
-requests, reviews, and historical evidence. Project #7 and Project #8 in GitHub
-are transitional inputs. The migration is not complete. See
+requests, reviews, and historical evidence. The team closed GitHub Project #7
+and Project #8. They are historical inputs. The migration is complete. See
 [`docs/agents/governance.md`](docs/agents/governance.md) for field ownership and
-the manual identity link and full PER-15 archive condition.
+the accepted PER delivery convention.
 <!-- vale ste.NounClusters = YES -->
 <!-- vale ste.UnapprovedWords = YES -->
 
@@ -71,8 +71,8 @@ Use one of these lane prefixes:
 <!-- vale ste.UnapprovedWords = NO -->
 - `codex/PER-123-short-name`
 
-Other lane names can also include their PER identity. This linkage remains a
-manual convention until PER-2 verifies automation.
+Other lane names can also include their PER identity. Use `Part of PER-N` for
+partial delivery and `Fixes PER-N` only for the final accepted delivery.
 <!-- vale ste.UnapprovedWords = YES -->
 
 Keep unrelated user changes unchanged. Report an unrelated fault unless the owner

--- a/docs/agents/governance.md
+++ b/docs/agents/governance.md
@@ -47,15 +47,21 @@ Linear alone is canonical for issue identity, scope, status, priority,
 dependencies, horizon, milestones, schedule, and current work. GitHub supplies
 source control, pull requests, reviews, and historical evidence.
 
-GitHub Project #7 and Project #8 are transitional migration inputs. The
-migration is not complete. Archive either project only after full PER-15
-acceptance. Full acceptance requires a Linear identity or redirect for each
-commitment that remains.
+The team closed GitHub Project #7 and Project #8. They are historical inputs.
+The migration is complete, and PER-15 is complete. Both projects remain
+recoverable evidence. Neither supplies current fields, views, estimates, or
+status.
 
-PER-2 tracks status automation. The team has not verified automation. Until
-then, use this manual convention: link the work to its PER identity in the
-branch name, pull request title, or pull request description. GitHub Project
-fields are not authoritative.
+PER-2 records the accepted delivery automation. Link each pull request to its
+PER identity in the branch name, title, or description. Use `Part of PER-N` as
+a non-closing reference for a partial delivery. Use `Fixes PER-N` as a closing
+reference only on the final delivery that satisfies the issue.
+
+A multi-pull-request issue must remain open after every partial merge. Draft
+and review activity keep the linked issue in progress. Only the merged closing
+reference completes it. The automation does not require GitHub Project fields.
+Imported historical issue sync cannot override canonical Linear project
+scope, hierarchy, horizon, milestone, or priority.
 <!-- vale ste.Dictionary = YES -->
 <!-- vale ste.NounClusters = YES -->
 <!-- vale ste.UnapprovedWords = YES -->

--- a/tests/unit/governance/test_constitution_v4.py
+++ b/tests/unit/governance/test_constitution_v4.py
@@ -425,7 +425,7 @@ def test_contributor_entry_points_route_work_tracking_to_linear(relative_path: s
     required = ("linear", "canonical", "github", "project #7", "project #8")
     missing = tuple(phrase for phrase in required if phrase not in text)
     assert missing == (), f"{relative_path} is missing {missing}"
-    assert "migration is not complete" in text or "migration remains in progress" in text
+    assert "migration is complete" in text
 
 
 def test_control_authority_states_the_linear_github_boundary() -> None:
@@ -450,8 +450,9 @@ def test_control_authority_states_the_linear_github_boundary() -> None:
         "historical evidence",
         "project #7",
         "project #8",
-        "transitional migration inputs",
-        "full per-15 acceptance",
+        "team closed github project #7 and project #8",
+        "historical inputs",
+        "per-15 is complete",
         "ai/state.yaml",
         "historical implementation evidence",
         "project/",
@@ -714,20 +715,21 @@ def test_copilot_restore_key_guidance_is_scoped_to_python_venv_caches() -> None:
     assert missing == (), f".github/copilot-instructions.md is missing {missing}"
 
 
-def test_control_authority_keeps_per_2_identity_linkage_manual() -> None:
-    """The guide does not promise unverified Linear status automation."""
+def test_control_authority_documents_per_2_delivery_automation() -> None:
+    """The guide distinguishes partial delivery from final issue completion."""
     text = " ".join(_repository_text(_CONTROL_AUTHORITY_PATH).lower().split())
     required = (
         "per-2",
-        "manual convention",
-        "branch name",
-        "pull request title",
-        "pull request description",
-        "team has not verified automation",
-        "github project fields are not authoritative",
+        "part of per-n",
+        "fixes per-n",
+        "non-closing",
+        "closing",
+        "multi-pull-request",
+        "automation does not require github project fields",
     )
     missing = tuple(phrase for phrase in required if phrase not in text)
     assert missing == (), f"{_CONTROL_AUTHORITY_PATH} is missing {missing}"
+    assert "team has not verified automation" not in text
 
 
 @pytest.mark.parametrize("relative_path", _LIVE_ORIENTATION_PATHS + _BEHAVIORAL_CONTRACT_PATHS)


### PR DESCRIPTION
## Summary

- record the completed Linear governance migration and closed GitHub boards
- define `Part of PER-N` for partial delivery and `Fixes PER-N` only for final acceptance
- replace the stale automation-unverified behavioral contract

Linear: PER-2

Fixes PER-2
Part of PER-15
Part of PER-5

## Verification

- `vale CLAUDE.md CONTRIBUTORS.md docs/agents/governance.md .github/copilot-instructions.md` — 0 findings
- targeted governance RED: 6 expected failures before guidance changes
- Constitution/governance contract file: 129 passed
- pre-push non-documentation safety hooks: green

The Rust umbrella/docs gate and unrelated Python engine pytest hook were intentionally not run.