### PR TITLE
feat(economy): add routed material circuit

### DIFF
--- a/ai/decisions/ADR239_routed_material_circuit_v2.yaml
+++ b/ai/decisions/ADR239_routed_material_circuit_v2.yaml
@@ -1,0 +1,123 @@
+ADR239_routed_material_circuit_v2:
+  status: "accepted"
+  date: "2026-08-26"
+  title: >-
+    Routed Material Circuit V2 reserves exact corridor capacity and advances
+    one authoritative freight-lot state before delivery and realization
+  crate: babylon-material-circuit
+  production_dependencies:
+    - babylon-kernel
+  forbidden_dependencies:
+    - babylon-graph
+    - babylon-bsl
+    - babylon-tick
+    - babylon-persistence
+    - babylon-client
+  live_activation: false
+  context: |
+    PER-31 must propagate material shortages through named routes, transit
+    time, and finite corridor capacity. Material Circuit V1 owns exact
+    inventory and orders, but its supplier relation carries only one local
+    delay and its lot jumps directly from source to destination. Adding a
+    second freight register beside that state would duplicate the transit
+    principal and make conservation depend on reconciliation.
+
+    The first routed slice does not yet have the exact organization-money,
+    claim, or escrow ledger that PER-36 owns. A freight implementation cannot
+    invent temporary currency buckets or call quantity realization monetary
+    settlement. Selected sovereigns, residual trade blocs, route choice, and
+    rerouting also need real consumers before their identities become state.
+  decision: |
+    `MaterialCircuitStateV2` is a versioned successor in the existing
+    `babylon-material-circuit` crate. V1 types, bytes, digest, transition, and
+    refusal registry remain frozen. V2 reuses unchanged exact production,
+    inventory, capacity, labor, and identity rows while replacing local
+    supplier delays and local transit lots with site-to-logistics-node rows,
+    supplier-route rows, ordered route legs, corridor-week capacity rows, an
+    order row with attributed cumulative loss, and one routed freight-lot row.
+
+    A supplier route is unique for one buyer, supplier, good, and unit in this
+    slice. Each route has between one and 16 contiguous positive-duration
+    legs. The leg ceiling is a Designed transition-fuel bound, not a geographic
+    or political limit. Route identity and connected node endpoints determine
+    the path; canonical order never chooses a route.
+
+    Dispatch groups every open order request by its exact supplier-inventory
+    principal and by every `(corridor, departure week, unit)` reservation that
+    its route needs. Each group grants
+    `floor(available * request / total requests)`. One order's dispatch is the
+    minimum of all its grants. Residual inventory and capacity remain in their
+    principals. The transition debits the exact shipped inventory and reserves
+    the same opening quantity on every future route leg before it creates one
+    freight lot. Future reservations are conservative: later physical loss
+    does not release capacity that was already committed.
+
+    One freight lot names one order, route, current leg, leg-arrival week,
+    source, destination, good, unit, dispatch week, and exact quantity. It is
+    the sole transit state for that principal. A leg completion applies its
+    exact parts-per-million loss with checked integer arithmetic, attributes
+    the loss to the order and corridor, and either advances the same lot to the
+    next leg or consumes it at the destination. Only final retained arrival
+    credits destination inventory, accepted delivery, and commodity quantity
+    realization. At every opening state, shipped quantity equals delivered
+    quantity plus attributed loss plus the exact quantity in the order's one
+    or more live freight lots.
+
+    Complete V2 state bytes use the `babylon.material-circuit-state.v2`
+    domain, schema version 2, fixed field order, unsigned big-endian integers,
+    raw 32-byte identities, canonical rows, and closed access-mode tags. The
+    decoder refuses a wrong domain or version, malformed topology, duplicate
+    identity, noncanonical order, truncation, or trailing bytes. SHA-256 names
+    the validated complete state.
+
+    V2 remains a detached Rust transition. It does not alter graph state,
+    BSL, `TickSession`, nominal world identity, persistence, Archive, or Bevy.
+    It does not activate gameplay or complete PER-31. A later PER-31 slice may
+    add jurisdiction-bearing border policy and participant-selected rerouting
+    only with named consumers. PER-36 alone may add exact money, claims,
+    escrow, default, and double-entry settlement.
+  consequences: |
+    Corridor capacity and route duration now have a direct causal path to
+    dispatch, inventory, loss, delivery, realization, and following-week
+    production. Removing one corridor-week capacity can leave orders on other
+    routes unchanged, so spatially heterogeneous shortages can emerge without
+    country actors or all-pairs supply edges.
+
+    Conservative whole-route reservation avoids a waiting-lot split that
+    would place one lot identity in two transit states. It can leave capacity
+    unused after a downstream bottleneck or later loss. That residual is an
+    explicit cost of the first bounded contract, not canonical-order priority.
+
+    The V2 wire contract must freeze before any world-hash or persistence
+    successor binds it. The later live cutover must select V2 as the sole
+    material register and retire the V1 gameplay path rather than dual-write.
+  verification: |
+    Scenario and property tests must prove dispatch-before-arrival, final-leg
+    delivery, route continuity, capacity reservation, stock and transit
+    conservation, cumulative attributed loss, order-neutral scarcity,
+    insertion-order identity, checked-overflow atomicity, exact bytes and
+    digest, decoder refusal, maximum route legs, and a severed-corridor twin
+    with heterogeneous inventory and realization effects.
+
+    `contracts/material_circuit_v2.yaml` freezes the 1,053-byte base state and
+    its SHA-256 digest
+    `a0ca4c774cf74110ffc3611aa1bd7609cbee07e360477e99363f268b93d7cf31`.
+    Its shared JSONL corpus binds those values, the 16-leg ceiling, and the
+    derived 1,114,112-resource-group ceiling to executable Rust tests.
+
+    Formatting and Clippy pedantic checks run with warnings denied. V1 exact
+    bytes, digest, decoder refusals, scenario laws, and property laws remain
+    unchanged.
+  preserves:
+    - ADR223 TickSession atomicity and NominalWorldHash V1 bytes
+    - ADR224 BSL causal roles, exact effects, and audit receipts
+    - ADR229 Rust gameplay-contract authority and frozen Python boundary
+    - ADR232 material causality, successor versioning, and no authored sigmoid
+    - ADR238 Material Circuit V1 bytes, digest, transition, and refusals
+  supersedes: []
+  related:
+    - ADR220_rust_owned_postgresql_persistence_boundary
+    - ADR223_whole_tick_atomicity_world_hash
+    - ADR229_rust_gameplay_contract_authority
+    - ADR232_neel_integration_program_architecture
+    - ADR238_material_circuit_v1

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -1105,3 +1105,8 @@ decisions:
     status: accepted
     date: '2026-08-26'
     file: ADR238_material_circuit_v1.yaml
+  ADR239_routed_material_circuit_v2:
+    title: 'Routed Material Circuit V2 reserves exact corridor capacity and advances one authoritative freight-lot state before delivery and realization'
+    status: accepted
+    date: '2026-08-26'
+    file: ADR239_routed_material_circuit_v2.yaml

--- a/contracts/material_circuit_v2.yaml
+++ b/contracts/material_circuit_v2.yaml
@@ -1,0 +1,354 @@
+meta:
+  contract: MaterialCircuitV2
+  schema_version: 2
+  status: accepted
+  evidence_class: Designed
+  live_activation: false
+  rust_owner: babylon-material-circuit
+
+preserves:
+  - every Material Circuit V1 type, byte, digest, transition, and refusal code
+  - every existing graph, BSL, nominal-world-hash, and Practice Contract byte
+  - the frozen Python engine as reference-only evidence
+  - the PER-36 ownership of money, claims, escrow, default, and settlement
+
+domains:
+  state: babylon.material-circuit-state.v2
+  freight_lot_identity: babylon.freight-lot.v2
+  terminator_hex: "00"
+
+encoding:
+  byte_order: big-endian
+  integer_encoding: unsigned-fixed-width
+  quantity_encoding: u64
+  loss_rate_encoding: u32-parts-per-million
+  identity_encoding: raw-32-bytes
+  row_count_encoding: u32
+  trailing_bytes: forbidden
+  noncanonical_row_order: forbidden
+
+state_field_order:
+  - schema_version
+  - opening_week
+  - site_logistics_nodes
+  - process_outputs
+  - input_output_coefficients
+  - labor_coefficients
+  - supplier_routes
+  - route_legs
+  - inventory
+  - orders
+  - backlog
+  - routed_freight_lots
+  - corridor_capacity
+  - process_capacity
+  - labor_capacity
+  - production_commitments
+
+site_logistics_node_field_order:
+  - site_id
+  - logistics_node_id
+
+process_output_field_order:
+  - process_id
+  - site_id
+  - output_good_id
+  - unit_id
+  - quantity_per_batch
+
+input_output_coefficient_field_order:
+  - process_id
+  - input_good_id
+  - unit_id
+  - quantity_per_batch
+
+labor_coefficient_field_order:
+  - process_id
+  - labor_unit_id
+  - quantity_per_batch
+
+supplier_route_field_order:
+  - buyer_site_id
+  - supplier_site_id
+  - good_id
+  - unit_id
+  - route_id
+
+route_leg_field_order:
+  - route_id
+  - leg_index
+  - corridor_id
+  - from_node_id
+  - to_node_id
+  - travel_weeks
+  - loss_ppm
+
+inventory_field_order:
+  - site_id
+  - good_id
+  - unit_id
+  - on_hand_quantity
+
+order_field_order:
+  - order_id
+  - access_mode
+  - buyer_site_id
+  - supplier_site_id
+  - good_id
+  - unit_id
+  - ordered_quantity
+  - shipped_quantity
+  - lost_quantity
+  - delivered_quantity
+  - realized_quantity
+
+backlog_field_order:
+  - order_id
+  - unshipped_quantity
+
+routed_freight_lot_field_order:
+  - lot_id
+  - order_id
+  - route_id
+  - dispatch_week
+  - current_leg_index
+  - leg_arrival_week
+  - source_site_id
+  - destination_site_id
+  - good_id
+  - unit_id
+  - quantity
+
+corridor_capacity_field_order:
+  - corridor_id
+  - unit_id
+  - departure_week
+  - available_quantity
+
+process_capacity_field_order:
+  - process_id
+  - site_id
+  - week
+  - available_batches
+
+labor_capacity_field_order:
+  - site_id
+  - labor_unit_id
+  - week
+  - available_quantity
+
+production_commitment_field_order:
+  - process_id
+  - site_id
+  - week
+  - planned_batches
+
+access_modes:
+  commodity_sale: 1
+
+canonical_order:
+  site_logistics_nodes:
+    - site_id
+  process_outputs:
+    - process_id
+  input_output_coefficients:
+    - process_id
+    - good_id
+    - unit_id
+  labor_coefficients:
+    - process_id
+  supplier_routes:
+    - buyer_site_id
+    - supplier_site_id
+    - good_id
+    - unit_id
+  route_legs:
+    - route_id
+    - leg_index
+  inventory:
+    - site_id
+    - good_id
+    - unit_id
+  orders:
+    - order_id
+  backlog:
+    - order_id
+  routed_freight_lots:
+    - leg_arrival_week
+    - lot_id
+  corridor_capacity:
+    - departure_week
+    - corridor_id
+    - unit_id
+  process_capacity:
+    - week
+    - site_id
+    - process_id
+  labor_capacity:
+    - week
+    - site_id
+    - unit_id
+  production_commitments:
+    - week
+    - site_id
+    - process_id
+  priority: canonical order grants no material priority and selects no route
+
+route_laws:
+  - each site binds to one unique logistics node and each node binds to one site
+  - a supplier relation selects one route for one buyer, supplier, good, and unit
+  - each referenced route contains one to 16 contiguous positive-duration legs
+  - a supplier route begins at the supplier node and ends at the buyer node
+  - each corridor capacity row references a corridor that exists in route topology
+  - unused route topology can persist after a supplier relation disappears
+  - a missing supplier relation leaves a new order in backlog and moves no goods
+
+weekly_transition_order:
+  - validate and canonicalize the complete opening state
+  - complete each due route leg and attribute its exact loss
+  - advance retained goods to the next leg or credit final destination inventory
+  - record accepted delivery and commodity quantity realization only after final arrival
+  - execute prior-week production commitments through current Leontief limits
+  - allocate remaining supplier inventory and every route-leg capacity proportionally
+  - reserve exact capacity for every future leg before dispatch
+  - debit supplier inventory and create one routed freight lot per order and dispatch week
+  - rebuild exact unshipped backlog
+  - derive following-week production from closing inputs, labor, and capacity
+  - discard consumed capacity rows and validate the canonical successor
+
+freight_allocation_law:
+  request: each open routed order requests its full unshipped quantity
+  resources: >-
+    the supplier inventory principal and every corridor, departure-week, and
+    unit principal on the selected route
+  group_grant: floor(available * requested_i / total_requested)
+  order_dispatch: the minimum grant across all required resource principals
+  intermediate: exact wide integer product and sum over u64 quantities
+  residual: division remainder stays in its inventory or capacity principal
+  reservation: the dispatched opening quantity debits every future route leg
+  missing_capacity: the affected order remains backlog and no goods move
+
+freight_lot_law:
+  identity_preimage:
+    - freight_lot_identity domain bytes
+    - terminator byte
+    - order_id
+    - dispatch_week
+  identity_algorithm: SHA-256
+  uniqueness: one live lot for each order and dispatch week
+  transit_state: the lot current-leg fields are the sole routed transit state
+  leg_arrival: dispatch week plus the cumulative positive route-leg durations
+  leg_loss: floor(quantity * loss_ppm / 1000000)
+  loss_attribution: cumulative order loss and a corridor-bearing loss receipt
+  final_arrival: only retained final-leg quantity credits destination inventory
+  conservative_capacity: later freight loss does not release reserved capacity
+
+production_law:
+  authority: unchanged Material Circuit V1 exact production transition
+  actual_batches: >-
+    min(planned batches, available process batches, each order-neutral shared
+    labor grant divided by labor per batch, and each order-neutral shared input
+    grant divided by its input per batch)
+  temporal_priority: >-
+    final arrivals credit inventory before current commitments execute; closing
+    inventory can form a following-week commitment
+  input_debit: each material input and labor quantity is debited before output is credited
+  zero_supply: zero production is a committed material outcome, not an engine error
+
+conservation_laws:
+  - realized quantity is at most delivered quantity
+  - lost plus delivered quantity is at most shipped quantity
+  - shipped quantity is at most ordered quantity
+  - backlog equals ordered quantity minus shipped quantity
+  - shipped equals delivered plus lost plus the exact live freight quantity for the order
+  - dispatch debits supplier inventory by the exact routed-lot quantity
+  - dispatch debits every route-leg capacity by the exact routed-lot opening quantity
+  - leg loss reduces the lot by the exact attributed loss quantity
+  - final arrival consumes the lot and credits exact retained destination inventory
+  - checked overflow refuses without publishing a successor state
+
+limits:
+  rows_per_family:
+    value: 65536
+    classification: Designed
+    purpose: serialization, memory, and transition fuel ceiling, not material abundance
+  route_legs_per_route:
+    value: 16
+    classification: Designed
+    purpose: whole-route reservation fuel ceiling, not geographic or political rank
+  freight_resource_groups:
+    value: 1114112
+    derivation: rows_per_family * (route_legs_per_route + one inventory principal)
+  loss_parts_per_million_denominator:
+    value: 1000000
+    classification: Designed
+
+canonical_lengths:
+  fixed_state_header_bytes: 100
+  site_logistics_node_row_bytes: 64
+  process_output_row_bytes: 136
+  input_output_coefficient_row_bytes: 104
+  labor_coefficient_row_bytes: 72
+  supplier_route_row_bytes: 160
+  route_leg_row_bytes: 136
+  inventory_row_bytes: 104
+  order_row_bytes: 201
+  backlog_row_bytes: 40
+  routed_freight_lot_row_bytes: 250
+  corridor_capacity_row_bytes: 80
+  process_capacity_row_bytes: 80
+  labor_capacity_row_bytes: 80
+  production_commitment_row_bytes: 80
+
+digest_contract:
+  algorithm: SHA-256
+  preimage: validated canonical complete-state bytes
+
+base_vector:
+  family_row_counts:
+    site_logistics_nodes: 2
+    process_outputs: 0
+    input_output_coefficients: 0
+    labor_coefficients: 0
+    supplier_routes: 1
+    route_legs: 1
+    inventory: 2
+    orders: 1
+    backlog: 1
+    routed_freight_lots: 0
+    corridor_capacity: 1
+    process_capacity: 0
+    labor_capacity: 0
+    production_commitments: 0
+  canonical_bytes: 1053
+  digest_hex: a0ca4c774cf74110ffc3611aa1bd7609cbee07e360477e99363f268b93d7cf31
+
+error_codes:
+  row_limit: 1
+  zero_quantity: 2
+  duplicate_row: 3
+  order_invariant: 4
+  backlog_invariant: 5
+  freight_invariant: 6
+  process_invariant: 7
+  week_invariant: 8
+  arithmetic: 9
+  route_invariant: 10
+  capacity_invariant: 11
+  wire_limit: 12
+  wire_domain: 13
+  wire_version: 14
+  wire_truncated: 15
+  wire_trailing: 16
+  wire_enum: 17
+  wire_noncanonical: 18
+
+excluded_surfaces:
+  - money, price, claims, escrow, default, double-entry settlement, or monetary realization
+  - sovereign, jurisdiction, country, residual trade-bloc, tariff, or customs identities
+  - participant-selected route choice, rerouting, waiting lots, or capacity release after loss
+  - access modes other than commodity sale
+  - service or care production
+  - strike, blockade, occupation, damage, or capital-strike effects
+  - graph, BSL, TickSession, nominal-world-hash, envelope, or persistence integration
+  - receipt bytes, Archive output, Bevy action, or gameplay activation

