### PR TITLE
chore(repo): ignore local worktree artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ chromadb/
 .continue*
 .continuerules
 .continuerc.json
+/.codex/
+/.kimi-code/
 
 *.pyc
 
@@ -80,6 +82,8 @@ reports/sim-runs/
 # qa:regression first-divergence attribution (E4; transient — rewritten/removed
 # every compare run, only present while a dense-gate FAIL is being diagnosed)
 reports/qa-first-divergence.json
+# Local-only human/agent reports; durable reports remain tracked.
+/reports/*.LOCAL-*.md
 # Daemonized sim pidfiles/logs (sim:e2e-bg)
 .sim-pids/
 
@@ -129,10 +133,14 @@ node_modules
 # One-off tool dumps (regenerable; were briefly tracked pre-Program-14)
 pytest_out.txt
 ast_usages.txt
+/kimi-debug-session_*.zip
 
 # Claude's scratch space (ai/ tree is Claude-owned; scratch contents are ephemeral)
 ai/scratch/*
 !ai/scratch/README.md
+# Local knowledge-tool state and Percy's private research inbox.
+/ai/.obsidian/
+/ai/_inbox/phil-neel/
 
 # ai/_inbox is the owner's drop-zone (parsed items → ai/_inbox/archive/). Keep the
 # text notes tracked, but babylon_books/ is 555 MB of reference PDFs — never commit it.


### PR DESCRIPTION
## Summary

Keep private and machine-local artifacts out of repository status without broad ignores:

- root .codex directory
- root .kimi-code directory
- root reports files matching *.LOCAL-*.md
- root kimi-debug-session_*.zip archives
- root ai/.obsidian directory
- root ai/_inbox/phil-neel directory

The rules are deliberately root-scoped and narrow. Ordinary Markdown reports, non-LOCAL report files, other inbox topics, similarly named nested paths, and unrelated ZIP files remain trackable.

Part of PER-265

## Verification

- mise run test:q -- tests/unit/tools/test_repo_hygiene.py (12 passed)
- mise run check:worktree-contract
- git diff --check origin/dev...HEAD
- git check-ignore -v --no-index positive checks for all six patterns
- negative checks for broad inbox and non-LOCAL report paths
- pre-push fast gate, sentinel family, public-surface baseline, import-linter, radon, semgrep, baseline ceremony, whitespace, EOF, large-file, and LFS checks passed
- rust-full-gate skipped for this .gitignore-only change