### PR TITLE
fix(ci): permit optional Dependabot skips

### DIFF
--- a/tests/unit/tools/test_pr_merge_rollup.py
+++ b/tests/unit/tools/test_pr_merge_rollup.py
@@ -31,6 +31,10 @@ DEV_BLOCKING_CHECKS = (
     "Baseline Ceremony Gate (§6.5 provenance)",
     "Postgres Integration Tier (PG 17, pinned runtime)",
 )
+OPTIONAL_DEPENDABOT_CHECKS = (
+    "Classify Dependabot update",
+    "Dependabot Eligibility",
+)
 
 
 def _entry(
@@ -113,3 +117,29 @@ class TestRollupFailuresLatestPerCheck:
         ]
         failures = pr_merge._rollup_failures(rollup)
         assert any(critical in failure and "SKIPPED" in failure for failure in failures)
+
+    def test_optional_dependabot_checks_may_skip_on_a_human_pr(self) -> None:
+        rollup = [
+            *_dev_manifest_green(),
+            *[
+                _entry(name, "SKIPPED", "2026-08-26T02:48:05Z")
+                for name in OPTIONAL_DEPENDABOT_CHECKS
+            ],
+        ]
+        assert pr_merge._rollup_failures(rollup) == []
+
+    def test_optional_dependabot_failure_still_refuses(self) -> None:
+        rollup = [
+            *_dev_manifest_green(),
+            _entry(OPTIONAL_DEPENDABOT_CHECKS[0], "FAILURE", "2026-08-26T02:48:05Z"),
+        ]
+        failures = pr_merge._rollup_failures(rollup)
+        assert any(OPTIONAL_DEPENDABOT_CHECKS[0] in failure for failure in failures)
+
+    def test_unknown_skipped_check_still_refuses(self) -> None:
+        rollup = [
+            *_dev_manifest_green(),
+            _entry("Unregistered Optional Check", "SKIPPED", "2026-08-26T02:48:05Z"),
+        ]
+        failures = pr_merge._rollup_failures(rollup)
+        assert any("Unregistered Optional Check" in failure for failure in failures)

--- a/tools/pr_merge.py
+++ b/tools/pr_merge.py
@@ -48,7 +48,11 @@ COPILOT_BOT_ID = 175728472
 COPILOT_BOT_NODE_ID = "BOT_kgDOCnlnWA"
 DEPENDABOT_LOGIN = "dependabot[bot]"
 DEPENDABOT_BOT_ID = 49699333
+DEPENDABOT_CLASSIFIER_CHECK = "Classify Dependabot update"
 DEPENDABOT_ELIGIBILITY_CHECK = "Dependabot Eligibility"
+OPTIONAL_SKIPPED_CHECKS: Final[frozenset[str]] = frozenset(
+    {DEPENDABOT_CLASSIFIER_CHECK, DEPENDABOT_ELIGIBILITY_CHECK}
+)
 DEPENDABOT_WORKFLOW_PATH = ".github/workflows/dependabot-automerge.yml"
 DEPENDABOT_WORKFLOW_ID = 214604133
 CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
@@ -207,7 +211,11 @@ def _rollup_failures(
         requirement = expected.get(name)
         if status and status != "COMPLETED":
             failures.append(f"{name}: still {status}")
-        elif requirement is None and conclusion != "SUCCESS":
+        elif (
+            requirement is None
+            and conclusion != "SUCCESS"
+            and not (conclusion == "SKIPPED" and name in OPTIONAL_SKIPPED_CHECKS)
+        ):
             failures.append(f"{name}: {conclusion}")
         elif requirement is not None and conclusion not in requirement.allowed_conclusions:
             failures.append(f"{name}: {conclusion}")


### PR DESCRIPTION
## Summary

- allow exactly the two default-branch Dependabot workflow contexts to conclude `SKIPPED` on normal human PRs
- keep every required manifest check, unknown check, failure, and in-progress state fail-closed
- unblock the sanctioned verifier for fully green PR #754 without bypassing policy

## Verification

- RED: live PR #754 and the focused contract were refused only for `Classify Dependabot update: SKIPPED` and `Dependabot Eligibility: SKIPPED`
- GREEN: 9 focused rollup tests passed
- 80 full sanctioned-merger policy tests passed
- Ruff lint/format and strict MyPy passed
- repository hooks and pre-push mirror passed
- repaired verifier accepted PR #754 at exact head `1aafaf94`

Part of PER-264
Also part of PER-259