--- a/contracts/material_circuit_v2_vectors.jsonl
+++ b/contracts/material_circuit_v2_vectors.jsonl
@@ -1,0 +1,2 @@
+{"case_id":"base-opening-state","kind":"state","data":{"canonical_bytes":1053,"digest_hex":"a0ca4c774cf74110ffc3611aa1bd7609cbee07e360477e99363f268b93d7cf31"}}
+{"case_id":"manifest","kind":"manifest","data":{"schema_version":2,"schema_sha256":"4249c6c2d238b7c5db1c552ec1a720a5830c27e2429b3c4a8a3d29277dd31c72","quantity_width_bits":64,"rows_per_family":65536,"route_legs_per_route":16,"freight_resource_groups":1114112,"error_code_count":18,"access_mode_count":1,"loss_ppm_denominator":1000000}}

--- a/rust/crates/babylon-material-circuit/src/lib.rs
+++ b/rust/crates/babylon-material-circuit/src/lib.rs
@@ -3,12 +3,23 @@
 #![warn(clippy::pedantic)]
 
 mod model;
+mod model_v2;
 mod transition;
+mod transition_v2;
 mod wire;
+mod wire_common;
+mod wire_v2;
 
 pub use model::*;
+pub use model_v2::*;
 pub use transition::advance_material_circuit_v1;
+pub use transition_v2::advance_material_circuit_v2;
 pub use wire::{
     decode_material_circuit_state_v1, encode_material_circuit_state_v1,
     material_circuit_state_v1_digest, MATERIAL_CIRCUIT_STATE_V1_DOMAIN_BYTES,
+};
+pub use wire_v2::{
+    decode_material_circuit_state_v2, encode_material_circuit_state_v2,
+    material_circuit_state_v2_digest, MATERIAL_CIRCUIT_STATE_V2_DOMAIN_BYTES,
+    MATERIAL_CIRCUIT_V2_SOURCE_SHA256,
 };

--- a/rust/crates/babylon-material-circuit/src/model.rs
+++ b/rust/crates/babylon-material-circuit/src/model.rs
@@ -25,6 +25,8 @@ macro_rules! identity_type {
     };
 }
 
+pub(crate) use identity_type;
+
 identity_type!(SiteIdV1);
 identity_type!(GoodIdV1);
 identity_type!(UnitIdV1);

--- a/rust/crates/babylon-material-circuit/src/model_v2.rs
+++ b/rust/crates/babylon-material-circuit/src/model_v2.rs
@@ -1,0 +1,227 @@
+//! Versioned routed-freight successor rows for the material circuit.
+
+use crate::model::identity_type;
+use crate::{
+    BacklogRowV1, CapacityRowV1, InputOutputCoefficientV1, InventoryRowV1, LaborCapacityRowV1,
+    LaborCoefficientV1, OrderAccessModeV1, OrderIdV1, ProcessOutputV1, ProductionCommitmentV1,
+    ProductionReceiptV1, SiteIdV1, UnitIdV1, MAX_MATERIAL_CIRCUIT_ROWS_V1,
+};
+
+/// Designed route-depth ceiling for bounded reservation work.
+pub const MAX_ROUTE_LEGS_PER_ROUTE_V2: usize = 16;
+/// Derived ceiling for one inventory request plus every route-leg request per order.
+pub const MAX_FREIGHT_RESOURCE_GROUPS_V2: usize =
+    MAX_MATERIAL_CIRCUIT_ROWS_V1 * (MAX_ROUTE_LEGS_PER_ROUTE_V2 + 1);
+/// Parts-per-million denominator for exact freight loss.
+pub const FREIGHT_LOSS_PARTS_PER_MILLION_V2: u32 = 1_000_000;
+
+identity_type!(LogisticsNodeIdV2);
+identity_type!(CorridorIdV2);
+identity_type!(RouteIdV2);
+identity_type!(FreightLotIdV2);
+
+/// Connect one material site to one logistics node.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SiteLogisticsNodeV2 {
+    pub site_id: SiteIdV1,
+    pub node_id: LogisticsNodeIdV2,
+}
+
+/// The unique routed supplier relation for one exact order principal.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SupplierRouteV2 {
+    pub buyer_site_id: SiteIdV1,
+    pub supplier_site_id: SiteIdV1,
+    pub good_id: crate::GoodIdV1,
+    pub unit_id: UnitIdV1,
+    pub route_id: RouteIdV2,
+}
+
+/// One connected positive-duration route leg.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RouteLegV2 {
+    pub route_id: RouteIdV2,
+    pub leg_index: u16,
+    pub corridor_id: CorridorIdV2,
+    pub from_node_id: LogisticsNodeIdV2,
+    pub to_node_id: LogisticsNodeIdV2,
+    pub travel_weeks: u16,
+    pub loss_ppm: u32,
+}
+
+/// Available, unreserved exact capacity for one corridor departure week.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CorridorCapacityV2 {
+    pub corridor_id: CorridorIdV2,
+    pub unit_id: UnitIdV1,
+    pub week: u64,
+    pub available: u64,
+}
+
+/// Cumulative order quantities with an explicit freight-loss destination.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct OrderRowV2 {
+    pub order_id: OrderIdV1,
+    pub access_mode: OrderAccessModeV1,
+    pub buyer_site_id: SiteIdV1,
+    pub supplier_site_id: SiteIdV1,
+    pub good_id: crate::GoodIdV1,
+    pub unit_id: UnitIdV1,
+    pub ordered: u64,
+    pub shipped: u64,
+    pub lost: u64,
+    pub delivered: u64,
+    pub realized: u64,
+}
+
+/// One authoritative in-transit state for one exact routed lot.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RoutedFreightLotV2 {
+    pub lot_id: FreightLotIdV2,
+    pub order_id: OrderIdV1,
+    pub route_id: RouteIdV2,
+    pub dispatch_week: u64,
+    pub current_leg_index: u16,
+    pub leg_arrival_week: u64,
+    pub source_site_id: SiteIdV1,
+    pub destination_site_id: SiteIdV1,
+    pub good_id: crate::GoodIdV1,
+    pub unit_id: UnitIdV1,
+    pub quantity: u64,
+}
+
+/// Complete V2 auxiliary-register state at the opening of `week`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaterialCircuitStateV2 {
+    pub week: u64,
+    pub site_logistics_nodes: Vec<SiteLogisticsNodeV2>,
+    pub process_outputs: Vec<ProcessOutputV1>,
+    pub input_coefficients: Vec<InputOutputCoefficientV1>,
+    pub labor_coefficients: Vec<LaborCoefficientV1>,
+    pub supplier_routes: Vec<SupplierRouteV2>,
+    pub route_legs: Vec<RouteLegV2>,
+    pub inventory: Vec<InventoryRowV1>,
+    pub orders: Vec<OrderRowV2>,
+    pub backlog: Vec<BacklogRowV1>,
+    pub freight: Vec<RoutedFreightLotV2>,
+    pub corridor_capacities: Vec<CorridorCapacityV2>,
+    pub capacities: Vec<CapacityRowV1>,
+    pub labor: Vec<LaborCapacityRowV1>,
+    pub production_commitments: Vec<ProductionCommitmentV1>,
+}
+
+/// Exact V2 routed-material refusal classes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum MaterialCircuitErrorV2 {
+    RowLimit = 1,
+    ZeroQuantity = 2,
+    DuplicateRow = 3,
+    OrderInvariant = 4,
+    BacklogInvariant = 5,
+    FreightInvariant = 6,
+    ProcessInvariant = 7,
+    WeekInvariant = 8,
+    Arithmetic = 9,
+    RouteInvariant = 10,
+    CapacityInvariant = 11,
+    WireLimit = 12,
+    WireDomain = 13,
+    WireVersion = 14,
+    WireTruncated = 15,
+    WireTrailing = 16,
+    WireEnum = 17,
+    WireNoncanonical = 18,
+}
+
+/// Unknown language-neutral routed-material refusal code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnknownMaterialCircuitErrorCodeV2(pub u16);
+
+impl TryFrom<u16> for MaterialCircuitErrorV2 {
+    type Error = UnknownMaterialCircuitErrorCodeV2;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::RowLimit),
+            2 => Ok(Self::ZeroQuantity),
+            3 => Ok(Self::DuplicateRow),
+            4 => Ok(Self::OrderInvariant),
+            5 => Ok(Self::BacklogInvariant),
+            6 => Ok(Self::FreightInvariant),
+            7 => Ok(Self::ProcessInvariant),
+            8 => Ok(Self::WeekInvariant),
+            9 => Ok(Self::Arithmetic),
+            10 => Ok(Self::RouteInvariant),
+            11 => Ok(Self::CapacityInvariant),
+            12 => Ok(Self::WireLimit),
+            13 => Ok(Self::WireDomain),
+            14 => Ok(Self::WireVersion),
+            15 => Ok(Self::WireTruncated),
+            16 => Ok(Self::WireTrailing),
+            17 => Ok(Self::WireEnum),
+            18 => Ok(Self::WireNoncanonical),
+            _ => Err(UnknownMaterialCircuitErrorCodeV2(value)),
+        }
+    }
+}
+
+impl From<MaterialCircuitErrorV2> for u16 {
+    fn from(value: MaterialCircuitErrorV2) -> Self {
+        value as Self
+    }
+}
+
+impl From<crate::MaterialCircuitErrorV1> for MaterialCircuitErrorV2 {
+    fn from(value: crate::MaterialCircuitErrorV1) -> Self {
+        match value {
+            crate::MaterialCircuitErrorV1::RowLimit => Self::RowLimit,
+            crate::MaterialCircuitErrorV1::ZeroQuantity => Self::ZeroQuantity,
+            crate::MaterialCircuitErrorV1::DuplicateRow => Self::DuplicateRow,
+            crate::MaterialCircuitErrorV1::OrderInvariant => Self::OrderInvariant,
+            crate::MaterialCircuitErrorV1::BacklogInvariant => Self::BacklogInvariant,
+            crate::MaterialCircuitErrorV1::TransitInvariant => Self::FreightInvariant,
+            crate::MaterialCircuitErrorV1::ProcessInvariant => Self::ProcessInvariant,
+            crate::MaterialCircuitErrorV1::WeekInvariant => Self::WeekInvariant,
+            crate::MaterialCircuitErrorV1::Arithmetic => Self::Arithmetic,
+            crate::MaterialCircuitErrorV1::WireLimit => Self::WireLimit,
+            crate::MaterialCircuitErrorV1::WireDomain => Self::WireDomain,
+            crate::MaterialCircuitErrorV1::WireVersion => Self::WireVersion,
+            crate::MaterialCircuitErrorV1::WireTruncated => Self::WireTruncated,
+            crate::MaterialCircuitErrorV1::WireTrailing => Self::WireTrailing,
+            crate::MaterialCircuitErrorV1::WireEnum => Self::WireEnum,
+            crate::MaterialCircuitErrorV1::WireNoncanonical => Self::WireNoncanonical,
+        }
+    }
+}
+
+/// Inventory and whole-route capacity reserved for one new freight lot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoutedDispatchReceiptV2 {
+    pub lot_id: FreightLotIdV2,
+    pub order_id: OrderIdV1,
+    pub route_id: RouteIdV2,
+    pub quantity: u64,
+    pub final_arrival_week: u64,
+}
+
+/// Exact goods lost when one route leg completes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FreightLossReceiptV2 {
+    pub lot_id: FreightLotIdV2,
+    pub order_id: OrderIdV1,
+    pub corridor_id: CorridorIdV2,
+    pub quantity: u64,
+}
+
+/// Atomic result of closing one routed material-circuit week.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaterialCircuitTransitionV2 {
+    pub state: MaterialCircuitStateV2,
+    pub production: Vec<ProductionReceiptV1>,
+    pub dispatches: Vec<RoutedDispatchReceiptV2>,
+    pub losses: Vec<FreightLossReceiptV2>,
+    pub arrivals: Vec<crate::ArrivalReceiptV1>,
+    pub deliveries: Vec<crate::DeliveryReceiptV1>,
+    pub realizations: Vec<crate::RealizationReceiptV1>,
+}

