### PR TITLE
feat(economy): add exact material circuit

### DIFF
--- a/ai/decisions/ADR238_material_circuit_v1.yaml
+++ b/ai/decisions/ADR238_material_circuit_v1.yaml
@@ -1,0 +1,144 @@
+ADR238_material_circuit_v1:
+  status: "accepted"
+  date: "2026-08-26"
+  title: >-
+    Material Circuit V1 makes orders, exact stocks, delayed delivery,
+    realization, and Leontief production one conserved Rust transition
+  crate: babylon-material-circuit
+  production_dependencies:
+    - babylon-kernel
+  forbidden_dependencies:
+    - babylon-graph
+    - babylon-bsl
+    - babylon-tick
+    - babylon-persistence
+    - babylon-client
+  live_activation: false
+  context: |
+    PER-30 requires orders, input-output coefficients, supplier candidates,
+    inventory, backlog, capacity, and following-week production. The live BSL
+    production conformance pack computes floating production value and credits
+    wealth. It has no exact goods, order, transit, delivery, or realization
+    principal and cannot prove the required stock-flow laws.
+
+    The frozen Python circulation modules remain reference-only under ADR229.
+    Reusing their diagnostic rates, days-of-inventory thresholds, or direct
+    production-to-wealth shortcut would create a second gameplay authority and
+    would not close an exact material ledger.
+
+    Canonical order must also remain computational identity rather than hidden
+    allocation priority. A scarce supplier stock therefore needs a conserved
+    order-neutral allocation law. Transport routing, corridor capacity, loss,
+    rerouting, and monetary settlement remain PER-31 work and must not be
+    smuggled into this local contract.
+  decision: |
+    `babylon-material-circuit` owns `MaterialCircuitStateV1` and the pure
+    `advance_material_circuit_v1` transition. Its language-neutral bytes and
+    laws live in `contracts/material_circuit_v1.yaml` and
+    `contracts/material_circuit_v1_vectors.jsonl`. Rust is the sole executable
+    implementation.
+
+    Every material identity is a distinct 32-byte type. Conserved quantities,
+    weeks, cumulative order quantities, and batch counts use unsigned 64-bit
+    integers. Checked arithmetic refuses overflow. Proportional clearing uses
+    an unsigned 128-bit intermediate, so the product and aggregate of bounded
+    unsigned 64-bit quantities remain exact.
+
+    The complete opening state owns process outputs, input-output and labor
+    coefficients, supplier candidates, inventory, commodity-sale orders,
+    backlog, sparse transit lots, process capacity, labor capacity, and one
+    following-week production commitment per process. Every row family has a
+    Designed 65,536-row serialization and transition-fuel ceiling. It is not a
+    limit on firms, workers, organizations, goods, or material abundance.
+
+    A week first credits due lots to destination inventory. It then records an
+    accepted delivery and commodity realization in that order. Dispatch cannot
+    arrive during its dispatch week. Realized quantity must remain at most
+    delivered quantity, delivered at most shipped, and shipped at most ordered.
+    Backlog always equals ordered minus shipped.
+
+    Current production consumes a prior-week commitment. For each exact labor
+    or material-input principal shared by competing processes, the transition
+    grants `floor(available * requested_i / total_requested)` to every process.
+    Residual stays with the resource principal; canonical process order receives
+    none. Actual batches equal the minimum of planned batches, process capacity,
+    each labor grant divided by labor per batch, and each material grant divided
+    by its exact input coefficient. The transition debits all used inputs and
+    labor before it credits output. Missing stock, labor, capacity, or a supplier
+    relation produces zero or partial material work and backlog; it is not an
+    engine error.
+
+    A prior-week production commitment executes before new order dispatch.
+    That temporal claim is explicit and does not depend on canonical row order.
+    Remaining supplier inventory clears across open orders proportionally by
+    `floor(available * unshipped_i / total_unshipped)`. Integer residual remains
+    supplier inventory. Canonical order receives no remainder and chooses no
+    material winner.
+
+    Dispatch debits supplier inventory and creates one sparse lot with an
+    arrival week at least one week later. Arrival removes the same exact lot and
+    credits destination inventory. Closing delivered inputs, closing labor, and
+    next-week capacity derive the following-week production commitment. That
+    commitment is the next transition's real consumer and is bounded again when
+    it executes.
+
+    Complete state bytes use one fixed domain, a version and opening week,
+    fixed field order, canonical row order, unsigned big-endian integers, and
+    raw 32-byte identities. The decoder refuses the wrong domain or version,
+    unknown access modes, truncation, trailing bytes, and noncanonical order.
+    SHA-256 identifies the validated complete state.
+
+    This slice does not alter graph or BSL state, `TickSession`, nominal world
+    identity, persistence, Archive, or Bevy. It does not activate gameplay and
+    does not claim PER-30 complete. Routed freight, losses, rerouting, price,
+    escrow, default, and settlement remain PER-31. Services, access modes beyond
+    commodity sale, waste, ecology, reproduction, and disruptive practices need
+    their separately governed consumers.
+  consequences: |
+    PER-30 now has an executable exact causal keel rather than a diagnostic
+    inventory ratio. Severing the supplier relation, withholding inputs, or
+    reducing labor or process capacity changes shipments, backlog, and later
+    production through named carriers. Delays prevent arrival, delivery, and
+    realization from collapsing into dispatch.
+
+    The current BSL production pack remains a frozen-port conformance surface;
+    it is not a consumer of this state and cannot certify the new mechanics.
+    Live activation requires the successor auxiliary-register ownership,
+    post-state basis, nominal world hash, envelope, tick integration, and a real
+    decision surface. That later cutover must retire direct production-to-wealth
+    authority where the conserved circuit supersedes it. It must not dual-write.
+
+    V1 graph, BSL, practice, persistence, and nominal-world-hash bytes remain
+    unchanged. PER-31 can extend the sparse local lot contract with routed
+    transit and settlement without redefining order or inventory conservation.
+  verification: |
+    Rust scenario tests prove shipment before arrival, accepted delivery before
+    realization, following-week input timing, Leontief bottlenecks, severed
+    supplier backlog, zero-supply material outcomes, checked-overflow atomicity,
+    canonical permutation identity, exact bytes, exact digest, decode round
+    trip, and wrong-domain, wrong-version, truncation, and trailing-byte
+    refusals. The derived 131,072 production-resource-group ceiling processes
+    its final legal group and refuses the first excess group.
+
+    Exhaustive bounded property tests cover 2,100 small two-order scarcity
+    combinations and 1,183 small input-labor-capacity combinations. They prove
+    stock conservation, shipped at most ordered and available, residual stock,
+    input debit, output credit, capacity bounds, and order-permutation identity.
+    A separate shared-input and shared-labor twin proves that process order
+    grants no material priority. Formatting and Clippy pedantic checks run with
+    warnings denied.
+  preserves:
+    - ADR223 TickSession atomicity and NominalWorldHash V1 bytes
+    - ADR224 BSL causal roles, exact effects, and audit receipts
+    - ADR229 Rust gameplay-contract authority and frozen Python boundary
+    - ADR232 material causality, successor versioning, and no authored sigmoid
+    - ADR236 order-neutral proportional allocation precedent
+  supersedes: []
+  related:
+    - ADR118_vol1_u5_headless_parity
+    - ADR200_production_port_handoff
+    - ADR220_rust_owned_postgresql_persistence_boundary
+    - ADR223_whole_tick_atomicity_world_hash
+    - ADR229_rust_gameplay_contract_authority
+    - ADR232_neel_integration_program_architecture
+    - ADR236_practice_resource_allocation_v2

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -1100,3 +1100,8 @@ decisions:
     status: accepted
     date: '2026-08-26'
     file: ADR237_strike_proposal_v2.yaml
+  ADR238_material_circuit_v1:
+    title: 'Material Circuit V1 makes orders, exact stocks, delayed delivery, realization, and Leontief production one conserved Rust transition'
+    status: accepted
+    date: '2026-08-26'
+    file: ADR238_material_circuit_v1.yaml

--- a/contracts/material_circuit_v1.yaml
+++ b/contracts/material_circuit_v1.yaml
@@ -1,0 +1,276 @@
+meta:
+  contract: MaterialCircuitV1
+  schema_version: 1
+  status: accepted
+  evidence_class: Designed
+  live_activation: false
+  rust_owner: babylon-material-circuit
+
+preserves:
+  - every existing graph, BSL, nominal-world-hash, and Practice Contract byte
+  - the frozen Python engine as reference-only evidence
+  - the PER-31 ownership of routed freight, loss, rerouting, and settlement
+
+domains:
+  state: babylon.material-circuit-state.v1
+  terminator_hex: "00"
+
+encoding:
+  byte_order: big-endian
+  integer_encoding: unsigned-fixed-width
+  quantity_encoding: u64
+  identity_encoding: raw-32-bytes
+  row_count_encoding: u32
+  trailing_bytes: forbidden
+  noncanonical_row_order: forbidden
+
+state_field_order:
+  - schema_version
+  - opening_week
+  - process_outputs
+  - input_output_coefficients
+  - labor_coefficients
+  - supplier_candidates
+  - inventory
+  - orders
+  - backlog
+  - transit_lots
+  - capacities
+  - labor_capacity
+  - production_commitments
+
+process_output_field_order:
+  - process_id
+  - site_id
+  - output_good_id
+  - unit_id
+  - quantity_per_batch
+
+input_output_coefficient_field_order:
+  - process_id
+  - input_good_id
+  - unit_id
+  - quantity_per_batch
+
+labor_coefficient_field_order:
+  - process_id
+  - labor_unit_id
+  - quantity_per_batch
+
+supplier_candidate_field_order:
+  - buyer_site_id
+  - supplier_site_id
+  - good_id
+  - unit_id
+  - transit_delay_weeks
+
+inventory_field_order:
+  - site_id
+  - good_id
+  - unit_id
+  - on_hand_quantity
+
+order_field_order:
+  - order_id
+  - access_mode
+  - buyer_site_id
+  - supplier_site_id
+  - good_id
+  - unit_id
+  - ordered_quantity
+  - shipped_quantity
+  - delivered_quantity
+  - realized_quantity
+
+backlog_field_order:
+  - order_id
+  - unshipped_quantity
+
+transit_lot_field_order:
+  - order_id
+  - dispatch_week
+  - arrival_week
+  - source_site_id
+  - destination_site_id
+  - good_id
+  - unit_id
+  - quantity
+
+capacity_field_order:
+  - process_id
+  - site_id
+  - week
+  - available_batches
+
+labor_capacity_field_order:
+  - site_id
+  - labor_unit_id
+  - week
+  - available_quantity
+
+production_commitment_field_order:
+  - process_id
+  - site_id
+  - week
+  - planned_batches
+
+access_modes:
+  commodity_sale: 1
+
+canonical_order:
+  process_outputs:
+    - process_id
+  input_output_coefficients:
+    - process_id
+    - good_id
+    - unit_id
+  labor_coefficients:
+    - process_id
+  supplier_candidates:
+    - buyer_site_id
+    - supplier_site_id
+    - good_id
+    - unit_id
+  inventory:
+    - site_id
+    - good_id
+    - unit_id
+  orders:
+    - order_id
+  backlog:
+    - order_id
+  transit_lots:
+    - arrival_week
+    - order_id
+    - dispatch_week
+  capacities:
+    - week
+    - site_id
+    - process_id
+  labor_capacity:
+    - week
+    - site_id
+    - unit_id
+  production_commitments:
+    - week
+    - site_id
+    - process_id
+  priority: canonical order grants no material priority
+
+weekly_transition_order:
+  - validate and canonicalize the complete opening state
+  - credit due arrivals to destination inventory
+  - record accepted delivery for each credited commodity-sale arrival
+  - record realization only after that accepted delivery
+  - execute prior-week production commitments through current Leontief limits
+  - allocate remaining supplier inventory proportionally across open orders
+  - debit supplier inventory and create delayed transit lots
+  - rebuild exact unshipped backlog
+  - derive following-week production from closing inputs, labor, and capacity
+  - discard consumed current-week labor and capacity rows
+  - validate and canonicalize the complete successor state
+
+production_law:
+  actual_batches: >-
+    min(planned batches, available process batches, each order-neutral shared
+    labor grant divided by labor per batch, and each order-neutral shared input
+    grant divided by its input per batch)
+  shared_scarcity: >-
+    each exact labor or input principal grants floor(available * requested_i /
+    total_requested) to every competing process; integer residual remains with
+    the resource principal
+  shared_priority: canonical process order receives no residual and selects no winner
+  temporal_priority: >-
+    a prior-week production commitment executes before new order dispatch; this
+    is commitment timing, not canonical-row priority
+  input_debit: each material input and labor quantity is debited before output is credited
+  output_credit: actual batches times exact output quantity per batch
+  zero_supply: zero production is a committed material outcome, not an engine error
+
+order_allocation_law:
+  grouping: open orders group by exact supplier inventory identity
+  full_supply: every order receives its remaining unshipped quantity
+  scarcity: shipped_i = floor(available * unshipped_i / total_unshipped)
+  intermediate: u128 product and sum over u64 quantities
+  residual: division remainder stays in supplier inventory
+  missing_supplier_relation: the order remains backlog and no goods move
+  missing_stock: the order remains backlog and no goods are created
+
+timing_laws:
+  - transit delay is at least one week
+  - dispatch never arrives or realizes during its dispatch week
+  - arrival credits destination inventory before accepted delivery
+  - accepted delivery precedes commodity realization
+  - delivered inputs can create a following-week commitment but not a new arrival-week commitment
+  - a stored following-week commitment is bounded again when it executes
+
+conservation_laws:
+  - realized quantity is at most delivered quantity
+  - delivered quantity is at most shipped quantity
+  - shipped quantity is at most ordered quantity
+  - backlog equals ordered quantity minus shipped quantity
+  - dispatch debits supplier inventory by the exact transit-lot quantity
+  - arrival removes the exact transit lot and credits destination inventory by the same quantity
+  - opening transit plus dispatch equals arrival plus closing transit
+  - proportional allocation never exceeds opening available inventory
+  - shared production grants never exceed opening labor or material input
+  - checked overflow refuses without publishing a successor state
+
+limits:
+  rows_per_family:
+    value: 65536
+    classification: Designed
+    purpose: serialization, memory, and transition fuel ceiling, not material abundance
+  production_resource_groups:
+    value: 131072
+    derivation: rows_per_family * 2 for the disjoint input and labor resource families
+
+canonical_lengths:
+  fixed_state_header_bytes: 88
+  process_output_row_bytes: 136
+  input_output_coefficient_row_bytes: 104
+  labor_coefficient_row_bytes: 72
+  supplier_candidate_row_bytes: 130
+  inventory_row_bytes: 104
+  order_row_bytes: 193
+  backlog_row_bytes: 40
+  transit_lot_row_bytes: 184
+  capacity_row_bytes: 80
+  labor_capacity_row_bytes: 80
+  production_commitment_row_bytes: 80
+
+digest_contract:
+  algorithm: SHA-256
+  preimage: validated canonical complete-state bytes
+
+base_vector:
+  canonical_bytes: 1555
+  digest_hex: 3576baa1af2a38be8a1376259dc4423a470607ad9eef5969715931e16b30620a
+
+error_codes:
+  row_limit: 1
+  zero_quantity: 2
+  duplicate_row: 3
+  order_invariant: 4
+  backlog_invariant: 5
+  transit_invariant: 6
+  process_invariant: 7
+  week_invariant: 8
+  arithmetic: 9
+  wire_limit: 10
+  wire_domain: 11
+  wire_version: 12
+  wire_truncated: 13
+  wire_trailing: 14
+  wire_enum: 15
+  wire_noncanonical: 16
+
+excluded_surfaces:
+  - monetary price, escrow, default, or settlement
+  - corridor, port, rail, road, border, loss, or rerouting state
+  - access modes other than commodity sale
+  - service or care production
+  - waste, spoilage, damage, or ecological residue
+  - strike, blockade, occupation, damage, or capital-strike effects
+  - graph, BSL, TickSession, nominal-world-hash, envelope, or persistence integration
+  - receipt bytes, Archive output, Bevy action, or gameplay activation

--- a/contracts/material_circuit_v1_vectors.jsonl
+++ b/contracts/material_circuit_v1_vectors.jsonl
@@ -1,0 +1,2 @@
+{"case_id":"base-opening-state","kind":"state","data":{"canonical_bytes":1555,"digest_hex":"3576baa1af2a38be8a1376259dc4423a470607ad9eef5969715931e16b30620a"}}
+{"case_id":"manifest","kind":"manifest","data":{"schema_version":1,"quantity_width_bits":64,"rows_per_family":65536,"production_resource_groups":131072,"error_code_count":16,"access_mode_count":1}}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -435,6 +435,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "babylon-material-circuit"
+version = "0.1.0"
+dependencies = [
+ "babylon-kernel",
+ "serde_json",
+]
+
+[[package]]
 name = "babylon-persistence"
 version = "0.1.0"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/babylon-kernel",
+    "crates/babylon-material-circuit",
     "crates/babylon-practice-contract",
     "crates/babylon-graph",
     "crates/babylon-bsl",

--- a/rust/crates/babylon-material-circuit/Cargo.toml
+++ b/rust/crates/babylon-material-circuit/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "babylon-material-circuit"
+description = "Exact conserved production, inventory, order, and realization transitions"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+babylon-kernel = { path = "../babylon-kernel" }
+
+[dev-dependencies]
+serde_json = "1"
+
+[lib]
+name = "babylon_material_circuit"
+path = "src/lib.rs"

--- a/rust/crates/babylon-material-circuit/src/lib.rs
+++ b/rust/crates/babylon-material-circuit/src/lib.rs
@@ -1,0 +1,14 @@
+//! Exact conserved production, inventory, order, and realization transitions.
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+
+mod model;
+mod transition;
+mod wire;
+
+pub use model::*;
+pub use transition::advance_material_circuit_v1;
+pub use wire::{
+    decode_material_circuit_state_v1, encode_material_circuit_state_v1,
+    material_circuit_state_v1_digest, MATERIAL_CIRCUIT_STATE_V1_DOMAIN_BYTES,
+};

