### PR TITLE
feat(kernel): add replay identity and RNG V2

### DIFF
--- a/docs/superpowers/plans/2026-08-26-per-60-replay-action-tick-content-hash-plan.md
+++ b/docs/superpowers/plans/2026-08-26-per-60-replay-action-tick-content-hash-plan.md
@@ -1,0 +1,1166 @@
+<!-- vale off -->
+
+# PER-60 Replay, Action, and Tick Content Hash Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ratify and implement Babylon's versioned replay seed, ordered Practice action identity, stable world identity, and canonical `TickContentHashV1`, producing the database-free identity boundary needed by an honest future `CommittedTickEnvelope`.
+
+**Architecture:** Kernel owns replay primitives, seed-aware RNG V2, nominal digest types, and the fixed outer hash. Practice owns actor and ordered-action identity. Graph owns stable element, carrier, resolver, and stable-state identity. BSL owns semantic discriminants and the real typed RNG carrier path. Tick composes prepared mechanics, world registers, payload, and one shared detached transaction used by legacy and replay sessions. One schema and JSONL corpus bind all exact bytes to Rust and an independent Python verifier without making Python authoritative.
+
+**Tech Stack:** Rust 2021 workspace, `sha2`, `rand_chacha` 0.10 compatibility, BSL, `babylon-kernel`, `babylon-practice-contract`, `babylon-graph`, `babylon-bsl`, `babylon-tick`, `babylon-persistence`, Python 3.12, Pytest, YAML, JSONL, Cargo, Clippy, Vale
+
+**Spec:** `docs/superpowers/specs/2026-08-26-per-60-replay-action-tick-content-hash-design.md`
+
+## File Map
+
+### Kernel identity and RNG
+
+- Create `rust/crates/babylon-kernel/src/replay.rs`: `ReplaySessionIdV1`, `ReplaySeed`, `RngLayoutVersion`, `RngDomainV2`, checked codec helpers, and typed `RngSeedContext`.
+- Modify `rust/crates/babylon-kernel/src/rng.rs`: preserve V1 exactly and add the low-level V2 seed and stream entry points.
+- Create `rust/crates/babylon-kernel/src/tick_content_hash.rs`: digest newtypes, exact ten-section composer, and checked canonical preimage.
+- Modify `rust/crates/babylon-kernel/src/lib.rs`: expose the new typed production surface.
+- Create `rust/crates/babylon-kernel/tests/replay_identity.rs`: replay-session, replay-seed, and layout boundary tests.
+- Create `rust/crates/babylon-kernel/tests/rng_v2.rs`: exact V1 preservation and cross-block V2 stream tests.
+- Create `rust/crates/babylon-kernel/tests/tick_content_hash.rs`: typed outer-composer tests and mutation coverage.
+- Modify `rust/crates/babylon-persistence/src/hashes.rs`: retain persistence-only hashes and compatibility-alias kernel-owned `RefDigestV1` as `RefDigest` and `TickContentHashV1` as `TickContentHash` rather than duplicating them.
+- Modify `rust/crates/babylon-persistence/src/lib.rs`: preserve the existing persistence names and methods while proving they are the kernel-owned nominal types.
+
+### Practice actor and action identity
+
+- Create `rust/crates/babylon-practice-contract/src/actor_v2.rs`: opaque eight-byte `ActorOrganizationIdV2`.
+- Modify `rust/crates/babylon-practice-contract/src/authority_v2.rs`: use the actor newtype without moving V2 bytes.
+- Modify `rust/crates/babylon-practice-contract/src/intent_v2.rs`: use the actor newtype in intent and proposal identity.
+- Modify `rust/crates/babylon-practice-contract/src/batch_v2.rs`: validate and order the actor newtype.
+- Modify `rust/crates/babylon-practice-contract/src/resource_v2.rs`: use the actor newtype for ownership and proposal rows.
+- Modify `rust/crates/babylon-practice-contract/src/strike_v2.rs`: use the actor newtype in organization relations.
+- Create `rust/crates/babylon-practice-contract/src/ordered_action_v1.rs`: private action and batch types, ActionId derivation, empty constructor, and trusted non-empty projector.
+- Modify `rust/crates/babylon-practice-contract/src/lib.rs`: expose the actor and ordered-action modules.
+- Modify `rust/crates/babylon-practice-contract/tests/authority_v2.rs`, `authority_v2_contract.rs`, `batch_v2.rs`, `intent_v2.rs`, `intent_v2_contract.rs`, `resource_v2.rs`, `strike_v2.rs`, and `strike_v2_contract.rs`: convert numeric fixture values through `ActorOrganizationIdV2::from_bytes(value.to_be_bytes())` while preserving expected bytes.
+- Create `rust/crates/babylon-practice-contract/tests/actor_v2.rs`: opacity, byte ordering, and frozen-wire regression tests.
+- Create `rust/crates/babylon-practice-contract/tests/ordered_action_v1.rs`: empty and structural non-empty projection tests.
+
+### Stable graph identity
+
+- Create `rust/crates/babylon-graph/src/stable_element.rs`: stable binary keys, ASCII carrier segments, sealed resolver, manifest, topology validation, and graph-owned carrier builder.
+- Create `rust/crates/babylon-graph/src/stable_state.rs`: exact eight-section stable graph encoder and digest.
+- Modify `rust/crates/babylon-graph/src/lib.rs`: expose stable identity modules.
+- Create `rust/crates/babylon-graph/tests/stable_identity.rs`: cross-substrate, allocation-order, topology-seal, bounds, and codec tests.
+
+### BSL semantics and real RNG path
+
+- Modify `rust/crates/babylon-bsl/src/scenario.rs`: retain scenario scope and both node and hyperedge authored-name maps.
+- Modify `rust/crates/babylon-bsl/src/types.rs`: expose checked snapshots for fields, enum types, and member declaration order.
+- Modify `rust/crates/babylon-bsl/src/fuel.rs`: expose intrinsic-cost rows under exact limits.
+- Modify `rust/crates/babylon-bsl/src/causal_contract.rs`: expose governed role, evidence, effect, and shape canonicalization.
+- Create `rust/crates/babylon-bsl/src/identity_codec.rs`: exact `ValueV1`, `BslTypeV1`, and governed discriminant encoders.
+- Create `rust/crates/babylon-bsl/src/identity_sections.rs`: prepared-environment section and tick-payload section snapshots.
+- Modify `rust/crates/babylon-bsl/src/intrinsic_host.rs`: carry typed V1/V2 RNG context and graph-validated carrier bytes.
+- Modify `rust/crates/babylon-bsl/src/evaluator.rs`: resolve subjects and active elements through the sealed graph resolver.
+- Modify `rust/crates/babylon-bsl/src/tick.rs`: thread one typed draw context into the real `rng-draw` intrinsic.
+- Modify `rust/crates/babylon-bsl/src/lib.rs`: expose the identity encoders and typed section values.
+- Create `rust/crates/babylon-bsl/tests/tick_identity_contract.rs`: exact discriminants, order semantics, refusal, and bound tests.
+- Modify `rust/crates/babylon-bsl/tests/r9_chapters.rs`: prove real V1/V2 RNG dispatch and V1 preservation.
+
+### Tick composition and replay seam
+
+- Modify `rust/crates/babylon-tick/src/phase_order.rs`: expose the already governed 34-slot/four-alias bytes and digest without changing them.
+- Create `rust/crates/babylon-tick/src/replay_identity.rs`: prepared environment, register manifest/set, stable world, and exact payload composition.
+- Create `rust/crates/babylon-tick/src/replay_session.rs`: `ReplayTickSession` and `IdentifiedTickReportV1`.
+- Modify `rust/crates/babylon-tick/src/session.rs`: route legacy `TickSession` through the shared typed transaction.
+- Modify `rust/crates/babylon-tick/src/lib.rs`: retain full preparation identity and host the single detached causal loop.
+- Modify `rust/crates/babylon-tick/Cargo.toml`: promote `babylon-practice-contract` to a production dependency for the typed action batch.
+- Create `rust/crates/babylon-tick/tests/replay_session.rs`: end-to-end identity, seed propagation, atomicity, and empty-action enforcement.
+- Create `rust/crates/babylon-tick/tests/tick_content_hash_v1_contract.rs`: shared corpus consumption and bounded test parser.
+
+### Shared contract and decision evidence
+
+- Create `contracts/tick_content_hash_v1.yaml`: one language-neutral schema for every PER-60 layout, discriminant, ceiling, and exclusion.
+- Create `contracts/tick_content_hash_v1_vectors.jsonl`: valid, refused, mutation, and end-to-end vectors.
+- Create `tools/verify_tick_content_hash_v1.py`: independent bounded Python verifier for the schema and vectors.
+- Create `tests/unit/tools/test_verify_tick_content_hash_v1.py`: verifier acceptance and mutation-refusal tests.
+- Create `ai/decisions/ADR240_replay_action_tick_content_identity.yaml`: accepted ownership, P27 disposition, Gate 3 boundary, and supersession record.
+- Modify `ai/decisions/index.yaml`: add ADR240 and advance the index version according to the existing sequence.
+- Create `tests/unit/decisions/test_adr240_replay_action_tick_content_identity.py`: bind the exact decision and index entry.
+- Modify `src/babylon/kernel/tick_hash.py`: correct the live module wording so P27 remains a compatibility oracle outside authoritative Rust `TickContentHashV1`.
+- Modify `docs/reference/determinism-contract.rst`: record accepted V1 layouts, vectors, and resolved P27 disposition.
+- Modify `docs/concepts/architecture.rst`: distinguish replay-session physics identity from separate campaign durability identity.
+
+## Global Constraints
+
+- Every change serves the playable game slice by making one detached player-decision tick replayable and auditable. Do not add infrastructure without a direct identity-boundary consumer in this plan.
+- Keep the existing P27 Python bytes, digests, fixtures, and tests unchanged. P27 remains an executable compatibility oracle outside authoritative `TickContentHashV1`.
+- Keep RNG V1's unversioned preimage, validation behavior, four-draw vector, and `TickSession` results byte-identical.
+- Do not edit accepted Practice V2 YAML, pinned source SHA constants, canonical field descriptions, existing JSONL bytes, or manifests. Their `actor_org_id_u64` and `type: u64` descriptions remain frozen.
+- `ActorOrganizationIdV2` is an opaque `[u8; 8]`; add no numeric, graph-handle, arithmetic, `From<u64>`, or `TryFrom<u64>` API.
+- `StableCarrierKeyV2` belongs to `babylon-graph`. Kernel accepts validated bytes only because the existing dependency DAG forbids a graph type in kernel.
+- Production code is typed encoder/composer-only. Add no production raw decoder for replay, action batch, graph identity, prepared environment, world, payload, or outer hash.
+- The live Gate 3 replay path accepts only the exact empty action batch. A non-empty projection exists only for structural codec tests and confers no admission provenance.
+- Do not add PostgreSQL schema, migration, hydration, writer, Archive outbox, `CommittedTickEnvelope`, cutover, player action execution, BSL practice effects, dynamic topology, or Bevy integration.
+- Keep legacy `GraphStateHash` and `NominalWorldHash` unchanged and outside `TickContentHashV1`.
+- Use fixed-width big-endian integers for every new PER-60 canonical field, raw SHA-256 bytes, exact validated string bytes, checked arithmetic, fallible reservations, bounded iteration, and explicit typed errors. The explicitly governed ChaCha8 state words, block words, and V1 compatibility preimage retain their specified little-endian layouts.
+- Preserve semantic order where the design says order matters: rule execution, enum member declaration, event arrival, event payload source pairs including duplicates, and receipt publication. Sort only the declared canonical map/set lanes.
+- Show RED before each behavioral implementation, make the smallest GREEN change, refactor only after GREEN, and run the smallest applicable test after every edit.
+- Do not overlap heavy gates. Use `BLAS=1` for repository gates. Do not run Sphinx, `cargo doc`, `mise run ci:rust`, `mise run rust:check`, or another documentation-generating task.
+- Never stage `.codex/` or unrelated user changes. Commit each task with `SKIP=rust-full-gate mise run commit -- "..."` only after its scoped tests, format, and Clippy checks pass.
+
+---
+
+### Task 1: Kernel replay identity and exact RNG V2
+
+**Files:**
+
+- Create: `rust/crates/babylon-kernel/src/replay.rs`
+- Modify: `rust/crates/babylon-kernel/src/rng.rs`
+- Modify: `rust/crates/babylon-kernel/src/lib.rs`
+- Create: `rust/crates/babylon-kernel/tests/replay_identity.rs`
+- Create: `rust/crates/babylon-kernel/tests/rng_v2.rs`
+
+**Interfaces:**
+
+```rust
+pub struct ReplaySessionIdV1(Vec<u8>);
+pub struct ReplaySeed(i64);
+pub enum RngLayoutVersion { V1, V2 }
+pub struct RngDomainV2(String);
+pub enum RngSeedContext<'a> {
+    V1 { session: &'a SessionId },
+    V2 { session: &'a ReplaySessionIdV1, seed: ReplaySeed },
+}
+
+impl TryFrom<u32> for RngLayoutVersion {
+    type Error = ReplayIdentityError;
+}
+
+pub fn seed_for_v2(
+    session: &ReplaySessionIdV1,
+    seed: ReplaySeed,
+    tick: u64,
+    domain: &RngDomainV2,
+    validated_carrier_key: &[u8],
+) -> Result<[u8; 32], ReplayIdentityError>;
+```
+
+- [ ] **Step 1: Write replay primitive and layout boundary tests**
+
+  Add tests for 1-byte and 256-byte graphic ASCII sessions, canonical `u16` length framing, space/control/DEL/non-ASCII/empty/257-byte refusal, and exact `i64::{MIN,-1,0,1,MAX}` seed bytes. Assert `RngLayoutVersion::try_from` maps `1` and `2` exactly and returns the typed version error for `0`, `3`, and `u32::MAX`. Add compile-time API assertions that construct sessions only from checked bytes/strings and seeds only from `i64`.
+
+- [ ] **Step 2: Run the primitive test and verify RED**
+
+  ```bash
+  cd rust
+  cargo test -p babylon-kernel --test replay_identity --locked
+  ```
+
+  Expected: compile failure because the replay types and module do not exist.
+
+- [ ] **Step 3: Implement checked replay primitives**
+
+  Implement private fields, exact layout constants, borrowed byte accessors, canonical encoders, and a specific `ReplayIdentityError` for semantic string, version, length, conversion, and allocation failures. Do not add any campaign/persistence conversion or a Unicode normalization dependency.
+
+- [ ] **Step 4: Run the primitive test and verify GREEN**
+
+  ```bash
+  cd rust
+  cargo test -p babylon-kernel --test replay_identity --locked
+  ```
+
+- [ ] **Step 5: Write exact RNG V2 and V1-regression tests**
+
+  Pin the asymmetric V2 preimage and SHA-256 key, first nine `u64` draws, and fresh-stream first `f64::to_bits()`. Add one mutation assertion for seed, session, tick, domain, and carrier bytes. Copy the current V1 four-draw expected values into a regression test without changing them.
+
+- [ ] **Step 6: Run the RNG test and verify RED**
+
+  ```bash
+  cd rust
+  cargo test -p babylon-kernel --test rng_v2 --locked
+  ```
+
+  Expected: compile failure because `seed_for_v2` and the V2 carrier constructor do not exist.
+
+- [ ] **Step 7: Implement the exact V2 derivation and stream**
+
+  Keep `seed_for`, `KernelRng::for_carrier`, and V1 validation untouched. Add the exact `babylon.rng-stream\0` big-endian preimage and `KernelRng::for_carrier_v2`. Use `rand_chacha` only behind tests that prove the design's language-neutral ChaCha8 state words, four double rounds, counter placement, little-endian block words, `next_u64`, and `next_f64` results. Offer no stream id, seek, or tick-global API.
+
+- [ ] **Step 8: Refactor dispatch through one parsed layout**
+
+  Add the typed `RngSeedContext` dispatch in kernel so BSL and tick do not branch on numeric version values. Keep the low-level V2 byte API documented as tests/adapters only; the graph-owned caller provides provenance later.
+
+- [ ] **Step 9: Run the kernel gate and verify GREEN**
+
+  ```bash
+  cd rust
+  cargo fmt --all -- --check
+  cargo test -p babylon-kernel --locked
+  cargo clippy -p babylon-kernel --all-targets --locked -- -D warnings
+  ```
+
+- [ ] **Step 10: Commit kernel replay and RNG identity**
+
+  ```bash
+  git add rust/crates/babylon-kernel
+  SKIP=rust-full-gate mise run commit -- "feat(kernel): add replay identity and RNG V2"
+  ```
+
+---
+
+### Task 2: Kernel-owned digest types and fixed outer TickContentHash
+
+**Files:**
+
+- Create: `rust/crates/babylon-kernel/src/tick_content_hash.rs`
+- Modify: `rust/crates/babylon-kernel/src/lib.rs`
+- Create: `rust/crates/babylon-kernel/tests/tick_content_hash.rs`
+- Modify: `rust/crates/babylon-persistence/src/hashes.rs`
+- Modify: `rust/crates/babylon-persistence/src/lib.rs`
+- Modify: `rust/crates/babylon-persistence/Cargo.toml` only if a direct kernel dependency is absent at execution time
+
+**Interfaces:**
+
+```rust
+pub struct RefDigestV1([u8; 32]);
+pub struct PreparedEnvironmentDigestV1([u8; 32]);
+pub struct StableWorldDigestV1([u8; 32]);
+pub struct OrderedPracticeActionBatchDigestV1([u8; 32]);
+pub struct TickPayloadDigestV1([u8; 32]);
+pub struct TickContentHashV1([u8; 32]);
+pub struct TickContentPreimageV1(Vec<u8>);
+
+pub struct TickContentPartsV1<'a> {
+    pub session: &'a ReplaySessionIdV1,
+    pub resolve_tick: u64,
+    pub seed: ReplaySeed,
+    pub content: &'a ContentDigest,
+    pub reference: RefDigestV1,
+    pub prepared: PreparedEnvironmentDigestV1,
+    pub prior_world: StableWorldDigestV1,
+    pub actions: OrderedPracticeActionBatchDigestV1,
+    pub result_world: StableWorldDigestV1,
+    pub payload: TickPayloadDigestV1,
+}
+```
+
+- [ ] **Step 1: Write the exact outer-composer test**
+
+  Build asymmetric typed parts and assert the complete preimage is `349 + session.len()` bytes, begins with `babylon.tick-content\0`, carries layout 1, and contains tags `0x01` through `0x0a` exactly once in order. Assert the SHA-256 digest and one mutation per field and nested layout version.
+
+- [ ] **Step 2: Run the outer test and verify RED**
+
+  ```bash
+  cd rust
+  cargo test -p babylon-kernel --test tick_content_hash --locked
+  ```
+
+  Expected: compile failure because the nominal digest types and composer do not exist.
+
+- [ ] **Step 3: Implement private digest wrappers and composer**
+
+  Give every digest a private `[u8; 32]`, exact byte constructor/accessor, and no default. These constructors wrap an already-computed SHA-256 value for nominal typing and contract/persistence adapters; they do not decode a canonical identity object, prove provenance, or let `ReplayTickSession` accept caller-supplied prepared/world/payload digests. The authoritative replay session derives every such digest from its owning typed encoder, and only the outer composer creates its published `TickContentHashV1`. Implement the ten mandatory sections with checked capacity and `try_reserve_exact`; accept no optional/extension field. Keep campaign, database, P27, legacy graph/world hashes, allocator cursors, and wall time out.
+
+- [ ] **Step 4: Make persistence reuse kernel authority**
+
+  Remove only persistence's duplicate `TickContentHash` and `RefDigest` macro invocations. Preserve the public API exactly with `pub use babylon_kernel::{RefDigestV1 as RefDigest, TickContentHashV1 as TickContentHash}` and the existing `from_bytes`, `as_bytes`, and `to_hex` methods. Add `TypeId` assertions that the persistence names are the kernel types. Add no calculation logic and change no persistence schema or H3 reference-cohort meaning.
+
+- [ ] **Step 5: Run kernel and persistence gates**
+
+  ```bash
+  cd rust
+  cargo fmt --all -- --check
+  cargo test -p babylon-kernel -p babylon-persistence --locked
+  cargo clippy -p babylon-kernel -p babylon-persistence --all-targets --locked -- -D warnings
+  ```
+
+- [ ] **Step 6: Commit the digest boundary**
+
+  ```bash
+  git add rust/crates/babylon-kernel rust/crates/babylon-persistence
+  SKIP=rust-full-gate mise run commit -- "feat(kernel): own canonical tick content hash"
+  ```
+
+---
+
+### Task 3: Opaque Practice V2 actor identity with frozen bytes
+
+**Files:**
+
+- Create: `rust/crates/babylon-practice-contract/src/actor_v2.rs`
+- Modify: `rust/crates/babylon-practice-contract/src/authority_v2.rs`
+- Modify: `rust/crates/babylon-practice-contract/src/batch_v2.rs`
+- Modify: `rust/crates/babylon-practice-contract/src/intent_v2.rs`
+- Modify: `rust/crates/babylon-practice-contract/src/resource_v2.rs`
+- Modify: `rust/crates/babylon-practice-contract/src/strike_v2.rs`
+- Modify: `rust/crates/babylon-practice-contract/src/lib.rs`
+- Modify: `rust/crates/babylon-practice-contract/tests/authority_v2.rs`
+- Modify: `rust/crates/babylon-practice-contract/tests/authority_v2_contract.rs`
+- Modify: `rust/crates/babylon-practice-contract/tests/batch_v2.rs`
+- Modify: `rust/crates/babylon-practice-contract/tests/intent_v2.rs`
+- Modify: `rust/crates/babylon-practice-contract/tests/intent_v2_contract.rs`
+- Modify: `rust/crates/babylon-practice-contract/tests/resource_v2.rs`
+- Modify: `rust/crates/babylon-practice-contract/tests/strike_v2.rs`
+- Modify: `rust/crates/babylon-practice-contract/tests/strike_v2_contract.rs`
+- Create: `rust/crates/babylon-practice-contract/tests/actor_v2.rs`
+
+**Interface:**
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ActorOrganizationIdV2([u8; 8]);
+
+impl ActorOrganizationIdV2 {
+    pub const fn from_bytes(bytes: [u8; 8]) -> Self;
+    pub const fn to_bytes(self) -> [u8; 8];
+}
+```
+
+- [ ] **Step 1: Record frozen Practice V2 checksums and write actor tests**
+
+  Capture `sha256sum` for every accepted Practice V2 YAML and JSONL file in the task log. Add tests that the newtype orders by unsigned bytes, round-trips `[u8; 8]`, has no numeric accessor in production usage, and preserves the exact existing intent, authority, batch, resource, and strike vector bytes.
+
+- [ ] **Step 2: Run the actor test and verify RED**
+
+  ```bash
+  cd rust
+  cargo test -p babylon-practice-contract --test actor_v2 --locked
+  ```
+
+  Expected: compile failure because `ActorOrganizationIdV2` does not exist.
+
+- [ ] **Step 3: Add the actor type and migrate every V2 lane**
+
+  Replace V2 actor `u64` fields in authority lookup, `PracticeIntentV2`, `PracticeProposalKeyV2`, resolved batches, resource ownership, and strike relations. Decode eight bytes with `ActorOrganizationIdV2::from_bytes`; encode with `to_bytes`. Numeric JSON adapters may call `value.to_be_bytes()` only while constructing test values. Leave all V1 fields and the V1-only `admission.rs`, `codec.rs`, `tests/admission.rs`, `tests/codec_vectors.rs`, and `tests/schema_contract.rs` unchanged.
+
+- [ ] **Step 4: Search for incomplete actor migration**
+
+  ```bash
+  rg -n "actor_org_id:\s*u64|ActorOrganizationIdV2.*NodeId|From<u64>|TryFrom<u64>" rust/crates/babylon-practice-contract
+  ```
+
+  Expected: no V2 production actor remains `u64`, and no forbidden conversion exists. Any V1/schema-description hit must be named and intentionally preserved.
+
+- [ ] **Step 5: Prove all frozen bytes remain identical**
+
+  Run the whole crate and compare the previously captured checksums:
+
+  ```bash
+  cd rust
+  cargo fmt --all -- --check
+  cargo test -p babylon-practice-contract --locked
+  cargo clippy -p babylon-practice-contract --all-targets --locked -- -D warnings
+  cd ..
+  sha256sum contracts/practice_*_v2.yaml contracts/practice_*_v2_vectors.jsonl contracts/resolved_practice_batch_v2.yaml contracts/resolved_practice_batch_v2_vectors.jsonl
+  ```
+
+  Expected: tests pass and every contract checksum equals the recorded pre-change value.
+
+- [ ] **Step 6: Commit the actor refinement**
+
+  ```bash
+  git add rust/crates/babylon-practice-contract
+  SKIP=rust-full-gate mise run commit -- "refactor(practice): make V2 actor identity opaque"
+  ```
+
+---
+
+### Task 4: Ordered Practice action identity and empty runtime batch
+
+**Files:**
+
+- Create: `rust/crates/babylon-practice-contract/src/ordered_action_v1.rs`
+- Modify: `rust/crates/babylon-practice-contract/src/lib.rs`
+- Create: `rust/crates/babylon-practice-contract/tests/ordered_action_v1.rs`
+
+**Interfaces:**
+
+```rust
+pub struct PracticeActionIdV1([u8; 32]);
+pub struct OrderedPracticeActionV1 {
+    canonical_input_ordinal: u16,
+    action_id: PracticeActionIdV1,
+    intent: PracticeIntentV2,
+}
+pub struct OrderedPracticeActionBatchV1 {
+    session: ReplaySessionIdV1,
+    resolve_tick: u64,
+    items: Vec<OrderedPracticeActionV1>,
+    canonical_bytes: Vec<u8>,
+    digest: OrderedPracticeActionBatchDigestV1,
+}
+
+impl OrderedPracticeActionBatchV1 {
+    pub fn empty(
+        session: ReplaySessionIdV1,
+        resolve_tick: u64,
+    ) -> Result<Self, OrderedPracticeActionError>;
+    pub fn project(
+        session: ReplaySessionIdV1,
+        source: &ResolvedPracticeBatchV2,
+        trusted_ledger: &PracticeInputAuthorityLedgerV2,
+    ) -> Result<Self, OrderedPracticeActionError>;
+    pub fn session(&self) -> &ReplaySessionIdV1;
+    pub const fn resolve_tick(&self) -> u64;
+    pub fn items(&self) -> &[OrderedPracticeActionV1];
+    pub fn is_empty(&self) -> bool;
+}
+```
+
+- [ ] **Step 1: Write empty-batch and ActionId tests**
+
+  Assert exact `babylon.practice-action-id.v1\0` bytes and a 69-to-324-byte preimage. Assert exact empty batch bytes are `55 + session.len()`, the item count is zero, and session/tick are bound. Assert ordinal is absent from ActionId and changing an unrelated lower-sorting proposal changes later ordinals without moving the original ActionId.
+
+- [ ] **Step 2: Write trusted projector refusal tests**
+
+  Build a validated asymmetric `ResolvedPracticeBatchV2` plus `PracticeInputAuthorityLedgerV2`. Assert projection validates the source batch first, assigns contiguous `canonical_input_ordinal` values 0 through N-1, recomputes every ActionId, and refuses a ledger mismatch, unordered/duplicate proposal keys, mismatched tick, oversized intent, or more than 4,096 items. Add a compile-fail or visibility test proving callers cannot construct private actions from raw bytes, caller ordinals, or caller hashes.
+
+- [ ] **Step 3: Run the action tests and verify RED**
+
+  ```bash
+  cd rust
+  cargo test -p babylon-practice-contract --test ordered_action_v1 --locked
+  ```
+
+  Expected: compile failure because the private ordered-action types do not exist.
+
+- [ ] **Step 4: Implement the exact action and batch codecs**
+
+  Implement the fixed domains, schema versions, `u16` intent length, checked action bounds, private fields, borrowed accessors, public exact-empty constructor, and public deliberately constrained non-empty structural projector shown above. Call the existing full `ResolvedPracticeBatchV2` validation before projection. The projector is the only cross-crate way to construct a non-empty typed batch for the runtime guard test; it takes the complete batch and trusted ledger, and it still does not prove accepted-input provenance. Do not add a production decoder.
+
+- [ ] **Step 5: Run the Practice gate and verify GREEN**
+
+  ```bash
+  cd rust
+  cargo fmt --all -- --check
+  cargo test -p babylon-practice-contract --locked
+  cargo clippy -p babylon-practice-contract --all-targets --locked -- -D warnings
+  ```
+
+- [ ] **Step 6: Commit ordered action identity**
+
+  ```bash
+  git add rust/crates/babylon-practice-contract
+  SKIP=rust-full-gate mise run commit -- "feat(practice): add ordered action identity"
+  ```
+
+---
+
+### Task 5: Stable graph element resolver and carrier identity
+
+**Files:**
+
+- Create: `rust/crates/babylon-graph/src/stable_element.rs`
+- Modify: `rust/crates/babylon-graph/src/lib.rs`
+- Create: `rust/crates/babylon-graph/tests/stable_identity.rs`
+
+**Interfaces:**
+
+```rust
+pub enum StableElementKeyV1 {
+    Node { scenario: String, local_name: String },
+    Edge {
+        scenario: String,
+        edge_type: String,
+        source_local_name: String,
+        target_local_name: String,
+    },
+    Hyperedge { scenario: String, local_name: String },
+}
+pub struct StableElementCarrierSegmentV1(String);
+pub struct StableCarrierKeyV2(String);
+pub struct StableElementResolverManifestV1 { canonical_bytes: Vec<u8>, digest: [u8; 32] }
+pub struct StableElementResolverV1 {
+    scenario_scope: String,
+    node_by_handle: HashMap<NodeId, StableElementKeyV1>,
+    node_by_name: BTreeMap<String, NodeId>,
+    hyperedge_by_handle: HashMap<HyperedgeId, StableElementKeyV1>,
+    hyperedge_by_name: BTreeMap<String, HyperedgeId>,
+    sealed_topology: SealedTopologyV1,
+    manifest: StableElementResolverManifestV1,
+}
+
+impl StableElementResolverV1 {
+    pub fn seal<G: GraphSubstrate + CanonicalState>(
+        graph: &G,
+        scenario_scope: &str,
+        node_names: &HashMap<NodeId, String>,
+        hyperedge_names: &HashMap<HyperedgeId, String>,
+    ) -> Result<Self, StableIdentityError>;
+    pub fn node_key(&self, node: NodeId) -> Result<&StableElementKeyV1, StableIdentityError>;
+    pub fn hyperedge_key(
+        &self,
+        hyperedge: HyperedgeId,
+    ) -> Result<&StableElementKeyV1, StableIdentityError>;
+    pub fn edge_key(
+        &self,
+        edge_type: &str,
+        source: NodeId,
+        target: NodeId,
+    ) -> Result<StableElementKeyV1, StableIdentityError>;
+    pub fn carrier_key(
+        &self,
+        subject: &StableElementKeyV1,
+        active: &[StableElementKeyV1],
+        draw_slot: i64,
+    ) -> Result<StableCarrierKeyV2, StableIdentityError>;
+}
+```
+
+- [ ] **Step 1: Write exact stable-key and carrier tests**
+
+  Assert standalone binary node, directed edge, and hyperedge keys; their distinct ASCII carrier segments; zero-active and mixed node/edge/hyperedge carrier framing; outermost-to-innermost active order; canonical signed decimal draw slots; 256-element and 131,072-byte maxima; and maximum-plus-one refusal before allocation.
+
+- [ ] **Step 2: Write resolver and manifest tests**
+
+  Assert exact mandatory scenario/node/hyperedge sections, canonical sorting, 65,536 combined-row and 16 MiB ceilings, handle↔name bijections, parallel authored hyperedges, and refusal for missing, duplicate, dangling, non-ASCII, added, removed, or membership-mutated topology. Assert no Debug/raw-id fallback.
+
+- [ ] **Step 3: Run graph stable identity test and verify RED**
+
+  ```bash
+  cd rust
+  cargo test -p babylon-graph --test stable_identity --locked
+  ```
+
+  Expected: compile failure because the stable identity module does not exist.
+
+- [ ] **Step 4: Implement graph-owned codecs and sealed resolver**
+
+  Encode exact binary fields and ASCII framed segments once in graph. Store forward and inverse node/hyperedge mappings plus the sealed topology witness. Expose checked `node_key`, `hyperedge_key`, and `edge_key(edge_type, source, target)` resolution over graph-native ids so BSL never reimplements or forges stable keys. Validate edges through named endpoints. Keep node/hyperedge types out of element identity but inside the resolver manifest; keep edge type and ordered endpoints in edge identity.
+
+- [ ] **Step 5: Implement the private carrier builder**
+
+  Accept resolved stable elements only. Reframe each already-framed element segment as one opaque outer segment, append canonical slot text, use checked aggregate arithmetic, and expose only `validated_bytes()` from the private `StableCarrierKeyV2` field.
+
+- [ ] **Step 6: Run scoped graph checks**
+
+  ```bash
+  cd rust
+  cargo fmt --all -- --check
+  cargo test -p babylon-graph --test stable_identity --locked
+  cargo clippy -p babylon-graph --all-targets --locked -- -D warnings
+  ```
+
+- [ ] **Step 7: Commit stable element identity**
+
+  ```bash
+  git add rust/crates/babylon-graph
+  SKIP=rust-full-gate mise run commit -- "feat(graph): add stable element resolver"
+  ```
+
+---
+
+### Task 6: Stable graph-state bytes across substrates and handle allocation
+
+**Files:**
+
+- Create: `rust/crates/babylon-graph/src/stable_state.rs`
+- Modify: `rust/crates/babylon-graph/src/lib.rs`
+- Modify: `rust/crates/babylon-graph/tests/stable_identity.rs`
+
+**Interface:**
+
+```rust
+pub struct StableGraphStateV1 { canonical_bytes: Vec<u8>, digest: StableGraphStateHashV1 }
+
+pub fn encode_stable_graph_state_v1<G: CanonicalState>(
+    graph: &G,
+    resolver: &StableElementResolverV1,
+) -> Result<StableGraphStateV1, StableIdentityError>;
+```
+
+- [ ] **Step 1: Write exact eight-section state tests**
+
+  Build one asymmetric graph containing nodes, node real and currency fields, a directed edge with strength and another field, a named hyperedge with unsorted members, and a hyperedge field. Assert all tags `0x01` through `0x08` occur once in order, empty sections still emit counts, declared sorting is exact, negative zero becomes positive zero, and finite bits and signed `i128` micro-units are exact.
+
+- [ ] **Step 2: Write cross-substrate and handle-allocation tests**
+
+  Build semantically equal `MemoryGraph` and `HypergraphStore` values in different insertion orders and with genuinely different `NodeId` and `HyperedgeId` allocation histories. Assert stable bytes/digests equal while at least one legacy `GraphStateHash` differs. Assert unordered map, registry, and hyperedge-member insertion cannot move stable output.
+
+- [ ] **Step 3: Write refusal and bound tests**
+
+  Cover unknown owners, absent edges, empty hyperedges, unknown/duplicate members, duplicate fact keys, numeric/currency cross-lane collision, `/strength` duplication, NaN/infinity, per-section maxima, aggregate 1,048,576 fact units, and 64 MiB bytes. Every maximum-plus-one case must refuse before partial bytes escape.
+
+- [ ] **Step 4: Run the stable state test and verify RED**
+
+  ```bash
+  cd rust
+  cargo test -p babylon-graph --test stable_identity --locked
+  ```
+
+  Expected: compile failure because `StableGraphStateV1` and its encoder do not exist.
+
+- [ ] **Step 5: Implement stable-state encoding over the seven live listings**
+
+  Reuse `CanonicalState` listings rather than widening the substrate. Resolve every runtime handle through the sealed resolver, validate topology again at encoding, sort only the specified identity tuples, reject equal keys, and drop no empty section. Keep legacy graph hashing untouched.
+
+- [ ] **Step 6: Run graph gate and verify GREEN**
+
+  ```bash
+  cd rust
+  cargo fmt --all -- --check
+  cargo test -p babylon-graph --locked
+  cargo clippy -p babylon-graph --all-targets --locked -- -D warnings
+  ```
+
+- [ ] **Step 7: Commit stable graph state**
+
+  ```bash
+  git add rust/crates/babylon-graph
+  SKIP=rust-full-gate mise run commit -- "feat(graph): encode stable graph state"
+  ```
+
+---
+
+### Task 7: BSL identity discriminants and prepared/payload sections
+
+**Files:**
+
+- Create: `rust/crates/babylon-bsl/src/identity_codec.rs`
+- Create: `rust/crates/babylon-bsl/src/identity_sections.rs`
+- Modify: `rust/crates/babylon-bsl/src/{causal_contract,fuel,scenario,types,lib}.rs`
+- Create: `rust/crates/babylon-bsl/tests/tick_identity_contract.rs`
+- Modify: `rust/crates/babylon-tick/src/lib.rs` only to retain scenario scope and hyperedge authored-name maps in `PreparedRules`
+
+**Interfaces:**
+
+```rust
+pub struct PreparedBslSectionsV1 {
+    fields_and_exemptions: Vec<u8>,
+    intrinsic_costs: Vec<u8>,
+    constants: Vec<u8>,
+    enum_types: Vec<u8>,
+    vocabulary: Vec<u8>,
+    aggregate_rows: u32,
+}
+pub struct TickPayloadSectionsV1 {
+    rule_outcomes: Vec<u8>,
+    events: Vec<u8>,
+    receipts: Vec<u8>,
+    aggregate_rows: u32,
+}
+
+pub fn encode_value_v1(
+    value: &Value,
+    resolver: &StableElementResolverV1,
+    output: &mut Vec<u8>,
+) -> Result<(), IdentityCodecError>;
+```
+
+- [ ] **Step 1: Write one test for every governed discriminant**
+
+  Pin `ValueV1` tags `0x01..0x09`; `BslTypeV1` `0x01..0x0a`; field, role, evidence, effect, shape, and enum-kind tags; exact option/Boolean bytes; `ConstValueV1` restriction to value tags `0x01..0x05`; enum type-name resolution; and stable node/edge/hyperedge references through graph.
+
+- [ ] **Step 2: Write ordering and presence tests**
+
+  Assert resolved rule execution order, field and exemption sorting, intrinsic-cost sorting, constant sorting, enum-type sorting with member declaration order preserved, and closed-vocabulary outer/per-kind presence. Prove absent vocabulary differs from present-empty and that event arrival, duplicate payload labels in live source order, and receipt vector order remain semantic.
+
+- [ ] **Step 3: Run BSL identity tests and verify RED**
+
+  ```bash
+  cd rust
+  cargo test -p babylon-bsl --test tick_identity_contract --locked
+  ```
+
+  Expected: compile failure because identity codecs and section snapshots do not exist.
+
+- [ ] **Step 4: Retain stable scenario identity at preparation**
+
+  Extend `LoadedScenario`/`PreparedRules` with the validated scenario scope, node handle↔authored local-name map, and hyperedge handle↔authored local-name map already created during hydration. Do not infer names from runtime ids, types, members, or Debug. Preserve existing preparation behavior and all load refusals.
+
+- [ ] **Step 5: Implement one governed BSL tag table**
+
+  Put exact discriminants and canonical f64 logic in `identity_codec.rs`. Add checked helpers for `str32`, counts, options, and total bytes. Reuse graph's stable keys for reference values and one event-name canonicalizer for effects and payload events. Reject unknown enum ids, reference kinds, noncanonical values, non-finite floats, and semantic string violations.
+
+- [ ] **Step 6: Implement bounded section snapshots**
+
+  Expose read-only snapshots from live registries rather than duplicating registries in tick. Include the `TypeEnv` exemption ledger explicitly and distinguish no vocabulary from present-empty kinds. Apply the 65,536/64/1,048,576 row limits and 64 MiB ceiling before reserve.
+
+- [ ] **Step 7: Run BSL and tick preparation tests**
+
+  ```bash
+  cd rust
+  cargo fmt --all -- --check
+  cargo test -p babylon-bsl --locked
+  cargo test -p babylon-tick --lib --locked
+  cargo clippy -p babylon-bsl -p babylon-tick --all-targets --locked -- -D warnings
+  ```
+
+- [ ] **Step 8: Commit semantic identity sections**
+
+  ```bash
+  git add rust/crates/babylon-bsl rust/crates/babylon-tick/src/lib.rs
+  SKIP=rust-full-gate mise run commit -- "feat(bsl): encode replay identity sections"
+  ```
+
+---
+
+### Task 8: Thread seed-aware RNG V2 through the real BSL intrinsic
+
+**Files:**
+
+- Modify: `rust/crates/babylon-bsl/src/intrinsic_host.rs`
+- Modify: `rust/crates/babylon-bsl/src/evaluator.rs`
+- Modify: `rust/crates/babylon-bsl/src/tick.rs`
+- Modify: `rust/crates/babylon-bsl/tests/r9_chapters.rs`
+- Modify: `rust/crates/babylon-bsl/tests/tick_identity_contract.rs`
+- Modify: `rust/crates/babylon-tick/src/lib.rs`
+
+**Interface change:**
+
+```rust
+pub enum DrawIdentityContext<'a> {
+    V1 {
+        session: &'a SessionId,
+        domain: &'a str,
+        legacy_subject: &'a str,
+    },
+    V2 {
+        session: &'a ReplaySessionIdV1,
+        seed: ReplaySeed,
+        domain: RngDomainV2,
+        resolver: &'a StableElementResolverV1,
+        subject: StableElementKeyV1,
+    },
+}
+pub struct DrawContext<'a> {
+    pub identity: DrawIdentityContext<'a>,
+    pub tick: u64,
+}
+```
+
+  V1 retains its current unvalidated domain and legacy subject/carrier adapters exactly. The authoritative V2 branch must receive validated `RngDomainV2` and resolver-produced graph types and may not enter the old content-id/Debug fallback.
+
+- [ ] **Step 1: Write real-intrinsic mutation tests**
+
+  Execute one loaded rule containing `rng-draw`. Hold mechanics fixed and mutate V2 seed, session, tick, firing rule qname, subject node, nested active node, edge, hyperedge, and draw slot. Assert exact written `f64::to_bits()` changes for every mutation. Assert the stable active-element order is outermost first.
+
+- [ ] **Step 2: Write legacy V1 preservation and missing-provenance tests**
+
+  Assert the current V1 rule and four-draw results remain exact. Assert V2 refuses a missing resolver, unresolvable subject/element, dynamic topology, invalid domain, and caller-supplied raw stable-key bytes.
+
+- [ ] **Step 3: Run intrinsic tests and verify RED**
+
+  ```bash
+  cd rust
+  cargo test -p babylon-bsl --test r9_chapters --test tick_identity_contract --locked
+  ```
+
+  Expected: V2 tests fail because `DrawContext` still carries only legacy session/content-id data.
+
+- [ ] **Step 4: Replace the split helper path with typed dispatch**
+
+  Thread `RngSeedContext` through `run_tick_observed`, evaluator call context, `KernelIntrinsicHost`, and tick's shared `run_prepared_tick_with` seam. For V2, resolve subject plus active elements through `StableElementResolverV1`, call graph's `carrier_key`, and pass only `validated_bytes()` to kernel. For V1, call the unchanged `KernelRng::for_carrier` route with no V2 validation. Delete no legacy tests or V1 API. Task 8 prepares the live internal seam; Task 10 creates `ReplayTickSession` as its authoritative V2 caller.
+
+- [ ] **Step 5: Prove the production call graph contains the seed**
+
+  Use the end-to-end test plus a focused search:
+
+  ```bash
+  rg -n "RngSeedContext|ReplaySeed|carrier_key|seed_for_v2" rust/crates/babylon-{kernel,graph,bsl,tick}/src
+  ```
+
+  Expected after Task 8: `run_prepared_tick_with -> run_tick_observed -> DrawContext -> KernelIntrinsicHost -> graph carrier bytes -> kernel V2` is one real executable seam, while all existing callers still select V1. Task 10 must extend the proof to `ReplayTickSession -> run_prepared_tick_with`; no separate test-only hashing helper may substitute for execution.
+
+- [ ] **Step 6: Run BSL gate and verify GREEN**
+
+  ```bash
+  cd rust
+  cargo fmt --all -- --check
+  cargo test -p babylon-bsl --locked
+  cargo test -p babylon-tick --lib --locked
+  cargo clippy -p babylon-bsl -p babylon-tick --all-targets --locked -- -D warnings
+  ```
+
+- [ ] **Step 7: Commit real RNG V2 plumbing**
+
+  ```bash
+  git add rust/crates/babylon-bsl rust/crates/babylon-tick/src/lib.rs
+  SKIP=rust-full-gate mise run commit -- "feat(bsl): thread replay seed through rng draw"
+  ```
+
+---
+
+### Task 9: Prepared environment, registers, stable world, and exact payload
+
+**Files:**
+
+- Create: `rust/crates/babylon-tick/src/replay_identity.rs`
+- Modify: `rust/crates/babylon-tick/src/phase_order.rs`
+- Modify: `rust/crates/babylon-tick/src/lib.rs`
+- Create: `rust/crates/babylon-tick/tests/replay_session.rs`
+
+**Interfaces:**
+
+```rust
+pub struct PreparedEnvironmentV1 { canonical_bytes: Vec<u8>, digest: PreparedEnvironmentDigestV1 }
+pub struct WorldRegisterManifestV1 { canonical_bytes: Vec<u8>, digest: [u8; 32] }
+pub struct WorldRegisterSetV1 { canonical_bytes: Vec<u8>, digest: [u8; 32] }
+pub struct StableWorldV1 { canonical_bytes: Vec<u8>, digest: StableWorldDigestV1 }
+pub struct TickPayloadV1 { canonical_bytes: Vec<u8>, digest: TickPayloadDigestV1 }
+```
+
+- [ ] **Step 1: Write exact prepared-environment tests**
+
+  Assert the domain/layout and mandatory tags `0x01..0x0a`: verified loaded rules hash, unchanged phase schedule layout/digest, governed rule order, fields plus exemption ledger, intrinsic costs, constants, enum types, vocabulary presence, resolver manifest, and register manifest. Mutate every semantic row/order and nested layout and assert the owning digest moves.
+
+- [ ] **Step 2: Write exact register and stable-world tests**
+
+  Assert the register manifest has exactly `world/completed-tick` layout 1. Assert prior/result sets bind that manifest and encode non-negative `i64` completed ticks. Assert stable world contains only stable graph plus register-set layout/digests. Cover resolve tick 1, `i64::MAX`, zero, negative, overflow, wrong manifest, extra/missing/out-of-order register, and allocator-cursor exclusion.
+
+- [ ] **Step 3: Write exact payload tests**
+
+  Assert governed rule outcomes, executable event order, duplicate payload labels in source order, receipt vector order, and exact zero `u16` action-outcome count. Assert `TickReport.fired` equals the checked sum and is not separately encoded. Mutate rule, event, pair, and receipt order and prove the digest moves. Cover reference resolution, non-finite values, row limits, and 64 MiB ceiling.
+
+- [ ] **Step 4: Run replay identity tests and verify RED**
+
+  ```bash
+  cd rust
+  cargo test -p babylon-tick --test replay_session --locked
+  ```
+
+  Expected: compile failure because the tick-owned canonical objects do not exist.
+
+- [ ] **Step 5: Implement exact tick-owned composers**
+
+  Compose from graph and BSL returned objects; do not duplicate their tag tables. Recompute canonical rules hash from loaded forms and compare it to `ContentDigest.rules_hash` before session construction succeeds. Add one fallible `pub(crate)` `PhaseScheduleV1` canonical-bytes object/API beside the existing digest, derive that digest from the object without moving the current vector, and borrow both here. Enforce local and aggregate limits before allocation.
+
+- [ ] **Step 6: Run scoped tick identity checks**
+
+  ```bash
+  cd rust
+  cargo fmt --all -- --check
+  cargo test -p babylon-tick --test replay_session --locked
+  cargo clippy -p babylon-tick --all-targets --locked -- -D warnings
+  ```
+
+- [ ] **Step 7: Commit tick identity objects**
+
+  ```bash
+  git add rust/crates/babylon-tick
+  SKIP=rust-full-gate mise run commit -- "feat(tick): compose stable world identity"
+  ```
+
+---
+
+### Task 10: One shared detached transaction and executable ReplayTickSession
+
+**Files:**
+
+- Create: `rust/crates/babylon-tick/src/replay_session.rs`
+- Modify: `rust/crates/babylon-tick/src/session.rs`
+- Modify: `rust/crates/babylon-tick/src/lib.rs`
+- Modify: `rust/crates/babylon-tick/src/phase_order.rs`
+- Modify: `rust/crates/babylon-tick/Cargo.toml`
+- Modify: `rust/crates/babylon-tick/tests/replay_session.rs`
+
+**Interfaces:**
+
+```rust
+pub struct ReplayTickSession<G> {
+    graph: G,
+    prepared: PreparedRules,
+    completed_tick: i64,
+    session: ReplaySessionIdV1,
+    seed: ReplaySeed,
+    content: ContentDigest,
+    reference: RefDigestV1,
+    resolver: StableElementResolverV1,
+    register_manifest: WorldRegisterManifestV1,
+    prepared_environment: PreparedEnvironmentV1,
+}
+pub struct IdentifiedTickReportV1 {
+    legacy: TickReport,
+    action_batch_bytes: Vec<u8>,
+    action_batch_layout_version: u32,
+    action_batch_digest: OrderedPracticeActionBatchDigestV1,
+    prior_registers: WorldRegisterSetV1,
+    prior_world: StableWorldV1,
+    result_registers: WorldRegisterSetV1,
+    result_world: StableWorldV1,
+    payload: TickPayloadV1,
+    outer_preimage: TickContentPreimageV1,
+    resolver_manifest_digest: [u8; 32],
+    prepared_environment_digest: PreparedEnvironmentDigestV1,
+    prior_stable_graph_digest: StableGraphStateHashV1,
+    result_stable_graph_digest: StableGraphStateHashV1,
+    tick_content_hash: TickContentHashV1,
+}
+
+trait ReplayIdentityComposer {
+    fn compose(
+        &self,
+        inputs: ReplayIdentityInputs<'_>,
+    ) -> Result<ReplayIdentityArtifactsV1, ReplayTickError>;
+}
+
+impl<G> ReplayTickSession<G> {
+    pub fn new(
+        scenario_src: &str,
+        prelude_src: Option<&str>,
+        rule_src: &str,
+        graph: G,
+        session: ReplaySessionIdV1,
+        seed: ReplaySeed,
+        content: ContentDigest,
+        reference: RefDigestV1,
+    ) -> Result<Self, ReplayTickError>;
+    pub fn advance(
+        &mut self,
+        sink: &mut CollectingSink,
+        actions: &OrderedPracticeActionBatchV1,
+    ) -> Result<IdentifiedTickReportV1, ReplayTickError>;
+    pub fn resolver_manifest_bytes(&self) -> &[u8];
+    pub fn register_manifest_bytes(&self) -> &[u8];
+    pub fn prepared_environment_bytes(&self) -> &[u8];
+}
+```
+
+- [ ] **Step 1: Write construction and success-path tests**
+
+  Construct replay sessions for both supported graph substrates with session, seed, content, reference, scenario, optional prelude, and rules. The public constructor has no V1 or caller-selected numeric layout input: it constructs `RngSeedContext::V2` by type, and an API assertion proves a legacy `SessionId`/V1 context cannot construct it. Assert construction seals topology, verifies rules hash, and owns resolver/register/prepared bytes once. Borrow all three static diagnostic slices before and after two advances and assert the same session-owned storage remains; assert reports contain only their small digests and no cloned static preimages. Advance an exact empty batch and assert legacy report, exact action bytes and direct typed action digest/version, prior/result register and stable-world bytes, exact payload, outer preimage, all versions/digests, and `TickContentHashV1` agree.
+
+- [ ] **Step 2: Write real seed propagation and process identity tests**
+
+  Run the same fixture in two fresh test processes and across substrates. Assert exact bytes/digests agree. Mutate only `ReplaySeed`; assert real `rng-draw` written bits, result stable world, payload when applicable, and outer hash move while prepared environment, prior world, and empty action batch stay fixed.
+
+- [ ] **Step 3: Write runtime guard and atomic-failure tests**
+
+  Assert a non-empty structural batch, mismatched session, mismatched next tick, topology change, resolver failure, deterministic returned hash/codec reservation failure, event-sink reservation failure, and rule failure leave graph, sink events, receipts, completed tick, legacy hashes, nested identity, and outer hash unpublished. Inject the identity reservation failure through the crate-private `ReplayIdentityComposer` boundary, analogous to the existing prepared-sink/hash seams; do not attempt to provoke process OOM. Assert the action guard runs before detached adjudication.
+
+- [ ] **Step 4: Run replay session tests and verify RED**
+
+  ```bash
+  cd rust
+  cargo test -p babylon-tick --test replay_session --locked
+  ```
+
+  Expected: compile failure because `ReplayTickSession` and the shared execution-identity mode do not exist.
+
+- [ ] **Step 5: Extract one shared internal transaction**
+
+  Replace the session-specific call shape with a private typed execution mode: legacy V1 has no authoritative composer; replay V2 carries the resolver and a crate-private `ReplayIdentityComposer`. The production implementation runs the exact real codecs; a test implementation returns one deterministic typed reservation error at the same pre-publication boundary. Keep one detached graph, one causal rule loop, one event/receipt buffer, and one publication point. Perform every fallible stable encode, digest, payload, outer compose, and sink reserve before assigning graph, committing events, or incrementing completed tick.
+
+- [ ] **Step 6: Implement ReplayTickSession without per-tick static clones**
+
+  Cache resolver manifest, register manifest, and prepared environment exact bytes in the session and expose the borrowed diagnostic accessors shown above. Drop prior stable-graph bytes after digest and before rule execution; drop result stable-graph bytes after digest. Return only their digests in the report while retaining exact dynamic register/world/action/payload/outer bytes. Carry the accepted-action layout version and `OrderedPracticeActionBatchDigestV1` as direct typed report fields, and expose direct equality with the supplied empty batch digest; do not force PER-20 to decode the outer preimage. Keep the report explicitly non-durable.
+
+- [ ] **Step 7: Keep legacy and Bevy paths unchanged**
+
+  Route `TickSession` through the shared transaction with `RngSeedContext::V1`; preserve its public constructor, report, hashes, and V1 draws. Do not change `babylon-client`, Bevy engine link, PostgreSQL, or Python writer code.
+
+- [ ] **Step 8: Run tick and upstream crate gates**
+
+  ```bash
+  cd rust
+  cargo fmt --all -- --check
+  cargo test -p babylon-kernel -p babylon-graph -p babylon-bsl -p babylon-practice-contract -p babylon-tick --locked
+  cargo clippy -p babylon-kernel -p babylon-graph -p babylon-bsl -p babylon-practice-contract -p babylon-tick --all-targets --locked -- -D warnings
+  ```
+
+- [ ] **Step 9: Commit the executable replay seam**
+
+  ```bash
+  git add rust/crates/babylon-tick
+  SKIP=rust-full-gate mise run commit -- "feat(tick): execute identified replay ticks"
+  ```
+
+---
+
+### Task 11: One language-neutral schema, vectors, and independent verifier
+
+**Files:**
+
+- Create: `contracts/tick_content_hash_v1.yaml`
+- Create: `contracts/tick_content_hash_v1_vectors.jsonl`
+- Create: `rust/crates/babylon-tick/tests/tick_content_hash_v1_contract.rs`
+- Create: `tools/verify_tick_content_hash_v1.py`
+- Create: `tests/unit/tools/test_verify_tick_content_hash_v1.py`
+
+**Corpus row families:**
+
+- `replay_session`, `replay_seed`, `rng_v1`, `rng_v2`
+- `stable_element`, `carrier_segment`, `resolver_manifest`, `stable_graph`
+- `action_id`, `ordered_action_batch`
+- `bsl_discriminant`, `prepared_environment`
+- `register_manifest`, `register_set`, `stable_world`, `tick_payload`
+- `tick_content_hash`, `mutation`, `refusal`
+
+- [ ] **Step 1: Write verifier tests before the verifier**
+
+  Add Pytest cases that demand one bounded schema/corpus reader; exact valid-byte/digest agreement; an independent four-double-round ChaCha8 reference implementation; recomputation of the V2 SHA-256 key, first nine `u64` draws, and fresh-stream first `f64::to_bits()`; unknown tag/layout, truncation, duplicate/out-of-order mandatory tag, noncanonical Boolean/option, unknown discriminant, and trailing-byte refusal; fixed row/byte ceilings; and one mutation row for every outer input and nested layout.
+
+- [ ] **Step 2: Run verifier tests and verify RED**
+
+  ```bash
+  mise run test:q -- tests/unit/tools/test_verify_tick_content_hash_v1.py
+  ```
+
+  Expected: import failure because the verifier does not exist.
+
+- [ ] **Step 3: Write the language-neutral schema**
+
+  Record every exact domain, numeric layout, tag, byte order, semantic string bound, row/aggregate/byte ceiling, sorting or preserved-order rule, float rule, ownership boundary, production-decoder prohibition, runtime-empty action rule, and excluded identity. Record P27 and Practice V2 preservation explicitly.
+
+- [ ] **Step 4: Write the asymmetric shared vector corpus**
+
+  Include the unchanged RNG V1 four draws; replay session minimum/maximum and invalid classes; all seed extremes; one asymmetric V2 preimage and SHA-256 key, the first nine `u64` draws crossing a block boundary, and a separate fresh-stream first `f64` bit vector; every stable-element kind and carrier form; resolver and cross-allocation stable graph; asymmetric ActionId/non-empty structural batch plus exact empty runtime batch; every BSL discriminant and vocabulary presence; prepared environment; registers/world; payload; outer hash; mutation rows; and maximum/maximum-plus-one refusal rows.
+
+- [ ] **Step 5: Implement an independent bounded Python verifier**
+
+  Use only Python standard-library byte operations, `hashlib`, `json`, and `yaml` already owned by project tests. Implement the design's exact ChaCha8 constants, little-endian key/state words, four double rounds, quarter-round rotations, zero stream id, 64-bit counter, output word order, `next_u64`, and `next_f64` conversion independently; do not call Rust, `rand_chacha`, or the Python P27 encoder. Recompute and compare every RNG V2 vector literal. Give every parser loop a schema-derived fixed maximum and every cursor a checked end. Reject trailing bytes and malformed order. Keep this verifier test-only contract evidence, not a runtime writer.
+
+- [ ] **Step 6: Implement the bounded Rust contract-test parser**
+
+  In the tick integration test, parse the same JSONL and independently check domains, tags, lengths, counts, discriminants, digests, mutation expectations, and refusals. For the RNG V2 row, invoke the production `KernelRng` path and compare its recomputed key, nine `u64` draws, and fresh-stream `f64` bits to the corpus literals. Do not expose this parser from a production crate or add raw object decoders to production types.
+
+- [ ] **Step 7: Run both consumers and verify GREEN**
+
+  ```bash
+  mise run test:q -- tests/unit/tools/test_verify_tick_content_hash_v1.py
+  cd rust
+  cargo test -p babylon-tick --test tick_content_hash_v1_contract --locked
+  cargo clippy -p babylon-tick --test tick_content_hash_v1_contract --locked -- -D warnings
+  ```
+
+- [ ] **Step 8: Prove frozen corpora did not move**
+
+  ```bash
+  git diff --exit-code origin/dev -- contracts/practice_*_v2.yaml contracts/practice_*_v2_vectors.jsonl contracts/resolved_practice_batch_v2.yaml contracts/resolved_practice_batch_v2_vectors.jsonl
+  mise run test:q -- tests/unit/kernel/test_tick_hash.py
+  ```
+
+  Expected: no Practice V2 contract diff and all P27 tick-hash tests pass unchanged.
+
+- [ ] **Step 9: Commit shared identity vectors**
+
+  ```bash
+  git add contracts/tick_content_hash_v1.yaml contracts/tick_content_hash_v1_vectors.jsonl rust/crates/babylon-tick/tests/tick_content_hash_v1_contract.rs tools/verify_tick_content_hash_v1.py tests/unit/tools/test_verify_tick_content_hash_v1.py
+  SKIP=rust-full-gate mise run commit -- "test(contract): bind tick content identity vectors"
+  ```
+
+---
+
+### Task 12: Ratify ADR240 and correct live boundary documentation
+
+**Files:**
+
+- Create: `ai/decisions/ADR240_replay_action_tick_content_identity.yaml`
+- Modify: `ai/decisions/index.yaml`
+- Create: `tests/unit/decisions/test_adr240_replay_action_tick_content_identity.py`
+- Modify: `src/babylon/kernel/tick_hash.py`
+- Modify: `docs/reference/determinism-contract.rst`
+- Modify: `docs/concepts/architecture.rst`
+
+- [ ] **Step 1: Recheck ADR240 availability and write failing decision tests**
+
+  ```bash
+  test ! -e ai/decisions/ADR240_replay_action_tick_content_identity.yaml
+  rg -n "ADR240" ai/decisions tests/unit/decisions
+  ```
+
+  Then add a test requiring accepted status/date/title, crate ownership, Gate 3 live-empty action rule, P27 compatibility-oracle disposition, separate campaign/replay identity, exact vector path, preserved V1/Practice contracts, partial supersessions, and the exact decision-index entry.
+
+- [ ] **Step 2: Run the decision test and verify RED**
+
+  ```bash
+  mise run test:q -- tests/unit/decisions/test_adr240_replay_action_tick_content_identity.py
+  ```
+
+  Expected: failure because ADR240 and its index row do not exist.
+
+- [ ] **Step 3: Create ADR240 and update the decision index**
+
+  Record the design's ownership and exact boundaries. State that ADR220 byte compatibility means accepted `TickContentHashV1` vectors across implementations, not equality with P27 JSON. Preserve P27 execution/tests and Python writer authority until cutover. Record that runtime action batch is empty, non-empty projection has no accepted-input provenance, and PER-20/Gate 5 retain their scopes.
+
+- [ ] **Step 4: Correct only live documentation claims**
+
+  In the Python module docstring, describe P27 as frozen compatibility evidence outside authoritative Rust V1. In the determinism reference, close the open P27 disposition and link exact schema/vectors. In architecture, state replay session is material identity while campaign identity remains separate durability identity. Do not rewrite historical ADRs, specs, reports, or completed plans.
+
+- [ ] **Step 5: Run targeted docs and decision checks**
+
+  ```bash
+  mise run test:q -- tests/unit/decisions/test_adr240_replay_action_tick_content_identity.py tests/unit/kernel/test_tick_hash.py
+  vale ai/decisions/ADR240_replay_action_tick_content_identity.yaml src/babylon/kernel/tick_hash.py docs/reference/determinism-contract.rst docs/concepts/architecture.rst
+  git diff --check
+  ```
+
+  Expected: tests and Vale pass with no whitespace errors; no documentation build runs.
+
+- [ ] **Step 6: Commit the ratified boundary**
+
+  ```bash
+  git add ai/decisions/ADR240_replay_action_tick_content_identity.yaml ai/decisions/index.yaml tests/unit/decisions/test_adr240_replay_action_tick_content_identity.py src/babylon/kernel/tick_hash.py docs/reference/determinism-contract.rst docs/concepts/architecture.rst
+  SKIP=rust-full-gate mise run commit -- "docs(architecture): ratify tick content identity"
+  ```
+
+---
+
+### Task 13: Full verification, adversarial review, and Linear evidence
+
+**Files:**
+
+- Modify only files found defective by review, and rerun their owning RED/GREEN task before changing them.
+- Update Linear issue `PER-60` with commit, test, and boundary evidence; do not add source status anywhere else.
+
+- [ ] **Step 1: Inspect the complete diff and protected surfaces**
+
+  ```bash
+  git status --short
+  git diff --stat origin/dev...HEAD
+  git diff --check origin/dev...HEAD
+  git diff origin/dev...HEAD -- contracts/practice_*_v2.yaml contracts/practice_*_v2_vectors.jsonl contracts/resolved_practice_batch_v2.yaml contracts/resolved_practice_batch_v2_vectors.jsonl
+  rg -n "TODO|TBD|FIXME|placeholder|unimplemented!|todo!|panic!" rust/crates/babylon-{kernel,practice-contract,graph,bsl,tick,persistence} contracts/tick_content_hash_v1.yaml tools/verify_tick_content_hash_v1.py ai/decisions/ADR240_replay_action_tick_content_identity.yaml
+  ```
+
+  Expected: only intended files differ, protected contract diff is empty, and no incomplete implementation marker exists. Existing unrelated matches must be named and excluded by exact path/line evidence.
+
+- [ ] **Step 2: Run the smallest exact contract gates**
+
+  ```bash
+  mise run test:q -- tests/unit/tools/test_verify_tick_content_hash_v1.py tests/unit/decisions/test_adr240_replay_action_tick_content_identity.py tests/unit/kernel/test_tick_hash.py
+  cd rust
+  cargo fmt --all -- --check
+  cargo test -p babylon-kernel -p babylon-graph -p babylon-bsl -p babylon-practice-contract -p babylon-tick -p babylon-persistence --locked
+  cargo clippy -p babylon-kernel -p babylon-graph -p babylon-bsl -p babylon-practice-contract -p babylon-tick -p babylon-persistence --all-targets --locked -- -D warnings
+  ```
+
+- [ ] **Step 3: Run repository gates sequentially without docs**
+
+  Run each command only after the previous one finishes:
+
+  ```bash
+  BLAS=1 mise run check
+  BLAS=1 mise run rust:check-no-docs
+  BLAS=1 mise run qa:regression
+  BLAS=1 mise run qa:vault-regression-ci
+  BLAS=1 mise run check:gate-coverage
+  ```
+
+  Preserve the complete redirected logs and exact exit codes. Do not substitute watcher completion for the final result.
+
+- [ ] **Step 4: Request independent adversarial review**
+
+  Ask reviewers to compare implementation line-by-line with the committed design, focusing on exact byte layouts, fixed limits, semantic versus canonical order, actor provenance, resolver sealing, RNG V2 real-call propagation, transaction atomicity, raw-decoder absence, memory retention, V1/P27/frozen Practice preservation, and playable-slice scope. Require findings with file/line evidence and severity.
+
+- [ ] **Step 5: Address every review finding with TDD**
+
+  For each accepted finding, add or tighten the smallest failing behavioral test, run it to RED, implement the surgical correction, rerun it to GREEN, and rerun the owning crate's Clippy gate. Record why rejected findings conflict with the ratified design.
+
+- [ ] **Step 6: Repeat final verification at the exact reviewed head**
+
+  Re-run Steps 1 through 3 after the final correction. Record `git rev-parse HEAD`, all exit codes, and protected-file checksums. Do not claim completion from earlier commits or stale logs.
+
+- [ ] **Step 7: Commit any review-only corrections**
+
+  If review produced changes, repeat the owning task's exact `git add` command restricted to that task's reviewed files, inspect `git diff --cached`, and commit:
+
+  ```bash
+  SKIP=rust-full-gate mise run commit -- "fix(identity): close PER-60 review findings"
+  ```
+
+  If review produced no changes, do not create an empty commit.
+
+- [ ] **Step 8: Record Linear completion evidence**
+
+  Comment on `PER-60` with branch, exact head SHA, design and plan paths, task commits, exact green commands, vector/schema paths, ADR240, P27 and Practice preservation evidence, the live empty-action guard, and explicit PER-20/Gate 5/Bevy/PostgreSQL exclusions. Move issue status only when its own acceptance criteria are fully met.
+
+- [ ] **Step 9: Confirm the playable-slice handoff**
+
+  State the delivered boundary in one sentence: a database-free Rust replay tick now binds seed, mechanics, stable prior/result world, exact empty accepted actions, payload, and canonical hash atomically; PER-20 can next wrap that typed evidence in `CommittedTickEnvelope` without inventing identity.

--- a/docs/superpowers/specs/2026-08-26-per-60-replay-action-tick-content-hash-design.md
+++ b/docs/superpowers/specs/2026-08-26-per-60-replay-action-tick-content-hash-design.md
@@ -1,0 +1,1113 @@
+<!-- Vale: this normative design preserves governed identifiers and wire terms. -->
+<!-- vale Vale.Spelling = NO -->
+<!-- vale ste.UnapprovedWords = NO -->
+<!-- vale ste.NounClusters = NO -->
+<!-- The literal APIs, layouts, and failure predicates require the same local
+     heuristic exemptions as the repository's other executable designs. -->
+<!-- vale Vale.Terms = NO -->
+<!-- vale ste.Ambiguity = NO -->
+<!-- vale ste.Dictionary = NO -->
+<!-- vale ste.Gerunds = NO -->
+<!-- vale ste.LatinAbbrev = NO -->
+<!-- vale ste.Modals = NO -->
+<!-- vale ste.OneInstruction = NO -->
+<!-- vale ste.PassiveVoice = NO -->
+<!-- vale ste.ProcedureLength = NO -->
+<!-- vale ste.Semicolon = NO -->
+<!-- vale ste.SentenceLength = NO -->
+<!-- vale ste.ThisPronoun = NO -->
+<!-- vale strunk.ActiveVoice = NO -->
+<!-- vale strunk.CommonlyMisused = NO -->
+<!-- vale write-good.ThereIs = NO -->
+<!-- vale write-good.TooWordy = NO -->
+<!-- vale write-good.Weasel = NO -->
+
+# PER-60 Replay, Action, and Tick Content Identity Design
+
+Status: Director-authorized design for implementation
+Date: 2026-08-26
+Linear: PER-60
+Gate: Gate 3 database-free identity boundary
+
+## Goal
+
+PER-60 gives one detached Rust tick a complete, versioned, language-neutral
+identity. The result is the input boundary that PER-20 will later place inside
+CommittedTickEnvelope and persist atomically.
+
+This work serves the playable slice. It makes the future player decision loop
+replayable and auditable. It does not activate player actions, persistence,
+Archive delivery, or dynamic graph topology.
+
+The implementation succeeds when an identified tick binds all of these inputs
+and outputs:
+
+- the replay session and replay seed;
+- the RNG layout;
+- the content and reference identities;
+- the exact prepared mechanics environment;
+- the stable world before and after adjudication;
+- the ordered accepted-action batch, which is empty at runtime in Gate 3;
+- the exact ordered tick payload, including events and audit receipts; and
+- every nested layout version needed to interpret those values.
+
+The same semantic tick must produce the same canonical bytes and SHA-256 digest
+across processes, graph backends, and runtime-handle allocation orders.
+
+## Current facts
+
+The following statements describe live behavior at the design base,
+origin/dev commit 600e6b03cd3eff271cd4ccaecf5a914327d47581.
+
+- Python P27 has executable canonical bytes and pinned vectors.
+- Rust KernelRng uses ChaCha8 with one stream per stable carrier. Its current
+  seed derivation uses SessionId, tick, domain, stable key, and a fixed salt.
+  It has no replay seed.
+- TickSession advances a detached graph atomically and publishes events,
+  identity-free AuditReceipt rows, completed time, GraphStateHash, and
+  NominalWorldHash.
+- GraphStateHash encodes runtime NodeId and HyperedgeId values.
+  NominalWorldHash nests GraphStateHash and allocator cursors. Neither hash can
+  enter the authoritative TickContentHash.
+- The scenario loader already retains insertion-independent node names. It
+  also builds insertion-independent hyperedge names during hydration, but
+  discards that inverse map before returning.
+- ResolvedPracticeBatchV2 already validates complete PracticeProposalKeyV2
+  order. PracticeIntentV2 already binds actor, target, practice verb, proposal
+  nonce, quoted contracts, parameters, and evidence.
+- Executable intents and player actions do not exist. Gate 5 owns their
+  activation.
+
+## Director rulings
+
+### P27 disposition
+
+P27 remains executable and byte-pinned as a compatibility oracle. Its existing
+vectors must not change.
+
+P27 bytes and digests do not enter authoritative TickContentHashV1. The new
+Rust binary contract is the sole authoritative tick-content identity.
+
+This ruling supersedes only prior wording that required the modern Rust
+TickContentHash to equal P27 bytes. It does not retire P27 or weaken its tests.
+
+### Delivery boundary
+
+PER-60 implements the exact empty accepted-action batch in the live replay
+tick. It may implement and vector-test the non-empty action codec, because that
+codec defines ActionId and canonical order. It must not admit, adjudicate, or
+execute a non-empty action batch.
+
+PER-20 retains PostgreSQL schemas, hydration, CommittedTickEnvelope, outbox
+publication, and writer cutover. Gate 5 retains player input and action
+effects.
+
+## Canonical primitive rules
+
+All new PER-60 integers use fixed-width big-endian bytes. SHA-256 digests use
+32 raw bytes. Strings use exact UTF-8 bytes after validation and never use
+JSON, locale-sensitive formatting, or unordered map iteration.
+
+ReplaySessionIdV1 is the authoritative session form. It contains from 1
+through 256 ASCII graphic bytes in the inclusive range `0x21` through `0x7e`
+and encodes as:
+
+    u16 byte length
+    exact ASCII bytes
+
+ASCII makes normalization tables and Unicode-version drift irrelevant. The
+implementation rejects spaces, control bytes, DEL, and non-ASCII input; it
+never transforms case or bytes. The existing SessionId remains available to
+legacy logging and RNG V1. The new replay path validates a distinct
+ReplaySessionIdV1 before adjudication.
+
+ReplaySessionIdV1 is a logical replay namespace, not a rendering of
+CampaignIdV2, babylon-persistence CampaignId, a database row id, or another
+durability identity. No `From` or `TryFrom` implementation connects those
+types, and the authoritative composition root cannot accept one in place of a
+replay session. A string that happens to resemble a UUID does not change its
+type or provenance. PER-20 must persist campaign identity and replay session
+as separate typed fields and must supply them separately to persistence and
+the replay engine.
+
+Every collection has a declared fixed ceiling. Every integer conversion is
+checked. NaN and infinity refuse. Canonical floating-point encoders collapse
+negative zero to positive zero and otherwise write exact IEEE-754 bits.
+
+The layouts below use `str32(value)` for `u32` byte length followed by exact
+UTF-8 bytes. A semantic category can impose a lower limit than `u32`:
+
+- a BSL symbol or authored local name is 1 through 64 strict ASCII bytes;
+- a BSL qname is 1 through 128 strict ASCII bytes and at most four segments;
+- a structural node, edge, or hyperedge type member and a canonical full event
+  type are each 1 through 128 strict ASCII bytes at the replay boundary;
+- an intrinsic identity name is 1 through 96 strict ASCII bytes under its
+  existing delimiter rules; and
+- a governance or enum string without a narrower live grammar limit is at
+  most 4,194,304 UTF-8 bytes at the replay boundary.
+
+Encoders and verifiers apply the lower semantic ceiling first. They reject an
+object over its total-byte ceiling before any new PER-60 codec-buffer
+allocation, validate a count before reserving codec rows, use checked
+aggregate-row arithmetic, and reject trailing bytes. Existing CanonicalState
+listing methods materialize their seven Vec values before the stable encoder
+sees them; changing that substrate API is outside this slice. Process-level
+out-of-memory abort is not a recoverable codec error. These are admission
+limits for replay identity, not claims that an otherwise unbounded source
+token already had the same limit.
+
+## Replay seed and RNG layouts
+
+ReplaySeed is a signed i64 over the complete i64 range. Zero and negative
+values are valid when supplied explicitly.
+
+Its canonical form is i64.to_be_bytes. Its future PostgreSQL mapping is
+BIGINT NOT NULL with no default. A value outside the i64 range refuses before
+adjudication.
+
+RngLayoutVersion has two governed values:
+
+- V1 freezes the current seed_for and KernelRng behavior byte for byte. V1
+  ignores ReplaySeed and remains a compatibility path. It is not eligible for
+  a durable Gate 3 campaign.
+- V2 is the seed-aware replay layout. Every new replay session uses V2.
+
+RNG V2 derives one 32-byte ChaCha8 seed per carrier from this exact preimage:
+
+    ASCII "babylon.rng-stream" followed by NUL
+    u32 layout version 2
+    tag 0x01, ReplaySeed i64 big-endian
+    tag 0x02, ReplaySessionIdV1 canonical field
+    tag 0x03, resolve tick u64 big-endian
+    tag 0x04, u32 byte length and exact UTF-8 domain
+    tag 0x05, u32 byte length and exact UTF-8 stable carrier key
+
+SHA-256 of that preimage is the exact 32-byte ChaCha8 key. RNG V2 freezes the
+rand_chacha 0.10 output sequence as a language-neutral algorithm, independent
+of a future Rust dependency implementation:
+
+1. Form sixteen u32 state words. Words 0 through 3 are `0x61707865`,
+   `0x3320646e`, `0x79622d32`, and `0x6b206574`. Words 4 through 11 decode
+   consecutive four-byte key chunks as little-endian u32. Words 12 and 13 are
+   the low and high u32 halves of a zero-based 64-bit block counter. Words 14
+   and 15 are a zero 64-bit stream id.
+2. For each 64-byte block, copy the initial state and run four double rounds.
+   One quarter round `(a,b,c,d)` uses wrapping u32 addition and performs:
+   `a+=b; d^=a; d=rotl(d,16); c+=d; b^=c; b=rotl(b,12); a+=b; d^=a;
+   d=rotl(d,8); c+=d; b^=c; b=rotl(b,7)`.
+3. Each double round applies quarter rounds first to columns
+   `(0,4,8,12)`, `(1,5,9,13)`, `(2,6,10,14)`, `(3,7,11,15)`, then to
+   diagonals `(0,5,10,15)`, `(1,6,11,12)`, `(2,7,8,13)`, and
+   `(3,4,9,14)`.
+4. Add each original state word to its working word with wrapping u32
+   addition. The sixteen result words appear in index order and each word's
+   byte form is little-endian. Increment the 64-bit block counter by one with
+   wrapping arithmetic. The stream id remains zero.
+5. next_u64 consumes two consecutive result words: the first is bits 0 through
+   31 and the second is bits 32 through 63. next_f64 consumes one next_u64,
+   shifts it right by 11, converts that 53-bit integer exactly to f64, and
+   multiplies by exact `2^-53`.
+
+The API offers no stream-id setter, seek operation, or tick-global stream.
+An implementation can call rand_chacha 0.10, but the algorithm and vectors
+above own compatibility.
+
+An unknown layout refuses. A future RNG change creates V3 beside V2 and gets
+new vectors and a new ceremony. It never edits V2 in place.
+
+V1 keeps its existing unversioned preimage exactly: session UTF-8 bytes,
+little-endian tick, little-endian `0x0BA1_AC1A`, little-endian `u64` domain
+length and bytes, then little-endian `u64` key length and bytes. V1 gains no
+new validation, normalization, length cap, seed, or prefix.
+
+V2 introduces two validated boundary values:
+
+- RngDomainV2 is the firing rule qname: 1 through 128 strict ASCII bytes.
+- StableCarrierKeyV2 is a graph-owned private strict ASCII value of 1 through
+  131,072 bytes. The authoritative BSL path cannot construct it from an
+  arbitrary caller string.
+
+The stable carrier uses graph-owned StableElementCarrierSegmentV1, an exact
+ASCII rendering of the same validated semantic key as binary
+StableElementKeyV1. It is a second codec owned beside the binary codec, not the
+binary key bytes and not a BSL reimplementation. Each textual segment is
+decimal byte length, `:`, then exact bytes, and `|` separates segments:
+
+    node: framed("node", scenario qname, authored local name)
+    hyperedge: framed("hyperedge", scenario qname, authored local name)
+    edge: framed("edge", scenario qname, edge type,
+                 source local name, target local name)
+
+The graph-owned builder takes one resolved subject segment, at most 256
+resolved active-element segments in outermost-to-innermost order, and the
+canonical decimal i64 draw slot. The slot has no leading plus or zeroes; zero
+is `0`. The builder checks its segment count and 131,072-byte ceiling before
+allocation. V2 has no raw-id or debug fallback.
+
+The final bytes are exactly:
+
+    StableCarrierKeyV2 = framed(
+      subject_segment.ascii(),
+      active_segments[0].ascii(), ... in outermost-to-innermost order ...,
+      canonical_slot_ascii)
+
+The outer `framed` call applies the same decimal-byte-length, colon, and pipe
+framing again; each already-framed element rendering is one opaque ASCII
+segment at this level. With zero active elements, the exact form is
+`framed(subject_segment.ascii(), canonical_slot_ascii)`.
+
+The crate dependency direction is explicit. BSL resolves its subject and
+element stack through graph, asks graph to build StableCarrierKeyV2, and then
+passes only `validated_bytes()` to the low-level kernel V2 derivation. Kernel
+cannot name a graph type because graph already depends on kernel, so its raw
+byte entry point does not by itself prove provenance. ReplayTickSession's
+typed BSL path is the authoritative construction boundary; direct low-level
+kernel use is contract-test or adapter infrastructure, never tick execution.
+
+One typed RngSeedContext dispatches the real intrinsic path:
+
+- V1 contains SessionId and calls the unchanged V1 API;
+- V2 contains ReplaySessionIdV1 and ReplaySeed and calls only seed_for_v2; and
+- DrawContext carries the typed context, so `rng-draw` cannot ignore the V2
+  seed while a separate helper happens to hash it correctly.
+
+ReplayTickSession accepts only the V2 context. Legacy TickSession constructs
+V1. The numeric layout is parsed once in babylon-kernel; BSL and tick do not
+duplicate a `version == 2` branch.
+
+## Ordered Practice action identity
+
+PER-60 adds OrderedPracticeActionBatchV1. It is deliberately specific to the
+accepted Practice V2 contract. It is not a generic action framework.
+
+### Stable actor identity
+
+ActorOrganizationIdV2 is an opaque eight-byte domain identity with a private
+field. Its only primitive construction and projection are from and to exact
+`[u8; 8]` bytes. It has no arithmetic, numeric conversion, NodeId conversion,
+or graph dependency.
+
+Every Practice V2 actor lane uses this type: authority rows and lookup,
+PracticeIntentV2, PracticeProposalKeyV2, resource ownership, and strike
+organization relations. Its existing wire form remains the same eight bytes
+previously written by `u64::to_be_bytes`, and unsigned bytewise ordering stays
+the same. Existing V2 vectors therefore do not move. V1 actor fields remain
+unchanged.
+
+This is a Rust API and type-safety refinement over the frozen eight-byte
+`u64_be` wire slot. The accepted Practice V2 YAML files, their pinned source
+SHA constants, canonical encoders and decoders, JSONL vectors, and vector
+manifests remain byte-identical. They keep the existing `actor_org_id_u64` and
+`type: u64` wire descriptions. Numeric JSON fixture adapters may convert a
+parsed u64 through `to_be_bytes` solely to construct the Rust newtype. A
+schema-semantic or wire change requires a new Practice contract version and
+ceremony; it cannot land under ActorOrganizationIdV2.
+
+Gate 5 must provide an explicit stable actor-to-graph resolver before an actor
+can affect graph mechanics. A cast from ActorOrganizationIdV2 to NodeId is not
+such a resolver.
+
+### Proposal and canonical order
+
+PracticeProposalKeyV2 remains proposal identity:
+
+    resolve tick
+    input authority id
+    actor organization id
+    practice id
+    tagged stable target identity
+    proposal nonce
+
+For a non-empty structural projection, ResolvedPracticeBatchV2 validation runs
+first against the supplied trusted authority ledger. Its items already form
+one strictly ascending and unique proposal-key sequence. The Gate 3 empty form
+needs no campaign or authority-ledger input.
+
+The projector enumerates that sequence and assigns a contiguous zero-based
+u16 `canonical_input_ordinal`. This is the input ordinal required by PER-60.
+The existing 4,096 item ceiling limits valid ordinals to 0 through 4,095.
+
+The ordinal is an order witness and event or receipt correlation position. It
+is never initiative, scarcity priority, execution rank, or proposal identity.
+Shared material scarcity must remain order-neutral under ADR236.
+
+### ActionId
+
+Each accepted item reuses the exact PracticeIntentV2 canonical bytes. The
+nested intent supplies:
+
+- actor through actor_org_id;
+- target through TaggedPracticeTargetV2;
+- verb through PracticeIdV2; and
+- payload identity through practice_intent_v2_digest.
+
+actor_org_id is ActorOrganizationIdV2, not a numeric graph handle.
+
+ActionId is SHA-256 of:
+
+    ASCII "babylon.practice-action-id.v1" followed by NUL
+    u16 action-id schema version 1
+    ReplaySessionIdV1 canonical field
+    u16 nested PracticeIntent schema version 2
+    32-byte practice_intent_v2_digest
+
+ActionId excludes canonical_input_ordinal, campaign UUID, database identity,
+wall time, and ActionId itself. It therefore remains stable when an unrelated
+lower-sorting action changes later ordinals.
+
+### Batch bytes
+
+OrderedPracticeActionBatchV1 encodes:
+
+    ASCII "babylon.ordered-practice-action-batch.v1" followed by NUL
+    u16 schema version 1
+    ReplaySessionIdV1 canonical field
+    u64 resolve tick
+    u16 item count
+    for each item in canonical order:
+      u16 canonical_input_ordinal
+      32-byte ActionId
+      u16 intent byte length
+      exact PracticeIntentV2 canonical bytes
+
+Validation requires ordinal equality with array position, one resolve tick,
+strict ascending unique proposal keys, recomputed ActionId values, and bounded
+intent lengths. The batch digest is SHA-256 of the validated canonical batch
+bytes and never appears inside its own preimage.
+
+OrderedPracticeActionV1 and OrderedPracticeActionBatchV1 have private fields.
+The empty constructor is the only live Gate 3 constructor. The non-empty
+projector takes ReplaySessionIdV1, the complete ResolvedPracticeBatchV2, and
+the trusted PracticeInputAuthorityLedgerV2. It first runs the existing full
+resolved-batch validation, then clones exact intents, derives ordinals and
+ActionId values, and constructs the private batch. There is no constructor
+from loose intents, caller ordinals, caller ActionId values, or raw bytes.
+
+Resolved-batch validation proves structural and active-authority consistency
+relative to the supplied ledger. It does not prove submission history,
+resource allocation, or an accepted-input transaction; ADR235 leaves those
+owners outside that contract. The non-empty PER-60 vector is therefore a
+codec projection fixture, not evidence of live admission. Gate 5 and PER-20
+must supply accepted-input and commit provenance before a non-empty projection
+can become authoritative. A future rehydrator must replay the projector from
+the source batch and an independently trusted committed ledger, compare exact
+bytes, and return the recomputed value. Raw ordered bytes never confer
+acceptance.
+
+Exact action bounds are:
+
+- ActionId preimage is `68 + session byte length`, or 69 through 324 bytes;
+- an empty batch is `55 + session byte length`, or 56 through 311 bytes;
+- each item is `36 + intent byte length`, at most 16,420 bytes; and
+- the complete 4,096-item batch is at most 67,256,631 bytes.
+
+ReplayTickSession accepts the typed batch but requires the zero-item form. A
+non-empty form refuses before the detached tick starts. Gate 5 must change this
+explicit guard before any action can enter mechanics.
+
+### Refused and material outcomes
+
+A malformed or pre-admission-refused attempt receives no ActionId, ordinal,
+action event, receipt, or world-identity contribution. When decodable, its
+proposal key may identify the refusal outside authoritative tick content.
+
+An accepted action retains its ActionId for applied, partial, no-participation,
+materially failed, countered, or accepted no-op outcomes. Those outcomes will
+be authoritative payload rows after Gate 5 defines their schema.
+
+Canonical order may order serialized actions, events, and receipts. It must
+not decide a material winner. A noncommutative contention must use an explicit
+governed causal law or refuse.
+
+## Stable graph and world identity
+
+PER-60 adds one graph-owned stable identity path beside GraphStateHash. BSL
+supplies authored names; graph code owns validation, key bytes, state bytes,
+and hashes. Tick and BSL call that one resolver rather than re-encoding keys.
+
+### Stable element keys and resolver
+
+StableElementKeyV1 has these governed kind bytes and standalone encoding:
+
+    ASCII "babylon.stable-element" followed by NUL
+    u32 layout version 1
+    u8 kind: 0x01 node, 0x02 directed dyadic edge, 0x03 hyperedge
+    for node:
+      str32 scenario scope
+      str32 authored node local name
+    for edge:
+      str32 scenario scope
+      str32 edge type
+      str32 source node local name
+      str32 target node local name
+    for hyperedge:
+      str32 scenario scope
+      str32 authored hyperedge local name
+
+Node and hyperedge type are world facts, not identity components. An edge has
+no authored local name, so its type and ordered endpoints identify it. The
+largest standalone key is 428 bytes under the 128-byte structural-type replay
+ceiling. Parallel hyperedges remain distinct through authored local names,
+even when type and members match.
+
+StableElementCarrierSegmentV1 is the graph-owned ASCII renderer used only
+inside StableCarrierKeyV2. It renders the same validated semantic key as:
+
+    node: framed("node", scenario scope, authored node local name)
+    edge: framed("edge", scenario scope, edge type,
+                 source node local name, target node local name)
+    hyperedge: framed("hyperedge", scenario scope,
+                      authored hyperedge local name)
+
+It is not the standalone binary StableElementKeyV1 bytes. Graph code owns and
+tests both codecs so BSL cannot make their field identity drift.
+
+StableElementResolverManifestV1 encodes the stable resolver inputs without
+runtime handles:
+
+    ASCII "babylon.stable-element-resolver" followed by NUL
+    u32 layout version 1
+    tag 0x01, str32 scenario scope
+    tag 0x02, u32 node count
+      rows sorted by local name: str32 local name, str32 node type
+    tag 0x03, u32 hyperedge count
+      rows sorted by local name: str32 local name, str32 hyperedge type
+
+All three tags are mandatory. The combined node and hyperedge count is at
+most 65,536 and the manifest is at most 16,777,216 bytes. Its digest is
+SHA-256 of the exact bytes.
+
+The immutable StableElementResolverV1 also seals the hydrated topology. It
+requires a bijection between live node handles and authored node names and a
+second bijection between live hyperedge handles and authored hyperedge names.
+Every indexed edge must have two named live endpoints. Missing, extra,
+duplicate, dangling, or non-ASCII identities refuse. Any added or removed
+node, edge, hyperedge, or membership after sealing refuses.
+
+This fixed-topology contract is viable only because all six graph-shape verbs
+remain load-refused. No lookup may fall back to Debug, a decimal runtime id,
+insertion ordinal, type-plus-members synthesis, or allocator state.
+
+### Stable graph bytes
+
+StableGraphStateV1 consumes the same seven CanonicalState fact listings as the
+legacy graph hash, resolves every runtime handle, and encodes:
+
+    ASCII "babylon.stable-graph" followed by NUL
+    u32 layout version 1
+    tag 0x01, str32 scenario scope
+    tag 0x02, u32 node count
+      str32 node local name, str32 node type
+    tag 0x03, u32 node f64 attribute count
+      str32 node local name, str32 qname, u64 canonical f64 bits
+    tag 0x04, u32 dyadic edge count
+      str32 edge type, str32 source local name, str32 target local name,
+      u64 canonical strength bits
+    tag 0x05, u32 hyperedge count
+      str32 hyperedge local name, str32 hyperedge type, u32 member count,
+      then str32 member local names
+    tag 0x06, u32 edge f64 attribute count
+      str32 edge type, str32 source local name, str32 target local name,
+      str32 qname, u64 canonical f64 bits
+    tag 0x07, u32 node Currency attribute count
+      str32 node local name, str32 qname, i128 micro-units
+    tag 0x08, u32 hyperedge f64 attribute count
+      str32 hyperedge local name, str32 qname, u64 canonical f64 bits
+
+All eight tags are mandatory, exactly once, in order. Every listing section
+writes its count even when empty; this layout inherits no legacy empty-section
+elision. StableGraphStateHashV1 is SHA-256 of these exact bytes.
+
+Canonical unsigned-ASCII order is local name for nodes and hyperedges;
+`(node, qname)` for both node-attribute lanes; `(type, source, target)` for
+edges; `(type, source, target, qname)` for edge attributes; and `(hyperedge,
+qname)` for hyperedge attributes. Hyperedge members sort by node local name.
+Values never break a key tie. Equal keys refuse.
+
+The encoder also refuses an unknown attribute owner, an absent exact edge, an
+empty hyperedge, an unknown or duplicate member, a duplicated fact row, one
+`(node, qname)` present in both numeric lanes, or an edge-attribute
+`/strength` row. Edge strength has its only home in tag 0x04. BSL retains
+semantic field-owner and type validation; graph identity does not duplicate
+the BSL typechecker.
+
+V1 ceilings are:
+
+    stable nodes, edges, or hyperedges each: 65,536
+    rows in any attribute section: 1,048,576
+    members in one hyperedge: 65,536
+    all seven rows plus nested member references: 1,048,576 fact units
+    complete StableGraphStateV1 bytes: 67,108,864
+
+Counts and byte sizes use checked arithmetic before reserve or append.
+Finite f64 values normalize either zero to positive zero and encode exact
+big-endian bits. Currency writes its signed i128 micro-unit value.
+
+### World-register seam
+
+The only live mutable authoritative non-graph register is completed tick. It
+gets one explicit manifest rather than a list of speculative future fields.
+
+WorldRegisterManifestV1 encodes:
+
+    ASCII "babylon.world-register-manifest" followed by NUL
+    u32 manifest version 1
+    u32 entry count 1
+    str32 ASCII "world/completed-tick"
+    u32 register layout version 1
+
+WorldRegisterSetV1 encodes:
+
+    ASCII "babylon.world-register-set" followed by NUL
+    u32 set layout version 1
+    tag 0x01:
+      u32 manifest version 1
+      32-byte WorldRegisterManifestV1 digest
+    tag 0x02:
+      u32 entry count 1
+      str32 ASCII "world/completed-tick"
+      u32 register layout version 1
+      u32 payload length 8
+      non-negative completed tick as i64 big-endian
+
+WorldRegisterSetDigestV1 is SHA-256 of the exact set bytes.
+
+StableWorldV1 encodes:
+
+    ASCII "babylon.stable-world" followed by NUL
+    u32 layout version 1
+    tag 0x01:
+      u32 StableGraphState layout version 1
+      32-byte StableGraphStateHashV1
+    tag 0x02:
+      u32 WorldRegisterSet layout version 1
+      32-byte WorldRegisterSetV1 digest
+
+The prepared environment binds the same register-manifest version and digest.
+Prior and result register sets must match it exactly. Missing, extra,
+duplicate, out-of-order, unknown-version, or trailing data refuses.
+
+StableWorldDigestV1 is SHA-256 of the exact StableWorldV1 bytes. For an
+identified resolve tick from 1 through i64 maximum, the prior completed-tick
+register equals resolve tick minus one and the result register equals resolve
+tick. Both conversions and the subtraction are checked.
+
+Allocator cursors stay out. Phase schedule belongs to the prepared environment;
+events and receipts belong to the tick payload; seed, session, content,
+reference, and action identity belong to the outer tick hash. A real future
+register gets a named payload layout and a new manifest version when it becomes
+live. PER-60 does not predeclare inventory, reservation, knowledge, mint, or
+other future placeholders.
+
+GraphStateHash and NominalWorldHash remain unchanged for compatibility and
+administrative display. TickContentHashV1 never nests either one.
+
+## Prepared environment identity
+
+PreparedEnvironmentV1 commits the mechanics that the engine actually loaded,
+without encoding Rust HashMap order or runtime graph handles.
+
+### Shared BSL discriminants
+
+These tag assignments are governed wire data and never derive from Rust enum
+order:
+
+    ValueV1:
+      0x01 Int, then i64
+      0x02 Currency, then signed i128 micro-units
+      0x03 Real, then canonical f64
+      0x04 Ratio, then canonical f64 value,
+           u8 optional exclusive-floor presence and optional f64,
+           u8 optional inclusive-cap presence and optional f64
+      0x05 Bool, then u8 0 or 1
+      0x06 Enum, then str32 enum type and str32 member
+      0x07 NodeRef, then exact node-kind StableElementKeyV1 bytes
+      0x08 HyperedgeRef, then exact hyperedge-kind StableElementKeyV1 bytes
+      0x09 EdgeRef, then exact edge-kind StableElementKeyV1 bytes
+
+    BslTypeV1:
+      0x01 Probability, 0x02 Intensity, 0x03 Coefficient,
+      0x04 Currency, 0x05 Real, 0x06 Int, 0x07 Bool,
+      0x08 Enum, then str32 resolved enum type name,
+      0x09 NodeSet, then str32 NodeType member,
+      0x0a EdgeSet, then str32 EdgeType member
+
+    FieldKindV1:
+      0x01 Intensive, 0x02 Extensive, 0x03 NotApplicable
+
+    RuleRoleV1:
+      0x01 Mechanic, 0x02 Recognizer, 0x03 ExternalEvent, 0x04 Intent
+
+    EvidenceClassV1:
+      0x01 Observed, 0x02 Derived, 0x03 Calibrated, 0x04 Designed
+
+    EffectSignatureV1:
+      0x01 NodeField, then str32 qname
+      0x02 EdgeField, then str32 qname
+      0x03 HyperedgeField, then str32 qname
+      0x04 Event, then str32 canonical full EventType/MEMBER
+      0x05 Shape, then one u8 ShapeVerbV1 code
+
+    ShapeVerbV1:
+      0x01 AddNode, 0x02 RemoveNode, 0x03 AddEdge,
+      0x04 RemoveEdge, 0x05 AddHyperedge, 0x06 RemoveHyperedge
+
+    EnumKindV1:
+      0x01 NodeType, 0x02 EdgeType, 0x03 HyperedgeType, 0x04 EventType
+
+An option byte is exactly 0 for absent or 1 followed by its value. Any other
+byte refuses. ConstValueV1 permits only ValueV1 tags 0x01 through 0x05, which
+are exactly the live constant forms. An enum or reference constant is an
+invariant failure. BslTypeV1 resolves EnumTypeId to its declared type name and
+refuses an unknown id.
+
+babylon-bsl owns these codecs, registry snapshot helpers, and their semantic
+validation. babylon-tick composes their returned checked sections; it does not
+maintain a second tag table.
+
+### Governed phase schedule
+
+PreparedEnvironmentV1 reuses the existing PhaseScheduleV1 bytes:
+
+    ASCII "babylon.phase-schedule" followed by NUL
+    u32 layout version 1
+    u32 canonical slot count
+    for each slot in governed order:
+      str32 name
+      u8 partition: 0 material base, 1 action, 2 consequence
+      u8 ordinal
+      u16 default rank
+    u32 alias count
+    for each alias sorted by alias name:
+      str32 alias
+      str32 canonical slot
+      u16 resolved default rank
+
+Its current 34 slots and four compatibility aliases remain the live schedule.
+PhaseScheduleDigestV1 is SHA-256 of the exact bytes.
+
+### Prepared environment bytes
+
+PreparedEnvironmentV1 encodes these fixed sections exactly once and in order:
+
+    ASCII "babylon.prepared-environment" followed by NUL
+    u32 layout version 1
+    tag 0x01:
+      32-byte verified rules_hash
+    tag 0x02:
+      u32 PhaseSchedule layout version 1
+      32-byte PhaseScheduleDigestV1
+    tag 0x03:
+      u32 rule count
+      str32 rule qnames in resolved execution order
+    tag 0x04:
+      u32 field count
+      rows sorted by qname:
+        str32 qname, BslTypeV1, FieldKindV1
+      u32 exemption count
+      rows sorted by `(field_name, reason, owner, date)` byte tuple:
+        four str32 values in that order
+    tag 0x05:
+      u32 intrinsic count
+      rows sorted by intrinsic name:
+        str32 name, u64 declared cost
+    tag 0x06:
+      u32 constant count
+      rows sorted by qname:
+        str32 qname, ConstValueV1
+    tag 0x07:
+      u32 enum-type count
+      types sorted by type name:
+        str32 type name, u32 member count,
+        str32 members in declaration order
+    tag 0x08:
+      u8 closed-vocabulary option
+      when 1, exactly four EnumKindV1 rows in tag order:
+        u8 kind, u8 kind-present option,
+        when present, u32 member count and sorted str32 members
+    tag 0x09:
+      u32 StableElementResolverManifest layout version 1
+      32-byte StableElementResolverManifestV1 digest
+    tag 0x0a:
+      u32 WorldRegisterManifest layout version 1
+      32-byte WorldRegisterManifestV1 digest
+
+Vocabulary needs both the outer and per-kind presence bits. No vocabulary is
+different from a vocabulary with a present-empty kind: the latter rejects all
+members of that kind. Enum type rows sort, but each type's member declaration
+order remains semantic. The execution plan, rather than source or file order,
+sets rule order. Every other registry or map row uses the declared byte sort.
+
+The TypeEnv exemption ledger appears explicitly. The live rules hash covers
+canonical rule ASTs, not that ledger, despite an older source comment. Lint-only
+default findings stay out. The rules hash and full canonical AST commit loaded
+rule internals; the resolved id vector commits execution order. A semantic
+compiler or preparation change requires a new PreparedEnvironment layout
+rather than a selective encoding of incidental compiled fields.
+
+The implementation computes this object only after successful preparation. It
+recomputes the canonical rules hash from loaded rule forms and compares it with
+the rules half of the declared ContentDigest. Formatting and input-file order
+cannot move the result.
+
+PreparedEnvironmentDigestV1 is SHA-256 of the exact prepared-environment
+bytes.
+
+PreparedEnvironmentV1 is at most 67,108,864 bytes. Its ceilings are 65,536
+rules, fields, constants, enum types, and combined stable resolver rows; 64
+exemptions and intrinsic rows; 1,048,576 members in one enum or vocabulary
+kind; and 1,048,576 aggregate prepared rows. Encoders enforce per-section and
+aggregate counts before allocation.
+
+Content identity remains the existing pair of defines_hash and rules_hash.
+Reference identity is one explicit RefDigestV1 containing exactly 32 bytes and
+no default. The detached Rust boundary binds both. PER-20 will later validate
+and hydrate their durable sources.
+
+## Exact tick payload
+
+TickPayloadV1 is a canonical byte object, not only a digest. It encodes:
+
+    ASCII "babylon.tick-payload" followed by NUL
+    u32 layout version 1
+    tag 0x01:
+      u32 rule-outcome count
+      rows in governed execution order:
+        str32 rule qname, u64 fired count
+    tag 0x02:
+      u32 event count
+      rows in executable arrival order:
+        str32 canonical full EventType/MEMBER
+        u32 payload-item count
+        rows in live source order, duplicates preserved:
+          str32 label symbol, ValueV1
+    tag 0x03:
+      u32 receipt count
+      rows in published AuditReceipt vector order:
+        str32 rule qname, RuleRoleV1, EvidenceClassV1,
+        u32 ordinal, EffectSignatureV1
+    tag 0x04:
+      u16 accepted-action-outcome count, exactly zero in Gate 3
+
+The rule-outcome sequence exactly matches PreparedEnvironmentV1 tag 0x03.
+TickReport.fired is a checked derived sum of those rows, is not encoded again,
+and must agree before publication.
+
+Event order and payload-pair source order are semantic. The live sink accepts
+an ordered vector and preserves duplicate labels, so the identity codec does
+the same. It does not sort these rows. A bare event member is canonicalized to
+`EventType/member`; an already full event stays full. Event rows and
+EffectSignatureV1 reuse one BSL canonicalizer.
+
+Reference values resolve through StableElementResolverV1. A dynamically
+minted or missing reference refuses; there is no NodeId, HyperedgeId, raw edge
+handle, debug representation, unordered JSON, or resolver index in the bytes.
+
+AuditReceipt already excludes identity-bearing graph values and written
+values. Its per-rule ordinal remains the published events-first-then-writes
+ordinal and is not resorted. StableWorldV1 binds the resulting writes.
+
+TickPayloadV1 is at most 67,108,864 bytes. It permits at most 65,536 rule
+outcomes; 1,048,576 events, receipts, aggregate payload items, and aggregate
+tick rows; 1,048,576 items in one event; and 4,096 action outcomes, with the
+last count fixed to zero here. Each local and aggregate count is checked before
+allocation.
+
+TickPayloadDigestV1 is SHA-256 of the exact canonical payload bytes. The
+identified report publishes both bytes and digest so PER-20 can verify a
+future envelope without reconstructing event data that the tick discarded.
+
+## TickContentHashV1
+
+TickContentHashV1 is SHA-256 of this fixed outer preimage:
+
+    ASCII "babylon.tick-content" followed by NUL
+    u32 outer layout version 1
+    tag 0x01:
+      u32 ReplaySessionId layout version 1
+      ReplaySessionIdV1 canonical field
+    tag 0x02:
+      u64 resolve tick
+    tag 0x03:
+      u32 ReplaySeed layout version 1
+      u32 RNG layout version 2
+      ReplaySeed i64 big-endian
+    tag 0x04:
+      u32 ContentDigest layout version 1
+      32-byte defines_hash
+      32-byte rules_hash
+    tag 0x05:
+      u32 RefDigest layout version 1
+      32-byte reference digest
+    tag 0x06:
+      u32 PreparedEnvironment layout version 1
+      32-byte prepared-environment digest
+    tag 0x07:
+      u32 StableWorld layout version 1
+      32-byte prior-world digest
+    tag 0x08:
+      u32 OrderedPracticeActionBatch layout version 1
+      32-byte accepted-action-batch digest
+    tag 0x09:
+      u32 StableWorld layout version 1
+      32-byte result-world digest
+    tag 0x0a:
+      u32 TickPayload layout version 1
+      32-byte exact-payload digest
+
+All ten tags are mandatory and appear exactly once in this order. V1 accepts
+no extension tags. A new field or register requires a new outer or nested
+layout, depending on which contract owns it.
+
+The preimage excludes campaign UUID, PostgreSQL row id, wall time, database
+sequence, runtime graph handle, allocator cursor, unordered mapping, P27
+bytes, GraphStateHash, and NominalWorldHash.
+
+## Executable replay session seam
+
+The legacy TickSession API and RNG V1 results remain byte-compatible.
+
+PER-60 adds a typed ReplayTickSession. Construction requires:
+
+- ReplaySessionIdV1;
+- ReplaySeed;
+- RNG layout V2;
+- ContentDigest;
+- RefDigest;
+- scenario, prelude when present, and rule content; and
+- one supported graph substrate.
+
+Construction loads PreparedRules, retains the complete stable resolver, checks
+the declared rules hash, seals fixed topology, computes exact resolver and
+register manifests, and computes PreparedEnvironmentV1. ReplayTickSession
+owns the immutable resolver-manifest, register-manifest, and prepared-
+environment bytes once. It exposes borrowed diagnostic slices and never clones
+those static preimages into a tick report.
+
+TickSession and ReplayTickSession call one internal detached-tick transaction.
+They do not duplicate the causal rule loop. A typed execution identity mode
+supplies either legacy RngSeedContext V1 with no authoritative composer or
+replay RngSeedContext V2 with the PER-60 composer. Every other preparation,
+rule, event, receipt, graph, and publication step is shared.
+
+ReplayTickSession advance accepts an OrderedPracticeActionBatchV1. Gate 3
+requires that batch to be empty and to match the replay session and next tick.
+
+One replay advance follows this order:
+
+1. Check and derive the next positive resolve tick.
+2. Validate the exact empty OrderedPracticeActionBatchV1.
+3. Encode the prior StableGraphStateV1, WorldRegisterSetV1, and StableWorldV1.
+4. Run every prepared rule against the detached graph with RNG V2.
+5. Encode result StableGraphStateV1, WorldRegisterSetV1, StableWorldV1, and
+   exact TickPayloadV1.
+6. Compose and hash TickContentHashV1.
+7. Reserve the external event sink.
+8. Publish graph, events, completed tick, legacy administrative hashes,
+   exact nested identity objects, and TickContentHash as one success.
+
+Every new PER-60 codec or report buffer uses checked size arithmetic and
+fallible reservation, and every returned identity or digest completes against
+the detached graph before external sink reservation or state publication. Any
+returned execution, resolver, topology-seal, codec-reservation, or hash error
+leaves the graph, event sink, and completed tick unchanged. Process abort,
+including allocator abort, returns no recoverable error and is outside this
+atomicity claim. The hash never publishes ahead of the state it identifies.
+
+Prior StableGraphStateV1 bytes are dropped after their digest is complete and
+before rule execution. Result stable-graph bytes are dropped after their
+digest is complete. The graph encoder exposes exact bytes to contract tests
+and explicit diagnostics, but the live report does not retain or clone either
+large preimage.
+
+The returned IdentifiedTickReportV1 carries the legacy TickReport evidence;
+exact empty action-batch bytes; exact prior and result register-set and
+stable-world bytes; exact tick-payload and outer TickContentHash preimage
+bytes; all nested versions and digests; the resolver-manifest and prepared-
+environment digests; the prior and result stable-graph digests; and
+TickContentHashV1. Static resolver, register-manifest, and prepared bytes stay
+borrowed or shared by the session and are not copied per tick. The report is
+not a durability claim.
+
+The current Bevy engine link remains on legacy TickSession until Gate 3 gives
+it authoritative seed, content, and reference identities. The new replay path
+is executable end to end through database-free Rust integration tests.
+
+## Failure rules
+
+PER-60 production code is typed encoder and composer only. ReplayTickSession
+does not hydrate any new identity object from raw bytes. PER-20 owns future
+production decoders for persisted envelopes and their nested objects.
+
+The production path returns a typed error for:
+
+- an invalid replay session string;
+- an unknown numeric seed, RNG, action, prepared-environment, stable-element,
+  resolver-manifest, stable-graph, register-manifest, register-set, world,
+  payload, or outer layout version supplied to a typed constructor;
+- replay seed conversion outside i64;
+- a declared rules hash that differs from loaded canonical rules;
+- a missing, duplicate, or dangling stable graph identity;
+- any topology difference from the sealed resolver;
+- an unresolvable event reference;
+- a non-finite numeric value;
+- a semantic string violation;
+- a non-empty runtime action batch;
+- a mismatched action session or resolve tick;
+- a non-contiguous ordinal or unrecomputed ActionId; or
+- any checked count, length, tick, or allocation overflow.
+
+The bounded Rust contract-test parser and independent Python verifier also
+refuse an unknown BSL value, type, role, evidence, effect, shape, section, or
+kind tag; a noncanonical Boolean or option byte; a truncated field; an
+out-of-order or duplicate mandatory tag; and trailing bytes. Those parsers
+prove the language-neutral schema but are not production hydration APIs.
+
+No returned failure falls back to legacy hashes, raw runtime ids, debug
+strings, JSON, or P27.
+
+## Verification contract
+
+The implementation must add one language-neutral schema and one bounded JSONL
+vector corpus. The corpus includes:
+
+- the unchanged RNG V1 four-draw vector;
+- ReplaySessionIdV1 minimum and maximum bytes plus space, control, DEL, and
+  non-ASCII refusals;
+- an asymmetric RNG V2 preimage and digest, the first nine u64 draws so the
+  vector crosses the first 64-byte block, and the first f64 bits from a fresh
+  stream;
+- ReplaySeed i64 minimum, negative one, zero, one, and maximum encodings;
+- exact binary stable-element, ASCII carrier-segment, and resolver-manifest
+  bytes and digests;
+- one asymmetric ActionId and non-empty ordered-batch codec vector;
+- the exact empty runtime action-batch bytes and digest;
+- asymmetric stable graph, register manifest, register set, stable world,
+  prepared environment, payload, and outer TickContentHash bytes and digests;
+- each BSL value, type, role, evidence, effect, shape, and vocabulary-presence
+  discriminant; and
+- one mutation row for every identity input and nested layout version.
+
+Rust contract tests and an independent Python verifier read the same vectors.
+Their raw parsers use fixed byte, row, and loop ceilings. The Rust production
+surface remains typed encoder/composer-only.
+
+End-to-end verification must prove:
+
+- two independent processes produce identical canonical bytes and digests;
+- MemoryGraph and HypergraphStore produce identical stable bytes;
+- genuinely different NodeId and HyperedgeId allocations produce identical
+  stable bytes while the legacy GraphStateHash values differ;
+- storage, map, registry, and hyperedge-member insertion order cannot move
+  canonical output where order is not semantic;
+- changing semantic rule, event, event-payload-pair, receipt, or enum-member
+  order moves the owning identity;
+- every semantic input mutation moves its owning nested digest and the outer
+  TickContentHash;
+- ReplaySeed mutation crosses ReplayTickSession, run_tick, DrawContext,
+  KernelIntrinsicHost, and a real `rng-draw`, moving the exact written f64
+  bits, result StableWorld, and TickContentHash while prepared environment,
+  prior world, and the empty batch remain fixed;
+- V2 mutations to session, tick, rule domain, subject key, nested node, edge,
+  or hyperedge key, and draw slot move the real intrinsic result bits;
+- negative zero canonicalizes, while NaN and infinity refuse;
+- a failed replay tick publishes no state, event, receipt, or hash;
+- a non-empty batch cannot enter ReplayTickSession;
+- raw action-batch bytes cannot construct the trusted batch type;
+- every count, length, aggregate-row, and canonical-byte ceiling accepts its
+  maximum and refuses maximum plus one without partial publication; and
+- every existing P27 and RNG V1 vector remains unchanged.
+
+## Ownership
+
+- babylon-kernel owns ReplaySessionIdV1, ReplaySeed, RNG layout and the exact
+  ChaCha8 algorithm, low-level seed derivation from validated domain/key bytes,
+  digest wrappers, RefDigest, and the outer TickContentHash codec.
+- babylon-practice-contract owns ActorOrganizationIdV2, ActionId derivation,
+  private ordered-action values, projection validation, and batch bytes.
+- babylon-graph owns stable element keys, carrier segments, the private final
+  StableCarrierKeyV2 builder, resolver validation and manifest,
+  StableGraphStateV1, limits, exact bytes, and hashes.
+- babylon-bsl retains scenario node and hyperedge names; owns ValueV1 and the
+  BSL type, registry, event, and receipt section codecs; and accepts the typed
+  RNG context. It alone assembles the authoritative resolved element stack and
+  passes graph-validated carrier bytes to kernel.
+- babylon-tick composes PreparedEnvironmentV1, the register manifest and set,
+  StableWorldV1, and TickPayloadV1 from owned checked sections. It owns the
+  shared transaction, ReplayTickSession, report, and atomic publication.
+- babylon-persistence may re-export kernel digest types. It does not calculate
+  an independent TickContentHash.
+
+## Explicit non-goals
+
+PER-60 does not add:
+
+- a PostgreSQL table, migration, transaction, or writer;
+- CommittedTickEnvelope, Archive outbox, hydration, or cutover;
+- a persisted action-batch decoder;
+- production raw decoders for the new PER-60 identity objects;
+- a raw-byte path that confers accepted-action provenance;
+- a campaign UUID inside physics identity;
+- player action admission or adjudication;
+- BSL intent carriers or practice effects;
+- dynamic node or hyperedge identity allocation;
+- topology tombstones, generations, journals, or stable-mint rules;
+- a Merkle tree or partial-proof protocol;
+- a second generic action model; or
+- changes to legacy GraphStateHash, NominalWorldHash, or P27 bytes.
+
+## Supersession and preservation
+
+ADR240 will record this design.
+
+It preserves the Constitution, the current RNG V1 stream, P27 vectors,
+GraphStateHash, NominalWorldHash, PracticeIntentV2, PracticeProposalKeyV2,
+ResolvedPracticeBatchV2 admission validation, ADR236 order-neutral allocation,
+and the Python-writer boundary.
+
+It partially supersedes:
+
+- the historical persistence design and implementation-plan phrases that made
+  reproduction of the complete P27 encoder a Rust writer-cutover gate;
+- the Python tick-hash module claim that babylon-kernel must produce the
+  identical P27 digest;
+- the open P27 disposition in the live determinism reference, now resolved as
+  compatibility-oracle preservation outside TickContentHashV1;
+- the Neel plan and ADR233 destination that placed campaign UUID inside
+  NominalWorldHashV2, while preserving campaign-bound input authority and
+  durable campaign identity; and
+- the ADR235 implication that ResolvedPracticeBatchV2 itself is the final
+  detached-tick action identity, while preserving its admission bytes and
+  validation role.
+
+ADR220's byte-compatible writer gate remains. ADR240 clarifies that it means
+all implementations reproduce the accepted language-neutral
+TickContentHashV1 vectors; it does not mean those bytes equal P27 JSON.
+Campaign identity remains part of persistence, checkpoint, and envelope
+identity under PER-20, not material world physics.
+
+ResolvedPracticeBatchV2 remains the validated admission source.
+OrderedPracticeActionBatchV1 is its session-scoped identity projection. In
+Gate 3, only the empty form is authoritative; future non-empty authority also
+requires the accepted-input provenance that PER-60 deliberately does not mint.
+
+<!-- vale write-good.Weasel = YES -->
+<!-- vale write-good.TooWordy = YES -->
+<!-- vale write-good.ThereIs = YES -->
+<!-- vale strunk.CommonlyMisused = YES -->
+<!-- vale strunk.ActiveVoice = YES -->
+<!-- vale ste.ThisPronoun = YES -->
+<!-- vale ste.SentenceLength = YES -->
+<!-- vale ste.Semicolon = YES -->
+<!-- vale ste.ProcedureLength = YES -->
+<!-- vale ste.PassiveVoice = YES -->
+<!-- vale ste.OneInstruction = YES -->
+<!-- vale ste.Modals = YES -->
+<!-- vale ste.LatinAbbrev = YES -->
+<!-- vale ste.Gerunds = YES -->
+<!-- vale ste.Dictionary = YES -->
+<!-- vale ste.Ambiguity = YES -->
+<!-- vale Vale.Terms = YES -->
+<!-- vale ste.NounClusters = YES -->
+<!-- vale ste.UnapprovedWords = YES -->
+<!-- vale Vale.Spelling = YES -->

--- a/rust/crates/babylon-kernel/src/lib.rs
+++ b/rust/crates/babylon-kernel/src/lib.rs
@@ -9,6 +9,7 @@ pub mod content_digest;
 pub mod currency;
 pub mod event_bus;
 pub mod grid;
+pub mod replay;
 pub mod rng;
 pub mod scalars;
 pub mod transcendental;
@@ -20,7 +21,11 @@ pub use event_bus::{
     BlockedEvent, Event, EventBus, Handler, HandlerFailure, Intercept, Interceptor,
 };
 pub use grid::{quantize, GRID_PRECISION};
-pub use rng::{seed_for, KernelRng, SEED_SALT};
+pub use replay::{
+    ReplayIdentityError, ReplaySeed, ReplaySessionIdV1, RngDomainV2, RngLayoutVersion,
+    RngSeedContext,
+};
+pub use rng::{seed_for, seed_for_v2, KernelRng, SEED_SALT};
 pub use scalars::{
     Balance, Coefficient, Ideology, Intensity, OutOfBoundsError, Probability, Ratio,
 };

--- a/rust/crates/babylon-kernel/src/replay.rs
+++ b/rust/crates/babylon-kernel/src/replay.rs
@@ -9,6 +9,9 @@ const MIN_REPLAY_SESSION_BYTES: usize = 1;
 const MAX_REPLAY_SESSION_BYTES: usize = 256;
 const MIN_RNG_DOMAIN_BYTES: usize = 1;
 const MAX_RNG_DOMAIN_BYTES: usize = 128;
+const MIN_RNG_DOMAIN_SEGMENTS: usize = 2;
+const MAX_RNG_DOMAIN_SEGMENTS: usize = 4;
+const MAX_RNG_DOMAIN_SEGMENT_BYTES: usize = 64;
 
 /// A checked replay identity failure.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,6 +35,11 @@ pub enum ReplayIdentityError {
         minimum: usize,
         /// The inclusive upper bound.
         maximum: usize,
+    },
+    /// An RNG domain did not match the governed BSL qname grammar.
+    InvalidRngDomainQname {
+        /// The zero-based byte index where validation failed.
+        index: usize,
     },
     /// A numeric layout value is not governed by this replay boundary.
     UnsupportedRngLayoutVersion {
@@ -175,6 +183,7 @@ impl TryFrom<&str> for RngDomainV2 {
             "RNG domain",
             value.as_bytes(),
         )?;
+        validate_rng_domain_qname(value.as_bytes())?;
         let mut bytes = reserve_bytes("RNG domain", value.len())?;
         bytes.extend_from_slice(value.as_bytes());
         let domain =
@@ -202,6 +211,37 @@ pub enum RngSeedContext<'a> {
         /// The explicit replay seed.
         seed: ReplaySeed,
     },
+}
+
+fn validate_rng_domain_qname(value: &[u8]) -> Result<(), ReplayIdentityError> {
+    let mut segment_count = 1usize;
+    let mut segment_length = 0usize;
+    for index in 0..MAX_RNG_DOMAIN_BYTES {
+        let Some(byte) = value.get(index).copied() else {
+            break;
+        };
+        if byte == b'/' {
+            if segment_length == 0 || segment_count == MAX_RNG_DOMAIN_SEGMENTS {
+                return Err(ReplayIdentityError::InvalidRngDomainQname { index });
+            }
+            segment_count = segment_count.saturating_add(1);
+            segment_length = 0;
+            continue;
+        }
+        let valid = if segment_length == 0 {
+            byte.is_ascii_lowercase()
+        } else {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-'
+        };
+        if !valid || segment_length == MAX_RNG_DOMAIN_SEGMENT_BYTES {
+            return Err(ReplayIdentityError::InvalidRngDomainQname { index });
+        }
+        segment_length = segment_length.saturating_add(1);
+    }
+    if segment_count < MIN_RNG_DOMAIN_SEGMENTS || segment_length == 0 {
+        return Err(ReplayIdentityError::InvalidRngDomainQname { index: value.len() });
+    }
+    Ok(())
 }
 
 fn validate_ascii_graphic<const MINIMUM: usize, const MAXIMUM: usize>(

--- a/rust/crates/babylon-kernel/src/replay.rs
+++ b/rust/crates/babylon-kernel/src/replay.rs
@@ -1,0 +1,243 @@
+//! Checked replay identity primitives and parsed RNG layout selection.
+//!
+//! These values define the database-free replay boundary. They intentionally
+//! have no conversion to campaign, persistence, or graph identities.
+use crate::clock::SessionId;
+use std::collections::TryReserveError;
+
+const MIN_REPLAY_SESSION_BYTES: usize = 1;
+const MAX_REPLAY_SESSION_BYTES: usize = 256;
+const MIN_RNG_DOMAIN_BYTES: usize = 1;
+const MAX_RNG_DOMAIN_BYTES: usize = 128;
+
+/// A checked replay identity failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplayIdentityError {
+    /// A byte was not in the strict ASCII graphic range `0x21..=0x7e`.
+    InvalidAsciiGraphic {
+        /// The validated field's stable name.
+        field: &'static str,
+        /// The offending byte's zero-based index.
+        index: usize,
+        /// The offending byte.
+        byte: u8,
+    },
+    /// A field did not meet its inclusive byte-length bounds.
+    LengthOutOfBounds {
+        /// The validated field's stable name.
+        field: &'static str,
+        /// The received byte length.
+        actual: usize,
+        /// The inclusive lower bound.
+        minimum: usize,
+        /// The inclusive upper bound.
+        maximum: usize,
+    },
+    /// A numeric layout value is not governed by this replay boundary.
+    UnsupportedRngLayoutVersion {
+        /// The unsupported numeric value.
+        value: u32,
+    },
+    /// A checked integer conversion needed for a canonical codec failed.
+    IntegerConversion {
+        /// The conversion's stable field name.
+        field: &'static str,
+        /// The value that could not be represented.
+        value: usize,
+    },
+    /// A bounded canonical allocation could not reserve its required bytes.
+    Allocation {
+        /// The allocation's stable field name.
+        field: &'static str,
+        /// The requested capacity.
+        requested: usize,
+    },
+}
+
+/// The authoritative logical replay session namespace, encoded as strict
+/// graphic ASCII and never normalized.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ReplaySessionIdV1(Vec<u8>);
+
+impl ReplaySessionIdV1 {
+    /// The exact session bytes after checked construction.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Encode this session as a big-endian `u16` byte length and exact bytes.
+    ///
+    /// # Errors
+    /// Returns [`ReplayIdentityError`] if the bounded output cannot be
+    /// allocated or its checked length could not be represented as `u16`.
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, ReplayIdentityError> {
+        let length = checked_u16("replay session length", self.0.len())?;
+        let capacity =
+            self.0
+                .len()
+                .checked_add(2)
+                .ok_or(ReplayIdentityError::IntegerConversion {
+                    field: "replay session canonical capacity",
+                    value: self.0.len(),
+                })?;
+        let mut encoded = reserve_bytes("replay session canonical bytes", capacity)?;
+        encoded.extend_from_slice(&length.to_be_bytes());
+        encoded.extend_from_slice(&self.0);
+        Ok(encoded)
+    }
+}
+
+impl TryFrom<&[u8]> for ReplaySessionIdV1 {
+    type Error = ReplayIdentityError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        validate_ascii_graphic::<MIN_REPLAY_SESSION_BYTES, MAX_REPLAY_SESSION_BYTES>(
+            "replay session",
+            value,
+        )?;
+        let mut bytes = reserve_bytes("replay session", value.len())?;
+        bytes.extend_from_slice(value);
+        Ok(Self(bytes))
+    }
+}
+
+impl TryFrom<&str> for ReplaySessionIdV1 {
+    type Error = ReplayIdentityError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_bytes())
+    }
+}
+
+/// A caller-supplied replay seed with its full signed `i64` domain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ReplaySeed(i64);
+
+impl ReplaySeed {
+    /// Wrap one explicit signed replay seed.
+    #[must_use]
+    pub const fn new(value: i64) -> Self {
+        Self(value)
+    }
+
+    /// Return the seed's canonical signed big-endian bytes.
+    #[must_use]
+    pub const fn to_be_bytes(self) -> [u8; 8] {
+        self.0.to_be_bytes()
+    }
+}
+
+/// The governed RNG layouts parsed once at the replay boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RngLayoutVersion {
+    /// The frozen legacy layout.
+    V1,
+    /// The seed-aware replay layout.
+    V2,
+}
+
+impl TryFrom<u32> for RngLayoutVersion {
+    type Error = ReplayIdentityError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::V1),
+            2 => Ok(Self::V2),
+            _ => Err(ReplayIdentityError::UnsupportedRngLayoutVersion { value }),
+        }
+    }
+}
+
+/// A checked V2 RNG domain: a strict-ASCII firing-rule qname.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RngDomainV2(String);
+
+impl RngDomainV2 {
+    /// Borrow the checked UTF-8 domain text.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Borrow the checked ASCII domain bytes for a canonical preimage.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl TryFrom<&str> for RngDomainV2 {
+    type Error = ReplayIdentityError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        validate_ascii_graphic::<MIN_RNG_DOMAIN_BYTES, MAX_RNG_DOMAIN_BYTES>(
+            "RNG domain",
+            value.as_bytes(),
+        )?;
+        let mut bytes = reserve_bytes("RNG domain", value.len())?;
+        bytes.extend_from_slice(value.as_bytes());
+        let domain =
+            String::from_utf8(bytes).map_err(|_| ReplayIdentityError::IntegerConversion {
+                field: "RNG domain UTF-8",
+                value: value.len(),
+            })?;
+        Ok(Self(domain))
+    }
+}
+
+/// The typed context that prevents replay callers from selecting an unparsed
+/// numeric RNG layout.
+#[derive(Debug, Clone, Copy)]
+pub enum RngSeedContext<'a> {
+    /// Frozen V1 derivation using its legacy session identity.
+    V1 {
+        /// The legacy session identity.
+        session: &'a SessionId,
+    },
+    /// V2 derivation using the replay session and explicit replay seed.
+    V2 {
+        /// The checked replay session identity.
+        session: &'a ReplaySessionIdV1,
+        /// The explicit replay seed.
+        seed: ReplaySeed,
+    },
+}
+
+fn validate_ascii_graphic<const MINIMUM: usize, const MAXIMUM: usize>(
+    field: &'static str,
+    value: &[u8],
+) -> Result<(), ReplayIdentityError> {
+    if value.len() < MINIMUM || value.len() > MAXIMUM {
+        return Err(ReplayIdentityError::LengthOutOfBounds {
+            field,
+            actual: value.len(),
+            minimum: MINIMUM,
+            maximum: MAXIMUM,
+        });
+    }
+    for index in 0..MAXIMUM {
+        let Some(byte) = value.get(index).copied() else {
+            break;
+        };
+        if !(0x21..=0x7e).contains(&byte) {
+            return Err(ReplayIdentityError::InvalidAsciiGraphic { field, index, byte });
+        }
+    }
+    Ok(())
+}
+
+fn checked_u16(field: &'static str, value: usize) -> Result<u16, ReplayIdentityError> {
+    u16::try_from(value).map_err(|_| ReplayIdentityError::IntegerConversion { field, value })
+}
+
+fn reserve_bytes(field: &'static str, capacity: usize) -> Result<Vec<u8>, ReplayIdentityError> {
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(capacity)
+        .map_err(|_: TryReserveError| ReplayIdentityError::Allocation {
+            field,
+            requested: capacity,
+        })?;
+    Ok(bytes)
+}

--- a/rust/crates/babylon-kernel/src/rng.rs
+++ b/rust/crates/babylon-kernel/src/rng.rs
@@ -32,6 +32,7 @@
 //! closed epoch; stochastic baselines re-bless at cutover under
 //! ensemble-envelope comparison, not byte replay.
 use crate::clock::SessionId;
+use crate::replay::{ReplayIdentityError, ReplaySeed, ReplaySessionIdV1, RngDomainV2};
 use rand_chacha::ChaCha8Rng;
 use rand_core::{Rng, SeedableRng};
 use sha2::{Digest, Sha256};
@@ -62,6 +63,52 @@ pub fn seed_for(session_id: &SessionId, tick: u64, domain: &str, stable_key: &st
     hasher.finalize().into()
 }
 
+/// Derive the V2 `ChaCha8` key from one checked replay identity and validated
+/// carrier bytes.
+///
+/// The raw carrier bytes are a low-level adapter and contract-test entry
+/// point. Graph owns the authoritative provenance and validation of that key.
+///
+/// # Errors
+/// Returns [`ReplayIdentityError`] if a carrier length cannot be represented
+/// in this version's required big-endian `u32` field.
+pub fn seed_for_v2(
+    session: &ReplaySessionIdV1,
+    seed: ReplaySeed,
+    tick: u64,
+    domain: &RngDomainV2,
+    validated_carrier_key: &[u8],
+) -> Result<[u8; 32], ReplayIdentityError> {
+    let carrier_length = u32::try_from(validated_carrier_key.len()).map_err(|_| {
+        ReplayIdentityError::IntegerConversion {
+            field: "RNG V2 carrier length",
+            value: validated_carrier_key.len(),
+        }
+    })?;
+    let domain_length = u32::try_from(domain.as_bytes().len()).map_err(|_| {
+        ReplayIdentityError::IntegerConversion {
+            field: "RNG V2 domain length",
+            value: domain.as_bytes().len(),
+        }
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(b"babylon.rng-stream\0");
+    hasher.update(2u32.to_be_bytes());
+    hasher.update([0x01]);
+    hasher.update(seed.to_be_bytes());
+    hasher.update([0x02]);
+    hasher.update(session.canonical_bytes()?);
+    hasher.update([0x03]);
+    hasher.update(tick.to_be_bytes());
+    hasher.update([0x04]);
+    hasher.update(domain_length.to_be_bytes());
+    hasher.update(domain.as_bytes());
+    hasher.update([0x05]);
+    hasher.update(carrier_length.to_be_bytes());
+    hasher.update(validated_carrier_key);
+    Ok(hasher.finalize().into())
+}
+
 /// One carrier's pinned stream. Constructed only via
 /// [`KernelRng::for_carrier`] — there is deliberately no `from_entropy()`
 /// and no tick-global constructor: every stream is a pure function of
@@ -75,6 +122,22 @@ impl KernelRng {
         Self(ChaCha8Rng::from_seed(seed_for(
             session_id, tick, domain, stable_key,
         )))
+    }
+
+    /// The V2 stream for one graph-validated carrier at one replay tick.
+    ///
+    /// # Errors
+    /// Returns [`ReplayIdentityError`] when the exact V2 key preimage cannot
+    /// encode one of its checked fields.
+    pub fn for_carrier_v2(
+        session: &ReplaySessionIdV1,
+        seed: ReplaySeed,
+        tick: u64,
+        domain: &RngDomainV2,
+        validated_carrier_key: &[u8],
+    ) -> Result<Self, ReplayIdentityError> {
+        let key = seed_for_v2(session, seed, tick, domain, validated_carrier_key)?;
+        Ok(Self(ChaCha8Rng::from_seed(key)))
     }
 
     /// The next 64 uniformly distributed bits. The stream position behind

--- a/rust/crates/babylon-kernel/tests/replay_identity.rs
+++ b/rust/crates/babylon-kernel/tests/replay_identity.rs
@@ -1,4 +1,6 @@
-use babylon_kernel::{ReplayIdentityError, ReplaySeed, ReplaySessionIdV1, RngLayoutVersion};
+use babylon_kernel::{
+    ReplayIdentityError, ReplaySeed, ReplaySessionIdV1, RngDomainV2, RngLayoutVersion,
+};
 
 fn checked_session_from_bytes(bytes: &[u8]) -> Result<ReplaySessionIdV1, ReplayIdentityError> {
     ReplaySessionIdV1::try_from(bytes)
@@ -70,5 +72,36 @@ fn rng_layout_version_accepts_only_the_two_governed_layouts() {
             RngLayoutVersion::try_from(value),
             Err(ReplayIdentityError::UnsupportedRngLayoutVersion { value: actual }) if actual == value
         ));
+    }
+}
+
+#[test]
+fn rng_domain_accepts_only_bsl_qnames_at_the_boundaries() {
+    let maximum = format!("{}/{}/c/d", "a".repeat(64), "b".repeat(59));
+
+    for valid in ["a/b", "rule-name/segment-2", maximum.as_str()] {
+        let domain = RngDomainV2::try_from(valid).unwrap();
+        assert_eq!(domain.as_str(), valid);
+    }
+}
+
+#[test]
+fn rng_domain_rejects_non_qname_grammar() {
+    let oversized_segment = format!("{}/b", "a".repeat(65));
+    let invalid = [
+        "not-a-qname",
+        "UPPER/x",
+        "1lower/x",
+        "-leading/x",
+        "not/a_qname",
+        "/a/b",
+        "a//b",
+        "a/b/",
+        "a/b/c/d/e",
+        oversized_segment.as_str(),
+    ];
+
+    for value in invalid {
+        assert!(RngDomainV2::try_from(value).is_err(), "{value}");
     }
 }

--- a/rust/crates/babylon-kernel/tests/replay_identity.rs
+++ b/rust/crates/babylon-kernel/tests/replay_identity.rs
@@ -1,0 +1,74 @@
+use babylon_kernel::{ReplayIdentityError, ReplaySeed, ReplaySessionIdV1, RngLayoutVersion};
+
+fn checked_session_from_bytes(bytes: &[u8]) -> Result<ReplaySessionIdV1, ReplayIdentityError> {
+    ReplaySessionIdV1::try_from(bytes)
+}
+
+fn checked_session_from_string(value: &str) -> Result<ReplaySessionIdV1, ReplayIdentityError> {
+    ReplaySessionIdV1::try_from(value)
+}
+
+fn seed_from_i64(value: i64) -> ReplaySeed {
+    ReplaySeed::new(value)
+}
+
+#[test]
+fn checked_constructors_accept_graphic_ascii_at_the_session_boundaries() {
+    let one = checked_session_from_bytes(b"!").unwrap();
+    let maximum = checked_session_from_string(&"~".repeat(256)).unwrap();
+
+    assert_eq!(one.as_bytes(), b"!");
+    assert_eq!(maximum.as_bytes(), "~".repeat(256).as_bytes());
+}
+
+#[test]
+fn canonical_session_bytes_prefix_the_exact_u16_big_endian_length() {
+    let session = checked_session_from_string("A9!").unwrap();
+
+    assert_eq!(session.canonical_bytes().unwrap(), b"\0\x03A9!");
+}
+
+#[test]
+fn checked_session_rejects_non_graphic_or_out_of_range_bytes() {
+    let invalid = [
+        b"".as_slice(),
+        b"has space".as_slice(),
+        b"line\nfeed".as_slice(),
+        b"del\x7f".as_slice(),
+        "non-ascii-é".as_bytes(),
+    ];
+
+    for bytes in invalid {
+        assert!(checked_session_from_bytes(bytes).is_err(), "{bytes:?}");
+    }
+
+    assert!(checked_session_from_string(&"A".repeat(257)).is_err());
+}
+
+#[test]
+fn replay_seed_uses_exact_signed_i64_big_endian_bytes() {
+    let cases = [
+        (i64::MIN, [0x80, 0, 0, 0, 0, 0, 0, 0]),
+        (-1, [0xff; 8]),
+        (0, [0; 8]),
+        (1, [0, 0, 0, 0, 0, 0, 0, 1]),
+        (i64::MAX, [0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+    ];
+
+    for (value, expected) in cases {
+        assert_eq!(seed_from_i64(value).to_be_bytes(), expected);
+    }
+}
+
+#[test]
+fn rng_layout_version_accepts_only_the_two_governed_layouts() {
+    assert_eq!(RngLayoutVersion::try_from(1), Ok(RngLayoutVersion::V1));
+    assert_eq!(RngLayoutVersion::try_from(2), Ok(RngLayoutVersion::V2));
+
+    for value in [0, 3, u32::MAX] {
+        assert!(matches!(
+            RngLayoutVersion::try_from(value),
+            Err(ReplayIdentityError::UnsupportedRngLayoutVersion { value: actual }) if actual == value
+        ));
+    }
+}

--- a/rust/crates/babylon-kernel/tests/rng_v2.rs
+++ b/rust/crates/babylon-kernel/tests/rng_v2.rs
@@ -151,6 +151,7 @@ fn draws_from_blocks(first: &[u32; 16], second: &[u32; 16]) -> [u64; 9] {
 }
 
 fn reference_chacha8_block(key: [u8; 32], counter: u64) -> [u32; 16] {
+    let counter_bytes = counter.to_le_bytes();
     let mut state = [
         0x6170_7865,
         0x3320_646e,
@@ -164,8 +165,18 @@ fn reference_chacha8_block(key: [u8; 32], counter: u64) -> [u32; 16] {
         0,
         0,
         0,
-        counter as u32,
-        (counter >> 32) as u32,
+        u32::from_le_bytes([
+            counter_bytes[0],
+            counter_bytes[1],
+            counter_bytes[2],
+            counter_bytes[3],
+        ]),
+        u32::from_le_bytes([
+            counter_bytes[4],
+            counter_bytes[5],
+            counter_bytes[6],
+            counter_bytes[7],
+        ]),
         0,
         0,
     ];

--- a/rust/crates/babylon-kernel/tests/rng_v2.rs
+++ b/rust/crates/babylon-kernel/tests/rng_v2.rs
@@ -76,7 +76,7 @@ fn v2_seed_derivation_changes_when_any_identity_component_changes() {
     let other_session = ReplaySessionIdV1::try_from("per60-replay/A9?").unwrap();
     let seed = ReplaySeed::new(VECTOR_SEED);
     let domain = RngDomainV2::try_from("vitality/per60-vector").unwrap();
-    let other_domain = RngDomainV2::try_from("vitality/per60-vectoS").unwrap();
+    let other_domain = RngDomainV2::try_from("vitality/per60-vectos").unwrap();
     let original = seed_for_v2(&session, seed, VECTOR_TICK, &domain, VECTOR_CARRIER).unwrap();
 
     assert_ne!(

--- a/rust/crates/babylon-kernel/tests/rng_v2.rs
+++ b/rust/crates/babylon-kernel/tests/rng_v2.rs
@@ -1,0 +1,212 @@
+use babylon_kernel::{
+    seed_for, seed_for_v2, KernelRng, ReplaySeed, ReplaySessionIdV1, RngDomainV2, SessionId,
+};
+use sha2::{Digest, Sha256};
+
+const VECTOR_SEED: i64 = -72_623_859_790_382_856;
+const VECTOR_TICK: u64 = 0x1020_3040_5060_7080;
+const VECTOR_CARRIER: &[u8] = b"33:4:node|12:per60/vector|8:worker-A|2:-7";
+const EXPECTED_PREIMAGE: &[u8] = b"babylon.rng-stream\0\0\0\0\x02\x01\xfe\xfd\xfc\xfb\xfa\xf9\xf8\xf8\x02\0\x10per60-replay/A9!\x03\x10\x20\x30\x40\x50\x60\x70\x80\x04\0\0\0\x15vitality/per60-vector\x05\0\0\0\x2933:4:node|12:per60/vector|8:worker-A|2:-7";
+const EXPECTED_KEY: [u8; 32] = [
+    0x4b, 0xcd, 0x7e, 0x8b, 0xe8, 0xad, 0x6a, 0x8f, 0x78, 0x00, 0xcb, 0x06, 0xf4, 0xf4, 0x7d, 0xb0,
+    0x68, 0xdd, 0x07, 0x1c, 0x32, 0xa0, 0x0f, 0x1e, 0x15, 0x82, 0xc7, 0xba, 0x57, 0xcd, 0x5b, 0x4b,
+];
+const EXPECTED_DRAWS: [u64; 9] = [
+    0xb36e_fa0f_f8a5_0391,
+    0xfaa2_9b4d_2b52_78dc,
+    0x6804_eec3_79fe_a105,
+    0xf722_17da_d23c_28b2,
+    0xc427_2e13_09ce_8ddb,
+    0xd059_b020_2b47_fa5a,
+    0x5316_07eb_b892_bac3,
+    0x92a4_48a2_3497_ea02,
+    0x73db_ed74_ddd5_0f51,
+];
+const EXPECTED_F64_BITS: u64 = 0x3fe6_6ddf_41ff_14a0;
+
+#[test]
+fn v2_preimage_key_and_stream_match_the_language_neutral_vector() {
+    let session = ReplaySessionIdV1::try_from("per60-replay/A9!").unwrap();
+    let seed = ReplaySeed::new(VECTOR_SEED);
+    let domain = RngDomainV2::try_from("vitality/per60-vector").unwrap();
+
+    let independent_preimage = [
+        b"babylon.rng-stream\0".as_slice(),
+        &2u32.to_be_bytes(),
+        &[0x01],
+        &VECTOR_SEED.to_be_bytes(),
+        &[0x02],
+        &16u16.to_be_bytes(),
+        b"per60-replay/A9!",
+        &[0x03],
+        &VECTOR_TICK.to_be_bytes(),
+        &[0x04],
+        &21u32.to_be_bytes(),
+        b"vitality/per60-vector",
+        &[0x05],
+        &41u32.to_be_bytes(),
+        VECTOR_CARRIER,
+    ]
+    .concat();
+    assert_eq!(independent_preimage, EXPECTED_PREIMAGE);
+    assert_eq!(Sha256::digest(EXPECTED_PREIMAGE).as_slice(), EXPECTED_KEY);
+    assert_eq!(
+        seed_for_v2(&session, seed, VECTOR_TICK, &domain, VECTOR_CARRIER).unwrap(),
+        EXPECTED_KEY
+    );
+
+    let first_block = reference_chacha8_block(EXPECTED_KEY, 0);
+    let second_block = reference_chacha8_block(EXPECTED_KEY, 1);
+    let reference_draws = draws_from_blocks(&first_block, &second_block);
+    assert_eq!(reference_draws, EXPECTED_DRAWS);
+
+    let mut rng =
+        KernelRng::for_carrier_v2(&session, seed, VECTOR_TICK, &domain, VECTOR_CARRIER).unwrap();
+    let actual_draws = std::array::from_fn(|_| rng.next_u64());
+    assert_eq!(actual_draws, EXPECTED_DRAWS);
+
+    let mut fresh =
+        KernelRng::for_carrier_v2(&session, seed, VECTOR_TICK, &domain, VECTOR_CARRIER).unwrap();
+    assert_eq!(fresh.next_f64().to_bits(), EXPECTED_F64_BITS);
+}
+
+#[test]
+fn v2_seed_derivation_changes_when_any_identity_component_changes() {
+    let session = ReplaySessionIdV1::try_from("per60-replay/A9!").unwrap();
+    let other_session = ReplaySessionIdV1::try_from("per60-replay/A9?").unwrap();
+    let seed = ReplaySeed::new(VECTOR_SEED);
+    let domain = RngDomainV2::try_from("vitality/per60-vector").unwrap();
+    let other_domain = RngDomainV2::try_from("vitality/per60-vectoS").unwrap();
+    let original = seed_for_v2(&session, seed, VECTOR_TICK, &domain, VECTOR_CARRIER).unwrap();
+
+    assert_ne!(
+        seed_for_v2(
+            &session,
+            ReplaySeed::new(VECTOR_SEED + 1),
+            VECTOR_TICK,
+            &domain,
+            VECTOR_CARRIER,
+        )
+        .unwrap(),
+        original
+    );
+    assert_ne!(
+        seed_for_v2(&other_session, seed, VECTOR_TICK, &domain, VECTOR_CARRIER).unwrap(),
+        original
+    );
+    assert_ne!(
+        seed_for_v2(&session, seed, VECTOR_TICK + 1, &domain, VECTOR_CARRIER).unwrap(),
+        original
+    );
+    assert_ne!(
+        seed_for_v2(&session, seed, VECTOR_TICK, &other_domain, VECTOR_CARRIER).unwrap(),
+        original
+    );
+    assert_ne!(
+        seed_for_v2(
+            &session,
+            seed,
+            VECTOR_TICK,
+            &domain,
+            b"33:4:node|12:per60/vector|8:worker-A|2:-8",
+        )
+        .unwrap(),
+        original
+    );
+}
+
+#[test]
+fn v1_conformance_vector_remains_byte_for_byte_unchanged() {
+    let session = SessionId::new("conformance").unwrap();
+    let mut rng = KernelRng::for_carrier(&session, 1, "conformance-domain", "carrier-0");
+
+    assert_eq!(
+        [
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+            rng.next_u64(),
+        ],
+        [
+            0x6774_721d_2209_092f,
+            0x6d42_2bc9_af84_28f1,
+            0x0ce2_91ab_fcb1_1e7a,
+            0xdd11_9629_7249_5117,
+        ]
+    );
+    assert_ne!(
+        seed_for(&session, 1, "conformance-domain", "carrier-0"),
+        seed_for(&session, 1, "conformance-domain", "carrier-1")
+    );
+}
+
+fn draws_from_blocks(first: &[u32; 16], second: &[u32; 16]) -> [u64; 9] {
+    let mut words = [0u32; 32];
+    words[..16].copy_from_slice(first);
+    words[16..].copy_from_slice(second);
+    std::array::from_fn(|index| {
+        let word_index = index * 2;
+        u64::from(words[word_index]) | (u64::from(words[word_index + 1]) << 32)
+    })
+}
+
+fn reference_chacha8_block(key: [u8; 32], counter: u64) -> [u32; 16] {
+    let mut state = [
+        0x6170_7865,
+        0x3320_646e,
+        0x7962_2d32,
+        0x6b20_6574,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        counter as u32,
+        (counter >> 32) as u32,
+        0,
+        0,
+    ];
+    for index in 0..8 {
+        let offset = index * 4;
+        state[index + 4] = u32::from_le_bytes([
+            key[offset],
+            key[offset + 1],
+            key[offset + 2],
+            key[offset + 3],
+        ]);
+    }
+
+    let original = state;
+    for _ in 0..4 {
+        quarter_round(&mut state, 0, 4, 8, 12);
+        quarter_round(&mut state, 1, 5, 9, 13);
+        quarter_round(&mut state, 2, 6, 10, 14);
+        quarter_round(&mut state, 3, 7, 11, 15);
+        quarter_round(&mut state, 0, 5, 10, 15);
+        quarter_round(&mut state, 1, 6, 11, 12);
+        quarter_round(&mut state, 2, 7, 8, 13);
+        quarter_round(&mut state, 3, 4, 9, 14);
+    }
+    for index in 0..16 {
+        state[index] = state[index].wrapping_add(original[index]);
+    }
+    state
+}
+
+fn quarter_round(state: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize) {
+    state[a] = state[a].wrapping_add(state[b]);
+    state[d] ^= state[a];
+    state[d] = state[d].rotate_left(16);
+    state[c] = state[c].wrapping_add(state[d]);
+    state[b] ^= state[c];
+    state[b] = state[b].rotate_left(12);
+    state[a] = state[a].wrapping_add(state[b]);
+    state[d] ^= state[a];
+    state[d] = state[d].rotate_left(8);
+    state[c] = state[c].wrapping_add(state[d]);
+    state[b] ^= state[c];
+    state[b] = state[b].rotate_left(7);
+}


### PR DESCRIPTION
## Summary

Recovers and delivers PER-60 Task 1 after the original worktree was deleted.

- adds checked ReplaySessionIdV1, ReplaySeed, RngLayoutVersion, RngDomainV2, and typed RngSeedContext primitives;
- adds the exact seed-aware RNG V2 SHA-256 preimage and ChaCha8 stream while preserving RNG V1 byte for byte;
- adds exact replay-boundary and cross-block language-neutral RNG vectors; and
- commits the complete PER-60 design and 13-task implementation plan so the remaining boundary is durable.

Remaining PER-60 work is Tasks 2 through 13: the outer tick-content digest types, Practice actor and ordered-action identity, stable graph identity, BSL identity and live RNG plumbing, replay tick composition/session, shared schema and vectors, ADR240 documentation, and final adversarial verification.

## Linear delivery

- [x] `Part of PER-60` — recovered Task-1 partial delivery. Keep the Linear issue open.

Linear issue: https://linear.app/babylon/issue/PER-60

## Review evidence

Base branch: `dev` at `b46ca72bca2df2f50551d26b940f5875c1777652`.

Exact reviewed head SHA: `40739da7728afb33b239a944ccdc8e98ab29e7bc`.

- [x] The base branch is `dev`.
- [ ] All reported GitHub checks completed successfully for the exact reviewed head SHA and base branch above.
- [ ] Copilot evidence has been reviewed at the exact head.
- [ ] No unresolved review thread remains.

Local evidence at the exact head:

- `cargo fmt --all -- --check`
- `cargo test -p babylon-kernel --test replay_identity --locked`
- `cargo test -p babylon-kernel --test rng_v2 --locked`
- `cargo test -p babylon-kernel --locked`
- `cargo clippy -p babylon-kernel --all-targets --locked -- -D warnings`
- `BLAS=1 mise run rust:check-no-docs`
- targeted Vale on both new Markdown files
- `git diff --check origin/dev...HEAD`

The canonical no-documentation Rust gate found and then verified the explicit little-endian ChaCha8 counter split in the independent test oracle. The isolated worktree environment hook was skipped only because it requires a real `.env`; no `.env` was copied. The documented ignored `data/` symlink farm was recreated and the previously infrastructure-blocked 12 Python tests passed before the final push.

## Behavioral-contract disposition

- [x] Changed behavior: durable behavioral contracts were added in `rust/crates/babylon-kernel/tests/replay_identity.rs` and `rust/crates/babylon-kernel/tests/rng_v2.rs`.

Disposition and evidence: exact V1 preservation, V2 preimage/key, nine cross-block draws, fresh-stream f64 bits, field mutations, session bounds, seed extremes, and closed layout parsing.

## Baseline disposition

- [x] No governed baseline changed.

## Merge

- [x] Merge only with `mise run pr:merge -- N`.
- [x] Preserve the source branch because later PER-60 tasks depend on this lane.

## Questions for reviewers

This PR is intentionally limited to the recovered Task-1 kernel slice. Review whether its typed API and exact vectors provide the correct foundation for Tasks 2 through 13 without widening runtime authority.