--- a/rust/crates/babylon-material-circuit/src/transition.rs
+++ b/rust/crates/babylon-material-circuit/src/transition.rs
@@ -566,7 +566,7 @@ fn wide_product(multiplier: u64, multiplicand: u128) -> [u64; 3] {
     [high_limb, middle_limb, low_limb]
 }
 
-fn proportional_floor(
+pub(crate) fn proportional_floor(
     available: u64,
     requested: u128,
     total: u128,
@@ -641,6 +641,16 @@ fn execute_production(
     let allocations = allocate_production_batches(state, inventory, &commitments, state.week)?;
     debit_production_allocations(state, inventory, &commitments, &allocations)?;
     credit_production_allocations(state, inventory, commitments, &allocations, receipts)
+}
+
+pub(crate) fn execute_shared_production_v1(
+    state: &mut MaterialCircuitStateV1,
+) -> Result<Vec<ProductionReceiptV1>, MaterialCircuitErrorV1> {
+    let mut inventory = take_inventory(state);
+    let mut receipts = Vec::new();
+    execute_production(state, &mut inventory, &mut receipts)?;
+    publish_inventory(state, inventory);
+    Ok(receipts)
 }
 
 fn debit_production_allocations(
@@ -934,6 +944,17 @@ fn derive_next_week_production(
                 });
         }
     }
+    Ok(())
+}
+
+pub(crate) fn derive_shared_production_v1(
+    state: &mut MaterialCircuitStateV1,
+    next_week: u64,
+) -> Result<(), MaterialCircuitErrorV1> {
+    let inventory = take_inventory(state);
+    derive_next_week_production(state, &inventory, next_week)?;
+    prune_consumed_capacity(state, next_week);
+    publish_inventory(state, inventory);
     Ok(())
 }
 

