### PR TITLE
ci(postgres): split PR and exhaustive cadence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,8 +277,10 @@ jobs:
       - name: Bootstrap the canonical schema (digest-stamped, idempotent)
         run: mise run db:bootstrap
 
-      - name: Rust legacy adopter (bounded disposable PG proof)
-        timeout-minutes: 31
+      - name: Rust H3 atomicity and installed-mutation contracts
+        timeout-minutes: 22
+        env:
+          BABYLON_LEGACY_ADOPTER_LIVE_FOCUS: pr
         run: mise run test:rust-legacy-adopter-pg
 
       - name: PG-backed integration subset (declared, data-drive-free)

--- a/.github/workflows/weekly-pg-integration.yml
+++ b/.github/workflows/weekly-pg-integration.yml
@@ -17,6 +17,38 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  exhaustive-legacy-adopter:
+    name: Exhaustive Rust legacy adopter matrix (dev HEAD)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: dev
+      - uses: ./.github/actions/bootstrap-python
+        with:
+          gdal: "true"
+          server: "true"
+      - name: Install Rust toolchain (legacy adopter only)
+        run: |
+          CHANNEL="$(sed -n 's/^channel = "\(.*\)"$/\1/p' rust/rust-toolchain.toml)"
+          rustup toolchain install "$CHANNEL" --profile minimal --no-self-update
+      - name: Load persistence cargo cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust/target
+          key: >-
+            legacy-adopter-${{ runner.os }}-v2-${{
+            hashFiles('rust/Cargo.lock', 'rust/rust-toolchain.toml') }}
+          restore-keys: |
+            legacy-adopter-${{ runner.os }}-v2-
+      - name: Exhaustive adopter matrix and rollback proof
+        timeout-minutes: 31
+        run: mise run test:rust-legacy-adopter-pg
+
   postgres-integration:
     name: Postgres Integration (dev HEAD)
     if: vars.CI_REFDB_READY == 'true'

--- a/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
+++ b/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
@@ -2128,7 +2128,13 @@ fn pr_focus_reuses_the_h3_atomicity_and_installed_mutation_contracts() {
         "Some(\"installed_mutation\")",
         "Some(\"h3_reference_release\")",
     );
-    assert!(installed_focus.contains("phases.run(\"h3_installed_mutations\""));
+    assert!(installed_focus.contains("verify_h3_installed_mutations(phases, base)"));
+    let installed_helper = cte_slice(
+        live,
+        "fn verify_h3_installed_mutations(",
+        "fn verify_h3_pg_oracle_in_scratch(",
+    );
+    assert!(installed_helper.contains("phases.run(\"h3_installed_mutations\""));
     assert!(installer.contains("pub(super) fn verify_h3_reference_installed_mutations("));
     assert!(installer.contains("verify_installed_state_conflicts(base, &cohort)"));
     assert_eq!(installer.matches("mutate_orphan_membership,").count(), 1);
@@ -2218,14 +2224,12 @@ fn h3_atomicity_receipts_are_fixed_flushed_and_test_only() {
 }
 
 #[test]
