### PR TITLE
test(persistence): instrument H3 atomicity proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
     # The subset is DECLARED in .mise.toml (test:integration-pg) — widen it
     # only with green evidence; narrowing it is a gate change.
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 61
     steps:
       - uses: actions/checkout@v7
 
@@ -275,7 +275,7 @@ jobs:
         run: mise run db:bootstrap
 
       - name: Rust legacy adopter (bounded disposable PG proof)
-        timeout-minutes: 30
+        timeout-minutes: 31
         run: mise run test:rust-legacy-adopter-pg
 
       - name: PG-backed integration subset (declared, data-drive-free)

--- a/rust/crates/babylon-persistence/src/h3_reference_installer.rs
+++ b/rust/crates/babylon-persistence/src/h3_reference_installer.rs
@@ -1,5 +1,10 @@
 //! Transactional installation of one exact representative H3 reference cohort.
 
+#[cfg(test)]
+use std::io::Write as _;
+#[cfg(test)]
+use std::time::Duration;
+
 use postgres::{Client, Config, GenericClient, IsolationLevel, NoTls, Row, Transaction};
 
 use crate::h3_reference_cohort::MAX_H3_REFERENCE_CLOSURE_ROWS;
@@ -758,6 +763,57 @@ fn validate_header(
     Ok(())
 }
 
+#[cfg(test)]
+fn membership_receipt_identity(
+    operation: H3ReferenceInstallOperation,
+) -> (&'static str, &'static str, Option<usize>) {
+    let (query, context) = match operation {
+        H3ReferenceInstallOperation::ReadMembershipCardinality { context } => {
+            ("cardinality", context)
+        }
+        H3ReferenceInstallOperation::ReadMembershipRows { context } => ("rows", context),
+        _ => unreachable!("membership receipts accept only membership-read operations"),
+    };
+    match context {
+        H3ReferenceMembershipReadContext::InitialInspection => (query, "initial", None),
+        H3ReferenceMembershipReadContext::CommitAttempt { attempt } => {
+            (query, "commit", Some(attempt))
+        }
+        H3ReferenceMembershipReadContext::AmbiguousCommitReconciliation { attempt } => {
+            (query, "reconcile", Some(attempt))
+        }
+    }
+}
+
+#[cfg(test)]
+fn emit_membership_read_receipt(
+    operation: H3ReferenceInstallOperation,
+    elapsed: Duration,
+    rows: Option<usize>,
+    error: Option<&postgres::Error>,
+) {
+    let (query, context, attempt) = membership_receipt_identity(operation);
+    let attempt = attempt.map_or_else(|| "none".to_owned(), |value| value.to_string());
+    let rows = rows.map_or_else(|| "none".to_owned(), |value| value.to_string());
+    let sqlstate = error
+        .and_then(postgres::Error::as_db_error)
+        .map_or("none", |server| server.code().code());
+    if error.is_some() {
+        eprintln!(
+            "PER267_MEMBERSHIP_READ query={query} context={context} attempt={attempt} completion=error elapsed_ms={} rows={rows} sqlstate={sqlstate}",
+            elapsed.as_millis()
+        );
+    } else {
+        eprintln!(
+            "PER267_MEMBERSHIP_READ query={query} context={context} attempt={attempt} completion=ok elapsed_ms={} rows={rows} sqlstate={sqlstate}",
+            elapsed.as_millis()
+        );
+    }
+    std::io::stderr()
+        .flush()
+        .expect("PER-267 diagnostic receipt must flush");
+}
+
 fn verify_membership<ClientType: GenericClient>(
     client: &mut ClientType,
     cohort: &H3ReferenceCohort,
@@ -813,12 +869,20 @@ fn verify_membership_cardinality<ClientType: GenericClient>(
         actual: expected,
         max: MAX_H3_REFERENCE_CLOSURE_ROWS,
     })?;
-    let row = client
-        .query_one(
-            READ_MEMBERSHIP_CARDINALITY_SQL,
-            &[&ref_digest.as_bytes().as_slice(), &query_limit],
-        )
-        .map_err(|error| server_database_error(operation, &error))?;
+    #[cfg(test)]
+    let query_started = std::time::Instant::now();
+    let query = client.query_one(
+        READ_MEMBERSHIP_CARDINALITY_SQL,
+        &[&ref_digest.as_bytes().as_slice(), &query_limit],
+    );
+    #[cfg(test)]
+    emit_membership_read_receipt(
+        operation,
+        query_started.elapsed(),
+        query.as_ref().ok().map(|_| 1),
+        query.as_ref().err(),
+    );
+    let row = query.map_err(|error| server_database_error(operation, &error))?;
     let actual: i64 = decode_value(&row, 0, operation)?;
     let actual =
         usize::try_from(actual).map_err(|_| H3ReferenceInstallError::Decode { operation })?;
