### PR TITLE
chore(ci): remove stale license allowance

### DIFF
--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -50,7 +50,6 @@ allow = [
   "ISC",
   "Zlib",
   "Unicode-3.0",
-  "Unicode-DFS-2016",
   "MPL-2.0",
   "CC0-1.0",
   "Unlicense",


### PR DESCRIPTION
## Summary

Remove the stale `Unicode-DFS-2016` Cargo license allowance that PER-54's exact dependency-policy gate reports as unused. This makes the gate clean instead of treating a warning as acceptable completion noise.

PR #743 already delivered PER-54's downstream evidence crate, language-neutral vectors, classifiers, proof profiles, mutation harness, and BSL footprint audit. ADR229 later retired only the duplicate Python gameplay implementation; the committed fixtures and Rust contract tests remain the language-neutral behavioral authority.

## Linear delivery

- [ ] `Part of PER-N` — partial delivery. Keep the Linear issue open.
- [x] `Fixes PER-54` — final accepted delivery. Close the Linear issue after merge.

Linear issue: https://linear.app/percy-raskova/issue/PER-54/t3-groundwork-freeze-synthetic-emergence-evidence-contracts

## Review evidence

Base branch: `dev`

Exact reviewed head SHA: `ae5e0d49c056f52e36303fd57c81879409c9ef1c`

- [x] The base branch is `dev`, or the Director approved `main`.
  - Release PR from `dev`.
  - Critical hotfix from `fix/*`, with a mandatory backport PR to `dev`.
- [ ] For a `main` target, current `origin/main` is an ancestor of the exact
      reviewed head before `main.yml` passed on that head.
- [ ] For a `main` target, this PR produced the complete combined manifest.
- [x] All reported checks completed successfully for the exact reviewed head
      SHA and base branch above.
- [x] The Copilot review completed against the exact reviewed head SHA.
- [x] I fixed each accepted Copilot finding, provided a reply to every finding,
      and resolved all Copilot review threads.

## Behavioral-contract disposition

- [ ] Changed behavior: I added or updated a durable behavioral contract.
- [x] No behavior change: the current behavioral contracts are enough.

Disposition and evidence: Dependency policy only. `cargo deny check advisories bans licenses sources` is warning-free; existing T3 bytes, classifiers, profiles, fixtures, and mutation contracts are unchanged.

## Baseline disposition

- [x] No governed baseline changed.
- [ ] A governed baseline changed intentionally. I used
      `tools/generate_ceremony_message.py` and included the required ceremony
      record and `Baselines: blessed(<slug>)` trailer.

## Merge

- [x] Merge only with `mise run pr:merge -- N`. Use this PR number for `N`.
- [ ] For a `main` target, only the Director uses
      `mise run pr:merge -- N --director-main`.
- [x] Preserve the source branch by default. Delete it only after an explicit
      owner decision and a check for dependent work.

Do not run `gh pr merge` directly in any form.

## Verification

- `cargo deny check advisories bans licenses sources`
- `cargo fmt --all -- --check`
- `cargo test -p babylon-evidence --locked`
- `cargo clippy -p babylon-evidence --all-targets --locked -- -D warnings -D clippy::pedantic`
- `cargo test -p babylon-bsl --test sfs_profile_contract --locked`
- `cargo clippy -p babylon-bsl --all-targets --locked -- -D warnings -D clippy::pedantic`
- `cargo test -p bsl-lint --locked`
- `cargo clippy -p bsl-lint --all-targets --locked -- -D warnings`
- `mise run check` — 14,658 passed, 55 declared skips, one documented xfail
- `mise run check:bsl-sentinels` — exit 0; existing citation-drift warnings remain a separate governed cleanup surface
- `mise run qa:regression` — 12 scenarios and independent-process determinism pass
- `mise run qa:vault-regression-ci` — both bakes byte-identical
- `mise run check:gate-coverage` — exit 0, but the sensor declares its scope incomplete and is not counted as coverage proof

## Questions for reviewers

None.
