### PR TITLE
fix(ci): bound hosted runner provisioning

### DIFF
--- a/.github/actions/bootstrap-python/action.yml
+++ b/.github/actions/bootstrap-python/action.yml
@@ -61,4 +61,6 @@ runs:
     - name: Install GeoDjango system libraries
       if: inputs.gdal == 'true'
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends binutils libproj-dev gdal-bin
+      run: >-
+        "$GITHUB_ACTION_PATH/../../../tools/install_ci_apt_packages.sh"
+        binutils libproj-dev gdal-bin

--- a/.github/actions/postgres-up/action.yml
+++ b/.github/actions/postgres-up/action.yml
@@ -16,9 +16,13 @@ runs:
 
     - name: Build babylon-pg (GHA layer cache)
       uses: docker/bake-action@v7
+      env:
+        BABYLON_PG_DATA: babylon-pg-ci
       with:
         source: .
-        files: docker-compose.yml
+        files: |
+          docker-compose.yml
+          docker-compose.ci.yml
         targets: babylon-pg
         load: true
         set: |
@@ -27,4 +31,4 @@ runs:
 
     - name: Start Postgres (compose, port 5433)
       shell: bash
-      run: docker compose up -d --wait babylon-pg
+      run: tools/ci_postgres_compose.sh up

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,9 @@ jobs:
       # the four packages Bevy's own Linux CI installs; compile-time only, no
       # display server needed (tests run headless).
       - name: Install Bevy system dependencies (compile-time headers)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+        run: >-
+          tools/install_ci_apt_packages.sh
+          libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
 
       - name: Set up tools with mise
         uses: jdx/mise-action@v4
@@ -132,9 +131,11 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             rust/target
-          key: cargo-gate-${{ runner.os }}-v1-${{ hashFiles('rust/Cargo.lock') }}
+          key: >-
+            cargo-gate-${{ runner.os }}-v2-${{
+            hashFiles('rust/Cargo.lock', 'rust/rust-toolchain.toml') }}
           restore-keys: |
-            cargo-gate-${{ runner.os }}-v1-
+            cargo-gate-${{ runner.os }}-v2-
 
       - name: Rust full gate (CI parity with local rust:check)
         run: mise run rust:check
@@ -257,19 +258,20 @@ jobs:
         with:
           path: |
             ~/.cargo/registry
+            ~/.cargo/git
             rust/target
-          key: legacy-adopter-${{ runner.os }}-v1-${{ hashFiles('rust/Cargo.lock') }}
+          key: >-
+            legacy-adopter-${{ runner.os }}-v2-${{
+            hashFiles('rust/Cargo.lock', 'rust/rust-toolchain.toml') }}
           restore-keys: |
-            legacy-adopter-${{ runner.os }}-v1-
+            legacy-adopter-${{ runner.os }}-v2-
 
       - name: Build + start the isolated Postgres (CI fork; pinned runtime/package contract)
-        # BABYLON_PG_DATA as a bare name = a NAMED VOLUME (the base file's
-        # own convention) — inherently fresh on an ephemeral runner, so
-        # every job initdb's clean. See docker-compose.ci.yml for why this
+        # The shared wrapper selects BABYLON_PG_DATA=babylon-pg-ci. That bare
+        # name is a NAMED VOLUME (the base file's own convention), inherently
+        # fresh on an ephemeral runner. See docker-compose.ci.yml for why this
         # replaced the tmpfs override.
-        env:
-          BABYLON_PG_DATA: babylon-pg-ci
-        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --build --wait babylon-pg
+        uses: ./.github/actions/postgres-up
 
       - name: Bootstrap the canonical schema (digest-stamped, idempotent)
         run: mise run db:bootstrap
@@ -280,6 +282,10 @@ jobs:
 
       - name: PG-backed integration subset (declared, data-drive-free)
         run: mise run test:integration-pg