@@ -855,12 +919,20 @@ fn read_membership_rows<ClientType: GenericClient>(
         max: MAX_H3_REFERENCE_CLOSURE_ROWS,
     })?;
     let ref_digest = cohort.receipt().ref_digest();
-    let rows = client
-        .query(
-            READ_MEMBERSHIP_SQL,
-            &[&ref_digest.as_bytes().as_slice(), &query_limit],
-        )
-        .map_err(|error| server_database_error(operation, &error))?;
+    #[cfg(test)]
+    let query_started = std::time::Instant::now();
+    let query = client.query(
+        READ_MEMBERSHIP_SQL,
+        &[&ref_digest.as_bytes().as_slice(), &query_limit],
+    );
+    #[cfg(test)]
+    emit_membership_read_receipt(
+        operation,
+        query_started.elapsed(),
+        query.as_ref().ok().map(Vec::len),
+        query.as_ref().err(),
+    );
+    let rows = query.map_err(|error| server_database_error(operation, &error))?;
     if rows.len() > expected {
         return Err(H3ReferenceInstallError::Bounds {
             resource: H3ReferenceInstallBoundedResource::MembershipRows,
@@ -1300,9 +1372,11 @@ fn conflict(component: H3ReferenceInstallConflict) -> H3ReferenceInstallError {
 
 #[cfg(test)]
 pub(crate) mod live_postgres_tests {
+    use std::io::Write as _;
     use std::mem::size_of;
+    use std::time::Instant;
 
-    use postgres::{Config, NoTls};
+    use postgres::{error::SqlState, Config, NoTls};
 
     use super::{
         attempt_install_transaction, conflict, install_representative_h3_cohort,
@@ -1338,9 +1412,52 @@ pub(crate) mod live_postgres_tests {
         0x13, 0xa9,
     ];
 
+    #[derive(Debug, Clone, Copy)]
+    enum H3AtomicityPhase {
+        ForcedRollback,
+        KilledRetry,
+        CommittedReconciliation,
+    }
+
+    impl H3AtomicityPhase {
+        const fn label(self) -> &'static str {
+            match self {
+                Self::ForcedRollback => "forced_rollback",
+                Self::KilledRetry => "killed_retry",
+                Self::CommittedReconciliation => "committed_reconciliation",
+            }
+        }
+    }
+
+    fn start_phase(phase: H3AtomicityPhase, suite_started: Instant) -> Instant {
+        eprintln!(
+            "PER267_H3_PHASE phase={} completion=started phase_ms=0 cumulative_ms={}",
+            phase.label(),
+            suite_started.elapsed().as_millis()
+        );
+        std::io::stderr()
+            .flush()
+            .expect("PER-267 phase receipt must flush");
+        Instant::now()
+    }
+
+    fn finish_phase(phase: H3AtomicityPhase, phase_started: Instant, suite_started: Instant) {
+        eprintln!(
+            "PER267_H3_PHASE phase={} completion=complete phase_ms={} cumulative_ms={}",
+            phase.label(),
+            phase_started.elapsed().as_millis(),
+            suite_started.elapsed().as_millis()
+        );
+        std::io::stderr()
+            .flush()
+            .expect("PER-267 phase receipt must flush");
+    }
+
     pub(crate) fn verify_rollback_and_killed_retry(config: &Config, admin: &Config) {
+        let suite_started = Instant::now();
         let cohort = representative_cohort();
         assert_eq!(reference_counts(config), (0, 0, 0));
+        let forced_rollback_started = start_phase(H3AtomicityPhase::ForcedRollback, suite_started);
         let mut forced_failure =
             |client: &mut postgres::Client, cohort: &H3ReferenceCohort, attempt: usize| {
                 let transaction = prepare_install_transaction(
@@ -1360,7 +1477,13 @@ pub(crate) mod live_postgres_tests {
             })
         ));
         assert_eq!(reference_counts(config), (0, 0, 0));
+        finish_phase(
+            H3AtomicityPhase::ForcedRollback,
+            forced_rollback_started,
+            suite_started,
+        );
 
+        let killed_retry_started = start_phase(H3AtomicityPhase::KilledRetry, suite_started);
         let mut first_attempt = true;
         let mut killed_attempt =
             |client: &mut postgres::Client, cohort: &H3ReferenceCohort, attempt: usize| {
@@ -1379,9 +1502,17 @@ pub(crate) mod live_postgres_tests {
         );
         assert_eq!(report.commit_attempts(), 2);
         assert_eq!(reference_counts(config), (59_849, 1, 59_849));
+        finish_phase(
+            H3AtomicityPhase::KilledRetry,
+            killed_retry_started,
+            suite_started,
+        );
+        verify_membership_lock_timeout_preserves_server_diagnostic(config, &cohort);
     }
 
     pub(crate) fn verify_committed_reconciliation(config: &Config, admin: &Config) {
+        let suite_started = Instant::now();
+        let phase_started = start_phase(H3AtomicityPhase::CommittedReconciliation, suite_started);
         let cohort = representative_cohort();
         let mut first_attempt = true;
         let mut ambiguous_attempt =
@@ -1406,6 +1537,56 @@ pub(crate) mod live_postgres_tests {
         );
         assert_eq!(report.commit_attempts(), 1);
         assert_eq!(reference_counts(config), (59_849, 1, 59_849));
+        finish_phase(
+            H3AtomicityPhase::CommittedReconciliation,
+            phase_started,
+            suite_started,
+        );
+    }
+
+    fn verify_membership_lock_timeout_preserves_server_diagnostic(
+        config: &Config,
+        cohort: &H3ReferenceCohort,
+    ) {
+        let before = reference_counts(config);
+        let bounded = super::installer_config(config);
+        let mut session = super::LockedInstallSession::connect(&bounded).unwrap();
+        super::require_exact_schema_epoch(session.client()).unwrap();
+        super::prepare_installer_session(session.client()).unwrap();
+        let context = H3ReferenceMembershipReadContext::InitialInspection;
+        super::verify_membership_cardinality(session.client(), cohort, context).unwrap();
+
+        let mut blocker = config.connect(NoTls).unwrap();
+        let mut blocker_transaction = blocker.transaction().unwrap();
+        blocker_transaction
+            .batch_execute("LOCK TABLE babylon_ref.h3_cell IN ACCESS EXCLUSIVE MODE")
+            .unwrap();
+        let operation = super::H3ReferenceInstallOperation::ReadMembershipRows { context };
+        let result = super::read_membership_rows(session.client(), cohort, operation);
+        blocker_transaction.rollback().unwrap();
+        session.finish(Ok(())).unwrap();
+
+        let error = result.expect_err("the membership read must honor the bounded lock timeout");
+        match error {
+            super::H3ReferenceInstallError::Database {
+                operation:
+                    super::H3ReferenceInstallOperation::ReadMembershipRows {
+                        context: H3ReferenceMembershipReadContext::InitialInspection,
+                    },
+                diagnostic,
+            } => {
+                let server = diagnostic
+                    .server()
+                    .expect("the membership query must retain its server diagnostic");
+                assert_eq!(server.code(), &SqlState::LOCK_NOT_AVAILABLE);
+                assert!(!server.message().is_empty());
+            }
+            other => panic!("unexpected membership lock-timeout error: {other:?}"),
+        }
+        assert_eq!(reference_counts(config), before);
+
+        let reacquired = super::LockedInstallSession::connect(&bounded).unwrap();
+        reacquired.finish(Ok(())).unwrap();
     }
 
     pub(crate) fn verify_membership_cardinality_bound(config: &Config) {

--- a/rust/crates/babylon-persistence/src/h3_reference_installer.rs
+++ b/rust/crates/babylon-persistence/src/h3_reference_installer.rs
@@ -1453,8 +1453,11 @@ pub(crate) mod live_postgres_tests {
             .expect("PER-267 phase receipt must flush");
     }
 
-    pub(crate) fn verify_rollback_and_killed_retry(config: &Config, admin: &Config) {
-        let suite_started = Instant::now();
+    pub(crate) fn verify_rollback_and_killed_retry(
+        config: &Config,
+        admin: &Config,
+        suite_started: Instant,
+    ) {
         let cohort = representative_cohort();
         assert_eq!(reference_counts(config), (0, 0, 0));
         let forced_rollback_started = start_phase(H3AtomicityPhase::ForcedRollback, suite_started);
@@ -1510,8 +1513,11 @@ pub(crate) mod live_postgres_tests {
         verify_membership_lock_timeout_preserves_server_diagnostic(config, &cohort);
     }
 
-    pub(crate) fn verify_committed_reconciliation(config: &Config, admin: &Config) {
-        let suite_started = Instant::now();
+    pub(crate) fn verify_committed_reconciliation(
+        config: &Config,
+        admin: &Config,
+        suite_started: Instant,
+    ) {
         let phase_started = start_phase(H3AtomicityPhase::CommittedReconciliation, suite_started);
         let cohort = representative_cohort();
         let mut first_attempt = true;

--- a/rust/crates/babylon-persistence/src/schema_epoch.rs
+++ b/rust/crates/babylon-persistence/src/schema_epoch.rs
@@ -1267,6 +1267,7 @@ mod pure_tests {
 #[cfg(test)]
 mod live_rollback_tests {
     use std::str::FromStr;
+    use std::time::Instant;
 
     use postgres::error::SqlState;
 
@@ -1320,6 +1321,7 @@ mod live_rollback_tests {
     }
 
     fn verify_h3_installer_commit_protocol(base: &Config) {
+        let suite_started = Instant::now();
         let rollback_retry = TestDatabase::create(base, "hrollback");
         let rollback_config = rollback_retry.config(base);
         assert_eq!(
@@ -1331,6 +1333,7 @@ mod live_rollback_tests {
         crate::h3_reference_installer::live_postgres_tests::verify_rollback_and_killed_retry(
             &rollback_config,
             base,
+            suite_started,
         );
         rollback_retry.cleanup();
 
@@ -1345,6 +1348,7 @@ mod live_rollback_tests {
         crate::h3_reference_installer::live_postgres_tests::verify_committed_reconciliation(
             &reconciliation_config,
             base,
+            suite_started,
         );
         reconciliation.cleanup();
     }

--- a/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
+++ b/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
@@ -2137,6 +2137,7 @@ fn unknown_live_focus_fails_before_any_docker_side_effect() {
 #[test]
 fn h3_atomicity_receipts_are_fixed_flushed_and_test_only() {
     let installer = include_str!("../src/h3_reference_installer.rs");
+    let schema_epoch = include_str!("../src/schema_epoch.rs");
 
     assert!(installer.contains("PER267_MEMBERSHIP_READ query="));
     assert!(installer.contains("completion=ok"));
@@ -2154,6 +2155,29 @@ fn h3_atomicity_receipts_are_fixed_flushed_and_test_only() {
         );
     }
     assert!(!installer.contains("static mut"));
+
+    let protocol = cte_slice(
+        schema_epoch,
+        "fn verify_h3_installer_commit_protocol(base: &Config)",
+        "fn verify_post_ddl_rollback(base: &Config)",
+    );
+    assert_eq!(protocol.matches("Instant::now()").count(), 1);
+    assert_eq!(protocol.matches("suite_started").count(), 3);
+    for phase in [
+        cte_slice(
+            installer,
+            "pub(crate) fn verify_rollback_and_killed_retry(",
+            "pub(crate) fn verify_committed_reconciliation(",
+        ),
+        cte_slice(
+            installer,
+            "pub(crate) fn verify_committed_reconciliation(",
+            "fn verify_membership_lock_timeout_preserves_server_diagnostic(",
+        ),
+    ] {
+        assert!(phase.contains("suite_started: Instant"));
+        assert!(!phase.contains("Instant::now()"));
+    }
 }
 
 #[test]

--- a/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
+++ b/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
@@ -2072,7 +2072,7 @@ fn live_adopter_test_is_wired_into_the_remote_pg_tier() {
         1
     );
     assert!(job.contains(
-        "- name: Rust legacy adopter (bounded disposable PG proof)\n        timeout-minutes: 30\n        run: mise run test:rust-legacy-adopter-pg"
+        "- name: Rust legacy adopter (bounded disposable PG proof)\n        timeout-minutes: 31\n        run: mise run test:rust-legacy-adopter-pg"
     ));
     assert!(!job.contains("BABYLON_LEGACY_ADOPTER_TEST_DSN"));
     assert!(!job.contains("cargo doc"));
@@ -2082,8 +2082,53 @@ fn live_adopter_test_is_wired_into_the_remote_pg_tier() {
 }
 
 #[test]
+fn h3_atomicity_focus_is_fixed_and_cannot_replace_default_pg_gate() {
+    let runner = include_str!("../../../../tools/run_rust_legacy_adopter_pg.sh");
+    let focused =
+        "schema_epoch::live_rollback_tests::h3_installer_rollback_and_ambiguous_commit_reconciliation_are_atomic";
+    let full =
+        "schema_epoch::live_rollback_tests::rollback_and_ambiguous_commit_reconciliation_are_atomic";
+
+    assert!(runner.contains("BABYLON_LEGACY_ADOPTER_LIVE_FOCUS:-}"));
+    assert_eq!(runner.matches(focused).count(), 1);
+    assert_eq!(runner.matches(full).count(), 1);
+    assert!(runner.contains("--ignored --exact --test-threads=1"));
+    assert!(!runner.contains("cargo test -p babylon-persistence --lib \"$"));
+
+    let broad = runner
+        .find("--test legacy_adopter_postgres")
+        .expect("default broad contract must remain");
+    let full_position = runner
+        .find(full)
+        .expect("default full contract must remain");
+    assert!(broad < full_position);
+}
+
+#[test]
+fn h3_atomicity_receipts_are_fixed_flushed_and_test_only() {
+    let installer = include_str!("../src/h3_reference_installer.rs");
+
+    assert!(installer.contains("PER267_MEMBERSHIP_READ query="));
+    assert!(installer.contains("completion=ok"));
+    assert!(installer.contains("completion=error"));
+    assert!(installer.contains("std::io::stderr()"));
+    assert!(installer.contains(".flush()"));
+    for phase in [
+        "forced_rollback",
+        "killed_retry",
+        "committed_reconciliation",
+    ] {
+        assert!(
+            installer.contains(phase),
+            "missing fixed phase receipt: {phase}"
+        );
+    }
+    assert!(!installer.contains("static mut"));
+}
+
+#[test]
 fn ci_adopter_step_exceeds_the_full_bounded_runner_envelope() {
-    const CONTROL_PLANE_ENVELOPE_SECONDS: u64 = 4 * (10 + 2);
+    const CONTROL_PLANE_ENVELOPE_SECONDS: u64 = 5 * (10 + 2);
     const BUILD_ENVELOPE_SECONDS: u64 = 180 + 10;
     const START_ENVELOPE_SECONDS: u64 = 30 + 5;
     const READINESS_ENVELOPE_SECONDS: u64 = 90 + 2;
@@ -2101,7 +2146,7 @@ fn ci_adopter_step_exceeds_the_full_bounded_runner_envelope() {
     let workflow = include_str!("../../../../.github/workflows/ci.yml");
     let job = yaml_job(workflow, "  pg-integration:");
     assert!(job.contains(
-        "- name: Rust legacy adopter (bounded disposable PG proof)\n        timeout-minutes: 30\n        run: mise run test:rust-legacy-adopter-pg"
+        "- name: Rust legacy adopter (bounded disposable PG proof)\n        timeout-minutes: 31\n        run: mise run test:rust-legacy-adopter-pg"
     ));
     let job_seconds = job
         .lines()
@@ -2124,8 +2169,8 @@ fn ci_adopter_step_exceeds_the_full_bounded_runner_envelope() {
         .parse::<u64>()
         .unwrap()
         * 60;
-    assert_eq!(job_seconds, 60 * 60);
-    assert_eq!(ci_step_seconds, 30 * 60);
+    assert_eq!(job_seconds, 61 * 60);
+    assert_eq!(ci_step_seconds, 31 * 60);
     assert!(ci_step_seconds >= RUNNER_ENVELOPE_SECONDS + 120);
     assert!(job_seconds >= ci_step_seconds + 30 * 60);
 
@@ -2142,8 +2187,8 @@ fn ci_adopter_step_exceeds_the_full_bounded_runner_envelope() {
     }
     let rollback_phase = cte_slice(
         runner,
-        "if [ \"$status\" -eq 0 ]; then",
-        "\nfi\n\ncleanup_checked",
+        "if [ \"$status\" -eq 0 ] && [ -z \"$LIVE_FOCUS\" ]; then",
+        "\n  fi\nfi",
     );
     let rollback_timeout = rollback_phase
         .find("timeout --signal=TERM --kill-after=10s 300s")
@@ -2184,7 +2229,22 @@ fn ci_adopter_step_exceeds_the_full_bounded_runner_envelope() {
             "unbounded Docker call: {line}"
         );
     }
-    assert_eq!(docker_calls, 10);
+    assert_eq!(docker_calls, 11);
+}
+
+#[test]
+fn failed_pg_contract_emits_bounded_server_log_before_checked_cleanup() {
+    let runner = include_str!("../../../../tools/run_rust_legacy_adopter_pg.sh");
+    let logs = runner
+        .find("docker logs --timestamps --tail 200 \"$CONTAINER\"")
+        .expect("failure path must retain bounded server evidence");
+    let cleanup = runner
+        .rfind("cleanup_checked")
+        .expect("cleanup must remain checked");
+
+    assert!(runner.contains("if [ \"$status\" -ne 0 ]; then"));
+    assert!(runner.contains("docker logs --timestamps --tail 200 \"$CONTAINER\" >&2 || true"));
+    assert!(logs < cleanup);
 }
 
 #[test]

--- a/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
+++ b/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
@@ -14,6 +14,7 @@ use postgres::Config;
 use std::fmt::Write as _;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
+use std::process::Command;
 
 const ZERO_DIGEST: &str = "0000000000000000000000000000000000000000000000000000000000000000";
 const MAX_MIGRATION_DIRECTORY_ENTRIES: usize = 64;
@@ -2102,6 +2103,35 @@ fn h3_atomicity_focus_is_fixed_and_cannot_replace_default_pg_gate() {
         .find(full)
         .expect("default full contract must remain");
     assert!(broad < full_position);
+}
+
+#[test]
+fn unknown_live_focus_fails_before_any_docker_side_effect() {
+    let runner = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../tools/run_rust_legacy_adopter_pg.sh");
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let tool_directory = std::env::temp_dir().join(format!("babylon-per267-{unique}"));
+    std::fs::create_dir(&tool_directory).unwrap();
+    for tool in ["dirname", "od", "tr"] {
+        std::os::unix::fs::symlink(format!("/usr/bin/{tool}"), tool_directory.join(tool)).unwrap();
+    }
+    let output = Command::new("/usr/bin/bash")
+        .arg(runner)
+        .env("BABYLON_LEGACY_ADOPTER_LIVE_FOCUS", "unknown")
+        .env("PATH", &tool_directory)
+        .output()
+        .unwrap();
+    std::fs::remove_dir_all(tool_directory).unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).unwrap(),
+        "run_rust_legacy_adopter_pg: unsupported live focus: unknown\n"
+    );
+    assert!(output.stdout.is_empty());
 }
 
 #[test]

--- a/tools/run_rust_legacy_adopter_pg.sh
+++ b/tools/run_rust_legacy_adopter_pg.sh
@@ -8,6 +8,7 @@ readonly IMAGE="babylon-per20-legacy-adopter:local"
 # Internal handshake for the ignored Rust test. This runner forwards it only
 # after it proves exact ownership of the random-canary container below.
 readonly TEST_HARNESS_ACK="I_UNDERSTAND_PER20_DROPS_SCRATCH_DATABASES_ROLES_AND_CREATED_BABYLON_INTEL"
+readonly LIVE_FOCUS="${BABYLON_LEGACY_ADOPTER_LIVE_FOCUS:-}"
 CANARY="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
 readonly CANARY
 readonly CONTAINER="babylon-per20-adopter-${CANARY:0:12}"
@@ -179,17 +180,27 @@ printf 'PER-20 runtime ready: container=%s volume=%s port=%s\n' \
   "$CONTAINER" "$VOLUME" "$PORT"
 cd "$REPO_ROOT/rust"
 status=0
-timeout --signal=TERM --kill-after=10s 900s \
-  env \
-    BABYLON_LEGACY_ADOPTER_TEST_DSN="postgresql://test:test@127.0.0.1:$PORT/postgres" \
-    BABYLON_LEGACY_ADOPTER_DISPOSABLE_ACK="$TEST_HARNESS_ACK" \
-    BABYLON_LEGACY_ADOPTER_DISPOSABLE_CANARY="$CANARY" \
-    CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/rust/target}" \
-  cargo test -p babylon-persistence --test legacy_adopter_postgres --locked -- --nocapture \
-    --ignored --test-threads=1 || status=$?
+if [ "$LIVE_FOCUS" = "h3_atomicity" ]; then
+  timeout --signal=TERM --kill-after=10s 300s \
+    env \
+      BABYLON_LEGACY_ADOPTER_TEST_DSN="postgresql://test:test@127.0.0.1:$PORT/postgres" \
+      BABYLON_LEGACY_ADOPTER_DISPOSABLE_ACK="$TEST_HARNESS_ACK" \
+      BABYLON_LEGACY_ADOPTER_DISPOSABLE_CANARY="$CANARY" \
+      CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/rust/target}" \
+    cargo test -p babylon-persistence --lib \
+      schema_epoch::live_rollback_tests::h3_installer_rollback_and_ambiguous_commit_reconciliation_are_atomic \
+      --locked -- --nocapture --ignored --exact --test-threads=1 || status=$?
+else
+  timeout --signal=TERM --kill-after=10s 900s \
+    env \
+      BABYLON_LEGACY_ADOPTER_TEST_DSN="postgresql://test:test@127.0.0.1:$PORT/postgres" \
+      BABYLON_LEGACY_ADOPTER_DISPOSABLE_ACK="$TEST_HARNESS_ACK" \
+      BABYLON_LEGACY_ADOPTER_DISPOSABLE_CANARY="$CANARY" \
+      CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/rust/target}" \
+    cargo test -p babylon-persistence --test legacy_adopter_postgres --locked -- --nocapture \
+      --ignored --test-threads=1 || status=$?
 
-if [ "$status" -eq 0 ]; then
-  if [ -z "${BABYLON_LEGACY_ADOPTER_LIVE_FOCUS:-}" ]; then
+  if [ "$status" -eq 0 ] && [ -z "$LIVE_FOCUS" ]; then
     timeout --signal=TERM --kill-after=10s 300s \
       env \
         BABYLON_LEGACY_ADOPTER_TEST_DSN="postgresql://test:test@127.0.0.1:$PORT/postgres" \
@@ -200,6 +211,11 @@ if [ "$status" -eq 0 ]; then
         schema_epoch::live_rollback_tests::rollback_and_ambiguous_commit_reconciliation_are_atomic \
         --locked -- --nocapture --ignored --exact --test-threads=1 || status=$?
   fi
+fi
+
+if [ "$status" -ne 0 ]; then
+  timeout --signal=TERM --kill-after=2s 10s \
+    docker logs --timestamps --tail 200 "$CONTAINER" >&2 || true
 fi
 
 cleanup_checked

--- a/tools/run_rust_legacy_adopter_pg.sh
+++ b/tools/run_rust_legacy_adopter_pg.sh
@@ -20,6 +20,11 @@ die() {
   exit 2
 }
 
+case "$LIVE_FOCUS" in
+  "" | h3_atomicity) ;;
+  *) die "unsupported live focus: $LIVE_FOCUS" ;;
+esac
+
 require_container_absent() {
   local context="$1"
   local inspect_status


### PR DESCRIPTION
## Summary

- add a fixed H3-only live selector without weakening the default PostgreSQL gate
- emit flushed, test-only phase and membership-query receipts with elapsed time and SQLSTATE
- prove a deterministic AccessExclusive lock yields the preserved 55P03 diagnostic while counts and advisory-lock cleanup remain intact
- retain bounded PostgreSQL server logs on failure and checked cleanup

No production SQL, timeout, retry policy, or database setting changes.

Part of PER-267

## Verification

- `bash -n tools/run_rust_legacy_adopter_pg.sh`
- pre-commit: check-yaml, yamllint, actionlint, shellcheck
- `cargo fmt --all -- --check`
- `cargo test -p babylon-persistence --test legacy_adopter_contract --locked` (71 passed)
- `cargo test -p babylon-persistence --test h3_reference_installer_contract --locked` (6 passed)
- `cargo test -p babylon-persistence --lib h3_reference_installer::tests --locked` (8 passed)
- `cargo clippy -p babylon-persistence --all-targets --locked -- -D warnings`
- focused live PostgreSQL proof: 3 consecutive fresh runtimes, all green (about 59-61s each)
- default live PostgreSQL gate: broad adopter matrix green in 645.39s; rollback/reconciliation proof green in 275.63s; disposable runtime cleanup verified
