### PR TITLE
fix(ci): harden exact-head PR and Dependabot policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,69 @@
-## What does this PR do?
+<!-- Vale: this template preserves literal Git, GitHub, Linear, and CI terms. -->
+<!-- vale Vale.Spelling = NO -->
+<!-- vale ste.UnapprovedWords = NO -->
 
-<!-- Brief description of the change -->
+## Summary
 
-## Related Issue
+<!-- Describe the change and its player-facing or engineering purpose. -->
 
-<!-- Link to issue if applicable, or "N/A" -->
+## Linear delivery
 
-## Checklist
+<!-- Every PR must select exactly one disposition. Replace N with the issue number. -->
 
-Don't stress about the checklist - it's just a guide!
+- [ ] `Part of PER-N` — partial delivery. Keep the Linear issue open.
+- [ ] `Fixes PER-N` — final accepted delivery. Close the Linear issue after merge.
 
-- [ ] I've tested my changes locally
-- [ ] My code follows the existing style (or I'm okay with maintainer fixing it)
-- [ ] I've updated documentation if needed (optional - maintainer can help)
+Linear issue: <!-- Link the canonical Linear issue. -->
 
-## Questions for Reviewers
+## Review evidence
 
-<!-- Anything you're unsure about? Ask here! -->
+Base branch: <!-- Normally dev. -->
+
+Exact reviewed head SHA: <!-- Use the full 40-character commit SHA. -->
+
+- [ ] The base branch is `dev`, or the Director approved `main`.
+  - Release PR from `dev`.
+  - Critical hotfix from `fix/*`, with a mandatory backport PR to `dev`.
+- [ ] All reported checks completed successfully for the exact reviewed head
+      SHA and base branch above.
+- [ ] The Copilot review completed against the exact reviewed head SHA.
+- [ ] I fixed each accepted Copilot finding, provided a reply to every finding,
+      and resolved all Copilot review threads.
+
+## Behavioral-contract disposition
+
+<!-- Select one disposition and link the evidence or give the explanation. -->
+
+- [ ] Changed behavior: I added or updated a durable behavioral contract.
+- [ ] No behavior change: the current behavioral contracts are enough.
+
+Disposition and evidence:
+
+## Baseline disposition
+
+<!-- Select one disposition. Never bless a baseline to hide a fault. -->
+
+- [ ] No governed baseline changed.
+- [ ] A governed baseline changed intentionally. I used
+      `tools/generate_ceremony_message.py` and included the required ceremony
+      record and `Baselines: blessed(<slug>)` trailer.
+
+## Merge
+
+- [ ] Merge only with `mise run pr:merge -- N`. Use this PR number for `N`.
+- [ ] Preserve the source branch by default. Delete it only after an explicit
+      owner decision and a check for dependent work.
+
+Do not run `gh pr merge` directly in any form.
+
+## Questions for reviewers
+
+<!-- Identify unresolved questions. Leave blank when there are none. -->
 
 ______________________________________________________________________
 
-**First time contributing?** Welcome! Check out [CONTRIBUTORS.md](CONTRIBUTORS.md) for help getting started. Don't hesitate to ask questions in the comments.
+**New contributor?** Read [CONTRIBUTORS.md](../CONTRIBUTORS.md) before you open
+the PR.
+
+<!-- vale ste.UnapprovedWords = YES -->
+<!-- vale Vale.Spelling = YES -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,29 @@
 # Dependabot configuration for Babylon
 # Docs: https://docs.github.com/en/code-security/dependabot
 #
-# Promotion model (Program 15, Phase 3): Dependabot never opens PRs against
-# `main`. Every ecosystem below targets `dev`. `dev`'s required-checks
-# ruleset is what makes `.github/workflows/dependabot-automerge.yml`
-# truthful — a PR can only auto-merge once it has actually satisfied the
-# checks the ruleset requires, not merely because the workflow ran.
-# `main` never receives a Dependabot PR directly; it only receives changes
-# via the fast-forward promotion (`tools/promote.sh`) once `dev` is green.
+# Branch model (Program 15, Phase 3): `dev` is the default branch, so
+# Dependabot opens every PR against `dev`. Omitting `target-branch` is
+# deliberate: GitHub then applies this configuration to security updates too.
+# The required-checks ruleset and `.github/workflows/dependabot-automerge.yml`
+# allow only exact-head, fully verified merges.
+# `main` never receives a Dependabot PR directly. A Director-authorized release PR
+# from `dev` carries these changes through the main qualification manifest.
 #
 # CONFIG-AUTHORITY INVARIANT (2026-07-12): Dependabot reads THIS FILE — every
-# `target-branch` and every `ignore` below — from the repository's DEFAULT
+# group and every `ignore` below — from the repository's DEFAULT
 # branch ONLY. The default branch is now `dev` (changed from `main` on
 # 2026-07-12) precisely so rule/ignore edits take effect the moment they land
-# on `dev`, with no promotion required. If the default branch is ever moved
-# back to `main`, edits here go INERT until promoted — the Program-15
-# "promote before closing" gotcha. Keep the default branch = the branch you
-# edit this file on.
+# on `dev`, with no main release PR required. If the default branch is ever
+# moved back to `main`, edits here go INERT until a configuration PR reaches
+# `main`. Keep the default branch equal to the branch where this file changes.
 
 version: 2
 updates:
   # ==========================================================================
-  # Python dependencies (Poetry)
+  # Python dependencies (uv)
   # ==========================================================================
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
-    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -42,7 +40,7 @@ updates:
       - "python"
     groups:
       # Group all minor/patch updates into a single PR (reduces noise)
-      python-minor-patch:
+      uv-minor-patch:
         applies-to: version-updates
         patterns:
           - "*"
@@ -50,19 +48,13 @@ updates:
           - "minor"
           - "patch"
       # Security updates get their own group (higher priority)
-      python-security:
+      uv-security:
         applies-to: security-updates
         patterns:
           - "*"
-      # Majors arrive as ONE reviewable PR per ecosystem (never auto-merged —
-      # the automerge workflow only takes minor/patch). An agent unbundles
-      # locally if one member is red.
-      python-majors:
-        applies-to: version-updates
-        patterns:
-          - "*"
         update-types:
-          - "major"
+          - "minor"
+          - "patch"
     # Deferred majors (OWNER ITEM 55 — django 6 + mypy 2 modernization). This is
     # a deliberate railed batch (manage.py check + web suites + typecheck across
     # 567 files), not a drive-by bump: django-stubs 6 + drf-stubs cap `mypy<2.2`
@@ -84,7 +76,6 @@ updates:
   # ==========================================================================
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -98,10 +89,13 @@ updates:
       - "dependencies"
       - "ci"
     groups:
-      # Group all GitHub Actions updates together
-      github-actions-all:
+      # Major action updates remain individual manual-review PRs.
+      github-actions-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # ==========================================================================
   # Postgres base image (Docker) — monthly: base-image bumps are deliberate,
@@ -109,7 +103,6 @@ updates:
   # ==========================================================================
   - package-ecosystem: "docker"
     directory: "/docker/postgres"
-    target-branch: "dev"
     schedule:
       interval: "monthly"
       time: "09:00"
@@ -136,7 +129,6 @@ updates:
   # ==========================================================================
   - package-ecosystem: "cargo"
     directory: "/rust"
-    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -149,7 +141,6 @@ updates:
       prefix-development: "chore(deps-dev)"
     labels:
       - "dependencies"
-      - "rust"
     groups:
       rust-minor-patch:
         applies-to: version-updates
@@ -162,9 +153,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-      rust-majors:
-        applies-to: version-updates
-        patterns:
-          - "*"
         update-types:
-          - "major"
+          - "minor"
+          - "patch"

--- a/.github/settings/pr-policy.json
+++ b/.github/settings/pr-policy.json
@@ -1,0 +1,83 @@
+{
+  "repository": {
+    "allow_merge_commit": true,
+    "allow_squash_merge": false,
+    "allow_rebase_merge": false,
+    "allow_auto_merge": false,
+    "delete_branch_on_merge": false
+  },
+  "dev_ruleset": {
+    "name": "dev protection (PR, exact checks, resolved threads)",
+    "target": "branch",
+    "enforcement": "active",
+    "bypass_actors": [],
+    "conditions": {
+      "ref_name": {
+        "exclude": [],
+        "include": ["refs/heads/dev"]
+      }
+    },
+    "rules": [
+      {
+        "type": "deletion"
+      },
+      {
+        "type": "non_fast_forward"
+      },
+      {
+        "type": "pull_request",
+        "parameters": {
+          "allowed_merge_methods": ["merge"],
+          "dismiss_stale_reviews_on_push": false,
+          "required_reviewers": [],
+          "require_code_owner_review": false,
+          "require_last_push_approval": false,
+          "required_approving_review_count": 0,
+          "required_review_thread_resolution": true,
+          "require_extra_approval_for_unattributed_changes": false
+        }
+      },
+      {
+        "type": "required_status_checks",
+        "parameters": {
+          "strict_required_status_checks_policy": true,
+          "do_not_enforce_on_create": false,
+          "required_status_checks": [
+            {
+              "context": "Fast Gate (hygiene, lint, format, imports, types, lock)"
+            },
+            {
+              "context": "Unit Tests (xdist, coverage gate)"
+            },
+            {
+              "context": "Determinism Gate (byte-identical dense goldens)"
+            },
+            {
+              "context": "Secret Scan (gitleaks, full history)"
+            },
+            {
+              "context": "IaC Config Scan (trivy, HIGH+CRITICAL blocking)"
+            },
+            {
+              "context": "Security Audit (pip-audit policy — blocking since item-41)"
+            },
+            {
+              "context": "Rust Gate (fmt, clippy, test, doc — rust/ workspace)"
+            },
+            {
+              "context": "Baseline Ceremony Gate (§6.5 provenance)"
+            },
+            {
+              "context": "Postgres Integration Tier (PG 17, pinned runtime)"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "automerge_label": {
+    "name": "dependencies:automerge",
+    "color": "1f883d",
+    "description": "Patch/minor Dependabot update eligible for exact-head merge"
+  }
+}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,19 +1,25 @@
 # Dependabot automation has two trusted, event-driven phases.
 #
-# 1. `pull_request_target` reads Dependabot metadata from the trusted default
-#    branch, attests eligibility on the exact head, and manages one presentation
-#    label. It never checks out PR code.
-# 2. `workflow_run` resolves the completed run's exact head to one eligible PR,
-#    checks out trusted `dev`, and delegates to the repository merge verifier.
+# 1. `pull_request_target` manages one presentation label from trusted default-
+#    branch code. It never checks out PR code and grants no merge authority.
+# 2. `workflow_run` validates the native exact-head CI run, checks out trusted
+#    `dev`, and delegates eligibility and merging to the repository verifier.
 
 name: Dependabot Auto-Merge
+
+run-name: >-
+  ${{ github.event_name == 'workflow_run' &&
+      format('Dependabot eligibility for CI run {0} at {1}',
+        github.event.workflow_run.id, github.event.workflow_run.head_sha) ||
+      format('Dependabot presentation for PR {0}',
+        github.event.pull_request.number) }}
 
 on:
   pull_request_target:
     branches: [dev]
     types: [opened, reopened, synchronize]
   workflow_run:
-    workflows: [CI, CodeQL Security Scan]
+    workflows: [CI]
     types: [completed]
 
 permissions: {}
@@ -32,11 +38,16 @@ jobs:
     name: Classify Dependabot update
     if: >-
       github.event_name == 'pull_request_target' &&
-      github.event.pull_request.user.login == 'dependabot[bot]'
+      github.actor == 'dependabot[bot]' &&
+      github.event.sender.login == 'dependabot[bot]' &&
+      github.event.sender.id == 49699333 &&
+      github.event.sender.type == 'Bot' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.user.id == 49699333 &&
+      github.event.pull_request.user.type == 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      checks: write
       contents: read
       issues: write
       pull-requests: read
@@ -62,59 +73,12 @@ jobs:
         run: |
           set -euo pipefail
           eligible=false
-          conclusion=failure
           case " $ELIGIBLE_UPDATE_TYPES " in
             *" $UPDATE_TYPE "*)
               eligible=true
-              conclusion=success
               ;;
           esac
           printf 'eligible=%s\n' "$eligible" >> "$GITHUB_OUTPUT"
-          printf 'conclusion=%s\n' "$conclusion" >> "$GITHUB_OUTPUT"
-
-      - name: Publish exact-head eligibility check
-        shell: bash
-        env:
-          CHECK_CONCLUSION: ${{ steps.eligibility.outputs.conclusion }}
-          CHECK_NAME: Dependabot Eligibility
-          GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Refusing a non-canonical pull-request head SHA."
-            exit 1
-          fi
-          case "$CHECK_CONCLUSION" in
-            success)
-              title="Eligible Dependabot update"
-              summary="Trusted metadata classifies this exact head as patch or minor."
-              ;;
-            failure)
-              title="Ineligible Dependabot update"
-              summary="Trusted metadata does not classify this exact head as patch or minor."
-              ;;
-            *)
-              echo "Refusing unknown eligibility conclusion: $CHECK_CONCLUSION"
-              exit 1
-              ;;
-          esac
-          jq -n \
-            --arg name "$CHECK_NAME" \
-            --arg head_sha "$HEAD_SHA" \
-            --arg status completed \
-            --arg conclusion "$CHECK_CONCLUSION" \
-            --arg title "$title" \
-            --arg summary "$summary" \
-            '{
-              name: $name,
-              head_sha: $head_sha,
-              status: $status,
-              conclusion: $conclusion,
-              output: {title: $title, summary: $summary}
-            }' |
-            gh api --method POST \
-              "repos/$GITHUB_REPOSITORY/check-runs" --input -
 
       - name: Set eligibility label
         shell: bash
@@ -151,14 +115,17 @@ jobs:
           fi
 
   merge:
-    name: Merge exact eligible Dependabot PR
+    name: Dependabot Eligibility
     if: >-
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request'
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.name == 'CI'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      actions: read
+      checks: read
       contents: write
       pull-requests: write
       security-events: read
@@ -180,11 +147,19 @@ jobs:
           pulls="$(
             gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&base=dev&per_page=100"
           )"
+          pull_count="$(jq 'length' <<< "$pulls")"
+          if [ "$pull_count" -ge 100 ]; then
+            printf 'eligible=false\n' >> "$GITHUB_OUTPUT"
+            echo "Refusing a potentially truncated 100-PR candidate page."
+            exit 0
+          fi
           candidates="$(
             jq --arg head "$EXPECTED_HEAD" '
               [
                 .[:100][]
                 | select(.user.login == "dependabot[bot]")
+                | select(.user.id == 49699333)
+                | select(.user.type == "Bot")
                 | select(.head.sha == $head)
                 | .number
               ]
@@ -204,7 +179,10 @@ jobs:
         env:
           EXPECTED_HEAD: ${{ github.event.workflow_run.head_sha }}
           GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          CLASSIFIER_RUN_ID: ${{ github.run_id }}
           PR_NUMBER: ${{ steps.candidate.outputs.pr_number }}
         run: >-
           python3 tools/pr_merge.py "$PR_NUMBER" --expected-head "$EXPECTED_HEAD"
-          --dependabot
+          --dependabot --dependabot-source-run "$SOURCE_RUN_ID"
+          --dependabot-classifier-run "$CLASSIFIER_RUN_ID"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -88,9 +88,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
+          encoded_label="$(
+            jq -rn --arg label "$ELIGIBILITY_LABEL" '$label | @uri'
+          )"
           label_json="$(
             gh api \
-              "repos/$GITHUB_REPOSITORY/labels/dependencies%3Aautomerge"
+              "repos/$GITHUB_REPOSITORY/labels/$encoded_label"
           )"
           jq -e \
             --arg name "$ELIGIBILITY_LABEL" \

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,7 +1,8 @@
 # Dependabot automation has two trusted, event-driven phases.
 #
 # 1. `pull_request_target` reads Dependabot metadata from the trusted default
-#    branch and manages one eligibility label. It never checks out PR code.
+#    branch, attests eligibility on the exact head, and manages one presentation
+#    label. It never checks out PR code.
 # 2. `workflow_run` resolves the completed run's exact head to one eligible PR,
 #    checks out trusted `dev`, and delegates to the repository merge verifier.
 
@@ -35,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      checks: write
       contents: read
       issues: write
       pull-requests: read
@@ -60,10 +62,59 @@ jobs:
         run: |
           set -euo pipefail
           eligible=false
+          conclusion=failure
           case " $ELIGIBLE_UPDATE_TYPES " in
-            *" $UPDATE_TYPE "*) eligible=true ;;
+            *" $UPDATE_TYPE "*)
+              eligible=true
+              conclusion=success
+              ;;
           esac
           printf 'eligible=%s\n' "$eligible" >> "$GITHUB_OUTPUT"
+          printf 'conclusion=%s\n' "$conclusion" >> "$GITHUB_OUTPUT"
+
+      - name: Publish exact-head eligibility check
+        shell: bash
+        env:
+          CHECK_CONCLUSION: ${{ steps.eligibility.outputs.conclusion }}
+          CHECK_NAME: Dependabot Eligibility
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Refusing a non-canonical pull-request head SHA."
+            exit 1
+          fi
+          case "$CHECK_CONCLUSION" in
+            success)
+              title="Eligible Dependabot update"
+              summary="Trusted metadata classifies this exact head as patch or minor."
+              ;;
+            failure)
+              title="Ineligible Dependabot update"
+              summary="Trusted metadata does not classify this exact head as patch or minor."
+              ;;
+            *)
+              echo "Refusing unknown eligibility conclusion: $CHECK_CONCLUSION"
+              exit 1
+              ;;
+          esac
+          jq -n \
+            --arg name "$CHECK_NAME" \
+            --arg head_sha "$HEAD_SHA" \
+            --arg status completed \
+            --arg conclusion "$CHECK_CONCLUSION" \
+            --arg title "$title" \
+            --arg summary "$summary" \
+            '{
+              name: $name,
+              head_sha: $head_sha,
+              status: $status,
+              conclusion: $conclusion,
+              output: {title: $title, summary: $summary}
+            }' |
+            gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/check-runs" --input -
 
       - name: Set eligibility label
         shell: bash

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,91 +1,159 @@
-# Dependabot Auto-Merge Workflow
+# Dependabot automation has two trusted, event-driven phases.
 #
-# Merges Dependabot PRs to `dev` after EVERY check completes clean.
-# - Minor/patch version updates: eligible (low risk)
-# - GitHub Actions non-major updates: eligible
-# - Major updates: require manual review (breaking changes)
-#
-# ADR181 R2b (2026-07-30): `gh pr merge --auto` is BANNED repo-wide — the
-# #392 scar proved it merges past failing NON-required checks. This job
-# instead waits for every other check to complete (bounded poll, Power-of-10
-# rule 2), refuses on ANY failure — required or not — and only then merges.
+# 1. `pull_request_target` reads Dependabot metadata from the trusted default
+#    branch and manages one eligibility label. It never checks out PR code.
+# 2. `workflow_run` resolves the completed run's exact head to one eligible PR,
+#    checks out trusted `dev`, and delegates to the repository merge verifier.
 
 name: Dependabot Auto-Merge
 
 on:
-  pull_request:
-    branches:
-      - dev # Only trigger for PRs targeting dev
+  pull_request_target:
+    branches: [dev]
+    types: [opened, reopened, synchronize]
+  workflow_run:
+    workflows: [CI, CodeQL Security Scan]
+    types: [completed]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
+
+concurrency:
+  group: >-
+    dependabot-${{
+      github.event.pull_request.number ||
+      github.event.workflow_run.pull_requests[0].number ||
+      github.event.workflow_run.head_branch
+    }}
+  cancel-in-progress: false
 
 jobs:
-  dependabot-automerge:
-    name: Auto-merge Dependabot PRs
+  classify:
+    name: Classify Dependabot update
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
-    # Bounded wait: 40 polls x 60s inside a hard job ceiling.
-    timeout-minutes: 45
-    if: github.actor == 'dependabot[bot]'
-
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    env:
+      ELIGIBILITY_LABEL: dependencies:automerge
+      ELIGIBILITY_LABEL_COLOR: 1f883d
+      ELIGIBILITY_LABEL_DESCRIPTION: >-
+        Patch/minor Dependabot update eligible for exact-head merge
+      ELIGIBLE_UPDATE_TYPES: >-
+        version-update:semver-patch version-update:semver-minor
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: ${{ github.token }}
 
-      - name: Log update details
-        run: |
-          echo "Dependency: ${{ steps.metadata.outputs.dependency-names }}"
-          echo "Update type: ${{ steps.metadata.outputs.update-type }}"
-          echo "Ecosystem: ${{ steps.metadata.outputs.package-ecosystem }}"
-          echo "Previous version: ${{ steps.metadata.outputs.previous-version }}"
-          echo "New version: ${{ steps.metadata.outputs.new-version }}"
-
-      # One merge path for every eligible class: wait for all OTHER checks,
-      # refuse on any failure (required or not), then a plain --squash merge.
-      - name: Wait for all checks, refuse on any failure, then merge
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          (steps.metadata.outputs.package-ecosystem == 'github_actions' &&
-           steps.metadata.outputs.update-type != 'version-update:semver-major')
-        run: |
-          SELF="Auto-merge Dependabot PRs"
-          for i in $(seq 1 40); do
-            checks=$(gh pr checks "$PR_URL" --json name,bucket 2>/dev/null || echo '[]')
-            failed=$(jq --arg self "$SELF" \
-              '[.[] | select(.bucket == "fail" and .name != $self)] | length' <<<"$checks")
-            pending=$(jq --arg self "$SELF" \
-              '[.[] | select(.bucket == "pending" and .name != $self)] | length' <<<"$checks")
-            if [ "$failed" -gt 0 ]; then
-              gh pr comment "$PR_URL" --body \
-                "Auto-merge REFUSED: $failed check(s) failed. ADR181 R2b — a \
-          failing check blocks the merge even when non-required (the #392 class)."
-              exit 1
-            fi
-            if [ "$pending" -eq 0 ] && [ "$checks" != "[]" ]; then
-              echo "All checks complete and clean — merging."
-              gh pr merge --squash "$PR_URL"
-              exit 0
-            fi
-            echo "poll $i/40: $pending check(s) still pending"
-            sleep 60
-          done
-          echo "Checks did not complete inside the wait budget — NOT merging."
-          exit 1
+      - name: Classify update
+        id: eligibility
+        shell: bash
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # MAJOR updates require manual review - just add a comment
-      - name: Comment on major updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
         run: |
-          gh pr comment "$PR_URL" --body \
-            "**Major version update** - may contain breaking changes. Manual review required."
+          set -euo pipefail
+          eligible=false
+          case " $ELIGIBLE_UPDATE_TYPES " in
+            *" $UPDATE_TYPE "*) eligible=true ;;
+          esac
+          printf 'eligible=%s\n' "$eligible" >> "$GITHUB_OUTPUT"
+
+      - name: Set eligibility label
+        shell: bash
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ELIGIBLE: ${{ steps.eligibility.outputs.eligible }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          label_json="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/labels/dependencies%3Aautomerge"
+          )"
+          jq -e \
+            --arg name "$ELIGIBILITY_LABEL" \
+            --arg color "$ELIGIBILITY_LABEL_COLOR" \
+            --arg description "$ELIGIBILITY_LABEL_DESCRIPTION" \
+            '.name == $name and .color == $color and .description == $description' \
+            <<< "$label_json" >/dev/null
+
+          labels_json="$(
+            gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels
+          )"
+          has_label="$(
+            jq --arg label "$ELIGIBILITY_LABEL" \
+              'any(.labels[:100][]; .name == $label)' <<< "$labels_json"
+          )"
+          if [ "$ELIGIBLE" = true ] && [ "$has_label" = false ]; then
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --add-label "$ELIGIBILITY_LABEL"
+          elif [ "$ELIGIBLE" = false ] && [ "$has_label" = true ]; then
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --remove-label "$ELIGIBILITY_LABEL"
+          fi
+
+  merge:
+    name: Merge exact eligible Dependabot PR
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      security-events: read
+    steps:
+      - name: Checkout trusted merge verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: dev
+          persist-credentials: false
+
+      - name: Resolve exact eligible PR
+        id: candidate
+        shell: bash
+        env:
+          EXPECTED_HEAD: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          pulls="$(
+            gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&base=dev&per_page=100"
+          )"
+          candidates="$(
+            jq --arg head "$EXPECTED_HEAD" '
+              [
+                .[:100][]
+                | select(.user.login == "dependabot[bot]")
+                | select(.head.sha == $head)
+                | .number
+              ]
+            ' <<< "$pulls"
+          )"
+          candidate_count="$(jq 'length' <<< "$candidates")"
+          if [ "$candidate_count" -ne 1 ]; then
+            printf 'eligible=false\n' >> "$GITHUB_OUTPUT"
+            echo "Expected one eligible Dependabot PR at $EXPECTED_HEAD; found $candidate_count."
+            exit 0
+          fi
+          printf 'eligible=true\n' >> "$GITHUB_OUTPUT"
+          printf 'pr_number=%s\n' "$(jq -r '.[0]' <<< "$candidates")" >> "$GITHUB_OUTPUT"
+
+      - name: Merge
+        if: steps.candidate.outputs.eligible == 'true'
+        env:
+          EXPECTED_HEAD: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.candidate.outputs.pr_number }}
+        run: >-
+          python3 tools/pr_merge.py "$PR_NUMBER" --expected-head "$EXPECTED_HEAD"
+          --dependabot

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -73,6 +73,8 @@ Use one of these lane prefixes:
 
 Other lane names can also include their PER identity. Use `Part of PER-N` for
 partial delivery and `Fixes PER-N` only for the final accepted delivery.
+Every PR description must select exactly one of those two Linear delivery
+dispositions and link the canonical issue.
 <!-- vale ste.UnapprovedWords = YES -->
 
 Keep unrelated user changes unchanged. Report an unrelated fault unless the owner
@@ -95,29 +97,53 @@ mise run commit -- "type(scope): description"
 Run the checks that `CLAUDE.md` assigns to the changed area. Do not bless a
 baseline without its declared ceremony.
 
+<!-- Vale: these paragraphs preserve literal review and ceremony terms. -->
+<!-- vale ste.UnapprovedWords = NO -->
+Every PR needs a behavioral-contract disposition. For changed behavior, link
+the durable, implementation-independent contract that proves the change. For
+no behavior change, explain why the current contracts are enough.
+
+If a governed baseline changes intentionally, use
+`tools/generate_ceremony_message.py`. Include its ceremony record and the
+required `Baselines: blessed(<slug>)` trailer. If you did not intend the drift,
+stop and correct the fault.
+<!-- vale ste.UnapprovedWords = YES -->
+
 ## Merge to `dev`
 
+<!-- Vale: this procedure preserves literal GitHub review and branch terms. -->
+<!-- vale ste.UnapprovedWords = NO -->
 Before a merge, complete these steps:
 
-1. Check that each CI task finished.
-2. Check that the green task tested the PR head SHA.
-3. Read each Copilot comment.
-4. Correct the fault or reply with the rationale for no change.
-5. Check that no Copilot comment remains without a response.
+1. Confirm the base branch and record the exact reviewed head SHA.
+2. Confirm that all reported checks completed successfully for that exact
+   reviewed head SHA and base branch.
+3. Complete the Copilot review against that head. Fix each accepted finding or
+   reply with the rationale for no change.
+4. Confirm that every Copilot finding has a reply and that you resolved all
+   Copilot review threads.
+5. Confirm the behavioral-contract disposition and baseline disposition in the
+   PR description.
 6. Run the approved merge command.
 
 ```bash
 mise run pr:merge -- N
 ```
 
-Do not use `gh pr merge --auto`. The approved command also checks CodeQL and
-the merge target.
+Do not run `gh pr merge` directly in any form. The sanctioned command is the
+only merge path.
+
+Preserve the source branch by default. The standard command omits
+`--delete-branch`. Delete a source branch only after an explicit owner decision
+and a check that no open PR or other work depends on it.
+<!-- vale ste.UnapprovedWords = YES -->
 
 <!-- Vale: this paragraph preserves literal Git emergency-workflow terms. -->
 <!-- vale Vale.Spelling = NO -->
 <!-- vale ste.UnapprovedWords = NO -->
-A critical hotfix alone can branch from and target `main`. Only the Director
-can merge it. A backport PR to `dev` is mandatory after the merge.
+Only the Director merges to `main`. The two allowed sources are a release PR
+from `dev`, or a critical hotfix from `fix/*` that branches from `main`. A
+backport PR to `dev` is mandatory after a hotfix merge.
 <!-- vale ste.UnapprovedWords = YES -->
 <!-- vale Vale.Spelling = YES -->
 

--- a/ai/decisions/ADR230_exact_head_pr_and_dependabot_policy.yaml
+++ b/ai/decisions/ADR230_exact_head_pr_and_dependabot_policy.yaml
@@ -50,20 +50,30 @@ ADR230_exact_head_pr_and_dependabot_policy:
        refuses rather than silently paging beyond its fixed one-hundred-thread
        bound. The repository CodeQL alert floor must remain zero.
 
-    4. DEPENDABOT TRUST SPLIT. pull_request_target classifies Dependabot metadata
-       from trusted code and publishes an exact-head check run named Dependabot Eligibility.
-       The trusted GitHub Actions app records
-       success only for patch or minor updates and records failure otherwise.
-       Its eligibility label is presentation only and never merge authorization.
-       That phase never checks out pull-request code and never creates or updates
-       repository label metadata. A successful workflow_run resolves one open
-       Dependabot pull request at the completed run's exact head and checks out
-       trusted dev tooling. Immediately before the final ref snapshot, the merge
-       verifier queries bounded check runs on that head and requires the latest
-       exact-name check to be completed, successful, and owned by the canonical
-       GitHub Actions app. Commit author, committer, signature, and message fields
-       do not authorize eligibility. The workflow does not poll and does not call
-       a direct GitHub merge command. Major updates remain manual-review work.
+    4. DEPENDABOT TRUST SPLIT. pull_request_target manages an eligibility label
+       from trusted code without checking out pull-request code.
+       Its label is presentation only and never merge authorization. That
+       phase never creates
+       or updates repository label metadata. A completed native exact-head CI
+       pull_request run starts the trusted default-branch workflow_run consumer.
+       Its native job is named Dependabot Eligibility, but it does not publish a
+       custom check on the pull-request head.
+
+       Immediately before the final ref snapshot, the merge verifier requires
+       the immutable CI workflow ID, path, pull_request event, successful exact
+       head, exact pull-request association, canonical Dependabot event actor and
+       triggering actor, canonical GitHub Actions app, and matching check suite.
+       It also binds its current trusted workflow ID, path, run title, native job,
+       check-run ID, and suite to that source CI run and head. It then revalidates
+       the canonical Dependabot pull-request owner and exactly one current commit
+       before it reads update metadata. Commit author, committer, or signature
+       fields alone do not authorize eligibility.
+
+       The unattended mode accepts only patch and minor metadata. A major or
+       malformed update refuses unattended mode without creating a failing
+       pull-request check, so the normal reviewed path remains available. The
+       workflow does not execute pull-request code or artifacts and does not call
+       a direct GitHub merge command.
 
     5. CHECKED-IN SETTINGS. .github/settings/pr-policy.json is the desired
        repository merge policy, dev ruleset, and Dependabot eligibility label.
@@ -93,7 +103,10 @@ ADR230_exact_head_pr_and_dependabot_policy:
       conclusion, incomplete selected manifest, or open CodeQL alert blocks the
       wrapper.
     - Dependabot patch and minor updates can merge without a polling runner, but
-      only after the same exact-head acceptance path as every other pull request.
+      only after the native CI and trusted classifier provenance checks plus the
+      same exact-head acceptance path as every other pull request.
+    - A major Dependabot update cannot use unattended mode, but its normal
+      reviewed merge remains available after the standard checks pass.
     - Strict dev checks can require a branch refresh after dev moves. This cost
       is accepted because it binds green evidence to the base that will receive
       the merge.