+
+      - name: Stop Postgres
+        if: always()
+        run: tools/ci_postgres_compose.sh down
 
   security:
     # Blocking since 2026-07-11: item 41 closed the CVE wave (73 -> 5, the

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,7 +210,7 @@ jobs:
           -o addopts="" -vv -ra -l --tb=long --durations=0
       - name: Stop Postgres
         if: always()
-        run: docker compose down -v
+        run: tools/ci_postgres_compose.sh down
 
   # The Postgres-backed strict determinism bundle (spec-064): headless 5-tick
   # tri-county run compared like-for-like against the committed baseline.
@@ -243,7 +243,7 @@ jobs:
         run: mise run qa:storage-budget
       - name: Stop Postgres
         if: always()
-        run: docker compose down -v
+        run: tools/ci_postgres_compose.sh down
 
   # The requires_reference_db suites run here against the ci-data-v1 subset
   # artifact (item 40) — tests/unit's marked files are excluded from the

--- a/.github/workflows/nightly-michigan-smoke.yml
+++ b/.github/workflows/nightly-michigan-smoke.yml
@@ -43,4 +43,4 @@ jobs:
         run: mise run qa:michigan-rollover-smoke
       - name: Stop Postgres
         if: always()
-        run: docker compose down -v
+        run: tools/ci_postgres_compose.sh down

--- a/.github/workflows/weekly-pg-integration.yml
+++ b/.github/workflows/weekly-pg-integration.yml
@@ -45,4 +45,4 @@ jobs:
         run: mise run qa:tick-budget
       - name: Stop Postgres
         if: always()
-        run: docker compose down -v
+        run: tools/ci_postgres_compose.sh down

--- a/.github/workflows/weekly-py313.yml
+++ b/.github/workflows/weekly-py313.yml
@@ -30,7 +30,9 @@ jobs:
       - name: Install dependencies on 3.13
         run: uv sync --frozen --extra server --python 3.13
       - name: Install GeoDjango system libraries
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends binutils libproj-dev gdal-bin
+        run: >-
+          tools/install_ci_apt_packages.sh
+          binutils libproj-dev gdal-bin
       # Max verbosity by owner ruling (2026-07-11): CI logs are agent-read.
       - name: Full suite on 3.13
         run: >-

--- a/.github/workflows/weekly-sim-artifacts.yml
+++ b/.github/workflows/weekly-sim-artifacts.yml
@@ -44,8 +44,9 @@ jobs:
         run: mise run sim:sweep
       - name: Stop Postgres
         if: always()
-        run: docker compose down -v
+        run: tools/ci_postgres_compose.sh down
       - name: Upload results
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: sim-analysis-${{ github.run_id }}

--- a/.mise.toml
+++ b/.mise.toml
@@ -394,7 +394,7 @@ uv run coverage report --include='src/babylon/engine/systems/*' --fail-under=80
 """
 
 [tasks."test:rest-ci"]
-description = "CI heavy shard (program 15): everything outside tests/unit except the web-Postgres suites (their own job), PLUS slow-marked tests/unit tests (test:unit-ci excludes slow — without this second leg they would run nowhere in CI); max-verbosity output; includes slow; excludes red_phase/requires_reference_db/pacing_gate (G1's 520-tick gate is nightly-only via qa:pacing, never this shard)"
+description = "CI heavy shard (program 15): everything outside tests/unit except the web-Postgres suites (their own job), PLUS slow-marked tests/unit tests (test:unit-ci excludes slow — without this second leg they would run nowhere in CI); max-verbosity output; includes slow; excludes red_phase/requires_reference_db/pacing_gate (the frozen Python 520-tick gate stays unscheduled until the PER-268 Rust successor exists)"
 # NO coverage on this shard (program 15, 2026-07-11): pytest-cov under
 # `-n 4` xdist instruments all of src/babylon in every worker, and stacked on
 # the memory-heavy integration/property suites it OOM-killed a worker on the
@@ -1286,7 +1286,7 @@ uv run python -m babylon.engine.headless_runner \
 """
 
 [tasks."qa:pacing"]