--- a/rust/crates/babylon-material-circuit/src/model.rs
+++ b/rust/crates/babylon-material-circuit/src/model.rs
@@ -1,0 +1,271 @@
+//! Versioned exact-quantity rows for the local material circuit.
+
+/// Designed serialization and validation ceiling, not material abundance.
+pub const MAX_MATERIAL_CIRCUIT_ROWS_V1: usize = 65_536;
+/// Derived transition ceiling for disjoint input and labor resource groups.
+pub const MAX_PRODUCTION_RESOURCE_GROUPS_V1: usize = MAX_MATERIAL_CIRCUIT_ROWS_V1 * 2;
+
+macro_rules! identity_type {
+    ($name:ident) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[repr(transparent)]
+        pub struct $name([u8; 32]);
+
+        impl $name {
+            #[must_use]
+            pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+                Self(bytes)
+            }
+
+            #[must_use]
+            pub const fn as_bytes(self) -> [u8; 32] {
+                self.0
+            }
+        }
+    };
+}
+
+identity_type!(SiteIdV1);
+identity_type!(GoodIdV1);
+identity_type!(UnitIdV1);
+identity_type!(ProcessIdV1);
+identity_type!(OrderIdV1);
+
+/// One process output coefficient in exact units per batch.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ProcessOutputV1 {
+    pub process_id: ProcessIdV1,
+    pub site_id: SiteIdV1,
+    pub good_id: GoodIdV1,
+    pub unit_id: UnitIdV1,
+    pub quantity_per_batch: u64,
+}
+
+/// One Leontief material-input coefficient in exact units per batch.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct InputOutputCoefficientV1 {
+    pub process_id: ProcessIdV1,
+    pub good_id: GoodIdV1,
+    pub unit_id: UnitIdV1,
+    pub quantity_per_batch: u64,
+}
+
+/// Exact labor-time required for one process batch.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LaborCoefficientV1 {
+    pub process_id: ProcessIdV1,
+    pub unit_id: UnitIdV1,
+    pub quantity_per_batch: u64,
+}
+
+/// A materially possible buyer-supplier relation with a local transit delay.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SupplierCandidateV1 {
+    pub buyer_site_id: SiteIdV1,
+    pub supplier_site_id: SiteIdV1,
+    pub good_id: GoodIdV1,
+    pub unit_id: UnitIdV1,
+    pub transit_delay_weeks: u16,
+}
+
+/// Exact on-hand inventory at one site.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct InventoryRowV1 {
+    pub site_id: SiteIdV1,
+    pub good_id: GoodIdV1,
+    pub unit_id: UnitIdV1,
+    pub quantity: u64,
+}
+
+/// Closed V1 access mode for orders that can realize after delivery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum OrderAccessModeV1 {
+    CommoditySale = 1,
+}
+
+/// Cumulative commodity-sale order quantities.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct OrderRowV1 {
+    pub order_id: OrderIdV1,
+    pub access_mode: OrderAccessModeV1,
+    pub buyer_site_id: SiteIdV1,
+    pub supplier_site_id: SiteIdV1,
+    pub good_id: GoodIdV1,
+    pub unit_id: UnitIdV1,
+    pub ordered: u64,
+    pub shipped: u64,
+    pub delivered: u64,
+    pub realized: u64,
+}
+
+/// Materialized unshipped demand for one order.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BacklogRowV1 {
+    pub order_id: OrderIdV1,
+    pub quantity: u64,
+}
+
+/// One sparse local in-transit lot.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TransitLotV1 {
+    pub order_id: OrderIdV1,
+    pub dispatch_week: u64,
+    pub arrival_week: u64,
+    pub source_site_id: SiteIdV1,
+    pub destination_site_id: SiteIdV1,
+    pub good_id: GoodIdV1,
+    pub unit_id: UnitIdV1,
+    pub quantity: u64,
+}
+
+/// Available process batches at one site and week.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CapacityRowV1 {
+    pub process_id: ProcessIdV1,
+    pub site_id: SiteIdV1,
+    pub week: u64,
+    pub available_batches: u64,
+}
+
+/// Available attributed labor-time at one site and week.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LaborCapacityRowV1 {
+    pub site_id: SiteIdV1,
+    pub unit_id: UnitIdV1,
+    pub week: u64,
+    pub available: u64,
+}
+
+/// A plan derived at the prior close and bounded again when executed.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ProductionCommitmentV1 {
+    pub process_id: ProcessIdV1,
+    pub site_id: SiteIdV1,
+    pub week: u64,
+    pub planned_batches: u64,
+}
+
+/// Complete V1 auxiliary register state at the opening of `week`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaterialCircuitStateV1 {
+    pub week: u64,
+    pub process_outputs: Vec<ProcessOutputV1>,
+    pub input_coefficients: Vec<InputOutputCoefficientV1>,
+    pub labor_coefficients: Vec<LaborCoefficientV1>,
+    pub supplier_candidates: Vec<SupplierCandidateV1>,
+    pub inventory: Vec<InventoryRowV1>,
+    pub orders: Vec<OrderRowV1>,
+    pub backlog: Vec<BacklogRowV1>,
+    pub transit: Vec<TransitLotV1>,
+    pub capacities: Vec<CapacityRowV1>,
+    pub labor: Vec<LaborCapacityRowV1>,
+    pub production_commitments: Vec<ProductionCommitmentV1>,
+}
+
+/// Exact V1 material-circuit refusal classes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum MaterialCircuitErrorV1 {
+    RowLimit = 1,
+    ZeroQuantity = 2,
+    DuplicateRow = 3,
+    OrderInvariant = 4,
+    BacklogInvariant = 5,
+    TransitInvariant = 6,
+    ProcessInvariant = 7,
+    WeekInvariant = 8,
+    Arithmetic = 9,
+    WireLimit = 10,
+    WireDomain = 11,
+    WireVersion = 12,
+    WireTruncated = 13,
+    WireTrailing = 14,
+    WireEnum = 15,
+    WireNoncanonical = 16,
+}
+
+/// Unknown language-neutral material-circuit refusal code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnknownMaterialCircuitErrorCodeV1(pub u16);
+
+impl TryFrom<u16> for MaterialCircuitErrorV1 {
+    type Error = UnknownMaterialCircuitErrorCodeV1;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::RowLimit),
+            2 => Ok(Self::ZeroQuantity),
+            3 => Ok(Self::DuplicateRow),
+            4 => Ok(Self::OrderInvariant),
+            5 => Ok(Self::BacklogInvariant),
+            6 => Ok(Self::TransitInvariant),
+            7 => Ok(Self::ProcessInvariant),
+            8 => Ok(Self::WeekInvariant),
+            9 => Ok(Self::Arithmetic),
+            10 => Ok(Self::WireLimit),
+            11 => Ok(Self::WireDomain),
+            12 => Ok(Self::WireVersion),
+            13 => Ok(Self::WireTruncated),
+            14 => Ok(Self::WireTrailing),
+            15 => Ok(Self::WireEnum),
+            16 => Ok(Self::WireNoncanonical),
+            _ => Err(UnknownMaterialCircuitErrorCodeV1(value)),
+        }
+    }
+}
+
+impl From<MaterialCircuitErrorV1> for u16 {
+    fn from(value: MaterialCircuitErrorV1) -> Self {
+        value as Self
+    }
+}
+
+/// Actual production and its planned upper bound.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProductionReceiptV1 {
+    pub process_id: ProcessIdV1,
+    pub site_id: SiteIdV1,
+    pub planned_batches: u64,
+    pub produced_batches: u64,
+}
+
+/// Inventory moved into one sparse transit lot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DispatchReceiptV1 {
+    pub order_id: OrderIdV1,
+    pub quantity: u64,
+    pub arrival_week: u64,
+}
+
+/// One lot credited to destination inventory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArrivalReceiptV1 {
+    pub order_id: OrderIdV1,
+    pub quantity: u64,
+}
+
+/// Accepted commodity-sale delivery after destination inventory is credited.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeliveryReceiptV1 {
+    pub order_id: OrderIdV1,
+    pub quantity: u64,
+}
+
+/// Commodity quantity realized only after its accepted arrival.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RealizationReceiptV1 {
+    pub order_id: OrderIdV1,
+    pub quantity: u64,
+}
+
+/// Atomic result of closing one material-circuit week.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaterialCircuitTransitionV1 {
+    pub state: MaterialCircuitStateV1,
+    pub production: Vec<ProductionReceiptV1>,
+    pub dispatches: Vec<DispatchReceiptV1>,
+    pub arrivals: Vec<ArrivalReceiptV1>,
+    pub deliveries: Vec<DeliveryReceiptV1>,
+    pub realizations: Vec<RealizationReceiptV1>,
+}