--- a/rust/crates/babylon-material-circuit/src/transition_v2.rs
+++ b/rust/crates/babylon-material-circuit/src/transition_v2.rs
@@ -1,0 +1,857 @@
+//! Pure weekly transition for the exact routed material circuit.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use babylon_kernel::sha256_of;
+
+use crate::transition::{
+    canonical_state_v1, derive_shared_production_v1, execute_shared_production_v1,
+    proportional_floor,
+};
+use crate::{
+    ArrivalReceiptV1, BacklogRowV1, CorridorIdV2, DeliveryReceiptV1, FreightLossReceiptV2,
+    FreightLotIdV2, GoodIdV1, InventoryRowV1, MaterialCircuitErrorV2, MaterialCircuitStateV1,
+    MaterialCircuitStateV2, MaterialCircuitTransitionV2, OrderIdV1, RealizationReceiptV1,
+    RouteIdV2, RouteLegV2, RoutedDispatchReceiptV2, RoutedFreightLotV2, SiteIdV1, UnitIdV1,
+    FREIGHT_LOSS_PARTS_PER_MILLION_V2, MAX_FREIGHT_RESOURCE_GROUPS_V2,
+    MAX_MATERIAL_CIRCUIT_ROWS_V1, MAX_ROUTE_LEGS_PER_ROUTE_V2,
+};
+
+type InventoryKey = (SiteIdV1, GoodIdV1, UnitIdV1);
+type InventoryLedger = BTreeMap<InventoryKey, u64>;
+type SupplierKey = (SiteIdV1, SiteIdV1, GoodIdV1, UnitIdV1);
+type CapacityKey = (u64, CorridorIdV2, UnitIdV1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum FreightResourceKey {
+    Inventory(InventoryKey),
+    Corridor(CapacityKey),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FreightRequest {
+    order_index: usize,
+    requested: u64,
+}
+
+fn check_row_limits(state: &MaterialCircuitStateV2) -> Result<(), MaterialCircuitErrorV2> {
+    let lengths = [
+        state.site_logistics_nodes.len(),
+        state.process_outputs.len(),
+        state.input_coefficients.len(),
+        state.labor_coefficients.len(),
+        state.supplier_routes.len(),
+        state.route_legs.len(),
+        state.inventory.len(),
+        state.orders.len(),
+        state.backlog.len(),
+        state.freight.len(),
+        state.corridor_capacities.len(),
+        state.capacities.len(),
+        state.labor.len(),
+        state.production_commitments.len(),
+    ];
+    if lengths
+        .into_iter()
+        .any(|length| length > MAX_MATERIAL_CIRCUIT_ROWS_V1)
+    {
+        return Err(MaterialCircuitErrorV2::RowLimit);
+    }
+    Ok(())
+}
+
+fn canonicalize_rows(state: &mut MaterialCircuitStateV2) {
+    state.site_logistics_nodes.sort();
+    state.process_outputs.sort();
+    state.input_coefficients.sort();
+    state.labor_coefficients.sort();
+    state.supplier_routes.sort();
+    state.route_legs.sort();
+    state.inventory.sort();
+    state.orders.sort_by_key(|row| row.order_id);
+    state.backlog.sort_by_key(|row| row.order_id);
+    state
+        .freight
+        .sort_by_key(|row| (row.leg_arrival_week, row.lot_id));
+    state
+        .corridor_capacities
+        .sort_by_key(|row| (row.week, row.corridor_id, row.unit_id));
+    state
+        .capacities
+        .sort_by_key(|row| (row.week, row.site_id, row.process_id));
+    state
+        .labor
+        .sort_by_key(|row| (row.week, row.site_id, row.unit_id));
+    state
+        .production_commitments
+        .sort_by_key(|row| (row.week, row.site_id, row.process_id));
+}
+
+fn has_duplicate<T, K: PartialEq>(rows: &[T], key: impl Fn(&T) -> K) -> bool {
+    rows.windows(2)
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1)
+        .any(|pair| key(&pair[0]) == key(&pair[1]))
+}
+
+fn validate_unique_rows(state: &MaterialCircuitStateV2) -> Result<(), MaterialCircuitErrorV2> {
+    let node_ids: BTreeSet<_> = state
+        .site_logistics_nodes
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|row| row.node_id)
+        .collect();
+    let dispatch_ids: BTreeSet<_> = state
+        .freight
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|row| (row.order_id, row.dispatch_week))
+        .collect();
+    let duplicate = has_duplicate(&state.site_logistics_nodes, |row| row.site_id)
+        || node_ids.len() != state.site_logistics_nodes.len()
+        || has_duplicate(&state.supplier_routes, |row| {
+            (
+                row.buyer_site_id,
+                row.supplier_site_id,
+                row.good_id,
+                row.unit_id,
+            )
+        })
+        || has_duplicate(&state.route_legs, |row| (row.route_id, row.leg_index))
+        || has_duplicate(&state.inventory, |row| {
+            (row.site_id, row.good_id, row.unit_id)
+        })
+        || has_duplicate(&state.orders, |row| row.order_id)
+        || has_duplicate(&state.backlog, |row| row.order_id)
+        || has_duplicate(&state.freight, |row| row.lot_id)
+        || dispatch_ids.len() != state.freight.len()
+        || has_duplicate(&state.corridor_capacities, |row| {
+            (row.week, row.corridor_id, row.unit_id)
+        });
+    if duplicate {
+        return Err(MaterialCircuitErrorV2::DuplicateRow);
+    }
+    Ok(())
+}
+
+fn route_legs(state: &MaterialCircuitStateV2, route: RouteIdV2) -> &[RouteLegV2] {
+    let start = state.route_legs.partition_point(|row| row.route_id < route);
+    let end = state
+        .route_legs
+        .partition_point(|row| row.route_id <= route);
+    &state.route_legs[start..end]
+}
+
+fn site_node(state: &MaterialCircuitStateV2, site: SiteIdV1) -> Option<crate::LogisticsNodeIdV2> {
+    state
+        .site_logistics_nodes
+        .binary_search_by_key(&site, |row| row.site_id)
+        .ok()
+        .map(|index| state.site_logistics_nodes[index].node_id)
+}
+
+fn validate_route_legs(legs: &[RouteLegV2]) -> Result<(), MaterialCircuitErrorV2> {
+    if legs.is_empty() || legs.len() > MAX_ROUTE_LEGS_PER_ROUTE_V2 {
+        return Err(MaterialCircuitErrorV2::RouteInvariant);
+    }
+    for (index, leg) in legs
+        .iter()
+        .enumerate()
+        .take(MAX_ROUTE_LEGS_PER_ROUTE_V2 + 1)
+    {
+        if usize::from(leg.leg_index) != index
+            || leg.travel_weeks == 0
+            || leg.loss_ppm > FREIGHT_LOSS_PARTS_PER_MILLION_V2
+        {
+            return Err(MaterialCircuitErrorV2::RouteInvariant);
+        }
+        if index > 0 && legs[index - 1].to_node_id != leg.from_node_id {
+            return Err(MaterialCircuitErrorV2::RouteInvariant);
+        }
+    }
+    Ok(())
+}
+
+fn validate_routes(state: &MaterialCircuitStateV2) -> Result<(), MaterialCircuitErrorV2> {
+    let route_ids: BTreeSet<_> = state
+        .route_legs
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|row| row.route_id)
+        .collect();
+    let corridor_ids: BTreeSet<_> = state
+        .route_legs
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|row| row.corridor_id)
+        .collect();
+    for route in route_ids.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        validate_route_legs(route_legs(state, *route))?;
+    }
+    for supplier in state
+        .supplier_routes
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        let legs = route_legs(state, supplier.route_id);
+        validate_route_legs(legs)?;
+        if site_node(state, supplier.supplier_site_id) != Some(legs[0].from_node_id)
+            || site_node(state, supplier.buyer_site_id) != Some(legs[legs.len() - 1].to_node_id)
+        {
+            return Err(MaterialCircuitErrorV2::RouteInvariant);
+        }
+    }
+    if state
+        .corridor_capacities
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .any(|row| !corridor_ids.contains(&row.corridor_id))
+    {
+        return Err(MaterialCircuitErrorV2::CapacityInvariant);
+    }
+    Ok(())
+}
+
+fn order_index(state: &MaterialCircuitStateV2, order: OrderIdV1) -> Option<usize> {
+    state
+        .orders
+        .binary_search_by_key(&order, |row| row.order_id)
+        .ok()
+}
+
+fn supplier_routes(state: &MaterialCircuitStateV2) -> BTreeMap<SupplierKey, RouteIdV2> {
+    state
+        .supplier_routes
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|row| {
+            (
+                (
+                    row.buyer_site_id,
+                    row.supplier_site_id,
+                    row.good_id,
+                    row.unit_id,
+                ),
+                row.route_id,
+            )
+        })
+        .collect()
+}
+
+fn expected_leg_arrival(
+    lot: &RoutedFreightLotV2,
+    legs: &[RouteLegV2],
+) -> Result<u64, MaterialCircuitErrorV2> {
+    legs.iter()
+        .take(usize::from(lot.current_leg_index) + 1)
+        .try_fold(lot.dispatch_week, |week, leg| {
+            week.checked_add(u64::from(leg.travel_weeks))
+                .ok_or(MaterialCircuitErrorV2::Arithmetic)
+        })
+}
+
+fn validate_orders_and_freight(
+    state: &MaterialCircuitStateV2,
+) -> Result<(), MaterialCircuitErrorV2> {
+    if state.orders.len() != state.backlog.len() {
+        return Err(MaterialCircuitErrorV2::BacklogInvariant);
+    }
+    let routes = supplier_routes(state);
+    let mut in_transit = BTreeMap::<OrderIdV1, u128>::new();
+    for lot in state.freight.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        let Some(index) = order_index(state, lot.order_id) else {
+            return Err(MaterialCircuitErrorV2::FreightInvariant);
+        };
+        let order = &state.orders[index];
+        let supplier_key = (
+            order.buyer_site_id,
+            order.supplier_site_id,
+            order.good_id,
+            order.unit_id,
+        );
+        let legs = route_legs(state, lot.route_id);
+        if lot.quantity == 0
+            || lot.lot_id != freight_lot_id(lot.order_id, lot.dispatch_week)
+            || lot.dispatch_week >= state.week
+            || lot.leg_arrival_week < state.week
+            || usize::from(lot.current_leg_index) >= legs.len()
+            || routes.get(&supplier_key) != Some(&lot.route_id)
+            || lot.source_site_id != order.supplier_site_id
+            || lot.destination_site_id != order.buyer_site_id
+            || lot.good_id != order.good_id
+            || lot.unit_id != order.unit_id
+        {
+            return Err(MaterialCircuitErrorV2::FreightInvariant);
+        }
+        if expected_leg_arrival(lot, legs)? != lot.leg_arrival_week {
+            return Err(MaterialCircuitErrorV2::FreightInvariant);
+        }
+        let total = in_transit.entry(lot.order_id).or_default();
+        *total = total
+            .checked_add(u128::from(lot.quantity))
+            .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+    }
+    for (order, backlog) in state
+        .orders
+        .iter()
+        .zip(&state.backlog)
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        if order.ordered == 0 {
+            return Err(MaterialCircuitErrorV2::ZeroQuantity);
+        }
+        let accounted = order
+            .delivered
+            .checked_add(order.lost)
+            .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+        if order.realized > order.delivered
+            || accounted > order.shipped
+            || order.shipped > order.ordered
+        {
+            return Err(MaterialCircuitErrorV2::OrderInvariant);
+        }
+        if backlog.order_id != order.order_id || backlog.quantity != order.ordered - order.shipped {
+            return Err(MaterialCircuitErrorV2::BacklogInvariant);
+        }
+        if in_transit.get(&order.order_id).copied().unwrap_or(0)
+            != u128::from(order.shipped - accounted)
+        {
+            return Err(MaterialCircuitErrorV2::FreightInvariant);
+        }
+    }
+    Ok(())
+}
+
+fn production_state(state: &MaterialCircuitStateV2) -> MaterialCircuitStateV1 {
+    MaterialCircuitStateV1 {
+        week: state.week,
+        process_outputs: state.process_outputs.clone(),
+        input_coefficients: state.input_coefficients.clone(),
+        labor_coefficients: state.labor_coefficients.clone(),
+        supplier_candidates: Vec::new(),
+        inventory: state.inventory.clone(),
+        orders: Vec::new(),
+        backlog: Vec::new(),
+        transit: Vec::new(),
+        capacities: state.capacities.clone(),
+        labor: state.labor.clone(),
+        production_commitments: state.production_commitments.clone(),
+    }
+}
+
+fn merge_production_state(state: &mut MaterialCircuitStateV2, production: MaterialCircuitStateV1) {
+    state.inventory = production.inventory;
+    state.capacities = production.capacities;
+    state.labor = production.labor;
+    state.production_commitments = production.production_commitments;
+}
+
+pub(crate) fn canonical_state_v2(
+    state: &MaterialCircuitStateV2,
+) -> Result<MaterialCircuitStateV2, MaterialCircuitErrorV2> {
+    check_row_limits(state)?;
+    let mut canonical = state.clone();
+    canonicalize_rows(&mut canonical);
+    validate_unique_rows(&canonical)?;
+    validate_routes(&canonical)?;
+    validate_orders_and_freight(&canonical)?;
+    canonical_state_v1(&production_state(&canonical)).map_err(MaterialCircuitErrorV2::from)?;
+    if canonical.week == 0
+        || canonical
+            .corridor_capacities
+            .iter()
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+            .any(|row| row.week < canonical.week)
+    {
+        return Err(MaterialCircuitErrorV2::WeekInvariant);
+    }
+    Ok(canonical)
+}
+
+fn take_inventory(state: &mut MaterialCircuitStateV2) -> InventoryLedger {
+    std::mem::take(&mut state.inventory)
+        .into_iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|row| ((row.site_id, row.good_id, row.unit_id), row.quantity))
+        .collect()
+}
+
+fn publish_inventory(state: &mut MaterialCircuitStateV2, inventory: InventoryLedger) {
+    state.inventory = inventory
+        .into_iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|((site_id, good_id, unit_id), quantity)| InventoryRowV1 {
+            site_id,
+            good_id,
+            unit_id,
+            quantity,
+        })
+        .collect();
+}
+
+fn credit_inventory(
+    inventory: &mut InventoryLedger,
+    key: InventoryKey,
+    quantity: u64,
+) -> Result<(), MaterialCircuitErrorV2> {
+    if quantity == 0 {
+        return Ok(());
+    }
+    if let Some(current) = inventory.get_mut(&key) {
+        *current = current
+            .checked_add(quantity)
+            .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+        return Ok(());
+    }
+    if inventory.len() == MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        return Err(MaterialCircuitErrorV2::RowLimit);
+    }
+    inventory.insert(key, quantity);
+    Ok(())
+}
+
+fn debit_inventory(
+    inventory: &mut InventoryLedger,
+    key: InventoryKey,
+    quantity: u64,
+) -> Result<(), MaterialCircuitErrorV2> {
+    if quantity == 0 {
+        return Ok(());
+    }
+    let current = inventory
+        .get_mut(&key)
+        .ok_or(MaterialCircuitErrorV2::FreightInvariant)?;
+    *current = current
+        .checked_sub(quantity)
+        .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+    Ok(())
+}
+
+fn loss_quantity(quantity: u64, loss_ppm: u32) -> Result<u64, MaterialCircuitErrorV2> {
+    let loss = u128::from(quantity)
+        .checked_mul(u128::from(loss_ppm))
+        .ok_or(MaterialCircuitErrorV2::Arithmetic)?
+        / u128::from(FREIGHT_LOSS_PARTS_PER_MILLION_V2);
+    u64::try_from(loss).map_err(|_| MaterialCircuitErrorV2::Arithmetic)
+}
+
+fn process_due_freight(
+    state: &mut MaterialCircuitStateV2,
+    inventory: &mut InventoryLedger,
+    losses: &mut Vec<FreightLossReceiptV2>,
+    arrivals: &mut Vec<ArrivalReceiptV1>,
+    deliveries: &mut Vec<DeliveryReceiptV1>,
+    realizations: &mut Vec<RealizationReceiptV1>,
+) -> Result<(), MaterialCircuitErrorV2> {
+    let opening = std::mem::take(&mut state.freight);
+    let mut remaining = Vec::with_capacity(opening.len());
+    for mut lot in opening.into_iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        if lot.leg_arrival_week != state.week {
+            remaining.push(lot);
+            continue;
+        }
+        let index = usize::from(lot.current_leg_index);
+        let (corridor_id, loss_ppm, next_leg) = {
+            let legs = route_legs(state, lot.route_id);
+            let leg = &legs[index];
+            let next_leg = legs
+                .get(index + 1)
+                .map(|next| (next.leg_index, next.travel_weeks));
+            (leg.corridor_id, leg.loss_ppm, next_leg)
+        };
+        let lost = loss_quantity(lot.quantity, loss_ppm)?;
+        let retained = lot
+            .quantity
+            .checked_sub(lost)
+            .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+        let order_index =
+            order_index(state, lot.order_id).ok_or(MaterialCircuitErrorV2::FreightInvariant)?;
+        state.orders[order_index].lost = state.orders[order_index]
+            .lost
+            .checked_add(lost)
+            .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+        if lost > 0 {
+            losses.push(FreightLossReceiptV2 {
+                lot_id: lot.lot_id,
+                order_id: lot.order_id,
+                corridor_id,
+                quantity: lost,
+            });
+        }
+        if let Some((next_leg_index, next_travel_weeks)) = next_leg.filter(|_| retained > 0) {
+            lot.current_leg_index = next_leg_index;
+            lot.leg_arrival_week = state
+                .week
+                .checked_add(u64::from(next_travel_weeks))
+                .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+            lot.quantity = retained;
+            remaining.push(lot);
+            continue;
+        }
+        if retained > 0 {
+            credit_inventory(
+                inventory,
+                (lot.destination_site_id, lot.good_id, lot.unit_id),
+                retained,
+            )?;
+            let order = &mut state.orders[order_index];
+            order.delivered = order
+                .delivered
+                .checked_add(retained)
+                .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+            order.realized = order
+                .realized
+                .checked_add(retained)
+                .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+            arrivals.push(ArrivalReceiptV1 {
+                order_id: lot.order_id,
+                quantity: retained,
+            });
+            deliveries.push(DeliveryReceiptV1 {
+                order_id: lot.order_id,
+                quantity: retained,
+            });
+            realizations.push(RealizationReceiptV1 {
+                order_id: lot.order_id,
+                quantity: retained,
+            });
+        }
+    }
+    state.freight = remaining;
+    Ok(())
+}
+
+fn capacity_index(state: &MaterialCircuitStateV2, key: CapacityKey) -> Option<usize> {
+    state
+        .corridor_capacities
+        .binary_search_by_key(&key, |row| (row.week, row.corridor_id, row.unit_id))
+        .ok()
+}
+
+fn add_request(
+    groups: &mut BTreeMap<FreightResourceKey, Vec<FreightRequest>>,
+    key: FreightResourceKey,
+    order_index: usize,
+    requested: u64,
+) {
+    groups.entry(key).or_default().push(FreightRequest {
+        order_index,
+        requested,
+    });
+}
+
+fn resource_groups(
+    state: &MaterialCircuitStateV2,
+    routes: &BTreeMap<SupplierKey, RouteIdV2>,
+) -> Result<BTreeMap<FreightResourceKey, Vec<FreightRequest>>, MaterialCircuitErrorV2> {
+    let mut groups = BTreeMap::new();
+    for (index, order) in state
+        .orders
+        .iter()
+        .enumerate()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        let requested = order.ordered - order.shipped;
+        let key = (
+            order.buyer_site_id,
+            order.supplier_site_id,
+            order.good_id,
+            order.unit_id,
+        );
+        let Some(route) = routes.get(&key) else {
+            continue;
+        };
+        if requested == 0 {
+            continue;
+        }
+        add_request(
+            &mut groups,
+            FreightResourceKey::Inventory((order.supplier_site_id, order.good_id, order.unit_id)),
+            index,
+            requested,
+        );
+        let mut departure_week = state.week;
+        for leg in route_legs(state, *route)
+            .iter()
+            .take(MAX_ROUTE_LEGS_PER_ROUTE_V2 + 1)
+        {
+            add_request(
+                &mut groups,
+                FreightResourceKey::Corridor((departure_week, leg.corridor_id, order.unit_id)),
+                index,
+                requested,
+            );
+            departure_week = departure_week
+                .checked_add(u64::from(leg.travel_weeks))
+                .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+        }
+    }
+    ensure_resource_group_count(groups.len())?;
+    Ok(groups)
+}
+
+fn ensure_resource_group_count(count: usize) -> Result<(), MaterialCircuitErrorV2> {
+    if count > MAX_FREIGHT_RESOURCE_GROUPS_V2 {
+        Err(MaterialCircuitErrorV2::RowLimit)
+    } else {
+        Ok(())
+    }
+}
+
+fn resource_available(
+    state: &MaterialCircuitStateV2,
+    inventory: &InventoryLedger,
+    key: FreightResourceKey,
+) -> u64 {
+    match key {
+        FreightResourceKey::Inventory(inventory_key) => {
+            inventory.get(&inventory_key).copied().unwrap_or(0)
+        }
+        FreightResourceKey::Corridor(capacity_key) => capacity_index(state, capacity_key)
+            .map_or(0, |index| state.corridor_capacities[index].available),
+    }
+}
+
+fn order_allocations(
+    state: &MaterialCircuitStateV2,
+    inventory: &InventoryLedger,
+    groups: &BTreeMap<FreightResourceKey, Vec<FreightRequest>>,
+) -> Result<Vec<u64>, MaterialCircuitErrorV2> {
+    let mut allocations = vec![0_u64; state.orders.len()];
+    for requests in groups.values().take(MAX_FREIGHT_RESOURCE_GROUPS_V2) {
+        for request in requests.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+            allocations[request.order_index] = request.requested;
+        }
+    }
+    for (key, requests) in groups.iter().take(MAX_FREIGHT_RESOURCE_GROUPS_V2) {
+        let total = requests
+            .iter()
+            .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+            .try_fold(0_u128, |sum, request| {
+                sum.checked_add(u128::from(request.requested))
+                    .ok_or(MaterialCircuitErrorV2::Arithmetic)
+            })?;
+        let available = resource_available(state, inventory, *key);
+        for request in requests.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+            let grant = if u128::from(available) >= total {
+                request.requested
+            } else {
+                proportional_floor(available, u128::from(request.requested), total)
+                    .map_err(MaterialCircuitErrorV2::from)?
+            };
+            allocations[request.order_index] = allocations[request.order_index].min(grant);
+        }
+    }
+    Ok(allocations)
+}
+
+fn freight_lot_id(order: OrderIdV1, week: u64) -> FreightLotIdV2 {
+    let mut bytes = b"babylon.freight-lot.v2\0".to_vec();
+    bytes.extend_from_slice(&order.as_bytes());
+    bytes.extend_from_slice(&week.to_be_bytes());
+    FreightLotIdV2::from_bytes(sha256_of(&bytes))
+}
+
+fn reserve_route_capacity(
+    state: &mut MaterialCircuitStateV2,
+    route: RouteIdV2,
+    unit: UnitIdV1,
+    quantity: u64,
+) -> Result<u64, MaterialCircuitErrorV2> {
+    let mut departure_week = state.week;
+    let mut final_arrival_week = state.week;
+    let legs = route_legs(state, route).to_vec();
+    for leg in legs.iter().take(MAX_ROUTE_LEGS_PER_ROUTE_V2 + 1) {
+        let key = (departure_week, leg.corridor_id, unit);
+        let index = capacity_index(state, key).ok_or(MaterialCircuitErrorV2::CapacityInvariant)?;
+        state.corridor_capacities[index].available = state.corridor_capacities[index]
+            .available
+            .checked_sub(quantity)
+            .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+        final_arrival_week = departure_week
+            .checked_add(u64::from(leg.travel_weeks))
+            .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+        departure_week = final_arrival_week;
+    }
+    Ok(final_arrival_week)
+}
+
+fn apply_dispatches(
+    state: &mut MaterialCircuitStateV2,
+    inventory: &mut InventoryLedger,
+    routes: &BTreeMap<SupplierKey, RouteIdV2>,
+    allocations: &[u64],
+    receipts: &mut Vec<RoutedDispatchReceiptV2>,
+) -> Result<(), MaterialCircuitErrorV2> {
+    for (index, quantity) in allocations
+        .iter()
+        .copied()
+        .enumerate()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+    {
+        if quantity == 0 {
+            continue;
+        }
+        let order = state.orders[index].clone();
+        let supplier_key = (
+            order.buyer_site_id,
+            order.supplier_site_id,
+            order.good_id,
+            order.unit_id,
+        );
+        let route = routes[&supplier_key];
+        let legs = route_legs(state, route);
+        let first_arrival_week = state
+            .week
+            .checked_add(u64::from(legs[0].travel_weeks))
+            .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+        debit_inventory(
+            inventory,
+            (order.supplier_site_id, order.good_id, order.unit_id),
+            quantity,
+        )?;
+        let final_arrival_week = reserve_route_capacity(state, route, order.unit_id, quantity)?;
+        state.orders[index].shipped = state.orders[index]
+            .shipped
+            .checked_add(quantity)
+            .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+        let lot_id = freight_lot_id(order.order_id, state.week);
+        state.freight.push(RoutedFreightLotV2 {
+            lot_id,
+            order_id: order.order_id,
+            route_id: route,
+            dispatch_week: state.week,
+            current_leg_index: 0,
+            leg_arrival_week: first_arrival_week,
+            source_site_id: order.supplier_site_id,
+            destination_site_id: order.buyer_site_id,
+            good_id: order.good_id,
+            unit_id: order.unit_id,
+            quantity,
+        });
+        receipts.push(RoutedDispatchReceiptV2 {
+            lot_id,
+            order_id: order.order_id,
+            route_id: route,
+            quantity,
+            final_arrival_week,
+        });
+    }
+    Ok(())
+}
+
+fn dispatch_orders(
+    state: &mut MaterialCircuitStateV2,
+    inventory: &mut InventoryLedger,
+    receipts: &mut Vec<RoutedDispatchReceiptV2>,
+) -> Result<(), MaterialCircuitErrorV2> {
+    let routes = supplier_routes(state);
+    let groups = resource_groups(state, &routes)?;
+    let allocations = order_allocations(state, inventory, &groups)?;
+    apply_dispatches(state, inventory, &routes, &allocations, receipts)
+}
+
+fn rebuild_backlog(state: &mut MaterialCircuitStateV2) {
+    state.backlog = state
+        .orders
+        .iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .map(|order| BacklogRowV1 {
+            order_id: order.order_id,
+            quantity: order.ordered - order.shipped,
+        })
+        .collect();
+}
+
+fn execute_production(
+    state: &mut MaterialCircuitStateV2,
+) -> Result<Vec<crate::ProductionReceiptV1>, MaterialCircuitErrorV2> {
+    let mut production = production_state(state);
+    let receipts =
+        execute_shared_production_v1(&mut production).map_err(MaterialCircuitErrorV2::from)?;
+    merge_production_state(state, production);
+    Ok(receipts)
+}
+
+fn derive_next_production(
+    state: &mut MaterialCircuitStateV2,
+    next_week: u64,
+) -> Result<(), MaterialCircuitErrorV2> {
+    let mut production = production_state(state);
+    derive_shared_production_v1(&mut production, next_week)
+        .map_err(MaterialCircuitErrorV2::from)?;
+    merge_production_state(state, production);
+    Ok(())
+}
+
+fn prune_corridor_capacity(state: &mut MaterialCircuitStateV2, next_week: u64) {
+    state.corridor_capacities = std::mem::take(&mut state.corridor_capacities)
+        .into_iter()
+        .take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1)
+        .filter(|row| row.week >= next_week)
+        .collect();
+}
+
+/// Close one routed week atomically and return its canonical successor state.
+///
+/// # Errors
+/// Returns the first exact schema, route, conservation, bound, or arithmetic refusal.
+pub fn advance_material_circuit_v2(
+    opening: &MaterialCircuitStateV2,
+) -> Result<MaterialCircuitTransitionV2, MaterialCircuitErrorV2> {
+    let mut state = canonical_state_v2(opening)?;
+    let mut inventory = take_inventory(&mut state);
+    let mut losses = Vec::new();
+    let mut arrivals = Vec::new();
+    let mut deliveries = Vec::new();
+    let mut realizations = Vec::new();
+    let mut dispatches = Vec::new();
+    process_due_freight(
+        &mut state,
+        &mut inventory,
+        &mut losses,
+        &mut arrivals,
+        &mut deliveries,
+        &mut realizations,
+    )?;
+    publish_inventory(&mut state, inventory);
+    let production = execute_production(&mut state)?;
+    let mut inventory = take_inventory(&mut state);
+    dispatch_orders(&mut state, &mut inventory, &mut dispatches)?;
+    rebuild_backlog(&mut state);
+    publish_inventory(&mut state, inventory);
+    let next_week = state
+        .week
+        .checked_add(1)
+        .ok_or(MaterialCircuitErrorV2::Arithmetic)?;
+    derive_next_production(&mut state, next_week)?;
+    prune_corridor_capacity(&mut state, next_week);
+    state.week = next_week;
+    state = canonical_state_v2(&state)?;
+    Ok(MaterialCircuitTransitionV2 {
+        state,
+        production,
+        dispatches,
+        losses,
+        arrivals,
+        deliveries,
+        realizations,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_resource_group_count;
+    use crate::{MaterialCircuitErrorV2, MAX_FREIGHT_RESOURCE_GROUPS_V2};
+
+    #[test]
+    fn resource_group_ceiling_accepts_maximum_and_refuses_plus_one() {
+        assert_eq!(
+            ensure_resource_group_count(MAX_FREIGHT_RESOURCE_GROUPS_V2),
+            Ok(())
+        );
+        assert_eq!(
+            ensure_resource_group_count(MAX_FREIGHT_RESOURCE_GROUPS_V2 + 1),
+            Err(MaterialCircuitErrorV2::RowLimit)
+        );
+    }
+}

--- a/rust/crates/babylon-material-circuit/src/wire.rs
+++ b/rust/crates/babylon-material-circuit/src/wire.rs
@@ -3,6 +3,7 @@
 use babylon_kernel::sha256_of;
 
 use crate::transition::canonical_state_v1;
+use crate::wire_common::{Cursor, CursorError};
 use crate::{
     BacklogRowV1, CapacityRowV1, GoodIdV1, InputOutputCoefficientV1, InventoryRowV1,
     LaborCapacityRowV1, LaborCoefficientV1, MaterialCircuitErrorV1, MaterialCircuitStateV1,
@@ -14,56 +15,11 @@ use crate::{
 pub const MATERIAL_CIRCUIT_STATE_V1_DOMAIN_BYTES: &[u8] = b"babylon.material-circuit-state.v1";
 const SCHEMA_VERSION: u16 = 1;
 
-struct Cursor<'a> {
-    bytes: &'a [u8],
-    index: usize,
-}
-
-impl<'a> Cursor<'a> {
-    const fn new(bytes: &'a [u8]) -> Self {
-        Self { bytes, index: 0 }
-    }
-
-    fn take(&mut self, length: usize) -> Result<&'a [u8], MaterialCircuitErrorV1> {
-        let end = self
-            .index
-            .checked_add(length)
-            .ok_or(MaterialCircuitErrorV1::WireTruncated)?;
-        let output = self
-            .bytes
-            .get(self.index..end)
-            .ok_or(MaterialCircuitErrorV1::WireTruncated)?;
-        self.index = end;
-        Ok(output)
-    }
-
-    fn array<const N: usize>(&mut self) -> Result<[u8; N], MaterialCircuitErrorV1> {
-        self.take(N)?
-            .try_into()
-            .map_err(|_| MaterialCircuitErrorV1::WireTruncated)
-    }
-
-    fn u8(&mut self) -> Result<u8, MaterialCircuitErrorV1> {
-        Ok(self.array::<1>()?[0])
-    }
-
-    fn u16(&mut self) -> Result<u16, MaterialCircuitErrorV1> {
-        Ok(u16::from_be_bytes(self.array()?))
-    }
-
-    fn u32(&mut self) -> Result<u32, MaterialCircuitErrorV1> {
-        Ok(u32::from_be_bytes(self.array()?))
-    }
-
-    fn u64(&mut self) -> Result<u64, MaterialCircuitErrorV1> {
-        Ok(u64::from_be_bytes(self.array()?))
-    }
-
-    fn finish(self) -> Result<(), MaterialCircuitErrorV1> {
-        if self.index == self.bytes.len() {
-            Ok(())
-        } else {
-            Err(MaterialCircuitErrorV1::WireTrailing)
+impl From<CursorError> for MaterialCircuitErrorV1 {
+    fn from(value: CursorError) -> Self {
+        match value {
+            CursorError::Truncated => Self::WireTruncated,
+            CursorError::Trailing => Self::WireTrailing,
         }
     }
 }

--- a/rust/crates/babylon-material-circuit/src/wire_common.rs
+++ b/rust/crates/babylon-material-circuit/src/wire_common.rs
@@ -1,0 +1,59 @@
+//! Shared bounded cursor for material-circuit wire versions.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CursorError {
+    Truncated,
+    Trailing,
+}
+
+pub(crate) struct Cursor<'a> {
+    bytes: &'a [u8],
+    index: usize,
+}
+
+impl<'a> Cursor<'a> {
+    pub(crate) const fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, index: 0 }
+    }
+
+    pub(crate) fn take(&mut self, length: usize) -> Result<&'a [u8], CursorError> {
+        let end = self
+            .index
+            .checked_add(length)
+            .ok_or(CursorError::Truncated)?;
+        let output = self
+            .bytes
+            .get(self.index..end)
+            .ok_or(CursorError::Truncated)?;
+        self.index = end;
+        Ok(output)
+    }
+
+    pub(crate) fn array<const N: usize>(&mut self) -> Result<[u8; N], CursorError> {
+        self.take(N)?.try_into().map_err(|_| CursorError::Truncated)
+    }
+
+    pub(crate) fn u8(&mut self) -> Result<u8, CursorError> {
+        Ok(self.array::<1>()?[0])
+    }
+
+    pub(crate) fn u16(&mut self) -> Result<u16, CursorError> {
+        Ok(u16::from_be_bytes(self.array()?))
+    }
+
+    pub(crate) fn u32(&mut self) -> Result<u32, CursorError> {
+        Ok(u32::from_be_bytes(self.array()?))
+    }
+
+    pub(crate) fn u64(&mut self) -> Result<u64, CursorError> {
+        Ok(u64::from_be_bytes(self.array()?))
+    }
+
+    pub(crate) fn finish(self) -> Result<(), CursorError> {
+        if self.index == self.bytes.len() {
+            Ok(())
+        } else {
+            Err(CursorError::Trailing)
+        }
+    }
+}