--- a/ai/decisions/ADR230_exact_head_pr_and_dependabot_policy.yaml
+++ b/ai/decisions/ADR230_exact_head_pr_and_dependabot_policy.yaml
@@ -1,0 +1,103 @@
+ADR230_exact_head_pr_and_dependabot_policy:
+  status: "accepted"
+  date: "2026-08-25"
+  title: >-
+    Pull requests merge through one exact-head verifier, Dependabot separates
+    trusted classification from verified merging, and GitHub PR settings are
+    applied as a rollback-safe checked-in policy
+  context: |
+    ADR181 established the Copilot harvest and the sanctioned merge wrapper.
+    The 2026-08-24 and 2026-08-25 CI audit found that the implementation no
+    longer matched that intent. The wrapper pinned only the head during its
+    first read, did not require a completed head-anchored Copilot review or
+    resolved review threads, and delegated the final merge without GitHub's
+    atomic expected-head guard. Dependabot polled for up to forty minutes and
+    then invoked a direct merge path outside the wrapper.
+
+    The repository settings also disagreed with the written process. The dev
+    ruleset required checks but no pull request, did not require an up-to-date
+    branch or resolved conversations, and the repository enabled three merge
+    strategies plus auto-merge. These mutable settings had no checked-in
+    desired state, pre-mutation snapshot, readback, or tested rollback path.
+
+    Babylon has one Director and no standing second human reviewer. A required
+    approval count would block legitimate delivery without adding independent
+    review. The durable controls are exact source identity, deterministic CI,
+    completed Copilot review, explicit comment disposition, resolved threads,
+    and the CodeQL zero floor.
+  decision: |
+    1. SANCTIONED MERGE PATH. tools/pr_merge.py remains the sole merge command.
+       It accepts ordinary pull requests only when the base is dev. A main
+       target requires the explicit Director-only mode and a head of dev or
+       fix/*. The tool refuses deletion of dev and preserves source branches by
+       default.
+
+    2. EXACT VERDICT. The verifier records the exact head and base object IDs,
+       rejects a moved ref on its final read, and passes the verified exact head
+       to GitHub's atomic match-head merge guard. Callers can also provide an
+       expected head. Read-only verification runs the complete policy without
+       requesting a merge. tools/pr_policy.py owns separate complete manifest
+       values for dev and main. Every blocking check must exist and report
+       SUCCESS. Each advisory check has its own allowed conclusions. An unknown
+       failure blocks; an unknown success is information only after the selected
+       complete manifest is present.
+
+    3. REVIEW EVIDENCE. The exact head needs a completed Copilot review. The
+       verifier matches the exact endpoint-specific GraphQL review, REST review,
+       and REST inline-comment logins. It also checks the immutable bot ID, node
+       ID, and type wherever REST provides them. Every top-level Copilot comment
+       needs a reply, and every review thread must be resolved. Verification
+       refuses rather than silently paging beyond its fixed one-hundred-thread
+       bound. The repository CodeQL alert floor must remain zero.
+
+    4. DEPENDABOT TRUST SPLIT. pull_request_target may classify a verified
+       Dependabot patch or minor update and manage only its eligibility label.
+       The label is presentation only and never merge authorization. That phase
+       never checks out pull-request code and never creates or updates repository
+       label metadata. A successful workflow_run resolves one open Dependabot
+       pull request at the completed run's exact head and checks out trusted dev
+       tooling. Immediately before the final ref snapshot, the merge verifier
+       requires one verified Dependabot commit at that head and derives every
+       exact-head update type from its signed commit metadata. Only patch and
+       minor types pass. The workflow does not poll and does not call a direct
+       GitHub merge command. Major updates remain manual-review work.
+
+    5. CHECKED-IN SETTINGS. .github/settings/pr-policy.json is the desired
+       repository merge policy, dev ruleset, and Dependabot eligibility label.
+       The repository permits merge commits only, disables auto-merge, and does
+       not delete source branches automatically. The dev ruleset requires a
+       pull request, merge commits, strict required checks, and resolved review
+       threads. Its required contexts must exactly equal the typed dev blocking
+       manifest. Its approval count remains zero because this is a single-
+       Director repository and the executable review evidence supplies the
+       acceptance boundary.
+
+    6. SETTINGS TRANSACTION. A settings apply requires an exact green dev SHA.
+       The applicator writes a snapshot before its first mutation, rejects
+       concurrent settings or dev movement, reads back the desired state, and
+       reconciles attempted writes after a failure, restores every component
+       that differs from the snapshot, and verifies automatic and manual
+       rollback readback. A retained snapshot can be restored only while its
+       exact dev SHA remains current.
+
+    7. PR RECORD. Each pull-request description selects exactly one Linear
+       delivery disposition, records the base and exact reviewed head, records
+       CI and Copilot evidence, states its behavioral-contract and baseline
+       dispositions, and preserves the source branch unless its owner makes an
+       explicit deletion decision.
+  consequences: |
+    - A stale review, moved head, moved base, unresolved thread, disallowed
+      conclusion, incomplete selected manifest, or open CodeQL alert blocks the
+      wrapper.
+    - Dependabot patch and minor updates can merge without a polling runner, but
+      only after the same exact-head acceptance path as every other pull request.
+    - Strict dev checks can require a branch refresh after dev moves. This cost
+      is accepted because it binds green evidence to the base that will receive
+      the merge.
+    - GitHub UI changes become detectable drift. Remote policy mutations retain
+      a local rollback artifact and are never inferred from documentation.
+    - This decision refines ADR181 R1, R2a, R2b, and R10. It does not change
+      Linear's ownership of current work or the Director-only main boundary.
+  related:
+    - ADR181_ci_synergy_rulings
+    - ADR221_game_first_refoundation_v4

--- a/ai/decisions/ADR230_exact_head_pr_and_dependabot_policy.yaml
+++ b/ai/decisions/ADR230_exact_head_pr_and_dependabot_policy.yaml
@@ -50,17 +50,20 @@ ADR230_exact_head_pr_and_dependabot_policy:
        refuses rather than silently paging beyond its fixed one-hundred-thread
        bound. The repository CodeQL alert floor must remain zero.
 
-    4. DEPENDABOT TRUST SPLIT. pull_request_target may classify a verified
-       Dependabot patch or minor update and manage only its eligibility label.
-       The label is presentation only and never merge authorization. That phase
-       never checks out pull-request code and never creates or updates repository
-       label metadata. A successful workflow_run resolves one open Dependabot
-       pull request at the completed run's exact head and checks out trusted dev
-       tooling. Immediately before the final ref snapshot, the merge verifier
-       requires one verified Dependabot commit at that head and derives every
-       exact-head update type from its signed commit metadata. Only patch and
-       minor types pass. The workflow does not poll and does not call a direct
-       GitHub merge command. Major updates remain manual-review work.
+    4. DEPENDABOT TRUST SPLIT. pull_request_target classifies Dependabot metadata
+       from trusted code and publishes an exact-head check run named Dependabot Eligibility.
+       The trusted GitHub Actions app records
+       success only for patch or minor updates and records failure otherwise.
+       Its eligibility label is presentation only and never merge authorization.
+       That phase never checks out pull-request code and never creates or updates
+       repository label metadata. A successful workflow_run resolves one open
+       Dependabot pull request at the completed run's exact head and checks out
+       trusted dev tooling. Immediately before the final ref snapshot, the merge
+       verifier queries bounded check runs on that head and requires the latest
+       exact-name check to be completed, successful, and owned by the canonical
+       GitHub Actions app. Commit author, committer, signature, and message fields
+       do not authorize eligibility. The workflow does not poll and does not call
+       a direct GitHub merge command. Major updates remain manual-review work.
 
     5. CHECKED-IN SETTINGS. .github/settings/pr-policy.json is the desired
        repository merge policy, dev ruleset, and Dependabot eligibility label.

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -1,6 +1,6 @@
 meta:
-  version: 1.77.0
-  updated: '2026-08-23'
+  version: 1.78.0
+  updated: '2026-08-25'
   description: Architecture Decision Records Index
   format: See individual ADR files in this directory
   # ADR NUMBER ALLOCATION (controller ruling 2026-07-21, v1.0.0 parallel lanes —
@@ -1060,3 +1060,8 @@ decisions:
     status: accepted
     date: '2026-08-25'
     file: ADR229_rust_gameplay_contract_authority.yaml
+  ADR230_exact_head_pr_and_dependabot_policy:
+    title: 'Pull requests merge through one exact-head verifier, Dependabot separates trusted classification from verified merging, and GitHub PR settings are applied as a rollback-safe checked-in policy'
+    status: accepted
+    date: '2026-08-25'
+    file: ADR230_exact_head_pr_and_dependabot_policy.yaml

--- a/docs/agents/governance.md
+++ b/docs/agents/governance.md
@@ -110,8 +110,9 @@ each commit. Use `mise run commit` so the local hooks can check staged content.
 <!-- vale Vale.Spelling = NO -->
 <!-- vale ste.UnapprovedWords = NO -->
 Only the Director merges to `main`. The two allowed sources are a release PR
-from `dev`, or a critical hotfix from `fix/*` that branches from `main`. Every
-merged hotfix needs a mandatory backport PR to `dev`.
+from `dev`, or a critical hotfix PR from `fix/*` that branches from `main` and
+goes directly to `main`. Every merged hotfix needs a mandatory backport PR to
+`dev`.
 <!-- vale ste.UnapprovedWords = YES -->
 <!-- vale Vale.Spelling = YES -->
 Use the merge rules in `CONTRIBUTORS.md` for all other pull requests.

--- a/docs/agents/governance.md
+++ b/docs/agents/governance.md
@@ -52,10 +52,11 @@ The migration is complete, and PER-15 is complete. Both projects remain
 recoverable evidence. Neither supplies current fields, views, estimates, or
 status.
 
-PER-2 records the accepted delivery automation. Link each pull request to its
-PER identity in the branch name, title, or description. Use `Part of PER-N` as
-a non-closing reference for a partial delivery. Use `Fixes PER-N` as a closing
-reference only on the final delivery that satisfies the issue.
+PER-2 records the accepted delivery automation. Each pull-request description
+must link its canonical Linear issue and select exactly one delivery
+disposition. Use `Part of PER-N` as a non-closing reference for a partial
+delivery. Use `Fixes PER-N` as a closing reference only on the final delivery
+that satisfies the issue.
 
 A multi-pull-request issue must remain open after every partial merge. Draft
 and review activity keep the linked issue in progress. Only the merged closing
@@ -108,13 +109,45 @@ each commit. Use `mise run commit` so the local hooks can check staged content.
 <!-- Vale: this paragraph preserves literal Git emergency-workflow terms. -->
 <!-- vale Vale.Spelling = NO -->
 <!-- vale ste.UnapprovedWords = NO -->
-Only the Director moves `dev` to `main` for a release. A critical hotfix is the
-only bypass: branch from `main`, open directly to `main`, and use a
-Director-only merge. Every merged hotfix needs a mandatory backport PR to
-`dev`.
+Only the Director merges to `main`. The two allowed sources are a release PR
+from `dev`, or a critical hotfix from `fix/*` that branches from `main`. Every
+merged hotfix needs a mandatory backport PR to `dev`.
 <!-- vale ste.UnapprovedWords = YES -->
 <!-- vale Vale.Spelling = YES -->
 Use the merge rules in `CONTRIBUTORS.md` for all other pull requests.
+
+<!-- Vale: this section preserves literal GitHub review and branch terms. -->
+<!-- vale ste.UnapprovedWords = NO -->
+## PR acceptance
+
+The merge record identifies the base branch and exact reviewed head SHA. All
+reported checks must complete successfully against that exact reviewed head
+SHA and base branch.
+
+The Copilot review must complete against the reviewed head. Each accepted
+comment needs a fix. Every comment needs a reply. The final record marks all
+Copilot review threads resolved.
+
+Each PR records a behavioral-contract disposition. Changed behavior links a
+durable, implementation-independent contract. No behavior change includes an
+explanation of why the current contracts are enough.
+
+Each PR also records its baseline disposition. An intentional governed
+baseline change includes the declared ceremony, the record from
+`tools/generate_ceremony_message.py`, and the required
+`Baselines: blessed(<slug>)` trailer. Unintended drift is a fault, not a
+ceremony.
+
+The sole merge command is:
+
+```bash
+mise run pr:merge -- N
+```
+
+Do not run `gh pr merge` directly in any form. Preserve the source branch by
+default. Branch deletion requires an explicit owner decision and verification
+that no open PR or other work depends on the branch.
+<!-- vale ste.UnapprovedWords = YES -->
 
 ## Scope and records
 

--- a/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
+++ b/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
@@ -2043,10 +2043,14 @@ fn engine_manifests_remain_postgres_free() {
 #[test]
 fn postgres_ci_and_sanctioned_merger_share_the_pinned_runtime_name() {
     let workflow = include_str!("../../../../.github/workflows/ci.yml");
-    let merger = include_str!("../../../../tools/pr_merge.py");
+    let merge_policy = include_str!("../../../../tools/pr_policy.py");
+    let sanctioned_merger = include_str!("../../../../tools/pr_merge.py");
     let critical_check = "Postgres Integration Tier (PG 17, pinned runtime)";
     assert!(workflow.contains(&format!("    name: {critical_check}")));
-    assert!(merger.contains(&format!("\"{critical_check}\",")));
+    assert!(merge_policy.contains(&format!("\"{critical_check}\",")));
+    assert!(sanctioned_merger.contains("from tools.pr_policy import"));
+    assert!(sanctioned_merger.contains("manifest = manifest_for_base(base_ref)"));
+    assert!(!sanctioned_merger.contains(&format!("\"{critical_check}\",")));
     assert!(workflow.contains(
         "- name: Build + start the isolated Postgres (CI fork; pinned runtime/package contract)"
     ));

--- a/tests/unit/governance/test_pr_policy_decision.py
+++ b/tests/unit/governance/test_pr_policy_decision.py
@@ -1,0 +1,76 @@
+"""Behavior contract for the accepted PR and dependency-merge policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+ADR_KEY = "ADR230_exact_head_pr_and_dependabot_policy"
+ADR_PATH = ROOT / "ai" / "decisions" / f"{ADR_KEY}.yaml"
+INDEX_PATH = ROOT / "ai" / "decisions" / "index.yaml"
+POLICY_PATH = ROOT / ".github" / "settings" / "pr-policy.json"
+
+
+def _mapping(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_accepted_decision_records_every_pr_policy_boundary() -> None:
+    decision = _mapping(ADR_PATH)[ADR_KEY]
+    text = str(decision["decision"])
+
+    assert decision["status"] == "accepted"
+    assert decision["date"] == "2026-08-25"
+    assert "exact head" in text
+    assert "base" in text
+    assert "complete manifest" in text
+    assert "blocking" in text
+    assert "advisory" in text
+    assert "completed Copilot review" in text
+    assert "exact endpoint" in text
+    assert "immutable bot" in text
+    assert "resolved" in text
+    assert "pull_request_target" in text
+    assert "workflow_run" in text
+    assert "verified Dependabot commit" in text
+    assert "exact-head update type" in text
+    assert "label is presentation only" in text
+    assert "snapshot" in text
+    assert "rollback" in text
+    assert "attempted writes" in text
+    assert "ADR181_ci_synergy_rulings" in decision["related"]
+
+
+def test_decision_index_resolves_to_the_live_record() -> None:
+    index = _mapping(INDEX_PATH)
+    entry = index["decisions"][ADR_KEY]
+
+    assert index["meta"]["version"] == "1.78.0"
+    assert str(index["meta"]["updated"]) == "2026-08-25"
+    assert entry["status"] == "accepted"
+    assert entry["date"] == "2026-08-25"
+    assert entry["file"] == ADR_PATH.name
+
+
+def test_checked_in_policy_is_merge_only_strict_and_conversation_safe() -> None:
+    policy = _mapping(POLICY_PATH)
+    repository = policy["repository"]
+    assert repository == {
+        "allow_merge_commit": True,
+        "allow_squash_merge": False,
+        "allow_rebase_merge": False,
+        "allow_auto_merge": False,
+        "delete_branch_on_merge": False,
+    }
+
+    rules = {rule["type"]: rule for rule in policy["dev_ruleset"]["rules"]}
+    pull_request = rules["pull_request"]["parameters"]
+    checks = rules["required_status_checks"]["parameters"]
+    assert pull_request["allowed_merge_methods"] == ["merge"]
+    assert pull_request["required_review_thread_resolution"] is True
+    assert checks["strict_required_status_checks_policy"] is True

--- a/tests/unit/governance/test_pr_policy_decision.py
+++ b/tests/unit/governance/test_pr_policy_decision.py
@@ -37,8 +37,10 @@ def test_accepted_decision_records_every_pr_policy_boundary() -> None:
     assert "resolved" in text
     assert "pull_request_target" in text
     assert "workflow_run" in text
-    assert "verified Dependabot commit" in text
-    assert "exact-head update type" in text
+    assert "Dependabot Eligibility" in text
+    assert "GitHub Actions app" in text
+    assert "exact-head check run" in text
+    assert "signed commit metadata" not in text
     assert "label is presentation only" in text
     assert "snapshot" in text
     assert "rollback" in text

--- a/tests/unit/governance/test_pr_policy_decision.py
+++ b/tests/unit/governance/test_pr_policy_decision.py
@@ -23,6 +23,7 @@ def _mapping(path: Path) -> dict[str, Any]:
 def test_accepted_decision_records_every_pr_policy_boundary() -> None:
     decision = _mapping(ADR_PATH)[ADR_KEY]
     text = str(decision["decision"])
+    normalized = " ".join(text.split())
 
     assert decision["status"] == "accepted"
     assert decision["date"] == "2026-08-25"
@@ -39,9 +40,13 @@ def test_accepted_decision_records_every_pr_policy_boundary() -> None:
     assert "workflow_run" in text
     assert "Dependabot Eligibility" in text
     assert "GitHub Actions app" in text
-    assert "exact-head check run" in text
+    assert "native exact-head CI" in text
+    assert "workflow ID" in text
+    assert "event actor" in text
+    assert "exactly one current commit" in text
+    assert "normal reviewed path" in text
     assert "signed commit metadata" not in text
-    assert "label is presentation only" in text
+    assert "label is presentation only" in normalized
     assert "snapshot" in text
     assert "rollback" in text
     assert "attempted writes" in text

--- a/tests/unit/governance/test_v4_portfolio_alignment.py
+++ b/tests/unit/governance/test_v4_portfolio_alignment.py
@@ -540,8 +540,8 @@ def test_per_18_adr_and_catalog_are_exact() -> None:
     """The accepted decision and catalog row cannot pass as an empty placeholder."""
     catalog = _yaml_document(_ADR_INDEX)
     assert catalog["meta"] == {
-        "version": "1.77.0",
-        "updated": "2026-08-23",
+        "version": "1.78.0",
+        "updated": "2026-08-25",
         "description": "Architecture Decision Records Index",
         "format": "See individual ADR files in this directory",
     }

--- a/tests/unit/test_pr_governance_contract.py
+++ b/tests/unit/test_pr_governance_contract.py
@@ -1,0 +1,112 @@
+"""Repository contract for accepting and merging pull requests.
+
+These sentinels catch a regression that makes a required review fact optional,
+permits an unverified merge path, or drops the emergency ``main`` boundary.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = Path(".github/PULL_REQUEST_TEMPLATE.md")
+DEPENDABOT_CONFIG = Path(".github/dependabot.yml")
+GOVERNANCE_SURFACES = (
+    TEMPLATE,
+    Path("CONTRIBUTORS.md"),
+    Path("docs/agents/governance.md"),
+)
+MERGE_COMMAND = "mise run pr:merge -- N"
+
+
+def _text(path: Path) -> str:
+    """Return one live governance surface as repository text."""
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def _normalized(path: Path) -> str:
+    """Return lowercase prose with Markdown line wrapping removed."""
+    return " ".join(_text(path).lower().split())
+
+
+@pytest.mark.parametrize("path", GOVERNANCE_SURFACES)
+def test_every_pr_declares_one_linear_delivery_disposition(path: Path) -> None:
+    """Removing either partial or closing Linear syntax must fail the gate."""
+    text = _text(path)
+    assert "Part of PER-N" in text
+    assert "Fixes PER-N" in text
+
+
+def test_pr_template_contributors_link_resolves_to_repository_root() -> None:
+    """The contributor link must work from the template's ``.github`` path."""
+    match = re.search(r"\[CONTRIBUTORS\.md\]\(([^)]+)\)", _text(TEMPLATE))
+    assert match is not None
+    target = (ROOT / TEMPLATE.parent / match.group(1)).resolve()
+    assert target == (ROOT / "CONTRIBUTORS.md").resolve()
+    assert target.is_file()
+
+
+@pytest.mark.parametrize("path", GOVERNANCE_SURFACES)
+def test_merge_evidence_is_pinned_to_reviewed_head_and_base(path: Path) -> None:
+    """Review and green checks must identify the exact head and target base."""
+    text = _normalized(path)
+    assert "exact reviewed head sha" in text
+    assert "base branch" in text
+    assert "all reported checks" in text
+
+
+@pytest.mark.parametrize("path", GOVERNANCE_SURFACES)
+def test_copilot_review_requires_disposition_and_resolved_threads(path: Path) -> None:
+    """A completed review alone must not leave Copilot threads unresolved."""
+    text = _normalized(path)
+    assert "copilot review" in text
+    assert "fix" in text
+    assert "reply" in text
+    assert "resolved" in text
+
+
+@pytest.mark.parametrize("path", GOVERNANCE_SURFACES)
+def test_behavior_and_baseline_dispositions_are_explicit(path: Path) -> None:
+    """A PR must account for durable behavior evidence and baseline drift."""
+    text = _normalized(path)
+    assert "behavioral-contract disposition" in text
+    assert "no behavior change" in text
+    assert "baseline" in text
+    assert "ceremony" in text
+
+
+@pytest.mark.parametrize("path", GOVERNANCE_SURFACES)
+def test_only_sanctioned_merge_command_is_documented(path: Path) -> None:
+    """Direct GitHub CLI merge paths must remain explicitly forbidden."""
+    text = _text(path)
+    assert MERGE_COMMAND in text
+    assert "Do not run `gh pr merge` directly" in text
+
+
+@pytest.mark.parametrize("path", GOVERNANCE_SURFACES)
+def test_source_branch_is_preserved_by_default(path: Path) -> None:
+    """Routine merge guidance must not silently delete the evidence lane."""
+    assert "preserve the source branch by default" in _normalized(path)
+
+
+@pytest.mark.parametrize("path", GOVERNANCE_SURFACES)
+def test_main_documents_both_director_only_sources(path: Path) -> None:
+    """A release from dev and a critical hotfix are the only main sources."""
+    text = _normalized(path)
+    assert "director" in text
+    assert "release pr" in text
+    assert "from `dev`" in text
+    assert "critical hotfix" in text
+    assert "backport" in text
+
+
+def test_dependabot_config_names_pr_qualification_not_retired_promotion() -> None:
+    """Point-of-use guidance must not send releases through tools/promote.sh."""
+    text = _normalized(DEPENDABOT_CONFIG)
+    assert "main qualification" in text
+    assert "release pr" in text
+    assert "tools/promote.sh" not in text
+    assert "every every" not in text

--- a/tests/unit/test_workflow_hygiene.py
+++ b/tests/unit/test_workflow_hygiene.py
@@ -45,6 +45,9 @@ import yaml
 WORKFLOWS_DIR = Path(".github/workflows")
 ACTIONS_DIR = Path(".github/actions")
 FROZEN_ENGINE_PATH = WORKFLOWS_DIR / "frozen-engine.yml"
+DEPENDABOT_AUTOMERGE_PATH = WORKFLOWS_DIR / "dependabot-automerge.yml"
+DEPENDABOT_CONFIG_PATH = Path(".github/dependabot.yml")
+PR_POLICY_PATH = Path(".github/settings/pr-policy.json")
 FROZEN_REF = "p27-python-freeze"
 HYPERGRAPH_REF = "dc1c06abbbc7a3f8633d1561451e61e101ad2090"
 
@@ -228,6 +231,11 @@ def _frozen_engine_errors(workflow: dict[str, Any]) -> list[str]:
 
 def _frozen_engine_external_action_errors(workflow_text: str) -> list[str]:
     """Return mutable or unannotated external action references in the frozen gate."""
+    return _external_action_reference_errors(workflow_text, "frozen-engine.yml")
+
+
+def _external_action_reference_errors(workflow_text: str, filename: str) -> list[str]:
+    """Return mutable or unannotated external action references."""
     errors: list[str] = []
     for line_number, line in enumerate(workflow_text.splitlines(), start=1):
         match = _ACTION_USES_LINE.match(line)
@@ -237,10 +245,10 @@ def _frozen_engine_external_action_errors(workflow_text: str) -> list[str]:
         if action.startswith("./"):
             continue
         if not separator or not _ACTION_SHA.fullmatch(reference):
-            errors.append(f"frozen-engine.yml:{line_number}: external action must use a 40-hex SHA")
+            errors.append(f"{filename}:{line_number}: external action must use a 40-hex SHA")
         tag = match.group("tag")
         if tag is None or not _RELEASE_TAG.fullmatch(tag):
-            errors.append(f"frozen-engine.yml:{line_number}: external action must have a # vN tag")
+            errors.append(f"{filename}:{line_number}: external action must have a # vN tag")
     return errors
 
 
@@ -508,3 +516,208 @@ class TestDocReferencedWorkflowsTracked:
             "The scheduled workflow (.github/workflows/openwiki-update.yml) refreshes the wiki."
         )
         assert refs == {"openwiki-update.yml"}
+
+
+def _dependabot_update(config: dict[str, Any], ecosystem: str) -> dict[str, Any]:
+    """Return one Dependabot ecosystem entry, requiring an unambiguous match."""
+    updates = config.get("updates") or []
+    assert len(updates) == 4, f"expected four ecosystem entries, got {len(updates)}"
+    matches = [
+        updates[index] for index in range(4) if updates[index].get("package-ecosystem") == ecosystem
+    ]
+    assert len(matches) == 1, f"expected one {ecosystem!r} update entry, got {len(matches)}"
+    return matches[0]
+
+
+@pytest.mark.skipif(not WORKFLOWS_DIR.is_dir(), reason=".github/workflows not present")
+class TestDependabotPolicy:
+    """Dependabot metadata and merge authority stay separate and exact-head pinned."""
+
+    def test_workflow_uses_only_trusted_event_driven_phases(self) -> None:
+        """Untrusted PR code must never enter either privileged automation phase."""
+        workflow = yaml.safe_load(DEPENDABOT_AUTOMERGE_PATH.read_text())
+        triggers = _triggers(workflow)
+        assert set(triggers) == {"pull_request_target", "workflow_run"}
+        assert triggers["pull_request_target"] == {
+            "branches": ["dev"],
+            "types": ["opened", "reopened", "synchronize"],
+        }
+        assert triggers["workflow_run"] == {
+            "workflows": ["CI", "CodeQL Security Scan"],
+            "types": ["completed"],
+        }
+        assert workflow.get("permissions") == {}
+
+        classify = workflow["jobs"]["classify"]
+        assert classify["permissions"] == {
+            "contents": "read",
+            "issues": "write",
+            "pull-requests": "read",
+        }
+        assert "github.event.pull_request.user.login == 'dependabot[bot]'" in classify["if"]
+        assert not any(
+            str(step.get("uses", "")).startswith("actions/checkout") for step in classify["steps"]
+        )
+
+        merge = workflow["jobs"]["merge"]
+        assert merge["permissions"] == {
+            "contents": "write",
+            "pull-requests": "write",
+            "security-events": "read",
+        }
+        assert "github.event.workflow_run.conclusion == 'success'" in merge["if"]
+        assert "github.event.workflow_run.event == 'pull_request'" in merge["if"]
+
+    def test_workflow_has_per_pr_concurrency(self) -> None:
+        """Duplicate completion events must serialize on the same Dependabot PR."""
+        workflow = yaml.safe_load(DEPENDABOT_AUTOMERGE_PATH.read_text())
+        concurrency = workflow["concurrency"]
+        group = str(concurrency["group"])
+        assert "github.event.pull_request.number" in group
+        assert "github.event.workflow_run.pull_requests[0].number" in group
+        assert "github.event.workflow_run.head_branch" in group
+        assert concurrency["cancel-in-progress"] is False
+
+    def test_eligibility_is_exactly_patch_or_minor_and_is_reversible(self) -> None:
+        """A major or malformed update must lose the dedicated eligibility label."""
+        workflow = yaml.safe_load(DEPENDABOT_AUTOMERGE_PATH.read_text())
+        classify = workflow["jobs"]["classify"]
+        assert set(classify["env"]["ELIGIBLE_UPDATE_TYPES"].split()) == {
+            "version-update:semver-patch",
+            "version-update:semver-minor",
+        }
+        assert classify["env"]["ELIGIBILITY_LABEL"] == "dependencies:automerge"
+
+        eligibility = next(step for step in classify["steps"] if step.get("id") == "eligibility")
+        assert eligibility["env"]["UPDATE_TYPE"] == "${{ steps.metadata.outputs.update-type }}"
+        label = next(
+            step for step in classify["steps"] if step.get("name") == "Set eligibility label"
+        )
+        script = str(label["run"])
+        assert "steps.eligibility.outputs.eligible" in label["env"]["ELIGIBLE"]
+        assert "--add-label" in script
+        assert "--remove-label" in script
+
+    def test_eligibility_label_matches_the_transactional_repository_policy(self) -> None:
+        """Classification verifies managed metadata without becoming a second writer."""
+        workflow = yaml.safe_load(DEPENDABOT_AUTOMERGE_PATH.read_text())
+        policy = yaml.safe_load(PR_POLICY_PATH.read_text())
+        desired_label = policy["automerge_label"]
+        classify = workflow["jobs"]["classify"]
+        label_step = next(
+            step for step in classify["steps"] if step.get("name") == "Set eligibility label"
+        )
+        script = str(label_step["run"])
+
+        assert classify["env"]["ELIGIBILITY_LABEL"] == desired_label["name"]
+        assert desired_label["color"] in classify["env"]["ELIGIBILITY_LABEL_COLOR"]
+        assert desired_label["description"] in classify["env"]["ELIGIBILITY_LABEL_DESCRIPTION"]
+        assert "gh api" in script
+        assert "jq -e" in script
+        assert "gh label create" not in script
+        assert "--force" not in script
+
+    def test_merge_uses_trusted_dev_tools_and_exact_candidate_head(self) -> None:
+        """A moved, non-Dependabot, or ambiguous PR must never merge."""
+        workflow = yaml.safe_load(DEPENDABOT_AUTOMERGE_PATH.read_text())
+        merge = workflow["jobs"]["merge"]
+        checkout = next(
+            step
+            for step in merge["steps"]
+            if str(step.get("uses", "")).startswith("actions/checkout")
+        )
+        assert checkout["with"] == {"ref": "dev", "persist-credentials": False}
+
+        candidate = next(step for step in merge["steps"] if step.get("id") == "candidate")
+        candidate_script = str(candidate["run"])
+        assert "base=dev" in candidate_script
+        assert '.user.login == "dependabot[bot]"' in candidate_script
+        assert ".head.sha == $head" in candidate_script
+        assert ".name == $label" not in candidate_script
+        assert "candidate_count" in candidate_script and "-ne 1" in candidate_script
+        assert candidate["env"]["EXPECTED_HEAD"] == "${{ github.event.workflow_run.head_sha }}"
+
+        merge_step = next(step for step in merge["steps"] if step.get("name") == "Merge")
+        assert merge_step["if"] == "steps.candidate.outputs.eligible == 'true'"
+        assert merge_step["env"]["EXPECTED_HEAD"] == "${{ github.event.workflow_run.head_sha }}"
+        assert (
+            'python3 tools/pr_merge.py "$PR_NUMBER" --expected-head "$EXPECTED_HEAD" --dependabot'
+        ) in str(merge_step["run"])
+
+    def test_dependabot_workflow_external_actions_are_immutable_and_annotated(self) -> None:
+        """A mutable tag must never select code inside the privileged workflow."""
+        errors = _external_action_reference_errors(
+            DEPENDABOT_AUTOMERGE_PATH.read_text(),
+            DEPENDABOT_AUTOMERGE_PATH.name,
+        )
+        assert not errors, "\n".join(errors)
+
+    def test_external_action_checker_rejects_a_mutable_release_tag(self) -> None:
+        """Mutation witness: a release-looking tag is still a mutable reference."""
+        errors = _external_action_reference_errors(
+            "steps:\n  - uses: actions/checkout@v7 # v7.0.1\n",
+            "future.yml",
+        )
+        assert errors == ["future.yml:2: external action must use a 40-hex SHA"]
+
+    def test_workflow_never_polls_or_calls_gh_merge_directly(self) -> None:
+        """The old forty-minute waiter and bypass merge command must stay retired."""
+        workflow_text = DEPENDABOT_AUTOMERGE_PATH.read_text()
+        assert re.search(r"\bsleep\b", workflow_text) is None
+        assert re.search(r"\bseq\b", workflow_text) is None
+        assert "gh pr checks" not in workflow_text
+        assert "gh pr merge" not in workflow_text
+
+    def test_config_targets_default_branch_and_never_groups_majors(self) -> None:
+        """Security settings must apply and grouped PRs must stay low-risk."""
+        config = yaml.safe_load(DEPENDABOT_CONFIG_PATH.read_text())
+        updates = config["updates"]
+        assert len(updates) == 4
+        assert all("target-branch" not in updates[index] for index in range(4))
+
+        uv_groups = _dependabot_update(config, "uv")["groups"]
+        assert set(uv_groups) == {"uv-minor-patch", "uv-security"}
+        assert set(uv_groups["uv-minor-patch"]["update-types"]) == {"minor", "patch"}
+        assert set(uv_groups["uv-security"]["update-types"]) == {"minor", "patch"}
+
+        action_groups = _dependabot_update(config, "github-actions")["groups"]
+        assert set(action_groups) == {"github-actions-minor-patch"}
+        assert set(action_groups["github-actions-minor-patch"]["update-types"]) == {
+            "minor",
+            "patch",
+        }
+
+        cargo_groups = _dependabot_update(config, "cargo")["groups"]
+        assert set(cargo_groups) == {"rust-minor-patch", "rust-security"}
+        assert set(cargo_groups["rust-minor-patch"]["update-types"]) == {"minor", "patch"}
+        assert set(cargo_groups["rust-security"]["update-types"]) == {"minor", "patch"}
+
+    def test_config_uses_uv_and_retains_only_justified_major_ignores(self) -> None:
+        """The live uv lock and explicit deferred-major rails must stay represented."""
+        config = yaml.safe_load(DEPENDABOT_CONFIG_PATH.read_text())
+        uv = _dependabot_update(config, "uv")
+        assert {entry["dependency-name"]: entry["update-types"] for entry in uv["ignore"]} == {
+            "django": ["version-update:semver-major"],
+            "django-stubs": ["version-update:semver-major"],
+            "mypy": ["version-update:semver-major"],
+        }
+        docker = _dependabot_update(config, "docker")
+        assert docker["ignore"] == [
+            {
+                "dependency-name": "postgis/postgis",
+                "update-types": ["version-update:semver-major"],
+            }
+        ]
+
+    def test_config_does_not_request_nonexistent_rust_label(self) -> None:
+        """Cargo PR creation must not fail because the removed label is absent."""
+        config = yaml.safe_load(DEPENDABOT_CONFIG_PATH.read_text())
+        cargo = _dependabot_update(config, "cargo")
+        assert cargo["labels"] == ["dependencies"]
+        actions = _dependabot_update(config, "github-actions")
+        assert list(actions["groups"].values()) == [
+            {
+                "patterns": ["*"],
+                "update-types": ["minor", "patch"],
+            }
+        ]

--- a/tests/unit/test_workflow_hygiene.py
+++ b/tests/unit/test_workflow_hygiene.py
@@ -34,6 +34,7 @@ Four invariants, one per failure mode:
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -642,6 +643,72 @@ class TestDependabotPolicy:
         assert "jq -e" in script
         assert "gh label create" not in script
         assert "--force" not in script
+
+    def test_eligibility_label_api_path_uses_the_url_encoded_declared_label(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Repository metadata lookup must derive its URL path from the label variable."""
+        workflow = yaml.safe_load(DEPENDABOT_AUTOMERGE_PATH.read_text())
+        classify = workflow["jobs"]["classify"]
+        label_step = next(
+            step for step in classify["steps"] if step.get("name") == "Set eligibility label"
+        )
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        calls_path = tmp_path / "gh-calls.jsonl"
+        fake_gh = fake_bin / "gh"
+        fake_gh.write_text(
+            """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+with Path(os.environ["GH_CALLS"]).open("a") as calls:
+    calls.write(json.dumps(args) + "\\n")
+if args[0] == "api":
+    print(json.dumps({
+        "name": os.environ["ELIGIBILITY_LABEL"],
+        "color": os.environ["ELIGIBILITY_LABEL_COLOR"],
+        "description": os.environ["ELIGIBILITY_LABEL_DESCRIPTION"],
+    }))
+elif args[:2] == ["pr", "view"]:
+    print(json.dumps({"labels": [{"name": os.environ["ELIGIBILITY_LABEL"]}]}))
+else:
+    raise SystemExit(99)
+"""
+        )
+        fake_gh.chmod(0o755)
+        declared_label = "dependencies:automerge/next wave"
+        env = {
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "ELIGIBILITY_LABEL": declared_label,
+            "ELIGIBILITY_LABEL_COLOR": str(classify["env"]["ELIGIBILITY_LABEL_COLOR"]),
+            "ELIGIBILITY_LABEL_DESCRIPTION": str(classify["env"]["ELIGIBILITY_LABEL_DESCRIPTION"]),
+            "ELIGIBLE": "true",
+            "GH_CALLS": str(calls_path),
+            "GH_TOKEN": "test-token",
+            "GITHUB_REPOSITORY": "example/babylon",
+            "PR_NUMBER": "742",
+        }
+
+        result = subprocess.run(  # noqa: S603,S607 - executes the trusted workflow step
+            ["bash", "-c", str(label_step["run"])],
+            capture_output=True,
+            env=env,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, result.stderr
+        calls = [yaml.safe_load(line) for line in calls_path.read_text().splitlines()]
+        assert calls[0] == [
+            "api",
+            "repos/example/babylon/labels/dependencies%3Aautomerge%2Fnext%20wave",
+        ]
 
     def test_merge_uses_trusted_dev_tools_and_exact_candidate_head(self) -> None:
         """A moved, non-Dependabot, or ambiguous PR must never merge."""

--- a/tests/unit/test_workflow_hygiene.py
+++ b/tests/unit/test_workflow_hygiene.py
@@ -550,6 +550,7 @@ class TestDependabotPolicy:
 
         classify = workflow["jobs"]["classify"]
         assert classify["permissions"] == {
+            "checks": "write",
             "contents": "read",
             "issues": "write",
             "pull-requests": "read",
@@ -590,6 +591,27 @@ class TestDependabotPolicy:
 
         eligibility = next(step for step in classify["steps"] if step.get("id") == "eligibility")
         assert eligibility["env"]["UPDATE_TYPE"] == "${{ steps.metadata.outputs.update-type }}"
+        eligibility_script = str(eligibility["run"])
+        assert "conclusion=success" in eligibility_script
+        assert "conclusion=failure" in eligibility_script
+
+        attestation = next(
+            step
+            for step in classify["steps"]
+            if step.get("name") == "Publish exact-head eligibility check"
+        )
+        assert attestation["env"] == {
+            "CHECK_CONCLUSION": "${{ steps.eligibility.outputs.conclusion }}",
+            "CHECK_NAME": "Dependabot Eligibility",
+            "GH_TOKEN": "${{ github.token }}",
+            "HEAD_SHA": "${{ github.event.pull_request.head.sha }}",
+        }
+        attestation_script = str(attestation["run"])
+        assert "repos/$GITHUB_REPOSITORY/check-runs" in attestation_script
+        assert "jq -n" in attestation_script
+        assert "--arg status completed" in attestation_script
+        assert "--input -" in attestation_script
+
         label = next(
             step for step in classify["steps"] if step.get("name") == "Set eligibility label"
         )

--- a/tests/unit/test_workflow_hygiene.py
+++ b/tests/unit/test_workflow_hygiene.py
@@ -543,31 +543,49 @@ class TestDependabotPolicy:
             "types": ["opened", "reopened", "synchronize"],
         }
         assert triggers["workflow_run"] == {
-            "workflows": ["CI", "CodeQL Security Scan"],
+            "workflows": ["CI"],
             "types": ["completed"],
         }
         assert workflow.get("permissions") == {}
 
         classify = workflow["jobs"]["classify"]
         assert classify["permissions"] == {
-            "checks": "write",
             "contents": "read",
             "issues": "write",
             "pull-requests": "read",
         }
         assert "github.event.pull_request.user.login == 'dependabot[bot]'" in classify["if"]
+        assert "github.actor == 'dependabot[bot]'" in classify["if"]
+        assert "github.event.sender.login == 'dependabot[bot]'" in classify["if"]
+        assert "github.event.sender.id == 49699333" in classify["if"]
         assert not any(
             str(step.get("uses", "")).startswith("actions/checkout") for step in classify["steps"]
         )
 
         merge = workflow["jobs"]["merge"]
+        assert merge["name"] == "Dependabot Eligibility"
         assert merge["permissions"] == {
+            "actions": "read",
+            "checks": "read",
             "contents": "write",
             "pull-requests": "write",
             "security-events": "read",
         }
         assert "github.event.workflow_run.conclusion == 'success'" in merge["if"]
         assert "github.event.workflow_run.event == 'pull_request'" in merge["if"]
+        assert "github.event.workflow_run.name == 'CI'" in merge["if"]
+        run_name = str(workflow["run-name"])
+        assert "github.event.workflow_run.id" in run_name
+        assert "github.event.workflow_run.head_sha" in run_name
+
+    def test_non_dependabot_synchronizing_actor_cannot_classify(self) -> None:
+        """A branch update by any other actor must skip trusted metadata parsing."""
+        workflow = yaml.safe_load(DEPENDABOT_AUTOMERGE_PATH.read_text())
+        classify_if = str(workflow["jobs"]["classify"]["if"])
+
+        assert "github.actor == 'dependabot[bot]'" in classify_if
+        assert "github.event.sender.login == 'dependabot[bot]'" in classify_if
+        assert "github.event.sender.id == 49699333" in classify_if
 
     def test_workflow_has_per_pr_concurrency(self) -> None:
         """Duplicate completion events must serialize on the same Dependabot PR."""
@@ -592,25 +610,11 @@ class TestDependabotPolicy:
         eligibility = next(step for step in classify["steps"] if step.get("id") == "eligibility")
         assert eligibility["env"]["UPDATE_TYPE"] == "${{ steps.metadata.outputs.update-type }}"
         eligibility_script = str(eligibility["run"])
-        assert "conclusion=success" in eligibility_script
-        assert "conclusion=failure" in eligibility_script
+        assert "eligible=true" in eligibility_script
+        assert "conclusion=" not in eligibility_script
+        assert not any("check-runs" in str(step.get("run", "")) for step in classify["steps"])
 
-        attestation = next(
-            step
-            for step in classify["steps"]
-            if step.get("name") == "Publish exact-head eligibility check"
-        )
-        assert attestation["env"] == {
-            "CHECK_CONCLUSION": "${{ steps.eligibility.outputs.conclusion }}",
-            "CHECK_NAME": "Dependabot Eligibility",
-            "GH_TOKEN": "${{ github.token }}",
-            "HEAD_SHA": "${{ github.event.pull_request.head.sha }}",
-        }
-        attestation_script = str(attestation["run"])
-        assert "repos/$GITHUB_REPOSITORY/check-runs" in attestation_script
-        assert "jq -n" in attestation_script
-        assert "--arg status completed" in attestation_script
-        assert "--input -" in attestation_script
+        assert workflow["jobs"]["merge"]["name"] == "Dependabot Eligibility"
 
         label = next(
             step for step in classify["steps"] if step.get("name") == "Set eligibility label"
@@ -654,17 +658,24 @@ class TestDependabotPolicy:
         candidate_script = str(candidate["run"])
         assert "base=dev" in candidate_script
         assert '.user.login == "dependabot[bot]"' in candidate_script
+        assert ".user.id == 49699333" in candidate_script
+        assert '.user.type == "Bot"' in candidate_script
         assert ".head.sha == $head" in candidate_script
         assert ".name == $label" not in candidate_script
+        assert "pull_count=\"$(jq 'length'" in candidate_script
+        assert 'if [ "$pull_count" -ge 100 ]' in candidate_script
         assert "candidate_count" in candidate_script and "-ne 1" in candidate_script
         assert candidate["env"]["EXPECTED_HEAD"] == "${{ github.event.workflow_run.head_sha }}"
 
         merge_step = next(step for step in merge["steps"] if step.get("name") == "Merge")
         assert merge_step["if"] == "steps.candidate.outputs.eligible == 'true'"
         assert merge_step["env"]["EXPECTED_HEAD"] == "${{ github.event.workflow_run.head_sha }}"
-        assert (
-            'python3 tools/pr_merge.py "$PR_NUMBER" --expected-head "$EXPECTED_HEAD" --dependabot'
-        ) in str(merge_step["run"])
+        merge_script = str(merge_step["run"])
+        assert 'python3 tools/pr_merge.py "$PR_NUMBER" --expected-head "$EXPECTED_HEAD"' in (
+            merge_script
+        )
+        assert '--dependabot-source-run "$SOURCE_RUN_ID"' in merge_script
+        assert '--dependabot-classifier-run "$CLASSIFIER_RUN_ID"' in merge_script
 
     def test_dependabot_workflow_external_actions_are_immutable_and_annotated(self) -> None:
         """A mutable tag must never select code inside the privileged workflow."""

--- a/tests/unit/tools/test_pr_merge_policy.py
+++ b/tests/unit/tools/test_pr_merge_policy.py
@@ -19,6 +19,9 @@ OTHER_SHA = "c" * 40
 
 COPILOT_BOT_ID = 175728472
 COPILOT_BOT_NODE_ID = "BOT_kgDOCnlnWA"
+GITHUB_ACTIONS_APP_ID = 15368
+GITHUB_ACTIONS_APP_SLUG = "github-actions"
+DEPENDABOT_ELIGIBILITY_CHECK = "Dependabot Eligibility"
 
 DEV_BLOCKING_CHECKS = (
     "Fast Gate (hygiene, lint, format, imports, types, lock)",
@@ -82,6 +85,8 @@ elif args[0] == "api" and args[1].endswith("/reviews?per_page=100"):
     print(json.dumps(scenario["rest_reviews"]))
 elif args[0] == "api" and args[1].endswith("/pulls/742"):
     print(json.dumps(scenario["dependabot_pr"]))
+elif args[0] == "api" and "/check-runs?check_name=Dependabot%20Eligibility" in args[1]:
+    print(json.dumps(scenario["dependabot_check_runs"]))
 elif args[0] == "api" and args[1].endswith("/pulls/742/commits?per_page=100"):
     print(json.dumps(scenario["dependabot_commits"]))
 elif args[0] == "api" and "/comments" in args[1]:
@@ -137,6 +142,7 @@ def _dependabot_commit(
     return {
         "sha": head_sha,
         "author": {"login": "dependabot[bot]", "type": "Bot"},
+        "committer": {"login": "web-flow", "id": 19864447, "type": "User"},
         "commit": {
             "message": (
                 "Bump dependencies\n\n---\nupdated-dependencies:\n"
@@ -146,6 +152,31 @@ def _dependabot_commit(
             "verification": {"verified": True, "reason": "valid"},
         },
     }
+
+
+def _eligibility_check(
+    *,
+    check_id: int = 9101,
+    head_sha: str = HEAD_SHA,
+    status: str = "completed",
+    conclusion: str | None = "success",
+    app_id: int = GITHUB_ACTIONS_APP_ID,
+    app_slug: str = GITHUB_ACTIONS_APP_SLUG,
+    started_at: str = "2026-08-25T12:02:00Z",
+) -> dict[str, object]:
+    return {
+        "id": check_id,
+        "name": DEPENDABOT_ELIGIBILITY_CHECK,
+        "head_sha": head_sha,
+        "status": status,
+        "conclusion": conclusion,
+        "started_at": started_at,
+        "app": {"id": app_id, "slug": app_slug},
+    }
+
+
+def _eligibility_payload(*checks: dict[str, object]) -> dict[str, object]:
+    return {"total_count": len(checks), "check_runs": list(checks)}
 
 
 def _default_scenario() -> dict[str, object]:
@@ -171,6 +202,7 @@ def _default_scenario() -> dict[str, object]:
             "user": {"login": "dependabot[bot]", "type": "Bot"},
         },
         "dependabot_commits": [_dependabot_commit()],
+        "dependabot_check_runs": _eligibility_payload(_eligibility_check()),
         "threads": {
             "data": {
                 "repository": {
@@ -599,22 +631,46 @@ def test_director_main_rejects_complete_dev_manifest_as_wrong_qualification(
     assert _merge_calls(calls) == []
 
 
-def test_dependabot_mode_revalidates_verified_exact_head_metadata(tmp_path: Path) -> None:
-    result, calls = _run_pr_merge(tmp_path, "--dependabot")
+def test_dependabot_mode_requires_latest_canonical_exact_head_eligibility_check(
+    tmp_path: Path,
+) -> None:
+    scenario = _default_scenario()
+    scenario["dependabot_check_runs"] = _eligibility_payload(
+        _eligibility_check(
+            check_id=9100,
+            status="completed",
+            conclusion="failure",
+            started_at="2026-08-25T12:01:00Z",
+        ),
+        _eligibility_check(check_id=9101),
+    )
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
 
     assert result.returncode == 0, result.stderr
     assert len(_merge_calls(calls)) == 1
-    assert any(call[0] == "api" and call[1].endswith("/commits?per_page=100") for call in calls)
+    assert any(
+        call[0] == "api"
+        and f"/commits/{HEAD_SHA}/check-runs?" in call[1]
+        and "check_name=Dependabot%20Eligibility" in call[1]
+        and "filter=all" in call[1]
+        and "per_page=100" in call[1]
+        for call in calls
+    )
+    assert not any(call[0] == "api" and "/pulls/742/commits?" in call[1] for call in calls)
 
 
 def test_dependabot_major_update_is_never_authorized_by_a_label(tmp_path: Path) -> None:
     scenario = _default_scenario()
-    scenario["dependabot_commits"] = [_dependabot_commit(update_type="version-update:semver-major")]
+    scenario["dependabot_check_runs"] = _eligibility_payload(
+        _eligibility_check(conclusion="failure")
+    )
 
     result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
 
     assert result.returncode == 1
-    assert "semver-major" in result.stderr
+    assert DEPENDABOT_ELIGIBILITY_CHECK in result.stderr
+    assert "failure" in result.stderr
     assert _merge_calls(calls) == []
 
 
@@ -631,18 +687,93 @@ def test_dependabot_synchronization_invalidates_old_head_classification(tmp_path
     assert _merge_calls(calls) == []
 
 
-def test_dependabot_exact_head_must_be_one_verified_bot_commit(tmp_path: Path) -> None:
+def test_dependabot_attributed_commit_with_generic_signer_cannot_authorize(
+    tmp_path: Path,
+) -> None:
     scenario = _default_scenario()
-    commit = _dependabot_commit()
-    commit_payload = commit["commit"]
-    assert isinstance(commit_payload, dict)
-    commit_payload["verification"] = {"verified": False, "reason": "unsigned"}
-    scenario["dependabot_commits"] = [commit]
+    scenario["dependabot_commits"] = [_dependabot_commit()]
+    scenario["dependabot_check_runs"] = _eligibility_payload()
 
     result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
 
     assert result.returncode == 1
-    assert "verified Dependabot commit" in result.stderr
+    assert "missing" in result.stderr
+    assert DEPENDABOT_ELIGIBILITY_CHECK in result.stderr
+    assert not any(call[0] == "api" and "/pulls/742/commits?" in call[1] for call in calls)
+    assert _merge_calls(calls) == []
+
+
+def test_dependabot_eligibility_check_must_match_exact_head(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    scenario["dependabot_check_runs"] = _eligibility_payload(_eligibility_check(head_sha=OTHER_SHA))
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "head" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+@pytest.mark.parametrize(
+    ("app_id", "app_slug"),
+    [
+        (1, GITHUB_ACTIONS_APP_SLUG),
+        (GITHUB_ACTIONS_APP_ID, "attacker-actions"),
+    ],
+    ids=["wrong-app-id", "wrong-app-slug"],
+)
+def test_dependabot_eligibility_check_requires_canonical_actions_app(
+    tmp_path: Path,
+    app_id: int,
+    app_slug: str,
+) -> None:
+    scenario = _default_scenario()
+    scenario["dependabot_check_runs"] = _eligibility_payload(
+        _eligibility_check(app_id=app_id, app_slug=app_slug)
+    )
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "GitHub Actions app" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+@pytest.mark.parametrize(
+    ("status", "conclusion"),
+    [("queued", None), ("completed", "failure")],
+    ids=["incomplete", "non-success"],
+)
+def test_dependabot_eligibility_check_must_complete_successfully(
+    tmp_path: Path,
+    status: str,
+    conclusion: str | None,
+) -> None:
+    scenario = _default_scenario()
+    scenario["dependabot_check_runs"] = _eligibility_payload(
+        _eligibility_check(status=status, conclusion=conclusion)
+    )
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert f"status={status}" in result.stderr
+    assert f"conclusion={conclusion or ''}" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_dependabot_eligibility_check_refuses_a_full_page(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    checks = tuple(_eligibility_check(check_id=index + 1) for index in range(100))
+    scenario["dependabot_check_runs"] = {
+        "total_count": 100,
+        "check_runs": list(checks),
+    }
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "100-item safety bound" in result.stderr
     assert _merge_calls(calls) == []
 
 

--- a/tests/unit/tools/test_pr_merge_policy.py
+++ b/tests/unit/tools/test_pr_merge_policy.py
@@ -1082,3 +1082,14 @@ def test_delete_branch_still_refuses_a_stacked_child(tmp_path: Path) -> None:
     assert result.returncode == 1
     assert "open PR(s) [743] base on this branch" in result.stderr
     assert _merge_calls(calls) == []
+
+
+def test_delete_branch_refuses_an_exactly_full_child_page(tmp_path: Path) -> None:
+    scenario = copy.deepcopy(_default_scenario())
+    scenario["children"] = [{"number": number} for number in range(1, 101)]
+
+    result, calls = _run_pr_merge(tmp_path, "--delete-branch", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "child pull requests reached the 100-item safety bound" in result.stderr
+    assert _merge_calls(calls) == []

--- a/tests/unit/tools/test_pr_merge_policy.py
+++ b/tests/unit/tools/test_pr_merge_policy.py
@@ -1,0 +1,712 @@
+"""Behavior contracts for the sanctioned pull-request merge verifier."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PR_MERGE = REPO_ROOT / "tools" / "pr_merge.py"
+HEAD_SHA = "a" * 40
+BASE_SHA = "b" * 40
+OTHER_SHA = "c" * 40
+
+COPILOT_BOT_ID = 175728472
+COPILOT_BOT_NODE_ID = "BOT_kgDOCnlnWA"
+
+DEV_BLOCKING_CHECKS = (
+    "Fast Gate (hygiene, lint, format, imports, types, lock)",
+    "Unit Tests (xdist, coverage gate)",
+    "Determinism Gate (byte-identical dense goldens)",
+    "Secret Scan (gitleaks, full history)",
+    "IaC Config Scan (trivy, HIGH+CRITICAL blocking)",
+    "Security Audit (pip-audit policy — blocking since item-41)",
+    "Rust Gate (fmt, clippy, test, doc — rust/ workspace)",
+    "Baseline Ceremony Gate (§6.5 provenance)",
+    "Postgres Integration Tier (PG 17, pinned runtime)",
+)
+
+MAIN_BLOCKING_CHECKS = (
+    "Fast Gate (hygiene, lint, format, imports, types, lock)",
+    "Unit Tests (xdist, coverage gate)",
+    "Determinism Gate (byte-identical dense goldens)",
+    "Security Audit (pip-audit policy — blocking since item-41)",
+    "Non-Unit Tests (integration, scenarios, property, contract)",
+    "Postgres Integration (web bridge)",
+    "Determinism Bundle (Postgres-backed, strict)",
+    "Reference-Data Tests (ci-data-v1 subset)",
+    "Documentation Build (doctest blocks; manual advisory)",
+    "Secret Scan (gitleaks, full history)",
+    "IaC Config Scan (trivy, HIGH+CRITICAL blocking)",
+)
+
+MAIN_ADVISORY_CHECKS = (
+    "AI Tests (advisory — non-deterministic)",
+    "Image Scan (trivy — advisory until postgis bump)",
+)
+
+_FAKE_GH = r"""#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+scenario = json.loads(Path(os.environ["FAKE_GH_SCENARIO"]).read_text())
+with Path(os.environ["FAKE_GH_CALLS"]).open("a") as call_log:
+    call_log.write(json.dumps(args) + "\n")
+
+if args[:2] == ["pr", "view"]:
+    fields = args[args.index("--json") + 1]
+    if fields == "headRefOid,baseRefOid":
+        print(json.dumps(scenario["reread"]))
+    else:
+        print(json.dumps(scenario["view"]))
+elif args[:2] == ["api", "graphql"]:
+    print(json.dumps(scenario["threads"]))
+elif args[0] == "api" and args[1].startswith(
+    "repos/{owner}/{repo}/code-scanning/alerts?state=open"
+):
+    print(json.dumps(scenario["alerts"]))
+elif args[:2] == ["pr", "list"]:
+    print(json.dumps(scenario["children"]))
+elif args[:2] == ["pr", "merge"]:
+    print("merged")
+elif args[0] == "api" and args[1].endswith("/reviews?per_page=100"):
+    print(json.dumps(scenario["rest_reviews"]))
+elif args[0] == "api" and args[1].endswith("/pulls/742"):
+    print(json.dumps(scenario["dependabot_pr"]))
+elif args[0] == "api" and args[1].endswith("/pulls/742/commits?per_page=100"):
+    print(json.dumps(scenario["dependabot_commits"]))
+elif args[0] == "api" and "/comments" in args[1]:
+    print(json.dumps(scenario["comments"]))
+else:
+    print(f"unexpected fake gh arguments: {args}", file=sys.stderr)
+    raise SystemExit(97)
+"""
+
+
+def _check(
+    name: str,
+    *,
+    conclusion: str = "SUCCESS",
+    status: str = "COMPLETED",
+) -> dict[str, str]:
+    return {
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "startedAt": "2026-08-25T12:00:00Z",
+    }
+
+
+def _copilot_review(commit_oid: str = HEAD_SHA) -> dict[str, object]:
+    return {
+        "author": {"login": "copilot-pull-request-reviewer"},
+        "commit": {"oid": commit_oid},
+        "state": "COMMENTED",
+        "submittedAt": "2026-08-25T12:01:00Z",
+    }
+
+
+def _rest_copilot_review(commit_oid: str = HEAD_SHA) -> dict[str, object]:
+    return {
+        "user": {
+            "login": "copilot-pull-request-reviewer[bot]",
+            "id": COPILOT_BOT_ID,
+            "node_id": COPILOT_BOT_NODE_ID,
+            "type": "Bot",
+        },
+        "commit_id": commit_oid,
+        "state": "COMMENTED",
+        "submitted_at": "2026-08-25T12:01:00Z",
+    }
+
+
+def _dependabot_commit(
+    *,
+    head_sha: str = HEAD_SHA,
+    update_type: str = "version-update:semver-minor",
+) -> dict[str, object]:
+    return {
+        "sha": head_sha,
+        "author": {"login": "dependabot[bot]", "type": "Bot"},
+        "commit": {
+            "message": (
+                "Bump dependencies\n\n---\nupdated-dependencies:\n"
+                "- dependency-name: example\n"
+                f"  update-type: {update_type}\n..."
+            ),
+            "verification": {"verified": True, "reason": "valid"},
+        },
+    }
+
+
+def _default_scenario() -> dict[str, object]:
+    return {
+        "view": {
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefOid": HEAD_SHA,
+            "headRefName": "codex/PER-264-pr-policy",
+            "baseRefOid": BASE_SHA,
+            "baseRefName": "dev",
+            "statusCheckRollup": [_check(name) for name in DEV_BLOCKING_CHECKS],
+            "reviews": [_copilot_review()],
+        },
+        "reread": {"headRefOid": HEAD_SHA, "baseRefOid": BASE_SHA},
+        "rest_reviews": [_rest_copilot_review()],
+        "comments": [],
+        "alerts": [],
+        "children": [],
+        "dependabot_pr": {
+            "head": {"sha": HEAD_SHA},
+            "base": {"ref": "dev"},
+            "user": {"login": "dependabot[bot]", "type": "Bot"},
+        },
+        "dependabot_commits": [_dependabot_commit()],
+        "threads": {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [],
+                            "pageInfo": {"hasNextPage": False},
+                        }
+                    }
+                }
+            }
+        },
+    }
+
+
+def _run_pr_merge(
+    tmp_path: Path,
+    *arguments: str,
+    scenario: dict[str, object] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], list[list[str]]]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(_FAKE_GH)
+    fake_gh.chmod(0o755)
+    scenario_path = tmp_path / "scenario.json"
+    scenario_path.write_text(json.dumps(scenario or _default_scenario()))
+    calls_path = tmp_path / "calls.jsonl"
+    env = os.environ.copy()
+    env.update(
+        {
+            "FAKE_GH_CALLS": str(calls_path),
+            "FAKE_GH_SCENARIO": str(scenario_path),
+            "PATH": f"{fake_bin}:{env['PATH']}",
+        }
+    )
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(PR_MERGE), "742", *arguments],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    calls = (
+        [json.loads(line) for line in calls_path.read_text().splitlines()]
+        if calls_path.exists()
+        else []
+    )
+    return result, calls
+
+
+def _view(scenario: dict[str, object]) -> dict[str, object]:
+    view = scenario["view"]
+    assert isinstance(view, dict)
+    return view
+
+
+def _merge_calls(calls: list[list[str]]) -> list[list[str]]:
+    return [call for call in calls if call[:2] == ["pr", "merge"]]
+
+
+def _use_main_manifest(scenario: dict[str, object]) -> None:
+    _view(scenario)["statusCheckRollup"] = [
+        *(_check(name) for name in MAIN_BLOCKING_CHECKS),
+        *(_check(name, conclusion="NEUTRAL") for name in MAIN_ADVISORY_CHECKS),
+    ]
+
+
+def _thread_connection(scenario: dict[str, object]) -> dict[str, object]:
+    threads = scenario["threads"]
+    assert isinstance(threads, dict)
+    data = threads["data"]
+    assert isinstance(data, dict)
+    repository = data["repository"]
+    assert isinstance(repository, dict)
+    pull_request = repository["pullRequest"]
+    assert isinstance(pull_request, dict)
+    connection = pull_request["reviewThreads"]
+    assert isinstance(connection, dict)
+    return connection
+
+
+def test_verify_only_runs_full_policy_without_merging(tmp_path: Path) -> None:
+    result, calls = _run_pr_merge(tmp_path, "--verify-only")
+
+    assert result.returncode == 0, result.stderr
+    assert _merge_calls(calls) == []
+    assert "verified at" in result.stdout
+    assert any(call[:2] == ["api", "graphql"] for call in calls)
+
+
+def test_all_rest_list_queries_are_bounded_without_pagination(tmp_path: Path) -> None:
+    result, calls = _run_pr_merge(tmp_path, "--verify-only", "--delete-branch")
+
+    assert result.returncode == 0, result.stderr
+    assert not any("--paginate" in call for call in calls)
+    comments = next(call for call in calls if call[0] == "api" and "/comments" in call[1])
+    alerts = next(call for call in calls if call[0] == "api" and "code-scanning/alerts" in call[1])
+    children = next(call for call in calls if call[:2] == ["pr", "list"])
+    assert "per_page=100" in comments[1]
+    assert "per_page=100" in alerts[1]
+    assert children[children.index("--limit") + 1] == "100"
+
+
+def test_one_hundred_rest_items_refuses_at_the_static_bound(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    scenario["comments"] = [
+        {
+            "id": index,
+            "html_url": f"https://example.test/comment/{index}",
+            "in_reply_to_id": None,
+            "user": {"login": "human-reviewer"},
+        }
+        for index in range(100)
+    ]
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode != 0
+    assert "100-item safety bound" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_one_hundred_check_entries_refuse_a_potentially_truncated_rollup(
+    tmp_path: Path,
+) -> None:
+    scenario = _default_scenario()
+    rollup = _view(scenario)["statusCheckRollup"]
+    assert isinstance(rollup, list)
+    rollup.extend(
+        _check(f"Unknown successful extension {index}")
+        for index in range(100 - len(DEV_BLOCKING_CHECKS))
+    )
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode != 0
+    assert "100-item safety bound" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_expected_head_refuses_a_different_snapshot(tmp_path: Path) -> None:
+    result, calls = _run_pr_merge(
+        tmp_path,
+        "--verify-only",
+        "--expected-head",
+        OTHER_SHA,
+    )
+
+    assert result.returncode == 1
+    assert "expected head" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+@pytest.mark.parametrize("moved_ref", ["headRefOid", "baseRefOid"])
+def test_moved_snapshot_refuses_merge(tmp_path: Path, moved_ref: str) -> None:
+    scenario = _default_scenario()
+    reread = scenario["reread"]
+    assert isinstance(reread, dict)
+    reread[moved_ref] = OTHER_SHA
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert f"{moved_ref.removesuffix('RefOid')} moved" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_default_policy_requires_dev_base(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    _view(scenario)["baseRefName"] = "feature/stack"
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert "base branch feature/stack is not dev" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_main_base_requires_director_main_flag(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    _view(scenario).update({"baseRefName": "main", "headRefName": "fix/security"})
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert "base branch main is not dev" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+@pytest.mark.parametrize("head_name", ["dev", "fix/security"])
+def test_director_main_accepts_only_sanctioned_main_sources(tmp_path: Path, head_name: str) -> None:
+    scenario = _default_scenario()
+    _view(scenario).update({"baseRefName": "main", "headRefName": head_name})
+    _use_main_manifest(scenario)
+
+    result, calls = _run_pr_merge(tmp_path, "--director-main", scenario=scenario)
+
+    assert result.returncode == 0, result.stderr
+    assert len(_merge_calls(calls)) == 1
+
+
+def test_director_main_refuses_feature_source(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    _view(scenario).update({"baseRefName": "main", "headRefName": "feature/unsafe"})
+
+    result, calls = _run_pr_merge(tmp_path, "--director-main", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "main requires head dev or fix/*" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_director_main_flag_is_invalid_for_dev_base(tmp_path: Path) -> None:
+    result, calls = _run_pr_merge(tmp_path, "--director-main")
+
+    assert result.returncode == 1
+    assert "--director-main requires base main" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_delete_branch_never_deletes_dev(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    _view(scenario).update({"baseRefName": "main", "headRefName": "dev"})
+    _use_main_manifest(scenario)
+
+    result, calls = _run_pr_merge(
+        tmp_path,
+        "--director-main",
+        "--delete-branch",
+        scenario=scenario,
+    )
+
+    assert result.returncode == 1
+    assert "refused for protected branch dev" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_merge_is_atomically_matched_to_verified_head(tmp_path: Path) -> None:
+    result, calls = _run_pr_merge(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert _merge_calls(calls) == [
+        ["pr", "merge", "742", "--merge", "--match-head-commit", HEAD_SHA]
+    ]
+
+
+@pytest.mark.parametrize(
+    "reviews",
+    [
+        [],
+        [_copilot_review(OTHER_SHA)],
+        [
+            {
+                **_copilot_review(),
+                "state": "PENDING",
+                "submittedAt": None,
+            }
+        ],
+    ],
+    ids=["missing", "stale", "pending"],
+)
+def test_copilot_review_must_be_completed_on_verified_head(
+    tmp_path: Path, reviews: list[dict[str, object]]
+) -> None:
+    scenario = _default_scenario()
+    _view(scenario)["reviews"] = reviews
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert "completed Copilot review on verified head" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+@pytest.mark.parametrize(
+    "login",
+    ["attacker-copilot-reviewer", "copilot-pull-request-reviewer[bot]"],
+)
+def test_graphql_copilot_review_identity_is_exact(tmp_path: Path, login: str) -> None:
+    scenario = _default_scenario()
+    review = _copilot_review()
+    review["author"] = {"login": login}
+    _view(scenario)["reviews"] = [review]
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert "completed Copilot review on verified head" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("id", 1), ("node_id", "BOT_impostor"), ("type", "User")],
+)
+def test_rest_copilot_review_requires_immutable_bot_identity(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    scenario = _default_scenario()
+    review = _rest_copilot_review()
+    user = review["user"]
+    assert isinstance(user, dict)
+    user[field] = value
+    scenario["rest_reviews"] = [review]
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert "completed Copilot review on verified head" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_top_level_copilot_comment_still_requires_reply(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    scenario["comments"] = [
+        {
+            "id": 91,
+            "html_url": "https://example.test/comment/91",
+            "in_reply_to_id": None,
+            "user": {
+                "login": "Copilot",
+                "id": COPILOT_BOT_ID,
+                "node_id": COPILOT_BOT_NODE_ID,
+                "type": "Bot",
+            },
+        }
+    ]
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert "unaddressed Copilot comment" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+@pytest.mark.parametrize(
+    ("name", "conclusion", "status"),
+    [
+        (DEV_BLOCKING_CHECKS[0], "", "IN_PROGRESS"),
+        (DEV_BLOCKING_CHECKS[1], "SKIPPED", "COMPLETED"),
+        (DEV_BLOCKING_CHECKS[2], "NEUTRAL", "COMPLETED"),
+    ],
+    ids=["late", "skipped", "neutral"],
+)
+def test_every_dev_blocking_check_requires_explicit_success(
+    tmp_path: Path,
+    name: str,
+    conclusion: str,
+    status: str,
+) -> None:
+    scenario = _default_scenario()
+    rollup = _view(scenario)["statusCheckRollup"]
+    assert isinstance(rollup, list)
+    rollup[:] = [
+        _check(check_name, conclusion=conclusion, status=status)
+        if check_name == name
+        else _check(check_name)
+        for check_name in DEV_BLOCKING_CHECKS
+    ]
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert name in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_missing_expected_dev_check_blocks_registration_race(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    rollup = _view(scenario)["statusCheckRollup"]
+    assert isinstance(rollup, list)
+    rollup.pop(0)
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert DEV_BLOCKING_CHECKS[0] in result.stderr
+    assert "missing" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+@pytest.mark.parametrize("conclusion", ["NEUTRAL", "SKIPPED"])
+def test_unknown_non_successful_check_is_not_globally_advisory(
+    tmp_path: Path,
+    conclusion: str,
+) -> None:
+    scenario = _default_scenario()
+    rollup = _view(scenario)["statusCheckRollup"]
+    assert isinstance(rollup, list)
+    rollup.append(_check("Unknown extension", conclusion=conclusion))
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert "Unknown extension" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_unknown_success_is_informational_after_complete_manifest(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    rollup = _view(scenario)["statusCheckRollup"]
+    assert isinstance(rollup, list)
+    rollup.append(_check("Unknown successful extension"))
+
+    result, calls = _run_pr_merge(tmp_path, "--verify-only", scenario=scenario)
+
+    assert result.returncode == 0, result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_director_main_rejects_complete_dev_manifest_as_wrong_qualification(
+    tmp_path: Path,
+) -> None:
+    scenario = _default_scenario()
+    _view(scenario).update({"baseRefName": "main", "headRefName": "dev"})
+
+    result, calls = _run_pr_merge(tmp_path, "--director-main", scenario=scenario)
+
+    assert result.returncode == 1
+    assert MAIN_BLOCKING_CHECKS[4] in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_dependabot_mode_revalidates_verified_exact_head_metadata(tmp_path: Path) -> None:
+    result, calls = _run_pr_merge(tmp_path, "--dependabot")
+
+    assert result.returncode == 0, result.stderr
+    assert len(_merge_calls(calls)) == 1
+    assert any(call[0] == "api" and call[1].endswith("/commits?per_page=100") for call in calls)
+
+
+def test_dependabot_major_update_is_never_authorized_by_a_label(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    scenario["dependabot_commits"] = [_dependabot_commit(update_type="version-update:semver-major")]
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "semver-major" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_dependabot_synchronization_invalidates_old_head_classification(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    dependabot_pr = scenario["dependabot_pr"]
+    assert isinstance(dependabot_pr, dict)
+    dependabot_pr["head"] = {"sha": OTHER_SHA}
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "Dependabot head" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_dependabot_exact_head_must_be_one_verified_bot_commit(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    commit = _dependabot_commit()
+    commit_payload = commit["commit"]
+    assert isinstance(commit_payload, dict)
+    commit_payload["verification"] = {"verified": False, "reason": "unsigned"}
+    scenario["dependabot_commits"] = [commit]
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "verified Dependabot commit" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_unresolved_review_thread_refuses_merge(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    _thread_connection(scenario)["nodes"] = [
+        {
+            "isResolved": False,
+            "comments": {"nodes": [{"url": "https://example.test/thread/17"}]},
+        }
+    ]
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert "unresolved review thread https://example.test/thread/17" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_more_than_one_hundred_review_threads_refuses_instead_of_paging(
+    tmp_path: Path,
+) -> None:
+    scenario = _default_scenario()
+    connection = _thread_connection(scenario)
+    page_info = connection["pageInfo"]
+    assert isinstance(page_info, dict)
+    page_info["hasNextPage"] = True
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert "more than 100 review threads" in result.stderr
+    graph_calls = [call for call in calls if call[:2] == ["api", "graphql"]]
+    assert len(graph_calls) == 1
+    assert "--paginate" not in graph_calls[0]
+    assert "reviewThreads(first: 100)" in " ".join(graph_calls[0])
+    assert _merge_calls(calls) == []
+
+
+def test_exactly_one_hundred_complete_review_threads_remain_within_bound(
+    tmp_path: Path,
+) -> None:
+    scenario = _default_scenario()
+    connection = _thread_connection(scenario)
+    connection["nodes"] = [
+        {
+            "isResolved": True,
+            "comments": {"nodes": [{"url": f"https://example.test/thread/{index}"}]},
+        }
+        for index in range(100)
+    ]
+
+    result, calls = _run_pr_merge(tmp_path, "--verify-only", scenario=scenario)
+
+    assert result.returncode == 0, result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_delete_branch_still_refuses_a_stacked_child(tmp_path: Path) -> None:
+    scenario = copy.deepcopy(_default_scenario())
+    scenario["children"] = [{"number": 743}]
+
+    result, calls = _run_pr_merge(tmp_path, "--delete-branch", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "open PR(s) [743] base on this branch" in result.stderr
+    assert _merge_calls(calls) == []

--- a/tests/unit/tools/test_pr_merge_policy.py
+++ b/tests/unit/tools/test_pr_merge_policy.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import tools.pr_merge as pr_merge_tool
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PR_MERGE = REPO_ROOT / "tools" / "pr_merge.py"
@@ -32,6 +33,7 @@ SOURCE_RUN_ID = 31396722297
 CLASSIFIER_RUN_ID = 31396722301
 SOURCE_SUITE_ID = 78264088632
 CLASSIFIER_SUITE_ID = 78264088701
+MERGE_COMMIT_SHA = "d" * 40
 
 DEV_BLOCKING_CHECKS = (
     "Fast Gate (hygiene, lint, format, imports, types, lock)",
@@ -64,6 +66,51 @@ MAIN_ADVISORY_CHECKS = (
     "Image Scan (trivy — advisory until postgis bump)",
 )
 
+
+def test_gh_timeout_is_bounded_and_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed_timeout: object = None
+
+    def timeout(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        nonlocal observed_timeout
+        observed_timeout = kwargs.get("timeout")
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=30)
+
+    monkeypatch.setattr(pr_merge_tool.subprocess, "run", timeout)
+
+    with pytest.raises(pr_merge_tool.GitHubReadError, match="gh timed out after 30 seconds"):
+        pr_merge_tool._gh("pr", "view", "742")
+
+    assert observed_timeout == 30
+
+
+def test_gh_nonzero_exit_is_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
+    def nonzero(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            returncode=7,
+            cmd=args[0],
+            output="fallback output",
+            stderr="permission denied\n",
+        )
+
+    monkeypatch.setattr(pr_merge_tool.subprocess, "run", nonzero)
+
+    with pytest.raises(pr_merge_tool.GitHubReadError, match="gh failed: permission denied"):
+        pr_merge_tool._gh("pr", "view", "742")
+
+
+def test_gh_spawn_failure_is_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_spawn(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise OSError("executable unavailable")
+
+    monkeypatch.setattr(pr_merge_tool.subprocess, "run", fail_spawn)
+
+    with pytest.raises(
+        pr_merge_tool.GitHubReadError,
+        match="gh could not start: executable unavailable",
+    ):
+        pr_merge_tool._gh("pr", "view", "742")
+
+
 _FAKE_GH = r"""#!/usr/bin/env python3
 import json
 import os
@@ -77,8 +124,16 @@ with Path(os.environ["FAKE_GH_CALLS"]).open("a") as call_log:
 
 if args[:2] == ["pr", "view"]:
     fields = args[args.index("--json") + 1]
-    if fields == "headRefOid,baseRefOid":
+    if fields == "state,headRefOid,mergeCommit":
+        if scenario.get("reconciliation_failure"):
+            print(scenario["reconciliation_failure"], file=sys.stderr)
+            raise SystemExit(8)
+        print(json.dumps(scenario["merge_reconciliation"]))
+    elif fields == "headRefOid,baseRefOid":
         print(json.dumps(scenario["reread"]))
+    elif scenario.get("initial_view_failure"):
+        print(scenario["initial_view_failure"], file=sys.stderr)
+        raise SystemExit(7)
     else:
         print(json.dumps(scenario["view"]))
 elif args[:2] == ["api", "graphql"]:
@@ -90,6 +145,9 @@ elif args[0] == "api" and args[1].startswith(
 elif args[:2] == ["pr", "list"]:
     print(json.dumps(scenario["children"]))
 elif args[:2] == ["pr", "merge"]:
+    if scenario.get("merge_failure"):
+        print(scenario["merge_failure"], file=sys.stderr)
+        raise SystemExit(7)
     print("merged")
 elif args[0] == "api" and args[1].endswith("/reviews?per_page=100"):
     print(json.dumps(scenario["rest_reviews"]))
@@ -318,6 +376,14 @@ def _default_scenario() -> dict[str, object]:
         "comments": [],
         "alerts": [],
         "children": [],
+        "initial_view_failure": None,
+        "merge_failure": None,
+        "reconciliation_failure": None,
+        "merge_reconciliation": {
+            "state": "MERGED",
+            "headRefOid": HEAD_SHA,
+            "mergeCommit": {"oid": MERGE_COMMIT_SHA},
+        },
         "dependabot_pr": {
             "head": {"sha": HEAD_SHA},
             "base": {"ref": "dev"},
@@ -427,6 +493,146 @@ def _thread_connection(scenario: dict[str, object]) -> dict[str, object]:
     return connection
 
 
+@pytest.mark.parametrize("failure_kind", ["timeout", "nonzero", "spawn"])
+def test_mutating_merge_boundary_reconciles_every_command_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: str,
+) -> None:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        assert kwargs["timeout"] == 30
+        if command[1:3] == ["pr", "merge"]:
+            if failure_kind == "timeout":
+                raise subprocess.TimeoutExpired(cmd=command, timeout=30)
+            if failure_kind == "nonzero":
+                raise subprocess.CalledProcessError(7, command, stderr="transport failed")
+            raise OSError("executable unavailable")
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "state": "MERGED",
+                    "headRefOid": HEAD_SHA,
+                    "mergeCommit": {"oid": MERGE_COMMIT_SHA},
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(pr_merge_tool.subprocess, "run", run)
+
+    assert pr_merge_tool._merge_pr(742, HEAD_SHA, delete_branch=False) == ""
+    assert len(calls) == 2
+    assert calls[0][1:3] == ["pr", "merge"]
+    assert calls[1][1:3] == ["pr", "view"]
+
+
+def test_cli_read_failure_is_refused_without_traceback_or_unbounded_detail(
+    tmp_path: Path,
+) -> None:
+    scenario = _default_scenario()
+    scenario["initial_view_failure"] = "\x1b[31m" + ("authenticated detail\n" * 100)
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert result.stderr.startswith("pr:merge REFUSED — gh failed: ")
+    assert "Traceback" not in result.stderr
+    assert "\x1b" not in result.stderr
+    assert result.stderr.count("\n") == 1
+    assert len(result.stderr) <= 500
+    assert _merge_calls(calls) == []
+
+
+def test_cli_confirms_an_exact_head_merge_after_command_failure(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    scenario["merge_failure"] = "connection lost after request"
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 0, result.stderr
+    assert f"PR #742 merged at {HEAD_SHA}" in result.stdout
+    assert "INDETERMINATE" not in result.stderr
+    assert len(_merge_calls(calls)) == 1
+    assert (
+        sum(
+            call[:2] == ["pr", "view"]
+            and call[call.index("--json") + 1] == "state,headRefOid,mergeCommit"
+            for call in calls
+        )
+        == 1
+    )
+
+
+@pytest.mark.parametrize(
+    "reconciliation",
+    [
+        {"state": "OPEN", "headRefOid": HEAD_SHA, "mergeCommit": {"oid": MERGE_COMMIT_SHA}},
+        {
+            "state": "MERGED",
+            "headRefOid": OTHER_SHA,
+            "mergeCommit": {"oid": MERGE_COMMIT_SHA},
+        },
+        {"state": "MERGED", "headRefOid": HEAD_SHA, "mergeCommit": None},
+        {"state": "MERGED", "headRefOid": HEAD_SHA, "mergeCommit": "malformed"},
+        {"state": "MERGED", "headRefOid": HEAD_SHA, "mergeCommit": {"oid": ""}},
+    ],
+    ids=[
+        "not-merged",
+        "wrong-head",
+        "missing-merge-commit",
+        "malformed-merge-commit",
+        "empty-merge-commit-oid",
+    ],
+)
+def test_cli_reports_indeterminate_when_reconciliation_cannot_confirm_exact_merge(
+    tmp_path: Path,
+    reconciliation: dict[str, object],
+) -> None:
+    scenario = _default_scenario()
+    scenario["merge_failure"] = "connection lost after request"
+    scenario["merge_reconciliation"] = reconciliation
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 2
+    assert result.stderr.startswith("pr:merge INDETERMINATE — ")
+    assert "REFUSED" not in result.stderr
+    assert "Traceback" not in result.stderr
+    assert "merged at" not in result.stdout
+    assert len(_merge_calls(calls)) == 1
+
+
+def test_cli_reports_indeterminate_when_merge_reconciliation_read_fails(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    scenario["merge_failure"] = "connection lost after request"
+    scenario["reconciliation_failure"] = "reconciliation unavailable"
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 2
+    assert "pr:merge INDETERMINATE —" in result.stderr
+    assert "reconciliation failed" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert len(_merge_calls(calls)) == 1
+
+
+def test_confirmed_merge_warns_that_requested_branch_deletion_may_be_incomplete(
+    tmp_path: Path,
+) -> None:
+    scenario = _default_scenario()
+    scenario["merge_failure"] = "connection lost after request"
+
+    result, calls = _run_pr_merge(tmp_path, "--delete-branch", scenario=scenario)
+
+    assert result.returncode == 0, result.stderr
+    assert "branch deletion may be incomplete" in result.stderr
+    assert len(_merge_calls(calls)) == 1
+
+
 def test_verify_only_runs_full_policy_without_merging(tmp_path: Path) -> None:
     result, calls = _run_pr_merge(tmp_path, "--verify-only")
 
@@ -463,8 +669,10 @@ def test_one_hundred_rest_items_refuses_at_the_static_bound(tmp_path: Path) -> N
 
     result, calls = _run_pr_merge(tmp_path, scenario=scenario)
 
-    assert result.returncode != 0
+    assert result.returncode == 1
+    assert result.stderr.startswith("pr:merge REFUSED — ")
     assert "100-item safety bound" in result.stderr
+    assert "Traceback" not in result.stderr
     assert _merge_calls(calls) == []
 
 

--- a/tests/unit/tools/test_pr_merge_policy.py
+++ b/tests/unit/tools/test_pr_merge_policy.py
@@ -655,6 +655,34 @@ def test_all_rest_list_queries_are_bounded_without_pagination(tmp_path: Path) ->
     assert children[children.index("--limit") + 1] == "100"
 
 
+def test_ninety_nine_code_scanning_alerts_keep_the_zero_floor_refusal(
+    tmp_path: Path,
+) -> None:
+    scenario = _default_scenario()
+    scenario["alerts"] = [{"number": number, "state": "open"} for number in range(1, 100)]
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert "99 open code-scanning alert(s) — the zero floor is a STOP" in result.stderr
+    assert "code-scanning alerts reached the 100-item safety bound" not in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_exactly_full_code_scanning_page_refuses_as_potentially_truncated(
+    tmp_path: Path,
+) -> None:
+    scenario = _default_scenario()
+    scenario["alerts"] = [{"number": number, "state": "open"} for number in range(1, 101)]
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 1
+    assert "code-scanning alerts reached the 100-item safety bound" in result.stderr
+    assert "100 open code-scanning alert(s)" not in result.stderr
+    assert _merge_calls(calls) == []
+
+
 def test_one_hundred_rest_items_refuses_at_the_static_bound(tmp_path: Path) -> None:
     scenario = _default_scenario()
     scenario["comments"] = [

--- a/tests/unit/tools/test_pr_merge_policy.py
+++ b/tests/unit/tools/test_pr_merge_policy.py
@@ -21,7 +21,17 @@ COPILOT_BOT_ID = 175728472
 COPILOT_BOT_NODE_ID = "BOT_kgDOCnlnWA"
 GITHUB_ACTIONS_APP_ID = 15368
 GITHUB_ACTIONS_APP_SLUG = "github-actions"
+DEPENDABOT_BOT_ID = 49699333
 DEPENDABOT_ELIGIBILITY_CHECK = "Dependabot Eligibility"
+DEPENDABOT_WORKFLOW_PATH = ".github/workflows/dependabot-automerge.yml"
+DEPENDABOT_WORKFLOW_ID = 214604133
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+CI_WORKFLOW_ID = 176131131
+ELIGIBILITY_CHECK_ID = 93481313127
+SOURCE_RUN_ID = 31396722297
+CLASSIFIER_RUN_ID = 31396722301
+SOURCE_SUITE_ID = 78264088632
+CLASSIFIER_SUITE_ID = 78264088701
 
 DEV_BLOCKING_CHECKS = (
     "Fast Gate (hygiene, lint, format, imports, types, lock)",
@@ -85,8 +95,22 @@ elif args[0] == "api" and args[1].endswith("/reviews?per_page=100"):
     print(json.dumps(scenario["rest_reviews"]))
 elif args[0] == "api" and args[1].endswith("/pulls/742"):
     print(json.dumps(scenario["dependabot_pr"]))
-elif args[0] == "api" and "/check-runs?check_name=Dependabot%20Eligibility" in args[1]:
-    print(json.dumps(scenario["dependabot_check_runs"]))
+elif args[0] == "api" and args[1].endswith(f"/actions/runs/{scenario['source_run']['id']}"):
+    print(json.dumps(scenario["source_run"]))
+elif args[0] == "api" and args[1].endswith(
+    f"/actions/runs/{scenario['classifier_run']['id']}"
+):
+    print(json.dumps(scenario["classifier_run"]))
+elif args[0] == "api" and "/attempts/" in args[1] and "/jobs?" in args[1]:
+    print(json.dumps(scenario["classifier_jobs"]))
+elif args[0] == "api" and args[1].endswith(
+    f"/check-runs/{scenario['classifier_check']['id']}"
+):
+    print(json.dumps(scenario["classifier_check"]))
+elif args[0] == "api" and args[1].endswith(
+    f"/check-suites/{scenario['source_suite']['id']}"
+):
+    print(json.dumps(scenario["source_suite"]))
 elif args[0] == "api" and args[1].endswith("/pulls/742/commits?per_page=100"):
     print(json.dumps(scenario["dependabot_commits"]))
 elif args[0] == "api" and "/comments" in args[1]:
@@ -154,29 +178,127 @@ def _dependabot_commit(
     }
 
 
-def _eligibility_check(
+def _classifier_job(
     *,
-    check_id: int = 9101,
+    job_id: int = ELIGIBILITY_CHECK_ID,
+    run_id: int = CLASSIFIER_RUN_ID,
+    head_sha: str = BASE_SHA,
+    name: str = DEPENDABOT_ELIGIBILITY_CHECK,
+    status: str = "in_progress",
+    conclusion: str | None = None,
+) -> dict[str, object]:
+    return {
+        "id": job_id,
+        "run_id": run_id,
+        "head_sha": head_sha,
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "html_url": (
+            f"https://github.com/percy-raskova/babylon/actions/runs/{run_id}/job/{job_id}"
+        ),
+        "check_run_url": (
+            f"https://api.github.com/repos/percy-raskova/babylon/check-runs/{job_id}"
+        ),
+    }
+
+
+def _dependabot_actor(
+    *,
+    login: str = "dependabot[bot]",
+    actor_id: int = DEPENDABOT_BOT_ID,
+    actor_type: str = "Bot",
+) -> dict[str, object]:
+    return {"login": login, "id": actor_id, "type": actor_type}
+
+
+def _source_run(
+    *,
+    run_id: int = SOURCE_RUN_ID,
+    path: str = CI_WORKFLOW_PATH,
     head_sha: str = HEAD_SHA,
-    status: str = "completed",
-    conclusion: str | None = "success",
+    event: str = "pull_request",
+    actor: dict[str, object] | None = None,
+    triggering_actor: dict[str, object] | None = None,
+    suite_id: int = SOURCE_SUITE_ID,
+) -> dict[str, object]:
+    return {
+        "id": run_id,
+        "workflow_id": CI_WORKFLOW_ID,
+        "path": path,
+        "event": event,
+        "head_sha": head_sha,
+        "status": "completed",
+        "conclusion": "success",
+        "actor": actor or _dependabot_actor(),
+        "triggering_actor": triggering_actor or _dependabot_actor(),
+        "check_suite_id": suite_id,
+        "run_attempt": 1,
+        "head_repository": {"full_name": "percy-raskova/babylon"},
+        "repository": {"full_name": "percy-raskova/babylon"},
+        "pull_requests": [{"number": 742, "head": {"sha": head_sha}, "base": {"ref": "dev"}}],
+    }
+
+
+def _classifier_run(
+    *,
+    run_id: int = CLASSIFIER_RUN_ID,
+    source_run_id: int = SOURCE_RUN_ID,
+    source_head_sha: str = HEAD_SHA,
+    path: str = DEPENDABOT_WORKFLOW_PATH,
+    actor: dict[str, object] | None = None,
+    triggering_actor: dict[str, object] | None = None,
+) -> dict[str, object]:
+    return {
+        "id": run_id,
+        "workflow_id": DEPENDABOT_WORKFLOW_ID,
+        "path": path,
+        "event": "workflow_run",
+        "head_sha": BASE_SHA,
+        "status": "in_progress",
+        "conclusion": None,
+        "display_title": (
+            f"Dependabot eligibility for CI run {source_run_id} at {source_head_sha}"
+        ),
+        "actor": actor or _dependabot_actor(),
+        "triggering_actor": triggering_actor or _dependabot_actor(),
+        "check_suite_id": CLASSIFIER_SUITE_ID,
+        "run_attempt": 1,
+        "head_repository": {"full_name": "percy-raskova/babylon"},
+        "repository": {"full_name": "percy-raskova/babylon"},
+    }
+
+
+def _source_suite(
+    *,
+    suite_id: int = SOURCE_SUITE_ID,
+    head_sha: str = HEAD_SHA,
     app_id: int = GITHUB_ACTIONS_APP_ID,
     app_slug: str = GITHUB_ACTIONS_APP_SLUG,
-    started_at: str = "2026-08-25T12:02:00Z",
+) -> dict[str, object]:
+    return {
+        "id": suite_id,
+        "head_sha": head_sha,
+        "app": {"id": app_id, "slug": app_slug},
+        "pull_requests": [{"number": 742, "head": {"sha": head_sha}, "base": {"ref": "dev"}}],
+    }
+
+
+def _classifier_check(
+    *,
+    check_id: int = ELIGIBILITY_CHECK_ID,
+    app_id: int = GITHUB_ACTIONS_APP_ID,
+    app_slug: str = GITHUB_ACTIONS_APP_SLUG,
 ) -> dict[str, object]:
     return {
         "id": check_id,
         "name": DEPENDABOT_ELIGIBILITY_CHECK,
-        "head_sha": head_sha,
-        "status": status,
-        "conclusion": conclusion,
-        "started_at": started_at,
+        "head_sha": BASE_SHA,
+        "status": "in_progress",
+        "conclusion": None,
         "app": {"id": app_id, "slug": app_slug},
+        "check_suite": {"id": CLASSIFIER_SUITE_ID},
     }
-
-
-def _eligibility_payload(*checks: dict[str, object]) -> dict[str, object]:
-    return {"total_count": len(checks), "check_runs": list(checks)}
 
 
 def _default_scenario() -> dict[str, object]:
@@ -199,10 +321,18 @@ def _default_scenario() -> dict[str, object]:
         "dependabot_pr": {
             "head": {"sha": HEAD_SHA},
             "base": {"ref": "dev"},
-            "user": {"login": "dependabot[bot]", "type": "Bot"},
+            "user": {
+                "login": "dependabot[bot]",
+                "id": DEPENDABOT_BOT_ID,
+                "type": "Bot",
+            },
         },
         "dependabot_commits": [_dependabot_commit()],
-        "dependabot_check_runs": _eligibility_payload(_eligibility_check()),
+        "source_run": _source_run(),
+        "source_suite": _source_suite(),
+        "classifier_run": _classifier_run(),
+        "classifier_jobs": {"total_count": 1, "jobs": [_classifier_job()]},
+        "classifier_check": _classifier_check(),
         "threads": {
             "data": {
                 "repository": {
@@ -239,8 +369,18 @@ def _run_pr_merge(
             "PATH": f"{fake_bin}:{env['PATH']}",
         }
     )
+    command_arguments = list(arguments)
+    if "--dependabot" in command_arguments:
+        command_arguments.extend(
+            [
+                "--dependabot-source-run",
+                str(SOURCE_RUN_ID),
+                "--dependabot-classifier-run",
+                str(CLASSIFIER_RUN_ID),
+            ]
+        )
     result = subprocess.run(  # noqa: S603
-        [sys.executable, str(PR_MERGE), "742", *arguments],
+        [sys.executable, str(PR_MERGE), "742", *command_arguments],
         cwd=REPO_ROOT,
         env=env,
         capture_output=True,
@@ -631,47 +771,53 @@ def test_director_main_rejects_complete_dev_manifest_as_wrong_qualification(
     assert _merge_calls(calls) == []
 
 
-def test_dependabot_mode_requires_latest_canonical_exact_head_eligibility_check(
+def test_dependabot_mode_requires_native_ci_and_classifier_provenance(
     tmp_path: Path,
 ) -> None:
-    scenario = _default_scenario()
-    scenario["dependabot_check_runs"] = _eligibility_payload(
-        _eligibility_check(
-            check_id=9100,
-            status="completed",
-            conclusion="failure",
-            started_at="2026-08-25T12:01:00Z",
-        ),
-        _eligibility_check(check_id=9101),
-    )
-
-    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+    result, calls = _run_pr_merge(tmp_path, "--dependabot")
 
     assert result.returncode == 0, result.stderr
     assert len(_merge_calls(calls)) == 1
     assert any(
-        call[0] == "api"
-        and f"/commits/{HEAD_SHA}/check-runs?" in call[1]
-        and "check_name=Dependabot%20Eligibility" in call[1]
-        and "filter=all" in call[1]
-        and "per_page=100" in call[1]
+        call[0] == "api" and call[1].endswith(f"/actions/runs/{SOURCE_RUN_ID}") for call in calls
+    )
+    assert any(
+        call[0] == "api" and call[1].endswith(f"/actions/runs/{CLASSIFIER_RUN_ID}")
         for call in calls
     )
-    assert not any(call[0] == "api" and "/pulls/742/commits?" in call[1] for call in calls)
+    assert any(
+        call[0] == "api" and f"/actions/runs/{CLASSIFIER_RUN_ID}/attempts/1/jobs?" in call[1]
+        for call in calls
+    )
+    assert any(
+        call[0] == "api" and call[1].endswith(f"/check-runs/{ELIGIBILITY_CHECK_ID}")
+        for call in calls
+    )
+    assert any(call[0] == "api" and "/pulls/742/commits?per_page=100" in call[1] for call in calls)
 
 
-def test_dependabot_major_update_is_never_authorized_by_a_label(tmp_path: Path) -> None:
+def test_reviewed_major_update_uses_normal_path_but_dependabot_mode_refuses(
+    tmp_path: Path,
+) -> None:
     scenario = _default_scenario()
-    scenario["dependabot_check_runs"] = _eligibility_payload(
-        _eligibility_check(conclusion="failure")
+    scenario["dependabot_commits"] = [_dependabot_commit(update_type="version-update:semver-major")]
+
+    normal_dir = tmp_path / "normal"
+    normal_dir.mkdir()
+    normal, normal_calls = _run_pr_merge(normal_dir, scenario=scenario)
+    dependabot_dir = tmp_path / "dependabot"
+    dependabot_dir.mkdir()
+    unattended, unattended_calls = _run_pr_merge(
+        dependabot_dir,
+        "--dependabot",
+        scenario=scenario,
     )
 
-    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
-
-    assert result.returncode == 1
-    assert DEPENDABOT_ELIGIBILITY_CHECK in result.stderr
-    assert "failure" in result.stderr
-    assert _merge_calls(calls) == []
+    assert normal.returncode == 0, normal.stderr
+    assert len(_merge_calls(normal_calls)) == 1
+    assert unattended.returncode == 1
+    assert "only patch or minor" in unattended.stderr
+    assert _merge_calls(unattended_calls) == []
 
 
 def test_dependabot_synchronization_invalidates_old_head_classification(tmp_path: Path) -> None:
@@ -692,20 +838,72 @@ def test_dependabot_attributed_commit_with_generic_signer_cannot_authorize(
 ) -> None:
     scenario = _default_scenario()
     scenario["dependabot_commits"] = [_dependabot_commit()]
-    scenario["dependabot_check_runs"] = _eligibility_payload()
+    scenario["source_run"] = _source_run(
+        actor=_dependabot_actor(login="attacker", actor_id=7, actor_type="User"),
+        triggering_actor=_dependabot_actor(login="attacker", actor_id=7, actor_type="User"),
+    )
 
     result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
 
     assert result.returncode == 1
-    assert "missing" in result.stderr
-    assert DEPENDABOT_ELIGIBILITY_CHECK in result.stderr
+    assert "wrong CI workflow actor" in result.stderr
     assert not any(call[0] == "api" and "/pulls/742/commits?" in call[1] for call in calls)
     assert _merge_calls(calls) == []
 
 
-def test_dependabot_eligibility_check_must_match_exact_head(tmp_path: Path) -> None:
+def test_appended_non_dependabot_commit_cannot_reuse_an_exact_head_check(
+    tmp_path: Path,
+) -> None:
     scenario = _default_scenario()
-    scenario["dependabot_check_runs"] = _eligibility_payload(_eligibility_check(head_sha=OTHER_SHA))
+    scenario["dependabot_commits"] = [
+        _dependabot_commit(head_sha=OTHER_SHA),
+        {
+            "sha": HEAD_SHA,
+            "author": {"login": "attacker"},
+            "committer": {"login": "attacker"},
+        },
+    ]
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "exactly one current commit" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_forged_dependabot_author_with_different_committer_cannot_authorize(
+    tmp_path: Path,
+) -> None:
+    scenario = _default_scenario()
+    scenario["dependabot_commits"] = [_dependabot_commit()]
+    scenario["source_run"] = _source_run(
+        actor=_dependabot_actor(login="attacker", actor_id=7, actor_type="User"),
+        triggering_actor=_dependabot_actor(login="attacker", actor_id=7, actor_type="User"),
+    )
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "wrong CI workflow actor" in result.stderr
+    assert not any(call[0] == "api" and "/pulls/742/commits?" in call[1] for call in calls)
+    assert _merge_calls(calls) == []
+
+
+def test_same_actions_app_check_from_another_workflow_cannot_authorize(
+    tmp_path: Path,
+) -> None:
+    scenario = _default_scenario()
+    scenario["source_run"] = _source_run(path=".github/workflows/attacker.yml")
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "CI workflow path" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_dependabot_source_ci_run_must_match_exact_head(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    scenario["source_run"] = _source_run(head_sha=OTHER_SHA)
 
     result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
 
@@ -722,20 +920,18 @@ def test_dependabot_eligibility_check_must_match_exact_head(tmp_path: Path) -> N
     ],
     ids=["wrong-app-id", "wrong-app-slug"],
 )
-def test_dependabot_eligibility_check_requires_canonical_actions_app(
+def test_dependabot_source_suite_requires_canonical_actions_app(
     tmp_path: Path,
     app_id: int,
     app_slug: str,
 ) -> None:
     scenario = _default_scenario()
-    scenario["dependabot_check_runs"] = _eligibility_payload(
-        _eligibility_check(app_id=app_id, app_slug=app_slug)
-    )
+    scenario["source_suite"] = _source_suite(app_id=app_id, app_slug=app_slug)
 
     result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
 
     assert result.returncode == 1
-    assert "GitHub Actions app" in result.stderr
+    assert "check-suite app identity" in result.stderr
     assert _merge_calls(calls) == []
 
 
@@ -744,36 +940,81 @@ def test_dependabot_eligibility_check_requires_canonical_actions_app(
     [("queued", None), ("completed", "failure")],
     ids=["incomplete", "non-success"],
 )
-def test_dependabot_eligibility_check_must_complete_successfully(
+def test_dependabot_source_ci_run_must_complete_successfully(
     tmp_path: Path,
     status: str,
     conclusion: str | None,
 ) -> None:
     scenario = _default_scenario()
-    scenario["dependabot_check_runs"] = _eligibility_payload(
-        _eligibility_check(status=status, conclusion=conclusion)
-    )
+    source_run = scenario["source_run"]
+    assert isinstance(source_run, dict)
+    source_run.update({"status": status, "conclusion": conclusion})
 
     result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
 
     assert result.returncode == 1
-    assert f"status={status}" in result.stderr
-    assert f"conclusion={conclusion or ''}" in result.stderr
+    assert "did not complete successfully" in result.stderr
     assert _merge_calls(calls) == []
 
 
-def test_dependabot_eligibility_check_refuses_a_full_page(tmp_path: Path) -> None:
+def test_dependabot_classifier_jobs_refuse_a_full_page(tmp_path: Path) -> None:
     scenario = _default_scenario()
-    checks = tuple(_eligibility_check(check_id=index + 1) for index in range(100))
-    scenario["dependabot_check_runs"] = {
+    jobs = [_classifier_job(job_id=index + 1) for index in range(100)]
+    scenario["classifier_jobs"] = {
         "total_count": 100,
-        "check_runs": list(checks),
+        "jobs": jobs,
     }
 
     result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
 
     assert result.returncode == 1
     assert "100-item safety bound" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_classifier_run_must_bind_exact_source_run_and_head(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    scenario["classifier_run"] = _classifier_run(source_run_id=SOURCE_RUN_ID + 1)
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "source run/head binding mismatch" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_classifier_native_check_requires_canonical_actions_app(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    scenario["classifier_check"] = _classifier_check(app_id=1)
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "wrong Actions app identity" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_missing_native_classifier_job_refuses_dependabot_mode(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    scenario["classifier_jobs"] = {"total_count": 0, "jobs": []}
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "expected one native classifier job" in result.stderr
+    assert _merge_calls(calls) == []
+
+
+def test_completed_classifier_run_cannot_be_replayed(tmp_path: Path) -> None:
+    scenario = _default_scenario()
+    classifier_run = scenario["classifier_run"]
+    assert isinstance(classifier_run, dict)
+    classifier_run.update({"status": "completed", "conclusion": "failure"})
+
+    result, calls = _run_pr_merge(tmp_path, "--dependabot", scenario=scenario)
+
+    assert result.returncode == 1
+    assert "not currently executing" in result.stderr
     assert _merge_calls(calls) == []
 
 

--- a/tests/unit/tools/test_pr_merge_rollup.py
+++ b/tests/unit/tools/test_pr_merge_rollup.py
@@ -20,6 +20,18 @@ if _SPEC is None or _SPEC.loader is None:
 pr_merge = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(pr_merge)
 
+DEV_BLOCKING_CHECKS = (
+    "Fast Gate (hygiene, lint, format, imports, types, lock)",
+    "Unit Tests (xdist, coverage gate)",
+    "Determinism Gate (byte-identical dense goldens)",
+    "Secret Scan (gitleaks, full history)",
+    "IaC Config Scan (trivy, HIGH+CRITICAL blocking)",
+    "Security Audit (pip-audit policy — blocking since item-41)",
+    "Rust Gate (fmt, clippy, test, doc — rust/ workspace)",
+    "Baseline Ceremony Gate (§6.5 provenance)",
+    "Postgres Integration Tier (PG 17, pinned runtime)",
+)
+
 
 def _entry(
     name: str,
@@ -36,8 +48,8 @@ def _entry(
     }
 
 
-def _criticals_green() -> list[dict[str, str]]:
-    return [_entry(name, "SUCCESS", "2026-08-21T17:00:00Z") for name in pr_merge.CRITICAL_CHECKS]
+def _dev_manifest_green() -> list[dict[str, str]]:
+    return [_entry(name, "SUCCESS", "2026-08-21T17:00:00Z") for name in DEV_BLOCKING_CHECKS]
 
 
 class TestRollupFailuresLatestPerCheck:
@@ -47,7 +59,7 @@ class TestRollupFailuresLatestPerCheck:
             _entry("Security Audit", "FAILURE", "2026-08-21T18:11:11Z"),
             _entry("Security Audit", "SUCCESS", "2026-08-21T18:21:15Z"),
         ]
-        assert pr_merge._rollup_failures(rollup + _criticals_green()) == []
+        assert pr_merge._rollup_failures(rollup + _dev_manifest_green()) == []
 
     def test_latest_failure_still_refuses(self) -> None:
         rollup = [
@@ -89,15 +101,15 @@ class TestRollupFailuresLatestPerCheck:
                 "detailsUrl": f"{base}/222/job/1",
             },
         ]
-        assert pr_merge._rollup_failures(rollup + _criticals_green()) == []
+        assert pr_merge._rollup_failures(rollup + _dev_manifest_green()) == []
 
-    def test_critical_checks_still_require_explicit_pass(self) -> None:
-        """Dedupe must not weaken CRITICAL_CHECKS: a name whose latest entry
-        is SKIPPED/NEUTRAL still does not count as an explicit pass."""
-        critical = pr_merge.CRITICAL_CHECKS[0]
+    def test_every_blocking_check_still_requires_explicit_pass(self) -> None:
+        """Dedupe must not weaken the complete manifest's explicit-success rule."""
+        critical = DEV_BLOCKING_CHECKS[0]
         rollup = [
+            *[entry for entry in _dev_manifest_green() if entry["name"] != critical],
             _entry(critical, "SUCCESS", "2026-08-21T17:30:44Z"),
             _entry(critical, "SKIPPED", "2026-08-21T18:21:15Z"),
         ]
         failures = pr_merge._rollup_failures(rollup)
-        assert any("required an explicit PASS" in f for f in failures)
+        assert any(critical in failure and "SKIPPED" in failure for failure in failures)

--- a/tests/unit/tools/test_sync_github_pr_policy.py
+++ b/tests/unit/tools/test_sync_github_pr_policy.py
@@ -1,0 +1,562 @@
+"""Transactional contracts for the GitHub pull-request policy applicator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "sync_github_pr_policy",
+    Path(__file__).resolve().parents[3] / "tools" / "sync_github_pr_policy.py",
+)
+if _SPEC is None or _SPEC.loader is None:
+    raise RuntimeError("tools/sync_github_pr_policy.py failed import-spec resolution")
+policy_tool = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(policy_tool)
+
+DEV_BLOCKING_CHECKS = (
+    "Fast Gate (hygiene, lint, format, imports, types, lock)",
+    "Unit Tests (xdist, coverage gate)",
+    "Determinism Gate (byte-identical dense goldens)",
+    "Secret Scan (gitleaks, full history)",
+    "IaC Config Scan (trivy, HIGH+CRITICAL blocking)",
+    "Security Audit (pip-audit policy — blocking since item-41)",
+    "Rust Gate (fmt, clippy, test, doc — rust/ workspace)",
+    "Baseline Ceremony Gate (§6.5 provenance)",
+    "Postgres Integration Tier (PG 17, pinned runtime)",
+)
+
+
+def _ruleset(*, strict: bool, threads: bool) -> dict[str, Any]:
+    return {
+        "id": 18807584,
+        "name": "dev protection",
+        "target": "branch",
+        "source_type": "Repository",
+        "source": "percy-raskova/babylon",
+        "enforcement": "active",
+        "conditions": {"ref_name": {"exclude": [], "include": ["refs/heads/dev"]}},
+        "bypass_actors": [],
+        "rules": [
+            {"type": "deletion"},
+            {"type": "non_fast_forward"},
+            {
+                "type": "pull_request",
+                "parameters": {
+                    "allowed_merge_methods": ["merge"],
+                    "dismiss_stale_reviews_on_push": False,
+                    "required_reviewers": [],
+                    "require_code_owner_review": False,
+                    "require_last_push_approval": False,
+                    "required_approving_review_count": 0,
+                    "required_review_thread_resolution": threads,
+                    "require_extra_approval_for_unattributed_changes": False,
+                },
+            },
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "strict_required_status_checks_policy": strict,
+                    "do_not_enforce_on_create": False,
+                    "required_status_checks": [
+                        {"context": context} for context in DEV_BLOCKING_CHECKS
+                    ],
+                },
+            },
+        ],
+        "node_id": "read-only",
+        "created_at": "yesterday",
+        "updated_at": "today",
+    }
+
+
+def _repository(*, merge_only: bool) -> dict[str, Any]:
+    return {
+        "allow_merge_commit": True,
+        "allow_squash_merge": not merge_only,
+        "allow_rebase_merge": not merge_only,
+        "allow_auto_merge": not merge_only,
+        "delete_branch_on_merge": False,
+        "id": 123,
+        "full_name": "percy-raskova/babylon",
+    }
+
+
+def _policy() -> dict[str, Any]:
+    return {
+        "repository": policy_tool.normalize_repository(_repository(merge_only=True)),
+        "dev_ruleset": policy_tool.normalize_ruleset(_ruleset(strict=True, threads=True)),
+        "automerge_label": {
+            "name": "dependencies:automerge",
+            "color": "1f883d",
+            "description": "Patch/minor Dependabot update eligible for exact-head merge",
+        },
+    }
+
+
+class FakeApi:
+    """Small bounded API double with explicit state and injected failures."""
+
+    def __init__(self) -> None:
+        self.dev_sha = "a" * 40
+        self.ruleset = _ruleset(strict=False, threads=False)
+        self.repository = _repository(merge_only=False)
+        self.labels: list[dict[str, Any]] = []
+        self.check_runs = [
+            {
+                "id": index,
+                "name": context,
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-08-25T00:00:00Z",
+            }
+            for index, context in enumerate(DEV_BLOCKING_CHECKS, start=1)
+        ]
+        self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
+        self.fail_method_endpoint: tuple[str, str] | None = None
+        self.fail_oserror_method_endpoint: tuple[str, str] | None = None
+        self.mutate_then_fail_method_endpoint: tuple[str, str] | None = None
+        self.fail_ruleset_restore = False
+        self.mismatch_ruleset_readback = False
+        self.concurrent_ruleset_drift = False
+        self._ruleset_reads = 0
+        self.move_dev_on_read: int | None = None
+        self._dev_reads = 0
+
+    def get_json(self, endpoint: str) -> object:
+        self.calls.append(("GET", endpoint, None))
+        if endpoint == policy_tool.DEV_REF_ENDPOINT:
+            self._dev_reads += 1
+            if self._dev_reads == self.move_dev_on_read:
+                self.dev_sha = "b" * 40
+            return {"object": {"sha": self.dev_sha}}
+        if endpoint == policy_tool.RULESETS_ENDPOINT:
+            return [{"id": 18807584}]
+        if endpoint == policy_tool.DEV_RULESET_ENDPOINT.format(ruleset_id=18807584):
+            self._ruleset_reads += 1
+            value = deepcopy(self.ruleset)
+            if self.concurrent_ruleset_drift and self._ruleset_reads == 2:
+                value["name"] = "concurrent change"
+            if self.mismatch_ruleset_readback and self._ruleset_reads == 3:
+                value["enforcement"] = "disabled"
+            return value
+        if endpoint == policy_tool.REPOSITORY_ENDPOINT:
+            return deepcopy(self.repository)
+        if endpoint == policy_tool.LABELS_LIST_ENDPOINT:
+            return deepcopy(self.labels)
+        if endpoint == policy_tool.CHECK_RUNS_ENDPOINT.format(sha=self.dev_sha):
+            return {"total_count": len(self.check_runs), "check_runs": deepcopy(self.check_runs)}
+        raise AssertionError(f"unexpected GET {endpoint}")
+
+    def send_json(self, method: str, endpoint: str, payload: dict[str, Any]) -> object:
+        self.calls.append((method, endpoint, deepcopy(payload)))
+        if self.fail_method_endpoint == (method, endpoint):
+            self.fail_method_endpoint = None
+            raise policy_tool.GitHubApiError(f"injected {method} failure")
+        if self.fail_oserror_method_endpoint == (method, endpoint):
+            self.fail_oserror_method_endpoint = None
+            raise OSError(f"injected {method} spawn failure")
+        if (
+            self.fail_ruleset_restore
+            and method == "PUT"
+            and payload["rules"][-1]["parameters"]["strict_required_status_checks_policy"] is False
+        ):
+            raise policy_tool.GitHubApiError("injected ruleset restore failure")
+        if method == "POST" and endpoint == policy_tool.LABELS_ENDPOINT:
+            label = {"id": 99, **payload}
+            self.labels.append(label)
+            return self._write_result(method, endpoint, label)
+        if method == "DELETE" and endpoint == policy_tool.label_endpoint("dependencies:automerge"):
+            self.labels = [label for label in self.labels if label["name"] != payload["name"]]
+            return self._write_result(method, endpoint, {})
+        if method == "PATCH" and endpoint == policy_tool.REPOSITORY_ENDPOINT:
+            self.repository.update(payload)
+            return self._write_result(method, endpoint, self.repository)
+        if method == "PUT" and endpoint == policy_tool.DEV_RULESET_ENDPOINT.format(
+            ruleset_id=18807584
+        ):
+            current_id = self.ruleset["id"]
+            self.ruleset = {"id": current_id, **deepcopy(payload)}
+            return self._write_result(method, endpoint, self.ruleset)
+        raise AssertionError(f"unexpected {method} {endpoint}")
+
+    def _write_result(
+        self,
+        method: str,
+        endpoint: str,
+        result: dict[str, Any],
+    ) -> dict[str, Any]:
+        if self.mutate_then_fail_method_endpoint == (method, endpoint):
+            self.mutate_then_fail_method_endpoint = None
+            raise policy_tool.GitHubApiError(f"injected ambiguous {method} failure")
+        return deepcopy(result)
+
+
+def test_normalizers_strip_read_only_api_fields() -> None:
+    normalized_ruleset = policy_tool.normalize_ruleset(_ruleset(strict=False, threads=False))
+    normalized_repository = policy_tool.normalize_repository(_repository(merge_only=False))
+
+    assert set(normalized_ruleset) == {
+        "name",
+        "target",
+        "enforcement",
+        "bypass_actors",
+        "conditions",
+        "rules",
+    }
+    assert set(normalized_repository) == {
+        "allow_merge_commit",
+        "allow_squash_merge",
+        "allow_rebase_merge",
+        "allow_auto_merge",
+        "delete_branch_on_merge",
+    }
+
+
+def test_check_reports_drift_without_mutation() -> None:
+    api = FakeApi()
+
+    drift = policy_tool.check_policy(api, _policy())
+
+    assert drift == [
+        "repository merge settings differ",
+        "dev ruleset differs",
+        "automerge label is absent",
+    ]
+    assert all(method == "GET" for method, _endpoint, _payload in api.calls)
+
+
+def test_dev_ruleset_selection_refuses_a_shared_or_non_branch_scope() -> None:
+    shared = FakeApi()
+    shared.ruleset["conditions"]["ref_name"]["include"].append("refs/heads/main")
+    with pytest.raises(policy_tool.PolicyError, match="exact dev-only branch scope"):
+        policy_tool.check_policy(shared, _policy())
+
+    tagged = FakeApi()
+    tagged.ruleset["target"] = "tag"
+    with pytest.raises(policy_tool.PolicyError, match="exact dev-only branch scope"):
+        policy_tool.check_policy(tagged, _policy())
+
+
+def test_ruleset_enumeration_requests_one_bounded_complete_page() -> None:
+    assert "per_page=100" in policy_tool.RULESETS_ENDPOINT
+
+
+def test_required_status_contexts_cannot_be_empty() -> None:
+    policy = _policy()
+    status_rule = next(
+        rule for rule in policy["dev_ruleset"]["rules"] if rule["type"] == "required_status_checks"
+    )
+    status_rule["parameters"]["required_status_checks"] = []
+
+    with pytest.raises(policy_tool.PolicyError, match="at least one required status check"):
+        policy_tool._required_contexts(policy)
+
+
+def test_settings_policy_must_match_the_complete_typed_dev_manifest() -> None:
+    policy = _policy()
+    status_rule = next(
+        rule for rule in policy["dev_ruleset"]["rules"] if rule["type"] == "required_status_checks"
+    )
+    status_rule["parameters"]["required_status_checks"].pop()
+
+    with pytest.raises(policy_tool.PolicyError, match="complete dev check manifest"):
+        policy_tool._validate_policy(policy)
+
+
+def test_malformed_check_run_id_is_rejected_at_the_json_boundary(tmp_path: Path) -> None:
+    api = FakeApi()
+    api.check_runs[0]["id"] = "not-an-integer"
+
+    with pytest.raises(policy_tool.PolicyError, match="integer id"):
+        policy_tool.apply_policy(api, _policy(), api.dev_sha, tmp_path / "before.json")
+
+    assert all(method == "GET" for method, _endpoint, _payload in api.calls)
+
+
+def test_gh_api_has_a_fixed_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def timeout(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert kwargs["timeout"] == policy_tool.API_TIMEOUT_SECONDS
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(policy_tool.subprocess, "run", timeout)
+
+    with pytest.raises(policy_tool.GitHubApiError, match="timed out"):
+        policy_tool.GhApi._run(["repos/percy-raskova/babylon"])
+
+
+def test_gh_api_normalizes_an_os_spawn_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_spawn(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise OSError("gh executable unavailable")
+
+    monkeypatch.setattr(policy_tool.subprocess, "run", fail_spawn)
+
+    with pytest.raises(policy_tool.GitHubApiError, match="could not start"):
+        policy_tool.GhApi._run(["repos/percy-raskova/babylon"])
+
+
+def test_alternate_policy_label_is_refused_before_any_api_call(tmp_path: Path) -> None:
+    api = FakeApi()
+    policy = _policy()
+    policy["automerge_label"]["name"] = "dependencies:alternate"
+
+    with pytest.raises(policy_tool.PolicyError, match="canonical automerge label"):
+        policy_tool.apply_policy(api, policy, api.dev_sha, tmp_path / "before.json")
+
+    assert api.calls == []
+
+
+def test_apply_snapshots_before_mutation_and_verifies_readback(tmp_path: Path) -> None:
+    api = FakeApi()
+    snapshot_path = tmp_path / "before.json"
+
+    policy_tool.apply_policy(api, _policy(), api.dev_sha, snapshot_path)
+
+    snapshot = json.loads(snapshot_path.read_text())
+    assert snapshot["dev_sha"] == api.dev_sha
+    assert snapshot["dev_ruleset_id"] == 18807584
+    assert snapshot["automerge_label"] is None
+    first_write = next(index for index, call in enumerate(api.calls) if call[0] != "GET")
+    assert snapshot_path.is_file()
+    assert first_write > 0
+    assert policy_tool.check_policy(api, _policy()) == []
+
+
+def test_apply_refuses_moved_dev_or_non_green_checks_before_mutation(tmp_path: Path) -> None:
+    moved = FakeApi()
+    with pytest.raises(policy_tool.PolicyError, match="dev moved"):
+        policy_tool.apply_policy(moved, _policy(), "b" * 40, tmp_path / "moved.json")
+    assert all(method == "GET" for method, _endpoint, _payload in moved.calls)
+
+    red = FakeApi()
+    red.check_runs[0]["conclusion"] = "failure"
+    with pytest.raises(policy_tool.PolicyError, match=re.escape(DEV_BLOCKING_CHECKS[0])):
+        policy_tool.apply_policy(red, _policy(), red.dev_sha, tmp_path / "red.json")
+    assert all(method == "GET" for method, _endpoint, _payload in red.calls)
+
+
+def test_existing_snapshot_is_preserved_before_any_remote_mutation(tmp_path: Path) -> None:
+    api = FakeApi()
+    snapshot_path = tmp_path / "before.json"
+    sentinel = b"original rollback bytes\x00\xff"
+    snapshot_path.write_bytes(sentinel)
+
+    with pytest.raises(policy_tool.PolicyError, match="already exists"):
+        policy_tool.apply_policy(api, _policy(), api.dev_sha, snapshot_path)
+
+    assert snapshot_path.read_bytes() == sentinel
+    assert all(method == "GET" for method, _endpoint, _payload in api.calls)
+
+
+def test_concurrent_drift_aborts_before_first_mutation(tmp_path: Path) -> None:
+    api = FakeApi()
+    api.concurrent_ruleset_drift = True
+
+    with pytest.raises(policy_tool.PolicyError, match="changed after snapshot"):
+        policy_tool.apply_policy(api, _policy(), api.dev_sha, tmp_path / "before.json")
+
+    assert all(method == "GET" for method, _endpoint, _payload in api.calls)
+
+
+def test_moved_dev_after_green_evidence_aborts_before_first_mutation(tmp_path: Path) -> None:
+    api = FakeApi()
+    expected_sha = api.dev_sha
+    api.move_dev_on_read = 2
+
+    with pytest.raises(policy_tool.PolicyError, match="dev moved after green evidence"):
+        policy_tool.apply_policy(api, _policy(), expected_sha, tmp_path / "before.json")
+
+    assert all(method == "GET" for method, _endpoint, _payload in api.calls)
+
+
+def test_moved_dev_during_apply_rolls_back_every_mutation(tmp_path: Path) -> None:
+    api = FakeApi()
+    expected_sha = api.dev_sha
+    api.move_dev_on_read = 3
+    original_ruleset = deepcopy(api.ruleset)
+    original_repository = deepcopy(api.repository)
+
+    with pytest.raises(policy_tool.PolicyError, match="dev moved during policy apply"):
+        policy_tool.apply_policy(api, _policy(), expected_sha, tmp_path / "before.json")
+
+    assert policy_tool.normalize_ruleset(api.ruleset) == policy_tool.normalize_ruleset(
+        original_ruleset
+    )
+    assert api.repository == original_repository
+    assert api.labels == []
+
+
+def test_failed_ruleset_update_rolls_back_repo_and_new_label(tmp_path: Path) -> None:
+    api = FakeApi()
+    api.fail_method_endpoint = (
+        "PUT",
+        policy_tool.DEV_RULESET_ENDPOINT.format(ruleset_id=18807584),
+    )
+    original_repository = deepcopy(api.repository)
+
+    with pytest.raises(policy_tool.GitHubApiError, match="injected PUT failure"):
+        policy_tool.apply_policy(api, _policy(), api.dev_sha, tmp_path / "before.json")
+
+    assert api.repository == original_repository
+    assert api.labels == []
+    ruleset_endpoint = policy_tool.DEV_RULESET_ENDPOINT.format(ruleset_id=18807584)
+    assert sum(call[:2] == ("PUT", ruleset_endpoint) for call in api.calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("method", "endpoint"),
+    [
+        ("POST", policy_tool.LABELS_ENDPOINT),
+        ("PATCH", policy_tool.REPOSITORY_ENDPOINT),
+        ("PUT", policy_tool.DEV_RULESET_ENDPOINT.format(ruleset_id=18807584)),
+    ],
+)
+def test_ambiguous_committed_write_is_discovered_and_rolled_back(
+    tmp_path: Path,
+    method: str,
+    endpoint: str,
+) -> None:
+    api = FakeApi()
+    api.mutate_then_fail_method_endpoint = (method, endpoint)
+    original_ruleset = deepcopy(api.ruleset)
+    original_repository = deepcopy(api.repository)
+
+    with pytest.raises(policy_tool.GitHubApiError, match=f"ambiguous {method} failure"):
+        policy_tool.apply_policy(api, _policy(), api.dev_sha, tmp_path / "before.json")
+
+    assert policy_tool.normalize_ruleset(api.ruleset) == policy_tool.normalize_ruleset(
+        original_ruleset
+    )
+    assert api.repository == original_repository
+    assert api.labels == []
+
+
+def test_failed_label_create_does_not_delete_an_absent_label(tmp_path: Path) -> None:
+    api = FakeApi()
+    api.fail_method_endpoint = ("POST", policy_tool.LABELS_ENDPOINT)
+
+    with pytest.raises(policy_tool.GitHubApiError, match="injected POST failure"):
+        policy_tool.apply_policy(api, _policy(), api.dev_sha, tmp_path / "before.json")
+
+    assert not any(call[0] == "DELETE" for call in api.calls)
+    assert api.labels == []
+
+
+def test_failed_repository_update_rolls_back_only_the_created_label(tmp_path: Path) -> None:
+    api = FakeApi()
+    api.fail_method_endpoint = ("PATCH", policy_tool.REPOSITORY_ENDPOINT)
+    original_ruleset = deepcopy(api.ruleset)
+    original_repository = deepcopy(api.repository)
+
+    with pytest.raises(policy_tool.GitHubApiError, match="injected PATCH failure"):
+        policy_tool.apply_policy(api, _policy(), api.dev_sha, tmp_path / "before.json")
+
+    assert api.repository == original_repository
+    assert api.ruleset == original_ruleset
+    assert api.labels == []
+    assert not any(call[0] == "PUT" for call in api.calls)
+
+
+def test_oserror_after_label_creation_still_rolls_back_the_label(tmp_path: Path) -> None:
+    api = FakeApi()
+    api.fail_oserror_method_endpoint = ("PATCH", policy_tool.REPOSITORY_ENDPOINT)
+
+    with pytest.raises(OSError, match="spawn failure"):
+        policy_tool.apply_policy(api, _policy(), api.dev_sha, tmp_path / "before.json")
+
+    assert api.labels == []
+
+
+def test_readback_mismatch_rolls_back_every_mutation(tmp_path: Path) -> None:
+    api = FakeApi()
+    api.mismatch_ruleset_readback = True
+    original_ruleset = deepcopy(api.ruleset)
+    original_repository = deepcopy(api.repository)
+
+    with pytest.raises(policy_tool.PolicyError, match="readback mismatch"):
+        policy_tool.apply_policy(api, _policy(), api.dev_sha, tmp_path / "before.json")
+
+    assert policy_tool.normalize_ruleset(api.ruleset) == policy_tool.normalize_ruleset(
+        original_ruleset
+    )
+    assert api.repository == original_repository
+    assert api.labels == []
+
+
+def test_rollback_attempts_every_component_after_one_restore_fails(tmp_path: Path) -> None:
+    api = FakeApi()
+    api.mismatch_ruleset_readback = True
+    api.fail_ruleset_restore = True
+    original_repository = deepcopy(api.repository)
+
+    with pytest.raises(policy_tool.PolicyError, match="rollback also failed"):
+        policy_tool.apply_policy(api, _policy(), api.dev_sha, tmp_path / "before.json")
+
+    assert api.repository == original_repository
+    assert api.labels == []
+    assert any(call[0] == "DELETE" for call in api.calls)
+
+
+def test_manual_rollback_restores_snapshot_and_verifies_readback(tmp_path: Path) -> None:
+    api = FakeApi()
+    original_ruleset = deepcopy(api.ruleset)
+    original_repository = deepcopy(api.repository)
+    snapshot_path = tmp_path / "before.json"
+    policy_tool.apply_policy(api, _policy(), api.dev_sha, snapshot_path)
+
+    policy_tool.rollback_policy(api, policy_tool.load_snapshot(snapshot_path))
+
+    assert policy_tool.normalize_ruleset(api.ruleset) == policy_tool.normalize_ruleset(
+        original_ruleset
+    )
+    assert api.repository == original_repository
+    assert api.labels == []
+
+
+def test_manual_rollback_refuses_a_stale_dev_snapshot_without_mutation(tmp_path: Path) -> None:
+    api = FakeApi()
+    snapshot_path = tmp_path / "before.json"
+    policy_tool.apply_policy(api, _policy(), api.dev_sha, snapshot_path)
+    snapshot = policy_tool.load_snapshot(snapshot_path)
+    api.calls.clear()
+    api.dev_sha = "b" * 40
+
+    with pytest.raises(policy_tool.PolicyError, match="snapshot dev"):
+        policy_tool.rollback_policy(api, snapshot)
+
+    assert all(method == "GET" for method, _endpoint, _payload in api.calls)
+
+
+def test_manual_rollback_refuses_tampered_scope_before_mutation(tmp_path: Path) -> None:
+    api = FakeApi()
+    snapshot_path = tmp_path / "before.json"
+    policy_tool.apply_policy(api, _policy(), api.dev_sha, snapshot_path)
+    snapshot = policy_tool.load_snapshot(snapshot_path)
+    snapshot["dev_ruleset"]["conditions"]["ref_name"]["include"].append("refs/heads/main")
+    api.calls.clear()
+
+    with pytest.raises(policy_tool.PolicyError, match="exact dev-only branch scope"):
+        policy_tool.rollback_policy(api, snapshot)
+
+    assert api.calls == []
+
+
+def test_manual_rollback_refuses_a_different_ruleset_id_before_mutation(tmp_path: Path) -> None:
+    api = FakeApi()
+    snapshot_path = tmp_path / "before.json"
+    policy_tool.apply_policy(api, _policy(), api.dev_sha, snapshot_path)
+    snapshot = policy_tool.load_snapshot(snapshot_path)
+    snapshot["dev_ruleset_id"] = 999
+    api.calls.clear()
+
+    with pytest.raises(policy_tool.PolicyError, match="ruleset ID changed"):
+        policy_tool.rollback_policy(api, snapshot)
+
+    assert all(method == "GET" for method, _endpoint, _payload in api.calls)

--- a/tests/unit/tools/test_sync_github_pr_policy.py
+++ b/tests/unit/tools/test_sync_github_pr_policy.py
@@ -126,6 +126,7 @@ class FakeApi:
         self.fail_ruleset_restore = False
         self.mismatch_ruleset_readback = False
         self.concurrent_ruleset_drift = False
+        self.policy_error_ruleset_read: int | None = None
         self._ruleset_reads = 0
         self.move_dev_on_read: int | None = None
         self._dev_reads = 0
@@ -141,6 +142,8 @@ class FakeApi:
             return [{"id": 18807584}]
         if endpoint == policy_tool.DEV_RULESET_ENDPOINT.format(ruleset_id=18807584):
             self._ruleset_reads += 1
+            if self._ruleset_reads == self.policy_error_ruleset_read:
+                raise policy_tool.PolicyError("injected malformed ruleset readback")
             value = deepcopy(self.ruleset)
             if self.concurrent_ruleset_drift and self._ruleset_reads == 2:
                 value["name"] = "concurrent change"
@@ -271,6 +274,16 @@ def test_settings_policy_must_match_the_complete_typed_dev_manifest() -> None:
         policy_tool._validate_policy(policy)
 
 
+def test_settings_policy_context_order_is_not_authoritative() -> None:
+    policy = _policy()
+    status_rule = next(
+        rule for rule in policy["dev_ruleset"]["rules"] if rule["type"] == "required_status_checks"
+    )
+    status_rule["parameters"]["required_status_checks"].reverse()
+
+    policy_tool._validate_policy(policy)
+
+
 def test_malformed_check_run_id_is_rejected_at_the_json_boundary(tmp_path: Path) -> None:
     api = FakeApi()
     api.check_runs[0]["id"] = "not-an-integer"
@@ -340,6 +353,28 @@ def test_apply_refuses_moved_dev_or_non_green_checks_before_mutation(tmp_path: P
     with pytest.raises(policy_tool.PolicyError, match=re.escape(DEV_BLOCKING_CHECKS[0])):
         policy_tool.apply_policy(red, _policy(), red.dev_sha, tmp_path / "red.json")
     assert all(method == "GET" for method, _endpoint, _payload in red.calls)
+
+
+def test_apply_accepts_the_pr_only_baseline_gate_skipped_on_dev_push(tmp_path: Path) -> None:
+    api = FakeApi()
+    baseline = next(
+        run for run in api.check_runs if run["name"] == "Baseline Ceremony Gate (§6.5 provenance)"
+    )
+    baseline["conclusion"] = "skipped"
+
+    policy_tool.apply_policy(api, _policy(), api.dev_sha, tmp_path / "before.json")
+
+    assert policy_tool.check_policy(api, _policy()) == []
+
+
+def test_apply_refuses_any_other_skipped_dev_push_check(tmp_path: Path) -> None:
+    api = FakeApi()
+    api.check_runs[0]["conclusion"] = "skipped"
+
+    with pytest.raises(policy_tool.PolicyError, match=re.escape(DEV_BLOCKING_CHECKS[0])):
+        policy_tool.apply_policy(api, _policy(), api.dev_sha, tmp_path / "before.json")
+
+    assert all(method == "GET" for method, _endpoint, _payload in api.calls)
 
 
 def test_existing_snapshot_is_preserved_before_any_remote_mutation(tmp_path: Path) -> None:
@@ -481,6 +516,25 @@ def test_readback_mismatch_rolls_back_every_mutation(tmp_path: Path) -> None:
     original_repository = deepcopy(api.repository)
 
     with pytest.raises(policy_tool.PolicyError, match="readback mismatch"):
+        policy_tool.apply_policy(api, _policy(), api.dev_sha, tmp_path / "before.json")
+
+    assert policy_tool.normalize_ruleset(api.ruleset) == policy_tool.normalize_ruleset(
+        original_ruleset
+    )
+    assert api.repository == original_repository
+    assert api.labels == []
+
+
+def test_recoverable_policy_error_during_rollback_read_uses_attempted_writes(
+    tmp_path: Path,
+) -> None:
+    api = FakeApi()
+    api.move_dev_on_read = 3
+    api.policy_error_ruleset_read = 4
+    original_ruleset = deepcopy(api.ruleset)
+    original_repository = deepcopy(api.repository)
+
+    with pytest.raises(policy_tool.PolicyError, match="dev moved during policy apply"):
         policy_tool.apply_policy(api, _policy(), api.dev_sha, tmp_path / "before.json")
 
     assert policy_tool.normalize_ruleset(api.ruleset) == policy_tool.normalize_ruleset(

--- a/tools/pr_merge.py
+++ b/tools/pr_merge.py
@@ -323,6 +323,7 @@ def _child_prs(head_ref: str) -> list[int]:
             "number",
         ),
         "child pull requests",
+        refuse_full_page=True,
     )
     numbers: list[int] = []
     for pr in prs:

--- a/tools/pr_merge.py
+++ b/tools/pr_merge.py
@@ -361,6 +361,7 @@ def _open_alert_count() -> int:
                 f"?state=open&per_page={MAX_GITHUB_ITEMS}",
             ),
             "code-scanning alerts",
+            refuse_full_page=True,
         )
     )
 

--- a/tools/pr_merge.py
+++ b/tools/pr_merge.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -42,7 +43,12 @@ COPILOT_REST_COMMENT_LOGIN = "Copilot"
 COPILOT_BOT_ID = 175728472
 COPILOT_BOT_NODE_ID = "BOT_kgDOCnlnWA"
 DEPENDABOT_LOGIN = "dependabot[bot]"
+DEPENDABOT_BOT_ID = 49699333
 DEPENDABOT_ELIGIBILITY_CHECK = "Dependabot Eligibility"
+DEPENDABOT_WORKFLOW_PATH = ".github/workflows/dependabot-automerge.yml"
+DEPENDABOT_WORKFLOW_ID = 214604133
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+CI_WORKFLOW_ID = 176131131
 GITHUB_ACTIONS_APP_ID = 15368
 GITHUB_ACTIONS_APP_SLUG = "github-actions"
 
@@ -327,7 +333,12 @@ def _child_prs(head_ref: str) -> list[int]:
     return numbers
 
 
-def _dependabot_pr_problems(pr: int, head_oid: str) -> list[str]:
+def _dependabot_pr_problems(
+    pr: int,
+    head_oid: str,
+    source_run_id: int,
+    classifier_run_id: int,
+) -> list[str]:
     """Revalidate exact-head Dependabot authority from trusted GitHub records."""
     payload = _json_dict(
         _gh_json("api", f"repos/{{owner}}/{{repo}}/pulls/{pr}"),
@@ -335,9 +346,7 @@ def _dependabot_pr_problems(pr: int, head_oid: str) -> list[str]:
     )
     problems: list[str] = []
     user = payload.get("user")
-    if not isinstance(user, dict) or (
-        user.get("login") != DEPENDABOT_LOGIN or user.get("type") != "Bot"
-    ):
+    if not _is_canonical_dependabot(user):
         problems.append("Dependabot mode requires the exact Dependabot bot author")
     head = payload.get("head")
     rest_head = head.get("sha") if isinstance(head, dict) else None
@@ -347,68 +356,280 @@ def _dependabot_pr_problems(pr: int, head_oid: str) -> list[str]:
     rest_base = base.get("ref") if isinstance(base, dict) else None
     if rest_base != "dev":
         problems.append(f"Dependabot mode requires base dev, found {rest_base}")
-    problems.extend(_dependabot_eligibility_problems(head_oid))
+    if problems:
+        return problems
+    source_run = _json_dict(
+        _gh_json("api", f"repos/{{owner}}/{{repo}}/actions/runs/{source_run_id}"),
+        "Dependabot source CI run",
+    )
+    source_problems = _source_ci_run_problems(source_run, pr, head_oid, source_run_id)
+    if source_problems:
+        return source_problems
+    classifier_run = _json_dict(
+        _gh_json("api", f"repos/{{owner}}/{{repo}}/actions/runs/{classifier_run_id}"),
+        "Dependabot classifier run",
+    )
+    classifier_problems = _classifier_run_problems(
+        classifier_run,
+        head_oid,
+        source_run_id,
+        classifier_run_id,
+    )
+    if classifier_problems:
+        return classifier_problems
+    job_problems = _native_classifier_job_problems(classifier_run_id, classifier_run)
+    if job_problems:
+        return job_problems
+    return _dependabot_update_problems(pr, head_oid)
+
+
+def _is_canonical_dependabot(actor: object) -> bool:
+    """Match immutable Dependabot identity at REST and Actions boundaries."""
+    return isinstance(actor, dict) and (
+        actor.get("login") == DEPENDABOT_LOGIN
+        and actor.get("id") == DEPENDABOT_BOT_ID
+        and actor.get("type") == "Bot"
+    )
+
+
+def _positive_int(value: object, context: str) -> int:
+    """Require one positive JSON integer identifier."""
+    if type(value) is not int or value <= 0:
+        raise RuntimeError(f"{context} must be a positive integer")
+    return value
+
+
+def _source_ci_run_problems(
+    run: dict[str, object],
+    pr: int,
+    head_oid: str,
+    run_id: int,
+) -> list[str]:
+    """Bind authorization to the canonical native exact-head CI run."""
+    problems: list[str] = []
+    if run.get("id") != run_id or run.get("workflow_id") != CI_WORKFLOW_ID:
+        problems.append("Dependabot source: wrong CI workflow identity")
+    if run.get("path") != CI_WORKFLOW_PATH or run.get("event") != "pull_request":
+        problems.append("Dependabot source: wrong CI workflow path or event")
+    if run.get("head_sha") != head_oid:
+        problems.append("Dependabot source: CI run is not on exact PR head")
+    if run.get("status") != "completed" or run.get("conclusion") != "success":
+        problems.append("Dependabot source: CI run did not complete successfully")
+    if not _is_canonical_dependabot(run.get("actor")):
+        problems.append("Dependabot source: wrong CI workflow actor")
+    if not _is_canonical_dependabot(run.get("triggering_actor")):
+        problems.append("Dependabot source: wrong CI triggering actor")
+    problems.extend(_run_repository_problems(run, "Dependabot source"))
+    problems.extend(_run_pr_identity_problems(run, pr, head_oid, "Dependabot source"))
+    suite_id = _positive_int(run.get("check_suite_id"), "Dependabot source check_suite_id")
+    suite = _json_dict(
+        _gh_json("api", f"repos/{{owner}}/{{repo}}/check-suites/{suite_id}"),
+        "Dependabot source check suite",
+    )
+    problems.extend(_source_suite_problems(suite, pr, head_oid, suite_id))
     return problems
 
 
-def _dependabot_eligibility_problems(head_oid: str) -> list[str]:
-    """Require the latest exact-head eligibility check from GitHub Actions."""
+def _classifier_run_problems(
+    run: dict[str, object],
+    head_oid: str,
+    source_run_id: int,
+    classifier_run_id: int,
+) -> list[str]:
+    """Bind the verifier to its trusted default-branch workflow run."""
+    expected_title = f"Dependabot eligibility for CI run {source_run_id} at {head_oid}"
+    problems: list[str] = []
+    if run.get("id") != classifier_run_id or run.get("workflow_id") != DEPENDABOT_WORKFLOW_ID:
+        problems.append("Dependabot classifier: wrong workflow identity")
+    if run.get("path") != DEPENDABOT_WORKFLOW_PATH or run.get("event") != "workflow_run":
+        problems.append("Dependabot classifier: wrong workflow path or event")
+    if run.get("display_title") != expected_title:
+        problems.append("Dependabot classifier: source run/head binding mismatch")
+    if run.get("status") != "in_progress" or run.get("conclusion") is not None:
+        problems.append("Dependabot classifier: workflow run is not currently executing")
+    if not _is_canonical_dependabot(run.get("actor")):
+        problems.append("Dependabot classifier: wrong workflow actor")
+    if not _is_canonical_dependabot(run.get("triggering_actor")):
+        problems.append("Dependabot classifier: wrong triggering actor")
+    problems.extend(_run_repository_problems(run, "Dependabot classifier"))
+    return problems
+
+
+def _native_classifier_job_problems(
+    classifier_run_id: int,
+    classifier_run: dict[str, object],
+) -> list[str]:
+    """Require the verifier's native job/check and owning check suite."""
+    run_attempt = _positive_int(
+        classifier_run.get("run_attempt"),
+        "Dependabot classifier run_attempt",
+    )
     payload = _json_dict(
         _gh_json(
             "api",
-            f"repos/{{owner}}/{{repo}}/commits/{head_oid}/check-runs"
-            f"?check_name=Dependabot%20Eligibility&filter=all&per_page={MAX_GITHUB_ITEMS}",
+            f"repos/{{owner}}/{{repo}}/actions/runs/{classifier_run_id}"
+            f"/attempts/{run_attempt}/jobs?filter=latest&per_page={MAX_GITHUB_ITEMS}",
         ),
-        "Dependabot eligibility check runs",
+        "Dependabot classifier jobs",
     )
-    total_count = payload.get("total_count")
-    if type(total_count) is not int:
-        raise RuntimeError("Dependabot eligibility total_count must be an integer")
-    if total_count >= MAX_GITHUB_ITEMS:
-        raise RuntimeError(
-            f"Dependabot eligibility checks reached the {MAX_GITHUB_ITEMS}-item safety bound"
-        )
-    runs = _json_dicts(
-        payload.get("check_runs"),
-        "Dependabot eligibility checks",
-        refuse_full_page=True,
+    jobs = _bounded_counted_items(payload, "Dependabot classifier jobs", "jobs")
+    matches = [job for job in jobs if job.get("name") == DEPENDABOT_ELIGIBILITY_CHECK]
+    if len(matches) != 1:
+        return [f"{DEPENDABOT_ELIGIBILITY_CHECK}: expected one native classifier job"]
+    job = matches[0]
+    job_id = _positive_int(job.get("id"), "Dependabot classifier job id")
+    check_run = _json_dict(
+        _gh_json("api", f"repos/{{owner}}/{{repo}}/check-runs/{job_id}"),
+        "Dependabot classifier check run",
     )
-    if total_count != len(runs):
-        raise RuntimeError("Dependabot eligibility check response is incomplete")
-    exact_runs = [run for run in runs if run.get("name") == DEPENDABOT_ELIGIBILITY_CHECK]
-    if not exact_runs:
-        return [f"{DEPENDABOT_ELIGIBILITY_CHECK}: missing on exact head {head_oid}"]
-    latest = max(exact_runs, key=_eligibility_sort_key)
+    suite_id = _positive_int(
+        classifier_run.get("check_suite_id"),
+        "Dependabot classifier check_suite_id",
+    )
+    return _classifier_job_and_check_problems(
+        job,
+        check_run,
+        classifier_run,
+        classifier_run_id,
+        suite_id,
+    )
+
+
+def _classifier_job_and_check_problems(
+    job: dict[str, object],
+    check_run: dict[str, object],
+    run: dict[str, object],
+    run_id: int,
+    suite_id: int,
+) -> list[str]:
+    """Validate the native job/check equality and check-suite ownership."""
+    job_id = _positive_int(job.get("id"), "Dependabot classifier job id")
     problems: list[str] = []
-    if latest.get("head_sha") != head_oid:
-        problems.append(f"{DEPENDABOT_ELIGIBILITY_CHECK}: check is not on exact head {head_oid}")
-    app = latest.get("app")
-    if not isinstance(app, dict) or (
-        app.get("id") != GITHUB_ACTIONS_APP_ID or app.get("slug") != GITHUB_ACTIONS_APP_SLUG
+    if job.get("run_id") != run_id or job.get("head_sha") != run.get("head_sha"):
+        problems.append(f"{DEPENDABOT_ELIGIBILITY_CHECK}: native job/run mismatch")
+    if job.get("status") != "in_progress" or job.get("conclusion") is not None:
+        problems.append(f"{DEPENDABOT_ELIGIBILITY_CHECK}: native job is not executing")
+    if check_run.get("id") != job_id or check_run.get("name") != job.get("name"):
+        problems.append(f"{DEPENDABOT_ELIGIBILITY_CHECK}: native job/check ID mismatch")
+    if check_run.get("head_sha") != job.get("head_sha"):
+        problems.append(f"{DEPENDABOT_ELIGIBILITY_CHECK}: native job/check head mismatch")
+    if check_run.get("status") != job.get("status") or check_run.get("conclusion") != job.get(
+        "conclusion"
     ):
-        problems.append(f"{DEPENDABOT_ELIGIBILITY_CHECK}: wrong GitHub Actions app identity")
-    status = latest.get("status")
-    conclusion = latest.get("conclusion")
-    if not isinstance(status, str):
-        raise RuntimeError("Dependabot eligibility check status must be a string")
-    if conclusion is not None and not isinstance(conclusion, str):
-        raise RuntimeError("Dependabot eligibility check conclusion must be a string or null")
-    if status != "completed" or conclusion != "success":
-        problems.append(
-            f"{DEPENDABOT_ELIGIBILITY_CHECK}: status={status}, conclusion={conclusion or ''}"
-        )
+        problems.append(f"{DEPENDABOT_ELIGIBILITY_CHECK}: native job/check result mismatch")
+    app = check_run.get("app")
+    if not _is_actions_app(app):
+        problems.append(f"{DEPENDABOT_ELIGIBILITY_CHECK}: wrong Actions app identity")
+    suite_ref = _json_dict(check_run.get("check_suite"), "classifier check suite reference")
+    if suite_ref.get("id") != suite_id:
+        problems.append(f"{DEPENDABOT_ELIGIBILITY_CHECK}: wrong check suite")
     return problems
 
 
-def _eligibility_sort_key(check_run: dict[str, object]) -> tuple[str, int]:
-    """Return a validated latest-run key for one eligibility check."""
-    check_id = check_run.get("id")
-    if type(check_id) is not int:
-        raise RuntimeError("Dependabot eligibility check id must be an integer")
-    started_at = check_run.get("started_at")
-    if started_at is not None and not isinstance(started_at, str):
-        raise RuntimeError("Dependabot eligibility started_at must be a string or null")
-    return (started_at or "", check_id)
+def _source_suite_problems(
+    suite: dict[str, object],
+    pr: int,
+    head_oid: str,
+    suite_id: int,
+) -> list[str]:
+    """Validate the exact-head native CI check-suite association."""
+    problems: list[str] = []
+    if suite.get("id") != suite_id or suite.get("head_sha") != head_oid:
+        problems.append("Dependabot source: check suite is not on exact head")
+    if not _is_actions_app(suite.get("app")):
+        problems.append("Dependabot source: wrong check-suite app identity")
+    problems.extend(_run_pr_identity_problems(suite, pr, head_oid, "Dependabot source suite"))
+    return problems
+
+
+def _is_actions_app(app: object) -> bool:
+    """Match the canonical GitHub Actions app identity."""
+    return isinstance(app, dict) and (
+        app.get("id") == GITHUB_ACTIONS_APP_ID and app.get("slug") == GITHUB_ACTIONS_APP_SLUG
+    )
+
+
+def _run_repository_problems(run: dict[str, object], context: str) -> list[str]:
+    """Require the source and executing repository identities to agree."""
+    head_repository = _json_dict(run.get("head_repository"), f"{context} head repository")
+    repository = _json_dict(run.get("repository"), f"{context} repository")
+    if head_repository.get("full_name") != repository.get("full_name"):
+        return [f"{context}: repository mismatch"]
+    return []
+
+
+def _run_pr_identity_problems(
+    payload: dict[str, object],
+    pr: int,
+    head_oid: str,
+    context: str,
+) -> list[str]:
+    """Require one exact PR/head/base association on a run or suite."""
+    pulls = _json_dicts(
+        payload.get("pull_requests"),
+        f"{context} pull requests",
+        refuse_full_page=True,
+    )
+    matches = [pull for pull in pulls if _pull_matches(pull, pr, head_oid)]
+    return [] if len(pulls) == 1 and len(matches) == 1 else [f"{context}: PR identity mismatch"]
+
+
+def _pull_matches(pull: dict[str, object], pr: int, head_oid: str) -> bool:
+    """Match one exact PR number, head SHA, and dev base."""
+    head = pull.get("head")
+    base = pull.get("base")
+    return (
+        pull.get("number") == pr
+        and isinstance(head, dict)
+        and head.get("sha") == head_oid
+        and isinstance(base, dict)
+        and base.get("ref") == "dev"
+    )
+
+
+def _bounded_counted_items(
+    payload: dict[str, object],
+    context: str,
+    key: str,
+) -> list[dict[str, object]]:
+    """Validate a bounded GitHub total_count/list response."""
+    total_count = payload.get("total_count")
+    if type(total_count) is not int:
+        raise RuntimeError(f"{context} total_count must be an integer")
+    if total_count >= MAX_GITHUB_ITEMS:
+        raise RuntimeError(f"{context} reached the {MAX_GITHUB_ITEMS}-item safety bound")
+    items = _json_dicts(payload.get(key), context, refuse_full_page=True)
+    if total_count != len(items):
+        raise RuntimeError(f"{context} response is incomplete")
+    return items
+
+
+def _dependabot_update_problems(pr: int, head_oid: str) -> list[str]:
+    """Classify the sole exact-head commit after native actor provenance."""
+    commits = _json_dicts(
+        _gh_json(
+            "api",
+            f"repos/{{owner}}/{{repo}}/pulls/{pr}/commits?per_page={MAX_GITHUB_ITEMS}",
+        ),
+        "Dependabot pull-request commits",
+        refuse_full_page=True,
+    )
+    if len(commits) != 1:
+        return [f"Dependabot mode requires exactly one current commit, found {len(commits)}"]
+    commit = commits[0]
+    if commit.get("sha") != head_oid:
+        return ["Dependabot commit does not match the exact PR head"]
+    details = _json_dict(commit.get("commit"), "Dependabot commit details")
+    message = details.get("message")
+    if not isinstance(message, str):
+        raise RuntimeError("Dependabot commit message must be a string")
+    update_types = re.findall(r"(?m)^\s*update-type:\s*([^\s]+)\s*$", message)
+    if not update_types or len(update_types) >= MAX_GITHUB_ITEMS:
+        return ["Dependabot update metadata is missing or exceeds the safety bound"]
+    allowed = {"version-update:semver-patch", "version-update:semver-minor"}
+    if any(update_type not in allowed for update_type in update_types):
+        return ["Dependabot mode permits only patch or minor updates"]
+    return []
 
 
 def _base_policy_problems(
@@ -432,6 +653,20 @@ def _base_policy_problems(
     return problems
 
 
+def _dependabot_mode_problems(
+    pr: int,
+    head_oid: str,
+    source_run_id: int | None,
+    classifier_run_id: int | None,
+) -> list[str]:
+    """Validate required run identifiers before Dependabot provenance reads."""
+    if source_run_id is None or classifier_run_id is None:
+        return ["--dependabot requires source and classifier workflow run IDs"]
+    _positive_int(source_run_id, "Dependabot source run ID")
+    _positive_int(classifier_run_id, "Dependabot classifier run ID")
+    return _dependabot_pr_problems(pr, head_oid, source_run_id, classifier_run_id)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("pr", type=int)
@@ -440,6 +675,8 @@ def main() -> int:
     parser.add_argument("--expected-head")
     parser.add_argument("--director-main", action="store_true")
     parser.add_argument("--dependabot", action="store_true")
+    parser.add_argument("--dependabot-source-run", type=int)
+    parser.add_argument("--dependabot-classifier-run", type=int)
     args = parser.parse_args()
 
     view = _json_dict(
@@ -485,7 +722,14 @@ def main() -> int:
             f"--delete-branch refused: open PR(s) {children} base on this branch (#193 class)"
         )
     if args.dependabot:
-        problems.extend(_dependabot_pr_problems(args.pr, head_oid))
+        problems.extend(
+            _dependabot_mode_problems(
+                args.pr,
+                head_oid,
+                args.dependabot_source_run,
+                args.dependabot_classifier_run,
+            )
+        )
 
     # Race guard: neither side may move after its verdict snapshot.
     refs_now = _json_dict(

--- a/tools/pr_merge.py
+++ b/tools/pr_merge.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -43,13 +42,9 @@ COPILOT_REST_COMMENT_LOGIN = "Copilot"
 COPILOT_BOT_ID = 175728472
 COPILOT_BOT_NODE_ID = "BOT_kgDOCnlnWA"
 DEPENDABOT_LOGIN = "dependabot[bot]"
-ALLOWED_DEPENDABOT_UPDATE_TYPES = frozenset(
-    {"version-update:semver-patch", "version-update:semver-minor"}
-)
-_DEPENDABOT_UPDATE_TYPE = re.compile(
-    r"^\s*update-type:\s*(version-update:semver-[a-z]+)\s*$",
-    re.MULTILINE,
-)
+DEPENDABOT_ELIGIBILITY_CHECK = "Dependabot Eligibility"
+GITHUB_ACTIONS_APP_ID = 15368
+GITHUB_ACTIONS_APP_SLUG = "github-actions"
 
 _REVIEW_THREADS_QUERY = """
 query($owner: String!, $name: String!, $number: Int!) {
@@ -352,50 +347,68 @@ def _dependabot_pr_problems(pr: int, head_oid: str) -> list[str]:
     rest_base = base.get("ref") if isinstance(base, dict) else None
     if rest_base != "dev":
         problems.append(f"Dependabot mode requires base dev, found {rest_base}")
-    commits = _json_dicts(
-        _gh_json(
-            "api",
-            f"repos/{{owner}}/{{repo}}/pulls/{pr}/commits?per_page={MAX_GITHUB_ITEMS}",
-        ),
-        "Dependabot pull-request commits",
-        refuse_full_page=True,
-    )
-    problems.extend(_dependabot_commit_problems(commits, head_oid))
+    problems.extend(_dependabot_eligibility_problems(head_oid))
     return problems
 
 
-def _dependabot_commit_problems(
-    commits: list[dict[str, object]],
-    head_oid: str,
-) -> list[str]:
-    """Validate one verified Dependabot commit and its signed update metadata."""
-    if len(commits) != 1:
-        return [f"Dependabot exact head requires one commit, found {len(commits)}"]
-    candidate = commits[0]
-    author = candidate.get("author")
-    commit = candidate.get("commit")
-    commit_payload = commit if isinstance(commit, dict) else {}
-    verification = commit_payload.get("verification")
-    verified = verification if isinstance(verification, dict) else {}
-    if (
-        candidate.get("sha") != head_oid
-        or not isinstance(author, dict)
-        or author.get("login") != DEPENDABOT_LOGIN
-        or author.get("type") != "Bot"
-        or verified.get("verified") is not True
-        or verified.get("reason") != "valid"
+def _dependabot_eligibility_problems(head_oid: str) -> list[str]:
+    """Require the latest exact-head eligibility check from GitHub Actions."""
+    payload = _json_dict(
+        _gh_json(
+            "api",
+            f"repos/{{owner}}/{{repo}}/commits/{head_oid}/check-runs"
+            f"?check_name=Dependabot%20Eligibility&filter=all&per_page={MAX_GITHUB_ITEMS}",
+        ),
+        "Dependabot eligibility check runs",
+    )
+    total_count = payload.get("total_count")
+    if type(total_count) is not int:
+        raise RuntimeError("Dependabot eligibility total_count must be an integer")
+    if total_count >= MAX_GITHUB_ITEMS:
+        raise RuntimeError(
+            f"Dependabot eligibility checks reached the {MAX_GITHUB_ITEMS}-item safety bound"
+        )
+    runs = _json_dicts(
+        payload.get("check_runs"),
+        "Dependabot eligibility checks",
+        refuse_full_page=True,
+    )
+    if total_count != len(runs):
+        raise RuntimeError("Dependabot eligibility check response is incomplete")
+    exact_runs = [run for run in runs if run.get("name") == DEPENDABOT_ELIGIBILITY_CHECK]
+    if not exact_runs:
+        return [f"{DEPENDABOT_ELIGIBILITY_CHECK}: missing on exact head {head_oid}"]
+    latest = max(exact_runs, key=_eligibility_sort_key)
+    problems: list[str] = []
+    if latest.get("head_sha") != head_oid:
+        problems.append(f"{DEPENDABOT_ELIGIBILITY_CHECK}: check is not on exact head {head_oid}")
+    app = latest.get("app")
+    if not isinstance(app, dict) or (
+        app.get("id") != GITHUB_ACTIONS_APP_ID or app.get("slug") != GITHUB_ACTIONS_APP_SLUG
     ):
-        return ["Dependabot exact head is not one verified Dependabot commit"]
-    message = commit_payload.get("message")
-    if not isinstance(message, str):
-        return ["verified Dependabot commit has no message metadata"]
-    update_types = _DEPENDABOT_UPDATE_TYPE.findall(message)
-    if not update_types or len(update_types) >= MAX_GITHUB_ITEMS:
-        return ["verified Dependabot commit has no bounded update-type metadata"]
-    disallowed = sorted(set(update_types) - ALLOWED_DEPENDABOT_UPDATE_TYPES)
-    if disallowed:
-        return [f"Dependabot update type(s) are not eligible: {disallowed}"]
-    return []
+        problems.append(f"{DEPENDABOT_ELIGIBILITY_CHECK}: wrong GitHub Actions app identity")
+    status = latest.get("status")
+    conclusion = latest.get("conclusion")
+    if not isinstance(status, str):
+        raise RuntimeError("Dependabot eligibility check status must be a string")
+    if conclusion is not None and not isinstance(conclusion, str):
+        raise RuntimeError("Dependabot eligibility check conclusion must be a string or null")
+    if status != "completed" or conclusion != "success":
+        problems.append(
+            f"{DEPENDABOT_ELIGIBILITY_CHECK}: status={status}, conclusion={conclusion or ''}"
+        )
+    return problems
+
+
+def _eligibility_sort_key(check_run: dict[str, object]) -> tuple[str, int]:
+    """Return a validated latest-run key for one eligibility check."""
+    check_id = check_run.get("id")
+    if type(check_id) is not int:
+        raise RuntimeError("Dependabot eligibility check id must be an integer")
+    started_at = check_run.get("started_at")
+    if started_at is not None and not isinstance(started_at, str):
+        raise RuntimeError("Dependabot eligibility started_at must be a string or null")
+    return (started_at or "", check_id)
 
 
 def _base_policy_problems(

--- a/tools/pr_merge.py
+++ b/tools/pr_merge.py
@@ -1,19 +1,18 @@
 #!/usr/bin/env python3
 """The one sanctioned merge path (ADR181 R10): ``mise run pr:merge -- <pr>``.
 
-Mechanizes the four merge-protocol prose rules (CLAUDE.md "Merge protocol"),
+Mechanizes the merge-protocol prose rules (CLAUDE.md "Merge protocol"),
 each of which has already bitten:
 
 1. Never ``--auto`` (#392: it ignores failing non-required checks) — this
    wrapper simply has no such flag.
-2. All checks green AND ``headRefOid`` unchanged across the verdict snapshot
-   (a push between "checks green" and "merge" invalidates the verdict).
-3. The Copilot harvest: every top-level Copilot inline comment must carry a
-   reply (the fix-or-reply obligation, enforceable half). Plus the CodeQL
-   zero-floor: any open code-scanning alert is a STOP (CodeQL no longer runs
-   on PRs — R5b — so the alert DB, not a PR check, is the source of truth).
-4. ``--delete-branch`` refused while another open PR bases on this head
-   (#193: closes-not-merges the child on stacked PRs).
+2. All checks green AND both PR refs unchanged across the verdict snapshot.
+3. A completed Copilot review must target the verified head; every top-level
+   Copilot inline comment needs a reply; and every review thread must resolve.
+4. Any open code-scanning alert is a STOP (CodeQL no longer runs on PRs — R5b
+   — so the alert DB, not a PR check, is the source of truth).
+5. ``--delete-branch`` is refused for ``dev`` and while another open PR bases
+   on the head (#193: deleting it closes-not-merges the child).
 
 Stdlib + ``gh`` only.
 """
@@ -22,17 +21,53 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
+from pathlib import Path
 
-#: Checks that must be explicit PASSES (a skip is not a verdict for these).
-CRITICAL_CHECKS = (
-    "Rust Gate (fmt, clippy, test, doc — rust/ workspace)",
-    "Baseline Ceremony Gate (§6.5 provenance)",
-    "Postgres Integration Tier (PG 17, pinned runtime)",
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.pr_policy import (  # noqa: E402
+    DEV_CHECK_MANIFEST,
+    CheckRequirement,
+    manifest_for_base,
 )
 
-GREEN = {"SUCCESS", "NEUTRAL", "SKIPPED"}
+MAX_GITHUB_ITEMS = 100
+
+COMPLETED_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED", "COMMENTED"}
+COPILOT_GRAPHQL_LOGIN = "copilot-pull-request-reviewer"
+COPILOT_REST_REVIEW_LOGIN = "copilot-pull-request-reviewer[bot]"
+COPILOT_REST_COMMENT_LOGIN = "Copilot"
+COPILOT_BOT_ID = 175728472
+COPILOT_BOT_NODE_ID = "BOT_kgDOCnlnWA"
+DEPENDABOT_LOGIN = "dependabot[bot]"
+ALLOWED_DEPENDABOT_UPDATE_TYPES = frozenset(
+    {"version-update:semver-patch", "version-update:semver-minor"}
+)
+_DEPENDABOT_UPDATE_TYPE = re.compile(
+    r"^\s*update-type:\s*(version-update:semver-[a-z]+)\s*$",
+    re.MULTILINE,
+)
+
+_REVIEW_THREADS_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          comments(first: 1) {
+            nodes { url }
+          }
+        }
+        pageInfo { hasNextPage }
+      }
+    }
+  }
+}
+"""
 
 
 def _gh(*args: str) -> str:
@@ -42,6 +77,32 @@ def _gh(*args: str) -> str:
 
 def _gh_json(*args: str) -> object:
     return json.loads(_gh(*args))
+
+
+def _json_dict(value: object, context: str) -> dict[str, object]:
+    """Require one JSON object from a GitHub response."""
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{context} must be a JSON object")
+    return value
+
+
+def _json_dicts(
+    value: object,
+    context: str,
+    *,
+    refuse_full_page: bool = False,
+) -> list[dict[str, object]]:
+    """Require one JSON array containing only objects."""
+    if not isinstance(value, list):
+        raise RuntimeError(f"{context} must be a JSON array")
+    if len(value) > MAX_GITHUB_ITEMS or (refuse_full_page and len(value) == MAX_GITHUB_ITEMS):
+        raise RuntimeError(f"{context} reached the {MAX_GITHUB_ITEMS}-item safety bound")
+    items: list[dict[str, object]] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise RuntimeError(f"{context}[{index}] must be a JSON object")
+        items.append(item)
+    return items
 
 
 def _entry_sort_key(entry: dict[str, object]) -> tuple[str, int]:
@@ -64,104 +125,386 @@ def _entry_sort_key(entry: dict[str, object]) -> tuple[str, int]:
     return ("", run_id)
 
 
-def _rollup_failures(rollup: list[dict[str, object]]) -> list[str]:
-    """Names of rollup entries that are not green, plus missing criticals."""
+def _rollup_failures(
+    rollup: list[dict[str, object]],
+    manifest: tuple[CheckRequirement, ...] = DEV_CHECK_MANIFEST,
+) -> list[str]:
+    """Return incomplete or disallowed latest check conclusions."""
+    if len(rollup) >= MAX_GITHUB_ITEMS:
+        raise RuntimeError(f"status-check rollup reached the {MAX_GITHUB_ITEMS}-item safety bound")
+    if len(manifest) >= MAX_GITHUB_ITEMS:
+        raise RuntimeError(f"check manifest reached the {MAX_GITHUB_ITEMS}-item safety bound")
     latest: dict[str, dict[str, object]] = {}
     for entry in rollup:
         name = str(entry.get("name") or entry.get("context") or "?")
         if name not in latest or _entry_sort_key(entry) >= _entry_sort_key(latest[name]):
             latest[name] = entry
+    expected = {requirement.context: requirement for requirement in manifest}
     failures: list[str] = []
-    passed: set[str] = set()
+    reported: set[str] = set()
     for entry in latest.values():
         name = str(entry.get("name") or entry.get("context") or "?")
         status = str(entry.get("status") or "")
         conclusion = str(entry.get("conclusion") or entry.get("state") or "")
+        requirement = expected.get(name)
         if status and status != "COMPLETED":
             failures.append(f"{name}: still {status}")
-        elif conclusion not in GREEN:
+        elif requirement is None and conclusion != "SUCCESS":
             failures.append(f"{name}: {conclusion}")
-        elif conclusion == "SUCCESS":
-            passed.add(name)
+        elif requirement is not None and conclusion not in requirement.allowed_conclusions:
+            failures.append(f"{name}: {conclusion}")
+        if requirement is not None:
+            reported.add(name)
     failures.extend(
-        f"{name}: required an explicit PASS, none found"
-        for name in CRITICAL_CHECKS
-        if name not in passed
+        f"{requirement.context}: missing from complete {requirement.kind} manifest"
+        for requirement in manifest
+        if requirement.context not in reported
     )
     return failures
 
 
 def _unharvested_copilot_comments(pr: int) -> list[str]:
     """Top-level Copilot inline comments with no reply."""
-    comments = _gh_json("api", f"repos/{{owner}}/{{repo}}/pulls/{pr}/comments", "--paginate")
-    assert isinstance(comments, list)
+    comments = _json_dicts(
+        _gh_json(
+            "api",
+            f"repos/{{owner}}/{{repo}}/pulls/{pr}/comments?per_page={MAX_GITHUB_ITEMS}",
+        ),
+        "pull-request comments",
+        refuse_full_page=True,
+    )
     replied_to = {c.get("in_reply_to_id") for c in comments}
     return [
         f"unaddressed Copilot comment {c['html_url']}"
         for c in comments
-        if "copilot" in str(c.get("user", {}).get("login", "")).lower()
+        if _is_rest_copilot_comment(c.get("user"))
         and c.get("in_reply_to_id") is None
         and c["id"] not in replied_to
     ]
 
 
+def _is_graphql_copilot_review(author: object) -> bool:
+    """Match the exact Copilot identity emitted by ``gh pr view``."""
+    if not isinstance(author, dict):
+        return False
+    return author.get("login") == COPILOT_GRAPHQL_LOGIN
+
+
+def _is_canonical_rest_copilot(author: object, expected_login: str) -> bool:
+    """Match a REST Copilot actor by endpoint login and immutable bot identity."""
+    if not isinstance(author, dict):
+        return False
+    return (
+        author.get("login") == expected_login
+        and author.get("id") == COPILOT_BOT_ID
+        and author.get("node_id") == COPILOT_BOT_NODE_ID
+        and author.get("type") == "Bot"
+    )
+
+
+def _is_rest_copilot_review(author: object) -> bool:
+    return _is_canonical_rest_copilot(author, COPILOT_REST_REVIEW_LOGIN)
+
+
+def _is_rest_copilot_comment(author: object) -> bool:
+    return _is_canonical_rest_copilot(author, COPILOT_REST_COMMENT_LOGIN)
+
+
+def _rest_reviews(pr: int) -> list[dict[str, object]]:
+    return _json_dicts(
+        _gh_json(
+            "api",
+            f"repos/{{owner}}/{{repo}}/pulls/{pr}/reviews?per_page={MAX_GITHUB_ITEMS}",
+        ),
+        "REST pull-request reviews",
+        refuse_full_page=True,
+    )
+
+
+def _has_completed_copilot_review(
+    graphql_reviews: object,
+    rest_reviews: list[dict[str, object]],
+    head_oid: str,
+) -> bool:
+    """Whether both GitHub views identify Copilot's completed exact-head review."""
+    graphql_match = False
+    for review in _json_dicts(graphql_reviews, "GraphQL pull-request reviews"):
+        commit = review.get("commit")
+        commit_oid = commit.get("oid") if isinstance(commit, dict) else None
+        if (
+            _is_graphql_copilot_review(review.get("author"))
+            and review.get("submittedAt")
+            and review.get("state") in COMPLETED_REVIEW_STATES
+            and commit_oid == head_oid
+        ):
+            graphql_match = True
+    rest_match = any(
+        _is_rest_copilot_review(review.get("user"))
+        and review.get("submitted_at")
+        and review.get("state") in COMPLETED_REVIEW_STATES
+        and review.get("commit_id") == head_oid
+        for review in rest_reviews
+    )
+    return graphql_match and rest_match
+
+
+def _review_thread_problems(pr: int) -> list[str]:
+    """Query at most 100 threads and report every unresolved one."""
+    response = _json_dict(
+        _gh_json(
+            "api",
+            "graphql",
+            "-F",
+            "owner={owner}",
+            "-F",
+            "name={repo}",
+            "-F",
+            f"number={pr}",
+            "-f",
+            f"query={_REVIEW_THREADS_QUERY}",
+        ),
+        "review-thread response",
+    )
+    data = _json_dict(response.get("data"), "review-thread data")
+    repository = _json_dict(data.get("repository"), "review-thread repository")
+    pull_request = _json_dict(repository.get("pullRequest"), "review-thread pull request")
+    connection = _json_dict(pull_request.get("reviewThreads"), "review-thread connection")
+    page_info = _json_dict(connection.get("pageInfo"), "review-thread page info")
+    has_next_page = page_info.get("hasNextPage")
+    if not isinstance(has_next_page, bool):
+        raise RuntimeError("review-thread hasNextPage must be a boolean")
+    problems = (
+        ["more than 100 review threads — bounded verification refused"] if has_next_page else []
+    )
+    for node in _json_dicts(connection.get("nodes"), "review-thread nodes"):
+        is_resolved = node.get("isResolved")
+        if not isinstance(is_resolved, bool):
+            raise RuntimeError("review-thread isResolved must be a boolean")
+        if not is_resolved:
+            problems.append(f"unresolved review thread {_first_thread_url(node)}")
+    return problems
+
+
+def _first_thread_url(thread: dict[str, object]) -> str:
+    """Return the first comment URL identifying a review thread."""
+    comments = _json_dict(thread.get("comments"), "review-thread comments")
+    nodes = _json_dicts(comments.get("nodes"), "review-thread comment nodes")
+    if not nodes:
+        return "(URL unavailable)"
+    return str(nodes[0].get("url") or "(URL unavailable)")
+
+
 def _open_alert_count() -> int:
-    alerts = _gh_json("api", "repos/{owner}/{repo}/code-scanning/alerts?state=open", "--paginate")
-    assert isinstance(alerts, list)
-    return len(alerts)
+    return len(
+        _json_dicts(
+            _gh_json(
+                "api",
+                "repos/{owner}/{repo}/code-scanning/alerts"
+                f"?state=open&per_page={MAX_GITHUB_ITEMS}",
+            ),
+            "code-scanning alerts",
+        )
+    )
 
 
 def _child_prs(head_ref: str) -> list[int]:
-    prs = _gh_json("pr", "list", "--state", "open", "--base", head_ref, "--json", "number")
-    assert isinstance(prs, list)
-    return [p["number"] for p in prs]
+    prs = _json_dicts(
+        _gh_json(
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--base",
+            head_ref,
+            "--limit",
+            str(MAX_GITHUB_ITEMS),
+            "--json",
+            "number",
+        ),
+        "child pull requests",
+    )
+    numbers: list[int] = []
+    for pr in prs:
+        number = pr.get("number")
+        if not isinstance(number, int):
+            raise RuntimeError("child pull-request number must be an integer")
+        numbers.append(number)
+    return numbers
+
+
+def _dependabot_pr_problems(pr: int, head_oid: str) -> list[str]:
+    """Revalidate exact-head Dependabot authority from trusted GitHub records."""
+    payload = _json_dict(
+        _gh_json("api", f"repos/{{owner}}/{{repo}}/pulls/{pr}"),
+        "Dependabot pull request",
+    )
+    problems: list[str] = []
+    user = payload.get("user")
+    if not isinstance(user, dict) or (
+        user.get("login") != DEPENDABOT_LOGIN or user.get("type") != "Bot"
+    ):
+        problems.append("Dependabot mode requires the exact Dependabot bot author")
+    head = payload.get("head")
+    rest_head = head.get("sha") if isinstance(head, dict) else None
+    if rest_head != head_oid:
+        problems.append(f"Dependabot head moved: expected {head_oid}, found {rest_head}")
+    base = payload.get("base")
+    rest_base = base.get("ref") if isinstance(base, dict) else None
+    if rest_base != "dev":
+        problems.append(f"Dependabot mode requires base dev, found {rest_base}")
+    commits = _json_dicts(
+        _gh_json(
+            "api",
+            f"repos/{{owner}}/{{repo}}/pulls/{pr}/commits?per_page={MAX_GITHUB_ITEMS}",
+        ),
+        "Dependabot pull-request commits",
+        refuse_full_page=True,
+    )
+    problems.extend(_dependabot_commit_problems(commits, head_oid))
+    return problems
+
+
+def _dependabot_commit_problems(
+    commits: list[dict[str, object]],
+    head_oid: str,
+) -> list[str]:
+    """Validate one verified Dependabot commit and its signed update metadata."""
+    if len(commits) != 1:
+        return [f"Dependabot exact head requires one commit, found {len(commits)}"]
+    candidate = commits[0]
+    author = candidate.get("author")
+    commit = candidate.get("commit")
+    commit_payload = commit if isinstance(commit, dict) else {}
+    verification = commit_payload.get("verification")
+    verified = verification if isinstance(verification, dict) else {}
+    if (
+        candidate.get("sha") != head_oid
+        or not isinstance(author, dict)
+        or author.get("login") != DEPENDABOT_LOGIN
+        or author.get("type") != "Bot"
+        or verified.get("verified") is not True
+        or verified.get("reason") != "valid"
+    ):
+        return ["Dependabot exact head is not one verified Dependabot commit"]
+    message = commit_payload.get("message")
+    if not isinstance(message, str):
+        return ["verified Dependabot commit has no message metadata"]
+    update_types = _DEPENDABOT_UPDATE_TYPE.findall(message)
+    if not update_types or len(update_types) >= MAX_GITHUB_ITEMS:
+        return ["verified Dependabot commit has no bounded update-type metadata"]
+    disallowed = sorted(set(update_types) - ALLOWED_DEPENDABOT_UPDATE_TYPES)
+    if disallowed:
+        return [f"Dependabot update type(s) are not eligible: {disallowed}"]
+    return []
+
+
+def _base_policy_problems(
+    base_ref: str,
+    head_ref: str,
+    *,
+    director_main: bool,
+    delete_branch: bool,
+) -> list[str]:
+    """Enforce the ordinary dev lane and Director-only main lane."""
+    problems: list[str] = []
+    if director_main:
+        if base_ref != "main":
+            problems.append(f"--director-main requires base main, found {base_ref}")
+        elif head_ref != "dev" and not head_ref.startswith("fix/"):
+            problems.append(f"main requires head dev or fix/*, found {head_ref}")
+    elif base_ref != "dev":
+        problems.append(f"base branch {base_ref} is not dev")
+    if delete_branch and head_ref == "dev":
+        problems.append("--delete-branch refused for protected branch dev")
+    return problems
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("pr", type=int)
     parser.add_argument("--delete-branch", action="store_true")
+    parser.add_argument("--verify-only", action="store_true")
+    parser.add_argument("--expected-head")
+    parser.add_argument("--director-main", action="store_true")
+    parser.add_argument("--dependabot", action="store_true")
     args = parser.parse_args()
 
-    view = _gh_json(
-        "pr",
-        "view",
-        str(args.pr),
-        "--json",
-        "state,isDraft,headRefOid,headRefName,statusCheckRollup",
+    view = _json_dict(
+        _gh_json(
+            "pr",
+            "view",
+            str(args.pr),
+            "--json",
+            "state,isDraft,headRefOid,headRefName,baseRefOid,baseRefName,statusCheckRollup,reviews",
+        ),
+        "pull-request snapshot",
     )
-    assert isinstance(view, dict)
+    head_oid = str(view.get("headRefOid") or "")
+    head_ref = str(view.get("headRefName") or "")
+    base_oid = str(view.get("baseRefOid") or "")
+    base_ref = str(view.get("baseRefName") or "")
     problems: list[str] = []
-    if view["state"] != "OPEN" or view["isDraft"]:
-        problems.append(f"PR #{args.pr} is {view['state']}, draft={view['isDraft']}")
+    if view.get("state") != "OPEN" or view.get("isDraft"):
+        problems.append(f"PR #{args.pr} is {view.get('state')}, draft={view.get('isDraft')}")
+    problems.extend(
+        _base_policy_problems(
+            base_ref,
+            head_ref,
+            director_main=args.director_main,
+            delete_branch=args.delete_branch,
+        )
+    )
+    if args.expected_head is not None and args.expected_head != head_oid:
+        problems.append(f"expected head {args.expected_head}, found {head_oid}")
     rollup = view.get("statusCheckRollup") or []
     if not rollup:
         problems.append("no checks reported on the head commit")
-    problems.extend(_rollup_failures(rollup))
+    manifest = manifest_for_base(base_ref) if base_ref in {"dev", "main"} else ()
+    problems.extend(_rollup_failures(_json_dicts(rollup, "status-check rollup"), manifest))
+    if not _has_completed_copilot_review(view.get("reviews"), _rest_reviews(args.pr), head_oid):
+        problems.append("no completed Copilot review on verified head")
     problems.extend(_unharvested_copilot_comments(args.pr))
+    problems.extend(_review_thread_problems(args.pr))
     if (alerts := _open_alert_count()) > 0:
         problems.append(f"{alerts} open code-scanning alert(s) — the zero floor is a STOP")
-    if args.delete_branch and (children := _child_prs(view["headRefName"])):
+    if args.delete_branch and (children := _child_prs(head_ref)):
         problems.append(
             f"--delete-branch refused: open PR(s) {children} base on this branch (#193 class)"
         )
+    if args.dependabot:
+        problems.extend(_dependabot_pr_problems(args.pr, head_oid))
 
-    # Race guard: the head must not have moved since the verdict snapshot.
-    head_now = _gh_json("pr", "view", str(args.pr), "--json", "headRefOid")
-    assert isinstance(head_now, dict)
-    if head_now["headRefOid"] != view["headRefOid"]:
+    # Race guard: neither side may move after its verdict snapshot.
+    refs_now = _json_dict(
+        _gh_json("pr", "view", str(args.pr), "--json", "headRefOid,baseRefOid"),
+        "pull-request ref re-read",
+    )
+    if refs_now.get("headRefOid") != head_oid:
         problems.append("head moved while verifying — re-run against the new head")
+    if refs_now.get("baseRefOid") != base_oid:
+        problems.append("base moved while verifying — re-run against the new base")
 
     if problems:
         for problem in problems:
             print(f"pr:merge REFUSED — {problem}", file=sys.stderr)
         return 1
 
-    merge_args = ["pr", "merge", str(args.pr), "--merge"]
+    if args.verify_only:
+        print(f"pr:merge: PR #{args.pr} verified at {head_oid}")
+        return 0
+
+    merge_args = [
+        "pr",
+        "merge",
+        str(args.pr),
+        "--merge",
+        "--match-head-commit",
+        head_oid,
+    ]
     if args.delete_branch:
         merge_args.append("--delete-branch")
     print(_gh(*merge_args), end="")
-    print(f"pr:merge: PR #{args.pr} merged at {view['headRefOid']}")
+    print(f"pr:merge: PR #{args.pr} merged at {head_oid}")
     return 0
 
 

--- a/tools/pr_merge.py
+++ b/tools/pr_merge.py
@@ -25,6 +25,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import Final
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -35,6 +36,9 @@ from tools.pr_policy import (  # noqa: E402
 )
 
 MAX_GITHUB_ITEMS = 100
+GH_TIMEOUT_SECONDS: Final[int] = 30
+GH_ERROR_DETAIL_LIMIT: Final[int] = 400
+INDETERMINATE_EXIT_CODE: Final[int] = 2
 
 COMPLETED_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED", "COMMENTED"}
 COPILOT_GRAPHQL_LOGIN = "copilot-pull-request-reviewer"
@@ -71,13 +75,66 @@ query($owner: String!, $name: String!, $number: Int!) {
 """
 
 
+class GitHubReadError(RuntimeError):
+    """A bounded GitHub CLI read failed before producing trusted evidence."""
+
+
+class MergeIndeterminateError(RuntimeError):
+    """A mutating merge call could not be reconciled to one exact outcome."""
+
+
+def _bounded_error_detail(value: object) -> str:
+    """Return one sanitized, statically bounded child-process detail."""
+    if not isinstance(value, str):
+        return ""
+    truncated = len(value) > GH_ERROR_DETAIL_LIMIT
+    bounded = value[:GH_ERROR_DETAIL_LIMIT]
+    printable = re.sub(r"[\x00-\x1f\x7f-\x9f]", " ", bounded)
+    detail = " ".join(printable.split())
+    return detail + ("…" if truncated else "")
+
+
+def _gh_failure_message(
+    error: subprocess.TimeoutExpired | subprocess.CalledProcessError | OSError,
+) -> str:
+    """Normalize one bounded GitHub CLI failure without exposing raw output."""
+    if isinstance(error, subprocess.TimeoutExpired):
+        return f"gh timed out after {GH_TIMEOUT_SECONDS} seconds"
+    if isinstance(error, subprocess.CalledProcessError):
+        detail = (
+            _bounded_error_detail(error.stderr)
+            or _bounded_error_detail(error.stdout)
+            or f"exit {error.returncode}"
+        )
+        return f"gh failed: {detail}"
+    detail = _bounded_error_detail(str(error)) or type(error).__name__
+    return f"gh could not start: {detail}"
+
+
+def _run_gh(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run one GitHub CLI command with the shared fixed timeout."""
+    return subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=GH_TIMEOUT_SECONDS,
+    )
+
+
 def _gh(*args: str) -> str:
-    """Run gh and return stdout; a nonzero exit aborts loudly."""
-    return subprocess.run(["gh", *args], capture_output=True, text=True, check=True).stdout
+    """Run one bounded read and normalize command failures."""
+    try:
+        return _run_gh(*args).stdout
+    except (subprocess.TimeoutExpired, subprocess.CalledProcessError, OSError) as error:
+        raise GitHubReadError(_gh_failure_message(error)) from error
 
 
 def _gh_json(*args: str) -> object:
-    return json.loads(_gh(*args))
+    try:
+        return json.loads(_gh(*args))
+    except json.JSONDecodeError as error:
+        raise GitHubReadError("gh returned invalid JSON") from error
 
 
 def _json_dict(value: object, context: str) -> dict[str, object]:
@@ -668,7 +725,59 @@ def _dependabot_mode_problems(
     return _dependabot_pr_problems(pr, head_oid, source_run_id, classifier_run_id)
 
 
-def main() -> int:
+def _merge_pr(pr: int, head_oid: str, *, delete_branch: bool) -> str:
+    """Merge once, then reconcile a failed command without retrying it."""
+    merge_args = [
+        "pr",
+        "merge",
+        str(pr),
+        "--merge",
+        "--match-head-commit",
+        head_oid,
+    ]
+    if delete_branch:
+        merge_args.append("--delete-branch")
+    try:
+        return _run_gh(*merge_args).stdout
+    except (subprocess.TimeoutExpired, subprocess.CalledProcessError, OSError) as command_error:
+        command_failure = _gh_failure_message(command_error)
+    try:
+        reconciliation = _json_dict(
+            _gh_json(
+                "pr",
+                "view",
+                str(pr),
+                "--json",
+                "state,headRefOid,mergeCommit",
+            ),
+            "merge reconciliation",
+        )
+    except RuntimeError as reconciliation_error:
+        raise MergeIndeterminateError(
+            f"{command_failure}; reconciliation failed: {reconciliation_error}"
+        ) from None
+    merge_commit = reconciliation.get("mergeCommit")
+    merge_oid = merge_commit.get("oid") if isinstance(merge_commit, dict) else None
+    confirmed = (
+        reconciliation.get("state") == "MERGED"
+        and reconciliation.get("headRefOid") == head_oid
+        and isinstance(merge_oid, str)
+        and bool(merge_oid)
+    )
+    if not confirmed:
+        raise MergeIndeterminateError(
+            f"{command_failure}; reconciliation did not confirm the exact-head merge"
+        ) from None
+    if delete_branch:
+        print(
+            "pr:merge WARNING — merge confirmed after command failure; "
+            "branch deletion may be incomplete",
+            file=sys.stderr,
+        )
+    return ""
+
+
+def _main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("pr", type=int)
     parser.add_argument("--delete-branch", action="store_true")
@@ -751,19 +860,21 @@ def main() -> int:
         print(f"pr:merge: PR #{args.pr} verified at {head_oid}")
         return 0
 
-    merge_args = [
-        "pr",
-        "merge",
-        str(args.pr),
-        "--merge",
-        "--match-head-commit",
-        head_oid,
-    ]
-    if args.delete_branch:
-        merge_args.append("--delete-branch")
-    print(_gh(*merge_args), end="")
+    print(_merge_pr(args.pr, head_oid, delete_branch=args.delete_branch), end="")
     print(f"pr:merge: PR #{args.pr} merged at {head_oid}")
     return 0
+
+
+def main() -> int:
+    """Map typed read and mutation outcomes onto the stable CLI surface."""
+    try:
+        return _main()
+    except MergeIndeterminateError as error:
+        print(f"pr:merge INDETERMINATE — {error}", file=sys.stderr)
+        return INDETERMINATE_EXIT_CODE
+    except RuntimeError as error:
+        print(f"pr:merge REFUSED — {error}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/tools/pr_policy.py
+++ b/tools/pr_policy.py
@@ -17,6 +17,9 @@ class CheckRequirement:
     allowed_conclusions: frozenset[str]
 
 
+BASELINE_CEREMONY_CONTEXT: Final[str] = "Baseline Ceremony Gate (§6.5 provenance)"
+
+
 DEV_CHECK_MANIFEST: Final[tuple[CheckRequirement, ...]] = (
     CheckRequirement(
         "Fast Gate (hygiene, lint, format, imports, types, lock)",
@@ -45,9 +48,7 @@ DEV_CHECK_MANIFEST: Final[tuple[CheckRequirement, ...]] = (
         "blocking",
         frozenset({"SUCCESS"}),
     ),
-    CheckRequirement(
-        "Baseline Ceremony Gate (§6.5 provenance)", "blocking", frozenset({"SUCCESS"})
-    ),
+    CheckRequirement(BASELINE_CEREMONY_CONTEXT, "blocking", frozenset({"SUCCESS"})),
     CheckRequirement(
         "Postgres Integration Tier (PG 17, pinned runtime)",
         "blocking",

--- a/tools/pr_policy.py
+++ b/tools/pr_policy.py
@@ -1,0 +1,125 @@
+"""Typed, checked-in check manifests for Babylon pull-request policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal
+
+CheckKind = Literal["blocking", "advisory"]
+
+
+@dataclass(frozen=True, slots=True)
+class CheckRequirement:
+    """One expected check and its exact accepted conclusions."""
+
+    context: str
+    kind: CheckKind
+    allowed_conclusions: frozenset[str]
+
+
+DEV_CHECK_MANIFEST: Final[tuple[CheckRequirement, ...]] = (
+    CheckRequirement(
+        "Fast Gate (hygiene, lint, format, imports, types, lock)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+    CheckRequirement("Unit Tests (xdist, coverage gate)", "blocking", frozenset({"SUCCESS"})),
+    CheckRequirement(
+        "Determinism Gate (byte-identical dense goldens)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+    CheckRequirement("Secret Scan (gitleaks, full history)", "blocking", frozenset({"SUCCESS"})),
+    CheckRequirement(
+        "IaC Config Scan (trivy, HIGH+CRITICAL blocking)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+    CheckRequirement(
+        "Security Audit (pip-audit policy — blocking since item-41)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+    CheckRequirement(
+        "Rust Gate (fmt, clippy, test, doc — rust/ workspace)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+    CheckRequirement(
+        "Baseline Ceremony Gate (§6.5 provenance)", "blocking", frozenset({"SUCCESS"})
+    ),
+    CheckRequirement(
+        "Postgres Integration Tier (PG 17, pinned runtime)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+)
+
+MAIN_CHECK_MANIFEST: Final[tuple[CheckRequirement, ...]] = (
+    CheckRequirement(
+        "Fast Gate (hygiene, lint, format, imports, types, lock)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+    CheckRequirement("Unit Tests (xdist, coverage gate)", "blocking", frozenset({"SUCCESS"})),
+    CheckRequirement(
+        "Determinism Gate (byte-identical dense goldens)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+    CheckRequirement(
+        "Security Audit (pip-audit policy — blocking since item-41)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+    CheckRequirement(
+        "Non-Unit Tests (integration, scenarios, property, contract)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+    CheckRequirement("Postgres Integration (web bridge)", "blocking", frozenset({"SUCCESS"})),
+    CheckRequirement(
+        "Determinism Bundle (Postgres-backed, strict)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+    CheckRequirement(
+        "Reference-Data Tests (ci-data-v1 subset)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+    CheckRequirement(
+        "Documentation Build (doctest blocks; manual advisory)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+    CheckRequirement("Secret Scan (gitleaks, full history)", "blocking", frozenset({"SUCCESS"})),
+    CheckRequirement(
+        "IaC Config Scan (trivy, HIGH+CRITICAL blocking)",
+        "blocking",
+        frozenset({"SUCCESS"}),
+    ),
+    CheckRequirement(
+        "AI Tests (advisory — non-deterministic)",
+        "advisory",
+        frozenset({"SUCCESS", "NEUTRAL", "SKIPPED"}),
+    ),
+    CheckRequirement(
+        "Image Scan (trivy — advisory until postgis bump)",
+        "advisory",
+        frozenset({"SUCCESS", "NEUTRAL", "SKIPPED"}),
+    ),
+)
+
+DEV_BLOCKING_CONTEXTS: Final[tuple[str, ...]] = tuple(
+    requirement.context for requirement in DEV_CHECK_MANIFEST if requirement.kind == "blocking"
+)
+
+
+def manifest_for_base(base_ref: str) -> tuple[CheckRequirement, ...]:
+    """Return the exact expected manifest for one sanctioned base."""
+    if base_ref == "dev":
+        return DEV_CHECK_MANIFEST
+    if base_ref == "main":
+        return MAIN_CHECK_MANIFEST
+    raise ValueError(f"no check manifest for base {base_ref!r}")

--- a/tools/sync_github_pr_policy.py
+++ b/tools/sync_github_pr_policy.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""Check, apply, or roll back Babylon's GitHub pull-request policy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Protocol, cast
+from urllib.parse import quote
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.pr_policy import DEV_BLOCKING_CONTEXTS  # noqa: E402
+
+REPOSITORY = "percy-raskova/babylon"
+REPOSITORY_ENDPOINT = f"repos/{REPOSITORY}"
+RULESETS_ENDPOINT = f"{REPOSITORY_ENDPOINT}/rulesets?includes_parents=false&per_page=100"
+DEV_RULESET_ENDPOINT = f"{REPOSITORY_ENDPOINT}/rulesets/{{ruleset_id}}"
+DEV_REF_ENDPOINT = f"{REPOSITORY_ENDPOINT}/git/ref/heads/dev"
+LABELS_ENDPOINT = f"{REPOSITORY_ENDPOINT}/labels"
+LABELS_LIST_ENDPOINT = f"{LABELS_ENDPOINT}?per_page=100"
+CHECK_RUNS_ENDPOINT = f"{REPOSITORY_ENDPOINT}/commits/{{sha}}/check-runs?per_page=100"
+DEFAULT_POLICY_PATH = Path(".github/settings/pr-policy.json")
+
+MAX_RULESETS = 100
+MAX_LABELS = 100
+MAX_CHECK_RUNS = 100
+API_TIMEOUT_SECONDS = 30
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+CANONICAL_AUTOMERGE_LABEL = "dependencies:automerge"
+_UNKNOWN = object()
+
+RULESET_WRITABLE_FIELDS = (
+    "name",
+    "target",
+    "enforcement",
+    "bypass_actors",
+    "conditions",
+    "rules",
+)
+REPOSITORY_POLICY_FIELDS = (
+    "allow_merge_commit",
+    "allow_squash_merge",
+    "allow_rebase_merge",
+    "allow_auto_merge",
+    "delete_branch_on_merge",
+)
+LABEL_FIELDS = ("name", "color", "description")
+
+
+class PolicyError(RuntimeError):
+    """The requested policy transition is unsafe or unverifiable."""
+
+
+class GitHubApiError(RuntimeError):
+    """A GitHub CLI request failed or returned malformed JSON."""
+
+
+class Api(Protocol):
+    """Minimal GitHub API surface used by the transaction."""
+
+    def get_json(self, endpoint: str) -> object: ...
+
+    def send_json(self, method: str, endpoint: str, payload: dict[str, object]) -> object: ...
+
+
+class GhApi:
+    """GitHub API adapter implemented through the authenticated ``gh`` CLI."""
+
+    @staticmethod
+    def _run(args: list[str], input_text: str | None = None) -> str:
+        try:
+            result = subprocess.run(
+                ["gh", "api", *args],
+                input=input_text,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=API_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise GitHubApiError(f"gh api timed out after {API_TIMEOUT_SECONDS} seconds") from error
+        except subprocess.CalledProcessError as error:
+            detail = error.stderr.strip() or error.stdout.strip() or f"exit {error.returncode}"
+            raise GitHubApiError(f"gh api failed: {detail}") from error
+        except OSError as error:
+            raise GitHubApiError(f"gh api could not start: {error}") from error
+        return result.stdout
+
+    def get_json(self, endpoint: str) -> object:
+        output = self._run([endpoint])
+        try:
+            return json.loads(output)
+        except json.JSONDecodeError as error:
+            raise GitHubApiError(f"gh api returned invalid JSON for {endpoint}") from error
+
+    def send_json(self, method: str, endpoint: str, payload: dict[str, object]) -> object:
+        args = ["--method", method, endpoint]
+        input_text: str | None = None
+        if method != "DELETE":
+            args.extend(["--input", "-"])
+            input_text = json.dumps(payload, sort_keys=True)
+        output = self._run(args, input_text)
+        if not output.strip():
+            return {}
+        try:
+            return json.loads(output)
+        except json.JSONDecodeError as error:
+            raise GitHubApiError(f"gh api returned invalid JSON for {method} {endpoint}") from error
+
+
+def _object(value: object, description: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise PolicyError(f"{description} must be a JSON object")
+    return cast(dict[str, object], value)
+
+
+def _objects(value: object, description: str, maximum: int) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        raise PolicyError(f"{description} must be a JSON array")
+    if len(value) >= maximum:
+        raise PolicyError(f"{description} reached the {maximum}-item safety bound")
+    if not all(isinstance(item, dict) for item in value):
+        raise PolicyError(f"{description} contains a non-object item")
+    return cast(list[dict[str, object]], value)
+
+
+def _select_fields(payload: dict[str, object], fields: tuple[str, ...]) -> dict[str, object]:
+    missing = [field for field in fields if field not in payload]
+    if missing:
+        raise PolicyError(f"GitHub payload is missing required field(s): {missing}")
+    return {field: deepcopy(payload[field]) for field in fields}
+
+
+def normalize_ruleset(payload: dict[str, object]) -> dict[str, object]:
+    """Return only fields accepted by GitHub's ruleset update endpoint."""
+    return _select_fields(payload, RULESET_WRITABLE_FIELDS)
+
+
+def normalize_repository(payload: dict[str, object]) -> dict[str, object]:
+    """Return only repository merge-policy fields owned by PER-264."""
+    return _select_fields(payload, REPOSITORY_POLICY_FIELDS)
+
+
+def normalize_label(payload: dict[str, object]) -> dict[str, object]:
+    """Return the stable label fields owned by PER-264."""
+    return _select_fields(payload, LABEL_FIELDS)
+
+
+def _canonical_label(payload: dict[str, object], description: str) -> dict[str, object]:
+    label = normalize_label(payload)
+    if label["name"] != CANONICAL_AUTOMERGE_LABEL:
+        raise PolicyError(f"{description} must use the canonical automerge label")
+    return label
+
+
+def label_endpoint(name: str) -> str:
+    """Return the endpoint for one exact label name."""
+    return f"{REPOSITORY_ENDPOINT}/labels/{quote(name, safe='')}"
+
+
+def load_policy(path: Path = DEFAULT_POLICY_PATH) -> dict[str, object]:
+    """Load and minimally validate the checked-in desired policy."""
+    try:
+        raw = json.loads(path.read_text())
+    except OSError as error:
+        raise PolicyError(f"cannot read policy {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise PolicyError(f"policy {path} is not valid JSON") from error
+    policy = _object(raw, "policy")
+    _object(policy.get("repository"), "policy.repository")
+    _object(policy.get("dev_ruleset"), "policy.dev_ruleset")
+    _object(policy.get("automerge_label"), "policy.automerge_label")
+    _validate_policy(policy)
+    return policy
+
+
+def _exact_dev_scope(payload: dict[str, object]) -> bool:
+    if payload.get("target") != "branch":
+        return False
+    conditions = _object(payload.get("conditions"), "dev ruleset conditions")
+    ref_name = _object(conditions.get("ref_name"), "dev ruleset ref condition")
+    return ref_name.get("include") == ["refs/heads/dev"] and ref_name.get("exclude") == []
+
+
+def _dev_ruleset(api: Api) -> tuple[int, dict[str, object]]:
+    summaries = _objects(api.get_json(RULESETS_ENDPOINT), "repository rulesets", MAX_RULESETS)
+    matches: list[tuple[int, dict[str, object]]] = []
+    for summary in summaries:
+        ruleset_id = summary.get("id")
+        if not isinstance(ruleset_id, int):
+            raise PolicyError("ruleset summary has no integer id")
+        payload = _object(
+            api.get_json(DEV_RULESET_ENDPOINT.format(ruleset_id=ruleset_id)),
+            f"ruleset {ruleset_id}",
+        )
+        conditions = _object(payload.get("conditions"), f"ruleset {ruleset_id} conditions")
+        ref_name = _object(conditions.get("ref_name"), f"ruleset {ruleset_id} ref condition")
+        includes = ref_name.get("include")
+        if isinstance(includes, list) and "refs/heads/dev" in includes:
+            if not _exact_dev_scope(payload):
+                raise PolicyError(f"ruleset {ruleset_id} does not have exact dev-only branch scope")
+            matches.append((ruleset_id, payload))
+    if len(matches) != 1:
+        raise PolicyError(f"expected exactly one dev ruleset, found {len(matches)}")
+    return matches[0]
+
+
+def _labels(api: Api) -> list[dict[str, object]]:
+    return _objects(api.get_json(LABELS_LIST_ENDPOINT), "repository labels", MAX_LABELS)
+
+
+def _find_label(labels: list[dict[str, object]], name: str) -> dict[str, object] | None:
+    matches = [label for label in labels if label.get("name") == name]
+    if len(matches) > 1:
+        raise PolicyError(f"label {name!r} appears more than once")
+    return matches[0] if matches else None
+
+
+def _current_state(api: Api) -> dict[str, object]:
+    ruleset_id, ruleset = _dev_ruleset(api)
+    repository = _object(api.get_json(REPOSITORY_ENDPOINT), "repository")
+    labels = _labels(api)
+    return {
+        "dev_ruleset_id": ruleset_id,
+        "dev_ruleset": normalize_ruleset(ruleset),
+        "repository": normalize_repository(repository),
+        "automerge_label": _find_label(labels, CANONICAL_AUTOMERGE_LABEL),
+    }
+
+
+def _state_identity(state: dict[str, object]) -> dict[str, object]:
+    ruleset_id = state.get("dev_ruleset_id")
+    if not isinstance(ruleset_id, int):
+        raise PolicyError("state has no integer dev_ruleset_id")
+    ruleset = normalize_ruleset(_object(state.get("dev_ruleset"), "state dev ruleset"))
+    if not _exact_dev_scope(ruleset):
+        raise PolicyError("state ruleset does not have exact dev-only branch scope")
+    label = state.get("automerge_label")
+    normalized_label = (
+        None
+        if label is None
+        else _canonical_label(_object(label, "state automerge label"), "state label")
+    )
+    return {
+        "dev_ruleset_id": ruleset_id,
+        "dev_ruleset": ruleset,
+        "repository": normalize_repository(_object(state.get("repository"), "state repository")),
+        "automerge_label": normalized_label,
+    }
+
+
+def check_policy(api: Api, policy: dict[str, object]) -> list[str]:
+    """Return structural drift without mutating GitHub."""
+    _validate_policy(policy)
+    current = _current_state(api)
+    desired_repository = normalize_repository(_object(policy["repository"], "repository policy"))
+    desired_ruleset = normalize_ruleset(_object(policy["dev_ruleset"], "dev ruleset policy"))
+    desired_label = _canonical_label(_object(policy["automerge_label"], "label policy"), "policy")
+    drift: list[str] = []
+    if current["repository"] != desired_repository:
+        drift.append("repository merge settings differ")
+    if current["dev_ruleset"] != desired_ruleset:
+        drift.append("dev ruleset differs")
+    existing_label = current["automerge_label"]
+    if existing_label is None:
+        drift.append("automerge label is absent")
+    elif (
+        _canonical_label(_object(existing_label, "current automerge label"), "current label")
+        != desired_label
+    ):
+        drift.append("automerge label differs")
+    return drift
+
+
+def _dev_sha(api: Api) -> str:
+    ref = _object(api.get_json(DEV_REF_ENDPOINT), "dev ref")
+    target = _object(ref.get("object"), "dev ref object")
+    sha = target.get("sha")
+    if not isinstance(sha, str) or SHA_PATTERN.fullmatch(sha) is None:
+        raise PolicyError("dev ref has no canonical 40-hex SHA")
+    return sha
+
+
+def _required_contexts(policy: dict[str, object]) -> list[str]:
+    ruleset = _object(policy["dev_ruleset"], "dev ruleset policy")
+    rules = _objects(ruleset.get("rules"), "dev rules", MAX_RULESETS)
+    status_rules = [rule for rule in rules if rule.get("type") == "required_status_checks"]
+    if len(status_rules) != 1:
+        raise PolicyError("dev policy must contain exactly one required-status-checks rule")
+    parameters = _object(status_rules[0].get("parameters"), "status-check parameters")
+    checks = _objects(parameters.get("required_status_checks"), "required checks", MAX_CHECK_RUNS)
+    if not checks:
+        raise PolicyError("dev policy must contain at least one required status check")
+    contexts = [check.get("context") for check in checks]
+    if not all(isinstance(context, str) and context for context in contexts):
+        raise PolicyError("required status check has no context")
+    if len(set(contexts)) != len(contexts):
+        raise PolicyError("required status check contexts must be unique")
+    return cast(list[str], contexts)
+
+
+def _validate_policy(policy: dict[str, object]) -> None:
+    ruleset = normalize_ruleset(_object(policy.get("dev_ruleset"), "dev ruleset policy"))
+    if not _exact_dev_scope(ruleset):
+        raise PolicyError("desired ruleset must have exact dev-only branch scope")
+    contexts = tuple(_required_contexts(policy))
+    if contexts != DEV_BLOCKING_CONTEXTS:
+        raise PolicyError("required checks must equal the complete dev check manifest")
+    normalize_repository(_object(policy.get("repository"), "repository policy"))
+    _canonical_label(_object(policy.get("automerge_label"), "label policy"), "policy")
+
+
+def _verify_green_dev(api: Api, policy: dict[str, object], expected_sha: str) -> None:
+    actual_sha = _dev_sha(api)
+    if actual_sha != expected_sha:
+        raise PolicyError(f"dev moved: expected {expected_sha}, found {actual_sha}")
+    payload = _object(
+        api.get_json(CHECK_RUNS_ENDPOINT.format(sha=expected_sha)),
+        "dev check runs",
+    )
+    total_count = payload.get("total_count")
+    if type(total_count) is not int or total_count >= MAX_CHECK_RUNS:
+        raise PolicyError(f"dev check runs reached the {MAX_CHECK_RUNS}-item safety bound")
+    runs = _objects(payload.get("check_runs"), "dev check runs", MAX_CHECK_RUNS)
+    latest: dict[str, dict[str, object]] = {}
+    for candidate in runs:
+        name = candidate.get("name")
+        if not isinstance(name, str):
+            raise PolicyError("check run has no name")
+        run_id = candidate.get("id")
+        if type(run_id) is not int:
+            raise PolicyError(f"check run {name!r} has no integer id")
+        started_at = candidate.get("started_at")
+        if started_at is not None and not isinstance(started_at, str):
+            raise PolicyError(f"check run {name!r} has a non-string started_at")
+        prior = latest.get(name)
+        current_key = (started_at or "", run_id)
+        prior_id = prior.get("id") if prior is not None else 0
+        if type(prior_id) is not int:
+            raise PolicyError(f"prior check run {name!r} has no integer id")
+        prior_key = (
+            str(prior.get("started_at") or "") if prior is not None else "",
+            prior_id,
+        )
+        if prior is None or current_key >= prior_key:
+            latest[name] = candidate
+    problems: list[str] = []
+    for context in _required_contexts(policy):
+        selected = latest.get(context)
+        if selected is None:
+            problems.append(f"{context}: missing")
+            continue
+        status = str(selected.get("status") or "")
+        conclusion = str(selected.get("conclusion") or "")
+        if status != "completed" or conclusion != "success":
+            problems.append(f"{context}: status={status}, conclusion={conclusion}")
+    if problems:
+        raise PolicyError("exact dev checks are not green: " + "; ".join(problems))
+
+
+def _write_snapshot(path: Path, state: dict[str, object], dev_sha: str) -> None:
+    snapshot = {"dev_sha": dev_sha, **deepcopy(state)}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("x", encoding="utf-8") as snapshot_file:
+            snapshot_file.write(json.dumps(snapshot, indent=2, sort_keys=True) + "\n")
+            snapshot_file.flush()
+            os.fsync(snapshot_file.fileno())
+    except FileExistsError as error:
+        raise PolicyError(f"snapshot path already exists: {path}") from error
+
+
+def _label_update_payload(label: dict[str, object]) -> dict[str, object]:
+    return {
+        "new_name": label["name"],
+        "color": label["color"],
+        "description": label["description"],
+    }
+
+
+def _restore_label(api: Api, prior: object, current: object = _UNKNOWN) -> None:
+    if prior is None:
+        name = (
+            str(
+                _canonical_label(_object(current, "current automerge label"), "current label")[
+                    "name"
+                ]
+            )
+            if current is not _UNKNOWN and current is not None
+            else CANONICAL_AUTOMERGE_LABEL
+        )
+        api.send_json("DELETE", label_endpoint(name), {"name": name})
+        return
+    prior_label = _canonical_label(_object(prior, "snapshot automerge label"), "snapshot label")
+    if current is None:
+        api.send_json("POST", LABELS_ENDPOINT, prior_label)
+        return
+    current_name = (
+        str(_canonical_label(_object(current, "current automerge label"), "current label")["name"])
+        if current is not _UNKNOWN
+        else str(prior_label["name"])
+    )
+    api.send_json(
+        "PATCH",
+        label_endpoint(current_name),
+        _label_update_payload(prior_label),
+    )
+
+
+def _component_differences(
+    current: dict[str, object],
+    desired: dict[str, object],
+) -> tuple[bool, bool, bool]:
+    current_identity = _state_identity(current)
+    desired_identity = _state_identity(desired)
+    return (
+        current_identity["dev_ruleset"] != desired_identity["dev_ruleset"],
+        current_identity["repository"] != desired_identity["repository"],
+        current_identity["automerge_label"] != desired_identity["automerge_label"],
+    )
+
+
+def _restore_components(
+    api: Api,
+    before: dict[str, object],
+    current: dict[str, object] | None,
+    *,
+    restore_ruleset: bool,
+    restore_repository: bool,
+    restore_label: bool,
+) -> list[str]:
+    ruleset_id = before.get("dev_ruleset_id")
+    if not isinstance(ruleset_id, int):
+        raise PolicyError("snapshot has no integer dev_ruleset_id")
+    ruleset = normalize_ruleset(_object(before.get("dev_ruleset"), "snapshot dev ruleset"))
+    repository = normalize_repository(_object(before.get("repository"), "snapshot repository"))
+    current_label = current.get("automerge_label") if current is not None else _UNKNOWN
+    errors: list[str] = []
+    if restore_ruleset:
+        try:
+            api.send_json("PUT", DEV_RULESET_ENDPOINT.format(ruleset_id=ruleset_id), ruleset)
+        except (GitHubApiError, PolicyError, OSError) as error:
+            errors.append(f"ruleset restore failed: {error}")
+    if restore_repository:
+        try:
+            api.send_json("PATCH", REPOSITORY_ENDPOINT, repository)
+        except (GitHubApiError, PolicyError, OSError) as error:
+            errors.append(f"repository restore failed: {error}")
+    if restore_label:
+        try:
+            _restore_label(api, before.get("automerge_label"), current_label)
+        except (GitHubApiError, PolicyError, OSError) as error:
+            errors.append(f"label restore failed: {error}")
+    return errors
+
+
+def _restore_snapshot(
+    api: Api,
+    before: dict[str, object],
+    *,
+    attempted_ruleset: bool,
+    attempted_repository: bool,
+    attempted_label: bool,
+) -> None:
+    _state_identity(before)
+    current: dict[str, object] | None = None
+    restore_flags = (attempted_ruleset, attempted_repository, attempted_label)
+    try:
+        current = _current_state(api)
+        if current["dev_ruleset_id"] != before["dev_ruleset_id"]:
+            raise PolicyError("dev ruleset ID changed; restore refused")
+        restore_flags = _component_differences(current, before)
+    except (GitHubApiError, OSError):
+        pass
+    errors = _restore_components(
+        api,
+        before,
+        current,
+        restore_ruleset=restore_flags[0],
+        restore_repository=restore_flags[1],
+        restore_label=restore_flags[2],
+    )
+    try:
+        restored = _state_identity(_current_state(api)) == _state_identity(before)
+    except (GitHubApiError, PolicyError, OSError) as error:
+        errors.append(f"rollback readback failed: {error}")
+        restored = False
+    if not restored:
+        errors.append("rollback readback does not match snapshot")
+    if errors and not restored:
+        raise PolicyError("; ".join(errors))
+
+
+def _apply_label(api: Api, desired: dict[str, object], current: object) -> None:
+    if current is None:
+        api.send_json("POST", LABELS_ENDPOINT, desired)
+        return
+    current_label = _canonical_label(_object(current, "current automerge label"), "current label")
+    if current_label != desired:
+        api.send_json(
+            "PATCH",
+            label_endpoint(str(current_label["name"])),
+            _label_update_payload(desired),
+        )
+
+
+def apply_policy(
+    api: Api,
+    policy: dict[str, object],
+    expected_dev_sha: str,
+    snapshot_path: Path,
+) -> None:
+    """Apply one coherent policy transaction and roll it back on any mismatch."""
+    if SHA_PATTERN.fullmatch(expected_dev_sha) is None:
+        raise PolicyError("--expected-dev-sha must be one canonical 40-hex SHA")
+    _validate_policy(policy)
+    _verify_green_dev(api, policy, expected_dev_sha)
+    before = _current_state(api)
+    _write_snapshot(snapshot_path, before, expected_dev_sha)
+    if _state_identity(_current_state(api)) != _state_identity(before):
+        raise PolicyError("GitHub settings changed after snapshot; no mutation was attempted")
+    if _dev_sha(api) != expected_dev_sha:
+        raise PolicyError("dev moved after green evidence; no mutation was attempted")
+
+    desired_repository = normalize_repository(_object(policy["repository"], "repository policy"))
+    desired_ruleset = normalize_ruleset(_object(policy["dev_ruleset"], "dev ruleset policy"))
+    desired_label = _canonical_label(_object(policy["automerge_label"], "label policy"), "policy")
+    ruleset_id = before["dev_ruleset_id"]
+    if not isinstance(ruleset_id, int):
+        raise PolicyError("current state has no integer dev_ruleset_id")
+
+    current_label = before["automerge_label"]
+    label_differs = (
+        current_label is None
+        or _canonical_label(_object(current_label, "current automerge label"), "current label")
+        != desired_label
+    )
+    repository_differs = before["repository"] != desired_repository
+    ruleset_differs = before["dev_ruleset"] != desired_ruleset
+    label_attempted = False
+    repository_attempted = False
+    ruleset_attempted = False
+
+    try:
+        if label_differs:
+            label_attempted = True
+            _apply_label(api, desired_label, current_label)
+        if repository_differs:
+            repository_attempted = True
+            api.send_json("PATCH", REPOSITORY_ENDPOINT, desired_repository)
+        if ruleset_differs:
+            ruleset_attempted = True
+            api.send_json(
+                "PUT",
+                DEV_RULESET_ENDPOINT.format(ruleset_id=ruleset_id),
+                desired_ruleset,
+            )
+        drift = check_policy(api, policy)
+        if drift:
+            raise PolicyError("GitHub policy readback mismatch: " + "; ".join(drift))
+        if _dev_sha(api) != expected_dev_sha:
+            raise PolicyError("dev moved during policy apply")
+    except (GitHubApiError, PolicyError, OSError) as primary_error:
+        try:
+            _restore_snapshot(
+                api,
+                before,
+                attempted_ruleset=ruleset_attempted,
+                attempted_repository=repository_attempted,
+                attempted_label=label_attempted,
+            )
+        except (GitHubApiError, PolicyError, OSError) as rollback_error:
+            raise PolicyError(
+                f"policy apply failed ({primary_error}); rollback also failed ({rollback_error})"
+            ) from rollback_error
+        raise
+
+
+def load_snapshot(path: Path) -> dict[str, object]:
+    """Load a previously retained transaction snapshot."""
+    try:
+        payload = json.loads(path.read_text())
+    except OSError as error:
+        raise PolicyError(f"cannot read snapshot {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise PolicyError(f"snapshot {path} is not valid JSON") from error
+    return _object(payload, "snapshot")
+
+
+def rollback_policy(api: Api, snapshot: dict[str, object]) -> None:
+    """Restore one snapshot only while its exact dev evidence is still current."""
+    desired = _state_identity(snapshot)
+    expected_dev_sha = snapshot.get("dev_sha")
+    if not isinstance(expected_dev_sha, str) or SHA_PATTERN.fullmatch(expected_dev_sha) is None:
+        raise PolicyError("snapshot has no canonical dev SHA")
+    if _dev_sha(api) != expected_dev_sha:
+        raise PolicyError("snapshot dev SHA is stale; rollback refused")
+
+    _restore_snapshot(
+        api,
+        snapshot,
+        attempted_ruleset=True,
+        attempted_repository=True,
+        attempted_label=True,
+    )
+    if _state_identity(_current_state(api)) != desired:
+        raise PolicyError("manual rollback readback mismatch")
+    if _dev_sha(api) != expected_dev_sha:
+        raise PolicyError("dev moved during manual rollback")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true")
+    mode.add_argument("--apply", action="store_true")
+    mode.add_argument("--rollback", type=Path)
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY_PATH)
+    parser.add_argument("--expected-dev-sha")
+    parser.add_argument("--snapshot", type=Path)
+    args = parser.parse_args()
+
+    api = GhApi()
+    try:
+        if args.rollback is not None:
+            rollback_policy(api, load_snapshot(args.rollback))
+            print(f"github-pr-policy: restored {args.rollback}")
+            return 0
+        policy = load_policy(args.policy)
+        if args.check:
+            drift = check_policy(api, policy)
+            for problem in drift:
+                print(f"github-pr-policy: DRIFT — {problem}")
+            return 1 if drift else 0
+        if args.expected_dev_sha is None or args.snapshot is None:
+            parser.error("--apply requires --expected-dev-sha and --snapshot")
+        apply_policy(api, policy, args.expected_dev_sha, args.snapshot)
+        print(f"github-pr-policy: applied at dev {args.expected_dev_sha}")
+        print(f"github-pr-policy: rollback snapshot retained at {args.snapshot}")
+        return 0
+    except (GitHubApiError, PolicyError, OSError) as error:
+        print(f"github-pr-policy: REFUSED — {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sync_github_pr_policy.py
+++ b/tools/sync_github_pr_policy.py
@@ -11,12 +11,17 @@ import subprocess
 import sys
 from copy import deepcopy
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Final, Protocol, cast
 from urllib.parse import quote
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from tools.pr_policy import DEV_BLOCKING_CONTEXTS  # noqa: E402
+from tools.pr_policy import (  # noqa: E402
+    BASELINE_CEREMONY_CONTEXT,
+    DEV_BLOCKING_CONTEXTS,
+    DEV_CHECK_MANIFEST,
+    CheckRequirement,
+)
 
 REPOSITORY = "percy-raskova/babylon"
 REPOSITORY_ENDPOINT = f"repos/{REPOSITORY}"
@@ -34,6 +39,17 @@ MAX_CHECK_RUNS = 100
 API_TIMEOUT_SECONDS = 30
 SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
 CANONICAL_AUTOMERGE_LABEL = "dependencies:automerge"
+DEV_PUSH_ATTESTATION_MANIFEST: Final[tuple[CheckRequirement, ...]] = tuple(
+    CheckRequirement(
+        requirement.context,
+        requirement.kind,
+        frozenset({"success", "skipped"})
+        if requirement.context == BASELINE_CEREMONY_CONTEXT
+        else frozenset({"success"}),
+    )
+    for requirement in DEV_CHECK_MANIFEST
+    if requirement.kind == "blocking"
+)
 _UNKNOWN = object()
 
 RULESET_WRITABLE_FIELDS = (
@@ -310,14 +326,14 @@ def _validate_policy(policy: dict[str, object]) -> None:
     ruleset = normalize_ruleset(_object(policy.get("dev_ruleset"), "dev ruleset policy"))
     if not _exact_dev_scope(ruleset):
         raise PolicyError("desired ruleset must have exact dev-only branch scope")
-    contexts = tuple(_required_contexts(policy))
-    if contexts != DEV_BLOCKING_CONTEXTS:
+    contexts = _required_contexts(policy)
+    if len(contexts) != len(DEV_BLOCKING_CONTEXTS) or set(contexts) != set(DEV_BLOCKING_CONTEXTS):
         raise PolicyError("required checks must equal the complete dev check manifest")
     normalize_repository(_object(policy.get("repository"), "repository policy"))
     _canonical_label(_object(policy.get("automerge_label"), "label policy"), "policy")
 
 
-def _verify_green_dev(api: Api, policy: dict[str, object], expected_sha: str) -> None:
+def _verify_green_dev(api: Api, expected_sha: str) -> None:
     actual_sha = _dev_sha(api)
     if actual_sha != expected_sha:
         raise PolicyError(f"dev moved: expected {expected_sha}, found {actual_sha}")
@@ -352,15 +368,15 @@ def _verify_green_dev(api: Api, policy: dict[str, object], expected_sha: str) ->
         if prior is None or current_key >= prior_key:
             latest[name] = candidate
     problems: list[str] = []
-    for context in _required_contexts(policy):
-        selected = latest.get(context)
+    for requirement in DEV_PUSH_ATTESTATION_MANIFEST:
+        selected = latest.get(requirement.context)
         if selected is None:
-            problems.append(f"{context}: missing")
+            problems.append(f"{requirement.context}: missing")
             continue
         status = str(selected.get("status") or "")
         conclusion = str(selected.get("conclusion") or "")
-        if status != "completed" or conclusion != "success":
-            problems.append(f"{context}: status={status}, conclusion={conclusion}")
+        if status != "completed" or conclusion not in requirement.allowed_conclusions:
+            problems.append(f"{requirement.context}: status={status}, conclusion={conclusion}")
     if problems:
         raise PolicyError("exact dev checks are not green: " + "; ".join(problems))
 
@@ -474,11 +490,12 @@ def _restore_snapshot(
     restore_flags = (attempted_ruleset, attempted_repository, attempted_label)
     try:
         current = _current_state(api)
+    except (GitHubApiError, PolicyError, OSError):
+        pass
+    else:
         if current["dev_ruleset_id"] != before["dev_ruleset_id"]:
             raise PolicyError("dev ruleset ID changed; restore refused")
         restore_flags = _component_differences(current, before)
-    except (GitHubApiError, OSError):
-        pass
     errors = _restore_components(
         api,
         before,
@@ -521,7 +538,7 @@ def apply_policy(
     if SHA_PATTERN.fullmatch(expected_dev_sha) is None:
         raise PolicyError("--expected-dev-sha must be one canonical 40-hex SHA")
     _validate_policy(policy)
-    _verify_green_dev(api, policy, expected_dev_sha)
+    _verify_green_dev(api, expected_dev_sha)
     before = _current_state(api)
     _write_snapshot(snapshot_path, before, expected_dev_sha)
     if _state_identity(_current_state(api)) != _state_identity(before):


### PR DESCRIPTION
## Summary

- make `dev` and Director-only `main` merge qualification use complete typed
  check manifests bound to the reviewed head SHA
- require exact Copilot identities, completed head-bound review, answered
  comments, resolved threads, and a clean code-scanning alert set
- make Dependabot patch/minor automation reuse the sanctioned merge verifier
  and prove native CI plus trusted classifier workflow provenance before
  reading update metadata
- add transactional GitHub settings check/apply/rollback support; this PR does
  not apply the remote settings
- bound every sanctioned `gh` operation; reconcile an ambiguous merge exactly
  once and report a distinct indeterminate outcome without retrying
- derive the Dependabot label API path from the canonical declared label with
  URI encoding, so label metadata verification cannot drift from policy
- refuse an exactly full code-scanning alert page because its completeness
  cannot be proved within the bounded merge verifier

## Linear delivery

- [x] `Part of PER-264` — partial delivery. Keep the Linear issue open.
- [ ] `Fixes PER-264` — final accepted delivery. Close the Linear issue after merge.

Linear issue: https://linear.app/percy-raskova/issue/PER-264/harden-babylon-pull-request-and-dependabot-merge-policy

Also part of PER-259.

## Review evidence

Base branch: `dev`

Exact reviewed head SHA: `9cdc11598dc90248927629495f9462cb5739975b`

- [x] The base branch is `dev`, or the Director approved `main`.
  - Release PR from `dev`.
  - Critical hotfix from `fix/*`, with a mandatory backport PR to `dev`.
- [x] All reported checks completed successfully for the exact reviewed head
      SHA and base branch above.
- [x] The Copilot review completed against the exact reviewed head SHA.
- [x] I fixed each accepted Copilot finding, provided a reply to every finding,
      and resolved all Copilot review threads.

Local evidence: 182 focused policy/governance tests and all 72 scoped Rust
persistence contract tests passed. Ruff, strict MyPy, scoped Clippy with
warnings denied, Rust formatting, Vale, and `git diff --check` passed. The
local doc-inclusive Rust pre-push leg was skipped as required for worktree
pushes and remains a hosted CI responsibility; every other applicable
pre-commit hook passed.

## Behavioral-contract disposition

- [x] Changed behavior: I added or updated a durable behavioral contract.
- [ ] No behavior change: the current behavioral contracts are enough.

Disposition and evidence: ADR230 plus executable policy, governance, workflow,
race, rollback, identity, provenance, exact-head, and manual-major contracts in
the six focused test files changed by this PR.

## Baseline disposition

- [x] No governed baseline changed.
- [ ] A governed baseline changed intentionally. I used
      `tools/generate_ceremony_message.py` and included the required ceremony
      record and `Baselines: blessed(<slug>)` trailer.

## Merge

- [x] Merge only with `mise run pr:merge -- N`. Use this PR number for `N`.
- [x] Preserve the source branch by default. Delete it only after an explicit
      owner decision and a check for dependent work.

Do not run `gh pr merge` directly in any form.

## Questions for reviewers

None.
