### PR TITLE
fix(ci): harden qualification and policy readback

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,7 +138,10 @@ jobs:
           gdal: "true"
           server: "true"
       - name: Run AI unit tests
-        run: uv run pytest tests/unit/ai -o addopts="" -vv -ra -l --tb=long --durations=0
+        run: >-
+          uv run pytest tests/unit/ai
+          -o addopts="" -m "not requires_ollama"
+          -vv -ra -l --tb=long --durations=0
 
   trivy-image:
     name: Main Qualification / Container Image Scan (advisory)

--- a/tests/unit/tools/test_main_qualification_policy.py
+++ b/tests/unit/tools/test_main_qualification_policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -105,6 +106,15 @@ def test_only_explicit_advisories_accept_a_failure_conclusion() -> None:
             assert "FAILURE" in requirement.allowed_conclusions
         else:
             assert requirement.allowed_conclusions == frozenset({"SUCCESS"})
+
+
+def test_ai_qualification_excludes_live_ollama_tests() -> None:
+    ai_job = _workflow()["jobs"]["ai-tests"]
+    test_step = next(step for step in ai_job["steps"] if step.get("name") == "Run AI unit tests")
+    argv = shlex.split(test_step["run"])
+    marker_index = argv.index("-m")
+
+    assert argv[marker_index + 1] == "not requires_ollama"
 
 
 def test_workflow_emits_every_qualification_context_once() -> None:

--- a/tests/unit/tools/test_sync_github_pr_policy.py
+++ b/tests/unit/tools/test_sync_github_pr_policy.py
@@ -274,6 +274,14 @@ def test_normalizers_strip_read_only_api_fields() -> None:
     }
 
 
+def test_ruleset_normalizer_ignores_github_rule_order() -> None:
+    desired = _ruleset(strict=True, threads=True)
+    github_readback = deepcopy(desired)
+    github_readback["rules"][-2:] = reversed(github_readback["rules"][-2:])
+
+    assert policy_tool.normalize_ruleset(github_readback) == policy_tool.normalize_ruleset(desired)
+
+
 def test_check_reports_drift_without_mutation() -> None:
     api = FakeApi()
 

--- a/tools/sync_github_pr_policy.py
+++ b/tools/sync_github_pr_policy.py
@@ -171,7 +171,13 @@ def _select_fields(payload: dict[str, object], fields: tuple[str, ...]) -> dict[
 
 def normalize_ruleset(payload: dict[str, object]) -> dict[str, object]:
     """Return only fields accepted by GitHub's ruleset update endpoint."""
-    return _select_fields(payload, RULESET_WRITABLE_FIELDS)
+    normalized = _select_fields(payload, RULESET_WRITABLE_FIELDS)
+    rules = _objects(normalized["rules"], "ruleset rules", MAX_RULESETS)
+    rule_types = [rule.get("type") for rule in rules]
+    if not all(isinstance(rule_type, str) for rule_type in rule_types):
+        raise PolicyError("ruleset rule has no string type")
+    normalized["rules"] = sorted(rules, key=lambda rule: str(rule["type"]))
+    return normalized
 
 
 def normalize_repository(payload: dict[str, object]) -> dict[str, object]:


### PR DESCRIPTION
## Summary

- keep hosted AI qualification offline by explicitly excluding requires_ollama tests after clearing pytest addopts
- compare GitHub rulesets semantically when GitHub reorders equivalent rules
- preserve exact-SHA attestation and rollback behavior

## Verification

- 196 AI tests passed; 5 live Ollama tests deselected
- 56 focused workflow and policy contracts passed
- targeted Ruff lint and formatting passed
- complete pre-push gate passed with the local Rust documentation leg skipped as required
- live GitHub policy apply and independent no-drift readback succeeded at dev da291b416d8e8fec12c1ce87e269a817c96bf89d

Part of PER-259