### PR TITLE
fix(governance): make Copilot evidence advisory

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,9 +29,10 @@ Exact reviewed head SHA: <!-- Use the full 40-character commit SHA. -->
 - [ ] For a `main` target, this PR produced the complete combined manifest.
 - [ ] All reported checks completed successfully for the exact reviewed head
       SHA and base branch above.
-- [ ] The Copilot review completed against the exact reviewed head SHA.
-- [ ] I fixed each accepted Copilot finding, provided a reply to every finding,
-      and resolved all Copilot review threads.
+- [ ] Copilot evidence is advisory when absent, stale, incomplete, API-failed,
+      identity-mismatched, or without a reply.
+- [ ] No unresolved review thread remains. Any unresolved review thread blocks
+      the merge, regardless of its author.
 
 ## Behavioral-contract disposition
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -84,7 +84,7 @@ description = "Run any command inside the vendored devshell and pass through tru
 run = 'MISE_TRUSTED_CONFIG_PATHS="${MISE_PROJECT_ROOT:-$PWD}" nix develop "git+file://${MISE_PROJECT_ROOT:-$PWD}" --command'
 
 [tasks."pr:merge"]
-description = "the ONE sanctioned merge path (ADR181 R10): all-green + head-pin + Copilot harvest + zero alert floor + stacked-PR guard"
+description = "the ONE sanctioned merge path: all-green + head-pin + Copilot advisory + unresolved review thread block + zero alert floor + stacked-PR guard"
 run = "python3 tools/pr_merge.py"
 
 [tasks."check:worktree-contract"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,12 +150,12 @@ A critical hotfix alone can branch from and target `main`. Its Director-only mer
 For a release, prove `origin/main` is an ancestor of `origin/dev`, then qualify exact `dev` with `main.yml`.
 After the Director merge, return main through `release:prepare-dev-sync` before `release:tag` can publish.
 <!-- vale ste.NounClusters = YES -->
-<!-- vale ste.UnapprovedWords = YES -->
 <!-- vale Vale.Spelling = YES -->
 Use `type(scope): description`, one logical unit, and the required co-author
 trailer. Commit with `mise run commit -- "type(scope): description"`.
 
-Before merge, pin green CI to the PR head SHA and address all Copilot comments.
+Before merge, pin green CI to the PR head SHA. Copilot evidence is advisory. An unresolved review thread blocks.
+<!-- vale ste.UnapprovedWords = YES -->
 Use only `mise run pr:merge -- N`. Do not use `gh pr merge --auto`. The Director
 controls all merges to `main`.
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -118,13 +118,14 @@ Before a merge, complete these steps:
 1. Confirm the base branch and record the exact reviewed head SHA.
 2. Confirm that all reported checks completed successfully for that exact
    reviewed head SHA and base branch.
-3. Complete the Copilot review against that head. Fix each accepted finding or
-   reply with the rationale for no change.
-4. Confirm that every Copilot finding has a reply and that you resolved all
-   Copilot review threads.
-5. Confirm the behavioral-contract disposition and baseline disposition in the
+3. Inspect the available Copilot input.
+4. Treat absent, stale, incomplete, identity-mismatched, or API-failed Copilot
+   input as advisory.
+5. Treat a top-level Copilot comment without a reply as advisory.
+6. Confirm that no unresolved review thread remains. Any such thread blocks the merge.
+7. Confirm the behavioral-contract disposition and baseline disposition in the
    PR description.
-6. Run the approved merge command.
+8. Run the approved merge command.
 
 ```bash
 mise run pr:merge -- N

--- a/ai/decisions/ADR241_copilot_advisory_merge_policy.yaml
+++ b/ai/decisions/ADR241_copilot_advisory_merge_policy.yaml
@@ -1,0 +1,57 @@
+ADR241_copilot_advisory_merge_policy:
+  status: "accepted"
+  date: "2026-08-26"
+  title: >-
+    Copilot evidence is advisory while exact-head CI and unresolved review
+    threads remain hard merge boundaries
+  context: |
+    Copilot is useful review input, but its availability, timing, endpoint
+    identity, and API health are external and stochastic. Making those signals
+    a merge precondition turned a suggestion into an unavailable or stale veto.
+    The Director approved a permanent override that keeps Copilot evidence
+    visible without letting Copilot availability decide whether a verified
+    pull request can merge.
+
+    Review threads are different evidence. An unresolved thread records an
+    open conversation from any reviewer and is already a repository protection
+    boundary. Required CI, exact ref identity, Linear PER delivery identity,
+    the CodeQL zero floor, and the sanctioned merge command are independent of
+    Copilot and remain mandatory.
+  decision: |
+    1. COPILOT IS ADVISORY. A missing, stale, pending, identity-mismatched, or
+       otherwise incomplete Copilot review does not block a merge. An
+       unreplied top-level Copilot comment is also advisory. The verifier emits
+       each observed condition as `pr:merge ADVISORY` evidence.
+
+    2. COPILOT READ FAILURES ARE BOUNDED. A failure from a Copilot-only REST
+       review or comment read becomes a typed, sanitized, length-bounded
+       advisory. A failure of a shared read that supplies required head, base,
+       CI, or review-thread evidence remains a refusal.
+
+    3. REVIEW THREADS REMAIN HARD. Any unresolved review thread blocks the
+       merge, regardless of author. The fixed one-hundred-thread bound and its
+       refusal on pagination remain unchanged.
+
+    4. ALL OTHER MERGE LAW REMAINS HARD. Required CI must report an allowed
+       conclusion for the exact head and exact base. PER identity and delivery
+       disposition remain mandatory. The CodeQL zero floor, moved-ref guards,
+       base policy, source-branch safeguards, and Dependabot provenance remain
+       mandatory. `mise run pr:merge -- N` remains the sole merge path.
+  consequences: |
+    - Copilot suggestions remain visible and available for human or agent
+      judgment, but their absence or nondisposition cannot veto delivery.
+    - An unresolved human, Copilot, or other review thread still refuses the
+      merge through both repository protection and the local verifier.
+    - This decision changes no required check, exact-head or exact-base guard,
+      Linear authority, main-release boundary, or merge command.
+  supersedes:
+    - >-
+      ADR181 R1 and the Copilot-harvest portion of R10 only; all other ADR181
+      rulings remain unchanged
+    - >-
+      ADR230 decision 3 and consequence clauses that make completed exact-head
+      Copilot review or top-level-comment replies preconditions only; its
+      unresolved-thread and all non-Copilot boundaries remain unchanged
+  related:
+    - ADR181_ci_synergy_rulings
+    - ADR230_exact_head_pr_and_dependabot_policy

--- a/ai/decisions/index.yaml
+++ b/ai/decisions/index.yaml
@@ -1,5 +1,5 @@
 meta:
-  version: 1.85.0
+  version: 1.86.0
   updated: '2026-08-26'
   description: Architecture Decision Records Index
   format: See individual ADR files in this directory
@@ -1110,3 +1110,8 @@ decisions:
     status: accepted
     date: '2026-08-26'
     file: ADR239_routed_material_circuit_v2.yaml
+  ADR241_copilot_advisory_merge_policy:
+    title: 'Copilot evidence is advisory while exact-head CI and unresolved review threads remain hard merge boundaries'
+    status: accepted
+    date: '2026-08-26'
+    file: ADR241_copilot_advisory_merge_policy.yaml

--- a/docs/agents/governance.md
+++ b/docs/agents/governance.md
@@ -168,9 +168,10 @@ The merge record identifies the base branch and exact reviewed head SHA. All
 reported checks must complete successfully against that exact reviewed head
 SHA and base branch.
 
-The Copilot review must complete against the reviewed head. Each accepted
-comment needs a fix. Every comment needs a reply. The final record marks all
-Copilot review threads resolved.
+Copilot review evidence is advisory. An absent, stale, incomplete,
+identity-mismatched, or API-failed review does not block a merge. A top-level
+comment without a reply is also advisory. Any unresolved review thread blocks
+the merge, regardless of its author.
 
 Each PR records a behavioral-contract disposition. Changed behavior links a
 durable, implementation-independent contract. No behavior change includes an

--- a/tests/unit/decisions/test_adr232_neel_integration_program_architecture.py
+++ b/tests/unit/decisions/test_adr232_neel_integration_program_architecture.py
@@ -45,7 +45,7 @@ def test_adr232_declares_the_approved_program_law_and_exact_index_row() -> None:
     ):
         assert required_text in decision_text
 
-    assert index_document["meta"]["version"] == "1.85.0"
+    assert index_document["meta"]["version"] == "1.86.0"
     assert str(index_document["meta"]["updated"]) == "2026-08-26"
     assert index_document["decisions"][ADR_STEM] == {
         "title": EXPECTED_TITLE,

--- a/tests/unit/decisions/test_adr233_practice_input_authority_v2.py
+++ b/tests/unit/decisions/test_adr233_practice_input_authority_v2.py
@@ -51,7 +51,7 @@ def test_adr233_declares_the_v2_authority_boundary_and_exact_index_row() -> None
     ):
         assert required_text in decision_text
 
-    assert index_document["meta"]["version"] == "1.85.0"
+    assert index_document["meta"]["version"] == "1.86.0"
     assert str(index_document["meta"]["updated"]) == "2026-08-26"
     assert index_document["decisions"][ADR_STEM] == {
         "title": EXPECTED_TITLE,

--- a/tests/unit/decisions/test_adr234_practice_intent_v2.py
+++ b/tests/unit/decisions/test_adr234_practice_intent_v2.py
@@ -49,7 +49,7 @@ def test_adr234_declares_the_v2_intent_boundary_and_exact_index_row() -> None:
     ):
         assert required_text in decision_text
 
-    assert index["meta"]["version"] == "1.85.0"
+    assert index["meta"]["version"] == "1.86.0"
     assert index["decisions"][ADR_STEM] == {
         "title": EXPECTED_TITLE,
         "status": "accepted",

--- a/tests/unit/decisions/test_adr235_resolved_practice_batch_v2.py
+++ b/tests/unit/decisions/test_adr235_resolved_practice_batch_v2.py
@@ -46,7 +46,7 @@ def test_adr235_declares_the_resolved_batch_boundary_and_exact_index_row() -> No
     ):
         assert required_text in decision_text
 
-    assert index["meta"]["version"] == "1.85.0"
+    assert index["meta"]["version"] == "1.86.0"
     assert index["decisions"][ADR_STEM] == {
         "title": EXPECTED_TITLE,
         "status": "accepted",

--- a/tests/unit/decisions/test_adr236_practice_resource_allocation_v2.py
+++ b/tests/unit/decisions/test_adr236_practice_resource_allocation_v2.py
@@ -48,7 +48,7 @@ def test_adr236_records_the_complete_allocator_law_and_exact_index_row() -> None
     ):
         assert required_text in decision_text
 
-    assert index["meta"]["version"] == "1.85.0"
+    assert index["meta"]["version"] == "1.86.0"
     assert index["decisions"][ADR_STEM] == {
         "title": EXPECTED_TITLE,
         "status": "accepted",

--- a/tests/unit/decisions/test_adr237_strike_proposal_v2.py
+++ b/tests/unit/decisions/test_adr237_strike_proposal_v2.py
@@ -47,7 +47,7 @@ def test_adr237_records_authoritative_habitation_and_worker_independence() -> No
     ):
         assert required_text in decision_text
 
-    assert index["meta"]["version"] == "1.85.0"
+    assert index["meta"]["version"] == "1.86.0"
     assert index["decisions"][ADR_STEM] == {
         "title": EXPECTED_TITLE,
         "status": "accepted",

--- a/tests/unit/decisions/test_adr238_material_circuit_v1.py
+++ b/tests/unit/decisions/test_adr238_material_circuit_v1.py
@@ -46,7 +46,7 @@ def test_adr238_records_the_exact_order_inventory_and_production_law() -> None:
     ):
         assert required_text in decision_text
 
-    assert index["meta"]["version"] == "1.85.0"
+    assert index["meta"]["version"] == "1.86.0"
     assert index["decisions"][ADR_STEM] == {
         "title": EXPECTED_TITLE,
         "status": "accepted",

--- a/tests/unit/governance/test_main_qualification_decision.py
+++ b/tests/unit/governance/test_main_qualification_decision.py
@@ -45,7 +45,7 @@ def test_decision_index_resolves_to_main_qualification_record() -> None:
     index = _mapping(INDEX_PATH)
     entry = index["decisions"][ADR_KEY]
 
-    assert index["meta"]["version"] == "1.85.0"
+    assert index["meta"]["version"] == "1.86.0"
     assert str(index["meta"]["updated"]) == "2026-08-26"
     assert entry == {
         "title": decision_title(),

--- a/tests/unit/governance/test_pr_policy_decision.py
+++ b/tests/unit/governance/test_pr_policy_decision.py
@@ -57,7 +57,7 @@ def test_decision_index_resolves_to_the_live_record() -> None:
     index = _mapping(INDEX_PATH)
     entry = index["decisions"][ADR_KEY]
 
-    assert index["meta"]["version"] == "1.85.0"
+    assert index["meta"]["version"] == "1.86.0"
     assert str(index["meta"]["updated"]) == "2026-08-26"
     assert entry["status"] == "accepted"
     assert entry["date"] == "2026-08-25"

--- a/tests/unit/governance/test_v4_portfolio_alignment.py
+++ b/tests/unit/governance/test_v4_portfolio_alignment.py
@@ -540,7 +540,7 @@ def test_per_18_adr_and_catalog_are_exact() -> None:
     """The accepted decision and catalog row cannot pass as an empty placeholder."""
     catalog = _yaml_document(_ADR_INDEX)
     assert catalog["meta"] == {
-        "version": "1.85.0",
+        "version": "1.86.0",
         "updated": "2026-08-26",
         "description": "Architecture Decision Records Index",
         "format": "See individual ADR files in this directory",

--- a/tests/unit/test_pr_governance_contract.py
+++ b/tests/unit/test_pr_governance_contract.py
@@ -10,6 +10,7 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 TEMPLATE = Path(".github/PULL_REQUEST_TEMPLATE.md")
@@ -24,6 +25,14 @@ MAIN_RELEASE_SURFACES = (
     Path("docs/agents/governance.md"),
 )
 MERGE_COMMAND = "mise run pr:merge -- N"
+COPILOT_ADVISORY_SURFACES = (
+    *GOVERNANCE_SURFACES,
+    Path("CLAUDE.md"),
+    Path(".mise.toml"),
+)
+COPILOT_ADVISORY_ADR_NAME = "ADR241_copilot_advisory_merge_policy"
+COPILOT_ADVISORY_ADR = Path("ai/decisions") / f"{COPILOT_ADVISORY_ADR_NAME}.yaml"
+ADR_INDEX = Path("ai/decisions/index.yaml")
 
 
 def _text(path: Path) -> str:
@@ -62,14 +71,42 @@ def test_merge_evidence_is_pinned_to_reviewed_head_and_base(path: Path) -> None:
     assert "all reported checks" in text
 
 
-@pytest.mark.parametrize("path", GOVERNANCE_SURFACES)
-def test_copilot_review_requires_disposition_and_resolved_threads(path: Path) -> None:
-    """A completed review alone must not leave Copilot threads unresolved."""
+@pytest.mark.parametrize("path", COPILOT_ADVISORY_SURFACES)
+def test_copilot_evidence_is_advisory_but_unresolved_threads_block(path: Path) -> None:
+    """Copilot availability cannot block, while unresolved threads still do."""
     text = _normalized(path)
-    assert "copilot review" in text
-    assert "fix" in text
-    assert "reply" in text
-    assert "resolved" in text
+    assert "copilot" in text
+    assert "advisory" in text
+    assert "unresolved review thread" in text
+    assert "block" in text or "refuse" in text
+
+
+def test_copilot_advisory_decision_is_precisely_scoped_and_indexed() -> None:
+    """The successor ADR must preserve every non-Copilot merge boundary."""
+    record = yaml.safe_load(_text(COPILOT_ADVISORY_ADR))
+    assert isinstance(record, dict)
+    decision = record[COPILOT_ADVISORY_ADR_NAME]
+    text = " ".join(str(decision["decision"]).split())
+    supersedes = " ".join(str(item) for item in decision["supersedes"])
+
+    assert decision["status"] == "accepted"
+    assert decision["date"] == "2026-08-26"
+    assert "Copilot" in text and "advisory" in text
+    assert "unresolved review thread" in text and "blocks" in text
+    assert "required ci" in text.lower()
+    assert "exact head" in text and "exact base" in text
+    assert "PER identity" in text
+    assert MERGE_COMMAND in text
+    assert "ADR181" in supersedes and "Copilot" in supersedes
+    assert "ADR230" in supersedes and "Copilot" in supersedes
+    assert "only" in supersedes
+
+    index = yaml.safe_load(_text(ADR_INDEX))
+    assert isinstance(index, dict)
+    entry = index["decisions"][COPILOT_ADVISORY_ADR_NAME]
+    assert index["meta"]["version"] == "1.86.0"
+    assert entry["file"] == COPILOT_ADVISORY_ADR.name
+    assert entry["status"] == "accepted"
 
 
 @pytest.mark.parametrize("path", GOVERNANCE_SURFACES)

--- a/tests/unit/tools/test_pr_merge_policy.py
+++ b/tests/unit/tools/test_pr_merge_policy.py
@@ -952,6 +952,43 @@ def test_top_level_copilot_comment_without_reply_is_advisory(tmp_path: Path) -> 
 
 
 @pytest.mark.parametrize(
+    "malformation",
+    ["missing-id", "unhashable-id", "unhashable-reply-id"],
+)
+def test_malformed_canonical_copilot_comment_is_a_bounded_advisory(
+    tmp_path: Path,
+    malformation: str,
+) -> None:
+    scenario = _default_scenario()
+    comment: dict[str, object] = {
+        "id": 91,
+        "html_url": "https://example.test/comment/91",
+        "in_reply_to_id": None,
+        "user": {
+            "login": "Copilot",
+            "id": COPILOT_BOT_ID,
+            "node_id": COPILOT_BOT_NODE_ID,
+            "type": "Bot",
+        },
+    }
+    if malformation == "missing-id":
+        comment.pop("id")
+    elif malformation == "unhashable-id":
+        comment["id"] = []
+    else:
+        comment["in_reply_to_id"] = []
+    scenario["comments"] = [comment]
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 0, result.stderr
+    assert "pr:merge ADVISORY — Copilot comment evidence unavailable" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert len(result.stderr) <= 550
+    assert len(_merge_calls(calls)) == 1
+
+
+@pytest.mark.parametrize(
     ("failure_field", "expected_context"),
     [
         ("rest_reviews_failure", "Copilot review evidence unavailable"),

--- a/tests/unit/tools/test_pr_merge_policy.py
+++ b/tests/unit/tools/test_pr_merge_policy.py
@@ -145,6 +145,9 @@ elif args[:2] == ["pr", "merge"]:
         raise SystemExit(7)
     print("merged")
 elif args[0] == "api" and args[1].endswith("/reviews?per_page=100"):
+    if scenario.get("rest_reviews_failure"):
+        print(scenario["rest_reviews_failure"], file=sys.stderr)
+        raise SystemExit(9)
     print(json.dumps(scenario["rest_reviews"]))
 elif args[0] == "api" and args[1].endswith("/pulls/742"):
     print(json.dumps(scenario["dependabot_pr"]))
@@ -167,6 +170,9 @@ elif args[0] == "api" and args[1].endswith(
 elif args[0] == "api" and args[1].endswith("/pulls/742/commits?per_page=100"):
     print(json.dumps(scenario["dependabot_commits"]))
 elif args[0] == "api" and "/comments" in args[1]:
+    if scenario.get("comments_failure"):
+        print(scenario["comments_failure"], file=sys.stderr)
+        raise SystemExit(10)
     print(json.dumps(scenario["comments"]))
 else:
     print(f"unexpected fake gh arguments: {args}", file=sys.stderr)
@@ -372,6 +378,8 @@ def _default_scenario() -> dict[str, object]:
         "alerts": [],
         "children": [],
         "initial_view_failure": None,
+        "rest_reviews_failure": None,
+        "comments_failure": None,
         "merge_failure": None,
         "reconciliation_failure": None,
         "merge_reconciliation": {
@@ -678,7 +686,7 @@ def test_exactly_full_code_scanning_page_refuses_as_potentially_truncated(
     assert _merge_calls(calls) == []
 
 
-def test_one_hundred_rest_items_refuses_at_the_static_bound(tmp_path: Path) -> None:
+def test_full_copilot_comment_page_is_a_bounded_advisory(tmp_path: Path) -> None:
     scenario = _default_scenario()
     scenario["comments"] = [
         {
@@ -692,11 +700,11 @@ def test_one_hundred_rest_items_refuses_at_the_static_bound(tmp_path: Path) -> N
 
     result, calls = _run_pr_merge(tmp_path, scenario=scenario)
 
-    assert result.returncode == 1
-    assert result.stderr.startswith("pr:merge REFUSED — ")
+    assert result.returncode == 0, result.stderr
+    assert result.stderr.startswith("pr:merge ADVISORY — Copilot comment evidence unavailable")
     assert "100-item safety bound" in result.stderr
     assert "Traceback" not in result.stderr
-    assert _merge_calls(calls) == []
+    assert len(_merge_calls(calls)) == 1
 
 
 def test_one_hundred_check_entries_refuse_a_potentially_truncated_rollup(
@@ -864,7 +872,7 @@ def test_merge_is_atomically_matched_to_verified_head(tmp_path: Path) -> None:
     ],
     ids=["missing", "stale", "pending"],
 )
-def test_copilot_review_must_be_completed_on_verified_head(
+def test_copilot_review_state_is_advisory_on_verified_head(
     tmp_path: Path, reviews: list[dict[str, object]]
 ) -> None:
     scenario = _default_scenario()
@@ -872,16 +880,16 @@ def test_copilot_review_must_be_completed_on_verified_head(
 
     result, calls = _run_pr_merge(tmp_path, scenario=scenario)
 
-    assert result.returncode == 1
-    assert "completed Copilot review on verified head" in result.stderr
-    assert _merge_calls(calls) == []
+    assert result.returncode == 0, result.stderr
+    assert "pr:merge ADVISORY — no completed Copilot review on verified head" in result.stderr
+    assert len(_merge_calls(calls)) == 1
 
 
 @pytest.mark.parametrize(
     "login",
     ["attacker-copilot-reviewer", "copilot-pull-request-reviewer[bot]"],
 )
-def test_graphql_copilot_review_identity_is_exact(tmp_path: Path, login: str) -> None:
+def test_graphql_copilot_review_identity_mismatch_is_advisory(tmp_path: Path, login: str) -> None:
     scenario = _default_scenario()
     review = _copilot_review()
     review["author"] = {"login": login}
@@ -889,16 +897,16 @@ def test_graphql_copilot_review_identity_is_exact(tmp_path: Path, login: str) ->
 
     result, calls = _run_pr_merge(tmp_path, scenario=scenario)
 
-    assert result.returncode == 1
-    assert "completed Copilot review on verified head" in result.stderr
-    assert _merge_calls(calls) == []
+    assert result.returncode == 0, result.stderr
+    assert "pr:merge ADVISORY — no completed Copilot review on verified head" in result.stderr
+    assert len(_merge_calls(calls)) == 1
 
 
 @pytest.mark.parametrize(
     ("field", "value"),
     [("id", 1), ("node_id", "BOT_impostor"), ("type", "User")],
 )
-def test_rest_copilot_review_requires_immutable_bot_identity(
+def test_rest_copilot_review_identity_mismatch_is_advisory(
     tmp_path: Path,
     field: str,
     value: object,
@@ -912,12 +920,12 @@ def test_rest_copilot_review_requires_immutable_bot_identity(
 
     result, calls = _run_pr_merge(tmp_path, scenario=scenario)
 
-    assert result.returncode == 1
-    assert "completed Copilot review on verified head" in result.stderr
-    assert _merge_calls(calls) == []
+    assert result.returncode == 0, result.stderr
+    assert "pr:merge ADVISORY — no completed Copilot review on verified head" in result.stderr
+    assert len(_merge_calls(calls)) == 1
 
 
-def test_top_level_copilot_comment_still_requires_reply(tmp_path: Path) -> None:
+def test_top_level_copilot_comment_without_reply_is_advisory(tmp_path: Path) -> None:
     scenario = _default_scenario()
     scenario["comments"] = [
         {
@@ -935,9 +943,37 @@ def test_top_level_copilot_comment_still_requires_reply(tmp_path: Path) -> None:
 
     result, calls = _run_pr_merge(tmp_path, scenario=scenario)
 
-    assert result.returncode == 1
-    assert "unaddressed Copilot comment" in result.stderr
-    assert _merge_calls(calls) == []
+    assert result.returncode == 0, result.stderr
+    assert (
+        "pr:merge ADVISORY — unaddressed Copilot comment "
+        "https://example.test/comment/91" in result.stderr
+    )
+    assert len(_merge_calls(calls)) == 1
+
+
+@pytest.mark.parametrize(
+    ("failure_field", "expected_context"),
+    [
+        ("rest_reviews_failure", "Copilot review evidence unavailable"),
+        ("comments_failure", "Copilot comment evidence unavailable"),
+    ],
+)
+def test_copilot_only_api_failure_is_a_bounded_advisory(
+    tmp_path: Path,
+    failure_field: str,
+    expected_context: str,
+) -> None:
+    scenario = _default_scenario()
+    scenario[failure_field] = "private detail\n" * 100
+
+    result, calls = _run_pr_merge(tmp_path, scenario=scenario)
+
+    assert result.returncode == 0, result.stderr
+    assert f"pr:merge ADVISORY — {expected_context}: gh failed:" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert "private detail" in result.stderr
+    assert len(result.stderr) <= 550
+    assert len(_merge_calls(calls)) == 1
 
 
 @pytest.mark.parametrize(

--- a/tools/pr_merge.py
+++ b/tools/pr_merge.py
@@ -7,8 +7,8 @@ each of which has already bitten:
 1. Never ``--auto`` (#392: it ignores failing non-required checks) — this
    wrapper simply has no such flag.
 2. All checks green AND both PR refs unchanged across the verdict snapshot.
-3. A completed Copilot review must target the verified head; every top-level
-   Copilot inline comment needs a reply; and every review thread must resolve.
+3. Copilot review state and unreplied top-level comments are advisory; every
+   review thread, regardless of author, must resolve.
 4. Any open code-scanning alert is a STOP (CodeQL no longer runs on PRs — R5b
    — so the alert DB, not a PR check, is the source of truth).
 5. ``--delete-branch`` is refused for ``dev`` and while another open PR bases
@@ -86,6 +86,10 @@ class GitHubReadError(RuntimeError):
 
 class MergeIndeterminateError(RuntimeError):
     """A mutating merge call could not be reconciled to one exact outcome."""
+
+
+class CopilotEvidenceReadError(RuntimeError):
+    """A bounded Copilot-only evidence read failed without blocking merge."""
 
 
 def _bounded_error_detail(value: object) -> str:
@@ -242,7 +246,7 @@ def _unharvested_copilot_comments(pr: int) -> list[str]:
     )
     replied_to = {c.get("in_reply_to_id") for c in comments}
     return [
-        f"unaddressed Copilot comment {c['html_url']}"
+        f"unaddressed Copilot comment {_bounded_error_detail(c.get('html_url'))}"
         for c in comments
         if _is_rest_copilot_comment(c.get("user"))
         and c.get("in_reply_to_id") is None
@@ -286,6 +290,30 @@ def _rest_reviews(pr: int) -> list[dict[str, object]]:
         "REST pull-request reviews",
         refuse_full_page=True,
     )
+
+
+def _copilot_evidence_error(context: str, error: RuntimeError) -> CopilotEvidenceReadError:
+    """Convert one Copilot-only read failure into bounded typed evidence."""
+    detail = _bounded_error_detail(str(error)) or type(error).__name__
+    return CopilotEvidenceReadError(f"{context} unavailable: {detail}")
+
+
+def _copilot_advisories(pr: int, graphql_reviews: object, head_oid: str) -> list[str]:
+    """Return non-blocking Copilot review and comment evidence."""
+    advisories: list[str] = []
+    try:
+        rest_reviews = _rest_reviews(pr)
+        completed = _has_completed_copilot_review(graphql_reviews, rest_reviews, head_oid)
+    except RuntimeError as error:
+        advisories.append(str(_copilot_evidence_error("Copilot review evidence", error)))
+    else:
+        if not completed:
+            advisories.append("no completed Copilot review on verified head")
+    try:
+        advisories.extend(_unharvested_copilot_comments(pr))
+    except RuntimeError as error:
+        advisories.append(str(_copilot_evidence_error("Copilot comment evidence", error)))
+    return advisories
 
 
 def _has_completed_copilot_review(
@@ -831,9 +859,7 @@ def _main() -> int:
         problems.append("no checks reported on the head commit")
     manifest = manifest_for_base(base_ref) if base_ref in {"dev", "main"} else ()
     problems.extend(_rollup_failures(_json_dicts(rollup, "status-check rollup"), manifest))
-    if not _has_completed_copilot_review(view.get("reviews"), _rest_reviews(args.pr), head_oid):
-        problems.append("no completed Copilot review on verified head")
-    problems.extend(_unharvested_copilot_comments(args.pr))
+    advisories = _copilot_advisories(args.pr, view.get("reviews"), head_oid)
     problems.extend(_review_thread_problems(args.pr))
     if (alerts := _open_alert_count()) > 0:
         problems.append(f"{alerts} open code-scanning alert(s) — the zero floor is a STOP")
@@ -861,6 +887,8 @@ def _main() -> int:
     if refs_now.get("baseRefOid") != base_oid:
         problems.append("base moved while verifying — re-run against the new base")
 
+    for advisory in advisories:
+        print(f"pr:merge ADVISORY — {advisory}", file=sys.stderr)
     if problems:
         for problem in problems:
             print(f"pr:merge REFUSED — {problem}", file=sys.stderr)

--- a/tools/pr_merge.py
+++ b/tools/pr_merge.py
@@ -292,7 +292,10 @@ def _rest_reviews(pr: int) -> list[dict[str, object]]:
     )
 
 
-def _copilot_evidence_error(context: str, error: RuntimeError) -> CopilotEvidenceReadError:
+def _copilot_evidence_error(
+    context: str,
+    error: RuntimeError | KeyError | TypeError,
+) -> CopilotEvidenceReadError:
     """Convert one Copilot-only read failure into bounded typed evidence."""
     detail = _bounded_error_detail(str(error)) or type(error).__name__
     return CopilotEvidenceReadError(f"{context} unavailable: {detail}")
@@ -304,14 +307,14 @@ def _copilot_advisories(pr: int, graphql_reviews: object, head_oid: str) -> list
     try:
         rest_reviews = _rest_reviews(pr)
         completed = _has_completed_copilot_review(graphql_reviews, rest_reviews, head_oid)
-    except RuntimeError as error:
+    except (RuntimeError, KeyError, TypeError) as error:
         advisories.append(str(_copilot_evidence_error("Copilot review evidence", error)))
     else:
         if not completed:
             advisories.append("no completed Copilot review on verified head")
     try:
         advisories.extend(_unharvested_copilot_comments(pr))
-    except RuntimeError as error:
+    except (RuntimeError, KeyError, TypeError) as error:
         advisories.append(str(_copilot_evidence_error("Copilot comment evidence", error)))
     return advisories
 


### PR DESCRIPTION
## Summary

- Make Copilot review availability, freshness, identity, API reads, and unreplied top-level comments bounded advisories.
- Keep unresolved review threads, required CI, exact head/base identity, PER delivery identity, and the sanctioned merge command as hard boundaries.
- Record the narrowly scoped decision in ADR241 and align all live contributor surfaces.

## Linear delivery

- [x] `Part of PER-259` — partial delivery. Keep the Linear issue open.
- [ ] `Fixes PER-259` — final accepted delivery. Close the Linear issue after merge.

Linear issue: https://linear.app/percy-raskova/issue/PER-259

## Review evidence

Base branch: `dev`

Exact reviewed head SHA: `778985446e0b8141f7cd9f3afb4265d6ebdbb22e`

- [x] The base branch is `dev`, or the Director approved `main`.
- [ ] All reported checks completed successfully for the exact reviewed head SHA and base branch above.
- [x] Copilot evidence is advisory when absent, stale, incomplete, API-failed, identity-mismatched, or without a reply.
- [x] No unresolved review thread remains. Any unresolved review thread blocks the merge, regardless of its author.

## Behavioral-contract disposition

- [x] Changed behavior: added and updated durable policy tests for advisory Copilot evidence, bounded read failures, and hard unresolved-thread refusal.
- [ ] No behavior change: the current behavioral contracts are enough.

Disposition and evidence: `tests/unit/tools/test_pr_merge_policy.py`, `tests/unit/test_pr_governance_contract.py`, and ADR241.

## Baseline disposition

- [x] No governed baseline changed.
- [ ] A governed baseline changed intentionally.

## Merge

- [x] Merge only with `mise run pr:merge -- N`. Use this PR number for `N`.
- [ ] For a `main` target, only the Director uses `mise run pr:merge -- N --director-main`.
- [x] Preserve the source branch by default.

## Questions for reviewers

None.