-description = "G1 standing gate: 520-tick (10yr) nationwide null-play pacing probe survival contract (spec-116 gate 1 / ADR079, owner ruling 2026-07-19). Multi-minute, single-flight — nightly-only, never mise run check/test:unit/test:rest-ci."
+description = "Frozen G1 reference: 520-tick (10yr) nationwide null-play pacing probe survival contract (spec-116 gate 1 / ADR079, owner ruling 2026-07-19). Manual-only through mise run qa:pacing; remains unscheduled until the PER-268 Rust successor exists; never part of mise run check/test:unit/test:rest-ci."
 run = """
 mkdir -p reports/test-results/pacing
 uv run pytest tests/integration/engine/test_pacing_gate_g1.py \

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,11 +1,10 @@
 # CI override for the isolated Postgres (ADR176 ruling 33: the CI config
 # fork + the PG-tier un-gate). Compose merge:
 #
-#   BABYLON_PG_DATA=babylon-pg-ci docker compose \
-#     -f docker-compose.yml -f docker-compose.ci.yml up -d --build --wait
+#   tools/ci_postgres_compose.sh up
 #
 # Differences from the dev shape, each deliberate:
-#   - BABYLON_PG_DATA=babylon-pg-ci (set by the CI job, not this file): a
+#   - BABYLON_PG_DATA=babylon-pg-ci (set by the shared CI wrapper): a
 #     bare name is a NAMED VOLUME per the base file's own convention —
 #     inherently fresh per job on an ephemeral runner, guaranteeing a clean
 #     initdb (no schema-stamp archaeology, no version-migration hazard).
@@ -28,6 +27,6 @@ services:
       - ./docker/postgres/postgresql.ci.conf:/etc/postgresql/postgresql.conf:ro
 
 volumes:
-  # Declared for the CI job's BABYLON_PG_DATA=babylon-pg-ci (top-level
+  # Declared for the CI wrapper's BABYLON_PG_DATA=babylon-pg-ci (top-level
   # volume sections merge by key; the base file only declares the dev name).
   babylon-pg-ci:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,7 @@ markers = [
     "cross_scale: marks tests for spec 062 cross-scale integration",
     "contract: Contract tests pinning cross-boundary interfaces (tests/contract/)",
     "requires_reference_db: Tests needing the reference SQLite DB (data/sqlite/marxist-data-3NF.sqlite) — excluded on the dev CI tier; main/nightly include them via the CI subset artifact (item 40)",
-    "pacing_gate: G1 standing 520-tick nationwide null-play pacing gate (spec-116 gate 1 / ADR079) — multi-minute, single-flight; runs ONLY via `mise run qa:pacing` / nightly, never in mise run check, test:unit, test:rest-ci, or py313-forward-compat",
+    "pacing_gate: frozen G1 520-tick nationwide null-play pacing reference (spec-116 gate 1 / ADR079) — manual-only via `mise run qa:pacing`; remains unscheduled until the PER-268 Rust successor exists; never in mise run check, test:unit, test:rest-ci, or py313-forward-compat",
     "requires_ollama: needs a live local Ollama daemon + chat model (multi-minute, probabilistic) — excluded from every fast gate; runs via `mise run test:ai`. The bare `ai` marker stays taxonomy-only (2026-07-16 re-tier: mock-based ai-suite tests DO run in fast gates)",
 ]
 # Enforce marker/config strictness via ini options: the --strict-markers /

--- a/tests/integration/engine/test_pacing_gate_g1.py
+++ b/tests/integration/engine/test_pacing_gate_g1.py
@@ -56,10 +56,10 @@ graph. This is why the gate:
   automatic sweep that would otherwise catch it by directory alone —
   ``mise run check`` / ``test:unit`` (different directory, unaffected),
   ``mise run test:rest-ci`` (marker-excluded: ``-m '... and not
-  pacing_gate'``), and the nightly ``py313-forward-compat`` leg
-  (same marker exclusion) — and is invoked ONLY via the dedicated
-  ``mise run qa:pacing`` task, wired into its own workflow
-  ``.github/workflows/nightly-pacing.yml`` (per-leg split, ADR181 R3);
+  pacing_gate'``), and the weekly ``py313-forward-compat`` leg
+  (same marker exclusion) — and can be invoked manually through the dedicated
+  ``mise run qa:pacing`` task. It has no scheduled Python workflow: PER-268
+  owns the Rust successor and forbids restoring this frozen engine run early;
 - is never part of the PR-blocking ``ci.yml`` path (that workflow only
   invokes ``test:unit-ci`` and ``qa:regression``, neither of which touches
   this file or directory).

--- a/tests/unit/tools/test_ci_host_contract.py
+++ b/tests/unit/tools/test_ci_host_contract.py
@@ -1,0 +1,289 @@
+"""Behavior contracts for bounded hosted-runner provisioning."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.unit.test_workflow_hygiene import (
+    _automation_paths,
+    _automation_step_locations,
+    _workflow_paths,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+APT_INSTALLER = REPO_ROOT / "tools" / "install_ci_apt_packages.sh"
+POSTGRES_COMPOSE = REPO_ROOT / "tools" / "ci_postgres_compose.sh"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+ACTIONS_DIR = REPO_ROOT / ".github" / "actions"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    """Write one executable test double."""
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+def _run_apt_installer(
+    tmp_path: Path,
+    failures_before_success: int,
+    *,
+    retry_delay_seconds: str = "0",
+    sudo_delay_seconds: str = "0",
+    timeout_seconds: str = "5",
+) -> subprocess.CompletedProcess[str]:
+    """Run the apt helper with a deterministic sudo/apt-get test double."""
+    if not APT_INSTALLER.is_file():
+        pytest.fail(f"missing bounded apt installer: {APT_INSTALLER}")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    call_log = tmp_path / "apt-calls.log"
+    _write_executable(
+        fake_bin / "sudo",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_APT_LOG"
+sleep "$FAKE_APT_DELAY_SECONDS"
+call_count="$(wc -l < "$FAKE_APT_LOG")"
+if (( call_count <= FAKE_APT_FAILURES_BEFORE_SUCCESS )); then
+  exit 42
+fi
+""",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "BABYLON_CI_APT_RETRY_DELAY_SECONDS": retry_delay_seconds,
+            "BABYLON_CI_APT_TIMEOUT_SECONDS": timeout_seconds,
+            "FAKE_APT_DELAY_SECONDS": sudo_delay_seconds,
+            "FAKE_APT_FAILURES_BEFORE_SUCCESS": str(failures_before_success),
+            "FAKE_APT_LOG": str(call_log),
+            "PATH": f"{fake_bin}:{env['PATH']}",
+        }
+    )
+    return subprocess.run(  # noqa: S603
+        [str(APT_INSTALLER), "binutils", "gdal-bin"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )
+
+
+def _apt_calls(tmp_path: Path) -> list[str]:
+    """Read calls captured by the apt test double."""
+    return (tmp_path / "apt-calls.log").read_text().splitlines()
+
+
+def test_bounded_apt_succeeds_without_retry(tmp_path: Path) -> None:
+    """A healthy mirror performs one update and one install."""
+    result = _run_apt_installer(tmp_path, failures_before_success=0)
+
+    assert result.returncode == 0, result.stderr
+    assert _apt_calls(tmp_path) == [
+        "-n env DEBIAN_FRONTEND=noninteractive apt-get update",
+        "-n env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "
+        "binutils gdal-bin",
+    ]
+
+
+def test_bounded_apt_recovers_from_one_transient_failure(tmp_path: Path) -> None:
+    """A transient update failure retries the complete apt transaction."""
+    result = _run_apt_installer(tmp_path, failures_before_success=1)
+
+    assert result.returncode == 0, result.stderr
+    assert len(_apt_calls(tmp_path)) == 3
+    assert "attempt 1 of 3 failed" in result.stderr
+
+
+def test_bounded_apt_stops_after_three_failed_attempts(tmp_path: Path) -> None:
+    """A dead mirror cannot consume the whole job timeout."""
+    result = _run_apt_installer(tmp_path, failures_before_success=99)
+
+    assert result.returncode != 0
+    assert len(_apt_calls(tmp_path)) == 3
+    assert "failed after 3 attempts" in result.stderr
+
+
+def test_bounded_apt_times_out_the_complete_transaction(tmp_path: Path) -> None:
+    """Update plus install share one per-attempt deadline."""
+    result = _run_apt_installer(
+        tmp_path,
+        failures_before_success=0,
+        sudo_delay_seconds="0.75",
+        timeout_seconds="1",
+    )
+
+    assert result.returncode != 0
+    assert len(_apt_calls(tmp_path)) == 6
+    assert "exit 124" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("timeout_seconds", "retry_delay_seconds", "message"),
+    [
+        ("301", "0", "APT_TIMEOUT_SECONDS cannot exceed 300"),
+        ("5", "31", "APT_RETRY_DELAY_SECONDS cannot exceed 30"),
+        ("00", "0", "APT_TIMEOUT_SECONDS must be a canonical positive integer"),
+        ("0400", "0", "APT_TIMEOUT_SECONDS must be a canonical positive integer"),
+        ("5", "00", "APT_RETRY_DELAY_SECONDS must be a canonical nonnegative integer"),
+        ("5", "031", "APT_RETRY_DELAY_SECONDS must be a canonical nonnegative integer"),
+        ("18446744073709551615", "0", "APT_TIMEOUT_SECONDS cannot exceed 300"),
+        ("5", "18446744073709551615", "APT_RETRY_DELAY_SECONDS cannot exceed 30"),
+    ],
+)
+def test_bounded_apt_rejects_unbounded_configuration(
+    tmp_path: Path,
+    timeout_seconds: str,
+    retry_delay_seconds: str,
+    message: str,
+) -> None:
+    """Environment overrides cannot defeat the fixed wall-time ceiling."""
+    result = _run_apt_installer(
+        tmp_path,
+        failures_before_success=0,
+        retry_delay_seconds=retry_delay_seconds,
+        timeout_seconds=timeout_seconds,
+    )
+
+    assert result.returncode == 2
+    assert message in result.stderr
+    assert not (tmp_path / "apt-calls.log").exists()
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        (
+            "up",
+            "babylon-pg-ci|compose -f docker-compose.yml -f docker-compose.ci.yml "
+            "up -d --wait babylon-pg",
+        ),
+        (
+            "down",
+            "babylon-pg-ci|compose -f docker-compose.yml -f docker-compose.ci.yml down -v",
+        ),
+    ],
+)
+def test_ci_postgres_wrapper_uses_one_runner_contract(
+    tmp_path: Path, command: str, expected: str
+) -> None:
+    """Start and cleanup use the same override and isolated named volume."""
+    if not POSTGRES_COMPOSE.is_file():
+        pytest.fail(f"missing CI Postgres wrapper: {POSTGRES_COMPOSE}")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    call_log = tmp_path / "docker-calls.log"
+    _write_executable(
+        fake_bin / "docker",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s|%s\\n' "$BABYLON_PG_DATA" "$*" > "$FAKE_DOCKER_LOG"
+""",
+    )
+    env = os.environ.copy()
+    env.update({"FAKE_DOCKER_LOG": str(call_log), "PATH": f"{fake_bin}:{env['PATH']}"})
+
+    result = subprocess.run(  # noqa: S603
+        [str(POSTGRES_COMPOSE), command],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert call_log.read_text().strip() == expected
+
+
+def test_automation_routes_apt_through_the_bounded_helper() -> None:
+    """No hosted runner can bypass the finite apt retry/timeout policy."""
+    violations = [
+        str(path)
+        for path in _automation_paths()
+        for _, step in _automation_step_locations(yaml.safe_load(path.read_text()))
+        if "apt-get" in str(step.get("run", ""))
+    ]
+    assert violations == []
+
+
+def test_every_postgres_action_caller_uses_checked_cleanup() -> None:
+    """Every hosted PostgreSQL job starts and stops the shared CI shape."""
+    violations: list[str] = []
+    for path in _workflow_paths():
+        workflow = yaml.safe_load(path.read_text())
+        for job_name, job in (workflow.get("jobs") or {}).items():
+            steps = job.get("steps") or []
+            uses_postgres = any(
+                step.get("uses") == "./.github/actions/postgres-up" for step in steps
+            )
+            runs_compose_directly = any(
+                "docker compose" in str(step.get("run", "")) for step in steps
+            )
+            cleanup = [
+                step for step in steps if step.get("run") == "tools/ci_postgres_compose.sh down"
+            ]
+            if runs_compose_directly:
+                violations.append(f"{path.name}:{job_name}: direct docker compose")
+            if uses_postgres and not (
+                len(cleanup) == 1 and str(cleanup[0].get("if", "")) == "always()"
+            ):
+                violations.append(f"{path.name}:{job_name}: missing checked cleanup")
+    assert violations == []
+
+
+def test_postgres_action_builds_the_ci_override_with_buildkit_cache() -> None:
+    """The shared image build and runtime consume the same Compose fork."""
+    action = (ACTIONS_DIR / "postgres-up" / "action.yml").read_text()
+    ci_compose = yaml.safe_load((REPO_ROOT / "docker-compose.ci.yml").read_text())
+
+    assert "docker-compose.yml" in action
+    assert "docker-compose.ci.yml" in action
+    assert "cache-from=type=gha,scope=babylon-pg" in action
+    assert "cache-to=type=gha,scope=babylon-pg,mode=max" in action
+    assert "tools/ci_postgres_compose.sh up" in action
+    assert ci_compose["services"]["babylon-pg"]["restart"] == "no"
+
+
+def test_ci_cargo_caches_track_git_sources_and_toolchain() -> None:
+    """Pinned Git sources and compiler changes invalidate the right caches."""
+    workflow = (WORKFLOWS_DIR / "ci.yml").read_text()
+
+    assert workflow.count("~/.cargo/git") >= 2
+    assert workflow.count("hashFiles('rust/Cargo.lock', 'rust/rust-toolchain.toml')") >= 2
+
+
+def test_scheduled_failure_artifacts_and_pacing_ownership_are_truthful() -> None:
+    """Slow evidence survives failure and no deleted Python nightly is claimed."""
+    weekly_sim = yaml.safe_load((WORKFLOWS_DIR / "weekly-sim-artifacts.yml").read_text())
+    upload = next(
+        step
+        for step in weekly_sim["jobs"]["sim-artifacts"]["steps"]
+        if str(step.get("uses", "")).startswith("actions/upload-artifact@")
+    )
+    pacing_text = (REPO_ROOT / "tests/integration/engine/test_pacing_gate_g1.py").read_text()
+    mise_text = (REPO_ROOT / ".mise.toml").read_text()
+    pyproject_text = (REPO_ROOT / "pyproject.toml").read_text()
+    pacing_task = tomllib.loads(mise_text)["tasks"]["qa:pacing"]["description"]
+    pacing_marker = next(
+        marker
+        for marker in tomllib.loads(pyproject_text)["tool"]["pytest"]["ini_options"]["markers"]
+        if marker.startswith("pacing_gate:")
+    )
+
+    assert str(upload.get("if", "")) == "always()"
+    assert "nightly-pacing.yml" not in pacing_text
+    assert "nightly-pacing.yml" not in mise_text
+    assert "nightly" not in pacing_task
+    assert "nightly" not in pacing_marker
+    assert "PER-268" in pacing_text
+    assert "PER-268" in pacing_task
+    assert "PER-268" in pacing_marker

--- a/tools/ci_postgres_compose.sh
+++ b/tools/ci_postgres_compose.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Apply one runner-sized PostgreSQL Compose contract to start and cleanup.
+
+set -euo pipefail
+
+readonly -a COMPOSE_ARGS=(
+  -f docker-compose.yml
+  -f docker-compose.ci.yml
+)
+export BABYLON_PG_DATA=babylon-pg-ci
+
+if (( $# != 1 )); then
+  echo "usage: ci_postgres_compose.sh {up|down|config}" >&2
+  exit 2
+fi
+
+case "$1" in
+  up)
+    exec docker compose "${COMPOSE_ARGS[@]}" up -d --wait babylon-pg
+    ;;
+  down)
+    exec docker compose "${COMPOSE_ARGS[@]}" down -v
+    ;;
+  config)
+    exec docker compose "${COMPOSE_ARGS[@]}" config
+    ;;
+  *)
+    echo "ci_postgres_compose: unknown command '$1'" >&2
+    exit 2
+    ;;
+esac