--- a/rust/crates/babylon-material-circuit/src/wire_v2.rs
+++ b/rust/crates/babylon-material-circuit/src/wire_v2.rs
@@ -1,0 +1,524 @@
+//! Canonical V2 routed-material state bytes for restart and replay.
+
+use babylon_kernel::sha256_of;
+
+use crate::transition_v2::canonical_state_v2;
+use crate::wire_common::{Cursor, CursorError};
+use crate::{
+    BacklogRowV1, CapacityRowV1, CorridorCapacityV2, CorridorIdV2, FreightLotIdV2, GoodIdV1,
+    InputOutputCoefficientV1, InventoryRowV1, LaborCapacityRowV1, LaborCoefficientV1,
+    LogisticsNodeIdV2, MaterialCircuitErrorV2, MaterialCircuitStateV2, OrderAccessModeV1,
+    OrderIdV1, OrderRowV2, ProcessIdV1, ProcessOutputV1, ProductionCommitmentV1, RouteIdV2,
+    RouteLegV2, RoutedFreightLotV2, SiteIdV1, SiteLogisticsNodeV2, SupplierRouteV2, UnitIdV1,
+    MAX_MATERIAL_CIRCUIT_ROWS_V1,
+};
+
+/// Canonical domain for one complete routed material-circuit opening state.
+pub const MATERIAL_CIRCUIT_STATE_V2_DOMAIN_BYTES: &[u8] = b"babylon.material-circuit-state.v2";
+/// SHA-256 of the complete language-neutral Material Circuit V2 contract source.
+pub const MATERIAL_CIRCUIT_V2_SOURCE_SHA256: [u8; 32] = [
+    0x42, 0x49, 0xc6, 0xc2, 0xd2, 0x38, 0xb7, 0xc5, 0xdb, 0x1c, 0x55, 0x2e, 0xc1, 0xa7, 0x20, 0xa5,
+    0x83, 0x0c, 0x27, 0xe2, 0x42, 0x9b, 0x3c, 0x4a, 0x8a, 0x3d, 0x29, 0x27, 0x7d, 0xd3, 0x1c, 0x72,
+];
+const SCHEMA_VERSION: u16 = 2;
+
+impl From<CursorError> for MaterialCircuitErrorV2 {
+    fn from(value: CursorError) -> Self {
+        match value {
+            CursorError::Truncated => Self::WireTruncated,
+            CursorError::Trailing => Self::WireTrailing,
+        }
+    }
+}
+
+fn row_count(cursor: &mut Cursor<'_>) -> Result<usize, MaterialCircuitErrorV2> {
+    let count = usize::try_from(cursor.u32()?).map_err(|_| MaterialCircuitErrorV2::WireLimit)?;
+    if count > MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        return Err(MaterialCircuitErrorV2::WireLimit);
+    }
+    Ok(count)
+}
+
+fn append_rows<T>(
+    output: &mut Vec<u8>,
+    rows: &[T],
+    mut append: impl FnMut(&mut Vec<u8>, &T),
+) -> Result<(), MaterialCircuitErrorV2> {
+    let count = u32::try_from(rows.len()).map_err(|_| MaterialCircuitErrorV2::WireLimit)?;
+    output.extend_from_slice(&count.to_be_bytes());
+    for row in rows.iter().take(MAX_MATERIAL_CIRCUIT_ROWS_V1 + 1) {
+        append(output, row);
+    }
+    Ok(())
+}
+
+fn decode_rows<T>(
+    cursor: &mut Cursor<'_>,
+    mut decode: impl FnMut(&mut Cursor<'_>) -> Result<T, MaterialCircuitErrorV2>,
+) -> Result<Vec<T>, MaterialCircuitErrorV2> {
+    let count = row_count(cursor)?;
+    let mut rows = Vec::with_capacity(count);
+    for index in 0..=MAX_MATERIAL_CIRCUIT_ROWS_V1 {
+        if index == count {
+            break;
+        }
+        rows.push(decode(cursor)?);
+    }
+    Ok(rows)
+}
+
+fn append_site_nodes(
+    output: &mut Vec<u8>,
+    rows: &[SiteLogisticsNodeV2],
+) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.site_id.as_bytes());
+        bytes.extend_from_slice(&row.node_id.as_bytes());
+    })
+}
+
+fn append_process_outputs(
+    output: &mut Vec<u8>,
+    rows: &[ProcessOutputV1],
+) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.process_id.as_bytes());
+        bytes.extend_from_slice(&row.site_id.as_bytes());
+        bytes.extend_from_slice(&row.good_id.as_bytes());
+        bytes.extend_from_slice(&row.unit_id.as_bytes());
+        bytes.extend_from_slice(&row.quantity_per_batch.to_be_bytes());
+    })
+}
+
+fn append_input_coefficients(
+    output: &mut Vec<u8>,
+    rows: &[InputOutputCoefficientV1],
+) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.process_id.as_bytes());
+        bytes.extend_from_slice(&row.good_id.as_bytes());
+        bytes.extend_from_slice(&row.unit_id.as_bytes());
+        bytes.extend_from_slice(&row.quantity_per_batch.to_be_bytes());
+    })
+}
+
+fn append_labor_coefficients(
+    output: &mut Vec<u8>,
+    rows: &[LaborCoefficientV1],
+) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.process_id.as_bytes());
+        bytes.extend_from_slice(&row.unit_id.as_bytes());
+        bytes.extend_from_slice(&row.quantity_per_batch.to_be_bytes());
+    })
+}
+
+fn append_supplier_routes(
+    output: &mut Vec<u8>,
+    rows: &[SupplierRouteV2],
+) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.buyer_site_id.as_bytes());
+        bytes.extend_from_slice(&row.supplier_site_id.as_bytes());
+        bytes.extend_from_slice(&row.good_id.as_bytes());
+        bytes.extend_from_slice(&row.unit_id.as_bytes());
+        bytes.extend_from_slice(&row.route_id.as_bytes());
+    })
+}
+
+fn append_route_legs(
+    output: &mut Vec<u8>,
+    rows: &[RouteLegV2],
+) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.route_id.as_bytes());
+        bytes.extend_from_slice(&row.leg_index.to_be_bytes());
+        bytes.extend_from_slice(&row.corridor_id.as_bytes());
+        bytes.extend_from_slice(&row.from_node_id.as_bytes());
+        bytes.extend_from_slice(&row.to_node_id.as_bytes());
+        bytes.extend_from_slice(&row.travel_weeks.to_be_bytes());
+        bytes.extend_from_slice(&row.loss_ppm.to_be_bytes());
+    })
+}
+
+fn append_inventory(
+    output: &mut Vec<u8>,
+    rows: &[InventoryRowV1],
+) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.site_id.as_bytes());
+        bytes.extend_from_slice(&row.good_id.as_bytes());
+        bytes.extend_from_slice(&row.unit_id.as_bytes());
+        bytes.extend_from_slice(&row.quantity.to_be_bytes());
+    })
+}
+
+fn append_orders(output: &mut Vec<u8>, rows: &[OrderRowV2]) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.order_id.as_bytes());
+        bytes.push(row.access_mode as u8);
+        bytes.extend_from_slice(&row.buyer_site_id.as_bytes());
+        bytes.extend_from_slice(&row.supplier_site_id.as_bytes());
+        bytes.extend_from_slice(&row.good_id.as_bytes());
+        bytes.extend_from_slice(&row.unit_id.as_bytes());
+        bytes.extend_from_slice(&row.ordered.to_be_bytes());
+        bytes.extend_from_slice(&row.shipped.to_be_bytes());
+        bytes.extend_from_slice(&row.lost.to_be_bytes());
+        bytes.extend_from_slice(&row.delivered.to_be_bytes());
+        bytes.extend_from_slice(&row.realized.to_be_bytes());
+    })
+}
+
+fn append_backlog(
+    output: &mut Vec<u8>,
+    rows: &[BacklogRowV1],
+) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.order_id.as_bytes());
+        bytes.extend_from_slice(&row.quantity.to_be_bytes());
+    })
+}
+
+fn append_freight(
+    output: &mut Vec<u8>,
+    rows: &[RoutedFreightLotV2],
+) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.lot_id.as_bytes());
+        bytes.extend_from_slice(&row.order_id.as_bytes());
+        bytes.extend_from_slice(&row.route_id.as_bytes());
+        bytes.extend_from_slice(&row.dispatch_week.to_be_bytes());
+        bytes.extend_from_slice(&row.current_leg_index.to_be_bytes());
+        bytes.extend_from_slice(&row.leg_arrival_week.to_be_bytes());
+        bytes.extend_from_slice(&row.source_site_id.as_bytes());
+        bytes.extend_from_slice(&row.destination_site_id.as_bytes());
+        bytes.extend_from_slice(&row.good_id.as_bytes());
+        bytes.extend_from_slice(&row.unit_id.as_bytes());
+        bytes.extend_from_slice(&row.quantity.to_be_bytes());
+    })
+}
+
+fn append_corridor_capacities(
+    output: &mut Vec<u8>,
+    rows: &[CorridorCapacityV2],
+) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.corridor_id.as_bytes());
+        bytes.extend_from_slice(&row.unit_id.as_bytes());
+        bytes.extend_from_slice(&row.week.to_be_bytes());
+        bytes.extend_from_slice(&row.available.to_be_bytes());
+    })
+}
+
+fn append_capacities(
+    output: &mut Vec<u8>,
+    rows: &[CapacityRowV1],
+) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.process_id.as_bytes());
+        bytes.extend_from_slice(&row.site_id.as_bytes());
+        bytes.extend_from_slice(&row.week.to_be_bytes());
+        bytes.extend_from_slice(&row.available_batches.to_be_bytes());
+    })
+}
+
+fn append_labor(
+    output: &mut Vec<u8>,
+    rows: &[LaborCapacityRowV1],
+) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.site_id.as_bytes());
+        bytes.extend_from_slice(&row.unit_id.as_bytes());
+        bytes.extend_from_slice(&row.week.to_be_bytes());
+        bytes.extend_from_slice(&row.available.to_be_bytes());
+    })
+}
+
+fn append_commitments(
+    output: &mut Vec<u8>,
+    rows: &[ProductionCommitmentV1],
+) -> Result<(), MaterialCircuitErrorV2> {
+    append_rows(output, rows, |bytes, row| {
+        bytes.extend_from_slice(&row.process_id.as_bytes());
+        bytes.extend_from_slice(&row.site_id.as_bytes());
+        bytes.extend_from_slice(&row.week.to_be_bytes());
+        bytes.extend_from_slice(&row.planned_batches.to_be_bytes());
+    })
+}
+
+fn decode_site_nodes(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<SiteLogisticsNodeV2>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        Ok(SiteLogisticsNodeV2 {
+            site_id: SiteIdV1::from_bytes(bytes.array()?),
+            node_id: LogisticsNodeIdV2::from_bytes(bytes.array()?),
+        })
+    })
+}
+
+fn decode_process_outputs(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<ProcessOutputV1>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        Ok(ProcessOutputV1 {
+            process_id: ProcessIdV1::from_bytes(bytes.array()?),
+            site_id: SiteIdV1::from_bytes(bytes.array()?),
+            good_id: GoodIdV1::from_bytes(bytes.array()?),
+            unit_id: UnitIdV1::from_bytes(bytes.array()?),
+            quantity_per_batch: bytes.u64()?,
+        })
+    })
+}
+
+fn decode_input_coefficients(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<InputOutputCoefficientV1>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        Ok(InputOutputCoefficientV1 {
+            process_id: ProcessIdV1::from_bytes(bytes.array()?),
+            good_id: GoodIdV1::from_bytes(bytes.array()?),
+            unit_id: UnitIdV1::from_bytes(bytes.array()?),
+            quantity_per_batch: bytes.u64()?,
+        })
+    })
+}
+
+fn decode_labor_coefficients(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<LaborCoefficientV1>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        Ok(LaborCoefficientV1 {
+            process_id: ProcessIdV1::from_bytes(bytes.array()?),
+            unit_id: UnitIdV1::from_bytes(bytes.array()?),
+            quantity_per_batch: bytes.u64()?,
+        })
+    })
+}
+
+fn decode_supplier_routes(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<SupplierRouteV2>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        Ok(SupplierRouteV2 {
+            buyer_site_id: SiteIdV1::from_bytes(bytes.array()?),
+            supplier_site_id: SiteIdV1::from_bytes(bytes.array()?),
+            good_id: GoodIdV1::from_bytes(bytes.array()?),
+            unit_id: UnitIdV1::from_bytes(bytes.array()?),
+            route_id: RouteIdV2::from_bytes(bytes.array()?),
+        })
+    })
+}
+
+fn decode_route_legs(cursor: &mut Cursor<'_>) -> Result<Vec<RouteLegV2>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        Ok(RouteLegV2 {
+            route_id: RouteIdV2::from_bytes(bytes.array()?),
+            leg_index: bytes.u16()?,
+            corridor_id: CorridorIdV2::from_bytes(bytes.array()?),
+            from_node_id: LogisticsNodeIdV2::from_bytes(bytes.array()?),
+            to_node_id: LogisticsNodeIdV2::from_bytes(bytes.array()?),
+            travel_weeks: bytes.u16()?,
+            loss_ppm: bytes.u32()?,
+        })
+    })
+}
+
+fn decode_inventory(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<InventoryRowV1>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        Ok(InventoryRowV1 {
+            site_id: SiteIdV1::from_bytes(bytes.array()?),
+            good_id: GoodIdV1::from_bytes(bytes.array()?),
+            unit_id: UnitIdV1::from_bytes(bytes.array()?),
+            quantity: bytes.u64()?,
+        })
+    })
+}
+
+fn decode_orders(cursor: &mut Cursor<'_>) -> Result<Vec<OrderRowV2>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        let order_id = OrderIdV1::from_bytes(bytes.array()?);
+        let access_mode = match bytes.u8()? {
+            1 => OrderAccessModeV1::CommoditySale,
+            _ => return Err(MaterialCircuitErrorV2::WireEnum),
+        };
+        Ok(OrderRowV2 {
+            order_id,
+            access_mode,
+            buyer_site_id: SiteIdV1::from_bytes(bytes.array()?),
+            supplier_site_id: SiteIdV1::from_bytes(bytes.array()?),
+            good_id: GoodIdV1::from_bytes(bytes.array()?),
+            unit_id: UnitIdV1::from_bytes(bytes.array()?),
+            ordered: bytes.u64()?,
+            shipped: bytes.u64()?,
+            lost: bytes.u64()?,
+            delivered: bytes.u64()?,
+            realized: bytes.u64()?,
+        })
+    })
+}
+
+fn decode_backlog(cursor: &mut Cursor<'_>) -> Result<Vec<BacklogRowV1>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        Ok(BacklogRowV1 {
+            order_id: OrderIdV1::from_bytes(bytes.array()?),
+            quantity: bytes.u64()?,
+        })
+    })
+}
+
+fn decode_freight(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<RoutedFreightLotV2>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        Ok(RoutedFreightLotV2 {
+            lot_id: FreightLotIdV2::from_bytes(bytes.array()?),
+            order_id: OrderIdV1::from_bytes(bytes.array()?),
+            route_id: RouteIdV2::from_bytes(bytes.array()?),
+            dispatch_week: bytes.u64()?,
+            current_leg_index: bytes.u16()?,
+            leg_arrival_week: bytes.u64()?,
+            source_site_id: SiteIdV1::from_bytes(bytes.array()?),
+            destination_site_id: SiteIdV1::from_bytes(bytes.array()?),
+            good_id: GoodIdV1::from_bytes(bytes.array()?),
+            unit_id: UnitIdV1::from_bytes(bytes.array()?),
+            quantity: bytes.u64()?,
+        })
+    })
+}
+
+fn decode_corridor_capacities(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<CorridorCapacityV2>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        Ok(CorridorCapacityV2 {
+            corridor_id: CorridorIdV2::from_bytes(bytes.array()?),
+            unit_id: UnitIdV1::from_bytes(bytes.array()?),
+            week: bytes.u64()?,
+            available: bytes.u64()?,
+        })
+    })
+}
+
+fn decode_capacities(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<CapacityRowV1>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        Ok(CapacityRowV1 {
+            process_id: ProcessIdV1::from_bytes(bytes.array()?),
+            site_id: SiteIdV1::from_bytes(bytes.array()?),
+            week: bytes.u64()?,
+            available_batches: bytes.u64()?,
+        })
+    })
+}
+
+fn decode_labor(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<LaborCapacityRowV1>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        Ok(LaborCapacityRowV1 {
+            site_id: SiteIdV1::from_bytes(bytes.array()?),
+            unit_id: UnitIdV1::from_bytes(bytes.array()?),
+            week: bytes.u64()?,
+            available: bytes.u64()?,
+        })
+    })
+}
+
+fn decode_commitments(
+    cursor: &mut Cursor<'_>,
+) -> Result<Vec<ProductionCommitmentV1>, MaterialCircuitErrorV2> {
+    decode_rows(cursor, |bytes| {
+        Ok(ProductionCommitmentV1 {
+            process_id: ProcessIdV1::from_bytes(bytes.array()?),
+            site_id: SiteIdV1::from_bytes(bytes.array()?),
+            week: bytes.u64()?,
+            planned_batches: bytes.u64()?,
+        })
+    })
+}
+
+/// Encode one complete validated V2 state in canonical big-endian order.
+///
+/// # Errors
+/// Returns the first exact state, route, row-bound, or wire-bound refusal.
+pub fn encode_material_circuit_state_v2(
+    state: &MaterialCircuitStateV2,
+) -> Result<Vec<u8>, MaterialCircuitErrorV2> {
+    let canonical = canonical_state_v2(state)?;
+    let mut output = Vec::new();
+    output.extend_from_slice(MATERIAL_CIRCUIT_STATE_V2_DOMAIN_BYTES);
+    output.push(0);
+    output.extend_from_slice(&SCHEMA_VERSION.to_be_bytes());
+    output.extend_from_slice(&canonical.week.to_be_bytes());
+    append_site_nodes(&mut output, &canonical.site_logistics_nodes)?;
+    append_process_outputs(&mut output, &canonical.process_outputs)?;
+    append_input_coefficients(&mut output, &canonical.input_coefficients)?;
+    append_labor_coefficients(&mut output, &canonical.labor_coefficients)?;
+    append_supplier_routes(&mut output, &canonical.supplier_routes)?;
+    append_route_legs(&mut output, &canonical.route_legs)?;
+    append_inventory(&mut output, &canonical.inventory)?;
+    append_orders(&mut output, &canonical.orders)?;
+    append_backlog(&mut output, &canonical.backlog)?;
+    append_freight(&mut output, &canonical.freight)?;
+    append_corridor_capacities(&mut output, &canonical.corridor_capacities)?;
+    append_capacities(&mut output, &canonical.capacities)?;
+    append_labor(&mut output, &canonical.labor)?;
+    append_commitments(&mut output, &canonical.production_commitments)?;
+    Ok(output)
+}
+
+/// Decode one complete canonical V2 state.
+///
+/// # Errors
+/// Returns the first domain, version, enum, wire, order, or state refusal.
+pub fn decode_material_circuit_state_v2(
+    payload: &[u8],
+) -> Result<MaterialCircuitStateV2, MaterialCircuitErrorV2> {
+    let mut cursor = Cursor::new(payload);
+    if cursor.take(MATERIAL_CIRCUIT_STATE_V2_DOMAIN_BYTES.len())?
+        != MATERIAL_CIRCUIT_STATE_V2_DOMAIN_BYTES
+        || cursor.u8()? != 0
+    {
+        return Err(MaterialCircuitErrorV2::WireDomain);
+    }
+    if cursor.u16()? != SCHEMA_VERSION {
+        return Err(MaterialCircuitErrorV2::WireVersion);
+    }
+    let state = MaterialCircuitStateV2 {
+        week: cursor.u64()?,
+        site_logistics_nodes: decode_site_nodes(&mut cursor)?,
+        process_outputs: decode_process_outputs(&mut cursor)?,
+        input_coefficients: decode_input_coefficients(&mut cursor)?,
+        labor_coefficients: decode_labor_coefficients(&mut cursor)?,
+        supplier_routes: decode_supplier_routes(&mut cursor)?,
+        route_legs: decode_route_legs(&mut cursor)?,
+        inventory: decode_inventory(&mut cursor)?,
+        orders: decode_orders(&mut cursor)?,
+        backlog: decode_backlog(&mut cursor)?,
+        freight: decode_freight(&mut cursor)?,
+        corridor_capacities: decode_corridor_capacities(&mut cursor)?,
+        capacities: decode_capacities(&mut cursor)?,
+        labor: decode_labor(&mut cursor)?,
+        production_commitments: decode_commitments(&mut cursor)?,
+    };
+    cursor.finish()?;
+    let canonical = canonical_state_v2(&state)?;
+    if canonical != state {
+        return Err(MaterialCircuitErrorV2::WireNoncanonical);
+    }
+    Ok(state)
+}
+
+/// Hash one complete validated canonical V2 state.
+///
+/// # Errors
+/// Returns the exact encoding refusal without publishing a digest.
+pub fn material_circuit_state_v2_digest(
+    state: &MaterialCircuitStateV2,
+) -> Result<[u8; 32], MaterialCircuitErrorV2> {
+    Ok(sha256_of(&encode_material_circuit_state_v2(state)?))
+}

