### PR TITLE
fix(persistence): prove committed tick crash boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
         run: mise run db:bootstrap
 
       - name: Rust PostgreSQL atomicity and installed-mutation contracts
-        timeout-minutes: 26
+        timeout-minutes: 28
         env:
           BABYLON_LEGACY_ADOPTER_LIVE_FOCUS: pr
         run: mise run test:rust-legacy-adopter-pg

--- a/rust/crates/babylon-persistence/src/committed_tick_writer.rs
+++ b/rust/crates/babylon-persistence/src/committed_tick_writer.rs
@@ -502,6 +502,53 @@ enum CommitAttempt {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommitTransactionStepV1 {
+    Begin,
+    PrepareTransaction,
+    EnsureCampaign,
+    LockCampaign,
+    InspectPresence,
+    RequireNextTick,
+    InsertRows { family: CommittedTickRowFamilyV1 },
+    InsertMarker,
+    Commit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommitBoundarySideV1 {
+    Before,
+    After,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CommitTransactionBoundaryV1 {
+    step: CommitTransactionStepV1,
+    side: CommitBoundarySideV1,
+}
+
+impl CommitTransactionBoundaryV1 {
+    const fn before(step: CommitTransactionStepV1) -> Self {
+        Self {
+            step,
+            side: CommitBoundarySideV1::Before,
+        }
+    }
+
+    const fn after(step: CommitTransactionStepV1) -> Self {
+        Self {
+            step,
+            side: CommitBoundarySideV1::After,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WriteTransactionOutcome {
+    Presence(StoredPresence),
+    Disconnected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CommitResolution {
     disposition: CommittedTickCommitDispositionV1,
     commit_attempts: usize,
@@ -720,16 +767,30 @@ impl CommitDriver for DatabaseCommitDriver<'_, '_, '_, '_> {
         &mut self,
         _after_attempt: usize,
     ) -> Result<StoredPresence, CommittedTickWriteErrorV1> {
-        self.session.reconnect(self.config)?;
-        require_exact_schema_epoch(self.session.client())?;
-        prepare_session(self.session.client())?;
-        match inspect_campaign(self.session.client(), self.campaign)? {
-            Some(true) => inspect_presence(self.session.client(), self.storage),
-            Some(false) => Err(CommittedTickWriteErrorV1::Conflict {
+        reconcile_after_ambiguous_commit(self.config, self.session, self.campaign, self.storage)
+    }
+}
+
+fn reconcile_after_ambiguous_commit(
+    config: &Config,
+    session: &mut LockedCommittedTickSession,
+    campaign: CampaignStorageRowV1<'_>,
+    storage: &CommittedTickStorageEnvelopeV1<'_>,
+) -> Result<StoredPresence, CommittedTickWriteErrorV1> {
+    session.reconnect(config)?;
+    require_exact_schema_epoch(session.client())?;
+    prepare_session(session.client())?;
+    match inspect_campaign(session.client(), campaign)? {
+        Some(true) => inspect_presence(session.client(), storage),
+        Some(false) => Err(CommittedTickWriteErrorV1::Conflict {
+            component: CommittedTickConflictComponentV1::CampaignIdentity,
+        }),
+        None => match inspect_presence(session.client(), storage)? {
+            StoredPresence::Absent => Ok(StoredPresence::Absent),
+            StoredPresence::Exact => Err(CommittedTickWriteErrorV1::Conflict {
                 component: CommittedTickConflictComponentV1::CampaignIdentity,
             }),
-            None => Ok(StoredPresence::Absent),
-        }
+        },
     }
 }
 
@@ -738,6 +799,22 @@ fn attempt_commit(
     campaign: CampaignStorageRowV1<'_>,
     storage: &CommittedTickStorageEnvelopeV1<'_>,
 ) -> Result<CommitAttempt, CommittedTickWriteErrorV1> {
+    attempt_commit_using(client, campaign, storage, &mut |_| false)
+}
+
+fn attempt_commit_using<Probe>(
+    client: &mut Client,
+    campaign: CampaignStorageRowV1<'_>,
+    storage: &CommittedTickStorageEnvelopeV1<'_>,
+    probe: &mut Probe,
+) -> Result<CommitAttempt, CommittedTickWriteErrorV1>
+where
+    Probe: FnMut(CommitTransactionBoundaryV1) -> bool,
+{
+    let begin_step = CommitTransactionStepV1::Begin;
+    if probe(CommitTransactionBoundaryV1::before(begin_step)) {
+        return Ok(CommitAttempt::Ambiguous);
+    }
     let mut transaction = client
         .build_transaction()
         .isolation_level(IsolationLevel::Serializable)
@@ -746,45 +823,127 @@ fn attempt_commit(
         .map_err(|error| {
             database_error(CommittedTickDatabaseOperationV1::BeginTransaction, &error)
         })?;
-    let write = write_transaction(&mut transaction, campaign, storage);
+    if probe(CommitTransactionBoundaryV1::after(begin_step)) {
+        return Ok(CommitAttempt::Ambiguous);
+    }
+    let write = write_transaction_using(&mut transaction, campaign, storage, probe);
     match write {
-        Ok(StoredPresence::Exact) => {
+        Ok(WriteTransactionOutcome::Presence(StoredPresence::Exact)) => {
             rollback(transaction)?;
             Ok(CommitAttempt::AlreadyCommitted)
         }
-        Ok(StoredPresence::Absent) => match transaction.commit() {
-            Ok(()) => Ok(CommitAttempt::Committed),
-            Err(error) if error.as_db_error().is_some() => Err(database_error(
-                CommittedTickDatabaseOperationV1::CommitTransaction,
-                &error,
-            )),
-            Err(_) => Ok(CommitAttempt::Ambiguous),
-        },
+        Ok(WriteTransactionOutcome::Presence(StoredPresence::Absent)) => {
+            let commit_step = CommitTransactionStepV1::Commit;
+            if probe(CommitTransactionBoundaryV1::before(commit_step)) {
+                return Ok(CommitAttempt::Ambiguous);
+            }
+            match transaction.commit() {
+                Ok(()) => {
+                    if probe(CommitTransactionBoundaryV1::after(commit_step)) {
+                        Ok(CommitAttempt::Ambiguous)
+                    } else {
+                        Ok(CommitAttempt::Committed)
+                    }
+                }
+                Err(error) if error.as_db_error().is_some() => Err(database_error(
+                    CommittedTickDatabaseOperationV1::CommitTransaction,
+                    &error,
+                )),
+                Err(_) => Ok(CommitAttempt::Ambiguous),
+            }
+        }
+        Ok(WriteTransactionOutcome::Disconnected) => Ok(CommitAttempt::Ambiguous),
         Err(primary) => rollback_preserving(transaction, primary),
     }
 }
 
-fn write_transaction(
+fn write_transaction_using<Probe>(
     transaction: &mut Transaction<'_>,
     campaign: CampaignStorageRowV1<'_>,
     storage: &CommittedTickStorageEnvelopeV1<'_>,
-) -> Result<StoredPresence, CommittedTickWriteErrorV1> {
+    probe: &mut Probe,
+) -> Result<WriteTransactionOutcome, CommittedTickWriteErrorV1>
+where
+    Probe: FnMut(CommitTransactionBoundaryV1) -> bool,
+{
+    let prepare_step = CommitTransactionStepV1::PrepareTransaction;
+    if probe(CommitTransactionBoundaryV1::before(prepare_step)) {
+        return Ok(WriteTransactionOutcome::Disconnected);
+    }
     prepare_transaction(transaction)?;
+    if probe(CommitTransactionBoundaryV1::after(prepare_step)) {
+        return Ok(WriteTransactionOutcome::Disconnected);
+    }
+
+    let campaign_step = CommitTransactionStepV1::EnsureCampaign;
+    if probe(CommitTransactionBoundaryV1::before(campaign_step)) {
+        return Ok(WriteTransactionOutcome::Disconnected);
+    }
     ensure_campaign(transaction, campaign)?;
+    if probe(CommitTransactionBoundaryV1::after(campaign_step)) {
+        return Ok(WriteTransactionOutcome::Disconnected);
+    }
+
     let campaign_text = campaign.campaign_id().as_uuid().to_string();
+    let lock_step = CommitTransactionStepV1::LockCampaign;
+    if probe(CommitTransactionBoundaryV1::before(lock_step)) {
+        return Ok(WriteTransactionOutcome::Disconnected);
+    }
     transaction
         .query_one(LOCK_CAMPAIGN_SQL, &[&campaign_text])
         .map_err(|error| database_error(CommittedTickDatabaseOperationV1::ReadCampaign, &error))?;
+    if probe(CommitTransactionBoundaryV1::after(lock_step)) {
+        return Ok(WriteTransactionOutcome::Disconnected);
+    }
+
+    let presence_step = CommitTransactionStepV1::InspectPresence;
+    if probe(CommitTransactionBoundaryV1::before(presence_step)) {
+        return Ok(WriteTransactionOutcome::Disconnected);
+    }
     match inspect_presence(transaction, storage)? {
-        StoredPresence::Exact => return Ok(StoredPresence::Exact),
+        StoredPresence::Exact => {
+            if probe(CommitTransactionBoundaryV1::after(presence_step)) {
+                return Ok(WriteTransactionOutcome::Disconnected);
+            }
+            return Ok(WriteTransactionOutcome::Presence(StoredPresence::Exact));
+        }
         StoredPresence::Absent => {}
     }
+    if probe(CommitTransactionBoundaryV1::after(presence_step)) {
+        return Ok(WriteTransactionOutcome::Disconnected);
+    }
+
+    let sequence_step = CommitTransactionStepV1::RequireNextTick;
+    if probe(CommitTransactionBoundaryV1::before(sequence_step)) {
+        return Ok(WriteTransactionOutcome::Disconnected);
+    }
     require_next_tick(transaction, storage)?;
+    if probe(CommitTransactionBoundaryV1::after(sequence_step)) {
+        return Ok(WriteTransactionOutcome::Disconnected);
+    }
+
     for batch in storage.batches() {
+        let insert_step = CommitTransactionStepV1::InsertRows {
+            family: batch.target().family(),
+        };
+        if probe(CommitTransactionBoundaryV1::before(insert_step)) {
+            return Ok(WriteTransactionOutcome::Disconnected);
+        }
         insert_batch(transaction, batch)?;
+        if probe(CommitTransactionBoundaryV1::after(insert_step)) {
+            return Ok(WriteTransactionOutcome::Disconnected);
+        }
+    }
+
+    let marker_step = CommitTransactionStepV1::InsertMarker;
+    if probe(CommitTransactionBoundaryV1::before(marker_step)) {
+        return Ok(WriteTransactionOutcome::Disconnected);
     }
     insert_marker(transaction, storage)?;
-    Ok(StoredPresence::Absent)
+    if probe(CommitTransactionBoundaryV1::after(marker_step)) {
+        return Ok(WriteTransactionOutcome::Disconnected);
+    }
+    Ok(WriteTransactionOutcome::Presence(StoredPresence::Absent))
 }
 
 fn require_exact_schema_epoch(client: &mut Client) -> Result<(), CommittedTickWriteErrorV1> {
@@ -1653,6 +1812,198 @@ mod tests {
         ));
     }
 
+    #[test]
+    #[ignore = "requires the owned disposable PER-20 PostgreSQL harness"]
+    fn live_crash_boundary_matrix_is_atomic_and_retryable() {
+        require_owned_disposable_harness();
+        let base = Config::from_str(
+            &std::env::var("BABYLON_LEGACY_ADOPTER_TEST_DSN").expect("owned harness DSN"),
+        )
+        .expect("valid owned harness DSN");
+        let scratch = WriterScratchDatabase::create(&base);
+        migrate_schema_epoch(&scratch.config).expect("fresh exact Rust schema epoch");
+        install_writer_reference_fixture(&scratch.config);
+
+        for (index, boundary) in committed_tick_crash_boundaries_v1().into_iter().enumerate() {
+            prove_crash_boundary_is_atomic(&scratch, index, boundary);
+        }
+    }
+
+    fn committed_tick_crash_boundaries_v1() -> Vec<CommitTransactionBoundaryV1> {
+        let mut steps = vec![
+            CommitTransactionStepV1::Begin,
+            CommitTransactionStepV1::PrepareTransaction,
+            CommitTransactionStepV1::EnsureCampaign,
+            CommitTransactionStepV1::LockCampaign,
+            CommitTransactionStepV1::InspectPresence,
+            CommitTransactionStepV1::RequireNextTick,
+        ];
+        steps.extend(
+            crate::committed_tick_envelope::ALL_COMMITTED_TICK_ROW_FAMILIES_V1
+                .map(|family| CommitTransactionStepV1::InsertRows { family }),
+        );
+        steps.extend([
+            CommitTransactionStepV1::InsertMarker,
+            CommitTransactionStepV1::Commit,
+        ]);
+
+        let mut boundaries = Vec::with_capacity(steps.len() * 2);
+        for step in steps {
+            boundaries.push(CommitTransactionBoundaryV1::before(step));
+            boundaries.push(CommitTransactionBoundaryV1::after(step));
+        }
+        assert_eq!(boundaries.len(), 32, "V1 crash matrix must stay exhaustive");
+        boundaries
+    }
+
+    fn prove_crash_boundary_is_atomic(
+        scratch: &WriterScratchDatabase,
+        index: usize,
+        boundary: CommitTransactionBoundaryV1,
+    ) {
+        let campaign_id = CampaignId::from_uuid(Uuid::from_u128(
+            0x3011_2233_4455_6677_8899_aabb_ccdd_0000
+                + u128::try_from(index).expect("bounded crash-matrix index"),
+        ));
+        let replay_session = ReplaySessionIdV1::try_from(format!("per20-crash-{index}").as_str())
+            .expect("valid crash-matrix replay session");
+        let content = ContentDigest {
+            defines_hash: [0x71; 32],
+            rules_hash: [0x82; 32],
+        };
+        let campaign = CampaignStorageRowV1::new(
+            campaign_id,
+            &replay_session,
+            ReplaySeed::new(-72),
+            &content,
+            RefDigestV1::from_bytes([0x53; 32]),
+        );
+        let index_byte = u8::try_from(index).expect("V1 crash matrix fits one byte");
+        let envelope = live_envelope(
+            campaign_id,
+            0,
+            0x60_u8.wrapping_add(index_byte),
+            0xd0_u8.wrapping_add(index_byte),
+            true,
+        );
+        let storage =
+            CommittedTickStorageEnvelopeV1::try_from(&envelope).expect("mapped crash envelope");
+
+        let proof = commit_through_crash_boundary_test_seam(
+            &scratch.config,
+            &scratch.base,
+            campaign,
+            &envelope,
+            boundary,
+        )
+        .unwrap_or_else(|error| panic!("crash boundary {boundary:?} failed: {error:?}"));
+        let committed_response_lost =
+            boundary == CommitTransactionBoundaryV1::after(CommitTransactionStepV1::Commit);
+        assert_eq!(
+            proof.observed_after_crash,
+            if committed_response_lost {
+                StoredPresence::Exact
+            } else {
+                StoredPresence::Absent
+            },
+            "unexpected restart state after {boundary:?}"
+        );
+        assert_eq!(proof.campaign_present_after_crash, committed_response_lost);
+        assert_eq!(
+            proof.report.disposition(),
+            if committed_response_lost {
+                CommittedTickCommitDispositionV1::ReconciledAfterAmbiguousCommit
+            } else {
+                CommittedTickCommitDispositionV1::Committed
+            }
+        );
+        assert_eq!(
+            proof.report.commit_attempts(),
+            if committed_response_lost { 1 } else { 2 }
+        );
+
+        let mut verifier = scratch.config.connect(NoTls).expect("matrix verifier");
+        assert_eq!(
+            inspect_campaign(&mut verifier, campaign).unwrap(),
+            Some(true)
+        );
+        assert_eq!(
+            inspect_presence(&mut verifier, &storage).unwrap(),
+            StoredPresence::Exact
+        );
+    }
+
+    struct CrashBoundaryProofV1 {
+        report: CommittedTickCommitReportV1,
+        observed_after_crash: StoredPresence,
+        campaign_present_after_crash: bool,
+    }
+
+    fn commit_through_crash_boundary_test_seam(
+        config: &Config,
+        admin: &Config,
+        campaign: CampaignStorageRowV1<'_>,
+        envelope: &CommittedTickEnvelopeV1,
+        target: CommitTransactionBoundaryV1,
+    ) -> Result<CrashBoundaryProofV1, CommittedTickWriteErrorV1> {
+        validate_legacy_connection_target(config)
+            .map_err(CommittedTickWriteErrorV1::ConnectionTarget)?;
+        let storage = CommittedTickStorageEnvelopeV1::try_from(envelope)
+            .map_err(CommittedTickWriteErrorV1::StorageMapping)?;
+        let bounded = bounded_config(config);
+        let mut session = LockedCommittedTickSession::connect(&bounded)?;
+        require_exact_schema_epoch(session.client())?;
+        prepare_session(session.client())?;
+        let initial = match inspect_campaign(session.client(), campaign)? {
+            Some(false) => {
+                return Err(CommittedTickWriteErrorV1::Conflict {
+                    component: CommittedTickConflictComponentV1::CampaignIdentity,
+                });
+            }
+            Some(true) => inspect_presence(session.client(), &storage)?,
+            None => StoredPresence::Absent,
+        };
+        let (resolution, injected, observed_after_crash, campaign_present_after_crash) = {
+            let mut driver = CrashBoundaryCommitDriver {
+                admin,
+                config: &bounded,
+                session: &mut session,
+                campaign,
+                storage: &storage,
+                target,
+                injected: false,
+                observed_after_crash: None,
+                campaign_present_after_crash: None,
+            };
+            let resolution = drive_commit(initial, &mut driver);
+            (
+                resolution,
+                driver.injected,
+                driver.observed_after_crash,
+                driver.campaign_present_after_crash,
+            )
+        };
+        let result = resolution.map(|resolution| {
+            assert!(
+                injected,
+                "target crash boundary was not reached: {target:?}"
+            );
+            CrashBoundaryProofV1 {
+                report: CommittedTickCommitReportV1 {
+                    disposition: resolution.disposition,
+                    resolve_tick: u64::try_from(storage.marker().resolve_tick())
+                        .expect("storage mapping checked non-negative u64 tick"),
+                    commit_attempts: resolution.commit_attempts,
+                },
+                observed_after_crash: observed_after_crash
+                    .expect("injected ambiguity must be reconciled"),
+                campaign_present_after_crash: campaign_present_after_crash
+                    .expect("injected ambiguity must observe campaign presence"),
+            }
+        });
+        session.finish(result)
+    }
+
     fn assert_checkpoint_only_hydration(
         config: &Config,
         campaign_id: CampaignId,
@@ -1952,6 +2303,91 @@ mod tests {
                 .batch_execute(&format!("DROP DATABASE \"{}\"", self.name))
                 .expect("drop writer scratch database");
         }
+    }
+
+    struct CrashBoundaryCommitDriver<'admin, 'config, 'session, 'campaign, 'storage> {
+        admin: &'admin Config,
+        config: &'config Config,
+        session: &'session mut LockedCommittedTickSession,
+        campaign: CampaignStorageRowV1<'campaign>,
+        storage: &'storage CommittedTickStorageEnvelopeV1<'storage>,
+        target: CommitTransactionBoundaryV1,
+        injected: bool,
+        observed_after_crash: Option<StoredPresence>,
+        campaign_present_after_crash: Option<bool>,
+    }
+
+    impl CommitDriver for CrashBoundaryCommitDriver<'_, '_, '_, '_, '_> {
+        fn attempt_commit(
+            &mut self,
+            _attempt: usize,
+        ) -> Result<CommitAttempt, CommittedTickWriteErrorV1> {
+            let pid = backend_pid(self.session.client());
+            let eligible = !self.injected;
+            let target = self.target;
+            let admin = self.admin;
+            let mut injected_now = false;
+            let mut probe = |boundary| {
+                if eligible && boundary == target {
+                    terminate_backend(admin, pid);
+                    injected_now = true;
+                    true
+                } else {
+                    false
+                }
+            };
+            let result = attempt_commit_using(
+                self.session.client(),
+                self.campaign,
+                self.storage,
+                &mut probe,
+            );
+            self.injected |= injected_now;
+            result
+        }
+
+        fn reconcile(
+            &mut self,
+            _after_attempt: usize,
+        ) -> Result<StoredPresence, CommittedTickWriteErrorV1> {
+            let presence = reconcile_after_ambiguous_commit(
+                self.config,
+                self.session,
+                self.campaign,
+                self.storage,
+            )?;
+            self.observed_after_crash = Some(presence);
+            self.campaign_present_after_crash = Some(
+                inspect_campaign(self.session.client(), self.campaign)?.is_some_and(|exact| exact),
+            );
+            Ok(presence)
+        }
+    }
+
+    fn backend_pid(client: &mut Client) -> i32 {
+        client
+            .query_one("SELECT pg_catalog.pg_backend_pid()", &[])
+            .expect("writer backend pid")
+            .try_get(0)
+            .expect("integer writer backend pid")
+    }
+
+    fn terminate_backend(admin: &Config, pid: i32) {
+        const TERMINATION_TIMEOUT_MILLIS: i64 = 5_000;
+        let terminated: bool = admin
+            .connect(NoTls)
+            .expect("crash injector connection")
+            .query_one(
+                "SELECT pg_catalog.pg_terminate_backend($1, $2)",
+                &[&pid, &TERMINATION_TIMEOUT_MILLIS],
+            )
+            .expect("terminate writer backend")
+            .try_get(0)
+            .expect("boolean backend termination result");
+        assert!(
+            terminated,
+            "writer backend must terminate at the target boundary"
+        );
     }
 
     struct ScriptedCommitDriver {

--- a/rust/crates/babylon-persistence/src/committed_tick_writer.rs
+++ b/rust/crates/babylon-persistence/src/committed_tick_writer.rs
@@ -543,12 +543,6 @@ impl CommitTransactionBoundaryV1 {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WriteTransactionOutcome {
-    Presence(StoredPresence),
-    Disconnected,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CommitResolution {
     disposition: CommittedTickCommitDispositionV1,
     commit_attempts: usize,
@@ -799,7 +793,7 @@ fn attempt_commit(
     campaign: CampaignStorageRowV1<'_>,
     storage: &CommittedTickStorageEnvelopeV1<'_>,
 ) -> Result<CommitAttempt, CommittedTickWriteErrorV1> {
-    attempt_commit_using(client, campaign, storage, &mut |_| false)
+    attempt_commit_using(client, campaign, storage, &mut |_| {})
 }
 
 fn attempt_commit_using<Probe>(
@@ -809,51 +803,69 @@ fn attempt_commit_using<Probe>(
     probe: &mut Probe,
 ) -> Result<CommitAttempt, CommittedTickWriteErrorV1>
 where
-    Probe: FnMut(CommitTransactionBoundaryV1) -> bool,
+    Probe: FnMut(CommitTransactionBoundaryV1),
 {
     let begin_step = CommitTransactionStepV1::Begin;
-    if probe(CommitTransactionBoundaryV1::before(begin_step)) {
-        return Ok(CommitAttempt::Ambiguous);
-    }
-    let mut transaction = client
+    probe(CommitTransactionBoundaryV1::before(begin_step));
+    let mut transaction = match client
         .build_transaction()
         .isolation_level(IsolationLevel::Serializable)
         .read_only(false)
         .start()
-        .map_err(|error| {
-            database_error(CommittedTickDatabaseOperationV1::BeginTransaction, &error)
-        })?;
-    if probe(CommitTransactionBoundaryV1::after(begin_step)) {
-        return Ok(CommitAttempt::Ambiguous);
-    }
+    {
+        Ok(transaction) => transaction,
+        Err(error) if postgres_error_is_connection_loss(&error) => {
+            return Ok(CommitAttempt::Ambiguous);
+        }
+        Err(error) => {
+            return Err(database_error(
+                CommittedTickDatabaseOperationV1::BeginTransaction,
+                &error,
+            ));
+        }
+    };
+    probe(CommitTransactionBoundaryV1::after(begin_step));
     let write = write_transaction_using(&mut transaction, campaign, storage, probe);
     match write {
-        Ok(WriteTransactionOutcome::Presence(StoredPresence::Exact)) => {
+        Ok(StoredPresence::Exact) => {
             rollback(transaction)?;
             Ok(CommitAttempt::AlreadyCommitted)
         }
-        Ok(WriteTransactionOutcome::Presence(StoredPresence::Absent)) => {
+        Ok(StoredPresence::Absent) => {
             let commit_step = CommitTransactionStepV1::Commit;
-            if probe(CommitTransactionBoundaryV1::before(commit_step)) {
-                return Ok(CommitAttempt::Ambiguous);
-            }
+            probe(CommitTransactionBoundaryV1::before(commit_step));
             match transaction.commit() {
                 Ok(()) => {
-                    if probe(CommitTransactionBoundaryV1::after(commit_step)) {
-                        Ok(CommitAttempt::Ambiguous)
-                    } else {
-                        Ok(CommitAttempt::Committed)
+                    probe(CommitTransactionBoundaryV1::after(commit_step));
+                    match client.simple_query("SELECT 1") {
+                        Ok(_) => Ok(CommitAttempt::Committed),
+                        Err(error) if postgres_error_is_connection_loss(&error) => {
+                            Ok(CommitAttempt::Ambiguous)
+                        }
+                        Err(error) => Err(database_error(
+                            CommittedTickDatabaseOperationV1::CommitTransaction,
+                            &error,
+                        )),
                     }
                 }
-                Err(error) if error.as_db_error().is_some() => Err(database_error(
+                Err(error) if postgres_error_is_connection_loss(&error) => {
+                    Ok(CommitAttempt::Ambiguous)
+                }
+                Err(error) => Err(database_error(
                     CommittedTickDatabaseOperationV1::CommitTransaction,
                     &error,
                 )),
-                Err(_) => Ok(CommitAttempt::Ambiguous),
             }
         }
-        Ok(WriteTransactionOutcome::Disconnected) => Ok(CommitAttempt::Ambiguous),
-        Err(primary) => rollback_preserving(transaction, primary),
+        Err(primary) => {
+            let failure = rollback_preserving(transaction, primary);
+            match failure {
+                Err(error) if is_connection_loss_transaction_failure(&error) => {
+                    Ok(CommitAttempt::Ambiguous)
+                }
+                other => other,
+            }
+        }
     }
 }
 
@@ -862,88 +874,58 @@ fn write_transaction_using<Probe>(
     campaign: CampaignStorageRowV1<'_>,
     storage: &CommittedTickStorageEnvelopeV1<'_>,
     probe: &mut Probe,
-) -> Result<WriteTransactionOutcome, CommittedTickWriteErrorV1>
+) -> Result<StoredPresence, CommittedTickWriteErrorV1>
 where
-    Probe: FnMut(CommitTransactionBoundaryV1) -> bool,
+    Probe: FnMut(CommitTransactionBoundaryV1),
 {
     let prepare_step = CommitTransactionStepV1::PrepareTransaction;
-    if probe(CommitTransactionBoundaryV1::before(prepare_step)) {
-        return Ok(WriteTransactionOutcome::Disconnected);
-    }
+    probe(CommitTransactionBoundaryV1::before(prepare_step));
     prepare_transaction(transaction)?;
-    if probe(CommitTransactionBoundaryV1::after(prepare_step)) {
-        return Ok(WriteTransactionOutcome::Disconnected);
-    }
+    probe(CommitTransactionBoundaryV1::after(prepare_step));
 
     let campaign_step = CommitTransactionStepV1::EnsureCampaign;
-    if probe(CommitTransactionBoundaryV1::before(campaign_step)) {
-        return Ok(WriteTransactionOutcome::Disconnected);
-    }
+    probe(CommitTransactionBoundaryV1::before(campaign_step));
     ensure_campaign(transaction, campaign)?;
-    if probe(CommitTransactionBoundaryV1::after(campaign_step)) {
-        return Ok(WriteTransactionOutcome::Disconnected);
-    }
+    probe(CommitTransactionBoundaryV1::after(campaign_step));
 
     let campaign_text = campaign.campaign_id().as_uuid().to_string();
     let lock_step = CommitTransactionStepV1::LockCampaign;
-    if probe(CommitTransactionBoundaryV1::before(lock_step)) {
-        return Ok(WriteTransactionOutcome::Disconnected);
-    }
+    probe(CommitTransactionBoundaryV1::before(lock_step));
     transaction
         .query_one(LOCK_CAMPAIGN_SQL, &[&campaign_text])
         .map_err(|error| database_error(CommittedTickDatabaseOperationV1::ReadCampaign, &error))?;
-    if probe(CommitTransactionBoundaryV1::after(lock_step)) {
-        return Ok(WriteTransactionOutcome::Disconnected);
-    }
+    probe(CommitTransactionBoundaryV1::after(lock_step));
 
     let presence_step = CommitTransactionStepV1::InspectPresence;
-    if probe(CommitTransactionBoundaryV1::before(presence_step)) {
-        return Ok(WriteTransactionOutcome::Disconnected);
-    }
+    probe(CommitTransactionBoundaryV1::before(presence_step));
     match inspect_presence(transaction, storage)? {
         StoredPresence::Exact => {
-            if probe(CommitTransactionBoundaryV1::after(presence_step)) {
-                return Ok(WriteTransactionOutcome::Disconnected);
-            }
-            return Ok(WriteTransactionOutcome::Presence(StoredPresence::Exact));
+            probe(CommitTransactionBoundaryV1::after(presence_step));
+            return Ok(StoredPresence::Exact);
         }
         StoredPresence::Absent => {}
     }
-    if probe(CommitTransactionBoundaryV1::after(presence_step)) {
-        return Ok(WriteTransactionOutcome::Disconnected);
-    }
+    probe(CommitTransactionBoundaryV1::after(presence_step));
 
     let sequence_step = CommitTransactionStepV1::RequireNextTick;
-    if probe(CommitTransactionBoundaryV1::before(sequence_step)) {
-        return Ok(WriteTransactionOutcome::Disconnected);
-    }
+    probe(CommitTransactionBoundaryV1::before(sequence_step));
     require_next_tick(transaction, storage)?;
-    if probe(CommitTransactionBoundaryV1::after(sequence_step)) {
-        return Ok(WriteTransactionOutcome::Disconnected);
-    }
+    probe(CommitTransactionBoundaryV1::after(sequence_step));
 
     for batch in storage.batches() {
         let insert_step = CommitTransactionStepV1::InsertRows {
             family: batch.target().family(),
         };
-        if probe(CommitTransactionBoundaryV1::before(insert_step)) {
-            return Ok(WriteTransactionOutcome::Disconnected);
-        }
+        probe(CommitTransactionBoundaryV1::before(insert_step));
         insert_batch(transaction, batch)?;
-        if probe(CommitTransactionBoundaryV1::after(insert_step)) {
-            return Ok(WriteTransactionOutcome::Disconnected);
-        }
+        probe(CommitTransactionBoundaryV1::after(insert_step));
     }
 
     let marker_step = CommitTransactionStepV1::InsertMarker;
-    if probe(CommitTransactionBoundaryV1::before(marker_step)) {
-        return Ok(WriteTransactionOutcome::Disconnected);
-    }
+    probe(CommitTransactionBoundaryV1::before(marker_step));
     insert_marker(transaction, storage)?;
-    if probe(CommitTransactionBoundaryV1::after(marker_step)) {
-        return Ok(WriteTransactionOutcome::Disconnected);
-    }
-    Ok(WriteTransactionOutcome::Presence(StoredPresence::Absent))
+    probe(CommitTransactionBoundaryV1::after(marker_step));
+    Ok(StoredPresence::Absent)
 }
 
 fn require_exact_schema_epoch(client: &mut Client) -> Result<(), CommittedTickWriteErrorV1> {
@@ -1588,6 +1570,28 @@ fn rollback_preserving<T>(
     }
 }
 
+fn postgres_error_is_connection_loss(error: &postgres::Error) -> bool {
+    error
+        .as_db_error()
+        .is_none_or(|server| sqlstate_is_connection_loss(server.code().code()))
+}
+
+fn sqlstate_is_connection_loss(code: &str) -> bool {
+    code.starts_with("08") || matches!(code, "57P01" | "57P02" | "57P03")
+}
+
+fn is_connection_loss_transaction_failure(error: &CommittedTickWriteErrorV1) -> bool {
+    match error {
+        CommittedTickWriteErrorV1::Database { diagnostic, .. } => diagnostic
+            .server()
+            .is_none_or(|server| sqlstate_is_connection_loss(server.code().code())),
+        CommittedTickWriteErrorV1::FailureAndRollback { primary, .. } => {
+            is_connection_loss_transaction_failure(primary)
+        }
+        _ => false,
+    }
+}
+
 fn decode<T: postgres::types::FromSqlOwned>(
     row: &Row,
     index: usize,
@@ -1697,6 +1701,35 @@ mod tests {
         ));
         assert_eq!(unresolved.attempt_index, 2);
         assert_eq!(unresolved.reconciliation_index, 2);
+    }
+
+    #[test]
+    fn connection_loss_failures_require_ambiguity_reconciliation() {
+        assert!(sqlstate_is_connection_loss("08006"));
+        assert!(sqlstate_is_connection_loss("57P01"));
+        assert!(!sqlstate_is_connection_loss("23505"));
+
+        let transport = CommittedTickWriteErrorV1::Database {
+            operation: CommittedTickDatabaseOperationV1::InsertMarker,
+            diagnostic: CommittedTickDatabaseDiagnosticV1 { server: None },
+        };
+        assert!(is_connection_loss_transaction_failure(&transport));
+
+        let wrapped = CommittedTickWriteErrorV1::FailureAndRollback {
+            primary: Box::new(transport),
+            rollback: Box::new(CommittedTickWriteErrorV1::Database {
+                operation: CommittedTickDatabaseOperationV1::RollbackTransaction,
+                diagnostic: CommittedTickDatabaseDiagnosticV1 { server: None },
+            }),
+        };
+        assert!(is_connection_loss_transaction_failure(&wrapped));
+
+        assert!(!is_connection_loss_transaction_failure(
+            &CommittedTickWriteErrorV1::TickSequence {
+                last_committed: Some(3),
+                requested: 5,
+            }
+        ));
     }
 
     #[test]
@@ -2331,9 +2364,6 @@ mod tests {
                 if eligible && boundary == target {
                     terminate_backend(admin, pid);
                     injected_now = true;
-                    true
-                } else {
-                    false
                 }
             };
             let result = attempt_commit_using(

--- a/rust/crates/babylon-persistence/src/writer_gate.rs
+++ b/rust/crates/babylon-persistence/src/writer_gate.rs
@@ -2,12 +2,17 @@
 
 /// Capability required by any future authoritative Rust tick writer.
 ///
-/// Its field is private, and this module provides no successful construction
-/// path while Python retains live writer authority.
+/// This type is structurally uninhabited while Python retains live writer
+/// authority. The crate's safe-code prohibition means no trait implementation,
+/// descendant module, or alternate function can forge a value.
+///
+/// ```compile_fail
+/// use babylon_persistence::RustWriterAuthority;
+///
+/// let _authority = RustWriterAuthority {};
+/// ```
 #[derive(Debug)]
-pub struct RustWriterAuthority {
-    _private: (),
-}
+pub enum RustWriterAuthority {}
 
 /// Exact reason Rust writer authority cannot currently be acquired.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
+++ b/rust/crates/babylon-persistence/tests/legacy_adopter_contract.rs
@@ -2042,7 +2042,7 @@ fn live_adopter_tests_are_split_between_pr_and_weekly_cadences() {
         1
     );
     assert!(pr_job.contains(
-        "- name: Rust PostgreSQL atomicity and installed-mutation contracts\n        timeout-minutes: 26\n        env:\n          BABYLON_LEGACY_ADOPTER_LIVE_FOCUS: pr\n        run: mise run test:rust-legacy-adopter-pg"
+        "- name: Rust PostgreSQL atomicity and installed-mutation contracts\n        timeout-minutes: 28\n        env:\n          BABYLON_LEGACY_ADOPTER_LIVE_FOCUS: pr\n        run: mise run test:rust-legacy-adopter-pg"
     ));
     assert!(!pr_job.contains("BABYLON_LEGACY_ADOPTER_TEST_DSN"));
     assert!(!pr_job.contains("cargo doc"));
@@ -2068,6 +2068,7 @@ fn pr_focus_reuses_the_postgres_atomicity_and_installed_mutation_contracts() {
     let runner = include_str!("../../../../tools/run_rust_legacy_adopter_pg.sh");
     let live = include_str!("legacy_adopter_postgres.rs");
     let installer = include_str!("support/h3_reference_installer_postgres.rs");
+    let writer = include_str!("../src/committed_tick_writer.rs");
     let focused =
         "schema_epoch::live_rollback_tests::h3_installer_rollback_and_ambiguous_commit_reconciliation_are_atomic";
     let full =
@@ -2082,10 +2083,16 @@ fn pr_focus_reuses_the_postgres_atomicity_and_installed_mutation_contracts() {
     assert!(runner.contains("[ \"$LIVE_FOCUS\" = \"committed_tick_writer\" ]"));
     assert_eq!(
         runner
-            .matches("committed_tick_writer::tests::live_marker_last_commit_retry_conflict_and_hydration_are_atomic")
+            .matches("committed_tick_writer::tests::live_")
             .count(),
         1
     );
+    for live_test in [
+        "fn live_marker_last_commit_retry_conflict_and_hydration_are_atomic()",
+        "fn live_crash_boundary_matrix_is_atomic_and_retryable()",
+    ] {
+        assert_eq!(writer.matches(live_test).count(), 1);
+    }
     assert!(live.contains("Some(\"h3_pg_oracle\")"));
     assert!(live.contains("Some(\"h3_reference_installer\")"));
     assert_eq!(runner.matches(focused).count(), 1);
@@ -2202,7 +2209,7 @@ fn ci_step_exceeds_the_focused_runner_envelope() {
     const BUILD_ENVELOPE_SECONDS: u64 = 180 + 10;
     const START_ENVELOPE_SECONDS: u64 = 30 + 5;
     const READINESS_ENVELOPE_SECONDS: u64 = 90 + 2;
-    const FOCUSED_CARGO_ENVELOPE_SECONDS: u64 = 3 * (300 + 10);
+    const FOCUSED_CARGO_ENVELOPE_SECONDS: u64 = 2 * (300 + 10) + (420 + 10);
     const CLEANUP_ENVELOPE_SECONDS: u64 = 35 + 12 + 12 + 35;
     const FOCUSED_RUNNER_ENVELOPE_SECONDS: u64 = CONTROL_PLANE_ENVELOPE_SECONDS
         + BUILD_ENVELOPE_SECONDS
@@ -2214,7 +2221,7 @@ fn ci_step_exceeds_the_focused_runner_envelope() {
     let pr_workflow = include_str!("../../../../.github/workflows/ci.yml");
     let pr_job = yaml_job(pr_workflow, "  pg-integration:");
     assert!(pr_job.contains(
-        "- name: Rust PostgreSQL atomicity and installed-mutation contracts\n        timeout-minutes: 26"
+        "- name: Rust PostgreSQL atomicity and installed-mutation contracts\n        timeout-minutes: 28"
     ));
     let pr_job_seconds = pr_job
         .lines()
@@ -2238,7 +2245,7 @@ fn ci_step_exceeds_the_focused_runner_envelope() {
         .unwrap()
         * 60;
     assert_eq!(pr_job_seconds, 61 * 60);
-    assert_eq!(pr_step_seconds, 26 * 60);
+    assert_eq!(pr_step_seconds, 28 * 60);
     assert!(pr_step_seconds >= FOCUSED_RUNNER_ENVELOPE_SECONDS + 120);
     assert!(pr_job_seconds >= pr_step_seconds + 30 * 60);
 }

--- a/rust/crates/babylon-persistence/tests/writer_gate.rs
+++ b/rust/crates/babylon-persistence/tests/writer_gate.rs
@@ -57,14 +57,19 @@ fn source_exposes_no_alternate_activation_channel() {
             "writer authority source must not expose forbidden activation token {token:?}"
         );
     }
-    assert!(source.contains("pub struct RustWriterAuthority"));
-    assert!(source.contains("_private: ()"));
-    assert!(!source.contains("pub _private"));
-    assert!(!source.contains("pub(crate) _private"));
+    assert!(source.contains("pub enum RustWriterAuthority {}"));
+    assert!(!source.contains("pub struct RustWriterAuthority"));
 }
 
 #[test]
 fn production_tree_has_exactly_one_closed_authority_definition() {
+    let gate_source = include_str!("../src/writer_gate.rs");
+    assert!(
+        gate_source.contains("pub enum RustWriterAuthority {}"),
+        "writer authority must be structurally uninhabited"
+    );
+    assert!(!gate_source.contains("pub struct RustWriterAuthority"));
+
     let source_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     let mut pending = vec![source_root];
     let mut rust_sources = Vec::new();
@@ -81,23 +86,27 @@ fn production_tree_has_exactly_one_closed_authority_definition() {
     rust_sources.sort();
 
     let mut request_definitions = 0;
-    let mut authority_definitions_or_literals = 0;
-    let mut authority_impls = 0;
+    let mut uninhabited_authority_definitions = 0;
+    let mut authority_variants_or_constructors = 0;
     for path in rust_sources {
         let source = std::fs::read_to_string(&path).expect("read UTF-8 production Rust source");
         request_definitions += source
             .matches("pub fn request_rust_writer_authority(")
             .count();
-        authority_definitions_or_literals += source.matches("RustWriterAuthority {").count();
-        authority_impls += source.matches("impl RustWriterAuthority").count();
+        uninhabited_authority_definitions +=
+            source.matches("pub enum RustWriterAuthority {}").count();
+        authority_variants_or_constructors += source.matches("RustWriterAuthority::").count();
     }
 
     assert_eq!(request_definitions, 1, "one public authority request path");
     assert_eq!(
-        authority_definitions_or_literals, 1,
-        "the private struct definition must be the only constructor-shaped source"
+        uninhabited_authority_definitions, 1,
+        "one structurally uninhabited authority type"
     );
-    assert_eq!(authority_impls, 0, "no alternate inherent constructor path");
+    assert_eq!(
+        authority_variants_or_constructors, 0,
+        "the authority enum must expose no variant or constructor path"
+    );
 }
 
 #[test]

--- a/rust/crates/babylon-persistence/tests/writer_gate.rs
+++ b/rust/crates/babylon-persistence/tests/writer_gate.rs
@@ -64,6 +64,43 @@ fn source_exposes_no_alternate_activation_channel() {
 }
 
 #[test]
+fn production_tree_has_exactly_one_closed_authority_definition() {
+    let source_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut pending = vec![source_root];
+    let mut rust_sources = Vec::new();
+    while let Some(directory) = pending.pop() {
+        for entry in std::fs::read_dir(directory).expect("read production source directory") {
+            let path = entry.expect("read production source entry").path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path.extension().is_some_and(|extension| extension == "rs") {
+                rust_sources.push(path);
+            }
+        }
+    }
+    rust_sources.sort();
+
+    let mut request_definitions = 0;
+    let mut authority_definitions_or_literals = 0;
+    let mut authority_impls = 0;
+    for path in rust_sources {
+        let source = std::fs::read_to_string(&path).expect("read UTF-8 production Rust source");
+        request_definitions += source
+            .matches("pub fn request_rust_writer_authority(")
+            .count();
+        authority_definitions_or_literals += source.matches("RustWriterAuthority {").count();
+        authority_impls += source.matches("impl RustWriterAuthority").count();
+    }
+
+    assert_eq!(request_definitions, 1, "one public authority request path");
+    assert_eq!(
+        authority_definitions_or_literals, 1,
+        "the private struct definition must be the only constructor-shaped source"
+    );
+    assert_eq!(authority_impls, 0, "no alternate inherent constructor path");
+}
+
+#[test]
 fn refusal_is_a_typed_public_error() {
     fn assert_error<T: std::error::Error + Send + Sync + 'static>() {}
 

--- a/tools/run_rust_legacy_adopter_pg.sh
+++ b/tools/run_rust_legacy_adopter_pg.sh
@@ -225,15 +225,15 @@ fi
 
 if [ "$status" -eq 0 ] &&
     { [ "$LIVE_FOCUS" = "committed_tick_writer" ] || [ "$LIVE_FOCUS" = "pr" ]; }; then
-  timeout --signal=TERM --kill-after=10s 300s \
+  timeout --signal=TERM --kill-after=10s 420s \
     env \
       BABYLON_LEGACY_ADOPTER_TEST_DSN="postgresql://test:test@127.0.0.1:$PORT/postgres" \
       BABYLON_LEGACY_ADOPTER_DISPOSABLE_ACK="$TEST_HARNESS_ACK" \
       BABYLON_LEGACY_ADOPTER_DISPOSABLE_CANARY="$CANARY" \
       CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/rust/target}" \
     cargo test -p babylon-persistence --lib \
-      committed_tick_writer::tests::live_marker_last_commit_retry_conflict_and_hydration_are_atomic \
-      --locked -- --nocapture --ignored --exact --test-threads=1 || status=$?
+      committed_tick_writer::tests::live_ \
+      --locked -- --nocapture --ignored --test-threads=1 || status=$?
 fi
 
 if [ "$status" -eq 0 ] &&


### PR DESCRIPTION
## Summary

- exercise the real committed-tick transaction path at all 32 V1 crash boundaries: before and after begin, preparation, campaign creation, campaign lock, presence inspection, next-tick validation, all eight row-family inserts, marker insert, and commit
- terminate the live PostgreSQL backend at every boundary and require the next real driver operation to observe the connection loss; prove every pre-COMMIT loss exposes neither campaign nor tick storage, then retries once to one exact commit
- prove post-COMMIT connection loss reconciles the exact stored envelope without a rewrite, including PostgreSQL connection/shutdown SQLSTATEs `08xxx` and `57P01`-`57P03`
- preserve Python as the sole live writer and make the Rust authority capability structurally uninhabited, with one closed request path and no constructor or activation alternative
- run both live committed-tick proofs in one bounded PostgreSQL harness invocation and adjust only the matching CI timeout envelope

## TDD evidence

Initial RED: the ignored live crash-matrix test failed to compile because the exhaustive boundary enumerator and real-path crash proof did not exist.

Review RED:

- forcing the probe to continue after backend termination failed at `Before Begin` with a real `BeginTransaction` connection error instead of the synthetic ambiguity path
- the production-tree gate failed when changed to require a structurally uninhabited authority type
- the first live GREEN attempt exposed PostgreSQL's `57P01` administrator-shutdown diagnostic at `After Begin`, proving connection-loss SQLSTATEs also require ambiguity reconciliation

Final GREEN:

- `BLAS=1 mise run check` — 14,664 passed, 55 skipped, 1 expected xfail
- `BLAS=1 mise run rust:check-no-docs` — green with only the broken host cache wrapper bypassed; every validation leg remained active
- `BABYLON_LEGACY_ADOPTER_LIVE_FOCUS=committed_tick_writer mise run test:rust-legacy-adopter-pg` — 2 passed in 213.77s; exact container and anonymous-volume cleanup verified
- `cargo test -p babylon-persistence --all-targets --locked` — green
- `cargo clippy -p babylon-persistence --all-targets --locked -- -D warnings -W clippy::pedantic` — green

## Boundaries

This does not activate the Rust writer, change Python authority, add compatibility or parallel paths, consume Archive receipts, or implement fog, Bevy, player actions, or PER-277.

Fixes PER-20