--- a/tools/install_ci_apt_packages.sh
+++ b/tools/install_ci_apt_packages.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Install hosted-runner apt packages with a fixed retry and timeout envelope.
+
+set -euo pipefail
+
+readonly MAX_ATTEMPTS=3
+readonly MAX_APT_TIMEOUT_SECONDS=300
+readonly MAX_RETRY_DELAY_SECONDS=30
+readonly APT_TIMEOUT_SECONDS="${BABYLON_CI_APT_TIMEOUT_SECONDS:-120}"
+readonly RETRY_DELAY_SECONDS="${BABYLON_CI_APT_RETRY_DELAY_SECONDS:-10}"
+
+case "$APT_TIMEOUT_SECONDS" in
+  "" | 0* | *[!0-9]*)
+    echo "install_ci_apt_packages: BABYLON_CI_APT_TIMEOUT_SECONDS must be a canonical positive integer (no leading zeros)" >&2
+    exit 2
+    ;;
+esac
+if (( ${#APT_TIMEOUT_SECONDS} > ${#MAX_APT_TIMEOUT_SECONDS} )) || \
+  (( APT_TIMEOUT_SECONDS > MAX_APT_TIMEOUT_SECONDS )); then
+  echo "install_ci_apt_packages: BABYLON_CI_APT_TIMEOUT_SECONDS cannot exceed $MAX_APT_TIMEOUT_SECONDS" >&2
+  exit 2
+fi
+
+case "$RETRY_DELAY_SECONDS" in
+  "" | 0[0-9]* | *[!0-9]*)
+    echo "install_ci_apt_packages: BABYLON_CI_APT_RETRY_DELAY_SECONDS must be a canonical nonnegative integer (no leading zeros)" >&2
+    exit 2
+    ;;
+esac
+if (( ${#RETRY_DELAY_SECONDS} > ${#MAX_RETRY_DELAY_SECONDS} )) || \
+  (( RETRY_DELAY_SECONDS > MAX_RETRY_DELAY_SECONDS )); then
+  echo "install_ci_apt_packages: BABYLON_CI_APT_RETRY_DELAY_SECONDS cannot exceed $MAX_RETRY_DELAY_SECONDS" >&2
+  exit 2
+fi
+
+if (( $# == 0 )); then
+  echo "usage: install_ci_apt_packages.sh PACKAGE [PACKAGE ...]" >&2
+  exit 2
+fi
+
+run_apt_transaction() {
+  # The timed child, not this parent shell, must expand status and package arguments.
+  # shellcheck disable=SC2016
+  timeout --signal=TERM --kill-after=10s "${APT_TIMEOUT_SECONDS}s" \
+    bash -c '
+      set -euo pipefail
+      sudo -n env DEBIAN_FRONTEND=noninteractive apt-get update || {
+        status=$?
+        echo "install_ci_apt_packages: apt-get update failed (exit $status)" >&2
+        exit "$status"
+      }
+      sudo -n env DEBIAN_FRONTEND=noninteractive apt-get \
+        install -y --no-install-recommends "$@" || {
+        status=$?
+        echo "install_ci_apt_packages: apt-get install failed (exit $status)" >&2
+        exit "$status"
+      }
+    ' install_ci_apt_packages "$@"
+}
+
+for attempt in 1 2 3; do
+  status=0
+  if run_apt_transaction "$@"; then
+    echo "install_ci_apt_packages: apt transaction succeeded on attempt $attempt"
+    exit 0
+  else
+    status=$?
+  fi
+
+  echo "install_ci_apt_packages: attempt $attempt of $MAX_ATTEMPTS failed (exit $status)" >&2
+  if (( attempt < MAX_ATTEMPTS && RETRY_DELAY_SECONDS > 0 )); then
+    sleep "$RETRY_DELAY_SECONDS"
+  fi
+done
+
+echo "install_ci_apt_packages: failed after $MAX_ATTEMPTS attempts" >&2
+exit 1


### PR DESCRIPTION
<!-- Vale: this PR body preserves literal tool names, identifiers, and verification commands. -->
<!-- vale Vale.Spelling = NO -->
<!-- vale Vale.Terms = NO -->
<!-- vale ste.Ambiguity = NO -->
<!-- vale ste.Gerunds = NO -->
<!-- vale ste.NounClusters = NO -->
<!-- vale ste.OneInstruction = NO -->
<!-- vale ste.ProcedureLength = NO -->
<!-- vale ste.SentenceLength = NO -->
<!-- vale ste.Semicolon = NO -->
<!-- vale ste.UnapprovedWords = NO -->

## What does this PR do?

- Routes every hosted PostgreSQL job through one runner-sized Compose contract with `restart: no`, an isolated named volume, BuildKit GHA layers, and checked cleanup.
- Replaces open-ended runner apt calls with one whole-transaction deadline, three fixed attempts, capped canonical-decimal overrides, and behavioral tests for success, recovery, exhaustion, timeout, leading-zero, and overflow cases.
- Caches Cargo Git sources against both the lockfile and pinned toolchain.
- Preserves weekly simulation artifacts after failure or cancellation and corrects frozen Python pacing ownership to the manual oracle / PER-268 Rust successor boundary.

## Related Issue

Fixes PER-262

## Checklist

- [x] Tested locally with RED -> GREEN process-level and workflow contracts
- [x] Passed repository commit and pre-push hooks
- [x] Passed actionlint, yamllint, ShellCheck, TOML/YAML parsing, Ruff, Compose render, and Buildx Bake parsing
- [x] Preserved unrelated work and added no game-law or baseline change

## Verification

- `mise run test:q -- tests/unit/tools/test_ci_host_contract.py tests/unit/test_workflow_hygiene.py` — 36 passed
- The timeout contract first failed while update/install had separate deadlines, then passed after one transaction-wide deadline.
- Canonical-decimal tests first failed for `00`, `0400`, and oversized integers, then passed after bounded validation.
- Independent read-only review: no remaining Critical or Important findings.
- Full local `mise run check`: static gates passed and the unit suite reached 99%; three unchanged subprocess-import tests exceeded their 60-second limits on the loaded workstation, and one passed alone. The PR's clean hosted runner is the acceptance environment for the full gate.

## Questions for Reviewers

Please focus on whether every hosted caller remains unable to bypass the shared apt/PostgreSQL contracts and whether the required check names stay stable.

<!-- vale ste.UnapprovedWords = YES -->
<!-- vale ste.Semicolon = YES -->
<!-- vale ste.SentenceLength = YES -->
<!-- vale ste.ProcedureLength = YES -->
<!-- vale ste.OneInstruction = YES -->
<!-- vale ste.NounClusters = YES -->
<!-- vale ste.Gerunds = YES -->
<!-- vale ste.Ambiguity = YES -->
<!-- vale Vale.Terms = YES -->
<!-- vale Vale.Spelling = YES -->