--- a/rust/crates/babylon-material-circuit/tests/routed_freight.rs
+++ b/rust/crates/babylon-material-circuit/tests/routed_freight.rs
@@ -1,0 +1,732 @@
+use babylon_material_circuit::{
+    advance_material_circuit_v2, decode_material_circuit_state_v2,
+    encode_material_circuit_state_v2, material_circuit_state_v2_digest, BacklogRowV1,
+    CapacityRowV1, CorridorCapacityV2, CorridorIdV2, GoodIdV1, InputOutputCoefficientV1,
+    InventoryRowV1, LaborCapacityRowV1, LaborCoefficientV1, LogisticsNodeIdV2,
+    MaterialCircuitStateV2, OrderAccessModeV1, OrderIdV1, OrderRowV2, ProcessIdV1, ProcessOutputV1,
+    RouteIdV2, RouteLegV2, SiteIdV1, SiteLogisticsNodeV2, SupplierRouteV2, UnitIdV1,
+    MATERIAL_CIRCUIT_STATE_V2_DOMAIN_BYTES, MATERIAL_CIRCUIT_V2_SOURCE_SHA256,
+    MAX_ROUTE_LEGS_PER_ROUTE_V2,
+};
+
+fn site(byte: u8) -> SiteIdV1 {
+    SiteIdV1::from_bytes([byte; 32])
+}
+
+fn good(byte: u8) -> GoodIdV1 {
+    GoodIdV1::from_bytes([byte; 32])
+}
+
+fn unit(byte: u8) -> UnitIdV1 {
+    UnitIdV1::from_bytes([byte; 32])
+}
+
+fn order(byte: u8) -> OrderIdV1 {
+    OrderIdV1::from_bytes([byte; 32])
+}
+
+fn node(byte: u8) -> LogisticsNodeIdV2 {
+    LogisticsNodeIdV2::from_bytes([byte; 32])
+}
+
+fn corridor(byte: u8) -> CorridorIdV2 {
+    CorridorIdV2::from_bytes([byte; 32])
+}
+
+fn route(byte: u8) -> RouteIdV2 {
+    RouteIdV2::from_bytes([byte; 32])
+}
+
+fn process(byte: u8) -> ProcessIdV1 {
+    ProcessIdV1::from_bytes([byte; 32])
+}
+
+fn hex(bytes: [u8; 32]) -> String {
+    use std::fmt::Write as _;
+    bytes
+        .iter()
+        .fold(String::with_capacity(64), |mut output, byte| {
+            let _ = write!(output, "{byte:02x}");
+            output
+        })
+}
+
+const SUPPLIER: u8 = 1;
+const BUYER: u8 = 2;
+const GOODS: u8 = 3;
+const GOODS_UNIT: u8 = 4;
+const ORDER: u8 = 5;
+const SUPPLIER_NODE: u8 = 6;
+const BUYER_NODE: u8 = 7;
+const CORRIDOR: u8 = 8;
+const ROUTE: u8 = 9;
+const CONTRACT_VECTORS: &str =
+    include_str!("../../../../contracts/material_circuit_v2_vectors.jsonl");
+const CONTRACT_SCHEMA: &[u8] = include_bytes!("../../../../contracts/material_circuit_v2.yaml");
+
+fn base_state() -> MaterialCircuitStateV2 {
+    MaterialCircuitStateV2 {
+        week: 1,
+        site_logistics_nodes: vec![
+            SiteLogisticsNodeV2 {
+                site_id: site(SUPPLIER),
+                node_id: node(SUPPLIER_NODE),
+            },
+            SiteLogisticsNodeV2 {
+                site_id: site(BUYER),
+                node_id: node(BUYER_NODE),
+            },
+        ],
+        process_outputs: Vec::new(),
+        input_coefficients: Vec::new(),
+        labor_coefficients: Vec::new(),
+        supplier_routes: vec![SupplierRouteV2 {
+            buyer_site_id: site(BUYER),
+            supplier_site_id: site(SUPPLIER),
+            good_id: good(GOODS),
+            unit_id: unit(GOODS_UNIT),
+            route_id: route(ROUTE),
+        }],
+        route_legs: vec![RouteLegV2 {
+            route_id: route(ROUTE),
+            leg_index: 0,
+            corridor_id: corridor(CORRIDOR),
+            from_node_id: node(SUPPLIER_NODE),
+            to_node_id: node(BUYER_NODE),
+            travel_weeks: 1,
+            loss_ppm: 0,
+        }],
+        inventory: vec![
+            InventoryRowV1 {
+                site_id: site(SUPPLIER),
+                good_id: good(GOODS),
+                unit_id: unit(GOODS_UNIT),
+                quantity: 10,
+            },
+            InventoryRowV1 {
+                site_id: site(BUYER),
+                good_id: good(GOODS),
+                unit_id: unit(GOODS_UNIT),
+                quantity: 0,
+            },
+        ],
+        orders: vec![OrderRowV2 {
+            order_id: order(ORDER),
+            access_mode: OrderAccessModeV1::CommoditySale,
+            buyer_site_id: site(BUYER),
+            supplier_site_id: site(SUPPLIER),
+            good_id: good(GOODS),
+            unit_id: unit(GOODS_UNIT),
+            ordered: 6,
+            shipped: 0,
+            lost: 0,
+            delivered: 0,
+            realized: 0,
+        }],
+        backlog: vec![BacklogRowV1 {
+            order_id: order(ORDER),
+            quantity: 6,
+        }],
+        freight: Vec::new(),
+        corridor_capacities: vec![CorridorCapacityV2 {
+            corridor_id: corridor(CORRIDOR),
+            unit_id: unit(GOODS_UNIT),
+            week: 1,
+            available: 4,
+        }],
+        capacities: Vec::new(),
+        labor: Vec::new(),
+        production_commitments: Vec::new(),
+    }
+}
+
+fn inventory_quantity(state: &MaterialCircuitStateV2, site_id: SiteIdV1) -> u64 {
+    state
+        .inventory
+        .iter()
+        .find(|row| row.site_id == site_id && row.good_id == good(GOODS))
+        .map_or(0, |row| row.quantity)
+}
+
+fn two_leg_state(second_leg_capacity: u64) -> MaterialCircuitStateV2 {
+    let mut state = base_state();
+    let middle = node(10);
+    state.route_legs = vec![
+        RouteLegV2 {
+            to_node_id: middle,
+            loss_ppm: 250_000,
+            ..state.route_legs[0].clone()
+        },
+        RouteLegV2 {
+            route_id: route(ROUTE),
+            leg_index: 1,
+            corridor_id: corridor(11),
+            from_node_id: middle,
+            to_node_id: node(BUYER_NODE),
+            travel_weeks: 1,
+            loss_ppm: 0,
+        },
+    ];
+    state.corridor_capacities = vec![
+        CorridorCapacityV2 {
+            available: 4,
+            ..state.corridor_capacities[0].clone()
+        },
+        CorridorCapacityV2 {
+            corridor_id: corridor(11),
+            unit_id: unit(GOODS_UNIT),
+            week: 2,
+            available: second_leg_capacity,
+        },
+    ];
+    state
+}
+
+fn two_route_state() -> MaterialCircuitStateV2 {
+    let mut state = base_state();
+    let second_buyer = site(12);
+    let second_node = node(13);
+    let second_order = order(14);
+    let second_route = route(15);
+    state.inventory[0].quantity = 12;
+    state.site_logistics_nodes.push(SiteLogisticsNodeV2 {
+        site_id: second_buyer,
+        node_id: second_node,
+    });
+    state.supplier_routes.push(SupplierRouteV2 {
+        buyer_site_id: second_buyer,
+        supplier_site_id: site(SUPPLIER),
+        good_id: good(GOODS),
+        unit_id: unit(GOODS_UNIT),
+        route_id: second_route,
+    });
+    state.route_legs.push(RouteLegV2 {
+        route_id: second_route,
+        leg_index: 0,
+        corridor_id: corridor(16),
+        from_node_id: node(SUPPLIER_NODE),
+        to_node_id: second_node,
+        travel_weeks: 1,
+        loss_ppm: 0,
+    });
+    state.inventory.push(InventoryRowV1 {
+        site_id: second_buyer,
+        good_id: good(GOODS),
+        unit_id: unit(GOODS_UNIT),
+        quantity: 0,
+    });
+    state.orders.push(OrderRowV2 {
+        order_id: second_order,
+        access_mode: OrderAccessModeV1::CommoditySale,
+        buyer_site_id: second_buyer,
+        supplier_site_id: site(SUPPLIER),
+        good_id: good(GOODS),
+        unit_id: unit(GOODS_UNIT),
+        ordered: 4,
+        shipped: 0,
+        lost: 0,
+        delivered: 0,
+        realized: 0,
+    });
+    state.backlog.push(BacklogRowV1 {
+        order_id: second_order,
+        quantity: 4,
+    });
+    state.corridor_capacities.push(CorridorCapacityV2 {
+        corridor_id: corridor(16),
+        unit_id: unit(GOODS_UNIT),
+        week: 1,
+        available: 4,
+    });
+    state
+}
+
+fn route_depth_state(leg_count: usize) -> MaterialCircuitStateV2 {
+    let mut state = base_state();
+    state.route_legs = (0..leg_count)
+        .map(|index| RouteLegV2 {
+            route_id: route(ROUTE),
+            leg_index: u16::try_from(index).expect("test route index must fit"),
+            corridor_id: corridor(60 + u8::try_from(index).expect("test corridor must fit")),
+            from_node_id: if index == 0 {
+                node(SUPPLIER_NODE)
+            } else {
+                node(19 + u8::try_from(index).expect("test node must fit"))
+            },
+            to_node_id: if index + 1 == leg_count {
+                node(BUYER_NODE)
+            } else {
+                node(20 + u8::try_from(index).expect("test node must fit"))
+            },
+            travel_weeks: 1,
+            loss_ppm: 0,
+        })
+        .collect();
+    state.corridor_capacities = state
+        .route_legs
+        .iter()
+        .map(|leg| CorridorCapacityV2 {
+            corridor_id: leg.corridor_id,
+            unit_id: unit(GOODS_UNIT),
+            week: 1 + u64::from(leg.leg_index),
+            available: 4,
+        })
+        .collect();
+    state
+}
+
+fn shipped_for(state: &MaterialCircuitStateV2, order_id: OrderIdV1) -> u64 {
+    state
+        .orders
+        .iter()
+        .find(|row| row.order_id == order_id)
+        .map_or(0, |row| row.shipped)
+}
+
+#[test]
+fn corridor_capacity_bounds_routed_dispatch() {
+    let outcome = advance_material_circuit_v2(&base_state()).expect("week one must close");
+
+    assert_eq!(outcome.state.week, 2);
+    assert_eq!(outcome.state.orders[0].shipped, 4);
+    assert_eq!(outcome.state.orders[0].delivered, 0);
+    assert_eq!(outcome.state.orders[0].realized, 0);
+    assert_eq!(outcome.state.backlog[0].quantity, 2);
+    assert_eq!(inventory_quantity(&outcome.state, site(SUPPLIER)), 6);
+    assert_eq!(inventory_quantity(&outcome.state, site(BUYER)), 0);
+    assert_eq!(outcome.dispatches.len(), 1);
+    assert_eq!(outcome.dispatches[0].quantity, 4);
+    assert_eq!(outcome.state.freight.len(), 1);
+    assert_eq!(outcome.state.freight[0].quantity, 4);
+    assert_eq!(outcome.state.freight[0].current_leg_index, 0);
+    assert_eq!(outcome.state.freight[0].leg_arrival_week, 2);
+}
+
+#[test]
+fn final_route_arrival_credits_inventory_before_realization() {
+    let first = advance_material_circuit_v2(&base_state()).expect("week one must close");
+    let second = advance_material_circuit_v2(&first.state).expect("week two must close");
+
+    assert!(second.state.freight.is_empty());
+    assert_eq!(inventory_quantity(&second.state, site(BUYER)), 4);
+    assert_eq!(second.state.orders[0].delivered, 4);
+    assert_eq!(second.state.orders[0].realized, 4);
+    assert_eq!(second.arrivals.len(), 1);
+    assert_eq!(second.deliveries.len(), 1);
+    assert_eq!(second.realizations.len(), 1);
+}
+
+#[test]
+fn missing_supplier_route_remains_backlog() {
+    let mut state = base_state();
+    state.supplier_routes.clear();
+
+    let outcome = advance_material_circuit_v2(&state)
+        .expect("a missing routed supplier relation is a material shortage");
+
+    assert!(outcome.dispatches.is_empty());
+    assert!(outcome.state.freight.is_empty());
+    assert_eq!(outcome.state.orders[0].shipped, 0);
+    assert_eq!(outcome.state.backlog[0].quantity, 6);
+    assert_eq!(inventory_quantity(&outcome.state, site(SUPPLIER)), 10);
+}
+
+#[test]
+fn capacity_for_an_unknown_corridor_refuses() {
+    let mut state = base_state();
+    state.corridor_capacities.push(CorridorCapacityV2 {
+        corridor_id: corridor(99),
+        unit_id: unit(GOODS_UNIT),
+        week: 1,
+        available: 1,
+    });
+
+    assert_eq!(
+        advance_material_circuit_v2(&state),
+        Err(babylon_material_circuit::MaterialCircuitErrorV2::CapacityInvariant)
+    );
+}
+
+#[test]
+fn freight_lot_identity_must_bind_order_and_dispatch_week() {
+    let first = advance_material_circuit_v2(&base_state()).expect("week one must close");
+    let mut state = first.state;
+    state.freight[0].lot_id = babylon_material_circuit::FreightLotIdV2::from_bytes([77; 32]);
+
+    assert_eq!(
+        advance_material_circuit_v2(&state),
+        Err(babylon_material_circuit::MaterialCircuitErrorV2::FreightInvariant)
+    );
+}
+
+#[test]
+fn freight_leg_arrival_must_match_the_reserved_route_schedule() {
+    let first = advance_material_circuit_v2(&base_state()).expect("week one must close");
+    let mut state = first.state;
+    state.freight[0].leg_arrival_week = 3;
+
+    assert_eq!(
+        advance_material_circuit_v2(&state),
+        Err(babylon_material_circuit::MaterialCircuitErrorV2::FreightInvariant)
+    );
+}
+
+#[test]
+fn future_leg_capacity_limits_origin_dispatch() {
+    let outcome = advance_material_circuit_v2(&two_leg_state(2)).expect("two-leg route must close");
+
+    assert_eq!(outcome.state.orders[0].shipped, 2);
+    assert_eq!(outcome.state.backlog[0].quantity, 4);
+    assert_eq!(outcome.state.freight[0].quantity, 2);
+    assert_eq!(outcome.dispatches[0].final_arrival_week, 3);
+    assert_eq!(inventory_quantity(&outcome.state, site(SUPPLIER)), 8);
+    assert_eq!(outcome.state.corridor_capacities[0].week, 2);
+    assert_eq!(outcome.state.corridor_capacities[0].available, 0);
+}
+
+#[test]
+fn completed_leg_loss_remains_attributed_before_final_delivery() {
+    let first = advance_material_circuit_v2(&two_leg_state(4)).expect("week one must close");
+    let second = advance_material_circuit_v2(&first.state).expect("week two must close");
+
+    assert_eq!(second.losses.len(), 1);
+    assert_eq!(second.losses[0].quantity, 1);
+    assert_eq!(second.state.orders[0].lost, 1);
+    assert_eq!(second.state.orders[0].delivered, 0);
+    assert_eq!(second.state.freight[0].quantity, 3);
+    assert_eq!(second.state.freight[0].current_leg_index, 1);
+    assert_eq!(second.state.freight[0].leg_arrival_week, 3);
+
+    let third = advance_material_circuit_v2(&second.state).expect("week three must close");
+    assert!(third.state.freight.is_empty());
+    assert_eq!(third.state.orders[0].shipped, 4);
+    assert_eq!(third.state.orders[0].lost, 1);
+    assert_eq!(third.state.orders[0].delivered, 3);
+    assert_eq!(third.state.orders[0].realized, 3);
+    assert_eq!(inventory_quantity(&third.state, site(BUYER)), 3);
+}
+
+#[test]
+fn final_arrival_can_form_and_execute_following_week_production() {
+    let mut state = base_state();
+    state.process_outputs.push(ProcessOutputV1 {
+        process_id: process(18),
+        site_id: site(BUYER),
+        good_id: good(19),
+        unit_id: unit(GOODS_UNIT),
+        quantity_per_batch: 5,
+    });
+    state.input_coefficients.push(InputOutputCoefficientV1 {
+        process_id: process(18),
+        good_id: good(GOODS),
+        unit_id: unit(GOODS_UNIT),
+        quantity_per_batch: 2,
+    });
+    state.labor_coefficients.push(LaborCoefficientV1 {
+        process_id: process(18),
+        unit_id: unit(20),
+        quantity_per_batch: 1,
+    });
+    state.capacities.push(CapacityRowV1 {
+        process_id: process(18),
+        site_id: site(BUYER),
+        week: 3,
+        available_batches: 2,
+    });
+    state.labor.push(LaborCapacityRowV1 {
+        site_id: site(BUYER),
+        unit_id: unit(20),
+        week: 3,
+        available: 2,
+    });
+
+    let dispatch = advance_material_circuit_v2(&state).expect("dispatch week must close");
+    assert!(dispatch.state.production_commitments.is_empty());
+    let arrival = advance_material_circuit_v2(&dispatch.state).expect("arrival week must close");
+    assert_eq!(arrival.state.production_commitments.len(), 1);
+    assert_eq!(arrival.state.production_commitments[0].planned_batches, 2);
+    let production =
+        advance_material_circuit_v2(&arrival.state).expect("production week must close");
+
+    assert_eq!(production.production.len(), 1);
+    assert_eq!(production.production[0].produced_batches, 2);
+    assert_eq!(inventory_quantity(&production.state, site(BUYER)), 0);
+    assert_eq!(
+        production
+            .state
+            .inventory
+            .iter()
+            .find(|row| row.site_id == site(BUYER) && row.good_id == good(19))
+            .expect("produced output inventory must exist")
+            .quantity,
+        10
+    );
+}
+
+#[test]
+fn route_depth_accepts_the_designed_maximum_and_refuses_plus_one() {
+    assert!(advance_material_circuit_v2(&route_depth_state(MAX_ROUTE_LEGS_PER_ROUTE_V2)).is_ok());
+    assert_eq!(
+        advance_material_circuit_v2(&route_depth_state(MAX_ROUTE_LEGS_PER_ROUTE_V2 + 1)),
+        Err(babylon_material_circuit::MaterialCircuitErrorV2::RouteInvariant)
+    );
+}
+
+#[test]
+fn arrival_overflow_refuses_atomically_without_mutating_the_opening_state() {
+    let dispatch = advance_material_circuit_v2(&base_state()).expect("dispatch week must close");
+    let mut opening = dispatch.state;
+    let buyer_inventory = opening
+        .inventory
+        .iter_mut()
+        .find(|row| row.site_id == site(BUYER))
+        .expect("buyer inventory must exist");
+    buyer_inventory.quantity = u64::MAX;
+    let opening_digest = material_circuit_state_v2_digest(&opening).expect("opening must hash");
+
+    assert_eq!(
+        advance_material_circuit_v2(&opening),
+        Err(babylon_material_circuit::MaterialCircuitErrorV2::Arithmetic)
+    );
+    assert_eq!(
+        material_circuit_state_v2_digest(&opening).expect("opening must remain valid"),
+        opening_digest
+    );
+}
+
+#[test]
+fn canonical_v2_state_round_trips_through_exact_bytes() {
+    let bytes = encode_material_circuit_state_v2(&base_state()).expect("base state must encode");
+    let decoded = decode_material_circuit_state_v2(&bytes).expect("canonical bytes must decode");
+    let digest = material_circuit_state_v2_digest(&base_state()).expect("base state must hash");
+
+    assert_eq!(bytes.len(), 1_053);
+    assert_eq!(
+        hex(digest),
+        "a0ca4c774cf74110ffc3611aa1bd7609cbee07e360477e99363f268b93d7cf31"
+    );
+    assert_eq!(decoded, base_state());
+    assert_eq!(
+        material_circuit_state_v2_digest(&decoded).expect("decoded state must hash"),
+        digest
+    );
+    let vector: serde_json::Value = serde_json::from_str(
+        CONTRACT_VECTORS
+            .lines()
+            .next()
+            .expect("the base vector must be first"),
+    )
+    .expect("the base vector must be valid JSON");
+    assert_eq!(vector["data"]["canonical_bytes"], bytes.len());
+    assert_eq!(vector["data"]["digest_hex"], hex(digest));
+    let manifest: serde_json::Value = serde_json::from_str(
+        CONTRACT_VECTORS
+            .lines()
+            .nth(1)
+            .expect("the manifest vector must be second"),
+    )
+    .expect("the manifest vector must be valid JSON");
+    assert_eq!(
+        babylon_kernel::sha256_of(CONTRACT_SCHEMA),
+        MATERIAL_CIRCUIT_V2_SOURCE_SHA256
+    );
+    assert_eq!(
+        manifest["data"]["schema_sha256"],
+        hex(MATERIAL_CIRCUIT_V2_SOURCE_SHA256)
+    );
+    assert_eq!(
+        manifest["data"]["route_legs_per_route"],
+        MAX_ROUTE_LEGS_PER_ROUTE_V2
+    );
+    assert_eq!(
+        manifest["data"]["freight_resource_groups"],
+        babylon_material_circuit::MAX_FREIGHT_RESOURCE_GROUPS_V2
+    );
+}
+
+#[test]
+fn v2_decoder_refuses_domain_version_truncation_and_trailing_bytes() {
+    let bytes = encode_material_circuit_state_v2(&base_state()).expect("base state must encode");
+    let mut wrong_domain = bytes.clone();
+    wrong_domain[0] ^= 1;
+    assert_eq!(
+        decode_material_circuit_state_v2(&wrong_domain),
+        Err(babylon_material_circuit::MaterialCircuitErrorV2::WireDomain)
+    );
+
+    let version_index = MATERIAL_CIRCUIT_STATE_V2_DOMAIN_BYTES.len() + 1;
+    let mut wrong_version = bytes.clone();
+    wrong_version[version_index + 1] = 3;
+    assert_eq!(
+        decode_material_circuit_state_v2(&wrong_version),
+        Err(babylon_material_circuit::MaterialCircuitErrorV2::WireVersion)
+    );
+    assert_eq!(
+        decode_material_circuit_state_v2(&bytes[..bytes.len() - 1]),
+        Err(babylon_material_circuit::MaterialCircuitErrorV2::WireTruncated)
+    );
+    let mut trailing = bytes;
+    trailing.push(0);
+    assert_eq!(
+        decode_material_circuit_state_v2(&trailing),
+        Err(babylon_material_circuit::MaterialCircuitErrorV2::WireTrailing)
+    );
+}
+
+#[test]
+fn v2_decoder_refuses_unknown_access_mode_and_noncanonical_rows() {
+    const HEADER_BYTES: usize = 44;
+    const SITE_ROW_BYTES: usize = 64;
+    const FIRST_SITE_ROW: usize = HEADER_BYTES + 4;
+    const ORDER_ACCESS_MODE_INDEX: usize = 740;
+
+    let bytes = encode_material_circuit_state_v2(&base_state()).expect("base state must encode");
+    let mut unknown_mode = bytes.clone();
+    unknown_mode[ORDER_ACCESS_MODE_INDEX] = 2;
+    assert_eq!(
+        decode_material_circuit_state_v2(&unknown_mode),
+        Err(babylon_material_circuit::MaterialCircuitErrorV2::WireEnum)
+    );
+
+    let mut noncanonical = bytes;
+    let first = noncanonical[FIRST_SITE_ROW..FIRST_SITE_ROW + SITE_ROW_BYTES].to_vec();
+    let second =
+        noncanonical[FIRST_SITE_ROW + SITE_ROW_BYTES..FIRST_SITE_ROW + 2 * SITE_ROW_BYTES].to_vec();
+    noncanonical[FIRST_SITE_ROW..FIRST_SITE_ROW + SITE_ROW_BYTES].copy_from_slice(&second);
+    noncanonical[FIRST_SITE_ROW + SITE_ROW_BYTES..FIRST_SITE_ROW + 2 * SITE_ROW_BYTES]
+        .copy_from_slice(&first);
+    assert_eq!(
+        decode_material_circuit_state_v2(&noncanonical),
+        Err(babylon_material_circuit::MaterialCircuitErrorV2::WireNoncanonical)
+    );
+}
+
+#[test]
+fn every_v2_refusal_code_round_trips_and_registry_is_closed() {
+    for code in 1_u16..=18 {
+        let error = babylon_material_circuit::MaterialCircuitErrorV2::try_from(code)
+            .expect("declared code must decode");
+        assert_eq!(u16::from(error), code);
+    }
+    assert!(babylon_material_circuit::MaterialCircuitErrorV2::try_from(0).is_err());
+    assert!(babylon_material_circuit::MaterialCircuitErrorV2::try_from(19).is_err());
+}
+
+#[test]
+fn severed_corridor_changes_only_its_routed_inventory_and_realization() {
+    let full = advance_material_circuit_v2(&two_route_state()).expect("both routes must close");
+    let mut severed_state = two_route_state();
+    severed_state
+        .corridor_capacities
+        .retain(|row| row.corridor_id != corridor(CORRIDOR));
+    let severed = advance_material_circuit_v2(&severed_state).expect("severed route must close");
+
+    assert_eq!(shipped_for(&full.state, order(ORDER)), 4);
+    assert_eq!(shipped_for(&severed.state, order(ORDER)), 0);
+    assert_eq!(shipped_for(&full.state, order(14)), 4);
+    assert_eq!(shipped_for(&severed.state, order(14)), 4);
+
+    let full_arrival = advance_material_circuit_v2(&full.state).expect("full arrival must close");
+    let severed_arrival =
+        advance_material_circuit_v2(&severed.state).expect("severed arrival must close");
+    assert_eq!(shipped_for(&full_arrival.state, order(ORDER)), 4);
+    assert_eq!(
+        full_arrival
+            .state
+            .orders
+            .iter()
+            .find(|row| row.order_id == order(ORDER))
+            .unwrap()
+            .realized,
+        4
+    );
+    assert_eq!(
+        severed_arrival
+            .state
+            .orders
+            .iter()
+            .find(|row| row.order_id == order(ORDER))
+            .unwrap()
+            .realized,
+        0
+    );
+    assert_eq!(
+        full_arrival
+            .state
+            .orders
+            .iter()
+            .find(|row| row.order_id == order(14))
+            .unwrap()
+            .realized,
+        4
+    );
+    assert_eq!(
+        severed_arrival
+            .state
+            .orders
+            .iter()
+            .find(|row| row.order_id == order(14))
+            .unwrap()
+            .realized,
+        4
+    );
+}
+
+#[test]
+fn shared_corridor_allocation_exhaustively_conserves_permutations() {
+    for available in 0_u64..=10 {
+        for corridor_available in 0_u64..=10 {
+            for first_requested in 1_u64..=5 {
+                for second_requested in 1_u64..=5 {
+                    let mut state = base_state();
+                    state.inventory[0].quantity = available;
+                    state.corridor_capacities[0].available = corridor_available;
+                    state.orders[0].ordered = first_requested;
+                    state.backlog[0].quantity = first_requested;
+                    state.orders.push(OrderRowV2 {
+                        order_id: order(17),
+                        ordered: second_requested,
+                        ..state.orders[0].clone()
+                    });
+                    state.backlog.push(BacklogRowV1 {
+                        order_id: order(17),
+                        quantity: second_requested,
+                    });
+                    let mut reversed = state.clone();
+                    reversed.orders.reverse();
+                    reversed.backlog.reverse();
+
+                    let outcome =
+                        advance_material_circuit_v2(&state).expect("allocation must close");
+                    let twin = advance_material_circuit_v2(&reversed)
+                        .expect("permuted allocation must close");
+                    let effective = available.min(corridor_available);
+                    let total_requested = first_requested + second_requested;
+                    let expected_first = if effective >= total_requested {
+                        first_requested
+                    } else {
+                        effective * first_requested / total_requested
+                    };
+                    let expected_second = if effective >= total_requested {
+                        second_requested
+                    } else {
+                        effective * second_requested / total_requested
+                    };
+
+                    assert_eq!(shipped_for(&outcome.state, order(ORDER)), expected_first);
+                    assert_eq!(shipped_for(&outcome.state, order(17)), expected_second);
+                    assert_eq!(
+                        inventory_quantity(&outcome.state, site(SUPPLIER))
+                            + expected_first
+                            + expected_second,
+                        available
+                    );
+                    assert_eq!(
+                        material_circuit_state_v2_digest(&outcome.state),
+                        material_circuit_state_v2_digest(&twin.state)
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add the versioned Material Circuit V2 routed-freight successor with named logistics nodes, bounded route legs, corridor-week capacity reservation, exact transit time, and attributed loss
- conserve exact production, inventory, backlog, in-transit goods, delivery, and commodity realization while preserving every V1 byte, digest, transition, and refusal code
- freeze and Rust-bind the language-neutral V2 schema, schema SHA-256, canonical state bytes, state digest, limits, and refusal registry

## Scope boundary

This is a detached, non-live Rust transition and a partial delivery of PER-31. It does not alter graph state, BSL, TickSession, world identity, persistence, Archive, or Bevy. Money, claims, escrow, default, and double-entry settlement remain owned by PER-36.

## Verification

- `cargo test -p babylon-material-circuit --locked`
- `cargo clippy -p babylon-material-circuit --all-targets --locked -- -D warnings -D clippy::pedantic`
- `mise run rust:check-no-docs`
- `mise run lint:yaml`
- `mise run qa:regression` (12 baselines plus independent determinism leg)
- `mise run qa:vault-regression-ci` (both independent bakes byte-identical to goldens)

The gate-coverage sensor self-reported `SCOPE: NOT DECLARED`; this PR does not count that result as coverage evidence.

Part of PER-31