-fn ci_and_weekly_steps_exceed_their_bounded_runner_envelopes() {
+fn ci_step_exceeds_the_focused_runner_envelope() {
     const CONTROL_PLANE_ENVELOPE_SECONDS: u64 = 5 * (10 + 2);
     const BUILD_ENVELOPE_SECONDS: u64 = 180 + 10;
     const START_ENVELOPE_SECONDS: u64 = 30 + 5;
     const READINESS_ENVELOPE_SECONDS: u64 = 90 + 2;
     const FOCUSED_CARGO_ENVELOPE_SECONDS: u64 = 2 * (300 + 10);
-    const EXHAUSTIVE_CARGO_ENVELOPE_SECONDS: u64 = 900 + 10;
-    const ROLLBACK_CARGO_ENVELOPE_SECONDS: u64 = 300 + 10;
     const CLEANUP_ENVELOPE_SECONDS: u64 = 35 + 12 + 12 + 35;
     const FOCUSED_RUNNER_ENVELOPE_SECONDS: u64 = CONTROL_PLANE_ENVELOPE_SECONDS
         + BUILD_ENVELOPE_SECONDS
@@ -2233,16 +2237,8 @@ fn ci_and_weekly_steps_exceed_their_bounded_runner_envelopes() {
         + READINESS_ENVELOPE_SECONDS
         + FOCUSED_CARGO_ENVELOPE_SECONDS
         + CLEANUP_ENVELOPE_SECONDS;
-    const EXHAUSTIVE_RUNNER_ENVELOPE_SECONDS: u64 = CONTROL_PLANE_ENVELOPE_SECONDS
-        + BUILD_ENVELOPE_SECONDS
-        + START_ENVELOPE_SECONDS
-        + READINESS_ENVELOPE_SECONDS
-        + EXHAUSTIVE_CARGO_ENVELOPE_SECONDS
-        + ROLLBACK_CARGO_ENVELOPE_SECONDS
-        + CLEANUP_ENVELOPE_SECONDS;
 
     let pr_workflow = include_str!("../../../../.github/workflows/ci.yml");
-    let weekly_workflow = include_str!("../../../../.github/workflows/weekly-pg-integration.yml");
     let pr_job = yaml_job(pr_workflow, "  pg-integration:");
     assert!(pr_job.contains(
         "- name: Rust H3 atomicity and installed-mutation contracts\n        timeout-minutes: 22"
@@ -2272,7 +2268,26 @@ fn ci_and_weekly_steps_exceed_their_bounded_runner_envelopes() {
     assert_eq!(pr_step_seconds, 22 * 60);
     assert!(pr_step_seconds >= FOCUSED_RUNNER_ENVELOPE_SECONDS + 120);
     assert!(pr_job_seconds >= pr_step_seconds + 30 * 60);
+}
 
+#[test]
+fn weekly_step_exceeds_the_exhaustive_runner_envelope() {
+    const CONTROL_PLANE_ENVELOPE_SECONDS: u64 = 5 * (10 + 2);
+    const BUILD_ENVELOPE_SECONDS: u64 = 180 + 10;
+    const START_ENVELOPE_SECONDS: u64 = 30 + 5;
+    const READINESS_ENVELOPE_SECONDS: u64 = 90 + 2;
+    const EXHAUSTIVE_CARGO_ENVELOPE_SECONDS: u64 = 900 + 10;
+    const ROLLBACK_CARGO_ENVELOPE_SECONDS: u64 = 300 + 10;
+    const CLEANUP_ENVELOPE_SECONDS: u64 = 35 + 12 + 12 + 35;
+    const EXHAUSTIVE_RUNNER_ENVELOPE_SECONDS: u64 = CONTROL_PLANE_ENVELOPE_SECONDS
+        + BUILD_ENVELOPE_SECONDS
+        + START_ENVELOPE_SECONDS
+        + READINESS_ENVELOPE_SECONDS
+        + EXHAUSTIVE_CARGO_ENVELOPE_SECONDS
+        + ROLLBACK_CARGO_ENVELOPE_SECONDS
+        + CLEANUP_ENVELOPE_SECONDS;
+
+    let weekly_workflow = include_str!("../../../../.github/workflows/weekly-pg-integration.yml");
     let weekly_job = yaml_job(weekly_workflow, "  exhaustive-legacy-adopter:");
     let weekly_step = weekly_job
         .split_once("      - name: Exhaustive adopter matrix and rollback proof")
@@ -2290,17 +2305,7 @@ fn ci_and_weekly_steps_exceed_their_bounded_runner_envelopes() {
     assert!(weekly_step_seconds >= EXHAUSTIVE_RUNNER_ENVELOPE_SECONDS + 120);
 
     let runner = include_str!("../../../../tools/run_rust_legacy_adopter_pg.sh");
-    for bounded_phase in [
-        "timeout --signal=TERM --kill-after=10s 180s \\",
-        "timeout --signal=TERM --kill-after=5s 30s docker run --detach \\",
-        "local deadline=$((SECONDS + 90))",
-        "for _attempt in {1..90}; do",
-        "timeout --signal=TERM --kill-after=1s \"${remaining}s\" \\",
-        "timeout --signal=TERM --kill-after=10s 300s \\",
-        "timeout --signal=TERM --kill-after=10s 900s \\",
-    ] {
-        assert!(runner.contains(bounded_phase));
-    }
+    assert!(runner.contains("timeout --signal=TERM --kill-after=10s 900s \\"));
     let rollback_phase = runner
         .rsplit_once("if [ \"$status\" -eq 0 ] && [ -z \"$LIVE_FOCUS\" ]; then")
         .unwrap()
@@ -2312,6 +2317,20 @@ fn ci_and_weekly_steps_exceed_their_bounded_runner_envelopes() {
         .find("cargo test -p babylon-persistence --lib")
         .unwrap();
     assert!(rollback_timeout < rollback_cargo);
+}
+
+#[test]
+fn live_runner_bounds_every_docker_control_plane_call() {
+    let runner = include_str!("../../../../tools/run_rust_legacy_adopter_pg.sh");
+    for bounded_phase in [
+        "timeout --signal=TERM --kill-after=10s 180s \\",
+        "timeout --signal=TERM --kill-after=5s 30s docker run --detach \\",
+        "local deadline=$((SECONDS + 90))",
+        "for _attempt in {1..90}; do",
+        "timeout --signal=TERM --kill-after=1s \"${remaining}s\" \\",
+    ] {
+        assert!(runner.contains(bounded_phase));
+    }
     assert_eq!(
         runner
             .matches("timeout --signal=TERM --kill-after=5s 30s \\\n    docker rm --force --volumes \"$CONTAINER\"")

--- a/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
+++ b/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
@@ -2058,9 +2058,10 @@ fn postgres_ci_and_sanctioned_merger_share_the_pinned_runtime_name() {
 }
 
 #[test]
-fn live_adopter_test_is_wired_into_the_remote_pg_tier() {
+fn live_adopter_tests_are_split_between_pr_and_weekly_cadences() {
     let mise = include_str!("../../../../.mise.toml");
-    let workflow = include_str!("../../../../.github/workflows/ci.yml");
+    let pr_workflow = include_str!("../../../../.github/workflows/ci.yml");
+    let weekly_workflow = include_str!("../../../../.github/workflows/weekly-pg-integration.yml");
     let runner = include_str!("../../../../tools/run_rust_legacy_adopter_pg.sh");
     let task = toml_section(mise, "[tasks.\"test:rust-legacy-adopter-pg\"]");
     assert!(task.contains("run = \"tools/run_rust_legacy_adopter_pg.sh\""));
@@ -2070,35 +2071,67 @@ fn live_adopter_test_is_wired_into_the_remote_pg_tier() {
         .contains("cargo test -p babylon-persistence --test legacy_adopter_postgres --locked --"));
     assert!(runner.contains("--ignored --test-threads=1"));
     assert!(!runner.contains("--manifest-path"));
-    let job = yaml_job(workflow, "  pg-integration:");
+
+    let pr_job = yaml_job(pr_workflow, "  pg-integration:");
     assert_eq!(
-        job.matches("run: mise run test:rust-legacy-adopter-pg")
+        pr_job
+            .matches("run: mise run test:rust-legacy-adopter-pg")
             .count(),
         1
     );
-    assert!(job.contains(
-        "- name: Rust legacy adopter (bounded disposable PG proof)\n        timeout-minutes: 31\n        run: mise run test:rust-legacy-adopter-pg"
+    assert!(pr_job.contains(
+        "- name: Rust H3 atomicity and installed-mutation contracts\n        timeout-minutes: 22\n        env:\n          BABYLON_LEGACY_ADOPTER_LIVE_FOCUS: pr\n        run: mise run test:rust-legacy-adopter-pg"
     ));
-    assert!(!job.contains("BABYLON_LEGACY_ADOPTER_TEST_DSN"));
-    assert!(!job.contains("cargo doc"));
+    assert!(!pr_job.contains("BABYLON_LEGACY_ADOPTER_TEST_DSN"));
+    assert!(!pr_job.contains("cargo doc"));
+
+    let weekly_job = yaml_job(weekly_workflow, "  exhaustive-legacy-adopter:");
+    assert!(weekly_job.contains("name: Exhaustive Rust legacy adopter matrix (dev HEAD)"));
+    assert!(weekly_job.contains("timeout-minutes: 40"));
+    assert!(weekly_job.contains("ref: dev"));
+    assert!(weekly_job.contains(
+        "- uses: ./.github/actions/bootstrap-python\n        with:\n          gdal: \"true\"\n          server: \"true\""
+    ));
+    assert!(!weekly_job.contains("uses: jdx/mise-action"));
+    assert!(weekly_job.contains(
+        "- name: Exhaustive adopter matrix and rollback proof\n        timeout-minutes: 31\n        run: mise run test:rust-legacy-adopter-pg"
+    ));
+    assert!(!weekly_job.contains("BABYLON_LEGACY_ADOPTER_LIVE_FOCUS"));
+    assert!(!weekly_job.contains("CI_REFDB_READY"));
 
     let synthetic = "jobs:\n  pg-integration:\n    run: true\n  unrelated:\n    run: mise run test:rust-legacy-adopter-pg\n  security:\n    run: true\n";
     assert!(!yaml_job(synthetic, "  pg-integration:").contains("test:rust-legacy-adopter-pg"));
 }
 
 #[test]
-fn h3_atomicity_focus_is_fixed_and_cannot_replace_default_pg_gate() {
+fn pr_focus_reuses_the_h3_atomicity_and_installed_mutation_contracts() {
     let runner = include_str!("../../../../tools/run_rust_legacy_adopter_pg.sh");
+    let live = include_str!("legacy_adopter_postgres.rs");
+    let installer = include_str!("support/h3_reference_installer_postgres.rs");
     let focused =
         "schema_epoch::live_rollback_tests::h3_installer_rollback_and_ambiguous_commit_reconciliation_are_atomic";
     let full =
         "schema_epoch::live_rollback_tests::rollback_and_ambiguous_commit_reconciliation_are_atomic";
 
     assert!(runner.contains("BABYLON_LEGACY_ADOPTER_LIVE_FOCUS:-}"));
+    assert!(runner.contains("\"\" | h3_atomicity | installed_mutation | pr)"));
     assert_eq!(runner.matches(focused).count(), 1);
     assert_eq!(runner.matches(full).count(), 1);
     assert!(runner.contains("--ignored --exact --test-threads=1"));
     assert!(!runner.contains("cargo test -p babylon-persistence --lib \"$"));
+    assert!(live.contains("Some(\"installed_mutation\")"));
+    assert!(live.contains(
+        "h3_reference_installer_postgres::verify_h3_reference_installed_mutations(base)"
+    ));
+    let installed_focus = cte_slice(
+        live,
+        "Some(\"installed_mutation\")",
+        "Some(\"h3_reference_release\")",
+    );
+    assert!(installed_focus.contains("phases.run(\"h3_installed_mutations\""));
+    assert!(installer.contains("pub(super) fn verify_h3_reference_installed_mutations("));
+    assert!(installer.contains("verify_installed_state_conflicts(base, &cohort)"));
+    assert_eq!(installer.matches("mutate_orphan_membership,").count(), 1);
 
     let broad = runner
         .find("--test legacy_adopter_postgres")
@@ -2185,28 +2218,36 @@ fn h3_atomicity_receipts_are_fixed_flushed_and_test_only() {
 }
 
 #[test]
-fn ci_adopter_step_exceeds_the_full_bounded_runner_envelope() {
+fn ci_and_weekly_steps_exceed_their_bounded_runner_envelopes() {
     const CONTROL_PLANE_ENVELOPE_SECONDS: u64 = 5 * (10 + 2);
     const BUILD_ENVELOPE_SECONDS: u64 = 180 + 10;
     const START_ENVELOPE_SECONDS: u64 = 30 + 5;
     const READINESS_ENVELOPE_SECONDS: u64 = 90 + 2;
-    const CARGO_ENVELOPE_SECONDS: u64 = 900 + 10;
+    const FOCUSED_CARGO_ENVELOPE_SECONDS: u64 = 2 * (300 + 10);
+    const EXHAUSTIVE_CARGO_ENVELOPE_SECONDS: u64 = 900 + 10;
     const ROLLBACK_CARGO_ENVELOPE_SECONDS: u64 = 300 + 10;
     const CLEANUP_ENVELOPE_SECONDS: u64 = 35 + 12 + 12 + 35;
-    const RUNNER_ENVELOPE_SECONDS: u64 = CONTROL_PLANE_ENVELOPE_SECONDS
+    const FOCUSED_RUNNER_ENVELOPE_SECONDS: u64 = CONTROL_PLANE_ENVELOPE_SECONDS
         + BUILD_ENVELOPE_SECONDS
         + START_ENVELOPE_SECONDS
         + READINESS_ENVELOPE_SECONDS
-        + CARGO_ENVELOPE_SECONDS
+        + FOCUSED_CARGO_ENVELOPE_SECONDS
+        + CLEANUP_ENVELOPE_SECONDS;
+    const EXHAUSTIVE_RUNNER_ENVELOPE_SECONDS: u64 = CONTROL_PLANE_ENVELOPE_SECONDS
+        + BUILD_ENVELOPE_SECONDS
+        + START_ENVELOPE_SECONDS
+        + READINESS_ENVELOPE_SECONDS
+        + EXHAUSTIVE_CARGO_ENVELOPE_SECONDS
         + ROLLBACK_CARGO_ENVELOPE_SECONDS
         + CLEANUP_ENVELOPE_SECONDS;
 
-    let workflow = include_str!("../../../../.github/workflows/ci.yml");
-    let job = yaml_job(workflow, "  pg-integration:");
-    assert!(job.contains(
-        "- name: Rust legacy adopter (bounded disposable PG proof)\n        timeout-minutes: 31\n        run: mise run test:rust-legacy-adopter-pg"
+    let pr_workflow = include_str!("../../../../.github/workflows/ci.yml");
+    let weekly_workflow = include_str!("../../../../.github/workflows/weekly-pg-integration.yml");
+    let pr_job = yaml_job(pr_workflow, "  pg-integration:");
+    assert!(pr_job.contains(
+        "- name: Rust H3 atomicity and installed-mutation contracts\n        timeout-minutes: 22"
     ));
-    let job_seconds = job
+    let pr_job_seconds = pr_job
         .lines()
         .take(MAX_WORKFLOW_JOB_BOUNDARY_CANDIDATES)
         .find_map(|line| line.trim().strip_prefix("timeout-minutes: "))
@@ -2214,12 +2255,12 @@ fn ci_adopter_step_exceeds_the_full_bounded_runner_envelope() {
         .parse::<u64>()
         .unwrap()
         * 60;
-    let adopter_step = cte_slice(
-        job,
-        "      - name: Rust legacy adopter (bounded disposable PG proof)",
+    let pr_adopter_step = cte_slice(
+        pr_job,
+        "      - name: Rust H3 atomicity and installed-mutation contracts",
         "      - name: PG-backed integration subset (declared, data-drive-free)",
     );
-    let ci_step_seconds = adopter_step
+    let pr_step_seconds = pr_adopter_step
         .lines()
         .take(MAX_WORKFLOW_JOB_BOUNDARY_CANDIDATES)
         .find_map(|line| line.trim().strip_prefix("timeout-minutes: "))
@@ -2227,10 +2268,26 @@ fn ci_adopter_step_exceeds_the_full_bounded_runner_envelope() {
         .parse::<u64>()
         .unwrap()
         * 60;
-    assert_eq!(job_seconds, 61 * 60);
-    assert_eq!(ci_step_seconds, 31 * 60);
-    assert!(ci_step_seconds >= RUNNER_ENVELOPE_SECONDS + 120);
-    assert!(job_seconds >= ci_step_seconds + 30 * 60);
+    assert_eq!(pr_job_seconds, 61 * 60);
+    assert_eq!(pr_step_seconds, 22 * 60);
+    assert!(pr_step_seconds >= FOCUSED_RUNNER_ENVELOPE_SECONDS + 120);
+    assert!(pr_job_seconds >= pr_step_seconds + 30 * 60);
+
+    let weekly_job = yaml_job(weekly_workflow, "  exhaustive-legacy-adopter:");
+    let weekly_step = weekly_job
+        .split_once("      - name: Exhaustive adopter matrix and rollback proof")
+        .unwrap()
+        .1;
+    let weekly_step_seconds = weekly_step
+        .lines()
+        .take(MAX_WORKFLOW_JOB_BOUNDARY_CANDIDATES)
+        .find_map(|line| line.trim().strip_prefix("timeout-minutes: "))
+        .unwrap()
+        .parse::<u64>()
+        .unwrap()
+        * 60;
+    assert_eq!(weekly_step_seconds, 31 * 60);
+    assert!(weekly_step_seconds >= EXHAUSTIVE_RUNNER_ENVELOPE_SECONDS + 120);
 
     let runner = include_str!("../../../../tools/run_rust_legacy_adopter_pg.sh");
     for bounded_phase in [
@@ -2239,15 +2296,15 @@ fn ci_adopter_step_exceeds_the_full_bounded_runner_envelope() {
         "local deadline=$((SECONDS + 90))",
         "for _attempt in {1..90}; do",
         "timeout --signal=TERM --kill-after=1s \"${remaining}s\" \\",
+        "timeout --signal=TERM --kill-after=10s 300s \\",
         "timeout --signal=TERM --kill-after=10s 900s \\",
     ] {
         assert!(runner.contains(bounded_phase));
     }
-    let rollback_phase = cte_slice(
-        runner,
-        "if [ \"$status\" -eq 0 ] && [ -z \"$LIVE_FOCUS\" ]; then",
-        "\n  fi\nfi",
-    );
+    let rollback_phase = runner
+        .rsplit_once("if [ \"$status\" -eq 0 ] && [ -z \"$LIVE_FOCUS\" ]; then")
+        .unwrap()
+        .1;
     let rollback_timeout = rollback_phase
         .find("timeout --signal=TERM --kill-after=10s 300s")
         .unwrap();

--- a/rust/crates/babylon-persistence/tests/legacy_adopter_postgres.rs
+++ b/rust/crates/babylon-persistence/tests/legacy_adopter_postgres.rs
@@ -239,6 +239,11 @@ fn run_first_live_phases(
                     base, template, owner,
                 );
             }
+            Some("installed_mutation") => {
+                phases.run("h3_installed_mutations", || {
+                    h3_reference_installer_postgres::verify_h3_reference_installed_mutations(base);
+                });
+            }
             Some("h3_reference_release") => {
                 h3_reference_installer_postgres::verify_h3_reference_release_equivalence(base);
             }

--- a/rust/crates/babylon-persistence/tests/legacy_adopter_postgres.rs
+++ b/rust/crates/babylon-persistence/tests/legacy_adopter_postgres.rs
@@ -239,11 +239,7 @@ fn run_first_live_phases(
                     base, template, owner,
                 );
             }
-            Some("installed_mutation") => {
-                phases.run("h3_installed_mutations", || {
-                    h3_reference_installer_postgres::verify_h3_reference_installed_mutations(base);
-                });
-            }
+            Some("installed_mutation") => verify_h3_installed_mutations(phases, base),
             Some("h3_reference_release") => {
                 h3_reference_installer_postgres::verify_h3_reference_release_equivalence(base);
             }
@@ -306,6 +302,12 @@ fn run_first_live_phases(
         verify_effective_authority_refusals(base, template)
     );
     true
+}
+
+fn verify_h3_installed_mutations(phases: &LivePhaseReceipts, base: &Config) {
+    phases.run("h3_installed_mutations", || {
+        h3_reference_installer_postgres::verify_h3_reference_installed_mutations(base);
+    });
 }
 
 fn verify_h3_pg_oracle_in_scratch(base: &Config, owner: &str) {

--- a/rust/crates/babylon-persistence/tests/support/h3_reference_installer_postgres.rs
+++ b/rust/crates/babylon-persistence/tests/support/h3_reference_installer_postgres.rs
@@ -78,6 +78,11 @@ pub(super) fn verify_h3_reference_installer(base: &Config, legacy_template: &str
     verify_preflight_artifact_identity_conflict(base, &cohort);
 }
 
+pub(super) fn verify_h3_reference_installed_mutations(base: &Config) {
+    let cohort = representative_cohort();
+    verify_installed_state_conflicts(base, &cohort);
+}
+
 pub(super) fn verify_h3_reference_release_equivalence(base: &Config) {
     let repository = repository_root();
     let bridge = required_path(BRIDGE_PARQUET_ENV);

--- a/tools/run_rust_legacy_adopter_pg.sh
+++ b/tools/run_rust_legacy_adopter_pg.sh
@@ -21,7 +21,7 @@ die() {
 }
 
 case "$LIVE_FOCUS" in
-  "" | h3_atomicity) ;;
+  "" | h3_atomicity | installed_mutation | pr) ;;
   *) die "unsupported live focus: $LIVE_FOCUS" ;;
 esac
 
@@ -185,7 +185,7 @@ printf 'PER-20 runtime ready: container=%s volume=%s port=%s\n' \
   "$CONTAINER" "$VOLUME" "$PORT"
 cd "$REPO_ROOT/rust"
 status=0
-if [ "$LIVE_FOCUS" = "h3_atomicity" ]; then
+if [ "$LIVE_FOCUS" = "h3_atomicity" ] || [ "$LIVE_FOCUS" = "pr" ]; then
   timeout --signal=TERM --kill-after=10s 300s \
     env \
       BABYLON_LEGACY_ADOPTER_TEST_DSN="postgresql://test:test@127.0.0.1:$PORT/postgres" \
@@ -195,7 +195,22 @@ if [ "$LIVE_FOCUS" = "h3_atomicity" ]; then
     cargo test -p babylon-persistence --lib \
       schema_epoch::live_rollback_tests::h3_installer_rollback_and_ambiguous_commit_reconciliation_are_atomic \
       --locked -- --nocapture --ignored --exact --test-threads=1 || status=$?
-else
+fi
+
+if [ "$status" -eq 0 ] &&
+    { [ "$LIVE_FOCUS" = "installed_mutation" ] || [ "$LIVE_FOCUS" = "pr" ]; }; then
+  timeout --signal=TERM --kill-after=10s 300s \
+    env \
+      BABYLON_LEGACY_ADOPTER_TEST_DSN="postgresql://test:test@127.0.0.1:$PORT/postgres" \
+      BABYLON_LEGACY_ADOPTER_DISPOSABLE_ACK="$TEST_HARNESS_ACK" \
+      BABYLON_LEGACY_ADOPTER_DISPOSABLE_CANARY="$CANARY" \
+      BABYLON_LEGACY_ADOPTER_LIVE_FOCUS=installed_mutation \
+      CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/rust/target}" \
+    cargo test -p babylon-persistence --test legacy_adopter_postgres --locked -- --nocapture \
+      --ignored --test-threads=1 || status=$?
+fi
+
+if [ "$status" -eq 0 ] && [ -z "$LIVE_FOCUS" ]; then
   timeout --signal=TERM --kill-after=10s 900s \
     env \
       BABYLON_LEGACY_ADOPTER_TEST_DSN="postgresql://test:test@127.0.0.1:$PORT/postgres" \
@@ -204,18 +219,18 @@ else
       CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/rust/target}" \
     cargo test -p babylon-persistence --test legacy_adopter_postgres --locked -- --nocapture \
       --ignored --test-threads=1 || status=$?
+fi
 
-  if [ "$status" -eq 0 ] && [ -z "$LIVE_FOCUS" ]; then
-    timeout --signal=TERM --kill-after=10s 300s \
-      env \
-        BABYLON_LEGACY_ADOPTER_TEST_DSN="postgresql://test:test@127.0.0.1:$PORT/postgres" \
-        BABYLON_LEGACY_ADOPTER_DISPOSABLE_ACK="$TEST_HARNESS_ACK" \
-        BABYLON_LEGACY_ADOPTER_DISPOSABLE_CANARY="$CANARY" \
-        CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/rust/target}" \
-      cargo test -p babylon-persistence --lib \
-        schema_epoch::live_rollback_tests::rollback_and_ambiguous_commit_reconciliation_are_atomic \
-        --locked -- --nocapture --ignored --exact --test-threads=1 || status=$?
-  fi
+if [ "$status" -eq 0 ] && [ -z "$LIVE_FOCUS" ]; then
+  timeout --signal=TERM --kill-after=10s 300s \
+    env \
+      BABYLON_LEGACY_ADOPTER_TEST_DSN="postgresql://test:test@127.0.0.1:$PORT/postgres" \
+      BABYLON_LEGACY_ADOPTER_DISPOSABLE_ACK="$TEST_HARNESS_ACK" \
+      BABYLON_LEGACY_ADOPTER_DISPOSABLE_CANARY="$CANARY" \
+      CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/rust/target}" \
+    cargo test -p babylon-persistence --lib \
+      schema_epoch::live_rollback_tests::rollback_and_ambiguous_commit_reconciliation_are_atomic \
+      --locked -- --nocapture --ignored --exact --test-threads=1 || status=$?
 fi
 
 if [ "$status" -ne 0 ]; then


### PR DESCRIPTION
## Summary

- keep canonical PostgreSQL bootstrap, focused H3 atomicity, installed-state mutation refusals, and the declared integration subset on every PR
- reuse the existing typed installed-state conflict suite, including orphan membership and no-write verification
- move the untouched exhaustive adopter/census matrix and legacy rollback proof to the weekly/manual diagnostic workflow
- share one task-owned disposable PostgreSQL runtime across the two focused Rust proofs

## Evidence

- RED/GREEN source contracts for PR versus weekly cadence and bounded timeout envelopes
- final live focused proof: H3 atomicity 67.29s; installed-mutation harness 48.66s, including a 35.16s named mutation phase
- task-owned random-canary container and anonymous-volume cleanup verified
- `cargo test -p babylon-persistence --locked`
- scoped Clippy with warnings denied and Rust formatting
- 49 focused workflow/host Python contracts
- Actionlint, ShellCheck, YAML lint, pre-commit, and pre-push mirror passed; local doc-inclusive Rust hook intentionally skipped per repository policy

Part of PER-267

Program: [PER-259](https://linear.app/percy-raskova/issue/PER-259)