### PR TITLE
docs(agents): require deletion over compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,13 +145,13 @@ Create regular lanes from `dev` and target `dev`. Use `feature/`, `fix/`, `docs/
 as `docs/agents/governance.md` directs: `Part of PER-N` for partial delivery and
 `Fixes PER-N` only for final acceptance. Never commit directly to `dev` or `main`.
 
+Delete obsolete code. Do not add shims, aliases, adapters, deprecated paths, or backward-compatibility layers unless the Director explicitly requires them.
 A critical hotfix alone can branch from and target `main`. Its Director-only merge requires a `dev` backport.
 For a release, prove `origin/main` is an ancestor of `origin/dev`, then qualify exact `dev` with `main.yml`.
 After the Director merge, return main through `release:prepare-dev-sync` before `release:tag` can publish.
 <!-- vale ste.NounClusters = YES -->
 <!-- vale ste.UnapprovedWords = YES -->
 <!-- vale Vale.Spelling = YES -->
-
 Use `type(scope): description`, one logical unit, and the required co-author
 trailer. Commit with `mise run commit -- "type(scope): description"`.
 


### PR DESCRIPTION
## Summary

- Make deletion the default when obsolete code is replaced.
- Forbid shims, aliases, adapters, deprecated paths, and backward-compatibility layers unless the Director explicitly requires them.
- Keep the live agent configuration at 199 lines; `AGENTS.md` continues to resolve to `CLAUDE.md`.

## Linear delivery

- [x] `Part of PER-262` — partial delivery. Keep the Linear issue open.
- [ ] `Fixes PER-N` — final accepted delivery. Close the Linear issue after merge.

## Review evidence

Base branch: `dev`

Exact reviewed head SHA: `a985dd02e6fc2e4b3d07c0993ca9fd30fff5ccdb`

- [x] The base branch is `dev`, or the Director approved `main`.
- [x] All reported local checks completed successfully for the exact reviewed head SHA and base branch above.
- [ ] The Copilot review completed against the exact reviewed head SHA.
- [ ] I fixed each accepted Copilot finding, provided a reply to every finding, and resolved all Copilot review threads.

On 2026-08-26, the Director explicitly waived the GitHub Copilot review because its token allowance was exhausted and it could not emit another review. No other merge condition is waived.

## Behavioral-contract disposition

- [ ] Changed behavior: I added or updated a durable behavioral contract.
- [x] No behavior change: the current behavioral contracts are enough.

Disposition and evidence: this changes contributor policy only. It does not change executable game behavior.

## Baseline disposition

- [x] No governed baseline changed.
- [ ] A governed baseline changed intentionally.

## Verification

- Every exact-head hosted check passed after the required rebase onto merged PR #780, including Unit (5m10s), Rust (8m2s), PostgreSQL, Fast Gate, determinism, both CodeQL languages, security, secret, IaC, and baseline policy.
- `vale CLAUDE.md`: 0 errors, 0 warnings, 0 suggestions.
- `wc -l CLAUDE.md`: 199 lines.
- `AGENTS.md` resolves to `CLAUDE.md`.
- Required commit hooks passed, including the managed-worktree contract, Markdown lint, secret scan, and commit policy.
- Pre-push fast pytest, full static sentinel family, whitespace, large-file, and Git LFS checks passed.

## Merge

- [x] Preserve the source branch. Delete it only after an explicit owner decision and a check for dependent work.

## Questions for reviewers

None.
