### PR TITLE
fix(ci): exclude untracked Nix worktree files

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -79,7 +79,10 @@ AUDIO_OUTPUT_DIR = "assets/audio"
 
 [tasks."nix"]
 description = "Run any command inside the vendored devshell and pass through trust for this already-trusted project root, including nested mise tasks."
-run = 'MISE_TRUSTED_CONFIG_PATHS="${MISE_PROJECT_ROOT:-$PWD}" nix develop "${MISE_PROJECT_ROOT:-$PWD}" --command'
+# Force Git's tracked-files accessor. Older Nix installations can classify a
+# linked worktree's .git file as path:, copying untracked rust/target into the
+# store before the flake fileset can filter it.
+run = 'MISE_TRUSTED_CONFIG_PATHS="${MISE_PROJECT_ROOT:-$PWD}" nix develop "git+file://${MISE_PROJECT_ROOT:-$PWD}" --command'
 
 [tasks."pr:merge"]
 description = "the ONE sanctioned merge path (ADR181 R10): all-green + head-pin + Copilot harvest + zero alert floor + stacked-PR guard"

--- a/tests/unit/test_mise_tasks.py
+++ b/tests/unit/test_mise_tasks.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import tomllib
 from pathlib import Path
 
 import pytest
 
-MISE_TOML = Path(".mise.toml")
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+MISE_TOML = REPOSITORY_ROOT / ".mise.toml"
 
 
 @pytest.mark.skipif(not MISE_TOML.exists(), reason=".mise.toml not present")
@@ -35,3 +39,43 @@ class TestMiseTaskDiscoverability:
     def test_sim_e2e_michigan_invokes_runner_module(self) -> None:
         block = self._e2e_block()
         assert "babylon.engine.headless_runner" in block
+
+
+def test_nix_task_forces_git_source_for_linked_worktree(tmp_path: Path) -> None:
+    """The Nix task must not copy a linked worktree as an unfiltered path source."""
+    task_script = tomllib.loads(MISE_TOML.read_text())["tasks"]["nix"]["run"]
+    linked_worktree = tmp_path / "linked worktree"
+    linked_worktree.mkdir()
+    (linked_worktree / ".git").write_text("gitdir: /tmp/babylon-common/worktrees/test\n")
+
+    capture_path = tmp_path / "nix-call.txt"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_nix = fake_bin / "nix"
+    fake_nix.write_text(
+        "#!/bin/sh\n"
+        'printf \'%s\\n\' "${MISE_TRUSTED_CONFIG_PATHS-}" > "$NIX_TASK_CAPTURE"\n'
+        'printf \'%s\\n\' "$@" >> "$NIX_TASK_CAPTURE"\n'
+    )
+    fake_nix.chmod(0o755)
+
+    environment = os.environ.copy()
+    environment["MISE_PROJECT_ROOT"] = str(linked_worktree)
+    environment["NIX_TASK_CAPTURE"] = str(capture_path)
+    environment["PATH"] = f"{fake_bin}{os.pathsep}{environment['PATH']}"
+    subprocess.run(  # noqa: S603 -- repository-owned task script under contract
+        ["bash", "-c", f'{task_script} "$@"', "nix-task-contract", "probe"],  # noqa: S607
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert capture_path.read_text().splitlines() == [
+        str(linked_worktree),
+        "develop",
+        f"git+file://{linked_worktree}",
+        "--command",
+        "probe",
+    ]

--- a/tests/unit/test_mise_tasks.py
+++ b/tests/unit/test_mise_tasks.py
@@ -41,6 +41,7 @@ class TestMiseTaskDiscoverability:
         assert "babylon.engine.headless_runner" in block
 
 
+@pytest.mark.skipif(not MISE_TOML.exists(), reason=".mise.toml not present")
 def test_nix_task_forces_git_source_for_linked_worktree(tmp_path: Path) -> None:
     """The Nix task must not copy a linked worktree as an unfiltered path source."""
     task_script = tomllib.loads(MISE_TOML.read_text())["tasks"]["nix"]["run"]


### PR DESCRIPTION
## Summary

- force the Mise Nix dev-shell task to use the Git tracked-files accessor for linked worktrees
- preserve the nested Mise trust propagation delivered by PR #743
- execute the real task string against a synthetic linked worktree so bare `path:` regression fails without copying into the Nix store

## Verification

- RED: focused contract failed because the task emitted a bare linked-worktree path
- GREEN: 4 focused Mise tests passed
- 10 combined Mise, worktree, and clean-archive dependency contracts passed
- Ruff lint and format, TOML parsing, commit hooks, and the pre-push mirror passed
- real Nix metadata resolved `git+file://` as `type: git`; the source snapshot was 201 MiB and excluded `.codex/` and `rust/target`
- real `mise run nix --` smoke preserved `MISE_TRUSTED_CONFIG_PATHS`

Part of PER-265
Also part of PER-259