--- a/rust/crates/babylon-material-circuit/src/transition.rs
+++ b/rust/crates/babylon-material-circuit/src/transition.rs
@@ -1,0 +1,972 @@
+//! Pure weekly transition for the exact local material circuit.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{
+    ArrivalReceiptV1, BacklogRowV1, DeliveryReceiptV1, DispatchReceiptV1, GoodIdV1, InventoryRowV1,
+    MaterialCircuitErrorV1, MaterialCircuitStateV1, MaterialCircuitTransitionV1, OrderIdV1,
+    ProcessIdV1, ProductionReceiptV1, RealizationReceiptV1, SiteIdV1, TransitLotV1, UnitIdV1,
+    MAX_MATERIAL_CIRCUIT_ROWS_V1, MAX_PRODUCTION_RESOURCE_GROUPS_V1,
+};
+
+type InventoryKey = (SiteIdV1, GoodIdV1, UnitIdV1);
+type SupplierKey = (SiteIdV1, SiteIdV1, GoodIdV1, UnitIdV1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ProductionResourceKey {
+    Input(InventoryKey),
+    Labor(SiteIdV1, UnitIdV1),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ProductionResourceRequest {
+    commitment_index: usize,
+    quantity_per_batch: u64,
+    requested: u64,
+}
+
+fn check_row_limits(state: &MaterialCircuitStateV1) -> Result<(), MaterialCircuitErrorV1> {
+    let lengths = [
+        state.process_outputs.len(),
+        state.input_coefficients.len(),
+        state.labor_coefficients.len(),
+        state.supplier_candidates.len(),
+        state.inventory.len(),
+        state.orders.len(),
+        state.backlog.len(),
+        state.transit.len(),
+        state.capacities.len(),
+        state.labor.len(),
+        state.production_commitments.len(),
+    ];
+    if lengths
+        .into_iter()
+        .any(|length| length > MAX_MATERIAL_CIRCUIT_ROWS_V1)
+    {
+        return Err(MaterialCircuitErrorV1::RowLimit);
+    }
+    Ok(())
+}
+
+fn has_duplicate<T, K: PartialEq>(rows: &[T], key: impl Fn(&T) -> K) -> bool {
+    rows.windows(2)
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1)
+        .any(|pair| key(&pair[0]) == key(&pair[1]))
+}
+
+fn canonicalize_rows(state: &mut MaterialCircuitStateV1) {
+    state.process_outputs.sort();
+    state.input_coefficients.sort();
+    state.labor_coefficients.sort();
+    state.supplier_candidates.sort();
+    state.inventory.sort();
+    state.orders.sort_by_key(|row| row.order_id);
+    state.backlog.sort_by_key(|row| row.order_id);
+    state
+        .transit
+        .sort_by_key(|row| (row.arrival_week, row.order_id, row.dispatch_week));
+    state
+        .capacities
+        .sort_by_key(|row| (row.week, row.site_id, row.process_id));
+    state
+        .labor
+        .sort_by_key(|row| (row.week, row.site_id, row.unit_id));
+    state
+        .production_commitments
+        .sort_by_key(|row| (row.week, row.site_id, row.process_id));
+}
+
+fn validate_unique_rows(state: &MaterialCircuitStateV1) -> Result<(), MaterialCircuitErrorV1> {
+    let transit_keys: BTreeSet<_> = state
+        .transit
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|row| (row.order_id, row.dispatch_week))
+        .collect();
+    let duplicate = has_duplicate(&state.process_outputs, |row| row.process_id)
+        || has_duplicate(&state.input_coefficients, |row| {
+            (row.process_id, row.good_id, row.unit_id)
+        })
+        || has_duplicate(&state.labor_coefficients, |row| row.process_id)
+        || has_duplicate(&state.supplier_candidates, |row| {
+            (
+                row.buyer_site_id,
+                row.supplier_site_id,
+                row.good_id,
+                row.unit_id,
+            )
+        })
+        || has_duplicate(&state.inventory, |row| {
+            (row.site_id, row.good_id, row.unit_id)
+        })
+        || has_duplicate(&state.orders, |row| row.order_id)
+        || has_duplicate(&state.backlog, |row| row.order_id)
+        || transit_keys.len() != state.transit.len()
+        || has_duplicate(&state.capacities, |row| {
+            (row.week, row.site_id, row.process_id)
+        })
+        || has_duplicate(&state.labor, |row| (row.week, row.site_id, row.unit_id))
+        || has_duplicate(&state.production_commitments, |row| {
+            (row.week, row.site_id, row.process_id)
+        });
+    if duplicate {
+        return Err(MaterialCircuitErrorV1::DuplicateRow);
+    }
+    Ok(())
+}
+
+fn validate_processes(state: &MaterialCircuitStateV1) -> Result<(), MaterialCircuitErrorV1> {
+    let process_ids: BTreeSet<_> = state
+        .process_outputs
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|row| row.process_id)
+        .collect();
+    for row in state
+        .process_outputs
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        if row.quantity_per_batch == 0 {
+            return Err(MaterialCircuitErrorV1::ZeroQuantity);
+        }
+    }
+    for row in state
+        .input_coefficients
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        if row.quantity_per_batch == 0 || !process_ids.contains(&row.process_id) {
+            return Err(MaterialCircuitErrorV1::ProcessInvariant);
+        }
+    }
+    for row in state
+        .labor_coefficients
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        if row.quantity_per_batch == 0 || !process_ids.contains(&row.process_id) {
+            return Err(MaterialCircuitErrorV1::ProcessInvariant);
+        }
+    }
+    if state.process_outputs.len() != state.labor_coefficients.len() {
+        return Err(MaterialCircuitErrorV1::ProcessInvariant);
+    }
+    for row in state
+        .capacities
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        let output = state
+            .process_outputs
+            .iter()
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+            .find(|output| output.process_id == row.process_id);
+        if output.is_none_or(|output| output.site_id != row.site_id) {
+            return Err(MaterialCircuitErrorV1::ProcessInvariant);
+        }
+    }
+    for row in state
+        .production_commitments
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        let output = state
+            .process_outputs
+            .iter()
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+            .find(|output| output.process_id == row.process_id);
+        if output.is_none_or(|output| output.site_id != row.site_id) {
+            return Err(MaterialCircuitErrorV1::ProcessInvariant);
+        }
+    }
+    Ok(())
+}
+
+fn validate_orders(state: &MaterialCircuitStateV1) -> Result<(), MaterialCircuitErrorV1> {
+    if state.orders.len() != state.backlog.len() {
+        return Err(MaterialCircuitErrorV1::BacklogInvariant);
+    }
+    for (order, backlog) in state
+        .orders
+        .iter()
+        .zip(&state.backlog)
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        if order.ordered == 0 {
+            return Err(MaterialCircuitErrorV1::ZeroQuantity);
+        }
+        if order.realized > order.delivered
+            || order.delivered > order.shipped
+            || order.shipped > order.ordered
+        {
+            return Err(MaterialCircuitErrorV1::OrderInvariant);
+        }
+        if backlog.order_id != order.order_id || backlog.quantity != order.ordered - order.shipped {
+            return Err(MaterialCircuitErrorV1::BacklogInvariant);
+        }
+    }
+    Ok(())
+}
+
+fn validate_transit(state: &MaterialCircuitStateV1) -> Result<(), MaterialCircuitErrorV1> {
+    let mut in_transit = BTreeMap::<OrderIdV1, u128>::new();
+    for lot in state.transit.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        let Some(order) = state
+            .orders
+            .iter()
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+            .find(|row| row.order_id == lot.order_id)
+        else {
+            return Err(MaterialCircuitErrorV1::TransitInvariant);
+        };
+        if lot.quantity == 0
+            || lot.dispatch_week >= lot.arrival_week
+            || lot.dispatch_week >= state.week
+            || lot.arrival_week < state.week
+            || lot.source_site_id != order.supplier_site_id
+            || lot.destination_site_id != order.buyer_site_id
+            || lot.good_id != order.good_id
+            || lot.unit_id != order.unit_id
+        {
+            return Err(MaterialCircuitErrorV1::TransitInvariant);
+        }
+        let total = in_transit.entry(lot.order_id).or_default();
+        *total = total
+            .checked_add(u128::from(lot.quantity))
+            .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+    }
+    for order in state.orders.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        let expected = u128::from(order.shipped - order.delivered);
+        if in_transit.get(&order.order_id).copied().unwrap_or(0) != expected {
+            return Err(MaterialCircuitErrorV1::TransitInvariant);
+        }
+    }
+    Ok(())
+}
+
+fn validate_weeks(state: &MaterialCircuitStateV1) -> Result<(), MaterialCircuitErrorV1> {
+    if state.week == 0
+        || state
+            .supplier_candidates
+            .iter()
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+            .any(|row| row.transit_delay_weeks == 0)
+        || state
+            .production_commitments
+            .iter()
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+            .any(|row| row.week != state.week || row.planned_batches == 0)
+        || state
+            .capacities
+            .iter()
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+            .any(|row| row.week < state.week)
+        || state
+            .labor
+            .iter()
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+            .any(|row| row.week < state.week)
+    {
+        return Err(MaterialCircuitErrorV1::WeekInvariant);
+    }
+    Ok(())
+}
+
+pub(crate) fn canonical_state_v1(
+    state: &MaterialCircuitStateV1,
+) -> Result<MaterialCircuitStateV1, MaterialCircuitErrorV1> {
+    check_row_limits(state)?;
+    let mut canonical = state.clone();
+    canonicalize_rows(&mut canonical);
+    validate_unique_rows(&canonical)?;
+    validate_processes(&canonical)?;
+    validate_orders(&canonical)?;
+    validate_transit(&canonical)?;
+    validate_weeks(&canonical)?;
+    Ok(canonical)
+}
+
+fn inventory_index(state: &MaterialCircuitStateV1, key: InventoryKey) -> Option<usize> {
+    state
+        .inventory
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .position(|row| (row.site_id, row.good_id, row.unit_id) == key)
+}
+
+fn credit_inventory(
+    state: &mut MaterialCircuitStateV1,
+    key: InventoryKey,
+    quantity: u64,
+) -> Result<(), MaterialCircuitErrorV1> {
+    if let Some(index) = inventory_index(state, key) {
+        state.inventory[index].quantity = state.inventory[index]
+            .quantity
+            .checked_add(quantity)
+            .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+        return Ok(());
+    }
+    if state.inventory.len() == MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        return Err(MaterialCircuitErrorV1::RowLimit);
+    }
+    state.inventory.push(InventoryRowV1 {
+        site_id: key.0,
+        good_id: key.1,
+        unit_id: key.2,
+        quantity,
+    });
+    Ok(())
+}
+
+fn debit_inventory(
+    state: &mut MaterialCircuitStateV1,
+    key: InventoryKey,
+    quantity: u64,
+) -> Result<(), MaterialCircuitErrorV1> {
+    if quantity == 0 {
+        return Ok(());
+    }
+    let index = inventory_index(state, key).ok_or(MaterialCircuitErrorV1::ProcessInvariant)?;
+    state.inventory[index].quantity = state.inventory[index]
+        .quantity
+        .checked_sub(quantity)
+        .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+    Ok(())
+}
+
+fn process_arrivals(
+    state: &mut MaterialCircuitStateV1,
+    arrivals: &mut Vec<ArrivalReceiptV1>,
+    deliveries: &mut Vec<DeliveryReceiptV1>,
+    realizations: &mut Vec<RealizationReceiptV1>,
+) -> Result<(), MaterialCircuitErrorV1> {
+    let opening = std::mem::take(&mut state.transit);
+    let mut remaining = Vec::with_capacity(opening.len());
+    for lot in opening.into_iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        if lot.arrival_week != state.week {
+            remaining.push(lot);
+            continue;
+        }
+        credit_inventory(
+            state,
+            (lot.destination_site_id, lot.good_id, lot.unit_id),
+            lot.quantity,
+        )?;
+        let order = state
+            .orders
+            .iter_mut()
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+            .find(|row| row.order_id == lot.order_id)
+            .ok_or(MaterialCircuitErrorV1::TransitInvariant)?;
+        order.delivered = order
+            .delivered
+            .checked_add(lot.quantity)
+            .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+        order.realized = order
+            .realized
+            .checked_add(lot.quantity)
+            .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+        if order.delivered > order.shipped || order.realized > order.delivered {
+            return Err(MaterialCircuitErrorV1::OrderInvariant);
+        }
+        arrivals.push(ArrivalReceiptV1 {
+            order_id: lot.order_id,
+            quantity: lot.quantity,
+        });
+        deliveries.push(DeliveryReceiptV1 {
+            order_id: lot.order_id,
+            quantity: lot.quantity,
+        });
+        realizations.push(RealizationReceiptV1 {
+            order_id: lot.order_id,
+            quantity: lot.quantity,
+        });
+    }
+    state.transit = remaining;
+    Ok(())
+}
+
+fn process_capacity(state: &MaterialCircuitStateV1, process: ProcessIdV1, week: u64) -> u64 {
+    state
+        .capacities
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .find(|row| row.process_id == process && row.week == week)
+        .map_or(0, |row| row.available_batches)
+}
+
+fn labor_capacity_index(
+    state: &MaterialCircuitStateV1,
+    site: SiteIdV1,
+    unit: UnitIdV1,
+    week: u64,
+) -> Option<usize> {
+    state
+        .labor
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .position(|row| row.site_id == site && row.unit_id == unit && row.week == week)
+}
+
+fn initial_production_allocations(
+    state: &MaterialCircuitStateV1,
+    commitments: &[crate::ProductionCommitmentV1],
+    week: u64,
+) -> Result<Vec<u64>, MaterialCircuitErrorV1> {
+    let mut allocations = Vec::with_capacity(commitments.len());
+    for commitment in commitments.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        let output = state
+            .process_outputs
+            .iter()
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+            .find(|row| row.process_id == commitment.process_id)
+            .ok_or(MaterialCircuitErrorV1::ProcessInvariant)?;
+        if output.site_id != commitment.site_id || commitment.week != week {
+            return Err(MaterialCircuitErrorV1::ProcessInvariant);
+        }
+        allocations.push(commitment.planned_batches.min(process_capacity(
+            state,
+            commitment.process_id,
+            week,
+        )));
+    }
+    Ok(allocations)
+}
+
+fn add_production_request(
+    groups: &mut BTreeMap<ProductionResourceKey, Vec<ProductionResourceRequest>>,
+    key: ProductionResourceKey,
+    commitment_index: usize,
+    quantity_per_batch: u64,
+    batches: u64,
+) -> Result<(), MaterialCircuitErrorV1> {
+    let requested = quantity_per_batch
+        .checked_mul(batches)
+        .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+    groups
+        .entry(key)
+        .or_default()
+        .push(ProductionResourceRequest {
+            commitment_index,
+            quantity_per_batch,
+            requested,
+        });
+    Ok(())
+}
+
+fn production_resource_groups(
+    state: &MaterialCircuitStateV1,
+    commitments: &[crate::ProductionCommitmentV1],
+    allocations: &[u64],
+) -> Result<BTreeMap<ProductionResourceKey, Vec<ProductionResourceRequest>>, MaterialCircuitErrorV1>
+{
+    let mut groups = BTreeMap::new();
+    for (index, commitment) in commitments
+        .iter()
+        .enumerate()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        let labor = state
+            .labor_coefficients
+            .iter()
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+            .find(|row| row.process_id == commitment.process_id)
+            .ok_or(MaterialCircuitErrorV1::ProcessInvariant)?;
+        add_production_request(
+            &mut groups,
+            ProductionResourceKey::Labor(commitment.site_id, labor.unit_id),
+            index,
+            labor.quantity_per_batch,
+            allocations[index],
+        )?;
+        for input in state
+            .input_coefficients
+            .iter()
+            .filter(|row| row.process_id == commitment.process_id)
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        {
+            add_production_request(
+                &mut groups,
+                ProductionResourceKey::Input((commitment.site_id, input.good_id, input.unit_id)),
+                index,
+                input.quantity_per_batch,
+                allocations[index],
+            )?;
+        }
+    }
+    Ok(groups)
+}
+
+fn production_resource_available(
+    state: &MaterialCircuitStateV1,
+    key: ProductionResourceKey,
+    week: u64,
+) -> u64 {
+    match key {
+        ProductionResourceKey::Input(inventory_key) => {
+            inventory_index(state, inventory_key).map_or(0, |index| state.inventory[index].quantity)
+        }
+        ProductionResourceKey::Labor(site, unit) => labor_capacity_index(state, site, unit, week)
+            .map_or(0, |index| state.labor[index].available),
+    }
+}
+
+fn apply_production_resource_limits(
+    state: &MaterialCircuitStateV1,
+    week: u64,
+    groups: &BTreeMap<ProductionResourceKey, Vec<ProductionResourceRequest>>,
+    allocations: &mut [u64],
+) -> Result<(), MaterialCircuitErrorV1> {
+    if groups.len() > MAX_PRODUCTION_RESOURCE_GROUPS_V1 {
+        return Err(MaterialCircuitErrorV1::RowLimit);
+    }
+    for (key, requests) in groups.iter().take(MAX_PRODUCTION_RESOURCE_GROUPS_V1) {
+        let total = requests.iter().try_fold(0_u128, |sum, request| {
+            sum.checked_add(u128::from(request.requested))
+                .ok_or(MaterialCircuitErrorV1::Arithmetic)
+        })?;
+        let available = production_resource_available(state, *key, week);
+        for request in requests.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+            let granted = if u128::from(available) >= total {
+                request.requested
+            } else {
+                let share = u128::from(available) * u128::from(request.requested) / total;
+                u64::try_from(share).map_err(|_| MaterialCircuitErrorV1::Arithmetic)?
+            };
+            allocations[request.commitment_index] =
+                allocations[request.commitment_index].min(granted / request.quantity_per_batch);
+        }
+    }
+    Ok(())
+}
+
+fn allocate_production_batches(
+    state: &MaterialCircuitStateV1,
+    commitments: &[crate::ProductionCommitmentV1],
+    week: u64,
+) -> Result<Vec<u64>, MaterialCircuitErrorV1> {
+    let mut allocations = initial_production_allocations(state, commitments, week)?;
+    let groups = production_resource_groups(state, commitments, &allocations)?;
+    apply_production_resource_limits(state, week, &groups, &mut allocations)?;
+    Ok(allocations)
+}
+
+fn execute_production(
+    state: &mut MaterialCircuitStateV1,
+    receipts: &mut Vec<ProductionReceiptV1>,
+) -> Result<(), MaterialCircuitErrorV1> {
+    let commitments = std::mem::take(&mut state.production_commitments);
+    let allocations = allocate_production_batches(state, &commitments, state.week)?;
+    for (index, commitment) in commitments
+        .into_iter()
+        .enumerate()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        apply_production_allocation(state, &commitment, allocations[index], receipts)?;
+    }
+    Ok(())
+}
+
+fn apply_production_allocation(
+    state: &mut MaterialCircuitStateV1,
+    commitment: &crate::ProductionCommitmentV1,
+    batches: u64,
+    receipts: &mut Vec<ProductionReceiptV1>,
+) -> Result<(), MaterialCircuitErrorV1> {
+    let output = state
+        .process_outputs
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .find(|row| row.process_id == commitment.process_id)
+        .cloned()
+        .ok_or(MaterialCircuitErrorV1::ProcessInvariant)?;
+    consume_production_inputs(state, commitment.process_id, commitment.site_id, batches)?;
+    let produced = output
+        .quantity_per_batch
+        .checked_mul(batches)
+        .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+    credit_inventory(
+        state,
+        (output.site_id, output.good_id, output.unit_id),
+        produced,
+    )?;
+    receipts.push(ProductionReceiptV1 {
+        process_id: commitment.process_id,
+        site_id: commitment.site_id,
+        planned_batches: commitment.planned_batches,
+        produced_batches: batches,
+    });
+    Ok(())
+}
+
+fn consume_production_inputs(
+    state: &mut MaterialCircuitStateV1,
+    process: ProcessIdV1,
+    site: SiteIdV1,
+    batches: u64,
+) -> Result<(), MaterialCircuitErrorV1> {
+    if batches == 0 {
+        return Ok(());
+    }
+    let inputs: Vec<_> = state
+        .input_coefficients
+        .iter()
+        .filter(|row| row.process_id == process)
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .cloned()
+        .collect();
+    for input in inputs.into_iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        let quantity = input
+            .quantity_per_batch
+            .checked_mul(batches)
+            .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+        debit_inventory(state, (site, input.good_id, input.unit_id), quantity)?;
+    }
+    let labor = state
+        .labor_coefficients
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .find(|row| row.process_id == process)
+        .cloned()
+        .ok_or(MaterialCircuitErrorV1::ProcessInvariant)?;
+    let labor_used = labor
+        .quantity_per_batch
+        .checked_mul(batches)
+        .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+    let index = labor_capacity_index(state, site, labor.unit_id, state.week)
+        .ok_or(MaterialCircuitErrorV1::ProcessInvariant)?;
+    state.labor[index].available = state.labor[index]
+        .available
+        .checked_sub(labor_used)
+        .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+    Ok(())
+}
+
+fn supplier_delays(state: &MaterialCircuitStateV1) -> BTreeMap<SupplierKey, u16> {
+    state
+        .supplier_candidates
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|row| {
+            (
+                (
+                    row.buyer_site_id,
+                    row.supplier_site_id,
+                    row.good_id,
+                    row.unit_id,
+                ),
+                row.transit_delay_weeks,
+            )
+        })
+        .collect()
+}
+
+fn request_groups(
+    state: &MaterialCircuitStateV1,
+    delays: &BTreeMap<SupplierKey, u16>,
+) -> BTreeMap<InventoryKey, Vec<usize>> {
+    let mut groups = BTreeMap::<InventoryKey, Vec<usize>>::new();
+    for (index, order) in state
+        .orders
+        .iter()
+        .enumerate()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        let candidate = (
+            order.buyer_site_id,
+            order.supplier_site_id,
+            order.good_id,
+            order.unit_id,
+        );
+        if order.shipped < order.ordered && delays.contains_key(&candidate) {
+            groups
+                .entry((order.supplier_site_id, order.good_id, order.unit_id))
+                .or_default()
+                .push(index);
+        }
+    }
+    groups
+}
+
+fn group_allocations(
+    state: &MaterialCircuitStateV1,
+    indices: &[usize],
+    available: u64,
+) -> Result<Vec<(usize, u64)>, MaterialCircuitErrorV1> {
+    let mut total = 0_u128;
+    for index in indices
+        .iter()
+        .copied()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        total = total
+            .checked_add(u128::from(
+                state.orders[index].ordered - state.orders[index].shipped,
+            ))
+            .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+    }
+    let mut allocations = Vec::with_capacity(indices.len());
+    for index in indices
+        .iter()
+        .copied()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        let requested = state.orders[index].ordered - state.orders[index].shipped;
+        let allocated = if u128::from(available) >= total {
+            requested
+        } else {
+            let share = u128::from(available) * u128::from(requested) / total;
+            u64::try_from(share).map_err(|_| MaterialCircuitErrorV1::Arithmetic)?
+        };
+        allocations.push((index, allocated));
+    }
+    Ok(allocations)
+}
+
+fn dispatch_orders(
+    state: &mut MaterialCircuitStateV1,
+    receipts: &mut Vec<DispatchReceiptV1>,
+) -> Result<(), MaterialCircuitErrorV1> {
+    let delays = supplier_delays(state);
+    let groups = request_groups(state, &delays);
+    for (inventory_key, indices) in groups.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        let available = inventory_index(state, *inventory_key)
+            .map_or(0, |index| state.inventory[index].quantity);
+        let allocations = group_allocations(state, indices, available)?;
+        let allocated = allocations.iter().try_fold(0_u64, |total, (_, quantity)| {
+            total
+                .checked_add(*quantity)
+                .ok_or(MaterialCircuitErrorV1::Arithmetic)
+        })?;
+        debit_inventory(state, *inventory_key, allocated)?;
+        apply_dispatches(state, &delays, allocations, receipts)?;
+    }
+    Ok(())
+}
+
+fn apply_dispatches(
+    state: &mut MaterialCircuitStateV1,
+    delays: &BTreeMap<SupplierKey, u16>,
+    allocations: Vec<(usize, u64)>,
+    receipts: &mut Vec<DispatchReceiptV1>,
+) -> Result<(), MaterialCircuitErrorV1> {
+    for (index, quantity) in allocations
+        .into_iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        if quantity == 0 {
+            continue;
+        }
+        let order = state.orders[index].clone();
+        let delay = delays[&(
+            order.buyer_site_id,
+            order.supplier_site_id,
+            order.good_id,
+            order.unit_id,
+        )];
+        let arrival_week = state
+            .week
+            .checked_add(u64::from(delay))
+            .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+        state.orders[index].shipped = state.orders[index]
+            .shipped
+            .checked_add(quantity)
+            .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+        state.transit.push(TransitLotV1 {
+            order_id: order.order_id,
+            dispatch_week: state.week,
+            arrival_week,
+            source_site_id: order.supplier_site_id,
+            destination_site_id: order.buyer_site_id,
+            good_id: order.good_id,
+            unit_id: order.unit_id,
+            quantity,
+        });
+        receipts.push(DispatchReceiptV1 {
+            order_id: order.order_id,
+            quantity,
+            arrival_week,
+        });
+    }
+    Ok(())
+}
+
+fn rebuild_backlog(state: &mut MaterialCircuitStateV1) {
+    state.backlog = state
+        .orders
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|order| BacklogRowV1 {
+            order_id: order.order_id,
+            quantity: order.ordered - order.shipped,
+        })
+        .collect();
+}
+
+fn derive_next_week_production(
+    state: &mut MaterialCircuitStateV1,
+    next_week: u64,
+) -> Result<(), MaterialCircuitErrorV1> {
+    let candidates: Vec<_> = state
+        .process_outputs
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|output| crate::ProductionCommitmentV1 {
+            process_id: output.process_id,
+            site_id: output.site_id,
+            week: next_week,
+            planned_batches: process_capacity(state, output.process_id, next_week),
+        })
+        .collect();
+    let allocations = allocate_production_batches(state, &candidates, next_week)?;
+    for (index, candidate) in candidates
+        .into_iter()
+        .enumerate()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        let batches = allocations[index];
+        if batches > 0 {
+            state
+                .production_commitments
+                .push(crate::ProductionCommitmentV1 {
+                    process_id: candidate.process_id,
+                    site_id: candidate.site_id,
+                    week: next_week,
+                    planned_batches: batches,
+                });
+        }
+    }
+    Ok(())
+}
+
+fn prune_consumed_capacity(state: &mut MaterialCircuitStateV1, next_week: u64) {
+    state.capacities = std::mem::take(&mut state.capacities)
+        .into_iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .filter(|row| row.week >= next_week)
+        .collect();
+    state.labor = std::mem::take(&mut state.labor)
+        .into_iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .filter(|row| row.week >= next_week)
+        .collect();
+}
+
+/// Close one week atomically and return its canonical successor state.
+///
+/// # Errors
+/// Returns the first exact schema, invariant, bound, or arithmetic refusal.
+pub fn advance_material_circuit_v1(
+    opening: &MaterialCircuitStateV1,
+) -> Result<MaterialCircuitTransitionV1, MaterialCircuitErrorV1> {
+    let mut state = canonical_state_v1(opening)?;
+    let mut arrivals = Vec::new();
+    let mut deliveries = Vec::new();
+    let mut realizations = Vec::new();
+    let mut production = Vec::new();
+    let mut dispatches = Vec::new();
+    process_arrivals(
+        &mut state,
+        &mut arrivals,
+        &mut deliveries,
+        &mut realizations,
+    )?;
+    execute_production(&mut state, &mut production)?;
+    dispatch_orders(&mut state, &mut dispatches)?;
+    rebuild_backlog(&mut state);
+    let next_week = state
+        .week
+        .checked_add(1)
+        .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+    derive_next_week_production(&mut state, next_week)?;
+    prune_consumed_capacity(&mut state, next_week);
+    state.week = next_week;
+    state = canonical_state_v1(&state)?;
+    Ok(MaterialCircuitTransitionV1 {
+        state,
+        production,
+        dispatches,
+        arrivals,
+        deliveries,
+        realizations,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn numbered_identity(index: usize) -> [u8; 32] {
+        let mut bytes = [0_u8; 32];
+        let number = u64::try_from(index).expect("designed group bound fits u64");
+        bytes[24..].copy_from_slice(&number.to_be_bytes());
+        bytes
+    }
+
+    fn empty_state() -> MaterialCircuitStateV1 {
+        MaterialCircuitStateV1 {
+            week: 1,
+            process_outputs: Vec::new(),
+            input_coefficients: Vec::new(),
+            labor_coefficients: Vec::new(),
+            supplier_candidates: Vec::new(),
+            inventory: Vec::new(),
+            orders: Vec::new(),
+            backlog: Vec::new(),
+            transit: Vec::new(),
+            capacities: Vec::new(),
+            labor: Vec::new(),
+            production_commitments: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn resource_group_bound_covers_both_families_and_refuses_plus_one() {
+        let site = SiteIdV1::from_bytes([1; 32]);
+        let unit = UnitIdV1::from_bytes([2; 32]);
+        let mut groups = BTreeMap::new();
+        for index in 0..MAX_PRODUCTION_RESOURCE_GROUPS_V1 {
+            groups.insert(
+                ProductionResourceKey::Input((
+                    site,
+                    GoodIdV1::from_bytes(numbered_identity(index)),
+                    unit,
+                )),
+                Vec::new(),
+            );
+        }
+        let last_key = ProductionResourceKey::Input((
+            site,
+            GoodIdV1::from_bytes(numbered_identity(MAX_PRODUCTION_RESOURCE_GROUPS_V1 - 1)),
+            unit,
+        ));
+        groups.insert(
+            last_key,
+            vec![ProductionResourceRequest {
+                commitment_index: 0,
+                quantity_per_batch: 1,
+                requested: 1,
+            }],
+        );
+        let mut allocations = [1];
+        assert_eq!(
+            apply_production_resource_limits(&empty_state(), 1, &groups, &mut allocations),
+            Ok(())
+        );
+        assert_eq!(allocations, [0]);
+
+        groups.insert(
+            ProductionResourceKey::Input((
+                site,
+                GoodIdV1::from_bytes(numbered_identity(MAX_PRODUCTION_RESOURCE_GROUPS_V1)),
+                unit,
+            )),
+            Vec::new(),
+        );
+        assert_eq!(
+            apply_production_resource_limits(&empty_state(), 1, &groups, &mut allocations),
+            Err(MaterialCircuitErrorV1::RowLimit)
+        );
+    }
+}

--- a/rust/crates/babylon-material-circuit/src/transition.rs
+++ b/rust/crates/babylon-material-circuit/src/transition.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 
 type InventoryKey = (SiteIdV1, GoodIdV1, UnitIdV1);
+type InventoryLedger = BTreeMap<InventoryKey, u64>;
 type SupplierKey = (SiteIdV1, SiteIdV1, GoodIdV1, UnitIdV1);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -22,7 +23,49 @@ enum ProductionResourceKey {
 struct ProductionResourceRequest {
     commitment_index: usize,
     quantity_per_batch: u64,
-    requested: u64,
+    requested: u128,
+}
+
+fn process_output(
+    state: &MaterialCircuitStateV1,
+    process: ProcessIdV1,
+) -> Option<&crate::ProcessOutputV1> {
+    state
+        .process_outputs
+        .binary_search_by_key(&process, |row| row.process_id)
+        .ok()
+        .map(|index| &state.process_outputs[index])
+}
+
+fn labor_coefficient(
+    state: &MaterialCircuitStateV1,
+    process: ProcessIdV1,
+) -> Option<&crate::LaborCoefficientV1> {
+    state
+        .labor_coefficients
+        .binary_search_by_key(&process, |row| row.process_id)
+        .ok()
+        .map(|index| &state.labor_coefficients[index])
+}
+
+fn input_coefficients(
+    state: &MaterialCircuitStateV1,
+    process: ProcessIdV1,
+) -> &[crate::InputOutputCoefficientV1] {
+    let start = state
+        .input_coefficients
+        .partition_point(|row| row.process_id < process);
+    let end = state
+        .input_coefficients
+        .partition_point(|row| row.process_id <= process);
+    &state.input_coefficients[start..end]
+}
+
+fn order_index(state: &MaterialCircuitStateV1, order: OrderIdV1) -> Option<usize> {
+    state
+        .orders
+        .binary_search_by_key(&order, |row| row.order_id)
+        .ok()
 }
 
 fn check_row_limits(state: &MaterialCircuitStateV1) -> Result<(), MaterialCircuitErrorV1> {
@@ -157,11 +200,7 @@ fn validate_processes(state: &MaterialCircuitStateV1) -> Result<(), MaterialCirc
         .iter()
         .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
     {
-        let output = state
-            .process_outputs
-            .iter()
-            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
-            .find(|output| output.process_id == row.process_id);
+        let output = process_output(state, row.process_id);
         if output.is_none_or(|output| output.site_id != row.site_id) {
             return Err(MaterialCircuitErrorV1::ProcessInvariant);
         }
@@ -171,11 +210,7 @@ fn validate_processes(state: &MaterialCircuitStateV1) -> Result<(), MaterialCirc
         .iter()
         .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
     {
-        let output = state
-            .process_outputs
-            .iter()
-            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
-            .find(|output| output.process_id == row.process_id);
+        let output = process_output(state, row.process_id);
         if output.is_none_or(|output| output.site_id != row.site_id) {
             return Err(MaterialCircuitErrorV1::ProcessInvariant);
         }
@@ -212,14 +247,10 @@ fn validate_orders(state: &MaterialCircuitStateV1) -> Result<(), MaterialCircuit
 fn validate_transit(state: &MaterialCircuitStateV1) -> Result<(), MaterialCircuitErrorV1> {
     let mut in_transit = BTreeMap::<OrderIdV1, u128>::new();
     for lot in state.transit.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
-        let Some(order) = state
-            .orders
-            .iter()
-            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
-            .find(|row| row.order_id == lot.order_id)
-        else {
+        let Some(index) = order_index(state, lot.order_id) else {
             return Err(MaterialCircuitErrorV1::TransitInvariant);
         };
+        let order = &state.orders[index];
         if lot.quantity == 0
             || lot.dispatch_week >= lot.arrival_week
             || lot.dispatch_week >= state.week
@@ -287,49 +318,60 @@ pub(crate) fn canonical_state_v1(
     Ok(canonical)
 }
 
-fn inventory_index(state: &MaterialCircuitStateV1, key: InventoryKey) -> Option<usize> {
-    state
-        .inventory
-        .iter()
+fn take_inventory(state: &mut MaterialCircuitStateV1) -> InventoryLedger {
+    std::mem::take(&mut state.inventory)
+        .into_iter()
         .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
-        .position(|row| (row.site_id, row.good_id, row.unit_id) == key)
+        .map(|row| ((row.site_id, row.good_id, row.unit_id), row.quantity))
+        .collect()
+}
+
+fn publish_inventory(state: &mut MaterialCircuitStateV1, inventory: InventoryLedger) {
+    state.inventory = inventory
+        .into_iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|((site_id, good_id, unit_id), quantity)| InventoryRowV1 {
+            site_id,
+            good_id,
+            unit_id,
+            quantity,
+        })
+        .collect();
 }
 
 fn credit_inventory(
-    state: &mut MaterialCircuitStateV1,
-    key: InventoryKey,
-    quantity: u64,
-) -> Result<(), MaterialCircuitErrorV1> {
-    if let Some(index) = inventory_index(state, key) {
-        state.inventory[index].quantity = state.inventory[index]
-            .quantity
-            .checked_add(quantity)
-            .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
-        return Ok(());
-    }
-    if state.inventory.len() == MAX_MATERIAL_CIRCUIT_ROWS_V1 {
-        return Err(MaterialCircuitErrorV1::RowLimit);
-    }
-    state.inventory.push(InventoryRowV1 {
-        site_id: key.0,
-        good_id: key.1,
-        unit_id: key.2,
-        quantity,
-    });
-    Ok(())
-}
-
-fn debit_inventory(
-    state: &mut MaterialCircuitStateV1,
+    inventory: &mut InventoryLedger,
     key: InventoryKey,
     quantity: u64,
 ) -> Result<(), MaterialCircuitErrorV1> {
     if quantity == 0 {
         return Ok(());
     }
-    let index = inventory_index(state, key).ok_or(MaterialCircuitErrorV1::ProcessInvariant)?;
-    state.inventory[index].quantity = state.inventory[index]
-        .quantity
+    if let Some(current) = inventory.get_mut(&key) {
+        *current = current
+            .checked_add(quantity)
+            .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+        return Ok(());
+    }
+    if inventory.len() == MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        return Err(MaterialCircuitErrorV1::RowLimit);
+    }
+    inventory.insert(key, quantity);
+    Ok(())
+}
+
+fn debit_inventory(
+    inventory: &mut InventoryLedger,
+    key: InventoryKey,
+    quantity: u64,
+) -> Result<(), MaterialCircuitErrorV1> {
+    if quantity == 0 {
+        return Ok(());
+    }
+    let current = inventory
+        .get_mut(&key)
+        .ok_or(MaterialCircuitErrorV1::ProcessInvariant)?;
+    *current = current
         .checked_sub(quantity)
         .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
     Ok(())
@@ -337,6 +379,7 @@ fn debit_inventory(
 
 fn process_arrivals(
     state: &mut MaterialCircuitStateV1,
+    inventory: &mut InventoryLedger,
     arrivals: &mut Vec<ArrivalReceiptV1>,
     deliveries: &mut Vec<DeliveryReceiptV1>,
     realizations: &mut Vec<RealizationReceiptV1>,
@@ -349,16 +392,13 @@ fn process_arrivals(
             continue;
         }
         credit_inventory(
-            state,
+            inventory,
             (lot.destination_site_id, lot.good_id, lot.unit_id),
             lot.quantity,
         )?;
-        let order = state
-            .orders
-            .iter_mut()
-            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
-            .find(|row| row.order_id == lot.order_id)
-            .ok_or(MaterialCircuitErrorV1::TransitInvariant)?;
+        let order_index =
+            order_index(state, lot.order_id).ok_or(MaterialCircuitErrorV1::TransitInvariant)?;
+        let order = &mut state.orders[order_index];
         order.delivered = order
             .delivered
             .checked_add(lot.quantity)
@@ -387,13 +427,19 @@ fn process_arrivals(
     Ok(())
 }
 
-fn process_capacity(state: &MaterialCircuitStateV1, process: ProcessIdV1, week: u64) -> u64 {
+fn process_capacity(
+    state: &MaterialCircuitStateV1,
+    process: ProcessIdV1,
+    site: SiteIdV1,
+    week: u64,
+) -> u64 {
     state
         .capacities
-        .iter()
-        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
-        .find(|row| row.process_id == process && row.week == week)
-        .map_or(0, |row| row.available_batches)
+        .binary_search_by_key(&(week, site, process), |row| {
+            (row.week, row.site_id, row.process_id)
+        })
+        .ok()
+        .map_or(0, |index| state.capacities[index].available_batches)
 }
 
 fn labor_capacity_index(
@@ -404,9 +450,10 @@ fn labor_capacity_index(
 ) -> Option<usize> {
     state
         .labor
-        .iter()
-        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
-        .position(|row| row.site_id == site && row.unit_id == unit && row.week == week)
+        .binary_search_by_key(&(week, site, unit), |row| {
+            (row.week, row.site_id, row.unit_id)
+        })
+        .ok()
 }
 
 fn initial_production_allocations(
@@ -416,11 +463,7 @@ fn initial_production_allocations(
 ) -> Result<Vec<u64>, MaterialCircuitErrorV1> {
     let mut allocations = Vec::with_capacity(commitments.len());
     for commitment in commitments.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
-        let output = state
-            .process_outputs
-            .iter()
-            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
-            .find(|row| row.process_id == commitment.process_id)
+        let output = process_output(state, commitment.process_id)
             .ok_or(MaterialCircuitErrorV1::ProcessInvariant)?;
         if output.site_id != commitment.site_id || commitment.week != week {
             return Err(MaterialCircuitErrorV1::ProcessInvariant);
@@ -428,6 +471,7 @@ fn initial_production_allocations(
         allocations.push(commitment.planned_batches.min(process_capacity(
             state,
             commitment.process_id,
+            commitment.site_id,
             week,
         )));
     }
@@ -441,8 +485,8 @@ fn add_production_request(
     quantity_per_batch: u64,
     batches: u64,
 ) -> Result<(), MaterialCircuitErrorV1> {
-    let requested = quantity_per_batch
-        .checked_mul(batches)
+    let requested = u128::from(quantity_per_batch)
+        .checked_mul(u128::from(batches))
         .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
     groups
         .entry(key)
@@ -467,11 +511,7 @@ fn production_resource_groups(
         .enumerate()
         .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
     {
-        let labor = state
-            .labor_coefficients
-            .iter()
-            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
-            .find(|row| row.process_id == commitment.process_id)
+        let labor = labor_coefficient(state, commitment.process_id)
             .ok_or(MaterialCircuitErrorV1::ProcessInvariant)?;
         add_production_request(
             &mut groups,
@@ -480,10 +520,8 @@ fn production_resource_groups(
             labor.quantity_per_batch,
             allocations[index],
         )?;
-        for input in state
-            .input_coefficients
+        for input in input_coefficients(state, commitment.process_id)
             .iter()
-            .filter(|row| row.process_id == commitment.process_id)
             .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
         {
             add_production_request(
@@ -500,20 +538,56 @@ fn production_resource_groups(
 
 fn production_resource_available(
     state: &MaterialCircuitStateV1,
+    inventory: &InventoryLedger,
     key: ProductionResourceKey,
     week: u64,
 ) -> u64 {
     match key {
         ProductionResourceKey::Input(inventory_key) => {
-            inventory_index(state, inventory_key).map_or(0, |index| state.inventory[index].quantity)
+            inventory.get(&inventory_key).copied().unwrap_or(0)
         }
         ProductionResourceKey::Labor(site, unit) => labor_capacity_index(state, site, unit, week)
             .map_or(0, |index| state.labor[index].available),
     }
 }
 
+fn wide_product(multiplier: u64, multiplicand: u128) -> [u64; 3] {
+    let low_mask = u128::from(u64::MAX);
+    let low_multiplicand =
+        u64::try_from(multiplicand & low_mask).expect("masking a u128 to 64 low bits must fit u64");
+    let low_product = u128::from(multiplier) * u128::from(low_multiplicand);
+    let high_product = u128::from(multiplier) * (multiplicand >> 64) + (low_product >> 64);
+    let high_limb =
+        u64::try_from(high_product >> 64).expect("shifting a u128 right by 64 bits must fit u64");
+    let middle_limb =
+        u64::try_from(high_product & low_mask).expect("masking a u128 to 64 low bits must fit u64");
+    let low_limb =
+        u64::try_from(low_product & low_mask).expect("masking a u128 to 64 low bits must fit u64");
+    [high_limb, middle_limb, low_limb]
+}
+
+fn proportional_floor(
+    available: u64,
+    requested: u128,
+    total: u128,
+) -> Result<u64, MaterialCircuitErrorV1> {
+    if total == 0 || requested > total {
+        return Err(MaterialCircuitErrorV1::Arithmetic);
+    }
+    let target = wide_product(available, requested);
+    let mut quotient = 0_u64;
+    for bit in (0_u32..64).rev() {
+        let candidate = quotient | (1_u64 << bit);
+        if candidate <= available && wide_product(candidate, total) <= target {
+            quotient = candidate;
+        }
+    }
+    Ok(quotient)
+}
+
 fn apply_production_resource_limits(
     state: &MaterialCircuitStateV1,
+    inventory: &InventoryLedger,
     week: u64,
     groups: &BTreeMap<ProductionResourceKey, Vec<ProductionResourceRequest>>,
     allocations: &mut [u64],
@@ -522,20 +596,25 @@ fn apply_production_resource_limits(
         return Err(MaterialCircuitErrorV1::RowLimit);
     }
     for (key, requests) in groups.iter().take(MAX_PRODUCTION_RESOURCE_GROUPS_V1) {
-        let total = requests.iter().try_fold(0_u128, |sum, request| {
-            sum.checked_add(u128::from(request.requested))
-                .ok_or(MaterialCircuitErrorV1::Arithmetic)
-        })?;
-        let available = production_resource_available(state, *key, week);
+        let total = requests
+            .iter()
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+            .try_fold(0_u128, |sum, request| {
+                sum.checked_add(request.requested)
+                    .ok_or(MaterialCircuitErrorV1::Arithmetic)
+            })?;
+        let available = production_resource_available(state, inventory, *key, week);
         for request in requests.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
-            let granted = if u128::from(available) >= total {
+            let granted_units = if u128::from(available) >= total {
                 request.requested
             } else {
-                let share = u128::from(available) * u128::from(request.requested) / total;
-                u64::try_from(share).map_err(|_| MaterialCircuitErrorV1::Arithmetic)?
+                u128::from(proportional_floor(available, request.requested, total)?)
             };
+            let granted_batches = granted_units / u128::from(request.quantity_per_batch);
+            let granted_batches =
+                u64::try_from(granted_batches).map_err(|_| MaterialCircuitErrorV1::Arithmetic)?;
             allocations[request.commitment_index] =
-                allocations[request.commitment_index].min(granted / request.quantity_per_batch);
+                allocations[request.commitment_index].min(granted_batches);
         }
     }
     Ok(())
@@ -543,65 +622,87 @@ fn apply_production_resource_limits(
 
 fn allocate_production_batches(
     state: &MaterialCircuitStateV1,
+    inventory: &InventoryLedger,
     commitments: &[crate::ProductionCommitmentV1],
     week: u64,
 ) -> Result<Vec<u64>, MaterialCircuitErrorV1> {
     let mut allocations = initial_production_allocations(state, commitments, week)?;
     let groups = production_resource_groups(state, commitments, &allocations)?;
-    apply_production_resource_limits(state, week, &groups, &mut allocations)?;
+    apply_production_resource_limits(state, inventory, week, &groups, &mut allocations)?;
     Ok(allocations)
 }
 
 fn execute_production(
     state: &mut MaterialCircuitStateV1,
+    inventory: &mut InventoryLedger,
     receipts: &mut Vec<ProductionReceiptV1>,
 ) -> Result<(), MaterialCircuitErrorV1> {
     let commitments = std::mem::take(&mut state.production_commitments);
-    let allocations = allocate_production_batches(state, &commitments, state.week)?;
+    let allocations = allocate_production_batches(state, inventory, &commitments, state.week)?;
+    debit_production_allocations(state, inventory, &commitments, &allocations)?;
+    credit_production_allocations(state, inventory, commitments, &allocations, receipts)
+}
+
+fn debit_production_allocations(
+    state: &mut MaterialCircuitStateV1,
+    inventory: &mut InventoryLedger,
+    commitments: &[crate::ProductionCommitmentV1],
+    allocations: &[u64],
+) -> Result<(), MaterialCircuitErrorV1> {
+    for (index, commitment) in commitments
+        .iter()
+        .enumerate()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        consume_production_inputs(
+            state,
+            inventory,
+            commitment.process_id,
+            commitment.site_id,
+            allocations[index],
+        )?;
+    }
+    Ok(())
+}
+
+fn credit_production_allocations(
+    state: &mut MaterialCircuitStateV1,
+    inventory: &mut InventoryLedger,
+    commitments: Vec<crate::ProductionCommitmentV1>,
+    allocations: &[u64],
+    receipts: &mut Vec<ProductionReceiptV1>,
+) -> Result<(), MaterialCircuitErrorV1> {
     for (index, commitment) in commitments
         .into_iter()
         .enumerate()
         .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
     {
-        apply_production_allocation(state, &commitment, allocations[index], receipts)?;
+        let output = process_output(state, commitment.process_id)
+            .cloned()
+            .ok_or(MaterialCircuitErrorV1::ProcessInvariant)?;
+        let batches = allocations[index];
+        let produced = output
+            .quantity_per_batch
+            .checked_mul(batches)
+            .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
+        credit_inventory(
+            inventory,
+            (output.site_id, output.good_id, output.unit_id),
+            produced,
+        )?;
+        receipts.push(ProductionReceiptV1 {
+            process_id: commitment.process_id,
+            site_id: commitment.site_id,
+            planned_batches: commitment.planned_batches,
+            produced_batches: batches,
+        });
     }
-    Ok(())
-}
-
-fn apply_production_allocation(
-    state: &mut MaterialCircuitStateV1,
-    commitment: &crate::ProductionCommitmentV1,
-    batches: u64,
-    receipts: &mut Vec<ProductionReceiptV1>,
-) -> Result<(), MaterialCircuitErrorV1> {
-    let output = state
-        .process_outputs
-        .iter()
-        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
-        .find(|row| row.process_id == commitment.process_id)
-        .cloned()
-        .ok_or(MaterialCircuitErrorV1::ProcessInvariant)?;
-    consume_production_inputs(state, commitment.process_id, commitment.site_id, batches)?;
-    let produced = output
-        .quantity_per_batch
-        .checked_mul(batches)
-        .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
-    credit_inventory(
-        state,
-        (output.site_id, output.good_id, output.unit_id),
-        produced,
-    )?;
-    receipts.push(ProductionReceiptV1 {
-        process_id: commitment.process_id,
-        site_id: commitment.site_id,
-        planned_batches: commitment.planned_batches,
-        produced_batches: batches,
-    });
     Ok(())
 }
 
 fn consume_production_inputs(
     state: &mut MaterialCircuitStateV1,
+    inventory: &mut InventoryLedger,
     process: ProcessIdV1,
     site: SiteIdV1,
     batches: u64,
@@ -609,25 +710,20 @@ fn consume_production_inputs(
     if batches == 0 {
         return Ok(());
     }
-    let inputs: Vec<_> = state
-        .input_coefficients
+    let inputs: Vec<_> = input_coefficients(state, process)
         .iter()
-        .filter(|row| row.process_id == process)
         .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
-        .cloned()
+        .map(|row| (row.good_id, row.unit_id, row.quantity_per_batch))
         .collect();
-    for input in inputs.into_iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
-        let quantity = input
-            .quantity_per_batch
+    for (good, unit, quantity_per_batch) in
+        inputs.into_iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        let quantity = quantity_per_batch
             .checked_mul(batches)
             .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
-        debit_inventory(state, (site, input.good_id, input.unit_id), quantity)?;
+        debit_inventory(inventory, (site, good, unit), quantity)?;
     }
-    let labor = state
-        .labor_coefficients
-        .iter()
-        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
-        .find(|row| row.process_id == process)
+    let labor = labor_coefficient(state, process)
         .cloned()
         .ok_or(MaterialCircuitErrorV1::ProcessInvariant)?;
     let labor_used = labor
@@ -726,20 +822,20 @@ fn group_allocations(
 
 fn dispatch_orders(
     state: &mut MaterialCircuitStateV1,
+    inventory: &mut InventoryLedger,
     receipts: &mut Vec<DispatchReceiptV1>,
 ) -> Result<(), MaterialCircuitErrorV1> {
     let delays = supplier_delays(state);
     let groups = request_groups(state, &delays);
     for (inventory_key, indices) in groups.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
-        let available = inventory_index(state, *inventory_key)
-            .map_or(0, |index| state.inventory[index].quantity);
+        let available = inventory.get(inventory_key).copied().unwrap_or(0);
         let allocations = group_allocations(state, indices, available)?;
         let allocated = allocations.iter().try_fold(0_u64, |total, (_, quantity)| {
             total
                 .checked_add(*quantity)
                 .ok_or(MaterialCircuitErrorV1::Arithmetic)
         })?;
-        debit_inventory(state, *inventory_key, allocated)?;
+        debit_inventory(inventory, *inventory_key, allocated)?;
         apply_dispatches(state, &delays, allocations, receipts)?;
     }
     Ok(())
@@ -806,6 +902,7 @@ fn rebuild_backlog(state: &mut MaterialCircuitStateV1) {
 
 fn derive_next_week_production(
     state: &mut MaterialCircuitStateV1,
+    inventory: &InventoryLedger,
     next_week: u64,
 ) -> Result<(), MaterialCircuitErrorV1> {
     let candidates: Vec<_> = state
@@ -816,10 +913,10 @@ fn derive_next_week_production(
             process_id: output.process_id,
             site_id: output.site_id,
             week: next_week,
-            planned_batches: process_capacity(state, output.process_id, next_week),
+            planned_batches: process_capacity(state, output.process_id, output.site_id, next_week),
         })
         .collect();
-    let allocations = allocate_production_batches(state, &candidates, next_week)?;
+    let allocations = allocate_production_batches(state, inventory, &candidates, next_week)?;
     for (index, candidate) in candidates
         .into_iter()
         .enumerate()
@@ -861,6 +958,7 @@ pub fn advance_material_circuit_v1(
     opening: &MaterialCircuitStateV1,
 ) -> Result<MaterialCircuitTransitionV1, MaterialCircuitErrorV1> {
     let mut state = canonical_state_v1(opening)?;
+    let mut inventory = take_inventory(&mut state);
     let mut arrivals = Vec::new();
     let mut deliveries = Vec::new();
     let mut realizations = Vec::new();
@@ -868,19 +966,21 @@ pub fn advance_material_circuit_v1(
     let mut dispatches = Vec::new();
     process_arrivals(
         &mut state,
+        &mut inventory,
         &mut arrivals,
         &mut deliveries,
         &mut realizations,
     )?;
-    execute_production(&mut state, &mut production)?;
-    dispatch_orders(&mut state, &mut dispatches)?;
+    execute_production(&mut state, &mut inventory, &mut production)?;
+    dispatch_orders(&mut state, &mut inventory, &mut dispatches)?;
     rebuild_backlog(&mut state);
     let next_week = state
         .week
         .checked_add(1)
         .ok_or(MaterialCircuitErrorV1::Arithmetic)?;
-    derive_next_week_production(&mut state, next_week)?;
+    derive_next_week_production(&mut state, &inventory, next_week)?;
     prune_consumed_capacity(&mut state, next_week);
+    publish_inventory(&mut state, inventory);
     state.week = next_week;
     state = canonical_state_v1(&state)?;
     Ok(MaterialCircuitTransitionV1 {
@@ -951,7 +1051,13 @@ mod tests {
         );
         let mut allocations = [1];
         assert_eq!(
-            apply_production_resource_limits(&empty_state(), 1, &groups, &mut allocations),
+            apply_production_resource_limits(
+                &empty_state(),
+                &BTreeMap::new(),
+                1,
+                &groups,
+                &mut allocations,
+            ),
             Ok(())
         );
         assert_eq!(allocations, [0]);
@@ -965,8 +1071,35 @@ mod tests {
             Vec::new(),
         );
         assert_eq!(
-            apply_production_resource_limits(&empty_state(), 1, &groups, &mut allocations),
+            apply_production_resource_limits(
+                &empty_state(),
+                &BTreeMap::new(),
+                1,
+                &groups,
+                &mut allocations,
+            ),
             Err(MaterialCircuitErrorV1::RowLimit)
+        );
+    }
+
+    #[test]
+    fn wide_proportional_floor_is_exact_without_overflow() {
+        for available in 0_u64..=20 {
+            for total in 1_u128..=20 {
+                for requested in 0_u128..=total {
+                    assert_eq!(
+                        proportional_floor(available, requested, total),
+                        Ok(
+                            available * u64::try_from(requested).expect("small request fits u64")
+                                / u64::try_from(total).expect("small total fits u64")
+                        )
+                    );
+                }
+            }
+        }
+        assert_eq!(
+            proportional_floor(u64::MAX, u128::MAX - 1, u128::MAX),
+            Ok(u64::MAX - 1)
         );
     }
 }

--- a/rust/crates/babylon-material-circuit/src/wire.rs
+++ b/rust/crates/babylon-material-circuit/src/wire.rs
@@ -1,0 +1,567 @@
+//! Canonical V1 state bytes for restart, replay, and language-neutral vectors.
+
+use babylon_kernel::sha256_of;
+
+use crate::transition::canonical_state_v1;
+use crate::{
+    BacklogRowV1, CapacityRowV1, GoodIdV1, InputOutputCoefficientV1, InventoryRowV1,
+    LaborCapacityRowV1, LaborCoefficientV1, MaterialCircuitErrorV1, MaterialCircuitStateV1,
+    OrderAccessModeV1, OrderIdV1, OrderRowV1, ProcessIdV1, ProcessOutputV1, ProductionCommitmentV1,
+    SiteIdV1, SupplierCandidateV1, TransitLotV1, UnitIdV1, MAX_MATERIAL_CIRCUIT_ROWS_V1,
+};
+
+/// Canonical domain for one complete material-circuit opening state.
+pub const MATERIAL_CIRCUIT_STATE_V1_DOMAIN_BYTES: &[u8] = b"babylon.material-circuit-state.v1";
+const SCHEMA_VERSION: u16 = 1;
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    index: usize,
+}
+
+impl<'a> Cursor<'a> {
+    const fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, index: 0 }
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], MaterialCircuitErrorV1> {
+        let end = self
+            .index
+            .checked_add(length)
+            .ok_or(MaterialCircuitErrorV1::WireTruncated)?;
+        let output = self
+            .bytes
+            .get(self.index..end)
+            .ok_or(MaterialCircuitErrorV1::WireTruncated)?;
+        self.index = end;
+        Ok(output)
+    }
+
+    fn array<const N: usize>(&mut self) -> Result<[u8; N], MaterialCircuitErrorV1> {
+        self.take(N)?
+            .try_into()
+            .map_err(|_| MaterialCircuitErrorV1::WireTruncated)
+    }
+
+    fn u8(&mut self) -> Result<u8, MaterialCircuitErrorV1> {
+        Ok(self.array::<1>()?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, MaterialCircuitErrorV1> {
+        Ok(u16::from_be_bytes(self.array()?))
+    }
+
+    fn u32(&mut self) -> Result<u32, MaterialCircuitErrorV1> {
+        Ok(u32::from_be_bytes(self.array()?))
+    }
+
+    fn u64(&mut self) -> Result<u64, MaterialCircuitErrorV1> {
+        Ok(u64::from_be_bytes(self.array()?))
+    }
+
+    fn finish(self) -> Result<(), MaterialCircuitErrorV1> {
+        if self.index == self.bytes.len() {
+            Ok(())
+        } else {
+            Err(MaterialCircuitErrorV1::WireTrailing)
+        }
+    }
+}
+
+fn row_count(cursor: &mut Cursor<'_>) -> Result<usize, MaterialCircuitErrorV1> {
+    let count = usize::try_from(cursor.u32()?).map_err(|_| MaterialCircuitErrorV1::WireLimit)?;
+    if count > MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        return Err(MaterialCircuitErrorV1::WireLimit);
+    }
+    Ok(count)
+}
+
+fn append_count(output: &mut Vec<u8>, length: usize) -> Result<(), MaterialCircuitErrorV1> {
+    let count = u32::try_from(length).map_err(|_| MaterialCircuitErrorV1::WireLimit)?;
+    output.extend_from_slice(&count.to_be_bytes());
+    Ok(())
+}
+
+fn append_process_outputs(
+    output: &mut Vec<u8>,
+    state: &MaterialCircuitStateV1,
+) -> Result<(), MaterialCircuitErrorV1> {
+    append_count(output, state.process_outputs.len())?;
+    for row in state
+        .process_outputs
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        output.extend_from_slice(&row.process_id.as_bytes());
+        output.extend_from_slice(&row.site_id.as_bytes());
+        output.extend_from_slice(&row.good_id.as_bytes());
+        output.extend_from_slice(&row.unit_id.as_bytes());
+        output.extend_from_slice(&row.quantity_per_batch.to_be_bytes());
+    }
+    Ok(())
+}
+
+fn append_input_coefficients(
+    output: &mut Vec<u8>,
+    state: &MaterialCircuitStateV1,
+) -> Result<(), MaterialCircuitErrorV1> {
+    append_count(output, state.input_coefficients.len())?;
+    for row in state
+        .input_coefficients
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        output.extend_from_slice(&row.process_id.as_bytes());
+        output.extend_from_slice(&row.good_id.as_bytes());
+        output.extend_from_slice(&row.unit_id.as_bytes());
+        output.extend_from_slice(&row.quantity_per_batch.to_be_bytes());
+    }
+    Ok(())
+}
+
+fn append_labor_coefficients(
+    output: &mut Vec<u8>,
+    state: &MaterialCircuitStateV1,
+) -> Result<(), MaterialCircuitErrorV1> {
+    append_count(output, state.labor_coefficients.len())?;
+    for row in state
+        .labor_coefficients
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        output.extend_from_slice(&row.process_id.as_bytes());
+        output.extend_from_slice(&row.unit_id.as_bytes());
+        output.extend_from_slice(&row.quantity_per_batch.to_be_bytes());
+    }
+    Ok(())
+}
+
+fn append_supplier_candidates(
+    output: &mut Vec<u8>,
+    state: &MaterialCircuitStateV1,
+) -> Result<(), MaterialCircuitErrorV1> {
+    append_count(output, state.supplier_candidates.len())?;
+    for row in state
+        .supplier_candidates
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        output.extend_from_slice(&row.buyer_site_id.as_bytes());
+        output.extend_from_slice(&row.supplier_site_id.as_bytes());
+        output.extend_from_slice(&row.good_id.as_bytes());
+        output.extend_from_slice(&row.unit_id.as_bytes());
+        output.extend_from_slice(&row.transit_delay_weeks.to_be_bytes());
+    }
+    Ok(())
+}
+
+fn append_inventory(
+    output: &mut Vec<u8>,
+    state: &MaterialCircuitStateV1,
+) -> Result<(), MaterialCircuitErrorV1> {
+    append_count(output, state.inventory.len())?;
+    for row in state
+        .inventory
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        output.extend_from_slice(&row.site_id.as_bytes());
+        output.extend_from_slice(&row.good_id.as_bytes());
+        output.extend_from_slice(&row.unit_id.as_bytes());
+        output.extend_from_slice(&row.quantity.to_be_bytes());
+    }
+    Ok(())
+}
+
+fn append_orders(
+    output: &mut Vec<u8>,
+    state: &MaterialCircuitStateV1,
+) -> Result<(), MaterialCircuitErrorV1> {
+    append_count(output, state.orders.len())?;
+    for row in state.orders.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        output.extend_from_slice(&row.order_id.as_bytes());
+        output.push(row.access_mode as u8);
+        output.extend_from_slice(&row.buyer_site_id.as_bytes());
+        output.extend_from_slice(&row.supplier_site_id.as_bytes());
+        output.extend_from_slice(&row.good_id.as_bytes());
+        output.extend_from_slice(&row.unit_id.as_bytes());
+        output.extend_from_slice(&row.ordered.to_be_bytes());
+        output.extend_from_slice(&row.shipped.to_be_bytes());
+        output.extend_from_slice(&row.delivered.to_be_bytes());
+        output.extend_from_slice(&row.realized.to_be_bytes());
+    }
+    Ok(())
+}
+
+fn append_backlog(
+    output: &mut Vec<u8>,
+    state: &MaterialCircuitStateV1,
+) -> Result<(), MaterialCircuitErrorV1> {
+    append_count(output, state.backlog.len())?;
+    for row in state.backlog.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        output.extend_from_slice(&row.order_id.as_bytes());
+        output.extend_from_slice(&row.quantity.to_be_bytes());
+    }
+    Ok(())
+}
+
+fn append_transit(
+    output: &mut Vec<u8>,
+    state: &MaterialCircuitStateV1,
+) -> Result<(), MaterialCircuitErrorV1> {
+    append_count(output, state.transit.len())?;
+    for row in state.transit.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        output.extend_from_slice(&row.order_id.as_bytes());
+        output.extend_from_slice(&row.dispatch_week.to_be_bytes());
+        output.extend_from_slice(&row.arrival_week.to_be_bytes());
+        output.extend_from_slice(&row.source_site_id.as_bytes());
+        output.extend_from_slice(&row.destination_site_id.as_bytes());
+        output.extend_from_slice(&row.good_id.as_bytes());
+        output.extend_from_slice(&row.unit_id.as_bytes());
+        output.extend_from_slice(&row.quantity.to_be_bytes());
+    }
+    Ok(())
+}
+
+fn append_capacities(
+    output: &mut Vec<u8>,
+    state: &MaterialCircuitStateV1,
+) -> Result<(), MaterialCircuitErrorV1> {
+    append_count(output, state.capacities.len())?;
+    for row in state
+        .capacities
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        output.extend_from_slice(&row.process_id.as_bytes());
+        output.extend_from_slice(&row.site_id.as_bytes());
+        output.extend_from_slice(&row.week.to_be_bytes());
+        output.extend_from_slice(&row.available_batches.to_be_bytes());
+    }
+    Ok(())
+}
+
+fn append_labor(
+    output: &mut Vec<u8>,
+    state: &MaterialCircuitStateV1,
+) -> Result<(), MaterialCircuitErrorV1> {
+    append_count(output, state.labor.len())?;
+    for row in state.labor.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        output.extend_from_slice(&row.site_id.as_bytes());
+        output.extend_from_slice(&row.unit_id.as_bytes());
+        output.extend_from_slice(&row.week.to_be_bytes());
+        output.extend_from_slice(&row.available.to_be_bytes());
+    }
+    Ok(())
+}
+
+fn append_production_commitments(
+    output: &mut Vec<u8>,
+    state: &MaterialCircuitStateV1,
+) -> Result<(), MaterialCircuitErrorV1> {
+    append_count(output, state.production_commitments.len())?;
+    for row in state
+        .production_commitments
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        output.extend_from_slice(&row.process_id.as_bytes());
+        output.extend_from_slice(&row.site_id.as_bytes());
+        output.extend_from_slice(&row.week.to_be_bytes());
+        output.extend_from_slice(&row.planned_batches.to_be_bytes());
+    }
+    Ok(())
+}
+
+fn decode_process_outputs(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<ProcessOutputV1>, MaterialCircuitErrorV1> {
+    let count = row_count(cursor)?;
+    let mut rows = Vec::with_capacity(count);
+    for index in 0..=MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        if index == count {
+            break;
+        }
+        rows.push(ProcessOutputV1 {
+            process_id: ProcessIdV1::from_bytes(cursor.array()?),
+            site_id: SiteIdV1::from_bytes(cursor.array()?),
+            good_id: GoodIdV1::from_bytes(cursor.array()?),
+            unit_id: UnitIdV1::from_bytes(cursor.array()?),
+            quantity_per_batch: cursor.u64()?,
+        });
+    }
+    Ok(rows)
+}
+
+fn decode_input_coefficients(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<InputOutputCoefficientV1>, MaterialCircuitErrorV1> {
+    let count = row_count(cursor)?;
+    let mut rows = Vec::with_capacity(count);
+    for index in 0..=MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        if index == count {
+            break;
+        }
+        rows.push(InputOutputCoefficientV1 {
+            process_id: ProcessIdV1::from_bytes(cursor.array()?),
+            good_id: GoodIdV1::from_bytes(cursor.array()?),
+            unit_id: UnitIdV1::from_bytes(cursor.array()?),
+            quantity_per_batch: cursor.u64()?,
+        });
+    }
+    Ok(rows)
+}
+
+fn decode_labor_coefficients(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<LaborCoefficientV1>, MaterialCircuitErrorV1> {
+    let count = row_count(cursor)?;
+    let mut rows = Vec::with_capacity(count);
+    for index in 0..=MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        if index == count {
+            break;
+        }
+        rows.push(LaborCoefficientV1 {
+            process_id: ProcessIdV1::from_bytes(cursor.array()?),
+            unit_id: UnitIdV1::from_bytes(cursor.array()?),
+            quantity_per_batch: cursor.u64()?,
+        });
+    }
+    Ok(rows)
+}
+
+fn decode_supplier_candidates(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<SupplierCandidateV1>, MaterialCircuitErrorV1> {
+    let count = row_count(cursor)?;
+    let mut rows = Vec::with_capacity(count);
+    for index in 0..=MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        if index == count {
+            break;
+        }
+        rows.push(SupplierCandidateV1 {
+            buyer_site_id: SiteIdV1::from_bytes(cursor.array()?),
+            supplier_site_id: SiteIdV1::from_bytes(cursor.array()?),
+            good_id: GoodIdV1::from_bytes(cursor.array()?),
+            unit_id: UnitIdV1::from_bytes(cursor.array()?),
+            transit_delay_weeks: cursor.u16()?,
+        });
+    }
+    Ok(rows)
+}
+
+fn decode_inventory(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<InventoryRowV1>, MaterialCircuitErrorV1> {
+    let count = row_count(cursor)?;
+    let mut rows = Vec::with_capacity(count);
+    for index in 0..=MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        if index == count {
+            break;
+        }
+        rows.push(InventoryRowV1 {
+            site_id: SiteIdV1::from_bytes(cursor.array()?),
+            good_id: GoodIdV1::from_bytes(cursor.array()?),
+            unit_id: UnitIdV1::from_bytes(cursor.array()?),
+            quantity: cursor.u64()?,
+        });
+    }
+    Ok(rows)
+}
+
+fn decode_orders(cursor: &mut Cursor<'_>) -> Result<Vec<OrderRowV1>, MaterialCircuitErrorV1> {
+    let count = row_count(cursor)?;
+    let mut rows = Vec::with_capacity(count);
+    for index in 0..=MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        if index == count {
+            break;
+        }
+        let order_id = OrderIdV1::from_bytes(cursor.array()?);
+        let access_mode = match cursor.u8()? {
+            1 => OrderAccessModeV1::CommoditySale,
+            _ => return Err(MaterialCircuitErrorV1::WireEnum),
+        };
+        rows.push(OrderRowV1 {
+            order_id,
+            access_mode,
+            buyer_site_id: SiteIdV1::from_bytes(cursor.array()?),
+            supplier_site_id: SiteIdV1::from_bytes(cursor.array()?),
+            good_id: GoodIdV1::from_bytes(cursor.array()?),
+            unit_id: UnitIdV1::from_bytes(cursor.array()?),
+            ordered: cursor.u64()?,
+            shipped: cursor.u64()?,
+            delivered: cursor.u64()?,
+            realized: cursor.u64()?,
+        });
+    }
+    Ok(rows)
+}
+
+fn decode_backlog(cursor: &mut Cursor<'_>) -> Result<Vec<BacklogRowV1>, MaterialCircuitErrorV1> {
+    let count = row_count(cursor)?;
+    let mut rows = Vec::with_capacity(count);
+    for index in 0..=MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        if index == count {
+            break;
+        }
+        rows.push(BacklogRowV1 {
+            order_id: OrderIdV1::from_bytes(cursor.array()?),
+            quantity: cursor.u64()?,
+        });
+    }
+    Ok(rows)
+}
+
+fn decode_transit(cursor: &mut Cursor<'_>) -> Result<Vec<TransitLotV1>, MaterialCircuitErrorV1> {
+    let count = row_count(cursor)?;
+    let mut rows = Vec::with_capacity(count);
+    for index in 0..=MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        if index == count {
+            break;
+        }
+        rows.push(TransitLotV1 {
+            order_id: OrderIdV1::from_bytes(cursor.array()?),
+            dispatch_week: cursor.u64()?,
+            arrival_week: cursor.u64()?,
+            source_site_id: SiteIdV1::from_bytes(cursor.array()?),
+            destination_site_id: SiteIdV1::from_bytes(cursor.array()?),
+            good_id: GoodIdV1::from_bytes(cursor.array()?),
+            unit_id: UnitIdV1::from_bytes(cursor.array()?),
+            quantity: cursor.u64()?,
+        });
+    }
+    Ok(rows)
+}
+
+fn decode_capacities(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<CapacityRowV1>, MaterialCircuitErrorV1> {
+    let count = row_count(cursor)?;
+    let mut rows = Vec::with_capacity(count);
+    for index in 0..=MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        if index == count {
+            break;
+        }
+        rows.push(CapacityRowV1 {
+            process_id: ProcessIdV1::from_bytes(cursor.array()?),
+            site_id: SiteIdV1::from_bytes(cursor.array()?),
+            week: cursor.u64()?,
+            available_batches: cursor.u64()?,
+        });
+    }
+    Ok(rows)
+}
+
+fn decode_labor(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<LaborCapacityRowV1>, MaterialCircuitErrorV1> {
+    let count = row_count(cursor)?;
+    let mut rows = Vec::with_capacity(count);
+    for index in 0..=MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        if index == count {
+            break;
+        }
+        rows.push(LaborCapacityRowV1 {
+            site_id: SiteIdV1::from_bytes(cursor.array()?),
+            unit_id: UnitIdV1::from_bytes(cursor.array()?),
+            week: cursor.u64()?,
+            available: cursor.u64()?,
+        });
+    }
+    Ok(rows)
+}
+
+fn decode_production_commitments(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<ProductionCommitmentV1>, MaterialCircuitErrorV1> {
+    let count = row_count(cursor)?;
+    let mut rows = Vec::with_capacity(count);
+    for index in 0..=MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        if index == count {
+            break;
+        }
+        rows.push(ProductionCommitmentV1 {
+            process_id: ProcessIdV1::from_bytes(cursor.array()?),
+            site_id: SiteIdV1::from_bytes(cursor.array()?),
+            week: cursor.u64()?,
+            planned_batches: cursor.u64()?,
+        });
+    }
+    Ok(rows)
+}
+
+/// Encode one complete validated state in canonical big-endian order.
+///
+/// # Errors
+/// Returns the first exact state, row-bound, or wire-bound refusal.
+pub fn encode_material_circuit_state_v1(
+    state: &MaterialCircuitStateV1,
+) -> Result<Vec<u8>, MaterialCircuitErrorV1> {
+    let canonical = canonical_state_v1(state)?;
+    let mut output = Vec::new();
+    output.extend_from_slice(MATERIAL_CIRCUIT_STATE_V1_DOMAIN_BYTES);
+    output.push(0);
+    output.extend_from_slice(&SCHEMA_VERSION.to_be_bytes());
+    output.extend_from_slice(&canonical.week.to_be_bytes());
+    append_process_outputs(&mut output, &canonical)?;
+    append_input_coefficients(&mut output, &canonical)?;
+    append_labor_coefficients(&mut output, &canonical)?;
+    append_supplier_candidates(&mut output, &canonical)?;
+    append_inventory(&mut output, &canonical)?;
+    append_orders(&mut output, &canonical)?;
+    append_backlog(&mut output, &canonical)?;
+    append_transit(&mut output, &canonical)?;
+    append_capacities(&mut output, &canonical)?;
+    append_labor(&mut output, &canonical)?;
+    append_production_commitments(&mut output, &canonical)?;
+    Ok(output)
+}
+
+/// Decode one complete canonical V1 state.
+///
+/// # Errors
+/// Returns the first domain, version, enum, wire, canonical-order, or state refusal.
+pub fn decode_material_circuit_state_v1(
+    payload: &[u8],
+) -> Result<MaterialCircuitStateV1, MaterialCircuitErrorV1> {
+    let mut cursor = Cursor::new(payload);
+    if cursor.take(MATERIAL_CIRCUIT_STATE_V1_DOMAIN_BYTES.len())?
+        != MATERIAL_CIRCUIT_STATE_V1_DOMAIN_BYTES
+        || cursor.u8()? != 0
+    {
+        return Err(MaterialCircuitErrorV1::WireDomain);
+    }
+    if cursor.u16()? != SCHEMA_VERSION {
+        return Err(MaterialCircuitErrorV1::WireVersion);
+    }
+    let state = MaterialCircuitStateV1 {
+        week: cursor.u64()?,
+        process_outputs: decode_process_outputs(&mut cursor)?,
+        input_coefficients: decode_input_coefficients(&mut cursor)?,
+        labor_coefficients: decode_labor_coefficients(&mut cursor)?,
+        supplier_candidates: decode_supplier_candidates(&mut cursor)?,
+        inventory: decode_inventory(&mut cursor)?,
+        orders: decode_orders(&mut cursor)?,
+        backlog: decode_backlog(&mut cursor)?,
+        transit: decode_transit(&mut cursor)?,
+        capacities: decode_capacities(&mut cursor)?,
+        labor: decode_labor(&mut cursor)?,
+        production_commitments: decode_production_commitments(&mut cursor)?,
+    };
+    cursor.finish()?;
+    let canonical = canonical_state_v1(&state)?;
+    if canonical != state {
+        return Err(MaterialCircuitErrorV1::WireNoncanonical);
+    }
+    Ok(state)
+}
+
+/// Hash one complete validated canonical state.
+///
+/// # Errors
+/// Returns the exact encoding refusal without publishing a digest.
+pub fn material_circuit_state_v1_digest(
+    state: &MaterialCircuitStateV1,
+) -> Result<[u8; 32], MaterialCircuitErrorV1> {
+    Ok(sha256_of(&encode_material_circuit_state_v1(state)?))
+}

--- a/rust/crates/babylon-material-circuit/tests/material_circuit.rs
+++ b/rust/crates/babylon-material-circuit/tests/material_circuit.rs
@@ -5,7 +5,7 @@ use babylon_material_circuit::{
     LaborCoefficientV1, MaterialCircuitErrorV1, MaterialCircuitStateV1, OrderAccessModeV1,
     OrderIdV1, OrderRowV1, ProcessIdV1, ProcessOutputV1, ProductionCommitmentV1, SiteIdV1,
     SupplierCandidateV1, UnitIdV1, MATERIAL_CIRCUIT_STATE_V1_DOMAIN_BYTES,
-    MAX_PRODUCTION_RESOURCE_GROUPS_V1,
+    MAX_MATERIAL_CIRCUIT_ROWS_V1, MAX_PRODUCTION_RESOURCE_GROUPS_V1,
 };
 
 fn site(byte: u8) -> SiteIdV1 {
@@ -26,6 +26,13 @@ fn process(byte: u8) -> ProcessIdV1 {
 
 fn order(byte: u8) -> OrderIdV1 {
     OrderIdV1::from_bytes([byte; 32])
+}
+
+fn numbered_good(index: usize) -> GoodIdV1 {
+    let mut bytes = [0_u8; 32];
+    let number = u64::try_from(index).expect("material row ceiling fits u64");
+    bytes[24..].copy_from_slice(&number.to_be_bytes());
+    GoodIdV1::from_bytes(bytes)
 }
 
 const SUPPLIER: u8 = 1;
@@ -255,6 +262,241 @@ fn leontief_output_is_bounded_by_labor_capacity_and_inputs() {
     assert_eq!(outcome.production[0].produced_batches, 2);
     assert_eq!(inventory_quantity(&outcome.state, FACTORY, GRAIN), 24);
     assert_eq!(inventory_quantity(&outcome.state, FACTORY, BREAD), 4);
+}
+
+#[test]
+fn production_debits_all_inputs_before_crediting_any_output() {
+    let producer = process(1);
+    let consumer = process(2);
+    let shared_good = good(3);
+    let consumer_output = good(4);
+    let production_site = site(5);
+    let goods_unit = unit(6);
+    let labor_unit = unit(7);
+    let state = MaterialCircuitStateV1 {
+        week: 1,
+        process_outputs: vec![
+            ProcessOutputV1 {
+                process_id: producer,
+                site_id: production_site,
+                good_id: shared_good,
+                unit_id: goods_unit,
+                quantity_per_batch: 1,
+            },
+            ProcessOutputV1 {
+                process_id: consumer,
+                site_id: production_site,
+                good_id: consumer_output,
+                unit_id: goods_unit,
+                quantity_per_batch: 1,
+            },
+        ],
+        input_coefficients: vec![InputOutputCoefficientV1 {
+            process_id: consumer,
+            good_id: shared_good,
+            unit_id: goods_unit,
+            quantity_per_batch: 1,
+        }],
+        labor_coefficients: vec![
+            LaborCoefficientV1 {
+                process_id: producer,
+                unit_id: labor_unit,
+                quantity_per_batch: 1,
+            },
+            LaborCoefficientV1 {
+                process_id: consumer,
+                unit_id: labor_unit,
+                quantity_per_batch: 1,
+            },
+        ],
+        supplier_candidates: Vec::new(),
+        inventory: vec![InventoryRowV1 {
+            site_id: production_site,
+            good_id: shared_good,
+            unit_id: goods_unit,
+            quantity: u64::MAX,
+        }],
+        orders: Vec::new(),
+        backlog: Vec::new(),
+        transit: Vec::new(),
+        capacities: vec![
+            CapacityRowV1 {
+                process_id: producer,
+                site_id: production_site,
+                week: 1,
+                available_batches: 1,
+            },
+            CapacityRowV1 {
+                process_id: consumer,
+                site_id: production_site,
+                week: 1,
+                available_batches: 1,
+            },
+        ],
+        labor: vec![LaborCapacityRowV1 {
+            site_id: production_site,
+            unit_id: labor_unit,
+            week: 1,
+            available: 2,
+        }],
+        production_commitments: vec![
+            ProductionCommitmentV1 {
+                process_id: producer,
+                site_id: production_site,
+                week: 1,
+                planned_batches: 1,
+            },
+            ProductionCommitmentV1 {
+                process_id: consumer,
+                site_id: production_site,
+                week: 1,
+                planned_batches: 1,
+            },
+        ],
+    };
+
+    let outcome = advance_material_circuit_v1(&state).expect("net-conserved production must close");
+    assert_eq!(
+        inventory_quantity(&outcome.state, 5, 3),
+        u64::MAX,
+        "the shared inventory must be debited before its output is credited"
+    );
+    assert_eq!(inventory_quantity(&outcome.state, 5, 4), 1);
+}
+
+#[test]
+fn proportional_production_uses_u128_for_unbounded_requested_units() {
+    let mut state = production_state_for_numeric_boundary();
+    state.production_commitments[0].planned_batches = u64::MAX;
+    state.capacities[0].available_batches = u64::MAX;
+    state.labor[0].available = u64::MAX;
+
+    let outcome = advance_material_circuit_v1(&state)
+        .expect("scarcity must bound an intermediate request larger than u64");
+    assert_eq!(outcome.production[0].produced_batches, 1);
+    assert_eq!(inventory_quantity(&outcome.state, 1, 2), 0);
+    assert_eq!(inventory_quantity(&outcome.state, 1, 3), 1);
+}
+
+fn production_state_for_numeric_boundary() -> MaterialCircuitStateV1 {
+    let production_site = site(1);
+    let input_good = good(2);
+    let output_good = good(3);
+    let goods_unit = unit(4);
+    let labor_unit = unit(5);
+    let process_id = process(6);
+    MaterialCircuitStateV1 {
+        week: 1,
+        process_outputs: vec![ProcessOutputV1 {
+            process_id,
+            site_id: production_site,
+            good_id: output_good,
+            unit_id: goods_unit,
+            quantity_per_batch: 1,
+        }],
+        input_coefficients: vec![InputOutputCoefficientV1 {
+            process_id,
+            good_id: input_good,
+            unit_id: goods_unit,
+            quantity_per_batch: 2,
+        }],
+        labor_coefficients: vec![LaborCoefficientV1 {
+            process_id,
+            unit_id: labor_unit,
+            quantity_per_batch: 1,
+        }],
+        supplier_candidates: Vec::new(),
+        inventory: vec![
+            InventoryRowV1 {
+                site_id: production_site,
+                good_id: input_good,
+                unit_id: goods_unit,
+                quantity: 2,
+            },
+            InventoryRowV1 {
+                site_id: production_site,
+                good_id: output_good,
+                unit_id: goods_unit,
+                quantity: 0,
+            },
+        ],
+        orders: Vec::new(),
+        backlog: Vec::new(),
+        transit: Vec::new(),
+        capacities: vec![CapacityRowV1 {
+            process_id,
+            site_id: production_site,
+            week: 1,
+            available_batches: 1,
+        }],
+        labor: vec![LaborCapacityRowV1 {
+            site_id: production_site,
+            unit_id: labor_unit,
+            week: 1,
+            available: 1,
+        }],
+        production_commitments: vec![ProductionCommitmentV1 {
+            process_id,
+            site_id: production_site,
+            week: 1,
+            planned_batches: 1,
+        }],
+    }
+}
+
+#[test]
+fn zero_production_does_not_create_an_empty_inventory_row() {
+    let production_site = site(1);
+    let output_good = GoodIdV1::from_bytes([0xff; 32]);
+    let goods_unit = unit(2);
+    let labor_unit = unit(3);
+    let process_id = process(4);
+    let inventory = (0..MAX_MATERIAL_CIRCUIT_ROWS_V1)
+        .map(|index| InventoryRowV1 {
+            site_id: production_site,
+            good_id: numbered_good(index),
+            unit_id: goods_unit,
+            quantity: 1,
+        })
+        .collect();
+    let state = MaterialCircuitStateV1 {
+        week: 1,
+        process_outputs: vec![ProcessOutputV1 {
+            process_id,
+            site_id: production_site,
+            good_id: output_good,
+            unit_id: goods_unit,
+            quantity_per_batch: 1,
+        }],
+        input_coefficients: Vec::new(),
+        labor_coefficients: vec![LaborCoefficientV1 {
+            process_id,
+            unit_id: labor_unit,
+            quantity_per_batch: 1,
+        }],
+        supplier_candidates: Vec::new(),
+        inventory,
+        orders: Vec::new(),
+        backlog: Vec::new(),
+        transit: Vec::new(),
+        capacities: Vec::new(),
+        labor: Vec::new(),
+        production_commitments: vec![ProductionCommitmentV1 {
+            process_id,
+            site_id: production_site,
+            week: 1,
+            planned_batches: 1,
+        }],
+    };
+
+    let outcome = advance_material_circuit_v1(&state).expect("zero production is a valid outcome");
+    assert_eq!(outcome.production[0].produced_batches, 0);
+    assert_eq!(outcome.state.inventory.len(), MAX_MATERIAL_CIRCUIT_ROWS_V1);
+    assert!(outcome
+        .state
+        .inventory
+        .iter()
+        .all(|row| row.good_id != output_good));
 }
 
 #[test]

--- a/rust/crates/babylon-material-circuit/tests/material_circuit.rs
+++ b/rust/crates/babylon-material-circuit/tests/material_circuit.rs
@@ -1,0 +1,477 @@
+use babylon_material_circuit::{
+    advance_material_circuit_v1, decode_material_circuit_state_v1,
+    encode_material_circuit_state_v1, material_circuit_state_v1_digest, BacklogRowV1,
+    CapacityRowV1, GoodIdV1, InputOutputCoefficientV1, InventoryRowV1, LaborCapacityRowV1,
+    LaborCoefficientV1, MaterialCircuitErrorV1, MaterialCircuitStateV1, OrderAccessModeV1,
+    OrderIdV1, OrderRowV1, ProcessIdV1, ProcessOutputV1, ProductionCommitmentV1, SiteIdV1,
+    SupplierCandidateV1, UnitIdV1, MATERIAL_CIRCUIT_STATE_V1_DOMAIN_BYTES,
+    MAX_PRODUCTION_RESOURCE_GROUPS_V1,
+};
+
+fn site(byte: u8) -> SiteIdV1 {
+    SiteIdV1::from_bytes([byte; 32])
+}
+
+fn good(byte: u8) -> GoodIdV1 {
+    GoodIdV1::from_bytes([byte; 32])
+}
+
+fn unit(byte: u8) -> UnitIdV1 {
+    UnitIdV1::from_bytes([byte; 32])
+}
+
+fn process(byte: u8) -> ProcessIdV1 {
+    ProcessIdV1::from_bytes([byte; 32])
+}
+
+fn order(byte: u8) -> OrderIdV1 {
+    OrderIdV1::from_bytes([byte; 32])
+}
+
+const SUPPLIER: u8 = 1;
+const FACTORY: u8 = 2;
+const GRAIN: u8 = 3;
+const BREAD: u8 = 4;
+const GOODS_UNIT: u8 = 5;
+const LABOR_UNIT: u8 = 6;
+const BAKERY: u8 = 7;
+const GRAIN_ORDER: u8 = 8;
+const CONTRACT_VECTORS: &str =
+    include_str!("../../../../contracts/material_circuit_v1_vectors.jsonl");
+
+fn hex(bytes: [u8; 32]) -> String {
+    use std::fmt::Write as _;
+    bytes
+        .iter()
+        .fold(String::with_capacity(64), |mut output, byte| {
+            let _ = write!(output, "{byte:02x}");
+            output
+        })
+}
+
+fn capacity_rows() -> Vec<CapacityRowV1> {
+    [1, 2, 3]
+        .into_iter()
+        .map(|week| CapacityRowV1 {
+            process_id: process(BAKERY),
+            site_id: site(FACTORY),
+            week,
+            available_batches: 3,
+        })
+        .collect()
+}
+
+fn labor_rows() -> Vec<LaborCapacityRowV1> {
+    [1, 2, 3]
+        .into_iter()
+        .map(|week| LaborCapacityRowV1 {
+            site_id: site(FACTORY),
+            unit_id: unit(LABOR_UNIT),
+            week,
+            available: 12,
+        })
+        .collect()
+}
+
+fn base_state() -> MaterialCircuitStateV1 {
+    MaterialCircuitStateV1 {
+        week: 1,
+        process_outputs: vec![ProcessOutputV1 {
+            process_id: process(BAKERY),
+            site_id: site(FACTORY),
+            good_id: good(BREAD),
+            unit_id: unit(GOODS_UNIT),
+            quantity_per_batch: 2,
+        }],
+        input_coefficients: vec![InputOutputCoefficientV1 {
+            process_id: process(BAKERY),
+            good_id: good(GRAIN),
+            unit_id: unit(GOODS_UNIT),
+            quantity_per_batch: 3,
+        }],
+        labor_coefficients: vec![LaborCoefficientV1 {
+            process_id: process(BAKERY),
+            unit_id: unit(LABOR_UNIT),
+            quantity_per_batch: 4,
+        }],
+        supplier_candidates: vec![SupplierCandidateV1 {
+            buyer_site_id: site(FACTORY),
+            supplier_site_id: site(SUPPLIER),
+            good_id: good(GRAIN),
+            unit_id: unit(GOODS_UNIT),
+            transit_delay_weeks: 1,
+        }],
+        inventory: vec![
+            InventoryRowV1 {
+                site_id: site(SUPPLIER),
+                good_id: good(GRAIN),
+                unit_id: unit(GOODS_UNIT),
+                quantity: 10,
+            },
+            InventoryRowV1 {
+                site_id: site(FACTORY),
+                good_id: good(GRAIN),
+                unit_id: unit(GOODS_UNIT),
+                quantity: 0,
+            },
+            InventoryRowV1 {
+                site_id: site(FACTORY),
+                good_id: good(BREAD),
+                unit_id: unit(GOODS_UNIT),
+                quantity: 0,
+            },
+        ],
+        orders: vec![OrderRowV1 {
+            order_id: order(GRAIN_ORDER),
+            access_mode: OrderAccessModeV1::CommoditySale,
+            buyer_site_id: site(FACTORY),
+            supplier_site_id: site(SUPPLIER),
+            good_id: good(GRAIN),
+            unit_id: unit(GOODS_UNIT),
+            ordered: 6,
+            shipped: 0,
+            delivered: 0,
+            realized: 0,
+        }],
+        backlog: vec![BacklogRowV1 {
+            order_id: order(GRAIN_ORDER),
+            quantity: 6,
+        }],
+        transit: Vec::new(),
+        capacities: capacity_rows(),
+        labor: labor_rows(),
+        production_commitments: Vec::new(),
+    }
+}
+
+fn inventory_quantity(state: &MaterialCircuitStateV1, site_byte: u8, good_byte: u8) -> u64 {
+    state
+        .inventory
+        .iter()
+        .take(babylon_material_circuit::MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .find(|row| row.site_id == site(site_byte) && row.good_id == good(good_byte))
+        .map_or(0, |row| row.quantity)
+}
+
+#[test]
+fn shipment_precedes_arrival_and_realization() {
+    let first = advance_material_circuit_v1(&base_state()).expect("week one must close");
+    assert_eq!(first.state.week, 2);
+    assert_eq!(first.dispatches.len(), 1);
+    assert!(first.arrivals.is_empty());
+    assert!(first.realizations.is_empty());
+    assert_eq!(first.state.orders[0].shipped, 6);
+    assert_eq!(first.state.orders[0].delivered, 0);
+    assert_eq!(first.state.orders[0].realized, 0);
+    assert_eq!(first.state.backlog[0].quantity, 0);
+    assert_eq!(inventory_quantity(&first.state, SUPPLIER, GRAIN), 4);
+    assert_eq!(inventory_quantity(&first.state, FACTORY, GRAIN), 0);
+
+    let second = advance_material_circuit_v1(&first.state).expect("week two must close");
+    assert_eq!(second.state.week, 3);
+    assert_eq!(second.arrivals.len(), 1);
+    assert_eq!(second.deliveries.len(), 1);
+    assert_eq!(second.realizations.len(), 1);
+    assert_eq!(second.state.orders[0].delivered, 6);
+    assert_eq!(second.state.orders[0].realized, 6);
+    assert_eq!(inventory_quantity(&second.state, FACTORY, GRAIN), 6);
+    assert_eq!(second.state.production_commitments[0].week, 3);
+    assert_eq!(second.state.production_commitments[0].planned_batches, 2);
+}
+
+#[test]
+fn delivered_inputs_feed_the_following_week_not_the_arrival_week() {
+    let first = advance_material_circuit_v1(&base_state()).expect("week one must close");
+    assert!(first.state.production_commitments.is_empty());
+
+    let second = advance_material_circuit_v1(&first.state).expect("week two must close");
+    assert_eq!(second.state.production_commitments[0].planned_batches, 2);
+    assert!(second.production.is_empty());
+
+    let third = advance_material_circuit_v1(&second.state).expect("week three must close");
+    assert_eq!(third.production[0].planned_batches, 2);
+    assert_eq!(third.production[0].produced_batches, 2);
+    assert_eq!(inventory_quantity(&third.state, FACTORY, GRAIN), 0);
+    assert_eq!(inventory_quantity(&third.state, FACTORY, BREAD), 4);
+}
+
+#[test]
+fn severed_supplier_relation_causes_backlog_without_creating_goods() {
+    let mut state = base_state();
+    state.supplier_candidates.clear();
+
+    let first = advance_material_circuit_v1(&state).expect("missing supply is a material outcome");
+    assert!(first.dispatches.is_empty());
+    assert_eq!(first.state.orders[0].shipped, 0);
+    assert_eq!(first.state.backlog[0].quantity, 6);
+    assert_eq!(inventory_quantity(&first.state, SUPPLIER, GRAIN), 10);
+
+    let second = advance_material_circuit_v1(&first.state).expect("week two must close");
+    assert!(second.arrivals.is_empty());
+    assert!(second.state.production_commitments.is_empty());
+}
+
+#[test]
+fn missing_stock_and_labor_are_material_shortages_not_engine_errors() {
+    let mut state = base_state();
+    state.inventory.remove(0);
+    state.labor = state
+        .labor
+        .into_iter()
+        .take(babylon_material_circuit::MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .filter(|row| row.week != 1)
+        .collect();
+    state.production_commitments = vec![ProductionCommitmentV1 {
+        process_id: process(BAKERY),
+        site_id: site(FACTORY),
+        week: 1,
+        planned_batches: 3,
+    }];
+
+    let outcome = advance_material_circuit_v1(&state).expect("zero supply must still close");
+    assert_eq!(outcome.production[0].produced_batches, 0);
+    assert!(outcome.dispatches.is_empty());
+    assert_eq!(outcome.state.backlog[0].quantity, 6);
+    assert_eq!(inventory_quantity(&outcome.state, FACTORY, BREAD), 0);
+}
+
+#[test]
+fn leontief_output_is_bounded_by_labor_capacity_and_inputs() {
+    let mut state = base_state();
+    state.orders.clear();
+    state.backlog.clear();
+    state.inventory[1].quantity = 30;
+    state.capacities[0].available_batches = 4;
+    state.labor[0].available = 10;
+    state.production_commitments = vec![ProductionCommitmentV1 {
+        process_id: process(BAKERY),
+        site_id: site(FACTORY),
+        week: 1,
+        planned_batches: 10,
+    }];
+
+    let outcome = advance_material_circuit_v1(&state).expect("bounded production must close");
+    assert_eq!(outcome.production[0].planned_batches, 10);
+    assert_eq!(outcome.production[0].produced_batches, 2);
+    assert_eq!(inventory_quantity(&outcome.state, FACTORY, GRAIN), 24);
+    assert_eq!(inventory_quantity(&outcome.state, FACTORY, BREAD), 4);
+}
+
+#[test]
+fn proportional_stock_allocation_has_no_order_priority() {
+    let mut state = base_state();
+    state.process_outputs.clear();
+    state.input_coefficients.clear();
+    state.labor_coefficients.clear();
+    state.capacities.clear();
+    state.labor.clear();
+    state.inventory[0].quantity = 4;
+    state.orders = vec![
+        OrderRowV1 {
+            ordered: 4,
+            ..state.orders[0].clone()
+        },
+        OrderRowV1 {
+            order_id: order(9),
+            ordered: 6,
+            ..state.orders[0].clone()
+        },
+    ];
+    state.backlog = vec![
+        BacklogRowV1 {
+            order_id: order(GRAIN_ORDER),
+            quantity: 4,
+        },
+        BacklogRowV1 {
+            order_id: order(9),
+            quantity: 6,
+        },
+    ];
+
+    let mut reversed = state.clone();
+    reversed.orders.reverse();
+    reversed.backlog.reverse();
+
+    let a = advance_material_circuit_v1(&state).expect("allocation must close");
+    let b = advance_material_circuit_v1(&reversed).expect("permuted allocation must close");
+    assert_eq!(a.state.orders[0].shipped, 1);
+    assert_eq!(a.state.orders[1].shipped, 2);
+    assert_eq!(inventory_quantity(&a.state, SUPPLIER, GRAIN), 1);
+    assert_eq!(
+        material_circuit_state_v1_digest(&a.state),
+        material_circuit_state_v1_digest(&b.state)
+    );
+}
+
+#[test]
+fn arithmetic_refusal_does_not_publish_a_partial_state() {
+    let mut state = base_state();
+    state.week = 2;
+    state.capacities = state
+        .capacities
+        .into_iter()
+        .take(babylon_material_circuit::MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .filter(|row| row.week >= 2)
+        .collect();
+    state.labor = state
+        .labor
+        .into_iter()
+        .take(babylon_material_circuit::MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .filter(|row| row.week >= 2)
+        .collect();
+    state.inventory[1].quantity = u64::MAX;
+    state.orders[0].shipped = 6;
+    state.backlog[0].quantity = 0;
+    state.transit.push(babylon_material_circuit::TransitLotV1 {
+        order_id: order(GRAIN_ORDER),
+        dispatch_week: 1,
+        arrival_week: 2,
+        source_site_id: site(SUPPLIER),
+        destination_site_id: site(FACTORY),
+        good_id: good(GRAIN),
+        unit_id: unit(GOODS_UNIT),
+        quantity: 6,
+    });
+    let before = material_circuit_state_v1_digest(&state).expect("opening state must encode");
+
+    assert_eq!(
+        advance_material_circuit_v1(&state),
+        Err(MaterialCircuitErrorV1::Arithmetic)
+    );
+    assert_eq!(
+        material_circuit_state_v1_digest(&state).expect("refusal must not mutate input"),
+        before
+    );
+}
+
+#[test]
+fn canonical_state_bytes_and_digest_are_pinned() {
+    let bytes = encode_material_circuit_state_v1(&base_state()).expect("base state must encode");
+    let digest = material_circuit_state_v1_digest(&base_state()).expect("base state must hash");
+    assert_eq!(bytes.len(), 1_555);
+    assert_eq!(
+        digest,
+        [
+            0x35, 0x76, 0xba, 0xa1, 0xaf, 0x2a, 0x38, 0xbe, 0x8a, 0x13, 0x76, 0x25, 0x9d, 0xc4,
+            0x42, 0x3a, 0x47, 0x06, 0x07, 0xad, 0x9e, 0xef, 0x59, 0x69, 0x71, 0x59, 0x31, 0xe1,
+            0x6b, 0x30, 0x62, 0x0a,
+        ]
+    );
+    assert_eq!(
+        decode_material_circuit_state_v1(&bytes).expect("canonical bytes must decode"),
+        base_state()
+    );
+    let vector: serde_json::Value = serde_json::from_str(
+        CONTRACT_VECTORS
+            .lines()
+            .next()
+            .expect("the base vector must be first"),
+    )
+    .expect("the base vector must be valid JSON");
+    assert_eq!(vector["data"]["canonical_bytes"], bytes.len());
+    assert_eq!(vector["data"]["digest_hex"], hex(digest));
+    let manifest: serde_json::Value = serde_json::from_str(
+        CONTRACT_VECTORS
+            .lines()
+            .nth(1)
+            .expect("the manifest vector must be second"),
+    )
+    .expect("the manifest vector must be valid JSON");
+    assert_eq!(
+        manifest["data"]["production_resource_groups"],
+        MAX_PRODUCTION_RESOURCE_GROUPS_V1
+    );
+}
+
+#[test]
+fn decoder_refuses_wrong_domain_version_truncation_and_trailing_bytes() {
+    let bytes = encode_material_circuit_state_v1(&base_state()).expect("base state must encode");
+    let mut wrong_domain = bytes.clone();
+    wrong_domain[0] ^= 1;
+    assert_eq!(
+        decode_material_circuit_state_v1(&wrong_domain),
+        Err(MaterialCircuitErrorV1::WireDomain)
+    );
+    let version_index = MATERIAL_CIRCUIT_STATE_V1_DOMAIN_BYTES.len() + 1;
+    let mut wrong_version = bytes.clone();
+    wrong_version[version_index + 1] = 2;
+    assert_eq!(
+        decode_material_circuit_state_v1(&wrong_version),
+        Err(MaterialCircuitErrorV1::WireVersion)
+    );
+    assert_eq!(
+        decode_material_circuit_state_v1(&bytes[..bytes.len() - 1]),
+        Err(MaterialCircuitErrorV1::WireTruncated)
+    );
+    let mut trailing = bytes;
+    trailing.push(0);
+    assert_eq!(
+        decode_material_circuit_state_v1(&trailing),
+        Err(MaterialCircuitErrorV1::WireTrailing)
+    );
+}
+
+#[test]
+fn decoder_refuses_unknown_access_mode_and_noncanonical_row_order() {
+    const INVENTORY_ROW_BYTES: usize = 104;
+    const INVENTORY_ROWS_START: usize = 506;
+    const ORDER_ACCESS_MODE_INDEX: usize = 854;
+    let bytes = encode_material_circuit_state_v1(&base_state()).expect("base state must encode");
+    let mut unknown_mode = bytes.clone();
+    unknown_mode[ORDER_ACCESS_MODE_INDEX] = 2;
+    assert_eq!(
+        decode_material_circuit_state_v1(&unknown_mode),
+        Err(MaterialCircuitErrorV1::WireEnum)
+    );
+
+    let mut noncanonical = bytes;
+    let first =
+        noncanonical[INVENTORY_ROWS_START..INVENTORY_ROWS_START + INVENTORY_ROW_BYTES].to_vec();
+    let second = noncanonical[INVENTORY_ROWS_START + INVENTORY_ROW_BYTES
+        ..INVENTORY_ROWS_START + 2 * INVENTORY_ROW_BYTES]
+        .to_vec();
+    noncanonical[INVENTORY_ROWS_START..INVENTORY_ROWS_START + INVENTORY_ROW_BYTES]
+        .copy_from_slice(&second);
+    noncanonical[INVENTORY_ROWS_START + INVENTORY_ROW_BYTES
+        ..INVENTORY_ROWS_START + 2 * INVENTORY_ROW_BYTES]
+        .copy_from_slice(&first);
+    assert_eq!(
+        decode_material_circuit_state_v1(&noncanonical),
+        Err(MaterialCircuitErrorV1::WireNoncanonical)
+    );
+}
+
+#[test]
+fn every_refusal_code_round_trips_and_the_registry_is_closed() {
+    for code in 1_u16..=16 {
+        let error = MaterialCircuitErrorV1::try_from(code).expect("declared code must decode");
+        assert_eq!(u16::from(error), code);
+    }
+    assert!(MaterialCircuitErrorV1::try_from(0).is_err());
+    assert!(MaterialCircuitErrorV1::try_from(17).is_err());
+}
+
+#[test]
+fn duplicate_dispatch_identity_is_rejected_even_when_arrival_weeks_differ() {
+    let mut state = base_state();
+    state.week = 2;
+    state.orders[0].shipped = 6;
+    state.backlog[0].quantity = 0;
+    state.transit = [2_u64, 3]
+        .into_iter()
+        .map(|arrival_week| babylon_material_circuit::TransitLotV1 {
+            order_id: order(GRAIN_ORDER),
+            dispatch_week: 1,
+            arrival_week,
+            source_site_id: site(SUPPLIER),
+            destination_site_id: site(FACTORY),
+            good_id: good(GRAIN),
+            unit_id: unit(GOODS_UNIT),
+            quantity: 3,
+        })
+        .collect();
+    assert_eq!(
+        advance_material_circuit_v1(&state),
+        Err(MaterialCircuitErrorV1::DuplicateRow)
+    );
+}

--- a/rust/crates/babylon-material-circuit/tests/property_laws.rs
+++ b/rust/crates/babylon-material-circuit/tests/property_laws.rs
@@ -1,0 +1,244 @@
+use babylon_material_circuit::{
+    advance_material_circuit_v1, material_circuit_state_v1_digest, BacklogRowV1, CapacityRowV1,
+    GoodIdV1, InputOutputCoefficientV1, InventoryRowV1, LaborCapacityRowV1, LaborCoefficientV1,
+    MaterialCircuitStateV1, OrderAccessModeV1, OrderIdV1, OrderRowV1, ProcessIdV1, ProcessOutputV1,
+    ProductionCommitmentV1, SiteIdV1, SupplierCandidateV1, UnitIdV1,
+};
+
+fn id<const BYTE: u8>() -> [u8; 32] {
+    [BYTE; 32]
+}
+
+fn allocation_state(available: u64, first: u64, second: u64) -> MaterialCircuitStateV1 {
+    let supplier = SiteIdV1::from_bytes(id::<1>());
+    let buyer = SiteIdV1::from_bytes(id::<2>());
+    let good = GoodIdV1::from_bytes(id::<3>());
+    let unit = UnitIdV1::from_bytes(id::<4>());
+    let orders = [(5, first), (6, second)]
+        .into_iter()
+        .map(|(identity, ordered)| OrderRowV1 {
+            order_id: OrderIdV1::from_bytes([identity; 32]),
+            access_mode: OrderAccessModeV1::CommoditySale,
+            buyer_site_id: buyer,
+            supplier_site_id: supplier,
+            good_id: good,
+            unit_id: unit,
+            ordered,
+            shipped: 0,
+            delivered: 0,
+            realized: 0,
+        })
+        .collect::<Vec<_>>();
+    MaterialCircuitStateV1 {
+        week: 1,
+        process_outputs: Vec::new(),
+        input_coefficients: Vec::new(),
+        labor_coefficients: Vec::new(),
+        supplier_candidates: vec![SupplierCandidateV1 {
+            buyer_site_id: buyer,
+            supplier_site_id: supplier,
+            good_id: good,
+            unit_id: unit,
+            transit_delay_weeks: 1,
+        }],
+        inventory: vec![InventoryRowV1 {
+            site_id: supplier,
+            good_id: good,
+            unit_id: unit,
+            quantity: available,
+        }],
+        backlog: orders
+            .iter()
+            .map(|order| BacklogRowV1 {
+                order_id: order.order_id,
+                quantity: order.ordered,
+            })
+            .collect(),
+        orders,
+        transit: Vec::new(),
+        capacities: Vec::new(),
+        labor: Vec::new(),
+        production_commitments: Vec::new(),
+    }
+}
+
+#[test]
+fn proportional_allocation_exhaustively_conserves_small_stocks() {
+    for available in 0_u64..=20 {
+        for first in 1_u64..=10 {
+            for second in 1_u64..=10 {
+                let state = allocation_state(available, first, second);
+                let outcome = advance_material_circuit_v1(&state).expect("allocation must close");
+                let total_requested = first + second;
+                let shipped: u64 = outcome
+                    .state
+                    .orders
+                    .iter()
+                    .take(babylon_material_circuit::MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+                    .map(|row| row.shipped)
+                    .sum();
+                let closing = outcome.state.inventory[0].quantity;
+                assert_eq!(closing + shipped, available);
+                assert!(shipped <= available.min(total_requested));
+                assert!(outcome
+                    .state
+                    .orders
+                    .iter()
+                    .take(babylon_material_circuit::MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+                    .all(|row| row.shipped <= row.ordered));
+                if available >= total_requested {
+                    assert_eq!(shipped, total_requested);
+                } else {
+                    assert_eq!(
+                        outcome.state.orders[0].shipped,
+                        available * first / total_requested
+                    );
+                    assert_eq!(
+                        outcome.state.orders[1].shipped,
+                        available * second / total_requested
+                    );
+                }
+                let mut reversed = state;
+                reversed.orders.reverse();
+                reversed.backlog.reverse();
+                let twin = advance_material_circuit_v1(&reversed).expect("twin must close");
+                assert_eq!(
+                    material_circuit_state_v1_digest(&outcome.state),
+                    material_circuit_state_v1_digest(&twin.state)
+                );
+            }
+        }
+    }
+}
+
+fn production_state(input: u64, labor: u64, capacity: u64) -> MaterialCircuitStateV1 {
+    let site = SiteIdV1::from_bytes(id::<1>());
+    let input_good = GoodIdV1::from_bytes(id::<2>());
+    let output_good = GoodIdV1::from_bytes(id::<3>());
+    let goods_unit = UnitIdV1::from_bytes(id::<4>());
+    let labor_unit = UnitIdV1::from_bytes(id::<5>());
+    let process = ProcessIdV1::from_bytes(id::<6>());
+    MaterialCircuitStateV1 {
+        week: 1,
+        process_outputs: vec![ProcessOutputV1 {
+            process_id: process,
+            site_id: site,
+            good_id: output_good,
+            unit_id: goods_unit,
+            quantity_per_batch: 5,
+        }],
+        input_coefficients: vec![InputOutputCoefficientV1 {
+            process_id: process,
+            good_id: input_good,
+            unit_id: goods_unit,
+            quantity_per_batch: 2,
+        }],
+        labor_coefficients: vec![LaborCoefficientV1 {
+            process_id: process,
+            unit_id: labor_unit,
+            quantity_per_batch: 3,
+        }],
+        supplier_candidates: Vec::new(),
+        inventory: vec![
+            InventoryRowV1 {
+                site_id: site,
+                good_id: input_good,
+                unit_id: goods_unit,
+                quantity: input,
+            },
+            InventoryRowV1 {
+                site_id: site,
+                good_id: output_good,
+                unit_id: goods_unit,
+                quantity: 0,
+            },
+        ],
+        orders: Vec::new(),
+        backlog: Vec::new(),
+        transit: Vec::new(),
+        capacities: vec![CapacityRowV1 {
+            process_id: process,
+            site_id: site,
+            week: 1,
+            available_batches: capacity,
+        }],
+        labor: vec![LaborCapacityRowV1 {
+            site_id: site,
+            unit_id: labor_unit,
+            week: 1,
+            available: labor,
+        }],
+        production_commitments: vec![ProductionCommitmentV1 {
+            process_id: process,
+            site_id: site,
+            week: 1,
+            planned_batches: 10,
+        }],
+    }
+}
+
+#[test]
+fn leontief_minimum_exhaustively_bounds_small_production() {
+    for input in 0_u64..=12 {
+        for labor in 0_u64..=12 {
+            for capacity in 0_u64..=6 {
+                let outcome =
+                    advance_material_circuit_v1(&production_state(input, labor, capacity))
+                        .expect("bounded production must close");
+                let expected = 10_u64.min(input / 2).min(labor / 3).min(capacity);
+                assert_eq!(outcome.production[0].produced_batches, expected);
+                assert_eq!(outcome.state.inventory[0].quantity, input - expected * 2);
+                assert_eq!(outcome.state.inventory[1].quantity, expected * 5);
+            }
+        }
+    }
+}
+
+#[test]
+fn shared_inputs_and_labor_allocate_without_process_order_priority() {
+    let mut state = production_state(12, 18, 4);
+    let second_process = ProcessIdV1::from_bytes(id::<7>());
+    state.process_outputs.push(ProcessOutputV1 {
+        process_id: second_process,
+        site_id: SiteIdV1::from_bytes(id::<1>()),
+        good_id: GoodIdV1::from_bytes(id::<8>()),
+        unit_id: UnitIdV1::from_bytes(id::<4>()),
+        quantity_per_batch: 5,
+    });
+    state.input_coefficients.push(InputOutputCoefficientV1 {
+        process_id: second_process,
+        good_id: GoodIdV1::from_bytes(id::<2>()),
+        unit_id: UnitIdV1::from_bytes(id::<4>()),
+        quantity_per_batch: 2,
+    });
+    state.labor_coefficients.push(LaborCoefficientV1 {
+        process_id: second_process,
+        unit_id: UnitIdV1::from_bytes(id::<5>()),
+        quantity_per_batch: 3,
+    });
+    state.capacities.push(CapacityRowV1 {
+        process_id: second_process,
+        site_id: SiteIdV1::from_bytes(id::<1>()),
+        week: 1,
+        available_batches: 4,
+    });
+    state.production_commitments[0].planned_batches = 4;
+    state.production_commitments.push(ProductionCommitmentV1 {
+        process_id: second_process,
+        site_id: SiteIdV1::from_bytes(id::<1>()),
+        week: 1,
+        planned_batches: 4,
+    });
+    let mut reversed = state.clone();
+    reversed.production_commitments.reverse();
+
+    let outcome = advance_material_circuit_v1(&state).expect("shared allocation must close");
+    let twin = advance_material_circuit_v1(&reversed).expect("permuted allocation must close");
+    assert_eq!(outcome.production[0].produced_batches, 3);
+    assert_eq!(outcome.production[1].produced_batches, 3);
+    assert_eq!(outcome.state.inventory[0].quantity, 0);
+    assert_eq!(
+        material_circuit_state_v1_digest(&outcome.state),
+        material_circuit_state_v1_digest(&twin.state)
+    );
+}

--- a/tests/unit/decisions/test_adr238_material_circuit_v1.py
+++ b/tests/unit/decisions/test_adr238_material_circuit_v1.py
@@ -1,0 +1,93 @@
+"""Exact decision-index contract for the V1 material circuit."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DECISIONS_DIR = Path(__file__).resolve().parents[3] / "ai" / "decisions"
+ADR_STEM = "ADR238_material_circuit_v1"
+ADR_PATH = DECISIONS_DIR / f"{ADR_STEM}.yaml"
+INDEX_PATH = DECISIONS_DIR / "index.yaml"
+CONTRACT_PATH = DECISIONS_DIR.parents[1] / "contracts" / "material_circuit_v1.yaml"
+EXPECTED_TITLE = (
+    "Material Circuit V1 makes orders, exact stocks, delayed delivery, "
+    "realization, and Leontief production one conserved Rust transition"
+)
+
+
+def _mapping(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_adr238_records_the_exact_order_inventory_and_production_law() -> None:
+    decision = _mapping(ADR_PATH)[ADR_STEM]
+    index = _mapping(INDEX_PATH)
+
+    assert decision["status"] == "accepted"
+    assert decision["date"] == "2026-08-26"
+    assert decision["title"] == EXPECTED_TITLE
+    assert decision["crate"] == "babylon-material-circuit"
+    assert decision["live_activation"] is False
+
+    decision_text = " ".join(str(decision["decision"]).split())
+    for required_text in (
+        "Every material identity is a distinct 32-byte type",
+        "unsigned 64-bit integers",
+        "floor(available * requested_i / total_requested)",
+        "canonical process order receives none",
+        "debits supplier inventory and creates one sparse lot",
+        "derive the following-week production commitment",
+        "does not activate gameplay",
+    ):
+        assert required_text in decision_text
+
+    assert index["meta"]["version"] == "1.85.0"
+    assert index["decisions"][ADR_STEM] == {
+        "title": EXPECTED_TITLE,
+        "status": "accepted",
+        "date": "2026-08-26",
+        "file": ADR_PATH.name,
+    }
+
+
+def test_adr238_schema_pins_conservation_bounds_and_inert_activation() -> None:
+    contract = _mapping(CONTRACT_PATH)
+
+    assert contract["encoding"] == {
+        "byte_order": "big-endian",
+        "integer_encoding": "unsigned-fixed-width",
+        "quantity_encoding": "u64",
+        "identity_encoding": "raw-32-bytes",
+        "row_count_encoding": "u32",
+        "trailing_bytes": "forbidden",
+        "noncanonical_row_order": "forbidden",
+    }
+    assert contract["access_modes"] == {"commodity_sale": 1}
+    assert contract["limits"] == {
+        "rows_per_family": {
+            "value": 65_536,
+            "classification": "Designed",
+            "purpose": (
+                "serialization, memory, and transition fuel ceiling, not material abundance"
+            ),
+        },
+        "production_resource_groups": {
+            "value": 131_072,
+            "derivation": (
+                "rows_per_family * 2 for the disjoint input and labor resource families"
+            ),
+        },
+    }
+    assert contract["canonical_order"]["priority"] == (
+        "canonical order grants no material priority"
+    )
+    assert contract["base_vector"] == {
+        "canonical_bytes": 1_555,
+        "digest_hex": "3576baa1af2a38be8a1376259dc4423a470607ad9eef5969715931e16b30620a",
+    }
+    assert any("gameplay activation" in surface for surface in contract["excluded_surfaces"])


### PR DESCRIPTION
## Summary

- add the Rust-owned exact V1 order, inventory, transit, realization, and Leontief production transition
- pin canonical language-neutral bytes, SHA-256 identity, closed refusals, and ADR238
- allocate scarce stock, labor, and inputs proportionally without canonical-order priority
- bind the derived 131,072 input-plus-labor resource-group ceiling and its maximum-plus-one refusal
- keep the slice explicitly non-live until successor tick, world-hash, envelope, persistence, and decision-surface integration

## Verification

- cargo fmt --all -- --check
- cargo test -p babylon-material-circuit --locked
- cargo clippy -p babylon-material-circuit --all-targets --locked -- -D warnings -D clippy::pedantic
- mise run rust:check-no-docs
- mise run check: 14,658 passed, 55 skipped, 1 deliberate xfail
- mise run qa:regression: 12 baselines and cross-process determinism passed
- mise run qa:vault-regression-ci: both golden vault bakes passed
- mise run lint:yaml
- mise run test:q -- tests/unit/decisions: 22 passed

Part of PER-30